### PR TITLE
New: Include node version in cache

### DIFF
--- a/lib/cli-engine/lint-result-cache.js
+++ b/lib/cli-engine/lint-result-cache.js
@@ -20,6 +20,7 @@ const hash = require("./hash");
 //-----------------------------------------------------------------------------
 
 const configHashCache = new WeakMap();
+const nodeVersion = process && process.version;
 
 /**
  * Calculates the hash of the config
@@ -28,7 +29,7 @@ const configHashCache = new WeakMap();
  */
 function hashOfConfigFor(config) {
     if (!configHashCache.has(config)) {
-        configHashCache.set(config, hash(`${pkg.version}_${stringify(config)}`));
+        configHashCache.set(config, hash(`${pkg.version}_${nodeVersion}_${stringify(config)}`));
     }
 
     return configHashCache.get(config);

--- a/tests/lib/cli-engine/lint-result-cache.js
+++ b/tests/lib/cli-engine/lint-result-cache.js
@@ -121,19 +121,17 @@ describe("LintResultCache", () => {
         });
 
         describe("when calculating the hashing", () => {
-            const calculateHash = sinon.stub();
-
             it("contains eslint version during hashing", () => {
                 const version = "eslint-=-version";
                 const NewLintResultCache = proxyquire("../../../lib/cli-engine/lint-result-cache.js", {
                     "../../package.json": { version },
-                    "./hash": calculateHash
+                    "./hash": hashStub
                 });
                 const newLintResultCache = new NewLintResultCache(cacheFileLocation);
 
                 newLintResultCache.getCachedLintResults(filePath, fakeConfig);
-                assert.ok(calculateHash.calledOnce);
-                assert.ok(calculateHash.calledWithMatch(version));
+                assert.ok(hashStub.calledOnce);
+                assert.ok(hashStub.calledWithMatch(version));
             });
 
             it("contains node version during hashing", () => {
@@ -141,13 +139,13 @@ describe("LintResultCache", () => {
 
                 sinon.stub(process, "version").value(version);
                 const NewLintResultCache = proxyquire("../../../lib/cli-engine/lint-result-cache.js", {
-                    "./hash": calculateHash
+                    "./hash": hashStub
                 });
                 const newLintResultCache = new NewLintResultCache(cacheFileLocation);
 
                 newLintResultCache.getCachedLintResults(filePath, fakeConfig);
-                assert.ok(calculateHash.calledOnce);
-                assert.ok(calculateHash.calledWithMatch("version"));
+                assert.ok(hashStub.calledOnce);
+                assert.ok(hashStub.calledWithMatch(version));
             });
         });
 

--- a/tests/lib/cli-engine/lint-result-cache.js
+++ b/tests/lib/cli-engine/lint-result-cache.js
@@ -120,6 +120,37 @@ describe("LintResultCache", () => {
             lintResultsCache = new LintResultCache(cacheFileLocation);
         });
 
+        describe("when calculating the hashing", () => {
+            const calculateHash = sinon.stub();
+
+            it("contains eslint version during hashing", () => {
+                const version = "eslint-=-version";
+                const NewLintResultCache = proxyquire("../../../lib/cli-engine/lint-result-cache.js", {
+                    "../../package.json": { version },
+                    "./hash": calculateHash
+                });
+                const newLintResultCache = new NewLintResultCache(cacheFileLocation);
+
+                newLintResultCache.getCachedLintResults(filePath, fakeConfig);
+                assert.ok(calculateHash.calledOnce);
+                assert.ok(calculateHash.calledWithMatch(version));
+            });
+
+            it("contains node version during hashing", () => {
+                const version = "node-=-version";
+
+                sinon.stub(process, "version").value(version);
+                const NewLintResultCache = proxyquire("../../../lib/cli-engine/lint-result-cache.js", {
+                    "./hash": calculateHash
+                });
+                const newLintResultCache = new NewLintResultCache(cacheFileLocation);
+
+                newLintResultCache.getCachedLintResults(filePath, fakeConfig);
+                assert.ok(calculateHash.calledOnce);
+                assert.ok(calculateHash.calledWithMatch("version"));
+            });
+        });
+
         describe("When file is changed", () => {
             beforeEach(() => {
                 hashStub.returns(hashOfConfig);


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Add node version to the key used in cache.

the result from the linting is possible to be different (some rules may fail) when the node is upgraded or downgraded.

**Is there anything you'd like reviewers to focus on?**
N/A

