### PR TITLE
Fix: indent rule with JSX spread props

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1492,6 +1492,17 @@ module.exports = {
                 );
             },
 
+            JSXSpreadAttribute(node) {
+                const openingCurly = sourceCode.getFirstToken(node);
+                const closingCurly = sourceCode.getLastToken(node);
+
+                offsets.setDesiredOffsets(
+                    [openingCurly.range[1], closingCurly.range[0]],
+                    openingCurly,
+                    1
+                );
+            },
+
             "*"(node) {
                 const firstToken = sourceCode.getFirstToken(node);
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -4889,6 +4889,18 @@ ruleTester.run("indent", rule, {
                 <a>baz qux</a>.
             </small>
         `,
+        unIndent`
+            <div
+                {...props}
+            />
+        `,
+        unIndent`
+            <div
+                {
+                    ...props
+                }
+            />
+        `,
         {
             code: unIndent`
                 a(b
@@ -9753,6 +9765,36 @@ ruleTester.run("indent", rule, {
                 </div>
             `,
             errors: expectedErrors([3, 8, 6, "Block"])
+        },
+        {
+            code: unIndent`
+                <div
+                {...props}
+                />
+            `,
+            output: unIndent`
+                <div
+                    {...props}
+                />
+            `,
+            errors: expectedErrors([2, 4, 0, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                <div
+                    {
+                      ...props
+                    }
+                />
+            `,
+            output: unIndent`
+                <div
+                    {
+                        ...props
+                    }
+                />
+            `,
+            errors: expectedErrors([3, 8, 6, "Punctuator"])
         },
         {
             code: unIndent`


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #12574

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Add code to the `indent` rule to specifically handle `JSXSpreadAttribute` nodes.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.