### PR TITLE
Fix: improve report location for object-curly-spacing

### DIFF
--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -74,16 +74,16 @@ module.exports = {
          * @returns {void}
          */
         function reportNoBeginningSpace(node, token) {
+            const nextToken = context.getSourceCode().getTokenAfter(token, { includeComments: true });
+
             context.report({
                 node,
-                loc: token.loc.start,
+                loc: { start: token.loc.end, end: nextToken.loc.start },
                 message: "There should be no space after '{{token}}'.",
                 data: {
                     token: token.value
                 },
                 fix(fixer) {
-                    const nextToken = context.getSourceCode().getTokenAfter(token, { includeComments: true });
-
                     return fixer.removeRange([token.range[1], nextToken.range[0]]);
                 }
             });
@@ -96,16 +96,16 @@ module.exports = {
          * @returns {void}
          */
         function reportNoEndingSpace(node, token) {
+            const previousToken = context.getSourceCode().getTokenBefore(token, { includeComments: true });
+
             context.report({
                 node,
-                loc: token.loc.start,
+                loc: { start: previousToken.loc.end, end: token.loc.start },
                 message: "There should be no space before '{{token}}'.",
                 data: {
                     token: token.value
                 },
                 fix(fixer) {
-                    const previousToken = context.getSourceCode().getTokenBefore(token, { includeComments: true });
-
                     return fixer.removeRange([previousToken.range[1], token.range[0]]);
                 }
             });
@@ -120,7 +120,7 @@ module.exports = {
         function reportRequiredBeginningSpace(node, token) {
             context.report({
                 node,
-                loc: token.loc.start,
+                loc: token.loc,
                 message: "A space is required after '{{token}}'.",
                 data: {
                     token: token.value
@@ -140,7 +140,7 @@ module.exports = {
         function reportRequiredEndingSpace(node, token) {
             context.report({
                 node,
-                loc: token.loc.start,
+                loc: token.loc,
                 message: "A space is required before '{{token}}'.",
                 data: {
                     token: token.value

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -190,13 +190,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 8
+                    column: 8,
+                    endLine: 1,
+                    endColumn: 9
                 },
                 {
                     message: "A space is required before '}'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 12
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 13
                 }
             ]
         },
@@ -210,7 +214,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required before '}'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 18
+                    column: 18,
+                    endLine: 1,
+                    endColumn: 19
                 }
             ]
         },
@@ -224,13 +230,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 8
+                    column: 8,
+                    endLine: 1,
+                    endColumn: 9
                 },
                 {
                     message: "A space is required before '}'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 17
+                    column: 17,
+                    endLine: 1,
+                    endColumn: 18
                 }
             ]
         },
@@ -244,7 +254,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required before '}'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 13
+                    column: 13,
+                    endLine: 1,
+                    endColumn: 14
                 }
             ]
         },
@@ -258,7 +270,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required before '}'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 16
+                    column: 16,
+                    endLine: 1,
+                    endColumn: 17
                 }
 
             ]
@@ -273,7 +287,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required before '}'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 21
+                    column: 21,
+                    endLine: 1,
+                    endColumn: 22
                 }
             ]
         },
@@ -287,7 +303,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 11
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 }
             ]
         },
@@ -301,7 +319,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 11
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 }
             ]
         },
@@ -315,7 +335,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required before '}'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 21
+                    column: 21,
+                    endLine: 1,
+                    endColumn: 22
                 }
 
             ]
@@ -330,13 +352,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 11
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 },
                 {
                     message: "A space is required before '}'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 15
+                    column: 15,
+                    endLine: 1,
+                    endColumn: 16
                 }
 
             ]
@@ -351,13 +377,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 11
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 },
                 {
                     message: "A space is required before '}'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 20
+                    column: 20,
+                    endLine: 1,
+                    endColumn: 21
                 }
             ]
         },
@@ -371,13 +401,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 8
+                    column: 8,
+                    endLine: 1,
+                    endColumn: 9
                 },
                 {
                     message: "A space is required before '}'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 13
+                    column: 13,
+                    endLine: 1,
+                    endColumn: 14
                 }
 
             ]
@@ -392,13 +426,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space after '{'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 8
+                    column: 9,
+                    endLine: 1,
+                    endColumn: 10
                 },
                 {
                     message: "There should be no space before '}'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 15
+                    column: 14,
+                    endLine: 1,
+                    endColumn: 15
                 }
             ]
         },
@@ -412,13 +450,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space after '{'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 8
+                    column: 9,
+                    endLine: 1,
+                    endColumn: 10
                 },
                 {
                     message: "There should be no space before '}'.",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 27
+                    column: 26,
+                    endLine: 1,
+                    endColumn: 27
                 }
             ]
         },
@@ -432,7 +474,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ExportNamedDeclaration",
                     line: 2,
