### PR TITLE
New: Add offsetTernaryExpressions option for indent rule

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -84,6 +84,7 @@ This rule has an object option:
 * `"ObjectExpression"` (default: 1) enforces indentation level for properties in objects. It can be set to the string `"first"`, indicating that all properties in the object should be aligned with the first property. This can also be set to `"off"` to disable checking for object properties.
 * `"ImportDeclaration"` (default: 1) enforces indentation level for import statements. It can be set to the string `"first"`, indicating that all imported members from a module should be aligned with the first member in the list. This can also be set to `"off"` to disable checking for imported module members.
 * `"flatTernaryExpressions": true` (`false` by default) requires no indentation for ternary expressions which are nested in other ternary expressions.
+* `"offsetTernaryExpressions": true` (`false` by default) requires indentation for values of ternary expressions.
 * `"ignoredNodes"` accepts an array of [selectors](/docs/developer-guide/selectors.md). If an AST node is matched by any of the selectors, the indentation of tokens which are direct children of that node will be ignored. This can be used as an escape hatch to relax the rule if you disagree with the indentation that it enforces for a particular syntactic pattern.
 * `"ignoreComments"` (default: false) can be used when comments do not need to be aligned with nodes on the previous or next line.
 
@@ -641,6 +642,76 @@ var a =
     foo ? bar :
     baz ? qux :
     boop;
+```
+
+### offsetTernaryExpressions
+
+Examples of **incorrect** code for this rule with the default `2, { "offsetTernaryExpressions": false }` option:
+
+```js
+/*eslint indent: ["error", 2, { "offsetTernaryExpressions": false }]*/
+
+condition
+  ? () => {
+      return true
+    }
+  : () => {
+      false
+    }
+```
+
+Examples of **correct** code for this rule with the default `2, { "offsetTernaryExpressions": false }` option:
+
+```js
+/*eslint indent: ["error", 2, { "offsetTernaryExpressions": false }]*/
+
+condition
+  ? () => {
+    return true
+  }
+  : condition2
+    ? () => {
+      return true
+    }
+    : () => {
+      return false
+    }
+```
+
+Examples of **incorrect** code for this rule with the `2, { "offsetTernaryExpressions": true }` option:
+
+```js
+/*eslint indent: ["error", 2, { "offsetTernaryExpressions": true }]*/
+
+condition
+  ? () => {
+    return true
+  }
+  : condition2
+    ? () => {
+      return true
+    }
+    : () => {
+      return false
+    }
+```
+
+Examples of **correct** code for this rule with the `2, { "offsetTernaryExpressions": true }` option:
+
+```js
+/*eslint indent: ["error", 2, { "offsetTernaryExpressions": true }]*/
+
+condition
+  ? () => {
+      return true
+    }
+  : condition2
+    ? () => {
+        return true
+      }
+    : () => {
+        return false
+      }
 ```
 
 ### ignoredNodes

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -590,6 +590,10 @@ module.exports = {
                         type: "boolean",
                         default: false
                     },
+                    offsetTernaryExpressions: {
+                        type: "boolean",
+                        default: false
+                    },
                     ignoredNodes: {
                         type: "array",
                         items: {
@@ -1142,7 +1146,8 @@ module.exports = {
                     offsets.setDesiredOffset(questionMarkToken, firstToken, 1);
                     offsets.setDesiredOffset(colonToken, firstToken, 1);
 
-                    offsets.setDesiredOffset(firstConsequentToken, firstToken, 1);
+                    offsets.setDesiredOffset(firstConsequentToken, firstToken,
+                        options.offsetTernaryExpressions ? 2 : 1);
 
                     /*
                      * The alternate and the consequent should usually have the same indentation.
@@ -1167,7 +1172,9 @@ module.exports = {
                          * If `baz` were aligned with `bar` rather than being offset by 1 from `foo`, `baz` would end up
                          * having no expected indentation.
                          */
-                        offsets.setDesiredOffset(firstAlternateToken, firstToken, 1);
+                        offsets.setDesiredOffset(firstAlternateToken, firstToken,
+                            firstAlternateToken.type === "Punctuator" &&
+                            options.offsetTernaryExpressions ? 2 : 1);
                     }
                 }
             },

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2097,6 +2097,86 @@ ruleTester.run("indent", rule, {
             `,
             options: [2]
         },
