### PR TITLE
Fix: don't ignore the entry directory (fixes #12604)

### DIFF
--- a/lib/cli-engine/file-enumerator.js
+++ b/lib/cli-engine/file-enumerator.js
@@ -375,9 +375,6 @@ class FileEnumerator {
      * @private
      */
     *_iterateFilesRecursive(directoryPath, options) {
-        if (this._isIgnoredFile(directoryPath + path.sep, options)) {
-            return;
-        }
         debug(`Enter the directory: ${directoryPath}`);
         const { configArrayFactory, extensionRegExp } = internalSlotsMap.get(this);
 
@@ -426,7 +423,20 @@ class FileEnumerator {
 
             // Dive into the sub directory.
             } else if (options.recursive && stat && stat.isDirectory()) {
-                yield* this._iterateFilesRecursive(filePath, options);
+                if (!config) {
+                    config = configArrayFactory.getConfigArrayForFile(
+                        filePath,
+                        { ignoreNotFoundError: true }
+                    );
+                }
+                const ignored = this._isIgnoredFile(
+                    filePath + path.sep,
+                    { ...options, config }
+                );
+
+                if (!ignored) {
+                    yield* this._iterateFilesRecursive(filePath, options);
+                }
             }
         }
 

--- a/tests/lib/cli-engine/file-enumerator.js
+++ b/tests/lib/cli-engine/file-enumerator.js
@@ -380,7 +380,7 @@ describe("FileEnumerator", () => {
 
                     assert.throws(() => {
                         listFiles(patterns);
-                    }, `No files matching '${patterns[0]}' were found.`);
+                    }, `All files matched by '${patterns[0]}' are ignored.`);
                 });
 
                 it("should return an ignored file, if ignore option is turned off", () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix: #12604 

**What changes did you make? (Give an overview)**

This PR fixes #12604 as unignoring the entry directory.

Previously, the `eslint dir` command had checked if the directly given directory (`dir`) is ignored by `.eslintignore` or not. By #12274, the ignore check has gotten to load config files from the directory that the `dir` exists in order to check `ignorePatterns` property. As a result, the `eslint .` command has gotten to try loading config files from `../`. Then if config files were not found from `../` and ancestors, ESLint loads personal config file.

I think that it's not intuitive if the `eslint .` command checks the ignore of `.`, so this PR changes that behavior. If `eslint dir` is present and `dir` is a directory, ESLint doesn't ignore `dir` itself.

Actually, this change has pretty small impacts. When `dir` is an ignored path, it still ignores `dir/**` even if ESLint doesn't ignore `dir` itself. Therefore, the only impact is error messages ("All files matched by 'dir' are ignored" instead of "No files matching 'dir' were found") in most cases.

**Is there anything you'd like reviewers to focus on?**

- Is this direction right?
