### PR TITLE
Update: array-callback-return checks Array.forEach (fixes #12551)

### DIFF
--- a/docs/rules/array-callback-return.md
+++ b/docs/rules/array-callback-return.md
@@ -10,9 +10,10 @@ var indexMap = myArray.reduce(function(memo, item, index) {
 }, {}); // Error: cannot set property 'b' of undefined
 ```
 
-This rule enforces usage of `return` statement in callbacks of array's methods.
-
 ## Rule Details
+
+This rule enforces usage of `return` statement in callbacks of array's methods.
+Additionaly, it may also enforce the `forEach` array method callback to __not__ return a value by using the `checkForEach` option.
 
 This rule finds callback functions of the following methods, then checks usage of `return` statement.
 
@@ -22,6 +23,7 @@ This rule finds callback functions of the following methods, then checks usage o
 * [`Array.prototype.find`](https://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.find)
 * [`Array.prototype.findIndex`](https://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.findindex)
 * [`Array.prototype.flatMap`](https://www.ecma-international.org/ecma-262/10.0/#sec-array.prototype.flatmap)
+* [`Array.prototype.forEach`](https://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.foreach) (optional, based on `checkForEach` parameter)
 * [`Array.prototype.map`](https://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.map)
 * [`Array.prototype.reduce`](https://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.reduce)
 * [`Array.prototype.reduceRight`](https://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.reduceright)
@@ -75,9 +77,12 @@ var bar = foo.map(node => node.getAttribute("id"));
 
 ## Options
 
-This rule has an object option:
+This rule accepts a configuration object with two options:
 
-* `"allowImplicit": false` (default) When set to true, allows implicitly returning `undefined` with a `return` statement containing no expression.
+* `"allowImplicit": false` (default) When set to `true`, allows callbacks of methods that require a return value to implicitly return `undefined` with a `return` statement containing no expression.
+* `"checkForEach": false` (default) When set to `true`, rule will also report `forEach` callbacks that return a value.
+
+### allowImplicit
 
 Examples of **correct** code for the `{ "allowImplicit": true }` option:
 
@@ -87,6 +92,58 @@ var undefAllTheThings = myArray.map(function(item) {
     return;
 });
 ```
+
+### checkForEach
+
+Examples of **incorrect** code for the `{ "checkForEach": true }` option:
+
+```js
+/*eslint array-callback-return: ["error", { checkForEach: true }]*/
+
+myArray.forEach(function(item) {
+    return handleItem(item)
+});
+
+myArray.forEach(function(item) {
+    if (item < 0) {
+        return x;
+    }
+    handleItem(item);
+});
+
+myArray.forEach(item => handleItem(item));
+
+myArray.forEach(item => {
+    return handleItem(item);
+});
+```
+
+Examples of **correct** code for the `{ "checkForEach": true }` option:
+
+```js
+/*eslint array-callback-return: ["error", { checkForEach: true }]*/
+
+myArray.forEach(function(item) {
+    handleItem(item)
+});
+
+myArray.forEach(function(item) {
+    if (item < 0) {
+        return;
+    }
+    handleItem(item);
+});
+
+myArray.forEach(function(item) {
+    handleItem(item);
+    return;
+});
+
+myArray.forEach(item => {
+    handleItem(item);
+});
+```
+
 
 ## Known Limitations
 

--- a/tests/lib/rules/array-callback-return.js
+++ b/tests/lib/rules/array-callback-return.js
@@ -16,53 +16,50 @@ const ruleTester = new RuleTester();
 
 const allowImplicitOptions = [{ allowImplicit: true }];
 
+const checkForEachOptions = [{ checkForEach: true }];
+
+const allowImplicitCheckForEach = [{ allowImplicit: true, checkForEach: true }];
+
 ruleTester.run("array-callback-return", rule, {
     valid: [
 
+        "foo.every(function(){}())",
+        "foo.every(function(){ return function() { return true; }; }())",
+        "foo.every(function(){ return function() { return; }; })",
+
+        "foo.forEach(bar || function(x) { var a=0; })",
+        "foo.forEach(bar || function(x) { return a; })",
+        "foo.forEach(function() {return function() { var a = 0;}}())",
+        "foo.forEach(function(x) { var a=0; })",
+        "foo.forEach(function(x) { return a;})",
+        "foo.forEach(function(x) { return; })",
+        "foo.forEach(function(x) { if (a === b) { return;} var a=0; })",
+        "foo.forEach(function(x) { if (a === b) { return x;} var a=0; })",
+        "foo.bar().forEach(function(x) { return; })",
+        "[\"foo\",\"bar\",\"baz\"].forEach(function(x) { return x; })",
+        { code: "foo.forEach(x => { var a=0; })", parserOptions: { ecmaVersion: 6 } },
+        { code: "foo.forEach(x => { if (a === b) { return;} var a=0; })", parserOptions: { ecmaVersion: 6 } },
+        { code: "foo.forEach(x => x)", parserOptions: { ecmaVersion: 6 } },
+        { code: "foo.forEach(val => y += val)", parserOptions: { ecmaVersion: 6 } },
+
+        { code: "foo.map(async function(){})", parserOptions: { ecmaVersion: 8 } },
+        { code: "foo.map(async () => {})", parserOptions: { ecmaVersion: 8 } },
+        { code: "foo.map(function* () {})", parserOptions: { ecmaVersion: 6 } },
+
         // options: { allowImplicit: false }
-        "Array.from(x, function() { return true; })",
-        "Int32Array.from(x, function() { return true; })",
         { code: "Array.from(x, function() { return true; })", options: [{ allowImplicit: false }] },
         { code: "Int32Array.from(x, function() { return true; })", options: [{ allowImplicit: false }] },
-
-        // options: { allowImplicit: true }
-        { code: "Array.from(x, function() { return; })", options: allowImplicitOptions },
-        { code: "Int32Array.from(x, function() { return; })", options: allowImplicitOptions },
-
-        "Arrow.from(x, function() {})",
-
-        // options: { allowImplicit: false }
         "foo.every(function() { return true; })",
         "foo.filter(function() { return true; })",
         "foo.find(function() { return true; })",
         "foo.findIndex(function() { return true; })",
         "foo.flatMap(function() { return true; })",
+        "foo.forEach(function() { return; })",
         "foo.map(function() { return true; })",
         "foo.reduce(function() { return true; })",
         "foo.reduceRight(function() { return true; })",
         "foo.some(function() { return true; })",
         "foo.sort(function() { return 0; })",
-
-        // options: { allowImplicit: true }
-        { code: "foo.every(function() { return; })", options: allowImplicitOptions },
-        { code: "foo.filter(function() { return; })", options: allowImplicitOptions },
-        { code: "foo.find(function() { return; })", options: allowImplicitOptions },
-        { code: "foo.findIndex(function() { return; })", options: allowImplicitOptions },
-        { code: "foo.flatMap(function() { return; })", options: allowImplicitOptions },
-        { code: "foo.map(function() { return; })", options: allowImplicitOptions },
-        { code: "foo.reduce(function() { return; })", options: allowImplicitOptions },
-        { code: "foo.reduceRight(function() { return; })", options: allowImplicitOptions },
-        { code: "foo.some(function() { return; })", options: allowImplicitOptions },
-        { code: "foo.sort(function() { return; })", options: allowImplicitOptions },
-
-        "foo.abc(function() {})",
-        "every(function() {})",
-        "foo[every](function() {})",
-        "var every = function() {}",
-        { code: "foo[`${every}`](function() {})", parserOptions: { ecmaVersion: 6 } },
-        { code: "foo.every(() => true)", parserOptions: { ecmaVersion: 6 } },
-
-        // options: { allowImplicit: false }
         { code: "foo.every(() => { return true; })", parserOptions: { ecmaVersion: 6 } },
         "foo.every(function() { if (a) return true; else return false; })",
         "foo.every(function() { switch (a) { case 0: bar(); default: return true; } })",
@@ -70,20 +67,54 @@ ruleTester.run("array-callback-return", rule, {
         "foo.every(function() { try { bar(); } finally { return true; } })",
 
         // options: { allowImplicit: true }
+        { code: "Array.from(x, function() { return; })", options: allowImplicitOptions },
+        { code: "Int32Array.from(x, function() { return; })", options: allowImplicitOptions },
+        { code: "foo.every(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.filter(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.find(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.findIndex(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.flatMap(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.forEach(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.map(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.reduce(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.reduceRight(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.some(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.sort(function() { return; })", options: allowImplicitOptions },
         { code: "foo.every(() => { return; })", options: allowImplicitOptions, parserOptions: { ecmaVersion: 6 } },
         { code: "foo.every(function() { if (a) return; else return a; })", options: allowImplicitOptions },
         { code: "foo.every(function() { switch (a) { case 0: bar(); default: return; } })", options: allowImplicitOptions },
         { code: "foo.every(function() { try { bar(); return; } catch (err) { return; } })", options: allowImplicitOptions },
         { code: "foo.every(function() { try { bar(); } finally { return; } })", options: allowImplicitOptions },
 
-        "foo.every(function(){}())",
-        "foo.every(function(){ return function() { return true; }; }())",
-        "foo.every(function(){ return function() { return; }; })",
-        { code: "foo.map(async function(){})", parserOptions: { ecmaVersion: 8 } },
-        { code: "foo.map(async () => {})", parserOptions: { ecmaVersion: 8 } },
-        { code: "foo.map(function* () {})", parserOptions: { ecmaVersion: 6 } }
+        // options: { checkForEach: true }
+        { code: "foo.forEach(function(x) { return; })", options: checkForEachOptions },
+        { code: "foo.forEach(function(x) { var a=0; })", options: checkForEachOptions },
+        { code: "foo.forEach(function(x) { if (a === b) { return;} var a=0; })", options: checkForEachOptions },
+        { code: "foo.forEach(function() {return function() { if (a == b) { return; }}}())", options: checkForEachOptions },
+        { code: "foo.forEach(x => { var a=0; })", options: checkForEachOptions, parserOptions: { ecmaVersion: 6 } },
+        { code: "foo.forEach(x => { if (a === b) { return;} var a=0; })", options: checkForEachOptions, parserOptions: { ecmaVersion: 6 } },
+        { code: "foo.forEach(x => { x })", options: checkForEachOptions, parserOptions: { ecmaVersion: 6 } },
+        { code: "foo.forEach(bar || function(x) { return; })", options: checkForEachOptions },
+        { code: "Array.from(x, function() { return true; })", options: checkForEachOptions },
+        { code: "Int32Array.from(x, function() { return true; })", options: checkForEachOptions },
+        { code: "foo.every(() => { return true; })", options: checkForEachOptions, parserOptions: { ecmaVersion: 6 } },
+        { code: "foo.every(function() { if (a) return 1; else return a; })", options: checkForEachOptions },
+        { code: "foo.every(function() { switch (a) { case 0: return bar(); default: return a; } })", options: checkForEachOptions },
+        { code: "foo.every(function() { try { bar(); return 1; } catch (err) { return err; } })", options: checkForEachOptions },
+        { code: "foo.every(function() { try { bar(); } finally { return 1; } })", options: checkForEachOptions },
+        { code: "foo.every(function() { return; })", options: allowImplicitCheckForEach },
+
+        "Arrow.from(x, function() {})",
+        "foo.abc(function() {})",
+        "every(function() {})",
+        "foo[every](function() {})",
+        "var every = function() {}",
+        { code: "foo[`${every}`](function() {})", parserOptions: { ecmaVersion: 6 } },
+        { code: "foo.every(() => true)", parserOptions: { ecmaVersion: 6 } }
+
     ],
     invalid: [
+
         { code: "Array.from(x, function() {})", errors: [{ messageId: "expectedInside", data: { name: "function" } }] },
         { code: "Array.from(x, function foo() {})", errors: [{ messageId: "expectedInside", data: { name: "function 'foo'" } }] },
         { code: "Int32Array.from(x, function() {})", errors: [{ messageId: "expectedInside", data: { name: "function" } }] },
@@ -134,6 +165,40 @@ ruleTester.run("array-callback-return", rule, {
         { code: "foo.every(function(){ return function() {}; }())", errors: [{ message: "Expected to return a value in function.", column: 30 }] },
         { code: "foo.every(function(){ return function foo() {}; }())", errors: [{ message: "Expected to return a value in function 'foo'.", column: 39 }] },
         { code: "foo.every(() => {})", options: [{ allowImplicit: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected to return a value in arrow function." }] },
-        { code: "foo.every(() => {})", options: [{ allowImplicit: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected to return a value in arrow function." }] }
+        { code: "foo.every(() => {})", options: [{ allowImplicit: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected to return a value in arrow function." }] },
+
+        // options: { allowImplicit: true }
+        { code: "Array.from(x, function() {})", options: allowImplicitOptions, errors: [{ messageId: "expectedInside", data: { name: "function" } }] },
+        { code: "foo.every(function() {})", options: allowImplicitOptions, errors: [{ messageId: "expectedInside", data: { name: "function" } }] },
+        { code: "foo.filter(function foo() {})", options: allowImplicitOptions, errors: [{ messageId: "expectedInside", data: { name: "function 'foo'" } }] },
+        { code: "foo.find(function foo() {})", options: allowImplicitOptions, errors: [{ messageId: "expectedInside", data: { name: "function 'foo'" } }] },
+        { code: "foo.map(function() {})", options: allowImplicitOptions, errors: [{ messageId: "expectedInside", data: { name: "function" } }] },
+        { code: "foo.reduce(function() {})", options: allowImplicitOptions, errors: [{ messageId: "expectedInside", data: { name: "function" } }] },
+        { code: "foo.reduceRight(function() {})", options: allowImplicitOptions, errors: [{ messageId: "expectedInside", data: { name: "function" } }] },
+        { code: "foo.bar.baz.every(function foo() {})", options: allowImplicitOptions, errors: [{ messageId: "expectedInside", data: { name: "function 'foo'" } }] },
+        { code: "foo.every(cb || function() {})", options: allowImplicitOptions, errors: ["Expected to return a value in function."] },
+        { code: "[\"foo\",\"bar\"].sort(function foo() {})", options: allowImplicitOptions, errors: [{ messageId: "expectedInside", data: { name: "function 'foo'" } }] },
+        { code: "foo.forEach(x => x)", options: allowImplicitCheckForEach, parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Arrow function" } }] },
+        { code: "foo.forEach(function(x) { if (a == b) {return x;}})", options: allowImplicitCheckForEach, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Function" } }] },
+        { code: "foo.forEach(function bar(x) { return x;})", options: allowImplicitCheckForEach, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Function 'bar'" } }] },
+
+        // // options: { checkForEach: true }
+        { code: "foo.forEach(x => x)", options: checkForEachOptions, parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Arrow function" } }] },
+        { code: "foo.forEach(val => y += val)", options: checkForEachOptions, parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Arrow function" } }] },
+        { code: "[\"foo\",\"bar\"].forEach(x => ++x)", options: checkForEachOptions, parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Arrow function" } }] },
+        { code: "foo.bar().forEach(x => x === y)", options: checkForEachOptions, parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Arrow function" } }] },
+        { code: "foo.forEach(function() {return function() { if (a == b) { return a; }}}())", options: checkForEachOptions, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Function" } }] },
+        { code: "foo.forEach(function(x) { if (a == b) {return x;}})", options: checkForEachOptions, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Function" } }] },
+        { code: "foo.forEach(function(x) { if (a == b) {return undefined;}})", options: checkForEachOptions, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Function" } }] },
+        { code: "foo.forEach(function bar(x) { return x;})", options: checkForEachOptions, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Function 'bar'" } }] },
+        { code: "foo.bar().forEach(function bar(x) { return x;})", options: checkForEachOptions, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Function 'bar'" } }] },
+        { code: "[\"foo\",\"bar\"].forEach(function bar(x) { return x;})", options: checkForEachOptions, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Function 'bar'" } }] },
+        { code: "foo.forEach((x) => { return x;})", options: checkForEachOptions, parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "expectedNoReturnValue", data: { name: "Arrow function" } }] },
+        { code: "Array.from(x, function() {})", options: checkForEachOptions, errors: [{ messageId: "expectedInside", data: { name: "function" } }] },
+        { code: "foo.every(function() {})", options: checkForEachOptions, errors: [{ messageId: "expectedInside", data: { name: "function" } }] },
+        { code: "foo.filter(function foo() {})", options: checkForEachOptions, errors: [{ messageId: "expectedInside", data: { name: "function 'foo'" } }] },
+        { code: "foo.filter(function foo() { return; })", options: checkForEachOptions, errors: [{ messageId: "expectedReturnValue", data: { name: "Function 'foo'" } }] },
+        { code: "foo.every(cb || function() {})", options: checkForEachOptions, errors: ["Expected to return a value in function."] }
+
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[x] Changes an existing rule

**What rule do you want to change?**
array-callback-return

**Does this change cause the rule to produce more or fewer warnings?**
more

**How will the change be implemented? (New option, new default behavior, etc.)?**
new option checkForEach created, defaulted to false. when true, rule will also check if Array.forEach callback has a return statement and warn if it does

**Please provide some example code that this change will affect:**

Examples of **incorrect** code for the `{ "checkForEach": true }` option:

```js
/*eslint array-callback-return: ["error", { checkForEach: true }]*/
myArray.forEach(function(item) {
    return handleItem(item)
});
```

Examples of **correct** code for the `{ "checkForEach": true }` option:

```js
/*eslint array-callback-return: ["error", { checkForEach: true }]*/
myArray.forEach(function(item) {
    handleItem(item)
});
myArray.forEach(function(item) {
    if (item < 0) {
        return;
    }
    handleItem(item);
});
```

**What does the rule currently do for this code?**

doesn't check

**What will the rule do after it's changed?**

check if Array.forEach callback has a return statement and warn if it does

**What changes did you make? (Give an overview)**

added `checkForEach` option which enables/disables the new rule check

**Is there anything you'd like reviewers to focus on?**