+        {
+            code: unIndent`
+              condition
+                ? () => {
+                  return true
+                }
+                : condition2
+                  ? () => {
+                    return true
+                  }
+                  : () => {
+                    return false
+                  }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+              condition
+                ? () => {
+                  return true
+                }
+                : condition2
+                  ? () => {
+                    return true
+                  }
+                  : () => {
+                    return false
+                  }
+            `,
+            options: [2, { offsetTernaryExpressions: false }]
+        },
+        {
+            code: unIndent`
+              condition
+                ? () => {
+                    return true
+                  }
+                : condition2
+                  ? () => {
+                      return true
+                    }
+                  : () => {
+                      return false
+                    }
+            `,
+            options: [2, { offsetTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+              condition
+                  ? () => {
+                          return true
+                      }
+                  : condition2
+                      ? () => {
+                              return true
+                          }
+                      : () => {
+                              return false
+                          }
+            `,
+            options: [4, { offsetTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+              condition
+              \t? () => {
+              \t\t\treturn true
+              \t\t}
+              \t: condition2
+              \t\t? () => {
+              \t\t\t\treturn true
+              \t\t\t}
+              \t\t: () => {
+              \t\t\t\treturn false
+              \t\t\t}
+            `,
+            options: ["tab", { offsetTernaryExpressions: true }]
+        },
         unIndent`
             [
                 foo ?
@@ -7692,6 +7772,88 @@ ruleTester.run("indent", rule, {
                 ]
             `,
             errors: expectedErrors([5, 4, 8, "Identifier"])
+        },
+        {
+            code: unIndent`
+              condition
+              ? () => {
+              return true
+              }
+              : condition2
+              ? () => {
+              return true
+              }
+              : () => {
+              return false
+              }
+            `,
+            output: unIndent`
+              condition
+                ? () => {
+                    return true
+                  }
+                : condition2
+                  ? () => {
+                      return true
+                    }
+                  : () => {
+                      return false
+                    }
+            `,
+            options: [2, { offsetTernaryExpressions: true }],
+            errors: expectedErrors([
+                [2, 2, 0, "Punctuator"],
+                [3, 6, 0, "Keyword"],
+                [4, 4, 0, "Punctuator"],
+                [5, 2, 0, "Punctuator"],
+                [6, 4, 0, "Punctuator"],
+                [7, 8, 0, "Keyword"],
+                [8, 6, 0, "Punctuator"],
+                [9, 4, 0, "Punctuator"],
+                [10, 8, 0, "Keyword"],
+                [11, 6, 0, "Punctuator"]
+            ])
+        },
+        {
+            code: unIndent`
+              condition
+              ? () => {
+              return true
+              }
+              : condition2
+              ? () => {
+              return true
+              }
+              : () => {
+              return false
+              }
+            `,
+            output: unIndent`
+              condition
+                ? () => {
+                  return true
+                }
+                : condition2
+                  ? () => {
+                    return true
+                  }
+                  : () => {
+                    return false
+                  }
+            `,
+            options: [2, { offsetTernaryExpressions: false }],
+            errors: expectedErrors([
+                [2, 2, 0, "Punctuator"],
+                [3, 4, 0, "Keyword"],
+                [4, 2, 0, "Punctuator"],
+                [5, 2, 0, "Punctuator"],
+                [6, 4, 0, "Punctuator"],
+                [7, 6, 0, "Keyword"],
+                [8, 4, 0, "Punctuator"],
+                [9, 4, 0, "Punctuator"],
+                [10, 6, 0, "Keyword"],
+                [11, 4, 0, "Punctuator"]
+            ])
         },
         {
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

Adds `offsetTernaryExpressions` boolean indent rule that solves following issues:
- https://github.com/eslint/eslint/issues/6606
- https://github.com/eslint/eslint/issues/7698
- https://github.com/standard/standard/issues/927
- https://github.com/standard/standard/issues/1451
- https://github.com/sheerun/prettier-standard/issues/76
- https://github.com/brodybits/prettierx/issues/41

**Please describe what the rule should do:**

Functions are normally formatted with indentation which looks nice:

```es6
commission => {
  return suggestions.hits.map(hit => something(hit))
}
```

but when ternary expression is used suddenly `return` is at the same level as argument:

```es6
search.premium
  ? commission => {
    return suggestions.hits.map(hit => something(hit))
  }
  : () => onOpen()
```

This is just one example of many of issues described in referenced github issues, that is: the values of ternary expression are indented at the same level as `?` and `:` instead of having its own indent level.

Here's an example with multi-level `?:`. That's how it is currently:

```es6
search.premium
  ? commission => {
    return suggestions.hits.map(hit => something(hit))
  }
  : something
    ? commission => {
      return suggestions.hits.map(hit => something(hit))
    }
    : null
```

And that's what many developers are expecting:

```es6
search.premium
  ? commission => {
      return suggestions.hits.map(hit => something(hit))
    }
  : something
    ? commission => {
        return suggestions.hits.map(hit => something(hit))
      }
    : null
```

Ternary expressions are very often used in JSX so this this issue is especially annoying. For example this is how this rule formats code currently:

```jsx
const Component = () => (
  <ul className='has-text-centered'>
    {landmarks.hits.length > 0
      ? landmarks.hits.map(({ name, objectID }) => (
        <li key={name}>
          <a href={`${process.env.DOMAIN}` + `/city/${objectID}`}>{name}</a>
        </li>
      ))
      : null}
  </ul>
)
```

And that's what many developers are expecting:

```jsx
const Component = () => (
  <ul className='has-text-centered'>
    {landmarks.hits.length > 0
      ? landmarks.hits.map(({ name, objectID }) => (
          <li key={name}>
            <a href={`${process.env.DOMAIN}` + `/city/${objectID}`}>{name}</a>
          </li>
        ))
      : null}
  </ul>
)
```
I get that it's not possible to make this rule a default, so I'm introducing `offsetTernaryExpressions` rules that allows to fix the number of issues above.

Actually this rule also makes it possible to indent ternary expressions similarly to how prettier does it. Here is multiline ternary expression as formatted by prettier:

```jsx
search.premium
  ? commission => {
      return suggestions.hits.map(hit => something(hit))
    }
  : something
  ? commission => {
      return suggestions.hits.map(hit => something(hit))
    }
  : null
```

Please note that prettier is putting `?:` at the same level as nested `?:`, but this rule is very separate from properly indenting `commission => { ... }` expressions.

**What category of rule is this? (place an "X" next to just one item)**

[X] Enforces code style
[ ] Warns about a potential error
[ ] Suggests an alternate way of doing something
[ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**

```es6
search.premium
  ? commission => {
    return suggestions.hits.map(hit => something(hit))
  }
  : () => onOpen()
```

```es6
const object = cond
  ? {
    foo: 'bar'
  }
  : {
    baz: 'qux'
  }
```

**Why should this rule be included in ESLint (instead of a plugin)?**

Enforcing indentation is deeply integrated into eslint. It's not efficient to do it in plugin.

**What changes did you make? (Give an overview)**

- Add boolean `offsetTernaryExpressions` rules that enforces the style described above
- Add tests and documentation for it
