### PR TITLE
Build: update browser build

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -562,19 +562,6 @@ target.karma = () => {
 
     target.webpack("production");
 
-    const browserFileLintOutput = new CLIEngine({
-        useEslintrc: false,
-        ignore: false,
-        allowInlineConfig: false,
-        baseConfig: { parserOptions: { ecmaVersion: 5 } }
-    }).executeOnFiles([`${BUILD_DIR}/eslint.js`]);
-
-    if (browserFileLintOutput.errorCount > 0) {
-        echo(`error: Failed to lint ${BUILD_DIR}/eslint.js as ES5 code`);
-        echo(CLIEngine.getFormatter("stylish")(browserFileLintOutput.results));
-        exit(1);
-    }
-
     const lastReturn = exec(`${getBinFile("karma")} start karma.conf.js`);
 
     if (lastReturn.code !== 0) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,9 +17,28 @@ module.exports = {
                 test: /\.m?js$/u,
                 loader: "babel-loader",
                 options: {
-                    presets: ["@babel/preset-env"]
+                    presets: [
+                        ["@babel/preset-env", {
+                            debug: true, // ← to print actual browser versions
+
+                            /*
+                             * We want to remove `transform-unicode-regex` convert because of https://github.com/eslint/eslint/pull/12662.
+                             *
+                             * With `>0.5%`, `@babel/preset-env@7.7.6` prints below:
+                             *
+                             *     transform-unicode-regex { "chrome":"49", "ie":"11", "safari":"5.1" }
+                             *
+                             * So this excludes those versions:
+                             *
+                             * - IE 11
+                             * - Chrome 49 (2016; the last version on Windows XP)
+                             * - Safari 5.1 (2011-2013; the last version on Windows)
+                             */
+                            targets: ">0.5%, not chrome 49, not ie 11, not safari 5.1"
+                        }]
+                    ]
                 },
-                exclude: /node_modules\/lodash/u
+                exclude: /node_modules[\\/]lodash/u
             }
         ]
     },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain: update the webpack configuration of browser tests and the online demo.

**What changes did you make? (Give an overview)**

This PR update our webpack configuration to not use `regjsparser` package as a follow up of #12662. 

After this change, `@babel/preset-env` prints below:

```
Using targets:
{
  "chrome": "76",
  "edge": "18",
  "firefox": "69",
  "ios": "12.2",
  "safari": "12.1",
  "samsung": "10.1"
}

Using modules transform: auto

Using plugins:
  transform-template-literals { "ios":"12.2", "safari":"12.1" }
  transform-function-name { "edge":"18" }
  transform-dotall-regex { "edge":"18", "firefox":"69" }
  proposal-async-generator-functions { "edge":"18" }
  proposal-object-rest-spread { "edge":"18" }
  proposal-unicode-property-regex { "edge":"18", "firefox":"69" }
  proposal-json-strings { "edge":"18" }
  transform-named-capturing-groups-regex { "edge":"18", "firefox":"69" }
  syntax-dynamic-import { "chrome":"76", "edge":"18", "firefox":"69", "ios":"12.2", "opera":"63", "safari":"12.1", "samsung":"10.1" }

Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.
```

**Is there anything you'd like reviewers to focus on?**

Are the versions OK?