### PR TITLE
Update: autofix bug in lines-between-class-members (fixes #12391)

### DIFF
--- a/lib/rules/lines-between-class-members.js
+++ b/lib/rules/lines-between-class-members.js
@@ -54,8 +54,8 @@ module.exports = {
         const sourceCode = context.getSourceCode();
 
         /**
-         * Return the last token among the consecutive comment tokens. "consecutive" means there is no empty line between tokens.
-         * If there is no any comment token, return token in the parameter.
+         * Return the last token among the consecutive comment tokens, that have no blank line in between.
+         * If there is no comment token, return token in the parameter.
          * @param {Token} token The last token in the member node.
          * @returns {Token} The comment token or token in parameter.
          */
@@ -69,8 +69,8 @@ module.exports = {
         }
 
         /**
-         * Return the fist token among the consecutive comment tokens. "consecutive" means there is no empty line between tokens.
-         * If there is no any comment token, return token in the parameter.
+         * Return the first token among the consecutive comment tokens, that have no blank line in between.
+         * If there is no comment token, return token in the parameter.
          * @param {Token} token The first token in the member node.
          * @returns {Token} The comment token or token in parameter.
          */

--- a/lib/rules/lines-between-class-members.js
+++ b/lib/rules/lines-between-class-members.js
@@ -96,6 +96,7 @@ module.exports = {
                     const beforePadding = getLastConsecutiveTokenAfter(curLast);
                     const afterPadding = getFirstConsecutiveTokenBefore(nextFirst);
                     const isPadded = afterPadding.loc.start.line - beforePadding.loc.start.line > 1;
+                    const hasPaddedComments = sourceCode.commentsExistBetween(beforePadding, afterPadding);
 
                     if ((options[0] === "always" && !skip && !isPadded) ||
                         (options[0] === "never" && isPadded)) {
@@ -103,6 +104,9 @@ module.exports = {
                             node: body[i + 1],
                             messageId: isPadded ? "never" : "always",
                             fix(fixer) {
+                                if (hasPaddedComments) {
+                                    return null;
+                                }
                                 return isPadded
                                     ? fixer.replaceTextRange([beforePadding.range[1], afterPadding.range[0]], "\n")
                                     : fixer.insertTextAfter(curLast, "\n");

--- a/lib/rules/lines-between-class-members.js
+++ b/lib/rules/lines-between-class-members.js
@@ -87,11 +87,11 @@ module.exports = {
 
         /**
          * Checks if there is a token or comment between two tokens.
-         * @param {*} before The token before.
-         * @param {*} after The token after.
+         * @param {Token} before The token before.
+         * @param {Token} after The token after.
          * @returns {boolean} True if there is a token or comment between two tokens.
          */
-        function hasTokenOrCommentBeteen(before, after) {
+        function hasTokenOrCommentBetween(before, after) {
             return sourceCode.getTokensBetween(before, after, { includeComments: true }).length !== 0;
         }
 
@@ -108,7 +108,7 @@ module.exports = {
                     const beforePadding = findLastConsecutiveTokenAfter(curLast, nextFirst, 1);
                     const afterPadding = findFirstConsecutiveTokenBefore(nextFirst, curLast, 1);
                     const isPadded = afterPadding.loc.start.line - beforePadding.loc.end.line > 1;
-                    const hasTokenInPadding = hasTokenOrCommentBeteen(beforePadding, afterPadding);
+                    const hasTokenInPadding = hasTokenOrCommentBetween(beforePadding, afterPadding);
                     const curLineLastToken = findLastConsecutiveTokenAfter(curLast, nextFirst, 0);
 
                     if ((options[0] === "always" && !skip && !isPadded) ||

--- a/lib/rules/lines-between-class-members.js
+++ b/lib/rules/lines-between-class-members.js
@@ -85,6 +85,16 @@ module.exports = {
             return nextFirstToken;
         }
 
+        /**
+         * Checks if there is a token or comment between two tokens.
+         * @param {*} before The token before.
+         * @param {*} after The token after.
+         * @returns {boolean} True if there is a token or comment between two tokens.
+         */
+        function hasTokenOrCommentBeteen(before, after) {
+            return sourceCode.getTokensBetween(before, after, { includeComments: true }).length !== 0;
+        }
+
         return {
             ClassBody(node) {
                 const body = node.body;
@@ -97,8 +107,8 @@ module.exports = {
                     const skip = !isMulti && options[1].exceptAfterSingleLine;
                     const beforePadding = findLastConsecutiveTokenAfter(curLast, nextFirst, 1);
                     const afterPadding = findFirstConsecutiveTokenBefore(nextFirst, curLast, 1);
-                    const isPadded = afterPadding.loc.start.line - beforePadding.loc.start.line > 1;
-                    const hasPaddedComments = sourceCode.commentsExistBetween(beforePadding, afterPadding);
+                    const isPadded = afterPadding.loc.start.line - beforePadding.loc.end.line > 1;
+                    const hasTokenInPadding = hasTokenOrCommentBeteen(beforePadding, afterPadding);
                     const curLineLastToken = findLastConsecutiveTokenAfter(curLast, nextFirst, 0);
 
                     if ((options[0] === "always" && !skip && !isPadded) ||
@@ -107,7 +117,7 @@ module.exports = {
                             node: body[i + 1],
                             messageId: isPadded ? "never" : "always",
                             fix(fixer) {
-                                if (hasPaddedComments) {
+                                if (hasTokenInPadding) {
                                     return null;
                                 }
                                 return isPadded

--- a/lib/rules/lines-between-class-members.js
+++ b/lib/rules/lines-between-class-members.js
@@ -54,62 +54,33 @@ module.exports = {
         const sourceCode = context.getSourceCode();
 
         /**
-         * Checks if there is padding between two tokens
-         * @param {Token} first The first token
-         * @param {Token} second The second token
-         * @returns {boolean} True if there is at least a line between the tokens
+         * Return the last token among the consecutive comment tokens. "consecutive" means there is no empty line between tokens.
+         * If there is no any comment token, return token in the parameter.
+         * @param {Token} token The last token in the member node.
+         * @returns {Token} The comment token or token in parameter.
          */
-        function isPaddingBetweenTokens(first, second) {
-            const comments = sourceCode.getCommentsBefore(second);
-            const len = comments.length;
+        function getLastConsecutiveTokenAfter(token) {
+            const after = sourceCode.getTokenAfter(token, { includeComments: true });
 
-            // If there is no comments
-            if (len === 0) {
-                const linesBetweenFstAndSnd = second.loc.start.line - first.loc.end.line - 1;
-
-                return linesBetweenFstAndSnd >= 1;
+            if (astUtils.isCommentToken(after) && after.loc.start.line - token.loc.end.line <= 1) {
+                return getLastConsecutiveTokenAfter(after);
             }
+            return token;
+        }
 
+        /**
+         * Return the fist token among the consecutive comment tokens. "consecutive" means there is no empty line between tokens.
+         * If there is no any comment token, return token in the parameter.
+         * @param {Token} token The first token in the member node.
+         * @returns {Token} The comment token or token in parameter.
+         */
+        function getFirstConsecutiveTokenBefore(token) {
+            const before = sourceCode.getTokenBefore(token, { includeComments: true });
 
-            // If there are comments
-            let sumOfCommentLines = 0; // the numbers of lines of comments
-            let prevCommentLineNum = -1; // line number of the end of the previous comment
-
-            for (let i = 0; i < len; i++) {
-                const commentLinesOfThisComment = comments[i].loc.end.line - comments[i].loc.start.line + 1;
-
-                sumOfCommentLines += commentLinesOfThisComment;
-
-                /*
-                 * If this comment and the previous comment are in the same line,
-                 * the count of comment lines is duplicated. So decrement sumOfCommentLines.
-                 */
-                if (prevCommentLineNum === comments[i].loc.start.line) {
-                    sumOfCommentLines -= 1;
-                }
-
-                prevCommentLineNum = comments[i].loc.end.line;
+            if (astUtils.isCommentToken(before) && token.loc.start.line - before.loc.end.line <= 1) {
+                return getFirstConsecutiveTokenBefore(before);
             }
-
-            /*
-             * If the first block and the first comment are in the same line,
-             * the count of comment lines is duplicated. So decrement sumOfCommentLines.
-             */
-            if (first.loc.end.line === comments[0].loc.start.line) {
-                sumOfCommentLines -= 1;
-            }
-
-            /*
-             * If the last comment and the second block are in the same line,
-             * the count of comment lines is duplicated. So decrement sumOfCommentLines.
-             */
-            if (comments[len - 1].loc.end.line === second.loc.start.line) {
-                sumOfCommentLines -= 1;
-            }
-
-            const linesBetweenFstAndSnd = second.loc.start.line - first.loc.end.line - 1;
-
-            return linesBetweenFstAndSnd - sumOfCommentLines >= 1;
+            return token;
         }
 
         return {
@@ -120,10 +91,11 @@ module.exports = {
                     const curFirst = sourceCode.getFirstToken(body[i]);
                     const curLast = sourceCode.getLastToken(body[i]);
                     const nextFirst = sourceCode.getFirstToken(body[i + 1]);
-                    const isPadded = isPaddingBetweenTokens(curLast, nextFirst);
                     const isMulti = !astUtils.isTokenOnSameLine(curFirst, curLast);
                     const skip = !isMulti && options[1].exceptAfterSingleLine;
-
+                    const beforePadding = getLastConsecutiveTokenAfter(curLast);
+                    const afterPadding = getFirstConsecutiveTokenBefore(nextFirst);
+                    const isPadded = afterPadding.loc.start.line - beforePadding.loc.start.line > 1;
 
                     if ((options[0] === "always" && !skip && !isPadded) ||
                         (options[0] === "never" && isPadded)) {
@@ -132,7 +104,7 @@ module.exports = {
                             messageId: isPadded ? "never" : "always",
                             fix(fixer) {
                                 return isPadded
-                                    ? fixer.replaceTextRange([curLast.range[1], nextFirst.range[0]], "\n")
+                                    ? fixer.replaceTextRange([beforePadding.range[1], afterPadding.range[0]], "\n")
                                     : fixer.insertTextAfter(curLast, "\n");
                             }
                         });

--- a/lib/rules/lines-between-class-members.js
+++ b/lib/rules/lines-between-class-members.js
@@ -54,33 +54,35 @@ module.exports = {
         const sourceCode = context.getSourceCode();
 
         /**
-         * Return the last token among the consecutive comment tokens, that have no blank line in between.
-         * If there is no comment token, return token in the parameter.
-         * @param {Token} token The last token in the member node.
-         * @returns {Token} The comment token or token in parameter.
+         * Return the last token among the consecutive tokens that have no exceed max line difference in between, before the first token in the next member.
+         * @param {Token} prevLastToken The last token in the previous member node.
+         * @param {Token} nextFirstToken The first token in the next member node.
+         * @param {number} maxLine The maximum number of allowed line difference between consecutive tokens.
+         * @returns {Token} The last token among the consecutive tokens.
          */
-        function getLastConsecutiveTokenAfter(token) {
-            const after = sourceCode.getTokenAfter(token, { includeComments: true });
+        function findLastConsecutiveTokenAfter(prevLastToken, nextFirstToken, maxLine) {
+            const after = sourceCode.getTokenAfter(prevLastToken, { includeComments: true });
 
-            if (astUtils.isCommentToken(after) && after.loc.start.line - token.loc.end.line <= 1) {
-                return getLastConsecutiveTokenAfter(after);
+            if (after !== nextFirstToken && after.loc.start.line - prevLastToken.loc.end.line <= maxLine) {
+                return findLastConsecutiveTokenAfter(after, nextFirstToken, maxLine);
             }
-            return token;
+            return prevLastToken;
         }
 
         /**
-         * Return the first token among the consecutive comment tokens, that have no blank line in between.
-         * If there is no comment token, return token in the parameter.
-         * @param {Token} token The first token in the member node.
-         * @returns {Token} The comment token or token in parameter.
+         * Return the first token among the consecutive tokens that have no exceed max line difference in between, after the last token in the previous member.
+         * @param {Token} nextFirstToken The first token in the next member node.
+         * @param {Token} prevLastToken The last token in the previous member node.
+         * @param {number} maxLine The maximum number of allowed line difference between consecutive tokens.
+         * @returns {Token} The first token among the consecutive tokens.
          */
-        function getFirstConsecutiveTokenBefore(token) {
-            const before = sourceCode.getTokenBefore(token, { includeComments: true });
+        function findFirstConsecutiveTokenBefore(nextFirstToken, prevLastToken, maxLine) {
+            const before = sourceCode.getTokenBefore(nextFirstToken, { includeComments: true });
 
-            if (astUtils.isCommentToken(before) && token.loc.start.line - before.loc.end.line <= 1) {
-                return getFirstConsecutiveTokenBefore(before);
+            if (before !== prevLastToken && nextFirstToken.loc.start.line - before.loc.end.line <= maxLine) {
+                return findFirstConsecutiveTokenBefore(before, prevLastToken, maxLine);
             }
-            return token;
+            return nextFirstToken;
         }
 
         return {
@@ -93,10 +95,11 @@ module.exports = {
                     const nextFirst = sourceCode.getFirstToken(body[i + 1]);
                     const isMulti = !astUtils.isTokenOnSameLine(curFirst, curLast);
                     const skip = !isMulti && options[1].exceptAfterSingleLine;
-                    const beforePadding = getLastConsecutiveTokenAfter(curLast);
-                    const afterPadding = getFirstConsecutiveTokenBefore(nextFirst);
+                    const beforePadding = findLastConsecutiveTokenAfter(curLast, nextFirst, 1);
+                    const afterPadding = findFirstConsecutiveTokenBefore(nextFirst, curLast, 1);
                     const isPadded = afterPadding.loc.start.line - beforePadding.loc.start.line > 1;
                     const hasPaddedComments = sourceCode.commentsExistBetween(beforePadding, afterPadding);
+                    const curLineLastToken = findLastConsecutiveTokenAfter(curLast, nextFirst, 0);
 
                     if ((options[0] === "always" && !skip && !isPadded) ||
                         (options[0] === "never" && isPadded)) {
@@ -109,7 +112,7 @@ module.exports = {
                                 }
                                 return isPadded
                                     ? fixer.replaceTextRange([beforePadding.range[1], afterPadding.range[0]], "\n")
-                                    : fixer.insertTextAfter(curLast, "\n");
+                                    : fixer.insertTextAfter(curLineLastToken, "\n");
                             }
                         });
                     }

--- a/tests/lib/rules/lines-between-class-members.js
+++ b/tests/lib/rules/lines-between-class-members.js
@@ -41,7 +41,7 @@ ruleTester.run("lines-between-class-members", rule, {
         "class A{ foo() {}/* a */ \n\n /* b */bar() {}}",
 
         "class A {\nfoo() {}\n/* comment */;\n;\n\nbar() {}\n}",
-        "class A {\nfoo() {}\n// comment */\n\n;\n;\nbar() {}\n}",
+        "class A {\nfoo() {}\n// comment\n\n;\n;\nbar() {}\n}",
 
         "class foo{ bar(){}\n\n;;baz(){}}",
         "class foo{ bar(){};\n\nbaz(){}}",
@@ -102,7 +102,7 @@ ruleTester.run("lines-between-class-members", rule, {
             options: ["never"],
             errors: [neverError]
         }, {
-            code: "class foo{ bar(){}\n\n// comment */\n\nbaz(){}}",
+            code: "class foo{ bar(){}\n\n// comment\n\nbaz(){}}",
             output: null,
             options: ["never"],
             errors: [neverError]
@@ -117,8 +117,8 @@ ruleTester.run("lines-between-class-members", rule, {
             options: ["never"],
             errors: [neverError]
         }, {
-            code: "class A {\nfoo() {}// comment */;\n;\n/* comment */\nbar() {}\n}",
-            output: "class A {\nfoo() {}// comment */;\n\n;\n/* comment */\nbar() {}\n}",
+            code: "class A {\nfoo() {}// comment\n;\n/* comment */\nbar() {}\n}",
+            output: "class A {\nfoo() {}// comment\n\n;\n/* comment */\nbar() {}\n}",
             options: ["always"],
             errors: [alwaysError]
         }, {

--- a/tests/lib/rules/lines-between-class-members.js
+++ b/tests/lib/rules/lines-between-class-members.js
@@ -93,6 +93,21 @@ ruleTester.run("lines-between-class-members", rule, {
             output: "class foo{ bar(){}\n/* comment-1 */\n/* comment-2 */\nbaz(){}}",
             options: ["never"],
             errors: [neverError]
+        }, {
+            code: "class foo{ bar(){}\n\n/* comment */\n\nbaz(){}}",
+            output: null,
+            options: ["never"],
+            errors: [neverError]
+        }, {
+            code: "class foo{ bar(){}\n\n// comment */\n\nbaz(){}}",
+            output: null,
+            options: ["never"],
+            errors: [neverError]
+        }, {
+            code: "class foo{ bar(){}\n/* comment-1 */\n\n/* comment-2 */\n\n/* comment-3 */\nbaz(){}}",
+            output: null,
+            options: ["never"],
+            errors: [neverError]
         }
     ]
 });

--- a/tests/lib/rules/lines-between-class-members.js
+++ b/tests/lib/rules/lines-between-class-members.js
@@ -73,6 +73,26 @@ ruleTester.run("lines-between-class-members", rule, {
             output: "class foo{ bar(){\n}\n\nbaz(){}}",
             options: ["always", { exceptAfterSingleLine: true }],
             errors: [alwaysError]
+        }, {
+            code: "class foo{ bar(){\n}\n/* comment */\nbaz(){}}",
+            output: "class foo{ bar(){\n}\n\n/* comment */\nbaz(){}}",
+            options: ["always", { exceptAfterSingleLine: true }],
+            errors: [alwaysError]
+        }, {
+            code: "class foo{ bar(){}\n\n// comment\nbaz(){}}",
+            output: "class foo{ bar(){}\n// comment\nbaz(){}}",
+            options: ["never"],
+            errors: [neverError]
+        }, {
+            code: "class foo{ bar(){}\n\n/* comment */\nbaz(){}}",
+            output: "class foo{ bar(){}\n/* comment */\nbaz(){}}",
+            options: ["never"],
+            errors: [neverError]
+        }, {
+            code: "class foo{ bar(){}\n/* comment-1 */\n\n/* comment-2 */\nbaz(){}}",
+            output: "class foo{ bar(){}\n/* comment-1 */\n/* comment-2 */\nbaz(){}}",
+            options: ["never"],
+            errors: [neverError]
         }
     ]
 });

--- a/tests/lib/rules/lines-between-class-members.js
+++ b/tests/lib/rules/lines-between-class-members.js
@@ -112,6 +112,11 @@ ruleTester.run("lines-between-class-members", rule, {
             options: ["never"],
             errors: [neverError]
         }, {
+            code: "class foo{ bar(){}\n/* comment-1 */\n\n;\n\n/* comment-3 */\nbaz(){}}",
+            output: null,
+            options: ["never"],
+            errors: [neverError]
+        }, {
             code: "class A {\nfoo() {}// comment */;\n;\n/* comment */\nbar() {}\n}",
             output: "class A {\nfoo() {}// comment */;\n\n;\n/* comment */\nbar() {}\n}",
             options: ["always"],

--- a/tests/lib/rules/lines-between-class-members.js
+++ b/tests/lib/rules/lines-between-class-members.js
@@ -40,6 +40,9 @@ ruleTester.run("lines-between-class-members", rule, {
         "class A{ foo() {}\n/* a */ /* b */\n\nbar() {}}",
         "class A{ foo() {}/* a */ \n\n /* b */bar() {}}",
 
+        "class A {\nfoo() {}\n/* comment */;\n;\n\nbar() {}\n}",
+        "class A {\nfoo() {}\n// comment */\n\n;\n;\nbar() {}\n}",
+
         "class foo{ bar(){}\n\n;;baz(){}}",
         "class foo{ bar(){};\n\nbaz(){}}",
 
@@ -108,6 +111,31 @@ ruleTester.run("lines-between-class-members", rule, {
             output: null,
             options: ["never"],
             errors: [neverError]
+        }, {
+            code: "class A {\nfoo() {}// comment */;\n;\n/* comment */\nbar() {}\n}",
+            output: "class A {\nfoo() {}// comment */;\n\n;\n/* comment */\nbar() {}\n}",
+            options: ["always"],
+            errors: [alwaysError]
+        }, {
+            code: "class A {\nfoo() {}\n/* comment */;\n;\n/* comment */\nbar() {}\n}",
+            output: "class A {\nfoo() {}\n\n/* comment */;\n;\n/* comment */\nbar() {}\n}",
+            options: ["always"],
+            errors: [alwaysError]
+        }, {
+            code: "class foo{ bar(){};\nbaz(){}}",
+            output: "class foo{ bar(){};\n\nbaz(){}}",
+            options: ["always"],
+            errors: [alwaysError]
+        }, {
+            code: "class foo{ bar(){} // comment \nbaz(){}}",
+            output: "class foo{ bar(){} // comment \n\nbaz(){}}",
+            options: ["always"],
+            errors: [alwaysError]
+        }, {
+            code: "class A {\nfoo() {}\n/* comment */;\n;\nbar() {}\n}",
+            output: "class A {\nfoo() {}\n\n/* comment */;\n;\nbar() {}\n}",
+            options: ["always"],
+            errors: [alwaysError]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This PR will fix three bugs in `lines-between-class-members`.
 1. #12391
 2. doesn't work well with `semicolons`. 
    * the actual master version.
    ```js
    /* eslint lines-between-class-members: ["error", "always"] */

    class A {
      foo() {}
      /* comment */;
      ;  // No error, but here is no blank line.
      bar() {}
    }
    ```
    * this PR
    ```js
    /* eslint lines-between-class-members: ["error", "always"] */

    class A {
      foo() {}
      /* comment */; // Lint Error
      ; 
      bar() {}
    }
    ```



 3. incorrect fixing trailing comments
    ```js
    /* eslint lines-between-class-members: ["error", "always"] */

    class foo{ 
      bar(){} //comment
      baz(){}
    }
     ```
    * the actual master version
    ```js
    /* eslint lines-between-class-members: ["error", "always"] */

     class foo{ 
       bar(){}
      //comment
       baz(){}
     }
     ```
   
    * this PR
    ```js
    /* eslint lines-between-class-members: ["error", "always"] */

     class foo{ 
       bar(){} //comment

       baz(){}
     }
     ```

**Is there anything you'd like reviewers to focus on?**
#12391 

