### PR TITLE
Chore: fix separateRequires tests for one-var rule

### DIFF
--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -201,13 +201,11 @@ ruleTester.run("one-var", rule, {
         },
         {
             code: "var foo = require('foo'), bar;",
-            options: [{ separateRequires: false, var: "always" }],
-            parserOptions: { env: { node: true } }
+            options: [{ separateRequires: false, var: "always" }]
         },
         {
             code: "var foo = require('foo'), bar = require('bar');",
-            options: [{ separateRequires: true, var: "always" }],
-            parserOptions: { env: { node: true } }
+            options: [{ separateRequires: true, var: "always" }]
         },
         {
             code: "var bar = 'bar'; var foo = require('foo');",
@@ -216,11 +214,6 @@ ruleTester.run("one-var", rule, {
         {
             code: "var foo = require('foo'); var bar = 'bar';",
             options: [{ separateRequires: true, var: "always" }]
-        },
-        {
-            code: "var foo = require('foo'); var bar = 'bar';",
-            options: [{ separateRequires: true, var: "always" }],
-            parserOptions: { env: { node: true } }
         },
 
         // https://github.com/eslint/eslint/issues/4680
@@ -968,7 +961,6 @@ ruleTester.run("one-var", rule, {
             code: "var foo = require('foo'), bar;",
             output: null,
             options: [{ separateRequires: true, var: "always" }],
-            parserOptions: { env: { node: true } },
             errors: [{
                 message: "Split requires to be separated into a single block.",
                 type: "VariableDeclaration",
@@ -980,7 +972,6 @@ ruleTester.run("one-var", rule, {
             code: "var foo, bar = require('bar');",
             output: null,
             options: [{ separateRequires: true, var: "always" }],
-            parserOptions: { env: { node: true } },
             errors: [{
                 message: "Split requires to be separated into a single block.",
                 type: "VariableDeclaration",
@@ -992,7 +983,6 @@ ruleTester.run("one-var", rule, {
             code: "let foo, bar = require('bar');",
             output: null,
             options: [{ separateRequires: true, let: "always" }],
-            parserOptions: { env: { node: true } },
             errors: [{
                 message: "Split requires to be separated into a single block.",
                 type: "VariableDeclaration",
@@ -1004,7 +994,6 @@ ruleTester.run("one-var", rule, {
             code: "const foo = 0, bar = require('bar');",
             output: null,
             options: [{ separateRequires: true, const: "always" }],
-            parserOptions: { env: { node: true } },
             errors: [{
                 message: "Split requires to be separated into a single block.",
                 type: "VariableDeclaration",
@@ -1016,7 +1005,6 @@ ruleTester.run("one-var", rule, {
             code: "const foo = require('foo'); const bar = require('bar');",
             output: "const foo = require('foo'),  bar = require('bar');",
             options: [{ separateRequires: true, const: "always" }],
-            parserOptions: { env: { node: true } },
             errors: [{
                 message: "Combine this with the previous 'const' statement.",
                 type: "VariableDeclaration",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain:

Some tests for the `separateRequires` option of the `one-var` rule had this:

```js
parserOptions: { env: { node: true } }
```

These are incorrect settings because `env` shouldn't be in `parserOptions`. It's just ignored as an unknown parser option.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Since the tests are passing without the `node` environment being actually set, I wasn't sure if the rule was working as intended. In particular, should the option apply to _global_ `require` or any `require` call.

By #9441, in particular [this thread](https://github.com/eslint/eslint/pull/9441#pullrequestreview-76335806) and [this comment](https://github.com/eslint/eslint/pull/9441#discussion_r158590263) it seems that the rule wasn't supposed to check if the `require` reference is global, so instead of fixing `env` I just removed these.

**Is there anything you'd like reviewers to focus on?**

One test became a duplicate, so it's completely removed.


