### PR TITLE
Update: report double extra parens in no-extra-parens (fixes #12127)

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -780,9 +780,19 @@ module.exports = {
                         tokensToIgnore.add(firstLeftToken);
                     }
                 }
-                if (!(node.type === "ForOfStatement" && node.right.type === "SequenceExpression") && hasExcessParens(node.right)) {
+
+                if (node.type === "ForOfStatement") {
+                    const hasExtraParens = node.right.type === "SequenceExpression"
+                        ? hasDoubleExcessParens(node.right)
+                        : hasExcessParens(node.right);
+
+                    if (hasExtraParens) {
+                        report(node.right);
+                    }
+                } else if (hasExcessParens(node.right)) {
                     report(node.right);
                 }
+
                 if (hasExcessParens(node.left)) {
                     report(node.left);
                 }

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -737,10 +737,13 @@ module.exports = {
             },
 
             ConditionalExpression(node) {
-                if (isReturnAssignException(node) || isCondAssignException(node)) {
+                if (isReturnAssignException(node)) {
                     return;
                 }
-                if (hasExcessParensWithPrecedence(node.test, precedence({ type: "LogicalExpression", operator: "||" }))) {
+                if (
+                    !isCondAssignException(node) &&
+                    hasExcessParensWithPrecedence(node.test, precedence({ type: "LogicalExpression", operator: "||" }))
+                ) {
                     report(node.test);
                 }
 

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -171,13 +171,15 @@ module.exports = {
 
         /**
          * Determines if a node that is expected to be parenthesised is surrounded by
-         * (potentially) invalid extra parentheses with considering precedence.
+         * (potentially) invalid extra parentheses with considering precedence level of the node.
+         * If the preference level of the node is higher or equal to precedence lower limit, it checks
+         * whether the node is surrounded by parentheses twice or not.
          * @param {ASTNode} node The node to be checked.
          * @param {number} precedenceLowerLimit The lower limit of precedence.
          * @returns {boolean} True if the node is has an unexpected extra pair of parentheses.
          * @private
          */
-        function hasExcessParensWithConsiderPrecedence(node, precedenceLowerLimit) {
+        function hasExcessParensWithPrecedence(node, precedenceLowerLimit) {
             if (ruleApplies(node) && isParenthesised(node)) {
                 if (
                     precedence(node) >= precedenceLowerLimit ||
@@ -431,7 +433,7 @@ module.exports = {
         function checkCallNew(node) {
             const callee = node.callee;
 
-            if (hasExcessParensWithConsiderPrecedence(callee, precedence(node))) {
+            if (hasExcessParensWithPrecedence(callee, precedence(node))) {
                 const hasNewParensException = callee.type === "NewExpression" && !isNewExpressionWithParens(callee);
 
                 if (
@@ -684,7 +686,7 @@ module.exports = {
         return {
             ArrayExpression(node) {
                 node.elements
-                    .filter(e => e && hasExcessParensWithConsiderPrecedence(e, PRECEDENCE_OF_ASSIGNMENT_EXPR))
+                    .filter(e => e && hasExcessParensWithPrecedence(e, PRECEDENCE_OF_ASSIGNMENT_EXPR))
                     .forEach(report);
             },
 
@@ -707,14 +709,14 @@ module.exports = {
                     if (astUtils.isOpeningParenToken(tokenBeforeFirst) && astUtils.isOpeningBraceToken(firstBodyToken)) {
                         tokensToIgnore.add(firstBodyToken);
                     }
-                    if (hasExcessParensWithConsiderPrecedence(node.body, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
+                    if (hasExcessParensWithPrecedence(node.body, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                         report(node.body);
                     }
                 }
             },
 
             AssignmentExpression(node) {
-                if (!isReturnAssignException(node) && hasExcessParensWithConsiderPrecedence(node.right, precedence(node))) {
+                if (!isReturnAssignException(node) && hasExcessParensWithPrecedence(node.right, precedence(node))) {
                     report(node.right);
                 }
             },
@@ -732,7 +734,7 @@ module.exports = {
             ClassBody(node) {
                 node.body
                     .filter(member => member.type === "MethodDefinition" && member.computed && member.key)
-                    .filter(member => hasExcessParensWithConsiderPrecedence(member.key, PRECEDENCE_OF_ASSIGNMENT_EXPR))
+                    .filter(member => hasExcessParensWithPrecedence(member.key, PRECEDENCE_OF_ASSIGNMENT_EXPR))
                     .forEach(member => report(member.key));
             },
 
@@ -740,15 +742,15 @@ module.exports = {
                 if (isReturnAssignException(node)) {
                     return;
                 }
-                if (hasExcessParensWithConsiderPrecedence(node.test, precedence({ type: "LogicalExpression", operator: "||" }))) {
+                if (hasExcessParensWithPrecedence(node.test, precedence({ type: "LogicalExpression", operator: "||" }))) {
                     report(node.test);
                 }
 
-                if (hasExcessParensWithConsiderPrecedence(node.consequent, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
+                if (hasExcessParensWithPrecedence(node.consequent, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                     report(node.consequent);
                 }
 
-                if (hasExcessParensWithConsiderPrecedence(node.alternate, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
+                if (hasExcessParensWithPrecedence(node.alternate, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                     report(node.alternate);
                 }
             },
@@ -939,7 +941,7 @@ module.exports = {
 
             ObjectExpression(node) {
                 node.properties
-                    .filter(property => property.value && hasExcessParensWithConsiderPrecedence(property.value, PRECEDENCE_OF_ASSIGNMENT_EXPR))
+                    .filter(property => property.value && hasExcessParensWithPrecedence(property.value, PRECEDENCE_OF_ASSIGNMENT_EXPR))
                     .forEach(property => report(property.value));
             },
 
@@ -947,7 +949,7 @@ module.exports = {
                 if (node.computed) {
                     const { key } = node;
 
-                    if (key && hasExcessParensWithConsiderPrecedence(key, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
+                    if (key && hasExcessParensWithPrecedence(key, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                         report(key);
                     }
                 }
@@ -1049,7 +1051,7 @@ module.exports = {
             AssignmentPattern(node) {
                 const { right } = node;
 
-                if (right && hasExcessParensWithConsiderPrecedence(right, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
+                if (right && hasExcessParensWithPrecedence(right, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                     report(right);
                 }
             }

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -499,7 +499,11 @@ module.exports = {
              * If `node.superClass` is a LeftHandSideExpression, parentheses are extra.
              * Otherwise, parentheses are needed.
              */
-            if (hasExcessParensWithPrecedence(node.superClass, PRECEDENCE_OF_UPDATE_EXPR)) {
+            const hasExtraParens = precedence(node.superClass) > PRECEDENCE_OF_UPDATE_EXPR
+                ? hasExcessParens(node.superClass)
+                : hasDoubleExcessParens(node.superClass);
+
+            if (hasExtraParens) {
                 report(node.superClass);
             }
         }

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -401,8 +401,7 @@ module.exports = {
             if (node.type === "UnaryExpression" && node.argument.type === "BinaryExpression" && node.argument.operator === "**") {
                 return;
             }
-
-            if (hasExcessParens(node.argument) && precedence(node.argument) >= precedence(node)) {
+            if (hasExcessParensWithPrecedence(node.argument, precedence(node))) {
                 report(node.argument);
             }
         }
@@ -503,11 +502,7 @@ module.exports = {
              * If `node.superClass` is a LeftHandSideExpression, parentheses are extra.
              * Otherwise, parentheses are needed.
              */
-            const hasExtraParens = precedence(node.superClass) > PRECEDENCE_OF_UPDATE_EXPR
-                ? hasExcessParens(node.superClass)
-                : hasDoubleExcessParens(node.superClass);
-
-            if (hasExtraParens) {
+            if (hasExcessParensWithPrecedence(node.superClass, PRECEDENCE_OF_UPDATE_EXPR)) {
                 report(node.superClass);
             }
         }
@@ -518,11 +513,7 @@ module.exports = {
          * @returns {void}
          */
         function checkSpreadOperator(node) {
-            const hasExtraParens = precedence(node.argument) >= PRECEDENCE_OF_ASSIGNMENT_EXPR
-                ? hasExcessParens(node.argument)
-                : hasDoubleExcessParens(node.argument);
-
-            if (hasExtraParens) {
+            if (hasExcessParensWithPrecedence(node.argument, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                 report(node.argument);
             }
         }
@@ -973,8 +964,10 @@ module.exports = {
             },
 
             SequenceExpression(node) {
+                const precedenceOfNode = precedence(node);
+
                 node.expressions
-                    .filter(e => hasExcessParens(e) && precedence(e) >= precedence(node))
+                    .filter(e => hasExcessParensWithPrecedence(e, precedenceOfNode))
                     .forEach(report);
             },
 
@@ -1003,11 +996,12 @@ module.exports = {
             AwaitExpression: checkUnaryUpdate,
 
             VariableDeclarator(node) {
-                if (node.init && hasExcessParens(node.init) &&
-                        precedence(node.init) >= PRECEDENCE_OF_ASSIGNMENT_EXPR &&
+                if (
+                    node.init && hasExcessParensWithPrecedence(node.init, PRECEDENCE_OF_ASSIGNMENT_EXPR) &&
 
-                        // RegExp literal is allowed to have parens (#1589)
-                        !(node.init.type === "Literal" && node.init.regex)) {
+                    // RegExp literal is allowed to have parens (#1589)
+                    !(node.init.type === "Literal" && node.init.regex)
+                ) {
                     report(node.init);
                 }
             },

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -392,15 +392,12 @@ module.exports = {
         }
 
         /**
-         * Evaluate Unary update
+         * Evaluate a argument in node.
          * @param {ASTNode} node node to evaluate
          * @returns {void}
          * @private
          */
-        function checkUnaryUpdate(node) {
-            if (node.type === "UnaryExpression" && node.argument.type === "BinaryExpression" && node.argument.operator === "**") {
-                return;
-            }
+        function checkArgumentWithPrecedence(node) {
             if (hasExcessParensWithPrecedence(node.argument, precedence(node))) {
                 report(node.argument);
             }
@@ -465,12 +462,12 @@ module.exports = {
             const leftPrecedence = precedence(node.left);
             const rightPrecedence = precedence(node.right);
             const isExponentiation = node.operator === "**";
-            const shouldSkipLeft = (NESTED_BINARY && (node.left.type === "BinaryExpression" || node.left.type === "LogicalExpression")) ||
-              node.left.type === "UnaryExpression" && isExponentiation;
+            const shouldSkipLeft = NESTED_BINARY && (node.left.type === "BinaryExpression" || node.left.type === "LogicalExpression");
             const shouldSkipRight = NESTED_BINARY && (node.right.type === "BinaryExpression" || node.right.type === "LogicalExpression");
 
             if (!shouldSkipLeft && hasExcessParens(node.left)) {
                 if (
+                    !(node.left.type === "UnaryExpression" && isExponentiation) &&
                     (leftPrecedence > prec || (leftPrecedence === prec && !isExponentiation)) ||
                     isParenthesisedTwice(node.left)
                 ) {
@@ -991,9 +988,9 @@ module.exports = {
                 }
             },
 
-            UnaryExpression: checkUnaryUpdate,
-            UpdateExpression: checkUnaryUpdate,
-            AwaitExpression: checkUnaryUpdate,
+            UnaryExpression: checkArgumentWithPrecedence,
+            UpdateExpression: checkArgumentWithPrecedence,
+            AwaitExpression: checkArgumentWithPrecedence,
 
             VariableDeclarator(node) {
                 if (

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -737,7 +737,7 @@ module.exports = {
             },
 
             ConditionalExpression(node) {
-                if (isReturnAssignException(node)) {
+                if (isReturnAssignException(node) || isCondAssignException(node)) {
                     return;
                 }
                 if (hasExcessParensWithPrecedence(node.test, precedence({ type: "LogicalExpression", operator: "||" }))) {

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -392,7 +392,7 @@ module.exports = {
         }
 
         /**
-         * Evaluate a argument in node.
+         * Evaluate a argument of the node.
          * @param {ASTNode} node node to evaluate
          * @returns {void}
          * @private

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -172,7 +172,7 @@ module.exports = {
         /**
          * Determines if a node that is expected to be parenthesised is surrounded by
          * (potentially) invalid extra parentheses with considering precedence level of the node.
-         * If the preference level of the node is higher or equal to precedence lower limit, it checks
+         * If the preference level of the node is not higher or equal to precedence lower limit, it also checks
          * whether the node is surrounded by parentheses twice or not.
          * @param {ASTNode} node The node to be checked.
          * @param {number} precedenceLowerLimit The lower limit of precedence.
@@ -451,9 +451,7 @@ module.exports = {
                 }
             }
             node.arguments
-                .filter(arg => hasExcessParens(arg))
-                .filter(arg => precedence(arg) >= PRECEDENCE_OF_ASSIGNMENT_EXPR ||
-                    hasDoubleExcessParens(arg))
+                .filter(arg => hasExcessParensWithPrecedence(arg, PRECEDENCE_OF_ASSIGNMENT_EXPR))
                 .forEach(report);
         }
 
@@ -475,7 +473,7 @@ module.exports = {
             if (!shouldSkipLeft && hasExcessParens(node.left)) {
                 if (
                     (leftPrecedence > prec || (leftPrecedence === prec && !isExponentiation)) ||
-                    hasDoubleExcessParens(node.left)
+                    isParenthesisedTwice(node.left)
                 ) {
                     report(node.left);
                 }
@@ -484,7 +482,7 @@ module.exports = {
             if (!shouldSkipRight && hasExcessParens(node.right)) {
                 if (
                     (rightPrecedence > prec || (rightPrecedence === prec && isExponentiation)) ||
-                    hasDoubleExcessParens(node.right)
+                    isParenthesisedTwice(node.right)
                 ) {
                     report(node.right);
                 }

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -170,6 +170,26 @@ module.exports = {
         }
 
         /**
+         * Determines if a node that is expected to be parenthesised is surrounded by
+         * (potentially) invalid extra parentheses with considering precedence.
+         * @param {ASTNode} node The node to be checked.
+         * @param {number} precedenceLowerLimit The lower limit of precedence.
+         * @returns {boolean} True if the node is has an unexpected extra pair of parentheses.
+         * @private
+         */
+        function hasExcessParensWithConsiderPrecedence(node, precedenceLowerLimit) {
+            if (ruleApplies(node) && isParenthesised(node)) {
+                if (
+                    precedence(node) >= precedenceLowerLimit ||
+                    isParenthesisedTwice(node)
+                ) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /**
          * Determines if a node test expression is allowed to have a parenthesised assignment
          * @param {ASTNode} node The node to be checked.
          * @returns {boolean} True if the assignment can be parenthesised.
@@ -411,7 +431,7 @@ module.exports = {
         function checkCallNew(node) {
             const callee = node.callee;
 
-            if (hasExcessParens(callee) && precedence(callee) >= precedence(node)) {
+            if (hasExcessParensWithConsiderPrecedence(callee, precedence(node))) {
                 const hasNewParensException = callee.type === "NewExpression" && !isNewExpressionWithParens(callee);
 
                 if (
@@ -429,7 +449,9 @@ module.exports = {
                 }
             }
             node.arguments
-                .filter(arg => hasExcessParens(arg) && precedence(arg) >= PRECEDENCE_OF_ASSIGNMENT_EXPR)
+                .filter(arg => hasExcessParens(arg))
+                .filter(arg => precedence(arg) >= PRECEDENCE_OF_ASSIGNMENT_EXPR ||
+                    hasDoubleExcessParens(arg))
                 .forEach(report);
         }
 
@@ -448,11 +470,22 @@ module.exports = {
               node.left.type === "UnaryExpression" && isExponentiation;
             const shouldSkipRight = NESTED_BINARY && (node.right.type === "BinaryExpression" || node.right.type === "LogicalExpression");
 
-            if (!shouldSkipLeft && hasExcessParens(node.left) && (leftPrecedence > prec || (leftPrecedence === prec && !isExponentiation))) {
-                report(node.left);
+            if (!shouldSkipLeft && hasExcessParens(node.left)) {
+                if (
+                    (leftPrecedence > prec || (leftPrecedence === prec && !isExponentiation)) ||
+                    hasDoubleExcessParens(node.left)
+                ) {
+                    report(node.left);
+                }
             }
-            if (!shouldSkipRight && hasExcessParens(node.right) && (rightPrecedence > prec || (rightPrecedence === prec && isExponentiation))) {
-                report(node.right);
+
+            if (!shouldSkipRight && hasExcessParens(node.right)) {
+                if (
+                    (rightPrecedence > prec || (rightPrecedence === prec && isExponentiation)) ||
+                    hasDoubleExcessParens(node.right)
+                ) {
+                    report(node.right);
+                }
             }
         }
 
@@ -651,7 +684,7 @@ module.exports = {
         return {
             ArrayExpression(node) {
                 node.elements
-                    .filter(e => e && hasExcessParens(e) && precedence(e) >= PRECEDENCE_OF_ASSIGNMENT_EXPR)
+                    .filter(e => e && hasExcessParensWithConsiderPrecedence(e, PRECEDENCE_OF_ASSIGNMENT_EXPR))
                     .forEach(report);
             },
 
@@ -674,18 +707,14 @@ module.exports = {
                     if (astUtils.isOpeningParenToken(tokenBeforeFirst) && astUtils.isOpeningBraceToken(firstBodyToken)) {
                         tokensToIgnore.add(firstBodyToken);
                     }
-                    if (hasExcessParens(node.body) && precedence(node.body) >= PRECEDENCE_OF_ASSIGNMENT_EXPR) {
+                    if (hasExcessParensWithConsiderPrecedence(node.body, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                         report(node.body);
                     }
                 }
             },
 
             AssignmentExpression(node) {
-                if (isReturnAssignException(node)) {
-                    return;
-                }
-
-                if (hasExcessParens(node.right) && precedence(node.right) >= precedence(node)) {
+                if (!isReturnAssignException(node) && hasExcessParensWithConsiderPrecedence(node.right, precedence(node))) {
                     report(node.right);
                 }
             },
@@ -702,8 +731,8 @@ module.exports = {
 
             ClassBody(node) {
                 node.body
-                    .filter(member => member.type === "MethodDefinition" && member.computed &&
-                        member.key && hasExcessParens(member.key) && precedence(member.key) >= PRECEDENCE_OF_ASSIGNMENT_EXPR)
+                    .filter(member => member.type === "MethodDefinition" && member.computed && member.key)
+                    .filter(member => hasExcessParensWithConsiderPrecedence(member.key, PRECEDENCE_OF_ASSIGNMENT_EXPR))
                     .forEach(member => report(member.key));
             },
 
@@ -711,16 +740,15 @@ module.exports = {
                 if (isReturnAssignException(node)) {
                     return;
                 }
-
-                if (hasExcessParens(node.test) && precedence(node.test) >= precedence({ type: "LogicalExpression", operator: "||" })) {
+                if (hasExcessParensWithConsiderPrecedence(node.test, precedence({ type: "LogicalExpression", operator: "||" }))) {
                     report(node.test);
                 }
 
-                if (hasExcessParens(node.consequent) && precedence(node.consequent) >= PRECEDENCE_OF_ASSIGNMENT_EXPR) {
+                if (hasExcessParensWithConsiderPrecedence(node.consequent, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                     report(node.consequent);
                 }
 
-                if (hasExcessParens(node.alternate) && precedence(node.alternate) >= PRECEDENCE_OF_ASSIGNMENT_EXPR) {
+                if (hasExcessParensWithConsiderPrecedence(node.alternate, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                     report(node.alternate);
                 }
             },
@@ -911,18 +939,15 @@ module.exports = {
 
             ObjectExpression(node) {
                 node.properties
-                    .filter(property => {
-                        const value = property.value;
-
-                        return value && hasExcessParens(value) && precedence(value) >= PRECEDENCE_OF_ASSIGNMENT_EXPR;
-                    }).forEach(property => report(property.value));
+                    .filter(property => property.value && hasExcessParensWithConsiderPrecedence(property.value, PRECEDENCE_OF_ASSIGNMENT_EXPR))
+                    .forEach(property => report(property.value));
             },
 
             Property(node) {
                 if (node.computed) {
                     const { key } = node;
 
-                    if (key && hasExcessParens(key) && precedence(key) >= PRECEDENCE_OF_ASSIGNMENT_EXPR) {
+                    if (key && hasExcessParensWithConsiderPrecedence(key, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                         report(key);
                     }
                 }
@@ -1024,7 +1049,7 @@ module.exports = {
             AssignmentPattern(node) {
                 const { right } = node;
 
-                if (right && hasExcessParens(right) && precedence(right) >= PRECEDENCE_OF_ASSIGNMENT_EXPR) {
+                if (right && hasExcessParensWithConsiderPrecedence(right, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                     report(right);
                 }
             }

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -1318,6 +1318,12 @@ ruleTester.run("no-extra-parens", rule, {
             1
         ),
         invalid(
+            "class A extends ((++foo)) {}",
+            "class A extends (++foo) {}",
+            "UpdateExpression",
+            1
+        ),
+        invalid(
             "for (foo of(bar));",
             "for (foo of bar);",
             "Identifier",

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -250,17 +250,22 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "var a = (b = c)", options: ["functions"] },
         { code: "_ => (a = 0)", options: ["functions"] },
 
-        // ["all", {conditionalAssign: false}] enables extra parens around conditional assignments
+        // ["all", { conditionalAssign: false }] enables extra parens around conditional assignments
         { code: "while ((foo = bar())) {}", options: ["all", { conditionalAssign: false }] },
         { code: "if ((foo = bar())) {}", options: ["all", { conditionalAssign: false }] },
         { code: "do; while ((foo = bar()))", options: ["all", { conditionalAssign: false }] },
         { code: "for (;(a = b););", options: ["all", { conditionalAssign: false }] },
+        { code: "var a = ((b = c)) ? foo : bar;", options: ["all", { conditionalAssign: false }] },
 
         // ["all", { nestedBinaryExpressions: false }] enables extra parens around conditional assignments
         { code: "a + (b * c)", options: ["all", { nestedBinaryExpressions: false }] },
         { code: "(a * b) + c", options: ["all", { nestedBinaryExpressions: false }] },
         { code: "(a * b) / c", options: ["all", { nestedBinaryExpressions: false }] },
         { code: "a || (b && c)", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "a + ((b * c))", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "((a * b)) + c", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "((a * b)) / c", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "a || ((b && c))", options: ["all", { nestedBinaryExpressions: false }] },
 
         // ["all", { returnAssign: false }] enables extra parens around expressions returned by return statements
         { code: "function a(b) { return b || c; }", options: ["all", { returnAssign: false }] },
@@ -276,6 +281,8 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "b => { return (b = 1) };", options: ["all", { returnAssign: false }] },
         { code: "b => { return (b = c) || (b = d) };", options: ["all", { returnAssign: false }] },
         { code: "b => { return c ? (d = b) : (e = b) };", options: ["all", { returnAssign: false }] },
+        { code: "function a(b) { return ((b = 1)); }", options: ["all", { returnAssign: false }] },
+        { code: "b => ((b = 1));", options: ["all", { returnAssign: false }] },
 
         // https://github.com/eslint/eslint/issues/3653
         "(function(){}).foo(), 1, 2;",
@@ -352,6 +359,8 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "foo in (bar in baz)", options: ["all", { nestedBinaryExpressions: false }] },
         { code: "foo + (bar + baz)", options: ["all", { nestedBinaryExpressions: false }] },
         { code: "foo && (bar && baz)", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "((foo instanceof bar)) instanceof baz", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "((foo in bar)) in baz", options: ["all", { nestedBinaryExpressions: false }] },
 
         // https://github.com/eslint/eslint/issues/9019
         "(async function() {});",
@@ -452,7 +461,9 @@ ruleTester.run("no-extra-parens", rule, {
 
         // ["all", { enforceForSequenceExpressions: false }]
         { code: "(a, b)", options: ["all", { enforceForSequenceExpressions: false }] },
+        { code: "((a, b))", options: ["all", { enforceForSequenceExpressions: false }] },
         { code: "(foo(), bar());", options: ["all", { enforceForSequenceExpressions: false }] },
+        { code: "((foo(), bar()));", options: ["all", { enforceForSequenceExpressions: false }] },
         { code: "if((a, b)){}", options: ["all", { enforceForSequenceExpressions: false }] },
         { code: "while ((val = foo(), val < 10));", options: ["all", { enforceForSequenceExpressions: false }] },
 
@@ -463,6 +474,7 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "(new foo(bar)).baz", options: ["all", { enforceForNewInMemberExpressions: false }] },
         { code: "(new foo.bar()).baz", options: ["all", { enforceForNewInMemberExpressions: false }] },
         { code: "(new foo.bar()).baz()", options: ["all", { enforceForNewInMemberExpressions: false }] },
+        { code: "((new foo.bar())).baz()", options: ["all", { enforceForNewInMemberExpressions: false }] },
 
         "let a = [ ...b ]",
         "let a = { ...b }",

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -2035,6 +2035,98 @@ ruleTester.run("no-extra-parens", rule, {
             "SequenceExpression",
             1,
             { parserOptions: { ecmaVersion: 2020 } }
-        )
+        ),
+
+        // https://github.com/eslint/eslint/issues/12127
+        {
+            code: "[1, ((2, 3))];",
+            output: "[1, (2, 3)];",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "const foo = () => ((bar, baz));",
+            output: "const foo = () => (bar, baz);",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "foo = ((bar, baz));",
+            output: "foo = (bar, baz);",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "foo + ((bar + baz));",
+            output: "foo + (bar + baz);",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "((foo + bar)) + baz;",
+            output: "(foo + bar) + baz;",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "foo * ((bar + baz));",
+            output: "foo * (bar + baz);",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "((foo + bar)) * baz;",
+            output: "(foo + bar) * baz;",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "new A(((foo, bar)))",
+            output: "new A((foo, bar))",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "class A{ [((foo, bar))]() {} }",
+            output: "class A{ [(foo, bar)]() {} }",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "new ((A, B))()",
+            output: "new (A, B)()",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "((foo, bar)) ? bar : baz;",
+            output: "(foo, bar) ? bar : baz;",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "((f ? o : o)) ? bar : baz;",
+            output: "(f ? o : o) ? bar : baz;",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "((f = oo)) ? bar : baz;",
+            output: "(f = oo) ? bar : baz;",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "foo ? ((bar, baz)) : baz;",
+            output: "foo ? (bar, baz) : baz;",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "foo ? bar : ((bar, baz));",
+            output: "foo ? bar : (bar, baz);",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "function foo(bar = ((baz1, baz2))) {}",
+            output: "function foo(bar = (baz1, baz2)) {}",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "var foo = { bar: ((baz1, baz2)) };",
+            output: "var foo = { bar: (baz1, baz2) };",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "var foo = { [((bar1, bar2))]: baz };",
+            output: "var foo = { [(bar1, bar2)]: baz };",
+            errors: [{ messageId: "unexpected" }]
+        }
     ]
 });

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -494,6 +494,7 @@ ruleTester.run("no-extra-parens", rule, {
         "const A = class extends B {}",
         "class A extends (B=C) {}",
         "const A = class extends (B=C) {}",
+        "class A extends (++foo) {}",
         "() => ({ foo: 1 })",
         "() => ({ foo: 1 }).foo",
         "() => ({ foo: 1 }.foo().bar).baz.qux()",

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -1336,6 +1336,12 @@ ruleTester.run("no-extra-parens", rule, {
             1
         ),
         invalid(
+            "for (foo of ((bar, baz)));",
+            "for (foo of (bar, baz));",
+            "SequenceExpression",
+            1
+        ),
+        invalid(
             "for ((foo)in bar);",
             "for (foo in bar);",
             "Identifier",

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -664,6 +664,9 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("(2 ** 3)", "2 ** 3", "BinaryExpression", null),
         invalid("(2 ** 3) + 1", "2 ** 3 + 1", "BinaryExpression", null),
         invalid("1 - (2 ** 3)", "1 - 2 ** 3", "BinaryExpression", null),
+        invalid("-((2 ** 3))", "-(2 ** 3)", "BinaryExpression", null),
+        invalid("typeof ((a ** b));", "typeof (a ** b);", "BinaryExpression", null),
+        invalid("((-2)) ** 3", "(-2) ** 3", "UnaryExpression", null),
 
         invalid("a = (b * c)", "a = b * c", "BinaryExpression", null, { options: ["all", { nestedBinaryExpressions: false }] }),
         invalid("(b * c)", "b * c", "BinaryExpression", null, { options: ["all", { nestedBinaryExpressions: false }] }),

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -648,6 +648,8 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("(a || b) ? c : d", "a || b ? c : d", "LogicalExpression"),
         invalid("a ? (b = c) : d", "a ? b = c : d", "AssignmentExpression"),
         invalid("a ? b : (c = d)", "a ? b : c = d", "AssignmentExpression"),
+        invalid("(c = d) ? (b) : c", "(c = d) ? b : c", "Identifier", null, { options: ["all", { conditionalAssign: false }] }),
+        invalid("(c = d) ? b : (c)", "(c = d) ? b : c", "Identifier", null, { options: ["all", { conditionalAssign: false }] }),
         invalid("f((a = b))", "f(a = b)", "AssignmentExpression"),
         invalid("a, (b = c)", "a, b = c", "AssignmentExpression"),
         invalid("a = (b * c)", "a = b * c", "BinaryExpression"),

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -199,6 +199,7 @@ ruleTester.run("no-extra-parens", rule, {
         "var regex = (/^a$/);",
         "function a(){ return (/^a$/); }",
         "function a(){ return (/^a$/).test('a'); }",
+        "var isA = ((/^a$/)).test('a');",
 
         // IIFE is allowed to have parens in any position (#655)
         "var foo = (function() { return bar(); }())",
@@ -643,6 +644,8 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("-(-foo)", "- -foo", "UnaryExpression"),
         invalid("+(-foo)", "+-foo", "UnaryExpression"),
         invalid("-(+foo)", "-+foo", "UnaryExpression"),
+        invalid("-((bar+foo))", "-(bar+foo)", "BinaryExpression"),
+        invalid("+((bar-foo))", "+(bar-foo)", "BinaryExpression"),
         invalid("++(foo)", "++foo", "Identifier"),
         invalid("--(foo)", "--foo", "Identifier"),
         invalid("(a || b) ? c : d", "a || b ? c : d", "LogicalExpression"),
@@ -743,6 +746,7 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("bar((class{}).foo(), 0);", "bar(class{}.foo(), 0);", "ClassExpression", null),
         invalid("bar[(class{}).foo()];", "bar[class{}.foo()];", "ClassExpression", null),
         invalid("var bar = (class{}).foo();", "var bar = class{}.foo();", "ClassExpression", null),
+        invalid("var foo = ((bar, baz));", "var foo = (bar, baz);", "SequenceExpression", null),
 
         // https://github.com/eslint/eslint/issues/4608
         invalid("function *a() { yield (b); }", "function *a() { yield b; }", "Identifier", null),
@@ -1031,6 +1035,7 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("async function a() { await (a()); }", "async function a() { await a(); }", "CallExpression", null),
         invalid("async function a() { await (+a); }", "async function a() { await +a; }", "UnaryExpression", null),
         invalid("async function a() { +(await a); }", "async function a() { +await a; }", "AwaitExpression", null),
+        invalid("async function a() { await ((a,b)); }", "async function a() { await (a,b); }", "SequenceExpression", null),
         invalid("(foo) instanceof bar", "foo instanceof bar", "Identifier", 1, { options: ["all", { nestedBinaryExpressions: false }] }),
         invalid("(foo) in bar", "foo in bar", "Identifier", 1, { options: ["all", { nestedBinaryExpressions: false }] }),
         invalid("(foo) + bar", "foo + bar", "Identifier", 1, { options: ["all", { nestedBinaryExpressions: false }] }),


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Fix #12127 



I tried to solve issue #12127 by adding just `|| hasDoubleExcessParens()` everywhere, but it had a performance issue when checking `ArrayExpression`'s element nodes.

So, I made a new function(`hasExcessParensWithConsiderPrecedence`) which checks extra parens with considering the precedence of a node. This function checks `isParenthesisedTwice` only if the node surrounded by at least one extra paren. 


**Is there anything you'd like reviewers to focus on?**

This pr doesn't change the option's behavior that @mdjermanovic [mentioned](https://github.com/eslint/eslint/issues/12127#issuecomment-522782361).
> There is also a question of options, do they allow just one pair or more.
