### PR TITLE
Chore: add package.json funding property

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.6.0",
   "author": "Nicholas C. Zakas <nicholas+npm@nczconsulting.com>",
   "description": "An AST-based pattern checker for JavaScript.",
+  "funding": "https://opencollective.com/eslint",
   "bin": {
     "eslint": "./bin/eslint.js"
   },


### PR DESCRIPTION
npm just added a new npm fund command in it's v6.13.0 release as part of the efforts to help out the OSS community.

refs:https://github.com/npm/cli/pull/273

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
add package.json funding property

**Is there anything you'd like reviewers to focus on?**


