### PR TITLE
Update: add outerIIFEBody: "off" to indent rule (fixes #11377)

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -281,7 +281,7 @@ Examples of **incorrect** code for this rule with the options `2, { "outerIIFEBo
 })();
 
 
-if(y) {
+if (y) {
 console.log('foo');
 }
 ```
@@ -300,7 +300,7 @@ function foo(x) {
 })();
 
 
-if(y) {
+if (y) {
    console.log('foo');
 }
 ```
@@ -326,13 +326,8 @@ function foo(x) {
 
 })();
 
-
 if (y) {
-console.log('foo');
-}
-
-if (y) {
-   console.log('foo');
+  console.log('foo');
 }
 ```
 

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -70,7 +70,7 @@ This rule has an object option:
 
 * `"SwitchCase"` (default: 0) enforces indentation level for `case` clauses in `switch` statements
 * `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators; can also take an object to define separate rules for `var`, `let` and `const` declarations. It can also be `"first"`, indicating all the declarators should be aligned with the first declarator.
-* `"outerIIFEBody"` (default: 1) enforces indentation level for file-level IIFEs.
+* `"outerIIFEBody"` (default: 1) enforces indentation level for file-level IIFEs. This can also be set to `"off"` to disable checking for file-level IIFEs.
 * `"MemberExpression"` (default: 1) enforces indentation level for multi-line property chains. This can also be set to `"off"` to disable checking for MemberExpression indentation.
 * `"FunctionDeclaration"` takes an object to define rules for function declarations.
     * `parameters` (default: 1) enforces indentation level for parameters in a function declaration. This can either be a number indicating indentation level, or the string `"first"` indicating that all parameters of the declaration must be aligned with the first parameter. This can also be set to `"off"` to disable checking for FunctionDeclaration parameters.
@@ -286,7 +286,7 @@ console.log('foo');
 }
 ```
 
-Examples of **correct** code for this rule with the options `2, {"outerIIFEBody": 0}`:
+Examples of **correct** code for this rule with the options `2, { "outerIIFEBody": 0 }`:
 
 ```js
 /*eslint indent: ["error", 2, { "outerIIFEBody": 0 }]*/
@@ -301,6 +301,37 @@ function foo(x) {
 
 
 if(y) {
+   console.log('foo');
+}
+```
+
+Examples of **correct** code for this rule with the options `2, { "outerIIFEBody":  "off" }`:
+
+```js
+/*eslint indent: ["error", 2, { "outerIIFEBody": "off" }]*/
+
+(function() {
+
+function foo(x) {
+  return x + 1;
+}
+
+})();
+
+(function() {
+
+  function foo(x) {
+    return x + 1;
+  }
+
+})();
+
+
+if (y) {
+console.log('foo');
+}
+
+if (y) {
    console.log('foo');
 }
 ```

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -540,8 +540,15 @@ module.exports = {
                         ]
                     },
                     outerIIFEBody: {
-                        type: "integer",
-                        minimum: 0
+                        oneOf: [
+                            {
+                                type: "integer",
+                                minimum: 0
+                            },
+                            {
+                                enum: ["off"]
+                            }
+                        ]
                     },
                     MemberExpression: {
                         oneOf: [
@@ -1092,7 +1099,6 @@ module.exports = {
             },
 
             "BlockStatement, ClassBody"(node) {
-
                 let blockIndentLevel;
 
                 if (node.parent && isOuterIIFE(node.parent)) {
@@ -1112,6 +1118,7 @@ module.exports = {
                 if (!astUtils.STATEMENT_LIST_PARENTS.has(node.parent.type)) {
                     offsets.setDesiredOffset(sourceCode.getFirstToken(node), sourceCode.getFirstToken(node.parent), 0);
                 }
+
                 addElementListIndent(node.body, sourceCode.getFirstToken(node), sourceCode.getLastToken(node), blockIndentLevel);
             },
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1788,6 +1788,49 @@ ruleTester.run("indent", rule, {
             options: [2, { outerIIFEBody: 0 }]
         },
         {
+            code: unIndent`
+                (function(x) {
+                    return x + 1;
+                })();
+            `,
+            options: [4, { outerIIFEBody: "off" }]
+        },
+        {
+            code: unIndent`
+                (function(x) {
+                return x + 1;
+                })();
+            `,
+            options: [4, { outerIIFEBody: "off" }]
+        },
+        {
+            code: unIndent`
+                ;(() => {
+                    function x(y) {
+                        return y + 1;
+                    }
+                })();
+            `,
+            options: [4, { outerIIFEBody: "off" }]
+        },
+        {
+            code: unIndent`
+                ;(() => {
+                function x(y) {
+                    return y + 1;
+                }
+                })();
+            `,
+            options: [4, { outerIIFEBody: "off" }]
+        },
+        {
+            code: unIndent`
+                function foo() {
+                }
+            `,
+            options: [4, { outerIIFEBody: "off" }]
+        },
+        {
             code: "Buffer.length",
             options: [4, { MemberExpression: 1 }]
         },
@@ -6985,6 +7028,78 @@ ruleTester.run("indent", rule, {
             `,
             options: ["tab", { outerIIFEBody: 3 }],
             errors: expectedErrors("tab", [[3, 2, 4, "Keyword"]])
+        },
+        {
+            code: unIndent`
+                (function(){
+                    function foo(x) {
+                    return x + 1;
+                    }
+                })();
+            `,
+            output: unIndent`
+                (function(){
+                    function foo(x) {
+                        return x + 1;
+                    }
+                })();
+            `,
+            options: [4, { outerIIFEBody: "off" }],
+            errors: expectedErrors([[3, 8, 4, "Keyword"]])
+        },
+        {
+            code: unIndent`
+                (function(){
+                function foo(x) {
+                return x + 1;
+                }
+                })();
+            `,
+            output: unIndent`
+                (function(){
+                function foo(x) {
+                    return x + 1;
+                }
+                })();
+            `,
+            options: [4, { outerIIFEBody: "off" }],
+            errors: expectedErrors([[3, 4, 0, "Keyword"]])
+        },
+        {
+            code: unIndent`
+                (() => {
+                    function foo(x) {
+                    return x + 1;
+                    }
+                })();
+            `,
+            output: unIndent`
+                (() => {
+                    function foo(x) {
+                        return x + 1;
+                    }
+                })();
+            `,
+            options: [4, { outerIIFEBody: "off" }],
+            errors: expectedErrors([[3, 8, 4, "Keyword"]])
+        },
+        {
+            code: unIndent`
+                (() => {
+                function foo(x) {
+                return x + 1;
+                }
+                })();
+            `,
+            output: unIndent`
+                (() => {
+                function foo(x) {
+                    return x + 1;
+                }
+                })();
+            `,
+            options: [4, { outerIIFEBody: "off" }],
+            errors: expectedErrors([[3, 4, 0, "Keyword"]])
         },
         {
             code: unIndent`


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->
fixes #11377 

**What changes did you make? (Give an overview)**
This PR adds the ability to set the `outerIIFEBody`  to `"off"`. This was a lot easier than I expected - the logic already allows for this, so I just needed to add the option to the JSON schema. 

**Is there anything you'd like reviewers to focus on?**
Nothing in particular!
