### PR TITLE
New: Add no-restricted-exports rule (fixes #10428)

### DIFF
--- a/docs/rules/no-restricted-exports.md
+++ b/docs/rules/no-restricted-exports.md
@@ -1,4 +1,4 @@
-# Disallow specified names in named exports (no-restricted-exports)
+# Disallow specified names in exports (no-restricted-exports)
 
 In a project, certain names may be disallowed from being used as exported names for various reasons.
 
@@ -10,12 +10,16 @@ This rule disallows specified names from being used as exported names.
 
 By default, this rule doesn't disallow any names. Only the names you specify in the configuration will be disallowed.
 
-This rule has one option, an array of strings, where each string is a name to be restricted.
+This rule has an object option:
+
+* `"restrictedNamedExports"` is an array of strings, where each string is a name to be restricted.
 
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-restricted-exports: ["error", ["foo", "bar", "Baz", "a", "b", "c", "d"]]*/
+/*eslint no-restricted-exports: ["error", {
+    "restrictedNamedExports": ["foo", "bar", "Baz", "a", "b", "c", "d"]
+}]*/
 
 export const foo = 1;
 
@@ -37,7 +41,9 @@ export { something as d } from 'some_module';
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-restricted-exports: ["error", ["foo", "bar", "Baz", "a", "b", "c", "d"]]*/
+/*eslint no-restricted-exports: ["error", {
+    "restrictedNamedExports": ["foo", "bar", "Baz", "a", "b", "c", "d"]
+}]*/
 
 export const quux = 1;
 
@@ -58,20 +64,20 @@ export { something } from 'some_module';
 
 ### Default exports
 
-By design, this rule never disallows default export declarations. If you configure `"default"` as a restricted name, that restriction will apply only to named export declarations.
+By design, this rule doesn't disallow `export default` declarations. If you configure `"default"` as a restricted name, that restriction will apply only to named export declarations.
 
 Examples of additional **incorrect** code for this rule:
 
 ```js
-/*eslint no-restricted-exports: ["error", ["default"]]*/
+/*eslint no-restricted-exports: ["error", { "restrictedNamedExports": ["default"] }]*/
 
 function foo() {}
 
-export {foo as default};
+export { foo as default };
 ```
 
 ```js
-/*eslint no-restricted-exports: ["error", ["default"]]*/
+/*eslint no-restricted-exports: ["error", { "restrictedNamedExports": ["default"] }]*/
 
 export { default } from 'some_module';
 ```
@@ -79,7 +85,7 @@ export { default } from 'some_module';
 Examples of additional **correct** code for this rule:
 
 ```js
-/*eslint no-restricted-exports: ["error", ["default", "foo"]]*/
+/*eslint no-restricted-exports: ["error", { "restrictedNamedExports": ["default", "foo"] }]*/
 
 export default function foo() {}
 ```
@@ -94,7 +100,7 @@ This rule doesn't inspect the content of source modules in re-export declaration
 export function foo() {}
 
 //----- my_module.js -----
-/*eslint no-restricted-exports: ["error", ["foo"]]*/
+/*eslint no-restricted-exports: ["error", { "restrictedNamedExports": ["foo"] }]*/
 
 export * from 'some_module'; // allowed, although this declaration exports "foo" from my_module
 ```

--- a/docs/rules/no-restricted-exports.md
+++ b/docs/rules/no-restricted-exports.md
@@ -1,0 +1,100 @@
+# Disallow specified names in named exports (no-restricted-exports)
+
+In a project, certain names may be disallowed from being used as exported names for various reasons.
+
+## Rule Details
+
+This rule disallows specified names from being used as exported names.
+
+## Options
+
+By default, this rule doesn't disallow any names. Only the names you specify in the configuration will be disallowed.
+
+This rule has one option, an array of strings, where each string is a name to be restricted.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-restricted-exports: ["error", ["foo", "bar", "Baz", "a", "b", "c", "d"]]*/
+
+export const foo = 1;
+
+export function bar() {}
+
+export class Baz {}
+
+const a = {};
+export { a };
+
+function someFunction() {}
+export { someFunction as b };
+
+export { c } from 'some_module';
+
+export { something as d } from 'some_module';
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-restricted-exports: ["error", ["foo", "bar", "Baz", "a", "b", "c", "d"]]*/
+
+export const quux = 1;
+
+export function myFunction() {}
+
+export class MyClass {}
+
+const a = {};
+export { a as myObject };
+
+function someFunction() {}
+export { someFunction };
+
+export { c as someName } from 'some_module';
+
+export { something } from 'some_module';
+```
+
+### Default exports
+
+By design, this rule never disallows default export declarations. If you configure `"default"` as a restricted name, that restriction will apply only to named export declarations.
+
+Examples of additional **incorrect** code for this rule:
+
+```js
+/*eslint no-restricted-exports: ["error", ["default"]]*/
+
+function foo() {}
+
+export {foo as default};
+```
+
+```js
+/*eslint no-restricted-exports: ["error", ["default"]]*/
+
+export { default } from 'some_module';
+```
+
+Examples of additional **correct** code for this rule:
+
+```js
+/*eslint no-restricted-exports: ["error", ["default", "foo"]]*/
+
+export default function foo() {}
+```
+
+## Known Limitations
+
+This rule doesn't inspect the content of source modules in re-export declarations. In particular, if you are re-exporting everything from another module's export, that export may include a restricted name. This rule cannot detect such cases.
+
+```js
+
+//----- some_module.js -----
+export function foo() {}
+
+//----- my_module.js -----
+/*eslint no-restricted-exports: ["error", ["foo"]]*/
+
+export * from 'some_module'; // allowed, although this declaration exports "foo" from my_module
+```

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -175,6 +175,7 @@ module.exports = new LazyLoadingRuleMap(Object.entries({
     "no-prototype-builtins": () => require("./no-prototype-builtins"),
     "no-redeclare": () => require("./no-redeclare"),
     "no-regex-spaces": () => require("./no-regex-spaces"),
+    "no-restricted-exports": () => require("./no-restricted-exports"),
     "no-restricted-globals": () => require("./no-restricted-globals"),
     "no-restricted-imports": () => require("./no-restricted-imports"),
     "no-restricted-modules": () => require("./no-restricted-modules"),

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview Rule to disallow specified names in named exports
+ * @author Milos Djermanovic
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        type: "suggestion",
+
+        docs: {
+            description: "disallow specified names in named exports",
+            category: "ECMAScript 6",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/no-restricted-exports"
+        },
+
+        schema: [
+            {
+                type: "array",
+                items: {
+                    type: "string"
+                },
+                uniqueItems: true
+            }
+        ],
+        fixable: "code",
+
+        messages: {
+            restricted: "'{{name}}' is restricted from being used as an exported name."
+        }
+    },
+
+    create(context) {
+
+        const restrictedNames = new Set(context.options[0]);
+
+        /**
+         * Checks and reports given exported identifier.
+         * @param {ASTNode} node exported `Identifer` node to check.
+         * @returns {void}
+         */
+        function checkExported(node) {
+            const name = node.name;
+
+            if (restrictedNames.has(name)) {
+                context.report({
+                    node,
+                    messageId: "restricted",
+                    data: { name }
+                });
+            }
+        }
+
+        return {
+            ExportNamedDeclaration(node) {
+                const declaration = node.declaration;
+
+                if (declaration) {
+                    if (declaration.type === "FunctionDeclaration" || declaration.type === "ClassDeclaration") {
+                        checkExported(declaration.id);
+                    } else if (declaration.type === "VariableDeclaration") {
+                        context.getDeclaredVariables(declaration)
+                            .map(v => v.defs.find(d => d.parent === declaration))
+                            .map(d => d.name) // Identifier nodes
+                            .forEach(checkExported);
+                    }
+                } else {
+                    node.specifiers
+                        .map(s => s.exported)
+                        .forEach(checkExported);
+                }
+            }
+        };
+    }
+};

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -29,7 +29,6 @@ module.exports = {
                 uniqueItems: true
             }
         ],
-        fixable: "code",
 
         messages: {
             restricted: "'{{name}}' is restricted from being used as an exported name."

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rule to disallow specified names in named exports
+ * @fileoverview Rule to disallow specified names in exports
  * @author Milos Djermanovic
  */
 
@@ -14,43 +14,47 @@ module.exports = {
         type: "suggestion",
 
         docs: {
-            description: "disallow specified names in named exports",
+            description: "disallow specified names in exports",
             category: "ECMAScript 6",
             recommended: false,
             url: "https://eslint.org/docs/rules/no-restricted-exports"
         },
 
-        schema: [
-            {
-                type: "array",
-                items: {
-                    type: "string"
-                },
-                uniqueItems: true
-            }
-        ],
+        schema: [{
+            type: "object",
+            properties: {
+                restrictedNamedExports: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    },
+                    uniqueItems: true
+                }
+            },
+            additionalProperties: false
+        }],
 
         messages: {
-            restricted: "'{{name}}' is restricted from being used as an exported name."
+            restrictedNamed: "'{{name}}' is restricted from being used as an exported name."
         }
     },
 
     create(context) {
 
-        const restrictedNames = new Set(context.options[0]);
+        const restrictedNames = new Set(context.options[0] && context.options[0].restrictedNamedExports);
 
         /**
          * Checks and reports given exported identifier.
          * @param {ASTNode} node exported `Identifer` node to check.
          * @returns {void}
          */
-        function checkExported(node) {
+        function checkExportedName(node) {
             const name = node.name;
 
             if (restrictedNames.has(name)) {
                 context.report({
                     node,
-                    messageId: "restricted",
+                    messageId: "restrictedNamed",
                     data: { name }
                 });
             }
@@ -62,17 +66,17 @@ module.exports = {
 
                 if (declaration) {
                     if (declaration.type === "FunctionDeclaration" || declaration.type === "ClassDeclaration") {
-                        checkExported(declaration.id);
+                        checkExportedName(declaration.id);
                     } else if (declaration.type === "VariableDeclaration") {
                         context.getDeclaredVariables(declaration)
                             .map(v => v.defs.find(d => d.parent === declaration))
                             .map(d => d.name) // Identifier nodes
-                            .forEach(checkExported);
+                            .forEach(checkExportedName);
                     }
                 } else {
                     node.specifiers
                         .map(s => s.exported)
-                        .forEach(checkExported);
+                        .forEach(checkExportedName);
                 }
             }
         };

--- a/tests/lib/rules/no-restricted-exports.js
+++ b/tests/lib/rules/no-restricted-exports.js
@@ -1,0 +1,452 @@
+/**
+ * @fileoverview Tests for the no-restricted-exports rule
+ * @author Milos Djermanovic
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-restricted-exports");
+const { RuleTester } = require("../../../lib/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018, sourceType: "module" } });
+
+ruleTester.run("no-restricted-exports", rule, {
+    valid: [
+
+        // nothing configured
+        "export var a;",
+        "export function a() {}",
+        "export class A {}",
+        "var a; export { a };",
+        "var b; export { b as a };",
+        "export { a } from 'foo';",
+        "export { b as a } from 'foo';",
+        { code: "export var a;", options: [[]] },
+        { code: "export function a() {}", options: [[]] },
+        { code: "export class A {}", options: [[]] },
+        { code: "var a; export { a };", options: [[]] },
+        { code: "var b; export { b as a };", options: [[]] },
+        { code: "export { a } from 'foo';", options: [[]] },
+        { code: "export { b as a } from 'foo';", options: [[]] },
+
+        // not a restricted name
+        { code: "export var a;", options: [["x"]] },
+        { code: "export let a;", options: [["x"]] },
+        { code: "export const a = 1;", options: [["x"]] },
+        { code: "export function a() {}", options: [["x"]] },
+        { code: "export function *a() {}", options: [["x"]] },
+        { code: "export async function a() {}", options: [["x"]] },
+        { code: "export async function *a() {}", options: [["x"]] },
+        { code: "export class A {}", options: [["x"]] },
+        { code: "var a; export { a };", options: [["x"]] },
+        { code: "var b; export { b as a };", options: [["x"]] },
+        { code: "export { a } from 'foo';", options: [["x"]] },
+        { code: "export { b as a } from 'foo';", options: [["x"]] },
+
+        // does not mistakenly disallow non-exported identifers that appear in named export declarations
+        { code: "export var b = a;", options: [["a"]] },
+        { code: "export let [b = a] = [];", options: [["a"]] },
+        { code: "export const [b] = [a];", options: [["a"]] },
+        { code: "export var { a: b } = {};", options: [["a"]] },
+        { code: "export let { b = a } = {};", options: [["a"]] },
+        { code: "export const { c: b = a } = {};", options: [["a"]] },
+        { code: "export function b(a) {}", options: [["a"]] },
+        { code: "export class A { a(){} }", options: [["a"]] },
+        { code: "export class A extends B {}", options: [["B"]] },
+        { code: "var a; export { a as b };", options: [["a"]] },
+        { code: "export { a as b } from 'foo';", options: [["a"]] },
+
+        // does not check source in re-export declarations
+        { code: "export { b } from 'a';", options: [["a"]] },
+
+        // does not check non-export declarations
+        { code: "var a;", options: [["a"]] },
+        { code: "let a;", options: [["a"]] },
+        { code: "const a = 1;", options: [["a"]] },
+        { code: "function a() {}", options: [["a"]] },
+        { code: "class A {}", options: [["A"]] },
+        { code: "import a from 'foo';", options: [["a"]] },
+        { code: "import { a } from 'foo';", options: [["a"]] },
+        { code: "import { b as a } from 'foo';", options: [["a"]] },
+
+        // does not check re-export all declarations
+        { code: "export * from 'foo';", options: [["a"]] },
+        { code: "export * from 'a';", options: [["a"]] },
+
+        // does not mistakenly disallow identifiers in export default declarations (a default export will export "default" name)
+        { code: "export default a;", options: [["a"]] },
+        { code: "export default function a() {}", options: [["a"]] },
+        { code: "export default class A {}", options: [["A"]] },
+        { code: "export default (function a() {});", options: [["a"]] },
+        { code: "export default (class A {});", options: [["A"]] },
+
+        // by design, restricted name "default" does not apply to default export declarations, although they do export the "default" name.
+        { code: "export default 1;", options: [["default"]] },
+
+        // "default" does not disallow re-exporting a renamed default export from another module
+        { code: "export { default as a } from 'foo';", options: [["default"]] }
+    ],
+
+    invalid: [
+
+        // full message test
+        {
+            code: "export function someFunction() {}",
+            options: [["someFunction"]],
+            errors: [{ message: "'someFunction' is restricted from being used as an exported name.", type: "Identifier" }]
+        },
+
+        // basic tests
+        {
+            code: "export var a;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export var a = 1;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export let a;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export let a = 1;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export const a = 1;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export function a() {}",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export function *a() {}",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export async function a() {}",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export async function *a() {}",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export class A {}",
+            options: [["A"]],
+            errors: [{ messageId: "restricted", data: { name: "A" }, type: "Identifier" }]
+        },
+        {
+            code: "let a; export { a };",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 17 }]
+        },
+        {
+            code: "export { a }; var a;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 10 }]
+        },
+        {
+            code: "let b; export { b as a };",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export { a } from 'foo';",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export { b as a } from 'foo';",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+
+        // destructuring
+        {
+            code: "export var [a] = [];",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export let { a } = {};",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export const { b: a } = {};",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export var [{ a }] = [];",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export let { b: { c: a = d } = e } = {};",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+
+        // reports the correct identifier node in the case of a redeclaration. Note: functions cannot be redeclared in a module.
+        {
+            code: "var a; export var a;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 19 }]
+        },
+        {
+            code: "export var a; var a;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 12 }]
+        },
+
+        // reports the correct identifier node when the same identifier appears elsewhere in the declaration
+        {
+            code: "export var a = a;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 12 }]
+        },
+        {
+            code: "export let b = a, a;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 19 }]
+        },
+        {
+            code: "export const a = 1, b = a;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 14 }]
+        },
+        {
+            code: "export var [a] = a;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 13 }]
+        },
+        {
+            code: "export let { a: a } = {};",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 17 }]
+        },
+        {
+            code: "export const { a: b, b: a } = {};",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 25 }]
+        },
+        {
+            code: "export var { b: a, a: b } = {};",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 17 }]
+        },
+        {
+            code: "export let a, { a: b } = {};",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 12 }]
+        },
+        {
+            code: "export const { a: b } = {}, a = 1;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 29 }]
+        },
+        {
+            code: "export var [a = a] = [];",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 13 }]
+        },
+        {
+            code: "export var { a: a = a } = {};",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 17 }]
+        },
+        {
+            code: "export let { a } = { a };",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 14 }]
+        },
+        {
+            code: "export function a(a) {};",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 17 }]
+        },
+        {
+            code: "export class A { A(){} };",
+            options: [["A"]],
+            errors: [{ messageId: "restricted", data: { name: "A" }, type: "Identifier", column: 14 }]
+        },
+        {
+            code: "var a; export { a as a };",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 22 }]
+        },
+        {
+            code: "let a, b; export { a as b, b as a };",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 33 }]
+        },
+        {
+            code: "const a = 1, b = 2; export { b as a, a as b };",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 35 }]
+        },
+        {
+            code: "var a; export { a as b, a };",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 25 }]
+        },
+        {
+            code: "export { a as a } from 'a';",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 15 }]
+        },
+        {
+            code: "export { a as b, b as a } from 'foo';",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 23 }]
+        },
+        {
+            code: "export { b as a, a as b } from 'foo';",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 15 }]
+        },
+
+        // Note: duplicate identifiers in the same export declaration are a 'duplicate export' syntax error. Example: export var a, a;
+
+        // invalid and valid or multiple ivalid in the same declaration
+        {
+            code: "export var a, b;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export let b, a;",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export const b = 1, a = 2;",
+            options: [["a", "b"]],
+            errors: [
+                { messageId: "restricted", data: { name: "b" }, type: "Identifier" },
+                { messageId: "restricted", data: { name: "a" }, type: "Identifier" }
+            ]
+        },
+        {
+            code: "export var a, b, c;",
+            options: [["a", "c"]],
+            errors: [
+                { messageId: "restricted", data: { name: "a" }, type: "Identifier" },
+                { messageId: "restricted", data: { name: "c" }, type: "Identifier" }
+            ]
+        },
+        {
+            code: "export let { a, b, c } = {};",
+            options: [["b", "c"]],
+            errors: [
+                { messageId: "restricted", data: { name: "b" }, type: "Identifier" },
+                { messageId: "restricted", data: { name: "c" }, type: "Identifier" }
+            ]
+        },
+        {
+            code: "export const [a, b, c, d] = {};",
+            options: [["b", "c"]],
+            errors: [
+                { messageId: "restricted", data: { name: "b" }, type: "Identifier" },
+                { messageId: "restricted", data: { name: "c" }, type: "Identifier" }
+            ]
+        },
+        {
+            code: "export var { a, x: b, c, d, e: y } = {}, e, f = {};",
+            options: [["foo", "a", "b", "bar", "d", "e", "baz"]],
+            errors: [
+                { messageId: "restricted", data: { name: "a" }, type: "Identifier" },
+                { messageId: "restricted", data: { name: "b" }, type: "Identifier" },
+                { messageId: "restricted", data: { name: "d" }, type: "Identifier" },
+                { messageId: "restricted", data: { name: "e" }, type: "Identifier", column: 42 }
+            ]
+        },
+        {
+            code: "var a, b; export { a, b };",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "let a, b; export { b, a };",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "const a = 1, b = 1; export { a, b };",
+            options: [["a", "b"]],
+            errors: [
+                { messageId: "restricted", data: { name: "a" }, type: "Identifier" },
+                { messageId: "restricted", data: { name: "b" }, type: "Identifier" }
+            ]
+        },
+        {
+            code: "export { a, b, c }; var a, b, c;",
+            options: [["a", "c"]],
+            errors: [
+                { messageId: "restricted", data: { name: "a" }, type: "Identifier" },
+                { messageId: "restricted", data: { name: "c" }, type: "Identifier" }
+            ]
+        },
+        {
+            code: "export { b as a, b } from 'foo';",
+            options: [["a"]],
+            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+        },
+        {
+            code: "export { b as a, b } from 'foo';",
+            options: [["b"]],
+            errors: [{ messageId: "restricted", data: { name: "b" }, type: "Identifier", column: 18 }]
+        },
+        {
+            code: "export { b as a, b } from 'foo';",
+            options: [["a", "b"]],
+            errors: [
+                { messageId: "restricted", data: { name: "a" }, type: "Identifier" },
+                { messageId: "restricted", data: { name: "b" }, type: "Identifier", column: 18 }
+            ]
+        },
+        {
+            code: "export { a, b, c, d, x as e, f, g } from 'foo';",
+            options: [["foo", "b", "bar", "d", "e", "f", "baz"]],
+            errors: [
+                { messageId: "restricted", data: { name: "b" }, type: "Identifier" },
+                { messageId: "restricted", data: { name: "d" }, type: "Identifier" },
+                { messageId: "restricted", data: { name: "e" }, type: "Identifier" },
+                { messageId: "restricted", data: { name: "f" }, type: "Identifier" }
+            ]
+        },
+
+        // reports "default" in named export declarations (when configured)
+        {
+            code: "var a; export { a as default };",
+            options: [["default"]],
+            errors: [{ messageId: "restricted", data: { name: "default" }, type: "Identifier", column: 22 }]
+        },
+        {
+            code: "export { default } from 'foo';",
+            options: [["default"]],
+            errors: [{ messageId: "restricted", data: { name: "default" }, type: "Identifier", column: 10 }]
+        }
+    ]
+});

--- a/tests/lib/rules/no-restricted-exports.js
+++ b/tests/lib/rules/no-restricted-exports.js
@@ -29,70 +29,77 @@ ruleTester.run("no-restricted-exports", rule, {
         "var b; export { b as a };",
         "export { a } from 'foo';",
         "export { b as a } from 'foo';",
-        { code: "export var a;", options: [[]] },
-        { code: "export function a() {}", options: [[]] },
-        { code: "export class A {}", options: [[]] },
-        { code: "var a; export { a };", options: [[]] },
-        { code: "var b; export { b as a };", options: [[]] },
-        { code: "export { a } from 'foo';", options: [[]] },
-        { code: "export { b as a } from 'foo';", options: [[]] },
+        { code: "export var a;", options: [{}] },
+        { code: "export function a() {}", options: [{}] },
+        { code: "export class A {}", options: [{}] },
+        { code: "var a; export { a };", options: [{}] },
+        { code: "var b; export { b as a };", options: [{}] },
+        { code: "export { a } from 'foo';", options: [{}] },
+        { code: "export { b as a } from 'foo';", options: [{}] },
+        { code: "export var a;", options: [{ restrictedNamedExports: [] }] },
+        { code: "export function a() {}", options: [{ restrictedNamedExports: [] }] },
+        { code: "export class A {}", options: [{ restrictedNamedExports: [] }] },
+        { code: "var a; export { a };", options: [{ restrictedNamedExports: [] }] },
+        { code: "var b; export { b as a };", options: [{ restrictedNamedExports: [] }] },
+        { code: "export { a } from 'foo';", options: [{ restrictedNamedExports: [] }] },
+        { code: "export { b as a } from 'foo';", options: [{ restrictedNamedExports: [] }] },
 
         // not a restricted name
-        { code: "export var a;", options: [["x"]] },
-        { code: "export let a;", options: [["x"]] },
-        { code: "export const a = 1;", options: [["x"]] },
-        { code: "export function a() {}", options: [["x"]] },
-        { code: "export function *a() {}", options: [["x"]] },
-        { code: "export async function a() {}", options: [["x"]] },
-        { code: "export async function *a() {}", options: [["x"]] },
-        { code: "export class A {}", options: [["x"]] },
-        { code: "var a; export { a };", options: [["x"]] },
-        { code: "var b; export { b as a };", options: [["x"]] },
-        { code: "export { a } from 'foo';", options: [["x"]] },
-        { code: "export { b as a } from 'foo';", options: [["x"]] },
+        { code: "export var a;", options: [{ restrictedNamedExports: ["x"] }] },
+        { code: "export let a;", options: [{ restrictedNamedExports: ["x"] }] },
+        { code: "export const a = 1;", options: [{ restrictedNamedExports: ["x"] }] },
+        { code: "export function a() {}", options: [{ restrictedNamedExports: ["x"] }] },
+        { code: "export function *a() {}", options: [{ restrictedNamedExports: ["x"] }] },
+        { code: "export async function a() {}", options: [{ restrictedNamedExports: ["x"] }] },
+        { code: "export async function *a() {}", options: [{ restrictedNamedExports: ["x"] }] },
+        { code: "export class A {}", options: [{ restrictedNamedExports: ["x"] }] },
+        { code: "var a; export { a };", options: [{ restrictedNamedExports: ["x"] }] },
+        { code: "var b; export { b as a };", options: [{ restrictedNamedExports: ["x"] }] },
+        { code: "export { a } from 'foo';", options: [{ restrictedNamedExports: ["x"] }] },
+        { code: "export { b as a } from 'foo';", options: [{ restrictedNamedExports: ["x"] }] },
 
         // does not mistakenly disallow non-exported identifers that appear in named export declarations
-        { code: "export var b = a;", options: [["a"]] },
-        { code: "export let [b = a] = [];", options: [["a"]] },
-        { code: "export const [b] = [a];", options: [["a"]] },
-        { code: "export var { a: b } = {};", options: [["a"]] },
-        { code: "export let { b = a } = {};", options: [["a"]] },
-        { code: "export const { c: b = a } = {};", options: [["a"]] },
-        { code: "export function b(a) {}", options: [["a"]] },
-        { code: "export class A { a(){} }", options: [["a"]] },
-        { code: "export class A extends B {}", options: [["B"]] },
-        { code: "var a; export { a as b };", options: [["a"]] },
-        { code: "export { a as b } from 'foo';", options: [["a"]] },
+        { code: "export var b = a;", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "export let [b = a] = [];", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "export const [b] = [a];", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "export var { a: b } = {};", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "export let { b = a } = {};", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "export const { c: b = a } = {};", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "export function b(a) {}", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "export class A { a(){} }", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "export class A extends B {}", options: [{ restrictedNamedExports: ["B"] }] },
+        { code: "var a; export { a as b };", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "export { a as b } from 'foo';", options: [{ restrictedNamedExports: ["a"] }] },
 
         // does not check source in re-export declarations
-        { code: "export { b } from 'a';", options: [["a"]] },
+        { code: "export { b } from 'a';", options: [{ restrictedNamedExports: ["a"] }] },
 
         // does not check non-export declarations
-        { code: "var a;", options: [["a"]] },
-        { code: "let a;", options: [["a"]] },
-        { code: "const a = 1;", options: [["a"]] },
-        { code: "function a() {}", options: [["a"]] },
-        { code: "class A {}", options: [["A"]] },
-        { code: "import a from 'foo';", options: [["a"]] },
-        { code: "import { a } from 'foo';", options: [["a"]] },
-        { code: "import { b as a } from 'foo';", options: [["a"]] },
+        { code: "var a;", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "let a;", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "const a = 1;", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "function a() {}", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "class A {}", options: [{ restrictedNamedExports: ["A"] }] },
+        { code: "import a from 'foo';", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "import { a } from 'foo';", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "import { b as a } from 'foo';", options: [{ restrictedNamedExports: ["a"] }] },
 
         // does not check re-export all declarations
-        { code: "export * from 'foo';", options: [["a"]] },
-        { code: "export * from 'a';", options: [["a"]] },
+        { code: "export * from 'foo';", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "export * from 'a';", options: [{ restrictedNamedExports: ["a"] }] },
 
         // does not mistakenly disallow identifiers in export default declarations (a default export will export "default" name)
-        { code: "export default a;", options: [["a"]] },
-        { code: "export default function a() {}", options: [["a"]] },
-        { code: "export default class A {}", options: [["A"]] },
-        { code: "export default (function a() {});", options: [["a"]] },
-        { code: "export default (class A {});", options: [["A"]] },
+        { code: "export default a;", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "export default function a() {}", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "export default class A {}", options: [{ restrictedNamedExports: ["A"] }] },
+        { code: "export default (function a() {});", options: [{ restrictedNamedExports: ["a"] }] },
+        { code: "export default (class A {});", options: [{ restrictedNamedExports: ["A"] }] },
 
         // by design, restricted name "default" does not apply to default export declarations, although they do export the "default" name.
-        { code: "export default 1;", options: [["default"]] },
+        { code: "export default 1;", options: [{ restrictedNamedExports: ["default"] }] },
 
         // "default" does not disallow re-exporting a renamed default export from another module
-        { code: "export { default as a } from 'foo';", options: [["default"]] }
+        { code: "export { default as a } from 'foo';", options: [{ restrictedNamedExports: ["default"] }] }
     ],
 
     invalid: [
@@ -100,231 +107,231 @@ ruleTester.run("no-restricted-exports", rule, {
         // full message test
         {
             code: "export function someFunction() {}",
-            options: [["someFunction"]],
+            options: [{ restrictedNamedExports: ["someFunction"] }],
             errors: [{ message: "'someFunction' is restricted from being used as an exported name.", type: "Identifier" }]
         },
 
         // basic tests
         {
             code: "export var a;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export var a = 1;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export let a;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export let a = 1;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export const a = 1;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export function a() {}",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export function *a() {}",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export async function a() {}",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export async function *a() {}",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export class A {}",
-            options: [["A"]],
-            errors: [{ messageId: "restricted", data: { name: "A" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["A"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "A" }, type: "Identifier" }]
         },
         {
             code: "let a; export { a };",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 17 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 17 }]
         },
         {
             code: "export { a }; var a;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 10 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 10 }]
         },
         {
             code: "let b; export { b as a };",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export { a } from 'foo';",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export { b as a } from 'foo';",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
 
         // destructuring
         {
             code: "export var [a] = [];",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export let { a } = {};",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export const { b: a } = {};",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export var [{ a }] = [];",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export let { b: { c: a = d } = e } = {};",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
 
         // reports the correct identifier node in the case of a redeclaration. Note: functions cannot be redeclared in a module.
         {
             code: "var a; export var a;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 19 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 19 }]
         },
         {
             code: "export var a; var a;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 12 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 12 }]
         },
 
         // reports the correct identifier node when the same identifier appears elsewhere in the declaration
         {
             code: "export var a = a;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 12 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 12 }]
         },
         {
             code: "export let b = a, a;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 19 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 19 }]
         },
         {
             code: "export const a = 1, b = a;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 14 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 14 }]
         },
         {
             code: "export var [a] = a;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 13 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 13 }]
         },
         {
             code: "export let { a: a } = {};",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 17 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 17 }]
         },
         {
             code: "export const { a: b, b: a } = {};",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 25 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 25 }]
         },
         {
             code: "export var { b: a, a: b } = {};",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 17 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 17 }]
         },
         {
             code: "export let a, { a: b } = {};",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 12 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 12 }]
         },
         {
             code: "export const { a: b } = {}, a = 1;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 29 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 29 }]
         },
         {
             code: "export var [a = a] = [];",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 13 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 13 }]
         },
         {
             code: "export var { a: a = a } = {};",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 17 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 17 }]
         },
         {
             code: "export let { a } = { a };",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 14 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 14 }]
         },
         {
             code: "export function a(a) {};",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 17 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 17 }]
         },
         {
             code: "export class A { A(){} };",
-            options: [["A"]],
-            errors: [{ messageId: "restricted", data: { name: "A" }, type: "Identifier", column: 14 }]
+            options: [{ restrictedNamedExports: ["A"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "A" }, type: "Identifier", column: 14 }]
         },
         {
             code: "var a; export { a as a };",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 22 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 22 }]
         },
         {
             code: "let a, b; export { a as b, b as a };",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 33 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 33 }]
         },
         {
             code: "const a = 1, b = 2; export { b as a, a as b };",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 35 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 35 }]
         },
         {
             code: "var a; export { a as b, a };",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 25 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 25 }]
         },
         {
             code: "export { a as a } from 'a';",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 15 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 15 }]
         },
         {
             code: "export { a as b, b as a } from 'foo';",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 23 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 23 }]
         },
         {
             code: "export { b as a, a as b } from 'foo';",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier", column: 15 }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier", column: 15 }]
         },
 
         // Note: duplicate identifiers in the same export declaration are a 'duplicate export' syntax error. Example: export var a, a;
@@ -332,121 +339,121 @@ ruleTester.run("no-restricted-exports", rule, {
         // invalid and valid or multiple ivalid in the same declaration
         {
             code: "export var a, b;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export let b, a;",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export const b = 1, a = 2;",
-            options: [["a", "b"]],
+            options: [{ restrictedNamedExports: ["a", "b"] }],
             errors: [
-                { messageId: "restricted", data: { name: "b" }, type: "Identifier" },
-                { messageId: "restricted", data: { name: "a" }, type: "Identifier" }
+                { messageId: "restrictedNamed", data: { name: "b" }, type: "Identifier" },
+                { messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }
             ]
         },
         {
             code: "export var a, b, c;",
-            options: [["a", "c"]],
+            options: [{ restrictedNamedExports: ["a", "c"] }],
             errors: [
-                { messageId: "restricted", data: { name: "a" }, type: "Identifier" },
-                { messageId: "restricted", data: { name: "c" }, type: "Identifier" }
+                { messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" },
+                { messageId: "restrictedNamed", data: { name: "c" }, type: "Identifier" }
             ]
         },
         {
             code: "export let { a, b, c } = {};",
-            options: [["b", "c"]],
+            options: [{ restrictedNamedExports: ["b", "c"] }],
             errors: [
-                { messageId: "restricted", data: { name: "b" }, type: "Identifier" },
-                { messageId: "restricted", data: { name: "c" }, type: "Identifier" }
+                { messageId: "restrictedNamed", data: { name: "b" }, type: "Identifier" },
+                { messageId: "restrictedNamed", data: { name: "c" }, type: "Identifier" }
             ]
         },
         {
             code: "export const [a, b, c, d] = {};",
-            options: [["b", "c"]],
+            options: [{ restrictedNamedExports: ["b", "c"] }],
             errors: [
-                { messageId: "restricted", data: { name: "b" }, type: "Identifier" },
-                { messageId: "restricted", data: { name: "c" }, type: "Identifier" }
+                { messageId: "restrictedNamed", data: { name: "b" }, type: "Identifier" },
+                { messageId: "restrictedNamed", data: { name: "c" }, type: "Identifier" }
             ]
         },
         {
             code: "export var { a, x: b, c, d, e: y } = {}, e, f = {};",
-            options: [["foo", "a", "b", "bar", "d", "e", "baz"]],
+            options: [{ restrictedNamedExports: ["foo", "a", "b", "bar", "d", "e", "baz"] }],
             errors: [
-                { messageId: "restricted", data: { name: "a" }, type: "Identifier" },
-                { messageId: "restricted", data: { name: "b" }, type: "Identifier" },
-                { messageId: "restricted", data: { name: "d" }, type: "Identifier" },
-                { messageId: "restricted", data: { name: "e" }, type: "Identifier", column: 42 }
+                { messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" },
+                { messageId: "restrictedNamed", data: { name: "b" }, type: "Identifier" },
+                { messageId: "restrictedNamed", data: { name: "d" }, type: "Identifier" },
+                { messageId: "restrictedNamed", data: { name: "e" }, type: "Identifier", column: 42 }
             ]
         },
         {
             code: "var a, b; export { a, b };",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "let a, b; export { b, a };",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "const a = 1, b = 1; export { a, b };",
-            options: [["a", "b"]],
+            options: [{ restrictedNamedExports: ["a", "b"] }],
             errors: [
-                { messageId: "restricted", data: { name: "a" }, type: "Identifier" },
-                { messageId: "restricted", data: { name: "b" }, type: "Identifier" }
+                { messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" },
+                { messageId: "restrictedNamed", data: { name: "b" }, type: "Identifier" }
             ]
         },
         {
             code: "export { a, b, c }; var a, b, c;",
-            options: [["a", "c"]],
+            options: [{ restrictedNamedExports: ["a", "c"] }],
             errors: [
-                { messageId: "restricted", data: { name: "a" }, type: "Identifier" },
-                { messageId: "restricted", data: { name: "c" }, type: "Identifier" }
+                { messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" },
+                { messageId: "restrictedNamed", data: { name: "c" }, type: "Identifier" }
             ]
         },
         {
             code: "export { b as a, b } from 'foo';",
-            options: [["a"]],
-            errors: [{ messageId: "restricted", data: { name: "a" }, type: "Identifier" }]
+            options: [{ restrictedNamedExports: ["a"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" }]
         },
         {
             code: "export { b as a, b } from 'foo';",
-            options: [["b"]],
-            errors: [{ messageId: "restricted", data: { name: "b" }, type: "Identifier", column: 18 }]
+            options: [{ restrictedNamedExports: ["b"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "b" }, type: "Identifier", column: 18 }]
         },
         {
             code: "export { b as a, b } from 'foo';",
-            options: [["a", "b"]],
+            options: [{ restrictedNamedExports: ["a", "b"] }],
             errors: [
-                { messageId: "restricted", data: { name: "a" }, type: "Identifier" },
-                { messageId: "restricted", data: { name: "b" }, type: "Identifier", column: 18 }
+                { messageId: "restrictedNamed", data: { name: "a" }, type: "Identifier" },
+                { messageId: "restrictedNamed", data: { name: "b" }, type: "Identifier", column: 18 }
             ]
         },
         {
             code: "export { a, b, c, d, x as e, f, g } from 'foo';",
-            options: [["foo", "b", "bar", "d", "e", "f", "baz"]],
+            options: [{ restrictedNamedExports: ["foo", "b", "bar", "d", "e", "f", "baz"] }],
             errors: [
-                { messageId: "restricted", data: { name: "b" }, type: "Identifier" },
-                { messageId: "restricted", data: { name: "d" }, type: "Identifier" },
-                { messageId: "restricted", data: { name: "e" }, type: "Identifier" },
-                { messageId: "restricted", data: { name: "f" }, type: "Identifier" }
+                { messageId: "restrictedNamed", data: { name: "b" }, type: "Identifier" },
+                { messageId: "restrictedNamed", data: { name: "d" }, type: "Identifier" },
+                { messageId: "restrictedNamed", data: { name: "e" }, type: "Identifier" },
+                { messageId: "restrictedNamed", data: { name: "f" }, type: "Identifier" }
             ]
         },
 
         // reports "default" in named export declarations (when configured)
         {
             code: "var a; export { a as default };",
-            options: [["default"]],
-            errors: [{ messageId: "restricted", data: { name: "default" }, type: "Identifier", column: 22 }]
+            options: [{ restrictedNamedExports: ["default"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "default" }, type: "Identifier", column: 22 }]
         },
         {
             code: "export { default } from 'foo';",
-            options: [["default"]],
-            errors: [{ messageId: "restricted", data: { name: "default" }, type: "Identifier", column: 10 }]
+            options: [{ restrictedNamedExports: ["default"] }],
+            errors: [{ messageId: "restrictedNamed", data: { name: "default" }, type: "Identifier", column: 10 }]
         }
     ]
 });

--- a/tools/rule-types.json
+++ b/tools/rule-types.json
@@ -162,6 +162,7 @@
     "no-prototype-builtins": "problem",
     "no-redeclare": "suggestion",
     "no-regex-spaces": "suggestion",
+    "no-restricted-exports": "suggestion",
     "no-restricted-globals": "suggestion",
     "no-restricted-imports": "suggestion",
     "no-restricted-modules": "suggestion",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] New rule #10428

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Examples of **incorrect** code for this rule:

```js
/*eslint no-restricted-exports: ["error", ["foo", "bar", "Baz", "a", "b", "c", "d"]]*/

export const foo = 1;

export function bar() {}

export class Baz {}

const a = {};
export { a };

function someFunction() {}
export { someFunction as b };

export { c } from 'some_module';

export { something as d } from 'some_module';
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

New rule `no-restricted-exports`

**Is there anything you'd like reviewers to focus on?**

* configuration

Configuration is `["error", ["foo", "bar"]]` instead of `["error", "foo", "bar"]`

This might be a better choice as it's clear that `"error"` isn't a restricted name, but it's different from other similar rules. Is it okay?  There was a discussion about this in #11331.

* custom messages

This wasn't mentioned in the issue thread, should the rule support custom messages for configured restricted names?

* reported nodes

The rule always reports `Identifier` nodes, rather than the declaration nodes (because a declaration can export more names, including the valid ones).


* export default

Configured `"default"` doesn't disallow `export default` (although it does export `"default"` name). Is it okay? There is a section in the documentation about this.

* export * from 'some_module'

This can export restricted names, but it's out of scope for this rule and noted in the Known Limitations section.

* documentation

I'm not sure what to note as a typical use case in the very first section (maybe nothing?).
