### PR TITLE
Update: no-void add an option to allow void as a statement

### DIFF
--- a/docs/rules/no-void.md
+++ b/docs/rules/no-void.md
@@ -54,8 +54,42 @@ Examples of **incorrect** code for this rule:
 /*eslint no-void: "error"*/
 
 void foo
+void someFunction();
 
 var foo = void bar();
+function baz() {
+    return void 0;
+}
+```
+
+## Options
+
+This rule has an object option:
+
+* `allowAsStatement` set to `true` allows the void operator to be used as a statement (Default `false`).
+
+### allowAsStatement
+
+When `allowAsStatement` is set to true, the rule will not error on cases that the void operator is used as a statement, i.e. when it's not used in an expression position, like in a variable assignment or a function return.
+
+Examples of **incorrect** code for `{ "allowAsStatement": true }`:
+
+```js
+/*eslint no-void: ["error", { "allowAsStatement": true }]*/
+
+var foo = void bar();
+function baz() {
+    return void 0;
+}
+```
+
+Examples of **correct** code for `{ "allowAsStatement": true }`:
+
+```js
+/*eslint no-void: ["error", { "allowAsStatement": true }]*/
+
+void foo;
+void someFunction();
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-void.js
+++ b/lib/rules/no-void.js
@@ -19,22 +19,46 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-void"
         },
 
-        schema: []
+        messages: {
+            noVoid: "Expected 'undefined' and instead saw 'void'."
+        },
+
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    allowAsStatement: {
+                        type: "boolean",
+                        default: false
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
     },
 
     create(context) {
+        const allowAsStatement =
+            context.options[0] && context.options[0].allowAsStatement;
 
         //--------------------------------------------------------------------------
         // Public
         //--------------------------------------------------------------------------
 
         return {
-            UnaryExpression(node) {
-                if (node.operator === "void") {
-                    context.report({ node, message: "Expected 'undefined' and instead saw 'void'." });
+            'UnaryExpression[operator="void"]'(node) {
+                if (
+                    allowAsStatement &&
+                    node.parent &&
+                    node.parent.type === "ExpressionStatement"
+                ) {
+                    return;
                 }
+                context.report({
+                    node,
+                    messageId: "noVoid"
+                });
             }
         };
-
     }
 };

--- a/tests/lib/rules/no-void.js
+++ b/tests/lib/rules/no-void.js
@@ -39,6 +39,16 @@ ruleTester.run("no-void", rule, {
             errors: [{ messageId: "noVoid" }]
         },
         {
+            code: "void 0",
+            options: [{}],
+            errors: [{ messageId: "noVoid" }]
+        },
+        {
+            code: "void 0",
+            options: [{ allowAsStatement: false }],
+            errors: [{ messageId: "noVoid" }]
+        },
+        {
             code: "void(0)",
             errors: [{ messageId: "noVoid" }]
         },

--- a/tests/lib/rules/no-void.js
+++ b/tests/lib/rules/no-void.js
@@ -8,8 +8,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require("../../../lib/rules/no-void"),
-    { RuleTester } = require("../../../lib/rule-tester");
+const rule = require("../../../lib/rules/no-void");
+const { RuleTester } = require("../../../lib/rule-tester");
 
 //------------------------------------------------------------------------------
 // Tests
@@ -18,32 +18,38 @@ const rule = require("../../../lib/rules/no-void"),
 const ruleTester = new RuleTester();
 
 ruleTester.run("no-void", rule, {
-
     valid: [
         "var foo = bar()",
         "foo.void()",
         "foo.void = bar",
-        "delete foo;"
+        "delete foo;",
+        {
+            code: "void 0",
+            options: [{ allowAsStatement: true }]
+        },
+        {
+            code: "void(0)",
+            options: [{ allowAsStatement: true }]
+        }
     ],
 
     invalid: [
         {
             code: "void 0",
-            errors: [{
-                message: "Expected 'undefined' and instead saw 'void'."
-            }]
+            errors: [{ messageId: "noVoid" }]
         },
         {
             code: "void(0)",
-            errors: [{
-                message: "Expected 'undefined' and instead saw 'void'."
-            }]
+            errors: [{ messageId: "noVoid" }]
         },
         {
             code: "var foo = void 0",
-            errors: [{
-                message: "Expected 'undefined' and instead saw 'void'."
-            }]
+            errors: [{ messageId: "noVoid" }]
+        },
+        {
+            code: "var foo = void 0",
+            options: [{ allowAsStatement: true }],
+            errors: [{ messageId: "noVoid" }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request?**
Changes an existing rule

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**
`no-void`

**Does this change cause the rule to produce more or fewer warnings?**
Fewer, when the option is turned on

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option

**Please provide some example code that this change will affect:**
Code that will now be valid, when the option is turned on:
```js
/*eslint no-void: ["error", { "allowAsStatement": true }]*/

void foo;
void someFunction();
```

**What does the rule currently do for this code?**
Errors for all `void` operator usage, regardless of context

**What will the rule do after it's changed?**
When the option is on, it will allow the `void` when used as a statement.

**Why?**
A common usage pattern I've seen out in the world is to use the `void` operator to mark promises as "consumed" without awaiting them.
I.e. it's a way for users to say "I am intentionally not awaiting this promise".

```ts
async function returnsPromise(): Promise<void> {}

void returnsPromise();
```

This pattern works well with our rule [`@typescript-eslint/no-floating-promises`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-floating-promises.md), which would otherwise error on the above promise if the `void` operator was omitted.

Feel free to push back, we could potentially extend this rule within `@typescript-eslint`, and make it type aware to only allow it for thenable values, but I thought I'd see if you guys thought there was value in this before forking.