### PR TITLE
Disable `functions` option if used object option, and `ecmaVersion: 5`

### DIFF
--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -45,26 +45,29 @@ function isTrailingCommaAllowed(lastItem) {
  * @returns {Object} The normalized option value.
  */
 function normalizeOptions(optionValue, ecmaVersion) {
+    let optionObjectValue;
+
     if (typeof optionValue === "string") {
-        return {
+        optionObjectValue = {
             arrays: optionValue,
             objects: optionValue,
             imports: optionValue,
             exports: optionValue,
-            functions: (!ecmaVersion || ecmaVersion < 8) ? "ignore" : optionValue
+            functions: optionValue
         };
-    }
-    if (typeof optionValue === "object" && optionValue !== null) {
-        return {
-            arrays: optionValue.arrays || DEFAULT_OPTIONS.arrays,
-            objects: optionValue.objects || DEFAULT_OPTIONS.objects,
-            imports: optionValue.imports || DEFAULT_OPTIONS.imports,
-            exports: optionValue.exports || DEFAULT_OPTIONS.exports,
-            functions: optionValue.functions || DEFAULT_OPTIONS.functions
-        };
+    } else if (typeof optionValue === "object" && optionValue !== null) {
+        optionObjectValue = optionValue;
+    } else {
+        optionObjectValue = DEFAULT_OPTIONS;
     }
 
-    return DEFAULT_OPTIONS;
+    return {
+        arrays: optionObjectValue.arrays || DEFAULT_OPTIONS.arrays,
+        objects: optionObjectValue.objects || DEFAULT_OPTIONS.objects,
+        imports: optionObjectValue.imports || DEFAULT_OPTIONS.imports,
+        exports: optionObjectValue.exports || DEFAULT_OPTIONS.exports,
+        functions: (!ecmaVersion || ecmaVersion < 8) ? "ignore" : (optionObjectValue.functions || DEFAULT_OPTIONS.functions)
+    };
 }
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -475,6 +475,10 @@ ruleTester.run("comma-dangle", rule, {
             code: "function foo(a,): {b: boolean} {}",
             options: [{ functions: "always" }],
             parser: parser("return-type-2")
+        },
+        {
+            code: "function foo(a) {}",
+            options: [{ functions: "always" }]
         }
     ],
     invalid: [
@@ -1725,6 +1729,7 @@ let d = 0;export {d,};
             output: "function foo(a,): {b: boolean,} {}",
             options: [{ functions: "always" }],
             parser: parser("return-type-1"),
+            parserOptions: { ecmaVersion: 8 },
             errors: [{ messageId: "missing" }]
         },
         {
@@ -1732,6 +1737,7 @@ let d = 0;export {d,};
             output: "function foo(a): {b: boolean} {}",
             options: [{ functions: "never" }],
             parser: parser("return-type-2"),
+            parserOptions: { ecmaVersion: 8 },
             errors: [{ messageId: "unexpected" }]
         },
 


### PR DESCRIPTION
This change leads to document behavior:
> `functions` should only be enabled when linting ECMAScript 2017 or higher.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
**Tell us about your environment**


* **ESLint Version:** 6.6.0
* **Node Version:** 12.13.0
* **npm Version:** 6.12.0
* **yarn Version:** 1.19.1

**What parser (default, Babel-ESLint, etc.) are you using?**
Default with `"ecmaVersion": 5`
**Please show your full configuration:**

<details>
<summary>Configuration</summary>

```js
module.exports = {
    'parserOptions': {
        'ecmaVersion': 5,
    },
    rules: {
        'comma-dangle': ['error', {// actually used from airbnb config
            arrays: 'always-multiline',
            objects: 'always-multiline',
            imports: 'always-multiline',
            exports: 'always-multiline',
            functions: 'always-multiline',
        }],
    },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**
```js
function foo(a, b) {
    console.log(a, b);
}
foo(
    1,
    2// dont need coma at here, because `'ecmaVersion': 5,`
);
```

**What did you expect to happen?**
Dont trigger error

**What actually happened? Please include the actual, raw output from ESLint.**
```
C:\Projects\github.com\forks\test-code\1.js
  7:6  error  Missing trailing comma  comma-dangle

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```


**What changes did you make? (Give an overview)**
Pre-cast options to the object format
Then fixed `functions` for the case `'ecmaVersion': < 8,`
This did not occur previously if the option was specified in the object format.

**Is there anything you'd like reviewers to focus on?**


