### PR TITLE
Fix: isSpaceBetweenTokens() recognizes spaces in JSXText (fixes #12614)

### DIFF
--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -447,7 +447,19 @@ class SourceCode extends TokenStore {
         while (currentToken !== finalToken) {
             const nextToken = this.getTokenAfter(currentToken, { includeComments: true });
 
-            if (currentToken.range[1] !== nextToken.range[0]) {
+            if (
+                currentToken.range[1] !== nextToken.range[0] ||
+
+                /*
+                 * For backward compatibility, check speces in JSXText.
+                 * https://github.com/eslint/eslint/issues/12614
+                 */
+                (
+                    nextToken !== finalToken &&
+                    nextToken.type === "JSXText" &&
+                    /\s/u.test(nextToken.value)
+                )
+            ) {
                 return true;
             }
 

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -90,6 +90,56 @@ function nodesOrTokensOverlap(first, second) {
         (second.range[0] <= first.range[0] && second.range[1] >= first.range[0]);
 }
 
+/**
+ * Determines if two nodes or tokens have at least one whitespace character
+ * between them. Order does not matter. Returns false if the given nodes or
+ * tokens overlap.
+ * @param {SourceCode} sourceCode The source code object.
+ * @param {ASTNode|Token} first The first node or token to check between.
+ * @param {ASTNode|Token} second The second node or token to check between.
+ * @param {boolean} checkInsideOfJSXText If `true` is present, check inside of JSXText tokens for backward compatibility.
+ * @returns {boolean} True if there is a whitespace character between
+ * any of the tokens found between the two given nodes or tokens.
+ * @public
+ */
+function isSpaceBetween(sourceCode, first, second, checkInsideOfJSXText) {
+    if (nodesOrTokensOverlap(first, second)) {
+        return false;
+    }
+
+    const [startingNodeOrToken, endingNodeOrToken] = first.range[1] <= second.range[0]
+        ? [first, second]
+        : [second, first];
+    const firstToken = sourceCode.getLastToken(startingNodeOrToken) || startingNodeOrToken;
+    const finalToken = sourceCode.getFirstToken(endingNodeOrToken) || endingNodeOrToken;
+    let currentToken = firstToken;
+
+    while (currentToken !== finalToken) {
+        const nextToken = sourceCode.getTokenAfter(currentToken, { includeComments: true });
+
+        if (
+            currentToken.range[1] !== nextToken.range[0] ||
+
+                /*
+                 * For backward compatibility, check speces in JSXText.
+                 * https://github.com/eslint/eslint/issues/12614
+                 */
+                (
+                    checkInsideOfJSXText &&
+                    nextToken !== finalToken &&
+                    nextToken.type === "JSXText" &&
+                    /\s/u.test(nextToken.value)
+                )
+        ) {
+            return true;
+        }
+
+        currentToken = nextToken;
+    }
+
+    return false;
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -433,54 +483,24 @@ class SourceCode extends TokenStore {
      * @public
      */
     isSpaceBetween(first, second) {
-        if (nodesOrTokensOverlap(first, second)) {
-            return false;
-        }
-
-        const [startingNodeOrToken, endingNodeOrToken] = first.range[1] <= second.range[0]
-            ? [first, second]
-            : [second, first];
-        const firstToken = this.getLastToken(startingNodeOrToken) || startingNodeOrToken;
-        const finalToken = this.getFirstToken(endingNodeOrToken) || endingNodeOrToken;
-        let currentToken = firstToken;
-
-        while (currentToken !== finalToken) {
-            const nextToken = this.getTokenAfter(currentToken, { includeComments: true });
-
-            if (
-                currentToken.range[1] !== nextToken.range[0] ||
-
-                /*
-                 * For backward compatibility, check speces in JSXText.
-                 * https://github.com/eslint/eslint/issues/12614
-                 */
-                (
-                    nextToken !== finalToken &&
-                    nextToken.type === "JSXText" &&
-                    /\s/u.test(nextToken.value)
-                )
-            ) {
-                return true;
-            }
-
-            currentToken = nextToken;
-        }
-
-        return false;
+        return isSpaceBetween(this, first, second, false);
     }
 
     /**
      * Determines if two nodes or tokens have at least one whitespace character
      * between them. Order does not matter. Returns false if the given nodes or
      * tokens overlap.
-     * @param {...ASTNode|Token} args The nodes or tokens to check between.
+     * For backward compatibility, this method returns true if there are
+     * `JSXText` tokens that contain whitespaces between the two.
+     * @param {ASTNode|Token} first The first node or token to check between.
+     * @param {ASTNode|Token} second The second node or token to check between.
      * @returns {boolean} True if there is a whitespace character between
      * any of the tokens found between the two given nodes or tokens.
      * @deprecated in favor of isSpaceBetween().
      * @public
      */
-    isSpaceBetweenTokens(...args) {
-        return this.isSpaceBetween(...args);
+    isSpaceBetweenTokens(first, second) {
+        return isSpaceBetween(this, first, second, true);
     }
 
     /**

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -2225,6 +2225,47 @@ describe("SourceCode", () => {
                     });
                 });
             });
+
+            it("JSXText tokens that contain only whitespaces should be handled as space", () => {
+                const code = "let jsx = <div>\n   {content}\n</div>";
+                const ast = espree.parse(code, { ...DEFAULT_CONFIG, ecmaFeatures: { jsx: true } });
+                const sourceCode = new SourceCode(code, ast);
+                const jsx = ast.body[0].declarations[0].init;
+                const interpolation = jsx.children[1];
+
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(jsx.openingElement, interpolation),
+                    true
+                );
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(interpolation, jsx.closingElement),
+                    true
+                );
+            });
+
+            it("JSXText tokens that contain both letters and whitespaces should be handled as space", () => {
+                const code = "let jsx = <div>\n   Hello\n</div>";
+                const ast = espree.parse(code, { ...DEFAULT_CONFIG, ecmaFeatures: { jsx: true } });
+                const sourceCode = new SourceCode(code, ast);
+                const jsx = ast.body[0].declarations[0].init;
+
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(jsx.openingElement, jsx.closingElement),
+                    true
+                );
+            });
+
+            it("JSXText tokens that contain only letters should NOT be handled as space", () => {
+                const code = "let jsx = <div>Hello</div>";
+                const ast = espree.parse(code, { ...DEFAULT_CONFIG, ecmaFeatures: { jsx: true } });
+                const sourceCode = new SourceCode(code, ast);
+                const jsx = ast.body[0].declarations[0].init;
+
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(jsx.openingElement, jsx.closingElement),
+                    false
+                );
+            });
         });
 
         describe("should return true when there is at least one whitespace character between a token and a node", () => {

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -2076,6 +2076,47 @@ describe("SourceCode", () => {
                     });
                 });
             });
+
+            it("JSXText tokens that contain only whitespaces should NOT be handled as space", () => {
+                const code = "let jsx = <div>\n   {content}\n</div>";
+                const ast = espree.parse(code, { ...DEFAULT_CONFIG, ecmaFeatures: { jsx: true } });
+                const sourceCode = new SourceCode(code, ast);
+                const jsx = ast.body[0].declarations[0].init;
+                const interpolation = jsx.children[1];
+
+                assert.strictEqual(
+                    sourceCode.isSpaceBetween(jsx.openingElement, interpolation),
+                    false
+                );
+                assert.strictEqual(
+                    sourceCode.isSpaceBetween(interpolation, jsx.closingElement),
+                    false
+                );
+            });
+
+            it("JSXText tokens that contain both letters and whitespaces should NOT be handled as space", () => {
+                const code = "let jsx = <div>\n   Hello\n</div>";
+                const ast = espree.parse(code, { ...DEFAULT_CONFIG, ecmaFeatures: { jsx: true } });
+                const sourceCode = new SourceCode(code, ast);
+                const jsx = ast.body[0].declarations[0].init;
+
+                assert.strictEqual(
+                    sourceCode.isSpaceBetween(jsx.openingElement, jsx.closingElement),
+                    false
+                );
+            });
+
+            it("JSXText tokens that contain only letters should NOT be handled as space", () => {
+                const code = "let jsx = <div>Hello</div>";
+                const ast = espree.parse(code, { ...DEFAULT_CONFIG, ecmaFeatures: { jsx: true } });
+                const sourceCode = new SourceCode(code, ast);
+                const jsx = ast.body[0].declarations[0].init;
+
+                assert.strictEqual(
+                    sourceCode.isSpaceBetween(jsx.openingElement, jsx.closingElement),
+                    false
+                );
+            });
         });
 
         describe("should return false either of the arguments' location is inside the other one", () => {

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -2225,47 +2225,6 @@ describe("SourceCode", () => {
                     });
                 });
             });
-
-            it("JSXText tokens that contain only whitespaces should be handled as space", () => {
-                const code = "let jsx = <div>\n   {content}\n</div>";
-                const ast = espree.parse(code, { ...DEFAULT_CONFIG, ecmaFeatures: { jsx: true } });
-                const sourceCode = new SourceCode(code, ast);
-                const jsx = ast.body[0].declarations[0].init;
-                const interpolation = jsx.children[1];
-
-                assert.strictEqual(
-                    sourceCode.isSpaceBetweenTokens(jsx.openingElement, interpolation),
-                    true
-                );
-                assert.strictEqual(
-                    sourceCode.isSpaceBetweenTokens(interpolation, jsx.closingElement),
-                    true
-                );
-            });
-
-            it("JSXText tokens that contain both letters and whitespaces should be handled as space", () => {
-                const code = "let jsx = <div>\n   Hello\n</div>";
-                const ast = espree.parse(code, { ...DEFAULT_CONFIG, ecmaFeatures: { jsx: true } });
-                const sourceCode = new SourceCode(code, ast);
-                const jsx = ast.body[0].declarations[0].init;
-
-                assert.strictEqual(
-                    sourceCode.isSpaceBetweenTokens(jsx.openingElement, jsx.closingElement),
-                    true
-                );
-            });
-
-            it("JSXText tokens that contain only letters should NOT be handled as space", () => {
-                const code = "let jsx = <div>Hello</div>";
-                const ast = espree.parse(code, { ...DEFAULT_CONFIG, ecmaFeatures: { jsx: true } });
-                const sourceCode = new SourceCode(code, ast);
-                const jsx = ast.body[0].declarations[0].init;
-
-                assert.strictEqual(
-                    sourceCode.isSpaceBetweenTokens(jsx.openingElement, jsx.closingElement),
-                    false
-                );
-            });
         });
 
         describe("should return true when there is at least one whitespace character between a token and a node", () => {
@@ -2449,6 +2408,47 @@ describe("SourceCode", () => {
                         );
                     });
                 });
+            });
+
+            it("JSXText tokens that contain only whitespaces should be handled as space", () => {
+                const code = "let jsx = <div>\n   {content}\n</div>";
+                const ast = espree.parse(code, { ...DEFAULT_CONFIG, ecmaFeatures: { jsx: true } });
+                const sourceCode = new SourceCode(code, ast);
+                const jsx = ast.body[0].declarations[0].init;
+                const interpolation = jsx.children[1];
+
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(jsx.openingElement, interpolation),
+                    true
+                );
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(interpolation, jsx.closingElement),
+                    true
+                );
+            });
+
+            it("JSXText tokens that contain both letters and whitespaces should be handled as space", () => {
+                const code = "let jsx = <div>\n   Hello\n</div>";
+                const ast = espree.parse(code, { ...DEFAULT_CONFIG, ecmaFeatures: { jsx: true } });
+                const sourceCode = new SourceCode(code, ast);
+                const jsx = ast.body[0].declarations[0].init;
+
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(jsx.openingElement, jsx.closingElement),
+                    true
+                );
+            });
+
+            it("JSXText tokens that contain only letters should NOT be handled as space", () => {
+                const code = "let jsx = <div>Hello</div>";
+                const ast = espree.parse(code, { ...DEFAULT_CONFIG, ecmaFeatures: { jsx: true } });
+                const sourceCode = new SourceCode(code, ast);
+                const jsx = ast.body[0].declarations[0].init;
+
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(jsx.openingElement, jsx.closingElement),
+                    false
+                );
             });
         });
 

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -2092,6 +2092,16 @@ describe("SourceCode", () => {
                     sourceCode.isSpaceBetween(interpolation, jsx.closingElement),
                     false
                 );
+
+                // Reversed order
+                assert.strictEqual(
+                    sourceCode.isSpaceBetween(interpolation, jsx.openingElement),
+                    false
+                );
+                assert.strictEqual(
+                    sourceCode.isSpaceBetween(jsx.closingElement, interpolation),
+                    false
+                );
             });
 
             it("JSXText tokens that contain both letters and whitespaces should NOT be handled as space", () => {
@@ -2104,6 +2114,12 @@ describe("SourceCode", () => {
                     sourceCode.isSpaceBetween(jsx.openingElement, jsx.closingElement),
                     false
                 );
+
+                // Reversed order
+                assert.strictEqual(
+                    sourceCode.isSpaceBetween(jsx.closingElement, jsx.openingElement),
+                    false
+                );
             });
 
             it("JSXText tokens that contain only letters should NOT be handled as space", () => {
@@ -2114,6 +2130,12 @@ describe("SourceCode", () => {
 
                 assert.strictEqual(
                     sourceCode.isSpaceBetween(jsx.openingElement, jsx.closingElement),
+                    false
+                );
+
+                // Reversed order
+                assert.strictEqual(
+                    sourceCode.isSpaceBetween(jsx.closingElement, jsx.openingElement),
                     false
                 );
             });
@@ -2466,6 +2488,16 @@ describe("SourceCode", () => {
                     sourceCode.isSpaceBetweenTokens(interpolation, jsx.closingElement),
                     true
                 );
+
+                // Reversed order
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(interpolation, jsx.openingElement),
+                    true
+                );
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(jsx.closingElement, interpolation),
+                    true
+                );
             });
 
             it("JSXText tokens that contain both letters and whitespaces should be handled as space", () => {
@@ -2478,6 +2510,12 @@ describe("SourceCode", () => {
                     sourceCode.isSpaceBetweenTokens(jsx.openingElement, jsx.closingElement),
                     true
                 );
+
+                // Reversed order
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(jsx.closingElement, jsx.openingElement),
+                    true
+                );
             });
 
             it("JSXText tokens that contain only letters should NOT be handled as space", () => {
@@ -2488,6 +2526,12 @@ describe("SourceCode", () => {
 
                 assert.strictEqual(
                     sourceCode.isSpaceBetweenTokens(jsx.openingElement, jsx.closingElement),
+                    false
+                );
+
+                // Reversed order
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(jsx.closingElement, jsx.openingElement),
                     false
                 );
             });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix: #12614 

**What changes did you make? (Give an overview)**

This PR changes `isSpaceBetweenTokens()` method to recognize spaces in `JSXText` tokens in order to fix #12614. The `JSXText` tokens include whitespaces such as indentation.

**Is there anything you'd like reviewers to focus on?**

- Is this direction right?