-                    column: 8
+                    column: 8,
+                    endLine: 2,
+                    endColumn: 9
                 },
                 {
                     message: "A space is required before '}'.",
@@ -452,13 +496,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ExportNamedDeclaration",
                     line: 2,
-                    column: 8
+                    column: 8,
+                    endLine: 2,
+                    endColumn: 9
                 },
                 {
                     message: "A space is required before '}'.",
                     type: "ExportNamedDeclaration",
                     line: 2,
-                    column: 24
+                    column: 24,
+                    endLine: 2,
+                    endColumn: 25
                 }
             ]
         },
@@ -472,7 +520,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ExportNamedDeclaration",
                     line: 2,
-                    column: 8
+                    column: 8,
+                    endLine: 2,
+                    endColumn: 9
                 }
             ]
         },
@@ -486,13 +536,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space after '{'.",
                     type: "ExportNamedDeclaration",
                     line: 2,
-                    column: 8
+                    column: 9,
+                    endLine: 2,
+                    endColumn: 10
                 },
                 {
                     message: "There should be no space before '}'.",
                     type: "ExportNamedDeclaration",
                     line: 2,
-                    column: 26
+                    column: 25,
+                    endLine: 2,
+                    endColumn: 26
                 }
             ]
         },
@@ -505,7 +559,11 @@ ruleTester.run("object-curly-spacing", rule, {
             errors: [
                 {
                     message: "There should be no space before '}'.",
-                    type: "ObjectExpression"
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 28,
+                    endLine: 1,
+                    endColumn: 29
                 }
             ]
         },
@@ -516,7 +574,11 @@ ruleTester.run("object-curly-spacing", rule, {
             errors: [
                 {
                     message: "There should be no space before '}'.",
-                    type: "ObjectExpression"
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 54,
+                    endLine: 1,
+                    endColumn: 55
                 }
             ]
         },
@@ -531,7 +593,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space before '}'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 43
+                    column: 42,
+                    endLine: 1,
+                    endColumn: 43
                 }
             ]
         },
@@ -544,7 +608,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space before '}'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 61
+                    column: 60,
+                    endLine: 1,
+                    endColumn: 61
                 }
             ]
         },
@@ -560,7 +626,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required before '}'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 9
+                    column: 9,
+                    endLine: 1,
+                    endColumn: 10
                 }
             ]
         },
@@ -574,7 +642,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space before '}'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 9
+                    column: 8,
+                    endLine: 1,
+                    endColumn: 9
                 }
             ]
         },
@@ -588,7 +658,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space before '}'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 10
+                    column: 9,
+                    endLine: 1,
+                    endColumn: 10
                 }
             ]
         },
@@ -602,13 +674,65 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space after '{'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 5
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 7
                 },
                 {
                     message: "There should be no space before '}'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 11
+                    column: 10,
+                    endLine: 1,
+                    endColumn: 11
+                }
+            ]
+        },
+        {
+            code: "var {  a:b  } = x;",
+            output: "var {a:b} = x;",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "There should be no space after '{'.",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 8
+                },
+                {
+                    message: "There should be no space before '}'.",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 13
+                }
+            ]
+        },
+        {
+            code: "var {   a:b    } = x;",
+            output: "var {a:b} = x;",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "There should be no space after '{'.",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 9
+                },
+                {
+                    message: "There should be no space before '}'.",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 16
                 }
             ]
         },
@@ -623,7 +747,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required before '}'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 39
+                    column: 39,
+                    endLine: 1,
+                    endColumn: 40
                 }
             ]
         },
@@ -636,7 +762,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required before '}'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 55
+                    column: 55,
+                    endLine: 1,
+                    endColumn: 56
                 }
             ]
         },
@@ -651,13 +779,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 11
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 },
                 {
                     message: "A space is required before '}'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 30
+                    column: 30,
+                    endLine: 1,
+                    endColumn: 31
                 }
             ]
         },
@@ -670,7 +802,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 11
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 }
             ]
         },
@@ -683,7 +817,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 11
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 }
             ]
         },
@@ -696,7 +832,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 11
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 }
             ]
         },
@@ -709,7 +847,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required before '}'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 31
+                    column: 31,
+                    endLine: 1,
+                    endColumn: 32
                 }
             ]
         },
@@ -722,7 +862,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required before '}'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 36
+                    column: 36,
+                    endLine: 1,
+                    endColumn: 37
                 }
             ]
         },
@@ -735,13 +877,40 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space after '{'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 11
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 13
                 },
                 {
                     message: "There should be no space before '}'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 32
+                    column: 31,
+                    endLine: 1,
+                    endColumn: 32
+                }
+            ]
+        },
+        {
+            code: "var obj = {  foo: bar, baz: qux };",
+            output: "var obj = {foo: bar, baz: qux};",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space after '{'.",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 14
+                },
+                {
+                    message: "There should be no space before '}'.",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 32,
+                    endLine: 1,
+                    endColumn: 33
                 }
             ]
         },
