### PR TITLE
Add example for func-style 

### DIFF
--- a/docs/rules/func-style.md
+++ b/docs/rules/func-style.md
@@ -77,6 +77,8 @@ Examples of **correct** code for this rule with the default `"expression"` optio
 var foo = function() {
     // ...
 };
+
+var foo = () => {};
 ```
 
 ### declaration


### PR DESCRIPTION
**Documentation update**

With the `allowArrowFunction` parameter, it was not clear at the first read that arrow function expression was include in the default option. I think adding this example will make it more clear