### PR TITLE
Fix: no-restricted-imports schema allows multiple paths/patterns objects

### DIFF
--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -72,14 +72,14 @@ module.exports = {
                 arrayOfStringsOrObjects,
                 {
                     type: "array",
-                    items: {
+                    items: [{
                         type: "object",
                         properties: {
                             paths: arrayOfStringsOrObjects,
                             patterns: arrayOfStrings
                         },
                         additionalProperties: false
-                    },
+                    }],
                     additionalItems: false
                 }
             ]

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -20,6 +20,7 @@ const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6, sourceType:
 
 ruleTester.run("no-restricted-imports", rule, {
     valid: [
+        "import os from \"os\";",
         { code: "import os from \"os\";", options: ["osx"] },
         { code: "import fs from \"fs\";", options: ["crypto"] },
         { code: "import path from \"path\";", options: ["crypto", "stream", "os"] },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix 
[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

At the moment, `no-restricted-imports` schema allows multiple objects with `paths`/`patterns` keys:

```js
/* eslint "no-restricted-imports": ["error", {
    "paths": ["foo"]
}, {
    "paths": ["bar"]
}] */

import a from "bar"; // no errors
```

[Online Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IFwibm8tcmVzdHJpY3RlZC1pbXBvcnRzXCI6IFtcImVycm9yXCIsIHtcbiAgICBcInBhdGhzXCI6IFtcImZvb1wiXVxufSwge1xuICAgIFwicGF0aHNcIjogW1wiYmFyXCJdXG59XSAqL1xuXG5pbXBvcnQgYSBmcm9tIFwiYmFyXCI7IC8vIG5vIGVycm9ycyIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6Im1vZHVsZSIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

This shouldn't be allowed because it isn't documented and it doesn't work as the user might expect. `paths` and `patterns` are being read only from the first object (at index 0), others are ignored.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fixed the schema to allow only 1 object with this form.

Also added a test to ensure that a configuration without any specified restricted imports is still allowed.

**Is there anything you'd like reviewers to focus on?**

This isn't related to #12638.

Marked as `fix` rather than `chore` because this change might break a build with an invalid configuration, which anyway didn't work as the user was expecting. Also, looks more like a `fix` than an `update`?