@@ -754,7 +923,24 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space before '}'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 31
+                    column: 30,
+                    endLine: 1,
+                    endColumn: 31
+                }
+            ]
+        },
+        {
+            code: "var obj = {foo: bar, baz: qux  };",
+            output: "var obj = {foo: bar, baz: qux};",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space before '}'.",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 30,
+                    endLine: 1,
+                    endColumn: 32
                 }
             ]
         },
@@ -767,7 +953,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space before '}'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 37
+                    column: 36,
+                    endLine: 1,
+                    endColumn: 37
                 }
             ]
         },
@@ -780,7 +968,24 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space after '{'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 11
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 13
+                }
+            ]
+        },
+        {
+            code: "var obj = {  foo: bar, baz: qux};",
+            output: "var obj = {foo: bar, baz: qux};",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space after '{'.",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 14
                 }
             ]
         },
@@ -793,7 +998,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space after '{'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 11
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 13
                 }
             ]
         },
@@ -806,7 +1013,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space before '}'.",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 11
+                    column: 10,
+                    endLine: 2,
+                    endColumn: 11
                 }
             ]
         },
@@ -819,13 +1028,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space after '{'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 11
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 13
                 },
                 {
                     message: "There should be no space after '{'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 18
+                    column: 19,
+                    endLine: 1,
+                    endColumn: 20
                 }
             ]
         },
@@ -838,13 +1051,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space before '}'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 28
+                    column: 27,
+                    endLine: 1,
+                    endColumn: 28
                 },
                 {
                     message: "There should be no space before '}'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 40
+                    column: 39,
+                    endLine: 1,
+                    endColumn: 40
                 }
             ]
         },
@@ -858,7 +1075,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 22
+                    column: 22,
+                    endLine: 1,
+                    endColumn: 23
                 }
             ]
         },
@@ -874,13 +1093,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 5
+                    column: 5,
+                    endLine: 1,
+                    endColumn: 6
                 },
                 {
                     message: "A space is required before '}'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 10
+                    column: 10,
+                    endLine: 1,
+                    endColumn: 11
                 }
             ]
         },
@@ -894,7 +1117,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required before '}'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 11
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 }
             ]
         },
@@ -908,7 +1133,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required before '}'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 16
+                    column: 16,
+                    endLine: 1,
+                    endColumn: 17
                 }
             ]
         },
@@ -922,7 +1149,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 5
+                    column: 5,
+                    endLine: 1,
+                    endColumn: 6
                 }
             ]
         },
@@ -936,7 +1165,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 5
+                    column: 5,
+                    endLine: 1,
+                    endColumn: 6
                 }
             ]
         },
@@ -950,13 +1181,17 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space after '{'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 5
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 7
                 },
                 {
                     message: "There should be no space before '}'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 12
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 }
             ]
         },
@@ -970,7 +1205,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space before '}'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 11
+                    column: 10,
+                    endLine: 1,
+                    endColumn: 11
                 }
             ]
         },
@@ -984,7 +1221,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space before '}'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 16
+                    column: 15,
+                    endLine: 1,
+                    endColumn: 16
                 }
             ]
         },
@@ -998,7 +1237,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space after '{'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 5
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 7
                 }
             ]
         },
@@ -1012,7 +1253,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required before '}'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 11
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 }
             ]
         },
@@ -1026,7 +1269,9 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "A space is required after '{'.",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 5
+                    column: 5,
+                    endLine: 1,
+                    endColumn: 6
                 }
             ]
         },
@@ -1039,7 +1284,11 @@ ruleTester.run("object-curly-spacing", rule, {
             errors: [
                 {
                     message: "A space is required before '}'.",
-                    type: "ObjectExpression"
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 25,
+                    endLine: 1,
+                    endColumn: 26
                 }
             ]
         },
@@ -1050,7 +1299,11 @@ ruleTester.run("object-curly-spacing", rule, {
             errors: [
                 {
                     message: "A space is required before '}'.",
-                    type: "ObjectExpression"
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 49,
+                    endLine: 1,
+                    endColumn: 50
                 }
             ]
         },
@@ -1064,7 +1317,11 @@ ruleTester.run("object-curly-spacing", rule, {
             errors: [
                 {
                     message: "There should be no space before '}'.",
-                    type: "ObjectPattern"
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 20,
+                    endLine: 1,
+                    endColumn: 21
                 }
             ]
         }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain:

Change `object-curly-spacing` report locations.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

* For missing spaces, the difference is small, the rule will now report complete `loc` of the curly braces instead of just `loc.start.`
* For disallowed spaces,  the rule will now report the location of spaces (the range that should be removed) instead of the location of curly braces. like this:

![image](https://user-images.githubusercontent.com/44349756/68813294-b2dd2880-0675-11ea-914f-8610040ef5b7.png)

**Is there anything you'd like reviewers to focus on?**

Since this doesn't change the start line, it produces neither more nor fewer warnings, even in the case of `eslint-disable-*` comments.

I guess this could be accepted as a bug fix?
