### PR TITLE
Chore: remove unused code in max-lines-per-function

### DIFF
--- a/lib/rules/max-lines-per-function.js
+++ b/lib/rules/max-lines-per-function.js
@@ -54,9 +54,6 @@ const OPTIONS_OR_INTEGER_SCHEMA = {
 function getCommentLineNumbers(comments) {
     const map = new Map();
 
-    if (!comments) {
-        return map;
-    }
     comments.forEach(comment => {
         for (let i = comment.loc.start.line; i <= comment.loc.end.line; i++) {
             map.set(i, comment);


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ x ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

remove unused code in max-lines-per-function.

https://github.com/eslint/eslint/blob/8108f49f9fa0c2de80b3b66c847551beff585951/lib/rules/max-lines-per-function.js#L57-L59
Because the return value from `sourceCode.getAllComments()` is always truthy, checking falsy is useless.
   * in other rules, they didn't check whether the return value is falsy or not. 
  https://github.com/eslint/eslint/blob/219aecb78bc646d44bad27dc775a9b3d3dc58232/lib/rules/line-comment-position.js#L89-L93
https://github.com/eslint/eslint/blob/8108f49f9fa0c2de80b3b66c847551beff585951/lib/rules/capitalized-comments.js#L294-L296


**Is there anything you'd like reviewers to focus on?**

