### PR TITLE
Fix: no-mixed-spaces-and-tabs reports multiline strings

### DIFF
--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -30,7 +30,6 @@ module.exports = {
         const sourceCode = context.getSourceCode();
 
         let smartTabs;
-        const ignoredLocs = [];
 
         switch (context.options[0]) {
             case true: // Support old syntax, maybe add deprecation warning here
@@ -41,47 +40,23 @@ module.exports = {
                 smartTabs = false;
         }
 
-        /**
-         * Determines if a given line and column are before a location.
-         * @param {Location} loc The location object from an AST node.
-         * @param {int} line The line to check.
-         * @param {int} column The column to check.
-         * @returns {boolean} True if the line and column are before the location, false if not.
-         * @private
-         */
-        function beforeLoc(loc, line, column) {
-            if (line < loc.start.line) {
-                return true;
-            }
-            return line === loc.start.line && column < loc.start.column;
-        }
-
-        /**
-         * Determines if a given line and column are after a location.
-         * @param {Location} loc The location object from an AST node.
-         * @param {int} line The line to check.
-         * @param {int} column The column to check.
-         * @returns {boolean} True if the line and column are after the location, false if not.
-         * @private
-         */
-        function afterLoc(loc, line, column) {
-            if (line > loc.end.line) {
-                return true;
-            }
-            return line === loc.end.line && column > loc.end.column;
-        }
-
         //--------------------------------------------------------------------------
         // Public
         //--------------------------------------------------------------------------
 
         return {
 
-            TemplateElement(node) {
-                ignoredLocs.push(node.loc);
-            },
-
             "Program:exit"(node) {
+                const lines = sourceCode.lines,
+                    comments = sourceCode.getAllComments(),
+                    ignoredCommentLines = new Set();
+
+                // Add all lines except the first ones.
+                comments.forEach(comment => {
+                    for (let i = comment.loc.start.line + 1; i <= comment.loc.end.line; i++) {
+                        ignoredCommentLines.add(i);
+                    }
+                });
 
                 /*
                  * At least one space followed by a tab
@@ -89,24 +64,6 @@ module.exports = {
                  * characters begin.
                  */
                 let regex = /^(?=[\t ]*(\t | \t))/u;
-                const lines = sourceCode.lines,
-                    comments = sourceCode.getAllComments();
-
-                comments.forEach(comment => {
-                    ignoredLocs.push(comment.loc);
-                });
-
-                ignoredLocs.sort((first, second) => {
-                    if (beforeLoc(first, second.start.line, second.start.column)) {
-                        return 1;
-                    }
-
-                    if (beforeLoc(second, first.start.line, second.start.column)) {
-                        return -1;
-                    }
-
-                    return 0;
-                });
 
                 if (smartTabs) {
 
@@ -122,25 +79,19 @@ module.exports = {
 
                     if (match) {
                         const lineNumber = i + 1,
-                            column = match.index + 1;
+                            column = match.index + 1,
+                            loc = { line: lineNumber, column };
 
-                        for (let j = 0; j < ignoredLocs.length; j++) {
-                            if (beforeLoc(ignoredLocs[j], lineNumber, column)) {
-                                continue;
-                            }
-                            if (afterLoc(ignoredLocs[j], lineNumber, column)) {
-                                continue;
-                            }
+                        if (!ignoredCommentLines.has(lineNumber)) {
+                            const containingNode = sourceCode.getNodeByRangeIndex(sourceCode.getIndexFromLoc(loc));
 
-                            return;
+                            if (!(containingNode && ["Literal", "TemplateElement"].includes(containingNode.type))) {
+                                context.report({ node, loc, message: "Mixed spaces and tabs." });
+                            }
                         }
-
-                        context.report({ node, loc: { line: lineNumber, column }, message: "Mixed spaces and tabs." });
                     }
                 });
             }
-
         };
-
     }
 };

--- a/tests/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/tests/lib/rules/no-mixed-spaces-and-tabs.js
@@ -25,6 +25,12 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
         "\t/*\n\t * Hello\n\t */",
         "// foo\n\t/**\n\t * Hello\n\t */",
         "/*\n\n \t \n*/",
+        "/*\t */ //",
+        "/*\n \t*/ //",
+        "/*\n\t *//*\n \t*/",
+        "// \t",
+        "/*\n*/\t ",
+        "/* \t\n\t \n \t\n\t */ \t",
         {
             code: "\tvar x = 5,\n\t    y = 2;",
             options: [true]
@@ -95,6 +101,56 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                     message: "Mixed spaces and tabs.",
                     type: "Program",
                     line: 1
+                }
+            ]
+        },
+        {
+            code: " \t/* comment */",
+            errors: [
+                {
+                    message: "Mixed spaces and tabs.",
+                    type: "Program",
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "\t // comment",
+            errors: [
+                {
+                    message: "Mixed spaces and tabs.",
+                    type: "Program",
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "\t var a /* comment */ = 1;",
+            errors: [
+                {
+                    message: "Mixed spaces and tabs.",
+                    type: "Program",
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: " \tvar b = 1; // comment",
+            errors: [
+                {
+                    message: "Mixed spaces and tabs.",
+                    type: "Program",
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "/**/\n \t/*\n \t*/",
+            errors: [
+                {
+                    message: "Mixed spaces and tabs.",
+                    type: "Program",
+                    line: 2
                 }
             ]
         },

--- a/tests/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/tests/lib/rules/no-mixed-spaces-and-tabs.js
@@ -69,6 +69,8 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             code: "`foo${ 5 }\t    `;",
             env: { es6: true }
         },
+        "' \t\\\n\t multiline string';",
+        "'\t \\\n \tmultiline string';",
         {
             code: "\tvar x = 5,\n\t    y = 2;",
             options: ["smart-tabs"]
@@ -155,6 +157,26 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                     type: "Program",
                     line: 2,
                     column: 2
+                }
+            ]
+        },
+        {
+            code: "  \t'';",
+            errors: [
+                {
+                    message: "Mixed spaces and tabs.",
+                    type: "Program",
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "''\n\t ",
+            errors: [
+                {
+                    message: "Mixed spaces and tabs.",
+                    type: "Program",
+                    line: 2
                 }
             ]
         }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:**  6.6.0
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: 2015
    }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLW1peGVkLXNwYWNlcy1hbmQtdGFiczogZXJyb3IgKi9cblxuJ1xcXG5cdCAnIC8vIHRhYiBhbmQgc3BhY2UgYXQgdGhlIGJlZ2lubmluZyBvZiB0aGlzIGxpbmUiLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjYsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=)

```js
/* eslint no-mixed-spaces-and-tabs: error */

'\
	 ' // tab and space at the beginning of this line
```

**What did you expect to happen?**

No errors. Similar to how the rule ignores the content in template literals, it should ignore the content in strings.

**What actually happened? Please include the actual, raw output from ESLint.**

```
4:2  error  Mixed spaces and tabs  no-mixed-spaces-and-tabs
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fixed the code to ignore mixed spaces and tabs in strings.

Also, the code is simplified and (should be) optimized.

* Since the rule checks for mixed spaces and tabs only at the beginning of the lines, there is no need to compare the range with the comments' ranges. Comparing just lines should do the same thing.
* Multiline strings and template literals with mixed spaces and tabs at the beginning of a line are rare. Seems more optimal to chech this at the very last point before reporting the error, rather than to visit all Literal and TemplateElement nodes.

**Is there anything you'd like reviewers to focus on?**

Refactoring, is the code equivalent to the previous version? (apart from the string fix)

`column` is always same, because the captured `index` is always `0`. This doesn't affect the correctness of this rule, but it would be nice to improve the reported locations. Since this PR already has a big diff and the regexes should be changed to achieve this, it's better to do that in a separate PR.
