### PR TITLE
Fix: uglified autofix in key-spacing (fixes #11414)

### DIFF
--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -43,6 +43,18 @@ function isSingleLine(node) {
 }
 
 /**
+ * Checks whether all members in the group are on a single line.
+ * @param {ASTNode[]} group List of Property AST nodes.
+ * @returns {boolean} True if all memebers are on a single line.
+ */
+function isSingleLineGroup(group) {
+    const [firstMember] = group,
+        lastMemeber = last(group);
+
+    return firstMember.loc.start.line === lastMemeber.loc.end.line;
+}
+
+/**
  * Initializes a single option property from the configuration with defaults for undefined values
  * @param {Object} toOptions Object to be initialized
  * @param {Object} fromOptions Object to be initialized from
@@ -321,16 +333,22 @@ module.exports = {
 
         /**
          * Checks whether a property is a member of the property group it follows.
-         * @param {ASTNode} lastMember The last Property known to be in the group.
+         * @param {ASTNode} group The precede group.
          * @param {ASTNode} candidate The next Property that might be in the group.
          * @returns {boolean} True if the candidate property is part of the group.
          */
-        function continuesPropertyGroup(lastMember, candidate) {
-            const groupEndLine = lastMember.loc.start.line,
-                candidateStartLine = candidate.loc.start.line;
+        function continuesPropertyGroup(group, candidate) {
+            const lastMember = last(group),
+                groupEndLine = lastMember.loc.start.line,
+                candidateStartLine = candidate.loc.start.line,
+                lineDiff = candidateStartLine - groupEndLine;
 
-            if (candidateStartLine - groupEndLine <= 1) {
+            if (lineDiff === 0) {
                 return true;
+            }
+
+            if (lineDiff === 1) {
+                return group.length <= 1 || !isSingleLineGroup(group);
             }
 
             /*
@@ -528,7 +546,7 @@ module.exports = {
                 const currentGroup = last(groups),
                     prev = last(currentGroup);
 
-                if (!prev || continuesPropertyGroup(prev, property)) {
+                if (!prev || continuesPropertyGroup(currentGroup, property)) {
                     currentGroup.push(property);
                 } else {
                     groups.push([property]);
@@ -584,17 +602,6 @@ module.exports = {
         }
 
         /**
-         * Verifies vertical alignment, taking into account groups of properties.
-         * @param  {ASTNode} node ObjectExpression node being evaluated.
-         * @returns {void}
-         */
-        function verifyAlignment(node) {
-            createGroups(node).forEach(group => {
-                verifyGroupAlignment(group.filter(isKeyValueProperty));
-            });
-        }
-
-        /**
          * Verifies spacing of property conforms to specified options.
          * @param  {ASTNode} node Property node being evaluated.
          * @param {Object} lineOptions Configured singleLine or multiLine options
@@ -612,14 +619,32 @@ module.exports = {
         /**
          * Verifies spacing of each property in a list.
          * @param  {ASTNode[]} properties List of Property AST nodes.
+         * @param {Object} lineOptions Configured singleLine or multiLine options
          * @returns {void}
          */
-        function verifyListSpacing(properties) {
+        function verifyListSpacing(properties, lineOptions) {
             const length = properties.length;
 
             for (let i = 0; i < length; i++) {
-                verifySpacing(properties[i], singleLineOptions);
+                verifySpacing(properties[i], lineOptions);
             }
+        }
+
+        /**
+         * Verifies vertical alignment, taking into account groups of properties.
+         * @param  {ASTNode} node ObjectExpression node being evaluated.
+         * @returns {void}
+         */
+        function verifyAlignment(node) {
+            createGroups(node).forEach(group => {
+                const targetGroup = group.filter(isKeyValueProperty);
+
+                if (targetGroup.length && isSingleLineGroup(targetGroup)) {
+                    verifyListSpacing(targetGroup, multiLineOptions);
+                } else {
+                    verifyGroupAlignment(targetGroup);
+                }
+            });
         }
 
         //--------------------------------------------------------------------------
@@ -631,7 +656,7 @@ module.exports = {
             return {
                 ObjectExpression(node) {
                     if (isSingleLine(node)) {
-                        verifyListSpacing(node.properties.filter(isKeyValueProperty));
+                        verifyListSpacing(node.properties.filter(isKeyValueProperty), singleLineOptions);
                     } else {
                         verifyAlignment(node);
                     }

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -757,6 +757,103 @@ ruleTester.run("key-spacing", rule, {
             }
         }],
         parserOptions: { ecmaVersion: 6 }
+    },
+
+    // https://github.com/eslint/eslint/issues/11414
+    {
+        code: [
+            "var obj = {",
+            "   foo: 1, 'bar': 2, baz: 3",
+            "}"
+        ].join("\n"),
+        options: [{
+            singleLine: {
+                beforeColon: false,
+                afterColon: false
+            },
+            multiLine: {
+                beforeColon: false,
+                afterColon: true
+            }
+        }]
+    }, {
+        code: [
+            "var obj = {",
+            "   foo: 1, 'bar': 2, baz: 3",
+            "}"
+        ].join("\n"),
+        options: [{
+            singleLine: {
+                beforeColon: false,
+                afterColon: false
+            },
+            multiLine: {
+                align: "value"
+            }
+        }]
+    }, {
+        code: [
+            "var obj = {",
+            "   foo : 1, 'bar' : 2, baz : 3,",
+            "   short        : 4,",
+            "   longlonglong : 5",
+            "}"
+        ].join("\n"),
+        options: [{
+            singleLine: {
+                afterColon: true,
+                beforeColon: false
+            },
+            multiLine: {
+                afterColon: true,
+                beforeColon: true,
+                align: "colon"
+            }
+        }]
+    }, {
+        code: [
+            "var obj = {",
+            "   foo: 1, 'bar': 2, baz: 3,",
+            "   short:        4,",
+            "   longlonglong: 5",
+            "}"
+        ].join("\n"),
+        options: [{
+            align: "value"
+        }]
+    }, {
+        code: [
+            "var obj = {",
+            "   foo : 1, 'bar' : 2, baz : 3,",
+            "   short        : 4,",
+            "   longlonglong : 5",
+            "}"
+        ].join("\n"),
+        options: [{
+            align: "colon",
+            beforeColon: true
+        }]
+    }, {
+        code: [
+            "foo({",
+            "   foo: 1, 'bar': 2, baz: 3,",
+            "   short       :4,",
+            "   longlonglong:5",
+            "})"
+        ].join("\n"),
+        options: [{
+            multiLine: {
+                beforeColon: false,
+                afterColon: true,
+                mode: "strict"
+            },
+            align: {
+                beforeColon: false,
+                afterColon: false,
+                on: "colon",
+                mode: "minimum"
+            }
+        }]
     }],
 
     invalid: [{
@@ -1768,6 +1865,171 @@ ruleTester.run("key-spacing", rule, {
         errors: [
             { messageId: "missingKey", data: { computed: "", key: "foo" }, line: 1, column: 7, type: "Identifier" },
             { messageId: "missingValue", data: { computed: "", key: "foo" }, line: 1, column: 19, type: "Identifier" }
+        ]
+    }, // https://github.com/eslint/eslint/issues/11414
+    {
+        code: [
+            "var obj = {",
+            "   foo:1, 'bar':2, baz:3",
+            "}"
+        ].join("\n"),
+        output: [
+            "var obj = {",
+            "   foo: 1, 'bar': 2, baz: 3",
+            "}"
+        ].join("\n"),
+        options: [{
+            singleLine: {
+                beforeColon: false,
+                afterColon: false
+            },
+            multiLine: {
+                beforeColon: false,
+                afterColon: true
+            }
+        }],
+        errors: [
+            { messageId: "missingValue", data: { computed: "", key: "foo" }, line: 2, column: 8, type: "Literal" },
+            { messageId: "missingValue", data: { computed: "", key: "bar" }, line: 2, column: 17, type: "Literal" },
+            { messageId: "missingValue", data: { computed: "", key: "baz" }, line: 2, column: 24, type: "Literal" }
+        ]
+    }, {
+        code: [
+            "var obj = {",
+            "   foo : 1, 'bar' : 2, baz : 3",
+            "}"
+        ].join("\n"),
+        output: [
+            "var obj = {",
+            "   foo: 1, 'bar': 2, baz: 3",
+            "}"
+        ].join("\n"),
+        options: [{
+            singleLine: {
+                beforeColon: false,
+                afterColon: false
+            },
+            multiLine: {
+                align: "value"
+            }
+        }],
+        errors: [
+            { messageId: "extraKey", data: { computed: "", key: "foo" }, line: 2, column: 4, type: "Identifier" },
+            { messageId: "extraKey", data: { computed: "", key: "bar" }, line: 2, column: 13, type: "Literal" },
+            { messageId: "extraKey", data: { computed: "", key: "baz" }, line: 2, column: 24, type: "Identifier" }
+        ]
+    }, {
+        code: [
+            "var obj = {",
+            "   foo:1, 'bar':2, baz:3,",
+            "   short: 4,",
+            "   longlonglong : 5",
+            "}"
+        ].join("\n"),
+        output: [
+            "var obj = {",
+            "   foo : 1, 'bar' : 2, baz : 3,",
+            "   short        : 4,",
+            "   longlonglong : 5",
+            "}"
+        ].join("\n"),
+        options: [{
+            singleLine: {
+                afterColon: true,
+                beforeColon: false
+            },
+            multiLine: {
+                afterColon: true,
+                beforeColon: true,
+                align: "colon"
+            }
+        }],
+        errors: [
+            { messageId: "missingKey", data: { computed: "", key: "foo" }, line: 2, column: 4, type: "Identifier" },
+            { messageId: "missingValue", data: { computed: "", key: "foo" }, line: 2, column: 8, type: "Literal" },
+            { messageId: "missingKey", data: { computed: "", key: "bar" }, line: 2, column: 11, type: "Literal" },
+            { messageId: "missingValue", data: { computed: "", key: "bar" }, line: 2, column: 17, type: "Literal" },
+            { messageId: "missingKey", data: { computed: "", key: "baz" }, line: 2, column: 20, type: "Identifier" },
+            { messageId: "missingValue", data: { computed: "", key: "baz" }, line: 2, column: 24, type: "Literal" },
+            { messageId: "missingKey", data: { computed: "", key: "short" }, line: 3, column: 4, type: "Identifier" }
+        ]
+    }, {
+        code: [
+            "var obj = {",
+            "   foo: 1, 'bar': 2, baz: 3,",
+            "   short:4,",
+            "   longlonglong: 5",
+            "}"
+        ].join("\n"),
+        output: [
+            "var obj = {",
+            "   foo: 1, 'bar': 2, baz: 3,",
+            "   short:        4,",
+            "   longlonglong: 5",
+            "}"
+        ].join("\n"),
+        options: [{
+            align: "value"
+        }],
+        errors: [
+            { messageId: "missingValue", data: { computed: "", key: "short" }, line: 3, column: 10, type: "Literal" }
+        ]
+    }, {
+        code: [
+            "var obj = {",
+            "   foo : 1, 'bar' : 2, baz : 3,",
+            "   short :4,",
+            "   longlonglong : 5",
+            "}"
+        ].join("\n"),
+        output: [
+            "var obj = {",
+            "   foo : 1, 'bar' : 2, baz : 3,",
+            "   short        : 4,",
+            "   longlonglong : 5",
+            "}"
+        ].join("\n"),
+        options: [{
+            align: "colon",
+            beforeColon: true
+        }],
+        errors: [
+            { messageId: "missingKey", data: { computed: "", key: "short" }, line: 3, column: 4, type: "Identifier" },
+            { messageId: "missingValue", data: { computed: "", key: "short" }, line: 3, column: 11, type: "Literal" }
+        ]
+    }, {
+        code: [
+            "foo({",
+            "   foo : 1, 'bar' : 2, baz : 3,",
+            "   short       :   4,",
+            "   longlonglong:5",
+            "})"
+        ].join("\n"),
+        output: [
+            "foo({",
+            "   foo: 1, 'bar': 2, baz: 3,",
+            "   short       :4,",
+            "   longlonglong:5",
+            "})"
+        ].join("\n"),
+        options: [{
+            multiLine: {
+                beforeColon: false,
+                afterColon: true,
+                mode: "strict"
+            },
+            align: {
+                beforeColon: false,
+                afterColon: false,
+                on: "colon",
+                mode: "minimum"
+            }
+        }],
+        errors: [
+            { messageId: "extraKey", data: { computed: "", key: "foo" }, line: 2, column: 4, type: "Identifier" },
+            { messageId: "extraKey", data: { computed: "", key: "bar" }, line: 2, column: 13, type: "Literal" },
+            { messageId: "extraKey", data: { computed: "", key: "baz" }, line: 2, column: 24, type: "Identifier" },
+            { messageId: "extraValue", data: { computed: "", key: "short" }, line: 3, column: 20, type: "Literal" }
         ]
     }]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
fix this issue. #11414 
I made it ignore aligning a single line when it contains multiple properties.
Because I think the align option is for vertical only.

**Is there anything you'd like reviewers to focus on?**


