### PR TITLE
Update: fix counting jsx comment len in max-len (fixes #12213)

### DIFF
--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -184,13 +184,11 @@ module.exports = {
         }
 
         /**
-         * Check if a comment is in the single line JSXEmptyExpression.
-         * @param {ASTNode} comment The comment to check.
-         * @returns {boolean} True if the comment is in the single line JSXEmptyExpression.
+         * Check if a node is a JSXEmptyExpression contained in a single line JSXExpressionContainer.
+         * @param {ASTNode} node A node to check.
+         * @returns {boolean} True if the node is a JSXEmptyExpression contained in a single line JSXExpressionContainer.
          */
-        function isCommentInSingleLineJSXEmptyExpression(comment) {
-            const node = sourceCode.getNodeByRangeIndex(comment.range[0]);
-
+        function isJSXEmptyExpressionInSingleLineContainer(node) {
             if (!node || !node.parent || node.type !== "JSXEmptyExpression" || node.parent.type !== "JSXExpressionContainer") {
                 return false;
             }
@@ -270,6 +268,26 @@ module.exports = {
         }
 
         /**
+         * Returns an array of all comments in the source code.
+         * If the element in the array is a JSXEmptyExpression contained with a single line JSXExpressionContainer,
+         * the element is changed with JSXExpressionContainer node.
+         * @returns {ASTNode[]} An array of comment nodes
+         */
+        function getAllComments() {
+            return sourceCode
+                .getAllComments()
+                .map(comment => {
+                    const containingNode = sourceCode.getNodeByRangeIndex(comment.range[0]);
+
+                    if (isJSXEmptyExpressionInSingleLineContainer(containingNode)) {
+                        return containingNode.parent;
+                    }
+
+                    return comment;
+                });
+        }
+
+        /**
          * Check the program for max length
          * @param {ASTNode} node Node to examine
          * @returns {void}
@@ -281,7 +299,7 @@ module.exports = {
             const lines = sourceCode.lines,
 
                 // list of comments to ignore
-                comments = ignoreComments || maxCommentLength || ignoreTrailingComments ? sourceCode.getAllComments() : [];
+                comments = ignoreComments || maxCommentLength || ignoreTrailingComments ? getAllComments() : [];
 
             // we iterate over comments in parallel with the lines
             let commentsIndex = 0;
@@ -321,11 +339,6 @@ module.exports = {
 
                     // and step back by one
                     comment = comments[--commentsIndex];
-
-                    // check jsx comment
-                    if (isCommentInSingleLineJSXEmptyExpression(comment)) {
-                        comment = sourceCode.getNodeByRangeIndex(comment.range[0]).parent;
-                    }
 
                     if (isFullLineComment(line, lineNumber, comment)) {
                         lineIsComment = true;

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -274,17 +274,24 @@ module.exports = {
          * @returns {ASTNode[]} An array of comment nodes
          */
         function getAllComments() {
-            return sourceCode
-                .getAllComments()
-                .map(comment => {
-                    const containingNode = sourceCode.getNodeByRangeIndex(comment.range[0]);
+            const comments = [];
+
+            sourceCode.getAllComments()
+                .forEach(commentNode => {
+                    const containingNode = sourceCode.getNodeByRangeIndex(commentNode.range[0]);
 
                     if (isJSXEmptyExpressionInSingleLineContainer(containingNode)) {
-                        return containingNode.parent;
-                    }
 
-                    return comment;
+                        // push a unique node only
+                        if (comments[comments.length - 1] !== commentNode) {
+                            comments.push(containingNode.parent);
+                        }
+                    } else {
+                        comments.push(commentNode);
+                    }
                 });
+
+            return comments;
         }
 
         /**

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -283,7 +283,7 @@ module.exports = {
                     if (isJSXEmptyExpressionInSingleLineContainer(containingNode)) {
 
                         // push a unique node only
-                        if (comments[comments.length - 1] !== commentNode) {
+                        if (comments[comments.length - 1] !== containingNode.parent) {
                             comments.push(containingNode.parent);
                         }
                     } else {

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -184,6 +184,23 @@ module.exports = {
         }
 
         /**
+         * Check if a comment is in the single line JSXEmptyExpression.
+         * @param {ASTNode} comment The comment to check.
+         * @returns {boolean} True if the comment is in the single line JSXEmptyExpression.
+         */
+        function isCommentInSingleLineJSXEmptyExpression(comment) {
+            const node = sourceCode.getNodeByRangeIndex(comment.range[0]);
+
+            if (!node || !node.parent || node.type !== "JSXEmptyExpression" || node.parent.type !== "JSXExpressionContainer") {
+                return false;
+            }
+
+            const parent = node.parent;
+
+            return parent.loc.start.line === parent.loc.end.line;
+        }
+
+        /**
          * Gets the line after the comment and any remaining trailing whitespace is
          * stripped.
          * @param {string} line The source line with a trailing comment
@@ -304,6 +321,11 @@ module.exports = {
 
                     // and step back by one
                     comment = comments[--commentsIndex];
+
+                    // check jsx comment
+                    if (isCommentInSingleLineJSXEmptyExpression(comment)) {
+                        comment = sourceCode.getNodeByRangeIndex(comment.range[0]).parent;
+                    }
 
                     if (isFullLineComment(line, lineNumber, comment)) {
                         lineIsComment = true;

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -279,6 +279,56 @@ ruleTester.run("max-len", rule, {
                   "</>)",
             options: [37, { ignoreComments: true }],
             parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = (<>\n" +
+                "  {/* this line has 37 characters */}\n" +
+                "  <> </> {/* this line with two separate comments */} {/* have > 80 characters */ /* another comment in same braces */}\n" +
+                "</>)",
+            options: [37, { ignoreTrailingComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = (<>\n" +
+                "  {/* this line has 37 characters */}\n" +
+                "  <> </> {/* this line with two separate comments */} {/* have > 80 characters */ /* another comment in same braces */}\n" +
+                "</>)",
+            options: [37, { ignoreComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = (<>\n" +
+                "  {/*\n" +
+                "       this line has 34 characters\n" +
+                "   */}\n" +
+                "</>)",
+            options: [33, { comments: 34 }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = (<>\n" +
+                "  {/*\n" +
+                "       this line has 34 characters\n" +
+                "   */}\n" +
+                "</>)",
+            options: [33, { ignoreComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = (<>\n" +
+                "  {a & b /* this line has 34 characters\n" +
+                "   */}\n" +
+                "</>)",
+            options: [33, { ignoreTrailingComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = (<>\n" +
+                "  {a & b /* this line has 34 characters\n" +
+                "   */}\n" +
+                "</>)",
+            options: [33, { ignoreComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
         }
     ],
 
@@ -773,12 +823,44 @@ ruleTester.run("max-len", rule, {
             code: "var jsx = (<>\n" +
                   "{ 38/* this line has 38 characters */}\n" +
                   "</>)",
-            options: [15, { comments: 37 }],
+            options: [15, { comments: 38 }],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [
                 {
                     messageId: "max",
                     data: { lineLength: 38, maxLength: 15 },
+                    type: "Program",
+                    line: 2,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                  "{ 38/* this line has 38 characters */}\n" +
+                  "</>)",
+            options: [37, { ignoreTrailingComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 38, maxLength: 37 },
+                    type: "Program",
+                    line: 2,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                  "{ 38/* this line has 38 characters */}\n" +
+                  "</>)",
+            options: [37, { ignoreComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 38, maxLength: 37 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -927,6 +1009,57 @@ ruleTester.run("max-len", rule, {
                 {
                     messageId: "max",
                     data: { lineLength: 87, maxLength: 37 },
+                    type: "Program",
+                    line: 3,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                "  {/* this line has 37 characters */}\n" +
+                "  <> </> {/* this line with two separate comments */} {/* have > 80 characters */ /* another comment in same braces */}\n" +
+                "</>)",
+            options: [37],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 119, maxLength: 37 },
+                    type: "Program",
+                    line: 3,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                "  {/* this line has 37 characters */}\n" +
+                "  <> </> {/* this is not treated as a comment */ a & b} {/* trailing */ /* comments */}\n" +
+                "</>)",
+            options: [37, { ignoreTrailingComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 55, maxLength: 37 },
+                    type: "Program",
+                    line: 3,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                "  {/* this line has 37 characters */}\n" +
+                "  <> </> {/* this is not treated as a comment */ a & b} {/* trailing */ /* comments */}\n" +
+                "</>)",
+            options: [37, { ignoreComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 55, maxLength: 37 },
                     type: "Program",
                     line: 3,
                     column: 1

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -234,6 +234,36 @@ ruleTester.run("max-len", rule, {
                   "</>)",
             options: [37, { ignoreTrailingComments: true }],
             parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = <Foo>\n" +
+                  "         attr = {a && b/* this line has 57 characters */}\n" +
+                  "</Foo>;",
+            options: [57],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = <Foo>\n" +
+                  "         attr = {/* this line has 57 characters */a && b}\n" +
+                  "</Foo>;",
+            options: [57],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = <Foo>\n" +
+                  "         attr = \n" +
+                  "          {/* this line has 45 characters */}\n" +
+                  "</Foo>;",
+            options: [20, { comments: 45 }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = <Foo>\n" +
+                  "         attr = \n" +
+                  "          {/* this line has 45 characters */}\n" +
+                  "</Foo>;",
+            options: [20, { ignoreComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
         }
     ],
 
@@ -769,6 +799,71 @@ ruleTester.run("max-len", rule, {
                     data: { lineLength: 44, maxLength: 37 },
                     type: "Program",
                     line: 2,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = <Foo>\n" +
+                  "         attr = {a && b/* this line has 57 characters */}\n" +
+                  "</Foo>;",
+            options: [56],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 57, maxLength: 56 },
+                    type: "Program",
+                    line: 2,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = <Foo>\n" +
+                  "         attr = {/* this line has 57 characters */a && b}\n" +
+                  "</Foo>;",
+            options: [56],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 57, maxLength: 56 },
+                    type: "Program",
+                    line: 2,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = <Foo>\n" +
+                  "         attr = {a & b/* this line has 56 characters */}\n" +
+                  "</Foo>;",
+            options: [55, { ignoreTrailingComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 56, maxLength: 55 },
+                    type: "Program",
+                    line: 2,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = <Foo>\n" +
+                  "         attr = \n" +
+                  "          {/* this line has 45 characters */}\n" +
+                  "</Foo>;",
+            options: [80, { comments: 44 }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "maxComment",
+                    data: { lineLength: 45, maxCommentLength: 44 },
+                    type: "Program",
+                    line: 3,
                     column: 1
                 }
             ]

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -1065,6 +1065,40 @@ ruleTester.run("max-len", rule, {
                     column: 1
                 }
             ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                  "12345678901234{/*\n" +
+                  "*/}\n" +
+                  "</>)",
+            options: [14, { ignoreTrailingComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 15, maxLength: 14 },
+                    type: "Program",
+                    line: 2,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                  "{/*\n" +
+                  "this line has 31 characters */}\n" +
+                  "</>)",
+            options: [30, { comments: 100 }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 31, maxLength: 30 },
+                    type: "Program",
+                    line: 3,
+                    column: 1
+                }
+            ]
         }
     ]
 });

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -236,33 +236,48 @@ ruleTester.run("max-len", rule, {
             parserOptions: { ecmaFeatures: { jsx: true } }
         },
         {
-            code: "var jsx = <Foo>\n" +
+            code: "var jsx = <Foo\n" +
                   "         attr = {a && b/* this line has 57 characters */}\n" +
-                  "</Foo>;",
+                  "></Foo>;",
             options: [57],
             parserOptions: { ecmaFeatures: { jsx: true } }
         },
         {
-            code: "var jsx = <Foo>\n" +
+            code: "var jsx = <Foo\n" +
                   "         attr = {/* this line has 57 characters */a && b}\n" +
-                  "</Foo>;",
+                  "></Foo>;",
             options: [57],
             parserOptions: { ecmaFeatures: { jsx: true } }
         },
         {
-            code: "var jsx = <Foo>\n" +
+            code: "var jsx = <Foo\n" +
                   "         attr = \n" +
-                  "          {/* this line has 45 characters */}\n" +
-                  "</Foo>;",
-            options: [20, { comments: 45 }],
+                  "          {a & b/* this line has 50 characters */}\n" +
+                  "></Foo>;",
+            options: [50],
             parserOptions: { ecmaFeatures: { jsx: true } }
         },
         {
-            code: "var jsx = <Foo>\n" +
-                  "         attr = \n" +
-                  "          {/* this line has 45 characters */}\n" +
-                  "</Foo>;",
-            options: [20, { ignoreComments: true }],
+            code: "var jsx = (<>\n" +
+                 "  <> </> {/* this line with two separate comments */} {/* have 80 characters */}\n" +
+                  "</>)",
+            options: [80],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = (<>\n" +
+                 "  {/* this line has 37 characters */}\n" +
+                 "  <> </> {/* this line with two separate comments */} {/* have 80 characters */}\n" +
+                  "</>)",
+            options: [37, { ignoreTrailingComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = (<>\n" +
+                 "  {/* this line has 37 characters */}\n" +
+                 "  <> </> {/* this line with two separate comments */} {/* have 80 characters */}\n" +
+                  "</>)",
+            options: [37, { ignoreComments: true }],
             parserOptions: { ecmaFeatures: { jsx: true } }
         }
     ],
@@ -804,9 +819,9 @@ ruleTester.run("max-len", rule, {
             ]
         },
         {
-            code: "var jsx = <Foo>\n" +
+            code: "var jsx = <Foo\n" +
                   "         attr = {a && b/* this line has 57 characters */}\n" +
-                  "</Foo>;",
+                  "></Foo>;",
             options: [56],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [
@@ -820,9 +835,9 @@ ruleTester.run("max-len", rule, {
             ]
         },
         {
-            code: "var jsx = <Foo>\n" +
+            code: "var jsx = <Foo\n" +
                   "         attr = {/* this line has 57 characters */a && b}\n" +
-                  "</Foo>;",
+                  "></Foo>;",
             options: [56],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [
@@ -836,9 +851,9 @@ ruleTester.run("max-len", rule, {
             ]
         },
         {
-            code: "var jsx = <Foo>\n" +
+            code: "var jsx = <Foo\n" +
                   "         attr = {a & b/* this line has 56 characters */}\n" +
-                  "</Foo>;",
+                  "></Foo>;",
             options: [55, { ignoreTrailingComments: true }],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [
@@ -852,16 +867,66 @@ ruleTester.run("max-len", rule, {
             ]
         },
         {
-            code: "var jsx = <Foo>\n" +
+            code: "var jsx = <Foo\n" +
                   "         attr = \n" +
-                  "          {/* this line has 45 characters */}\n" +
-                  "</Foo>;",
-            options: [80, { comments: 44 }],
+                  "          {a & b /* this line has 51 characters */}\n" +
+                  "></Foo>;",
+            options: [30, { comments: 44 }],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [
                 {
-                    messageId: "maxComment",
-                    data: { lineLength: 45, maxCommentLength: 44 },
+                    messageId: "max",
+                    data: { lineLength: 51, maxLength: 30 },
+                    type: "Program",
+                    line: 3,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                 "  {/* this line has 37 characters */}\n" +
+                 "  <> </> {/* this line with two separate comments */} {/* have 80 characters */}\n" +
+                  "</>)",
+            options: [79],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 80, maxLength: 79 },
+                    type: "Program",
+                    line: 3,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                 "  <> </> {/* this line with two separate comments */} {/* have 87 characters */} <> </>\n" +
+                  "</>)",
+            options: [85, { ignoreTrailingComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 87, maxLength: 85 },
+                    type: "Program",
+                    line: 2,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                 "  {/* this line has 37 characters */}\n" +
+                 "  <> </> {/* this line with two separate comments */} {/* have 87 characters */} <> </>\n" +
+                  "</>)",
+            options: [37, { ignoreComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 87, maxLength: 37 },
                     type: "Program",
                     line: 3,
                     column: 1

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -195,6 +195,45 @@ ruleTester.run("max-len", rule, {
         {
             code: "\tfoo",
             options: [4, { tabWidth: 0 }]
+        },
+
+        // https://github.com/eslint/eslint/issues/12213
+        {
+            code: "var jsx = (<>\n" +
+                  "  { /* this line has 38 characters */}\n" +
+                  "</>)",
+            options: [15, { comments: 38 }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = (<>\n" +
+                  "\t\t{ /* this line has 40 characters */}\n" +
+                  "</>)",
+            options: [15, 4, { comments: 44 }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = (<>\n" +
+                  "  <> text </>{ /* this line has 49 characters */}\n" +
+                  "</>)",
+            options: [13, { ignoreComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = (<>\n" +
+                  "  {/* this line has 37 characters */}\n" +
+                  "  <> </> {/* this line has 44 characters */}\n" +
+                  "</>)",
+            options: [44, { comments: 37 }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var jsx = (<>\n" +
+                  "  {/* this line has 37 characters */}\n" +
+                  "  <> </> {/* this line has 44 characters */}\n" +
+                  "</>)",
+            options: [37, { ignoreTrailingComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
         }
     ],
 
@@ -647,6 +686,89 @@ ruleTester.run("max-len", rule, {
                     data: { lineLength: 1, maxLength: 0 },
                     type: "Program",
                     line: 1,
+                    column: 1
+                }
+            ]
+        },
+
+        // https://github.com/eslint/eslint/issues/12213
+        {
+            code: "var jsx = (<>\n" +
+                  "  { /* this line has 38 characters */}\n" +
+                  "</>)",
+            options: [15, { comments: 37 }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "maxComment",
+                    data: { lineLength: 38, maxCommentLength: 37 },
+                    type: "Program",
+                    line: 2,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                  "\t\t{ /* this line has 40 characters */}\n" +
+                  "</>)",
+            options: [15, 4, { comments: 40 }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "maxComment",
+                    data: { lineLength: 44, maxCommentLength: 40 },
+                    type: "Program",
+                    line: 2,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                  "{ 38/* this line has 38 characters */}\n" +
+                  "</>)",
+            options: [15, { comments: 37 }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 38, maxLength: 15 },
+                    type: "Program",
+                    line: 2,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                  "   <> 50 </>{ 50/* this line has 50 characters */}\n" +
+                  "</>)",
+            options: [49, { comments: 100 }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 50, maxLength: 49 },
+                    type: "Program",
+                    line: 2,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var jsx = (<>\n" +
+                  "         {/* this line has 44 characters */}\n" +
+                  "  <> </> {/* this line has 44 characters */}\n" +
+                  "</>)",
+            options: [37, { ignoreTrailingComments: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 44, maxLength: 37 },
+                    type: "Program",
+                    line: 2,
                     column: 1
                 }
             ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
This pr will fix #12213.

If the comment is in the single line jsx comment, change the comment node for checking with JSXExpressionContainer. 

ex)

```jsx
<>
  {/* comment */}
</>
```


**Is there anything you'd like reviewers to focus on?**


