### PR TITLE
Fix: ignore marker-only comments in spaced-comment (fixes #12036)

### DIFF
--- a/tests/lib/rules/spaced-comment.js
+++ b/tests/lib/rules/spaced-comment.js
@@ -304,6 +304,44 @@ ruleTester.run("spaced-comment", rule, {
         {
             code: "/***\u2028*/",
             options: ["always", { exceptions: ["*"] }]
+        },
+
+        // ignore marker-only comments, https://github.com/eslint/eslint/issues/12036
+        {
+            code: "//#endregion",
+            options: ["always", { line: { markers: ["#endregion"] } }]
+        },
+        {
+            code: "/*foo*/",
+            options: ["always", { block: { markers: ["foo"] } }]
+        },
+        {
+            code: "/*foo*/",
+            options: ["always", { block: { markers: ["foo"], balanced: true } }]
+        },
+        {
+            code: "/*foo*/ /*bar*/",
+            options: ["always", { markers: ["foo", "bar"] }]
+        },
+        {
+            code: "//foo\n//bar",
+            options: ["always", { markers: ["foo", "bar"] }]
+        },
+        {
+            code: "/* foo */",
+            options: ["never", { markers: [" foo "] }]
+        },
+        {
+            code: "// foo ",
+            options: ["never", { markers: [" foo "] }]
+        },
+        {
+            code: "//*", // "*" is a marker by default
+            options: ["always"]
+        },
+        {
+            code: "/***/", // "*" is a marker by default
+            options: ["always"]
         }
     ],
 
@@ -586,6 +624,65 @@ ruleTester.run("spaced-comment", rule, {
             output: null,
             options: ["never"],
             errors: 1
+        },
+
+        // not a marker-only comment, regression tests for https://github.com/eslint/eslint/issues/12036
+        {
+            code: "//#endregionfoo",
+            output: "//#endregion foo",
+            options: ["always", { line: { markers: ["#endregion"] } }],
+            errors: [{
+                message: "Expected space or tab after '//#endregion' in comment.",
+                type: "Line"
+            }]
+        },
+        {
+            code: "/*#endregion*/",
+            output: "/* #endregion*/", // not an allowed marker for block comments
+            options: ["always", { line: { markers: ["#endregion"] } }],
+            errors: [{
+                message: "Expected space or tab after '/*' in comment.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "/****/",
+            output: "/** **/",
+            options: ["always"],
+            errors: [{
+                message: "Expected space or tab after '/**' in comment.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "/****/",
+            output: "/** * */",
+            options: ["always", { block: { balanced: true } }],
+            errors: [
+                {
+                    message: "Expected space or tab after '/**' in comment.",
+                    type: "Block"
+                },
+                {
+                    message: "Expected space or tab before '*/' in comment.",
+                    type: "Block"
+                }
+            ]
+        },
+        {
+            code: "/* foo */",
+            output: "/*foo*/",
+            options: ["never", { block: { markers: ["foo"], balanced: true } }], // not " foo "
+            errors: [
+                {
+                    message: "Unexpected space or tab after '/*' in comment.",
+                    type: "Block"
+                },
+                {
+                    message: "Unexpected space or tab before '*/' in comment.",
+                    type: "Block"
+                }
+            ]
         }
     ]
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #12036

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

If the whole comment is equal to any of the specified markers, that comment will be ignored by this rule.

This applies to both line comments and block comments.

**Is there anything you'd like reviewers to focus on?**

This indirectly allows `/***/` and `//*` (`"*"` is always a marker).
