### PR TITLE
Update: rule 'padding-line-between-statements' - add number of lines

### DIFF
--- a/docs/rules/padding-line-between-statements.md
+++ b/docs/rules/padding-line-between-statements.md
@@ -42,6 +42,7 @@ You can supply any number of configurations. If a statement pair matches multipl
     - `"any"` just ignores the statement pair.
     - `"never"` disallows blank lines.
     - `"always"` requires one or more blank lines. Note it does not count lines that comments exist as blank lines.
+    - `{number}` (minimum: 1) requires a specified number of blank lines.
 
 - `STATEMENT_TYPE` is one of the following, or an array of the following.
     - `"*"` is wildcard. This matches any statements.
@@ -210,6 +211,44 @@ Examples of **correct** code for the `[{ blankLine: "always", prev: "directive",
 "use asm";
 
 foo();
+```
+
+----
+
+This configuration would require two blank lines before and after all `class` statement.
+
+Examples of **incorrect** code for the `[{ blankLine: 2, prev: "*", next: "class" }, { blankLine: 2, prev: "class", next: "*" }]` configuration:
+
+```js
+/*eslint padding-line-between-statements: [
+    "error",
+    { blankLine: 2, prev: "*", next: "class" },
+    { blankLine: 2, prev: "class", next: "*" }
+]*/
+
+"use strict";
+
+class A {}
+
+function b() {}
+```
+
+Examples of **correct** code for the `[{ blankLine: 2, prev: "*", next: "class" }, { blankLine: 2, prev: "class", next: "*" }]` configuration:
+
+```js
+/*eslint padding-line-between-statements: [
+    "error",
+    { blankLine: 2, prev: "*", next: "class" },
+    { blankLine: 2, prev: "class", next: "*" }
+]*/
+
+"use strict";
+
+
+class A {}
+
+
+function b() {}
 ```
 
 ## Compatibility

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -552,7 +552,7 @@ module.exports = {
          * Finds the last matched configure from configureList.
          * @param {ASTNode} prevNode The previous statement to match.
          * @param {ASTNode} nextNode The current statement to match.
-         * @returns {Object} The tester of the last matched configure.
+         * @returns {[number, Object]} The allowed number of blank lines and tester of the last matched configure.
          * @private
          */
         function getPaddingType(prevNode, nextNode) {
@@ -578,7 +578,7 @@ module.exports = {
          * @param {ASTNode} prevNode The previous statement to count.
          * @param {ASTNode} nextNode The current statement to count.
          * @param {number} blankLine Allowed number of blank lines.
-         * @returns {Array<Token[]>} The array of token pairs.
+         * @returns {[number, Array<Token[]>]} The number of blank lines found and array of token pairs.
          * @private
          */
         function getPaddingLineSequences(prevNode, nextNode, blankLine) {

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -498,7 +498,7 @@ module.exports = {
         messages: {
             unexpectedBlankLine: "Unexpected blank line before this statement.",
             expectedBlankLine: "Expected blank line before this statement.",
-            expectedCount: "Before this statement there are {{count}} blank line. Allowed is {{blankLine}}."
+            expectedCount: "Expected {{blankLine}} blank lines. Found {{count}}."
         }
     },
 

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -272,17 +272,33 @@ function verifyForNever(context, _, nextNode, paddingLines) {
  * @param {ASTNode} nextNode The next node to check.
  * @param {Array<Token[]>} paddingLines The array of token pairs that blank
  * lines exist between the pair.
+ * @param {number} blankLine Allowed number of blank lines.
+ * @param {number} foundBlankLine Number of blank lines found.
  * @returns {void}
  * @private
  */
-function verifyForAlways(context, prevNode, nextNode, paddingLines) {
+function verifyForAlways(context, prevNode, nextNode, paddingLines, blankLine, foundBlankLine) {
     if (paddingLines.length > 0) {
         return;
     }
 
+    let messageId = "expectedBlankLine";
+    let repeat = 1;
+    let data;
+
+    if (blankLine) {
+        messageId = "expectedCount";
+        repeat = blankLine;
+        data = {
+            blankLine,
+            count: foundBlankLine
+        };
+    }
+
     context.report({
         node: nextNode,
-        messageId: "expectedBlankLine",
+        messageId,
+        data,
         fix(fixer) {
             const sourceCode = context.getSourceCode();
             let prevToken = getActualLastToken(sourceCode, prevNode);
@@ -321,11 +337,17 @@ function verifyForAlways(context, prevNode, nextNode, paddingLines) {
                     }
                 }
             ) || nextNode;
-            const insertText = astUtils.isTokenOnSameLine(prevToken, nextToken)
-                ? "\n\n"
-                : "\n";
 
-            return fixer.insertTextAfter(prevToken, insertText);
+            const replaceText = "\n".repeat(repeat + 1);
+            let start = prevToken.range[1];
+            let end = start;
+
+            if (!astUtils.isTokenOnSameLine(prevToken, nextToken)) {
+                start = sourceCode.lineStartIndices[prevToken.loc.end.line] - 1;
+                end = sourceCode.lineStartIndices[nextToken.loc.start.line - 1];
+            }
+
+            return fixer.replaceTextRange([start, end], replaceText);
         }
     });
 }
@@ -441,7 +463,10 @@ module.exports = {
         schema: {
             definitions: {
                 paddingType: {
-                    enum: Object.keys(PaddingTypes)
+                    anyOf: [
+                        { enum: Object.keys(PaddingTypes) },
+                        { type: "integer", minimum: 1 }
+                    ]
                 },
                 statementType: {
                     anyOf: [
@@ -472,7 +497,8 @@ module.exports = {
 
         messages: {
             unexpectedBlankLine: "Unexpected blank line before this statement.",
-            expectedBlankLine: "Expected blank line before this statement."
+            expectedBlankLine: "Expected blank line before this statement.",
+            expectedCount: "Before this statement there are {{count}} blank line. Allowed is {{blankLine}}."
         }
     },
 
@@ -537,10 +563,13 @@ module.exports = {
                     match(nextNode, configure.next);
 
                 if (matched) {
-                    return PaddingTypes[configure.blankLine];
+                    if (typeof configure.blankLine === "number") {
+                        return [configure.blankLine, PaddingTypes.always];
+                    }
+                    return [0, PaddingTypes[configure.blankLine]];
                 }
             }
-            return PaddingTypes.any;
+            return [0, PaddingTypes.any];
         }
 
         /**
@@ -548,29 +577,32 @@ module.exports = {
          * Comments are separators of the padding line sequences.
          * @param {ASTNode} prevNode The previous statement to count.
          * @param {ASTNode} nextNode The current statement to count.
+         * @param {number} blankLine Allowed number of blank lines.
          * @returns {Array<Token[]>} The array of token pairs.
          * @private
          */
-        function getPaddingLineSequences(prevNode, nextNode) {
+        function getPaddingLineSequences(prevNode, nextNode, blankLine) {
             const pairs = [];
             let prevToken = getActualLastToken(sourceCode, prevNode);
+            let foundBlankLine = 0;
 
-            if (nextNode.loc.start.line - prevToken.loc.end.line >= 2) {
-                do {
-                    const token = sourceCode.getTokenAfter(
-                        prevToken,
-                        { includeComments: true }
-                    );
+            while (prevToken.range[0] < nextNode.range[0]) {
+                const token = sourceCode.getTokenAfter(
+                    prevToken,
+                    { includeComments: true }
+                );
+                const currentBlankLine = token.loc.start.line - prevToken.loc.end.line - 1;
 
-                    if (token.loc.start.line - prevToken.loc.end.line >= 2) {
-                        pairs.push([prevToken, token]);
-                    }
-                    prevToken = token;
-
-                } while (prevToken.range[0] < nextNode.range[0]);
+                if (currentBlankLine > foundBlankLine) {
+                    foundBlankLine = currentBlankLine;
+                }
+                if (blankLine ? (currentBlankLine === blankLine) : (currentBlankLine >= 1)) {
+                    pairs.push([prevToken, token]);
+                }
+                prevToken = token;
             }
 
-            return pairs;
+            return [foundBlankLine, pairs];
         }
 
         /**
@@ -594,10 +626,10 @@ module.exports = {
 
             // Verify.
             if (prevNode) {
-                const type = getPaddingType(prevNode, node);
-                const paddingLines = getPaddingLineSequences(prevNode, node);
+                const [blankLine, type] = getPaddingType(prevNode, node);
+                const [foundBlankLine, paddingLines] = getPaddingLineSequences(prevNode, node, blankLine);
 
-                type.verify(context, prevNode, node, paddingLines);
+                type.verify(context, prevNode, node, paddingLines, blankLine, foundBlankLine);
             }
 
             scopeInfo.prevNode = node;

--- a/tests/lib/rules/padding-line-between-statements.js
+++ b/tests/lib/rules/padding-line-between-statements.js
@@ -2275,6 +2275,43 @@ ruleTester.run("padding-line-between-statements", rule, {
             parserOptions: { ecmaFeatures: { globalReturn: true } }
         },
 
+        // Tests for number of empty rows
+        {
+            code: "var a=1\n\n\nclass A{}\n\n\nfunction b(){}",
+            options: [
+                { blankLine: 2, prev: "*", next: "class" },
+                { blankLine: 2, prev: "class", next: "*" }
+            ]
+        },
+        {
+            code: "var a=1\n\nclass A{}\n\nfunction b(){}",
+            options: [
+                { blankLine: 1, prev: "*", next: "class" },
+                { blankLine: 1, prev: "class", next: "*" }
+            ]
+        },
+        {
+            code: "var a=1\n\n\n/* comment */\nclass A{}\n\n\n/* comment */\nfunction b(){}",
+            options: [
+                { blankLine: 2, prev: "*", next: "class" },
+                { blankLine: 2, prev: "class", next: "*" }
+            ]
+        },
+        {
+            code: "var a=1\n\n/* comment */\nclass A{}\n\n/* comment */\nfunction b(){}",
+            options: [
+                { blankLine: 1, prev: "*", next: "class" },
+                { blankLine: 1, prev: "class", next: "*" }
+            ]
+        },
+        {
+            code: "var a=1\n\n/* comment */\n\n\nclass A{}\n\n/* comment */\n\n\nfunction b(){}",
+            options: [
+                { blankLine: 2, prev: "*", next: "class" },
+                { blankLine: 2, prev: "class", next: "*" }
+            ]
+        },
+
         //----------------------------------------------------------------------
         // From JSCS disallowPaddingNewLinesAfterBlocks
         // https://github.com/jscs-dev/node-jscs/blob/44f9b86eb0757fd4ca05a81a50450c5f1b25c37b/test/specs/rules/disallow-padding-newlines-after-blocks.js
@@ -4158,7 +4195,7 @@ ruleTester.run("padding-line-between-statements", rule, {
         },
         {
             code: "var greet = 'hello';    \nconsole.log(greet);",
-            output: "var greet = 'hello';\n    \nconsole.log(greet);",
+            output: "var greet = 'hello';    \n\nconsole.log(greet);",
             options: [
                 { blankLine: "always", prev: ["const", "let", "var"], next: "*" },
                 { blankLine: "any", prev: ["const", "let", "var"], next: ["const", "let", "var"] }
@@ -4699,6 +4736,80 @@ ruleTester.run("padding-line-between-statements", rule, {
                 { blankLine: "always", prev: "*", next: "return" }
             ],
             errors: [{ messageId: "expectedBlankLine" }]
+        },
+
+        // Tests for number of empty rows
+        {
+            code: "var a=1\n\n\nclass A{}\n\n\nfunction b(){}",
+            output: "var a=1\n\nclass A{}\n\nfunction b(){}",
+            options: [
+                { blankLine: 1, prev: "*", next: "class" },
+                { blankLine: 1, prev: "class", next: "*" }
+            ],
+            errors: [
+                "Before this statement there are 2 blank line. Allowed is 1.",
+                "Before this statement there are 2 blank line. Allowed is 1."
+            ]
+        },
+        {
+            code: "var a=1\n\nclass A{}\n\nfunction b(){}",
+            output: "var a=1\n\n\nclass A{}\n\n\nfunction b(){}",
+            options: [
+                { blankLine: 2, prev: "*", next: "class" },
+                { blankLine: 2, prev: "class", next: "*" }
+            ],
+            errors: [
+                "Before this statement there are 1 blank line. Allowed is 2.",
+                "Before this statement there are 1 blank line. Allowed is 2."
+            ]
+        },
+        {
+            code: "var a=1\n\n\n/* comment */\nclass A{}\n\n\n/* comment */\nfunction b(){}",
+            output: "var a=1\n\n/* comment */\nclass A{}\n\n/* comment */\nfunction b(){}",
+            options: [
+                { blankLine: 1, prev: "*", next: "class" },
+                { blankLine: 1, prev: "class", next: "*" }
+            ],
+            errors: [
+                "Before this statement there are 2 blank line. Allowed is 1.",
+                "Before this statement there are 2 blank line. Allowed is 1."
+            ]
+        },
+        {
+            code: "var a=1\n\n\n/* comment */\n\n\nclass A{}\n\n\n/* comment */function b(){}",
+            output: "var a=1\n\n/* comment */\n\n\nclass A{}\n\n/* comment */function b(){}",
+            options: [
+                { blankLine: 1, prev: "*", next: "class" },
+                { blankLine: 1, prev: "class", next: "*" }
+            ],
+            errors: [
+                "Before this statement there are 2 blank line. Allowed is 1.",
+                "Before this statement there are 2 blank line. Allowed is 1."
+            ]
+        },
+        {
+            code: "var a=1\n\n/* comment */\nclass A{}\n\n/* comment */\nfunction b(){}",
+            output: "var a=1\n\n\n/* comment */\nclass A{}\n\n\n/* comment */\nfunction b(){}",
+            options: [
+                { blankLine: 2, prev: "*", next: "class" },
+                { blankLine: 2, prev: "class", next: "*" }
+            ],
+            errors: [
+                "Before this statement there are 1 blank line. Allowed is 2.",
+                "Before this statement there are 1 blank line. Allowed is 2."
+            ]
+        },
+        {
+            code: "var a=1\n\n/* comment */\n\nclass A{}\n\n/* comment */function b(){}",
+            output: "var a=1\n\n\n/* comment */\n\nclass A{}\n\n\n/* comment */function b(){}",
+            options: [
+                { blankLine: 2, prev: "*", next: "class" },
+                { blankLine: 2, prev: "class", next: "*" }
+            ],
+            errors: [
+                "Before this statement there are 1 blank line. Allowed is 2.",
+                "Before this statement there are 1 blank line. Allowed is 2."
+            ]
         },
 
         //----------------------------------------------------------------------

--- a/tests/lib/rules/padding-line-between-statements.js
+++ b/tests/lib/rules/padding-line-between-statements.js
@@ -4747,8 +4747,8 @@ ruleTester.run("padding-line-between-statements", rule, {
                 { blankLine: 1, prev: "class", next: "*" }
             ],
             errors: [
-                "Before this statement there are 2 blank line. Allowed is 1.",
-                "Before this statement there are 2 blank line. Allowed is 1."
+                "Expected 1 blank lines. Found 2.",
+                "Expected 1 blank lines. Found 2."
             ]
         },
         {
@@ -4759,8 +4759,8 @@ ruleTester.run("padding-line-between-statements", rule, {
                 { blankLine: 2, prev: "class", next: "*" }
             ],
             errors: [
-                "Before this statement there are 1 blank line. Allowed is 2.",
-                "Before this statement there are 1 blank line. Allowed is 2."
+                "Expected 2 blank lines. Found 1.",
+                "Expected 2 blank lines. Found 1."
             ]
         },
         {
@@ -4771,8 +4771,8 @@ ruleTester.run("padding-line-between-statements", rule, {
                 { blankLine: 1, prev: "class", next: "*" }
             ],
             errors: [
-                "Before this statement there are 2 blank line. Allowed is 1.",
-                "Before this statement there are 2 blank line. Allowed is 1."
+                "Expected 1 blank lines. Found 2.",
+                "Expected 1 blank lines. Found 2."
             ]
         },
         {
@@ -4783,8 +4783,8 @@ ruleTester.run("padding-line-between-statements", rule, {
                 { blankLine: 1, prev: "class", next: "*" }
             ],
             errors: [
-                "Before this statement there are 2 blank line. Allowed is 1.",
-                "Before this statement there are 2 blank line. Allowed is 1."
+                "Expected 1 blank lines. Found 2.",
+                "Expected 1 blank lines. Found 2."
             ]
         },
         {
@@ -4795,8 +4795,8 @@ ruleTester.run("padding-line-between-statements", rule, {
                 { blankLine: 2, prev: "class", next: "*" }
             ],
             errors: [
-                "Before this statement there are 1 blank line. Allowed is 2.",
-                "Before this statement there are 1 blank line. Allowed is 2."
+                "Expected 2 blank lines. Found 1.",
+                "Expected 2 blank lines. Found 1."
             ]
         },
         {
@@ -4807,8 +4807,8 @@ ruleTester.run("padding-line-between-statements", rule, {
                 { blankLine: 2, prev: "class", next: "*" }
             ],
             errors: [
-                "Before this statement there are 1 blank line. Allowed is 2.",
-                "Before this statement there are 1 blank line. Allowed is 2."
+                "Expected 2 blank lines. Found 1.",
+                "Expected 2 blank lines. Found 1."
             ]
         },
 


### PR DESCRIPTION
 [x] Documentation update
 [x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
 [x] Add autofixing to a rule

**What rule do you want to change?**

<https://eslint.org/docs/rules/padding-line-between-statements>

**Does this change cause the rule to produce more or fewer warnings?**

No, the number of warnings will remain the same.

**How will the change be implemented? (New option, new default behavior, etc.)?**

For this rule, the set of possible options for using the `blankLine` parameter
    will be expanded by adding the ability to specify the required number of blank lines.

**Please provide some example code that this change will affect:**

```js
/*eslint padding-line-between-statements: [
    "error",
    { blankLine: 2, prev: "*", next: "class" },
    { blankLine: 2, prev: "class", next: "*" }
]*/

"use strict";


class A {}


function b() {}
```

**What does the rule currently do for this code?**

Currently, you cannot specify the required number of blank lines.

**What will the rule do after it's changed?**

The rule will start using the number of blank lines only after setting the `blankLine` parameter to a numeric value.
In this case, the problem will be displayed if the number of blank lines is greater than or less than the specified value.

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

1.  Added ability to specify numeric value in `meta.schema.definitions.paddingType`
2.  Added a new message view with the number of blank lines
3.  Added to `function verifyForAlways` output of new messages depending on `blankLine` parameter
4.  Changed the "rule fixer" so that it could replace blocks in the code with the required number of blank lines
5.  In `function getPaddingLineSequences` added search the current number of blank lines to display in the problem message
6.  Updated tests and documentation

**Is there anything you'd like reviewers to focus on?**

Do I need to cover any other cases with tests?

**Example**
This change will improve the readability of the source code by highlighting the concept blocks.
And it will also automate the process of formatting.

Here is an example of the configuration I plan to use with these updates:

```js
  "rules": {
    "lines-between-class-members": "error",
    "padding-line-between-statements": [
      "error",
      { "blankLine": 1, "prev": "*", "next": ["cjs-import", "cjs-export"] },
      { "blankLine": 1, "prev": ["cjs-import", "cjs-export"], "next": "*" },
      { "blankLine": 2, "prev": "expression", "next": ["cjs-import", "cjs-export"] },
      { "blankLine": 2, "prev": ["cjs-import", "cjs-export"], "next": "expression" },
      { "blankLine": 2, "prev": "*", "next": ["class", "function"] },
      { "blankLine": 2, "prev": ["class", "function"], "next": "*" },
      { "blankLine": 1, "prev": ["directive", "const", "let"], "next": "expression" },
      { "blankLine": 1, "prev": "expression", "next": ["const", "let", "return"] },
      { "blankLine": "never", "prev": "cjs-import", "next": "cjs-import" },
      { "blankLine": "never", "prev": "cjs-export", "next": "cjs-export" }
    ],
    "padded-blocks": [
      "error",
      { "blocks": "never", "classes": "always", "switches": "never" },
      { "allowSingleLineBlocks": true }
    ]
  }
```

Before `eslint . --fix`

```js
'use strict'
const any = require('any')
const { any2 } = require('any2')
const CONST1 = 'CONST1'
const CONST2 = 'CONST1'
/**
 * My class
 */
class Test {
  constructor() {
    this.a = any + any2 + CONST1
  }
  any(a) {
    let anyText = 'any'
    if (a) {
      anyText = 'a' + CONST2
    }
    return anyText
  }
}
/**
 * My function
 */
function test() {
  const t = new Test()
  console.log(t)
  return t
}
console.log('any' + test())
module.exports.Test = Test
module.exports.test = test
```

After `eslint . --fix`

```js
'use strict'

const any = require('any')
const { any2 } = require('any2')

const CONST1 = 'CONST1'
const CONST2 = 'CONST1'


/**
 * My class
 */
class Test {

  constructor() {
    this.a = any + any2 + CONST1
  }

  any(a) {
    let anyText = 'any'
    if (a) {
      anyText = 'a' + CONST2
    }
    return anyText
  }

}


/**
 * My function
 */
function test() {
  const t = new Test()

  console.log(t)

  return t
}


console.log('any' + test())


module.exports.Test = Test
module.exports.test = test
```

**PR:** https://github.com/eslint/eslint/pull/11788 

> **issue:** https://github.com/eslint/eslint/issues/12634 https://github.com/eslint/eslint/issues/12979