### PR TITLE
Chore: Refactor to use messageId in a number of rules

### DIFF
--- a/lib/rules/no-func-assign.js
+++ b/lib/rules/no-func-assign.js
@@ -22,7 +22,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-func-assign"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            isAFunction: "'{{name}}' is a function."
+        }
     },
 
     create(context) {
@@ -34,7 +38,13 @@ module.exports = {
          */
         function checkReference(references) {
             astUtils.getModifyingReferences(references).forEach(reference => {
-                context.report({ node: reference.identifier, message: "'{{name}}' is a function.", data: { name: reference.identifier.name } });
+                context.report({
+                    node: reference.identifier,
+                    messageId: "isAFunction",
+                    data: {
+                        name: reference.identifier.name
+                    }
+                });
             });
         }
 

--- a/lib/rules/no-global-assign.js
+++ b/lib/rules/no-global-assign.js
@@ -32,7 +32,11 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        messages: {
+            globalShouldNotBeModified: "Read-only global '{{name}}' should not be modified."
+        }
     },
 
     create(context) {
@@ -60,8 +64,10 @@ module.exports = {
             ) {
                 context.report({
                     node: identifier,
-                    message: "Read-only global '{{name}}' should not be modified.",
-                    data: identifier
+                    messageId: "globalShouldNotBeModified",
+                    data: {
+                        name: identifier.name
+                    }
                 });
             }
         }

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -187,7 +187,11 @@ module.exports = {
                 }
             },
             additionalProperties: false
-        }]
+        }],
+
+        messages: {
+            useRecommendation: "use `{{recommendation}}` instead."
+        }
     },
 
     create(context) {
@@ -204,7 +208,7 @@ module.exports = {
         function report(node, recommendation, shouldFix) {
             context.report({
                 node,
-                message: "use `{{recommendation}}` instead.",
+                messageId: "useRecommendation",
                 data: {
                     recommendation
                 },

--- a/lib/rules/no-implied-eval.js
+++ b/lib/rules/no-implied-eval.js
@@ -20,7 +20,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-implied-eval"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            impliedEval: "Implied eval. Consider passing a function instead of a string."
+        }
     },
 
     create(context) {
@@ -107,7 +111,10 @@ module.exports = {
                 // remove the entire substack, to avoid duplicate reports
                 const substack = impliedEvalAncestorsStack.pop();
 
-                context.report({ node: substack[0], message: "Implied eval. Consider passing a function instead of a string." });
+                context.report({
+                    node: substack[0],
+                    messageId: "impliedEval"
+                });
             }
         }
 

--- a/lib/rules/no-inline-comments.js
+++ b/lib/rules/no-inline-comments.js
@@ -21,7 +21,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-inline-comments"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            unexpectedInlineComment: "Unexpected comment inline with code."
+        }
     },
 
     create(context) {
@@ -64,7 +68,10 @@ module.exports = {
                 return;
             }
 
-            context.report({ node, message: "Unexpected comment inline with code." });
+            context.report({
+                node,
+                messageId: "unexpectedInlineComment"
+            });
         }
 
         //--------------------------------------------------------------------------

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -24,7 +24,11 @@ module.exports = {
             {
                 enum: ["functions", "both"]
             }
-        ]
+        ],
+
+        messages: {
+            moveDeclToRoot: "Move {{type}} declaration to {{body}} root."
+        }
     },
 
     create(context) {
@@ -68,7 +72,7 @@ module.exports = {
             if (!valid) {
                 context.report({
                     node,
-                    message: "Move {{type}} declaration to {{body}} root.",
+                    messageId: "moveDeclToRoot",
                     data: {
                         type: (node.type === "FunctionDeclaration" ? "function" : "variable"),
                         body: (body.type === "Program" ? "program" : "function body")

--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -40,6 +40,8 @@ module.exports = {
             },
             additionalProperties: false
         }]
+
+        // no messages, because the error text comes directly from the regexpp module
     },
 
     create(context) {

--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -37,7 +37,11 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        messages: {
+            unexpectedThis: "Unexpected 'this'."
+        }
     },
 
     create(context) {
@@ -130,7 +134,10 @@ module.exports = {
                 const current = stack.getCurrent();
 
                 if (current && !current.valid) {
-                    context.report({ node, message: "Unexpected 'this'." });
+                    context.report({
+                        node,
+                        messageId: "unexpectedThis"
+                    });
                 }
             }
         };

--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -59,7 +59,11 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        messages: {
+            noIrregularWhitespace: "Irregular whitespace not allowed."
+        }
     },
 
     create(context) {
@@ -161,7 +165,11 @@ module.exports = {
                         column: match.index
                     };
 
-                    errors.push({ node, message: "Irregular whitespace not allowed.", loc: location });
+                    errors.push({
+                        node,
+                        messageId: "noIrregularWhitespace",
+                        loc: location
+                    });
                 }
             });
         }
@@ -186,7 +194,11 @@ module.exports = {
                     column: sourceLines[lineIndex].length
                 };
 
-                errors.push({ node, message: "Irregular whitespace not allowed.", loc: location });
+                errors.push({
+                    node,
+                    messageId: "noIrregularWhitespace",
+                    loc: location
+                });
                 lastLineIndex = lineIndex;
             }
         }

--- a/lib/rules/no-iterator.js
+++ b/lib/rules/no-iterator.js
@@ -20,7 +20,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-iterator"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            noIterator: "Reserved name '__iterator__'."
+        }
     },
 
     create(context) {
@@ -32,7 +36,10 @@ module.exports = {
                 if (node.property &&
                         (node.property.type === "Identifier" && node.property.name === "__iterator__" && !node.computed) ||
                         (node.property.type === "Literal" && node.property.value === "__iterator__")) {
-                    context.report({ node, message: "Reserved name '__iterator__'." });
+                    context.report({
+                        node,
+                        messageId: "noIterator"
+                    });
                 }
             }
         };

--- a/lib/rules/no-label-var.js
+++ b/lib/rules/no-label-var.js
@@ -26,7 +26,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-label-var"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            identifierClashWithLabel: "Found identifier with same name as label."
+        }
     },
 
     create(context) {
@@ -62,7 +66,10 @@ module.exports = {
                  * with the innermost scope.
                  */
                 if (findIdentifier(scope, node.label.name)) {
-                    context.report({ node, message: "Found identifier with same name as label." });
+                    context.report({
+                        node,
+                        messageId: "identifierClashWithLabel"
+                    });
                 }
             }
 

--- a/lib/rules/no-labels.js
+++ b/lib/rules/no-labels.js
@@ -40,7 +40,13 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        messages: {
+            unexpectedLabel: "Unexpected labeled statement.",
+            unexpectedLabelInBreak: "Unexpected label in break statement.",
+            unexpectedLabelInContinue: "Unexpected label in continue statement."
+        }
     },
 
     create(context) {
@@ -113,7 +119,7 @@ module.exports = {
                 if (!isAllowed(scopeInfo.kind)) {
                     context.report({
                         node,
-                        message: "Unexpected labeled statement."
+                        messageId: "unexpectedLabel"
                     });
                 }
 
@@ -124,7 +130,7 @@ module.exports = {
                 if (node.label && !isAllowed(getKind(node.label.name))) {
                     context.report({
                         node,
-                        message: "Unexpected label in break statement."
+                        messageId: "unexpectedLabelInBreak"
                     });
                 }
             },
@@ -133,7 +139,7 @@ module.exports = {
                 if (node.label && !isAllowed(getKind(node.label.name))) {
                     context.report({
                         node,
-                        message: "Unexpected label in continue statement."
+                        messageId: "unexpectedLabelInContinue"
                     });
                 }
             }

--- a/lib/rules/no-lone-blocks.js
+++ b/lib/rules/no-lone-blocks.js
@@ -20,7 +20,12 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-lone-blocks"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            redundantBlock: "Block is redundant.",
+            redundantNestedBlock: "Nested block is redundant."
+        }
     },
 
     create(context) {
@@ -35,9 +40,12 @@ module.exports = {
          * @returns {void}
          */
         function report(node) {
-            const message = node.parent.type === "BlockStatement" ? "Nested block is redundant." : "Block is redundant.";
+            const messageId = node.parent.type === "BlockStatement" ? "redundantNestedBlock" : "redundantBlock";
 
-            context.report({ node, message });
+            context.report({
+                node,
+                messageId
+            });
         }
 
         /**

--- a/lib/rules/no-lonely-if.js
+++ b/lib/rules/no-lonely-if.js
@@ -20,7 +20,11 @@ module.exports = {
         },
 
         schema: [],
-        fixable: "code"
+        fixable: "code",
+
+        messages: {
+            unexpectedLonelyIf: "Unexpected if as the only statement in an else block."
+        }
     },
 
     create(context) {
@@ -38,7 +42,7 @@ module.exports = {
                         parent === grandparent.alternate) {
                     context.report({
                         node,
-                        message: "Unexpected if as the only statement in an else block.",
+                        messageId: "unexpectedLonelyIf",
                         fix(fixer) {
                             const openingElseCurly = sourceCode.getFirstToken(parent);
                             const closingElseCurly = sourceCode.getLastToken(parent);

--- a/lib/rules/no-mixed-operators.js
+++ b/lib/rules/no-mixed-operators.js
@@ -112,7 +112,11 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        messages: {
+            unexpectedMixedOperator: "Unexpected mix of '{{leftOperator}}' and '{{rightOperator}}'."
+        }
     },
 
     create(context) {
@@ -188,8 +192,6 @@ module.exports = {
             const parent = node.parent;
             const left = (getChildNode(parent) === node) ? node : parent;
             const right = (getChildNode(parent) !== node) ? node : parent;
-            const message =
-                "Unexpected mix of '{{leftOperator}}' and '{{rightOperator}}'.";
             const data = {
                 leftOperator: left.operator || "?:",
                 rightOperator: right.operator || "?:"
@@ -198,13 +200,13 @@ module.exports = {
             context.report({
                 node: left,
                 loc: getOperatorToken(left).loc,
-                message,
+                messageId: "unexpectedMixedOperator",
                 data
             });
             context.report({
                 node: right,
                 loc: getOperatorToken(right).loc,
-                message,
+                messageId: "unexpectedMixedOperator",
                 data
             });
         }

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -40,7 +40,12 @@ module.exports = {
                     }
                 ]
             }
-        ]
+        ],
+
+        messages: {
+            noMixRequire: "Do not mix 'require' and other declarations.",
+            noMixCoreModuleFileComputed: "Do not mix core, module, file and computed requires."
+        }
     },
 
     create(context) {
@@ -211,9 +216,15 @@ module.exports = {
             VariableDeclaration(node) {
 
                 if (isMixed(node.declarations)) {
-                    context.report({ node, message: "Do not mix 'require' and other declarations." });
+                    context.report({
+                        node,
+                        messageId: "noMixRequire"
+                    });
                 } else if (grouping && !isGrouped(node.declarations)) {
-                    context.report({ node, message: "Do not mix core, module, file and computed requires." });
+                    context.report({
+                        node,
+                        messageId: "noMixCoreModuleFileComputed"
+                    });
                 }
             }
         };

--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -23,7 +23,11 @@ module.exports = {
             {
                 enum: ["smart-tabs", true, false]
             }
-        ]
+        ],
+
+        messages: {
+            mixedSpacesAndTabs: "Mixed spaces and tabs."
+        }
     },
 
     create(context) {
@@ -86,7 +90,11 @@ module.exports = {
                             const containingNode = sourceCode.getNodeByRangeIndex(sourceCode.getIndexFromLoc(loc));
 
                             if (!(containingNode && ["Literal", "TemplateElement"].includes(containingNode.type))) {
-                                context.report({ node, loc, message: "Mixed spaces and tabs." });
+                                context.report({
+                                    node,
+                                    loc,
+                                    messageId: "mixedSpacesAndTabs"
+                                });
                             }
                         }
                     }

--- a/lib/rules/no-multi-assign.js
+++ b/lib/rules/no-multi-assign.js
@@ -21,7 +21,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-multi-assign"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            unexpectedChain: "Unexpected chained assignment."
+        }
     },
 
     create(context) {
@@ -35,7 +39,7 @@ module.exports = {
                 if (["AssignmentExpression", "VariableDeclarator"].indexOf(node.parent.type) !== -1) {
                     context.report({
                         node,
-                        message: "Unexpected chained assignment."
+                        messageId: "unexpectedChain"
                     });
                 }
             }

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -44,7 +44,11 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        messages: {
+            multipleSpaces: "Multiple spaces found before '{{displayValue}}'."
+        }
     },
 
     create(context) {
@@ -122,7 +126,7 @@ module.exports = {
                     context.report({
                         node: rightToken,
                         loc: { start: leftToken.loc.end, end: rightToken.loc.start },
-                        message: "Multiple spaces found before '{{displayValue}}'.",
+                        messageId: "multipleSpaces",
                         data: { displayValue },
                         fix: fixer => fixer.replaceTextRange([leftToken.range[1], rightToken.range[0]], " ")
                     });

--- a/lib/rules/no-multi-str.js
+++ b/lib/rules/no-multi-str.js
@@ -26,7 +26,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-multi-str"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            multilineString: "Multiline support is limited to browsers supporting ES5 only."
+        }
     },
 
     create(context) {
@@ -49,7 +53,10 @@ module.exports = {
 
             Literal(node) {
                 if (astUtils.LINEBREAK_MATCHER.test(node.raw) && !isJSXElement(node.parent)) {
-                    context.report({ node, message: "Multiline support is limited to browsers supporting ES5 only." });
+                    context.report({
+                        node,
+                        messageId: "multilineString"
+                    });
                 }
             }
         };

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -42,7 +42,13 @@ module.exports = {
                 required: ["max"],
                 additionalProperties: false
             }
-        ]
+        ],
+
+        messages: {
+            blankBeginningOfFile: "Too many blank lines at the beginning of file. Max of {{max}} allowed.",
+            blankEndOfFile: "Too many blank lines at the end of file. Max of {{max}} allowed.",
+            consecutiveBlank: "More than {{max}} blank {{pluralizedLines}} not allowed."
+        }
     },
 
     create(context) {
@@ -94,25 +100,31 @@ module.exports = {
 
                     // Given two line numbers of non-empty lines, report the lines between if the difference is too large.
                     .reduce((lastLineNumber, lineNumber) => {
-                        let message, maxAllowed;
+                        let messageId, maxAllowed;
 
                         if (lastLineNumber === 0) {
-                            message = "Too many blank lines at the beginning of file. Max of {{max}} allowed.";
+                            messageId = "blankBeginningOfFile";
                             maxAllowed = maxBOF;
                         } else if (lineNumber === allLines.length + 1) {
-                            message = "Too many blank lines at the end of file. Max of {{max}} allowed.";
+                            messageId = "blankEndOfFile";
                             maxAllowed = maxEOF;
                         } else {
-                            message = "More than {{max}} blank {{pluralizedLines}} not allowed.";
+                            messageId = "consecutiveBlank";
                             maxAllowed = max;
                         }
 
                         if (lineNumber - lastLineNumber - 1 > maxAllowed) {
                             context.report({
                                 node,
-                                loc: { start: { line: lastLineNumber + maxAllowed + 1, column: 0 }, end: { line: lineNumber, column: 0 } },
-                                message,
-                                data: { max: maxAllowed, pluralizedLines: maxAllowed === 1 ? "line" : "lines" },
+                                loc: {
+                                    start: { line: lastLineNumber + maxAllowed + 1, column: 0 },
+                                    end: { line: lineNumber, column: 0 }
+                                },
+                                messageId,
+                                data: {
+                                    max: maxAllowed,
+                                    pluralizedLines: maxAllowed === 1 ? "line" : "lines"
+                                },
                                 fix(fixer) {
                                     const rangeStart = sourceCode.getIndexFromLoc({ line: lastLineNumber + 1, column: 0 });
 

--- a/lib/rules/no-negated-condition.js
+++ b/lib/rules/no-negated-condition.js
@@ -19,7 +19,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-negated-condition"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            unexpectedNegated: "Unexpected negated condition."
+        }
     },
 
     create(context) {
@@ -72,12 +76,18 @@ module.exports = {
                 }
 
                 if (isNegatedIf(node)) {
-                    context.report({ node, message: "Unexpected negated condition." });
+                    context.report({
+                        node,
+                        messageId: "unexpectedNegated"
+                    });
                 }
             },
             ConditionalExpression(node) {
                 if (isNegatedIf(node)) {
-                    context.report({ node, message: "Unexpected negated condition." });
+                    context.report({
+                        node,
+                        messageId: "unexpectedNegated"
+                    });
                 }
             }
         };

--- a/lib/rules/no-nested-ternary.js
+++ b/lib/rules/no-nested-ternary.js
@@ -20,7 +20,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-nested-ternary"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            noNestedTernary: "Do not nest ternary expressions."
+        }
     },
 
     create(context) {
@@ -29,7 +33,10 @@ module.exports = {
             ConditionalExpression(node) {
                 if (node.alternate.type === "ConditionalExpression" ||
                         node.consequent.type === "ConditionalExpression") {
-                    context.report({ node, message: "Do not nest ternary expressions." });
+                    context.report({
+                        node,
+                        messageId: "noNestedTernary"
+                    });
                 }
             }
         };

--- a/lib/rules/no-new-func.js
+++ b/lib/rules/no-new-func.js
@@ -20,7 +20,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-new-func"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            noFunctionConstructor: "The Function constructor is eval."
+        }
     },
 
     create(context) {
@@ -36,7 +40,10 @@ module.exports = {
          * @private
          */
         function report(node) {
-            context.report({ node, message: "The Function constructor is eval." });
+            context.report({
+                node,
+                messageId: "noFunctionConstructor"
+            });
         }
 
         return {

--- a/lib/rules/no-new-object.js
+++ b/lib/rules/no-new-object.js
@@ -20,7 +20,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-new-object"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            preferLiteral: "The object literal notation {} is preferrable."
+        }
     },
 
     create(context) {
@@ -29,7 +33,10 @@ module.exports = {
 
             NewExpression(node) {
                 if (node.callee.name === "Object") {
-                    context.report({ node, message: "The object literal notation {} is preferrable." });
+                    context.report({
+                        node,
+                        messageId: "preferLiteral"
+                    });
                 }
             }
         };

--- a/lib/rules/no-new-require.js
+++ b/lib/rules/no-new-require.js
@@ -20,7 +20,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-new-require"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            noNewRequire: "Unexpected use of new with require."
+        }
     },
 
     create(context) {
@@ -29,7 +33,10 @@ module.exports = {
 
             NewExpression(node) {
                 if (node.callee.type === "Identifier" && node.callee.name === "require") {
-                    context.report({ node, message: "Unexpected use of new with require." });
+                    context.report({
+                        node,
+                        messageId: "noNewRequire"
+                    });
                 }
             }
         };

--- a/lib/rules/no-new-symbol.js
+++ b/lib/rules/no-new-symbol.js
@@ -20,7 +20,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-new-symbol"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            noNewSymbol: "`Symbol` cannot be called as a constructor."
+        }
     },
 
     create(context) {
@@ -35,7 +39,10 @@ module.exports = {
                         const node = ref.identifier;
 
                         if (node.parent && node.parent.type === "NewExpression") {
-                            context.report({ node, message: "`Symbol` cannot be called as a constructor." });
+                            context.report({
+                                node,
+                                messageId: "noNewSymbol"
+                            });
                         }
                     });
                 }

--- a/lib/rules/no-new-wrappers.js
+++ b/lib/rules/no-new-wrappers.js
@@ -20,7 +20,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-new-wrappers"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            noConstructor: "Do not use {{fn}} as a constructor."
+        }
     },
 
     create(context) {
@@ -31,7 +35,11 @@ module.exports = {
                 const wrapperObjects = ["String", "Number", "Boolean", "Math", "JSON"];
 
                 if (wrapperObjects.indexOf(node.callee.name) > -1) {
-                    context.report({ node, message: "Do not use {{fn}} as a constructor.", data: { fn: node.callee.name } });
+                    context.report({
+                        node,
+                        messageId: "noConstructor",
+                        data: { fn: node.callee.name }
+                    });
                 }
             }
         };

--- a/lib/rules/no-new.js
+++ b/lib/rules/no-new.js
@@ -21,14 +21,21 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-new"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            noNewStatement: "Do not use 'new' for side effects."
+        }
     },
 
     create(context) {
 
         return {
             "ExpressionStatement > NewExpression"(node) {
-                context.report({ node: node.parent, message: "Do not use 'new' for side effects." });
+                context.report({
+                    node: node.parent,
+                    messageId: "noNewStatement"
+                });
             }
         };
 

--- a/lib/rules/no-octal.js
+++ b/lib/rules/no-octal.js
@@ -20,7 +20,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-octal"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            noOcatal: "Octal literals should not be used."
+        }
     },
 
     create(context) {
@@ -29,7 +33,10 @@ module.exports = {
 
             Literal(node) {
                 if (typeof node.value === "number" && /^0[0-9]/u.test(node.raw)) {
-                    context.report({ node, message: "Octal literals should not be used." });
+                    context.report({
+                        node,
+                        messageId: "noOcatal"
+                    });
                 }
             }
         };

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -58,7 +58,12 @@ module.exports = {
                     }
                 ]
             }
-        ]
+        ],
+
+        messages: {
+            assignmentToFunctionParam: "Assignment to function parameter '{{name}}'.",
+            assignmentToFunctionParamProp: "Assignment to property of function parameter '{{name}}'."
+        }
     },
 
     create(context) {
@@ -177,9 +182,17 @@ module.exports = {
                 (index === 0 || references[index - 1].identifier !== identifier)
             ) {
                 if (reference.isWrite()) {
-                    context.report({ node: identifier, message: "Assignment to function parameter '{{name}}'.", data: { name: identifier.name } });
+                    context.report({
+                        node: identifier,
+                        messageId: "assignmentToFunctionParam",
+                        data: { name: identifier.name }
+                    });
                 } else if (props && isModifyingProp(reference) && !isIgnoredPropertyAssignment(identifier.name)) {
-                    context.report({ node: identifier, message: "Assignment to property of function parameter '{{name}}'.", data: { name: identifier.name } });
+                    context.report({
+                        node: identifier,
+                        messageId: "assignmentToFunctionParamProp",
+                        data: { name: identifier.name }
+                    });
                 }
             }
         }

--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -19,7 +19,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-path-concat"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            usePathFunctions: "Use path.join() or path.resolve() instead of + to create paths."
+        }
     },
 
     create(context) {
@@ -42,7 +46,10 @@ module.exports = {
                         (right.type === "Identifier" && MATCHER.test(right.name)))
                 ) {
 
-                    context.report({ node, message: "Use path.join() or path.resolve() instead of + to create paths." });
+                    context.report({
+                        node,
+                        messageId: "usePathFunctions"
+                    });
                 }
             }
 

--- a/lib/rules/no-plusplus.js
+++ b/lib/rules/no-plusplus.js
@@ -32,7 +32,11 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        messages: {
+            unexpectedUnaryOp: "Unary operator '{{operator}}' used."
+        }
     },
 
     create(context) {
@@ -52,7 +56,7 @@ module.exports = {
                 }
                 context.report({
                     node,
-                    message: "Unary operator '{{operator}}' used.",
+                    messageId: "unexpectedUnaryOp",
                     data: {
                         operator: node.operator
                     }

--- a/lib/rules/no-restricted-globals.js
+++ b/lib/rules/no-restricted-globals.js
@@ -5,13 +5,6 @@
 "use strict";
 
 //------------------------------------------------------------------------------
-// Helpers
-//------------------------------------------------------------------------------
-
-const DEFAULT_MESSAGE_TEMPLATE = "Unexpected use of '{{name}}'.",
-    CUSTOM_MESSAGE_TEMPLATE = "Unexpected use of '{{name}}'. {{customMessage}}";
-
-//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -46,6 +39,12 @@ module.exports = {
             },
             uniqueItems: true,
             minItems: 0
+        },
+
+        messages: {
+            defaultMessage: "Unexpected use of '{{name}}'.",
+            // eslint-disable-next-line eslint-plugin/report-message-format
+            customMessage: "Unexpected use of '{{name}}'. {{customMessage}}"
         }
     },
 
@@ -75,13 +74,13 @@ module.exports = {
         function reportReference(reference) {
             const name = reference.identifier.name,
                 customMessage = restrictedGlobalMessages[name],
-                message = customMessage
-                    ? CUSTOM_MESSAGE_TEMPLATE
-                    : DEFAULT_MESSAGE_TEMPLATE;
+                messageId = customMessage
+                    ? "customMessage"
+                    : "defaultMessage";
 
             context.report({
                 node: reference.identifier,
-                message,
+                messageId,
                 data: {
                     name,
                     customMessage

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -41,7 +41,11 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        messages: {
+            noShadow: "'{{name}}' is already declared in the upper scope."
+        }
     },
 
     create(context) {
@@ -163,7 +167,7 @@ module.exports = {
                 ) {
                     context.report({
                         node: variable.identifiers[0],
-                        message: "'{{name}}' is already declared in the upper scope.",
+                        messageId: "noShadow",
                         data: variable
                     });
                 }

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -157,7 +157,11 @@ module.exports = {
                     }
                 ]
             }
-        ]
+        ],
+
+        messages: {
+            usedBeforeDefined: "'{{name}}' was used before it was defined."
+        }
     },
 
     create(context) {
@@ -212,7 +216,7 @@ module.exports = {
                 // Reports.
                 context.report({
                     node: reference.identifier,
-                    message: "'{{name}}' was used before it was defined.",
+                    messageId: "usedBeforeDefined",
                     data: reference.identifier
                 });
             });

--- a/lib/rules/no-useless-constructor.js
+++ b/lib/rules/no-useless-constructor.js
@@ -143,7 +143,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-useless-constructor"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            noUselessConstructor: "Useless constructor."
+        }
     },
 
     create(context) {
@@ -165,7 +169,7 @@ module.exports = {
             if (superClass ? isRedundantSuperCall(body, ctorParams) : (body.length === 0)) {
                 context.report({
                     node,
-                    message: "Useless constructor."
+                    messageId: "noUselessConstructor"
                 });
             }
         }

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -110,7 +110,11 @@ module.exports = {
                     }
                 ]
             }
-        ]
+        ],
+
+        messages: {
+            wrongQuotes: "Strings must use {{description}}."
+        }
     },
 
     create(context) {
@@ -273,7 +277,7 @@ module.exports = {
                     if (!isValid) {
                         context.report({
                             node,
-                            message: "Strings must use {{description}}.",
+                            messageId: "wrongQuotes",
                             data: {
                                 description: settings.description
                             },
@@ -304,7 +308,7 @@ module.exports = {
 
                 context.report({
                     node,
-                    message: "Strings must use {{description}}.",
+                    messageId: "wrongQuotes",
                     data: {
                         description: settings.description
                     },

--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -39,7 +39,11 @@ module.exports = {
             url: "https://eslint.org/docs/rules/require-await"
         },
 
-        schema: []
+        schema: [],
+
+        messages: {
+            missingAwait: "{{name}} has no 'await' expression."
+        }
     },
 
     create(context) {
@@ -68,7 +72,7 @@ module.exports = {
                 context.report({
                     node,
                     loc: astUtils.getFunctionHeadLoc(node, sourceCode),
-                    message: "{{name}} has no 'await' expression.",
+                    messageId: "missingAwait",
                     data: {
                         name: capitalizeFirstLetter(
                             astUtils.getFunctionNameWithKind(node)

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -67,6 +67,11 @@ module.exports = {
                     maxItems: 2
                 }
             ]
+        },
+
+        messages: {
+            missingSemi: "Missing semicolon.",
+            extraSemi: "Extra semicolon."
         }
     },
 
@@ -91,12 +96,12 @@ module.exports = {
          */
         function report(node, missing) {
             const lastToken = sourceCode.getLastToken(node);
-            let message,
+            let messageId,
                 fix,
                 loc;
 
             if (!missing) {
-                message = "Missing semicolon.";
+                messageId = "missingSemi";
                 loc = {
                     start: lastToken.loc.end,
                     end: astUtils.getNextLocation(sourceCode, lastToken.loc.end)
@@ -105,7 +110,7 @@ module.exports = {
                     return fixer.insertTextAfter(lastToken, ";");
                 };
             } else {
-                message = "Extra semicolon.";
+                messageId = "extraSemi";
                 loc = lastToken.loc;
                 fix = function(fixer) {
 
@@ -123,7 +128,7 @@ module.exports = {
             context.report({
                 node,
                 loc,
-                message,
+                messageId,
                 fix
             });
 

--- a/tests/lib/rules/no-func-assign.js
+++ b/tests/lib/rules/no-func-assign.js
@@ -29,12 +29,65 @@ ruleTester.run("no-func-assign", rule, {
         { code: "import bar from 'bar'; function foo() { var foo = bar; }", parserOptions: { ecmaVersion: 6, sourceType: "module" } }
     ],
     invalid: [
-        { code: "function foo() {}; foo = bar;", errors: [{ message: "'foo' is a function.", type: "Identifier" }] },
-        { code: "function foo() { foo = bar; }", errors: [{ message: "'foo' is a function.", type: "Identifier" }] },
-        { code: "foo = bar; function foo() { };", errors: [{ message: "'foo' is a function.", type: "Identifier" }] },
-        { code: "[foo] = bar; function foo() { };", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'foo' is a function.", type: "Identifier" }] },
-        { code: "({x: foo = 0} = bar); function foo() { };", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'foo' is a function.", type: "Identifier" }] },
-        { code: "function foo() { [foo] = bar; }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'foo' is a function.", type: "Identifier" }] },
-        { code: "(function() { ({x: foo = 0} = bar); function foo() { }; })();", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'foo' is a function.", type: "Identifier" }] }
+        {
+            code: "function foo() {}; foo = bar;",
+            errors: [{
+                messageId: "isAFunction",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "function foo() { foo = bar; }",
+            errors: [{
+                messageId: "isAFunction",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "foo = bar; function foo() { };",
+            errors: [{
+                messageId: "isAFunction",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "[foo] = bar; function foo() { };",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "isAFunction",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "({x: foo = 0} = bar); function foo() { };",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "isAFunction",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "function foo() { [foo] = bar; }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "isAFunction",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "(function() { ({x: foo = 0} = bar); function foo() { }; })();",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "isAFunction",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-global-assign.js
+++ b/tests/lib/rules/no-global-assign.js
@@ -30,32 +30,98 @@ ruleTester.run("no-global-assign", rule, {
         "/*global a:true*/ a = 1"
     ],
     invalid: [
-        { code: "String = 'hello world';", errors: [{ message: "Read-only global 'String' should not be modified.", type: "Identifier" }] },
-        { code: "String++;", errors: [{ message: "Read-only global 'String' should not be modified.", type: "Identifier" }] },
+        {
+            code: "String = 'hello world';",
+            errors: [{
+                messageId: "globalShouldNotBeModified",
+                data: { name: "String" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "String++;",
+            errors: [{
+                messageId: "globalShouldNotBeModified",
+                data: { name: "String" },
+                type: "Identifier"
+            }]
+        },
         {
             code: "({Object = 0, String = 0} = {});",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Read-only global 'Object' should not be modified.", type: "Identifier" },
-                { message: "Read-only global 'String' should not be modified.", type: "Identifier" }
+                {
+                    messageId: "globalShouldNotBeModified",
+                    data: { name: "Object" },
+                    type: "Identifier"
+                },
+                {
+                    messageId: "globalShouldNotBeModified",
+                    data: { name: "String" },
+                    type: "Identifier"
+                }
             ]
         },
         {
             code: "top = 0;",
             env: { browser: true },
-            errors: [{ message: "Read-only global 'top' should not be modified.", type: "Identifier" }]
+            errors: [{
+                messageId: "globalShouldNotBeModified",
+                data: { name: "top" },
+                type: "Identifier"
+            }]
         },
         {
             code: "require = 0;",
             env: { node: true },
-            errors: [{ message: "Read-only global 'require' should not be modified.", type: "Identifier" }]
+            errors: [{
+                messageId: "globalShouldNotBeModified",
+                data: { name: "require" },
+                type: "Identifier"
+            }]
         },
 
         // Notifications of readonly are moved from no-undef: https://github.com/eslint/eslint/issues/4504
-        { code: "/*global b:false*/ function f() { b = 1; }", errors: [{ message: "Read-only global 'b' should not be modified.", type: "Identifier" }] },
-        { code: "function f() { b = 1; }", globals: { b: false }, errors: [{ message: "Read-only global 'b' should not be modified.", type: "Identifier" }] },
-        { code: "/*global b:false*/ function f() { b++; }", errors: [{ message: "Read-only global 'b' should not be modified.", type: "Identifier" }] },
-        { code: "/*global b*/ b = 1;", errors: [{ message: "Read-only global 'b' should not be modified.", type: "Identifier" }] },
-        { code: "Array = 1;", errors: [{ message: "Read-only global 'Array' should not be modified.", type: "Identifier" }] }
+        {
+            code: "/*global b:false*/ function f() { b = 1; }",
+            errors: [{
+                messageId: "globalShouldNotBeModified",
+                data: { name: "b" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "function f() { b = 1; }",
+            globals: { b: false },
+            errors: [{
+                messageId: "globalShouldNotBeModified",
+                data: { name: "b" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "/*global b:false*/ function f() { b++; }",
+            errors: [{
+                messageId: "globalShouldNotBeModified",
+                data: { name: "b" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "/*global b*/ b = 1;",
+            errors: [{
+                messageId: "globalShouldNotBeModified",
+                data: { name: "b" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "Array = 1;",
+            errors: [{
+                messageId: "globalShouldNotBeModified",
+                data: { name: "Array" },
+                type: "Identifier"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -94,149 +94,257 @@ ruleTester.run("no-implicit-coercion", rule, {
         {
             code: "!!foo",
             output: "Boolean(foo)",
-            errors: [{ message: "use `Boolean(foo)` instead.", type: "UnaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Boolean(foo)" },
+                type: "UnaryExpression"
+            }]
         },
         {
             code: "!!(foo + bar)",
             output: "Boolean(foo + bar)",
-            errors: [{ message: "use `Boolean(foo + bar)` instead.", type: "UnaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Boolean(foo + bar)" },
+                type: "UnaryExpression"
+            }]
         },
         {
             code: "~foo.indexOf(1)",
             output: null,
-            errors: [{ message: "use `foo.indexOf(1) !== -1` instead.", type: "UnaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "foo.indexOf(1) !== -1" },
+                type: "UnaryExpression"
+            }]
         },
         {
             code: "~foo.bar.indexOf(2)",
             output: null,
-            errors: [{ message: "use `foo.bar.indexOf(2) !== -1` instead.", type: "UnaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "foo.bar.indexOf(2) !== -1" },
+                type: "UnaryExpression"
+            }]
         },
         {
             code: "+foo",
             output: "Number(foo)",
-            errors: [{ message: "use `Number(foo)` instead.", type: "UnaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Number(foo)" },
+                type: "UnaryExpression"
+            }]
         },
         {
             code: "+foo.bar",
             output: "Number(foo.bar)",
-            errors: [{ message: "use `Number(foo.bar)` instead.", type: "UnaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Number(foo.bar)" },
+                type: "UnaryExpression"
+            }]
         },
         {
             code: "1*foo",
             output: "Number(foo)",
-            errors: [{ message: "use `Number(foo)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Number(foo)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "foo*1",
             output: "Number(foo)",
-            errors: [{ message: "use `Number(foo)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Number(foo)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "1*foo.bar",
             output: "Number(foo.bar)",
-            errors: [{ message: "use `Number(foo.bar)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Number(foo.bar)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "\"\"+foo",
             output: "String(foo)",
-            errors: [{ message: "use `String(foo)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(foo)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "``+foo",
             output: "String(foo)",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "use `String(foo)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(foo)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "foo+\"\"",
             output: "String(foo)",
-            errors: [{ message: "use `String(foo)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(foo)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "foo+``",
             output: "String(foo)",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "use `String(foo)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(foo)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "\"\"+foo.bar",
             output: "String(foo.bar)",
-            errors: [{ message: "use `String(foo.bar)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(foo.bar)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "``+foo.bar",
             output: "String(foo.bar)",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "use `String(foo.bar)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(foo.bar)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "foo.bar+\"\"",
             output: "String(foo.bar)",
-            errors: [{ message: "use `String(foo.bar)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(foo.bar)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "foo.bar+``",
             output: "String(foo.bar)",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "use `String(foo.bar)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(foo.bar)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "foo += \"\"",
             output: "foo = String(foo)",
-            errors: [{ message: "use `foo = String(foo)` instead.", type: "AssignmentExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "foo = String(foo)" },
+                type: "AssignmentExpression"
+            }]
         },
         {
             code: "foo += ``",
             output: "foo = String(foo)",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "use `foo = String(foo)` instead.", type: "AssignmentExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "foo = String(foo)" },
+                type: "AssignmentExpression"
+            }]
         },
         {
             code: "var a = !!foo",
             output: "var a = Boolean(foo)",
             options: [{ boolean: true, allow: ["~"] }],
-            errors: [{ message: "use `Boolean(foo)` instead.", type: "UnaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Boolean(foo)" },
+                type: "UnaryExpression"
+            }]
         },
         {
             code: "var a = ~foo.indexOf(1)",
             output: null,
             options: [{ boolean: true, allow: ["!!"] }],
-            errors: [{ message: "use `foo.indexOf(1) !== -1` instead.", type: "UnaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "foo.indexOf(1) !== -1" },
+                type: "UnaryExpression"
+            }]
         },
         {
             code: "var a = 1 * foo",
             output: "var a = Number(foo)",
             options: [{ boolean: true, allow: ["+"] }],
-            errors: [{ message: "use `Number(foo)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Number(foo)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "var a = +foo",
             output: "var a = Number(foo)",
             options: [{ boolean: true, allow: ["*"] }],
-            errors: [{ message: "use `Number(foo)` instead.", type: "UnaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Number(foo)" },
+                type: "UnaryExpression"
+            }]
         },
         {
             code: "var a = \"\" + foo",
             output: "var a = String(foo)",
             options: [{ boolean: true, allow: ["*"] }],
-            errors: [{ message: "use `String(foo)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(foo)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "var a = `` + foo",
             output: "var a = String(foo)",
             options: [{ boolean: true, allow: ["*"] }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "use `String(foo)` instead.", type: "BinaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(foo)" },
+                type: "BinaryExpression"
+            }]
         },
         {
             code: "typeof+foo",
             output: "typeof Number(foo)",
-            errors: [{ message: "use `Number(foo)` instead.", type: "UnaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Number(foo)" },
+                type: "UnaryExpression"
+            }]
         },
         {
             code: "typeof +foo",
             output: "typeof Number(foo)",
-            errors: [{ message: "use `Number(foo)` instead.", type: "UnaryExpression" }]
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Number(foo)" },
+                type: "UnaryExpression"
+            }]
         }
     ]
 });

--- a/tests/lib/rules/no-implied-eval.js
+++ b/tests/lib/rules/no-implied-eval.js
@@ -17,8 +17,7 @@ const rule = require("../../../lib/rules/no-implied-eval"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester(),
-    expectedErrorMessage = "Implied eval. Consider passing a function instead of a string.",
-    expectedError = { message: expectedErrorMessage, type: "CallExpression" };
+    expectedError = { messageId: "impliedEval", type: "CallExpression" };
 
 ruleTester.run("no-implied-eval", rule, {
     valid: [
@@ -90,14 +89,14 @@ ruleTester.run("no-implied-eval", rule, {
                 "})())",
             errors: [
                 {
-                    message: expectedErrorMessage,
+                    messageId: "impliedEval",
                     type: "CallExpression",
                     line: 1
                 },
 
                 // no error on line 2
                 {
-                    message: expectedErrorMessage,
+                    messageId: "impliedEval",
                     type: "CallExpression",
                     line: 3
                 }

--- a/tests/lib/rules/no-inline-comments.js
+++ b/tests/lib/rules/no-inline-comments.js
@@ -23,11 +23,11 @@ const ruleTester = new RuleTester({
         }
     }),
     lineError = {
-        message: "Unexpected comment inline with code.",
+        messageId: "unexpectedInlineComment",
         type: "Line"
     },
     blockError = {
-        message: "Unexpected comment inline with code.",
+        messageId: "unexpectedInlineComment",
         type: "Block"
     };
 

--- a/tests/lib/rules/no-inner-declarations.js
+++ b/tests/lib/rules/no-inner-declarations.js
@@ -54,40 +54,64 @@ ruleTester.run("no-inner-declarations", rule, {
         code: "if (test) { function doSomething() { } }",
         options: ["both"],
         errors: [{
-            message: "Move function declaration to program root.",
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "function",
+                body: "program"
+            },
             type: "FunctionDeclaration"
         }]
     }, {
         code: "function doSomething() { do { function somethingElse() { } } while (test); }",
         errors: [{
-            message: "Move function declaration to function body root.",
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "function",
+                body: "function body"
+            },
             type: "FunctionDeclaration"
         }]
     }, {
         code: "(function() { if (test) { function doSomething() { } } }());",
         errors: [{
-            message: "Move function declaration to function body root.",
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "function",
+                body: "function body"
+            },
             type: "FunctionDeclaration"
         }]
     }, {
         code: "while (test) { var foo; }",
         options: ["both"],
         errors: [{
-            message: "Move variable declaration to program root.",
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "variable",
+                body: "program"
+            },
             type: "VariableDeclaration"
         }]
     }, {
         code: "function doSomething() { if (test) { var foo = 42; } }",
         options: ["both"],
         errors: [{
-            message: "Move variable declaration to function body root.",
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "variable",
+                body: "function body"
+            },
             type: "VariableDeclaration"
         }]
     }, {
         code: "(function() { if (test) { var foo; } }());",
         options: ["both"],
         errors: [{
-            message: "Move variable declaration to function body root.",
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "variable",
+                body: "function body"
+            },
             type: "VariableDeclaration"
         }]
     }]

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -92,8 +92,8 @@ function extractPatterns(patterns, type) {
 //------------------------------------------------------------------------------
 
 const errors = [
-    { message: "Unexpected 'this'.", type: "ThisExpression" },
-    { message: "Unexpected 'this'.", type: "ThisExpression" }
+    { messageId: "unexpectedThis", type: "ThisExpression" },
+    { messageId: "unexpectedThis", type: "ThisExpression" }
 ];
 
 const patterns = [

--- a/tests/lib/rules/no-irregular-whitespace.js
+++ b/tests/lib/rules/no-irregular-whitespace.js
@@ -19,11 +19,11 @@ const rule = require("../../../lib/rules/no-irregular-whitespace"),
 const ruleTester = new RuleTester();
 
 const expectedErrors = [{
-    message: "Irregular whitespace not allowed.",
+    messageId: "noIrregularWhitespace",
     type: "Program"
 }];
 const expectedCommentErrors = [{
-    message: "Irregular whitespace not allowed.",
+    messageId: "noIrregularWhitespace",
     type: "Program",
     line: 1,
     column: 4
@@ -262,13 +262,13 @@ ruleTester.run("no-irregular-whitespace", rule, {
             code: "var a = 'b',\u2028c = 'd',\ne = 'f'\u2028",
             errors: [
                 {
-                    message: "Irregular whitespace not allowed.",
+                    messageId: "noIrregularWhitespace",
                     type: "Program",
                     line: 1,
                     column: 13
                 },
                 {
-                    message: "Irregular whitespace not allowed.",
+                    messageId: "noIrregularWhitespace",
                     type: "Program",
                     line: 3,
                     column: 8
@@ -279,19 +279,19 @@ ruleTester.run("no-irregular-whitespace", rule, {
             code: "var any \u3000 = 'thing', other \u3000 = 'thing';\nvar third \u3000 = 'thing';",
             errors: [
                 {
-                    message: "Irregular whitespace not allowed.",
+                    messageId: "noIrregularWhitespace",
                     type: "Program",
                     line: 1,
                     column: 9
                 },
                 {
-                    message: "Irregular whitespace not allowed.",
+                    messageId: "noIrregularWhitespace",
                     type: "Program",
                     line: 1,
                     column: 28
                 },
                 {
-                    message: "Irregular whitespace not allowed.",
+                    messageId: "noIrregularWhitespace",
                     type: "Program",
                     line: 2,
                     column: 11
@@ -478,13 +478,13 @@ ruleTester.run("no-irregular-whitespace", rule, {
             code: "var any = /\u3000/, other = /\u000B/;",
             errors: [
                 {
-                    message: "Irregular whitespace not allowed.",
+                    messageId: "noIrregularWhitespace",
                     type: "Program",
                     line: 1,
                     column: 12
                 },
                 {
-                    message: "Irregular whitespace not allowed.",
+                    messageId: "noIrregularWhitespace",
                     type: "Program",
                     line: 1,
                     column: 25
@@ -496,13 +496,13 @@ ruleTester.run("no-irregular-whitespace", rule, {
             options: [{ skipStrings: false }],
             errors: [
                 {
-                    message: "Irregular whitespace not allowed.",
+                    messageId: "noIrregularWhitespace",
                     type: "Program",
                     line: 1,
                     column: 12
                 },
                 {
-                    message: "Irregular whitespace not allowed.",
+                    messageId: "noIrregularWhitespace",
                     type: "Program",
                     line: 1,
                     column: 25
@@ -515,13 +515,13 @@ ruleTester.run("no-irregular-whitespace", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
-                    message: "Irregular whitespace not allowed.",
+                    messageId: "noIrregularWhitespace",
                     type: "Program",
                     line: 1,
                     column: 12
                 },
                 {
-                    message: "Irregular whitespace not allowed.",
+                    messageId: "noIrregularWhitespace",
                     type: "Program",
                     line: 1,
                     column: 25
@@ -534,7 +534,7 @@ ruleTester.run("no-irregular-whitespace", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
-                    message: "Irregular whitespace not allowed.",
+                    messageId: "noIrregularWhitespace",
                     type: "Program",
                     line: 1,
                     column: 14

--- a/tests/lib/rules/no-iterator.js
+++ b/tests/lib/rules/no-iterator.js
@@ -24,8 +24,26 @@ ruleTester.run("no-iterator", rule, {
         "var __iterator__ = null;"
     ],
     invalid: [
-        { code: "var a = test.__iterator__;", errors: [{ message: "Reserved name '__iterator__'.", type: "MemberExpression" }] },
-        { code: "Foo.prototype.__iterator__ = function() {};", errors: [{ message: "Reserved name '__iterator__'.", type: "MemberExpression" }] },
-        { code: "var a = test['__iterator__'];", errors: [{ message: "Reserved name '__iterator__'.", type: "MemberExpression" }] }
+        {
+            code: "var a = test.__iterator__;",
+            errors: [{
+                messageId: "noIterator",
+                type: "MemberExpression"
+            }]
+        },
+        {
+            code: "Foo.prototype.__iterator__ = function() {};",
+            errors: [{
+                messageId: "noIterator",
+                type: "MemberExpression"
+            }]
+        },
+        {
+            code: "var a = test['__iterator__'];",
+            errors: [{
+                messageId: "noIterator",
+                type: "MemberExpression"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-label-var.js
+++ b/tests/lib/rules/no-label-var.js
@@ -24,8 +24,26 @@ ruleTester.run("no-label-var", rule, {
         "function bar() { var x = foo; q: for(;;) { break q; } }"
     ],
     invalid: [
-        { code: "var x = foo; function bar() { x: for(;;) { break x; } }", errors: [{ message: "Found identifier with same name as label.", type: "LabeledStatement" }] },
-        { code: "function bar() { var x = foo; x: for(;;) { break x; } }", errors: [{ message: "Found identifier with same name as label.", type: "LabeledStatement" }] },
-        { code: "function bar(x) { x: for(;;) { break x; } }", errors: [{ message: "Found identifier with same name as label.", type: "LabeledStatement" }] }
+        {
+            code: "var x = foo; function bar() { x: for(;;) { break x; } }",
+            errors: [{
+                messageId: "identifierClashWithLabel",
+                type: "LabeledStatement"
+            }]
+        },
+        {
+            code: "function bar() { var x = foo; x: for(;;) { break x; } }",
+            errors: [{
+                messageId: "identifierClashWithLabel",
+                type: "LabeledStatement"
+            }]
+        },
+        {
+            code: "function bar(x) { x: for(;;) { break x; } }",
+            errors: [{
+                messageId: "identifierClashWithLabel",
+                type: "LabeledStatement"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-labels.js
+++ b/tests/lib/rules/no-labels.js
@@ -38,118 +38,266 @@ ruleTester.run("no-labels", rule, {
         {
             code: "label: while(true) {}",
             errors: [{
-                message: "Unexpected labeled statement.",
+                messageId: "unexpectedLabel",
                 type: "LabeledStatement"
             }]
         },
         {
             code: "label: while (true) { break label; }",
-            errors: [{
-                message: "Unexpected labeled statement.",
-                type: "LabeledStatement"
-            }, {
-                message: "Unexpected label in break statement.",
-                type: "BreakStatement"
-            }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                },
+                {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
         {
             code: "label: while (true) { continue label; }",
-            errors: [{
-                message: "Unexpected labeled statement.",
-                type: "LabeledStatement"
-            }, {
-                message: "Unexpected label in continue statement.",
-                type: "ContinueStatement"
-            }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                },
+                {
+                    messageId: "unexpectedLabelInContinue",
+                    type: "ContinueStatement"
+                }
+            ]
         },
 
         {
             code: "A: var foo = 0;",
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }]
+            errors: [{
+                messageId: "unexpectedLabel",
+                type: "LabeledStatement"
+            }]
         },
         {
             code: "A: break A;",
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                },
+                {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
         {
             code: "A: { if (foo()) { break A; } bar(); };",
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                },
+                {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
         {
             code: "A: if (a) { if (foo()) { break A; } bar(); };",
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                },
+                {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
         {
             code: "A: switch (a) { case 0: break A; default: break; };",
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                },
+                {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
         {
             code: "A: switch (a) { case 0: B: { break A; } default: break; };",
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                },
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                },
+                {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
 
         // {allowLoop: true} option.
         {
             code: "A: var foo = 0;",
             options: [{ allowLoop: true }],
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }]
+            errors: [{
+                messageId: "unexpectedLabel",
+                type: "LabeledStatement"
+            }]
         },
         {
             code: "A: break A;",
             options: [{ allowLoop: true }],
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                },
+                {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
         {
             code: "A: { if (foo()) { break A; } bar(); };",
             options: [{ allowLoop: true }],
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                },
+                {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
         {
             code: "A: if (a) { if (foo()) { break A; } bar(); };",
             options: [{ allowLoop: true }],
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                },
+                {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
         {
             code: "A: switch (a) { case 0: break A; default: break; };",
             options: [{ allowLoop: true }],
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                },
+                {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
 
         // {allowSwitch: true} option.
         {
             code: "A: var foo = 0;",
             options: [{ allowSwitch: true }],
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }]
+            errors: [{
+                messageId: "unexpectedLabel",
+                type: "LabeledStatement"
+            }]
         },
         {
             code: "A: break A;",
             options: [{ allowSwitch: true }],
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                }, {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
         {
             code: "A: { if (foo()) { break A; } bar(); };",
             options: [{ allowSwitch: true }],
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                }, {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
         {
             code: "A: if (a) { if (foo()) { break A; } bar(); };",
             options: [{ allowSwitch: true }],
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                }, {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
         {
             code: "A: while (a) { break A; }",
             options: [{ allowSwitch: true }],
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                }, {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
         {
             code: "A: do { if (b) { break A; } } while (a);",
             options: [{ allowSwitch: true }],
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                }, {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         },
         {
             code: "A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }",
             options: [{ allowSwitch: true }],
-            errors: [{ message: "Unexpected labeled statement.", type: "LabeledStatement" }, { message: "Unexpected label in break statement.", type: "BreakStatement" }]
+            errors: [
+                {
+                    messageId: "unexpectedLabel",
+                    type: "LabeledStatement"
+                }, {
+                    messageId: "unexpectedLabelInBreak",
+                    type: "BreakStatement"
+                }
+            ]
         }
     ]
 });

--- a/tests/lib/rules/no-lone-blocks.js
+++ b/tests/lib/rules/no-lone-blocks.js
@@ -60,40 +60,119 @@ ruleTester.run("no-lone-blocks", rule, {
         { code: "function foo() { { const x = 4 } const x = 3 }", parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
-        { code: "{}", errors: [{ message: "Block is redundant.", type: "BlockStatement" }] },
-        { code: "{var x = 1;}", errors: [{ message: "Block is redundant.", type: "BlockStatement" }] },
-        { code: "foo(); {} bar();", errors: [{ message: "Block is redundant.", type: "BlockStatement" }] },
-        { code: "if (foo) { bar(); {} baz(); }", errors: [{ message: "Nested block is redundant.", type: "BlockStatement" }] },
+        {
+            code: "{}",
+            errors: [{
+                messageId: "redundantBlock",
+                type: "BlockStatement"
+            }]
+        },
+        {
+            code: "{var x = 1;}",
+            errors: [{
+                messageId: "redundantBlock",
+                type: "BlockStatement"
+            }]
+        },
+        {
+            code: "foo(); {} bar();",
+            errors: [{
+                messageId: "redundantBlock",
+                type: "BlockStatement"
+            }]
+        },
+        {
+            code: "if (foo) { bar(); {} baz(); }",
+            errors: [{
+                messageId: "redundantNestedBlock",
+                type: "BlockStatement"
+            }]
+        },
         {
             code: "{ \n{ } }",
             errors: [
-                { message: "Block is redundant.", type: "BlockStatement", line: 1 },
-                { message: "Nested block is redundant.", type: "BlockStatement", line: 2 }]
+                {
+                    messageId: "redundantBlock",
+                    type: "BlockStatement",
+                    line: 1
+                },
+                {
+                    messageId: "redundantNestedBlock",
+                    type: "BlockStatement",
+                    line: 2
+                }
+            ]
         },
-        { code: "function foo() { bar(); {} baz(); }", errors: [{ message: "Nested block is redundant.", type: "BlockStatement" }] },
-        { code: "while (foo) { {} }", errors: [{ message: "Nested block is redundant.", type: "BlockStatement" }] },
+        {
+            code: "function foo() { bar(); {} baz(); }",
+            errors: [{
+                messageId: "redundantNestedBlock",
+                type: "BlockStatement"
+            }]
+        },
+        {
+            code: "while (foo) { {} }",
+            errors: [{
+                messageId: "redundantNestedBlock",
+                type: "BlockStatement"
+            }]
+        },
 
         // Non-block-level bindings, even in ES6
-        { code: "{ function bar() {} }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Block is redundant.", type: "BlockStatement" }] },
-        { code: "{var x = 1;}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Block is redundant.", type: "BlockStatement" }] },
+        {
+            code: "{ function bar() {} }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "redundantBlock",
+                type: "BlockStatement"
+            }]
+        },
+        {
+            code: "{var x = 1;}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "redundantBlock",
+                type: "BlockStatement"
+            }]
+        },
 
         {
             code: "{ \n{var x = 1;}\n let y = 2; } {let z = 1;}",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Nested block is redundant.", type: "BlockStatement", line: 2 }]
+            errors: [{
+                messageId: "redundantNestedBlock",
+                type: "BlockStatement",
+                line: 2
+            }]
         },
         {
             code: "{ \n{let x = 1;}\n var y = 2; } {let z = 1;}",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Block is redundant.", type: "BlockStatement", line: 1 }]
+            errors: [{
+                messageId: "redundantBlock",
+                type: "BlockStatement",
+                line: 1
+            }]
         },
         {
             code: "{ \n{var x = 1;}\n var y = 2; }\n {var z = 1;}",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Block is redundant.", type: "BlockStatement", line: 1 },
-                { message: "Nested block is redundant.", type: "BlockStatement", line: 2 },
-                { message: "Block is redundant.", type: "BlockStatement", line: 4 }
+                {
+                    messageId: "redundantBlock",
+                    type: "BlockStatement",
+                    line: 1
+                },
+                {
+                    messageId: "redundantNestedBlock",
+                    type: "BlockStatement",
+                    line: 2
+                },
+                {
+                    messageId: "redundantBlock",
+                    type: "BlockStatement",
+                    line: 4
+                }
             ]
         },
         {
@@ -106,7 +185,11 @@ ruleTester.run("no-lone-blocks", rule, {
                     }
               }
             `,
-            errors: [{ message: "Block is redundant.", type: "BlockStatement", line: 5 }]
+            errors: [{
+                messageId: "redundantBlock",
+                type: "BlockStatement",
+                line: 5
+            }]
         },
         {
             code: `
@@ -118,7 +201,11 @@ ruleTester.run("no-lone-blocks", rule, {
                 foo();
               }
             `,
-            errors: [{ message: "Block is redundant.", type: "BlockStatement", line: 4 }]
+            errors: [{
+                messageId: "redundantBlock",
+                type: "BlockStatement",
+                line: 4
+            }]
         },
         {
             code: `
@@ -129,13 +216,11 @@ ruleTester.run("no-lone-blocks", rule, {
               }
             `,
             parserOptions: { ecmaVersion: 6 },
-            errors: [
-                {
-                    message: "Nested block is redundant.",
-                    type: "BlockStatement",
-                    line: 3
-                }
-            ]
+            errors: [{
+                messageId: "redundantNestedBlock",
+                type: "BlockStatement",
+                line: 3
+            }]
         },
         {
             code: `
@@ -145,13 +230,11 @@ ruleTester.run("no-lone-blocks", rule, {
                 }
               }
             `,
-            errors: [
-                {
-                    message: "Nested block is redundant.",
-                    type: "BlockStatement",
-                    line: 3
-                }
-            ]
+            errors: [{
+                messageId: "redundantNestedBlock",
+                type: "BlockStatement",
+                line: 3
+            }]
         }
     ]
 });

--- a/tests/lib/rules/no-lonely-if.js
+++ b/tests/lib/rules/no-lonely-if.js
@@ -16,7 +16,7 @@ const rule = require("../../../lib/rules/no-lonely-if"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester();
-const errors = [{ message: "Unexpected if as the only statement in an else block.", type: "IfStatement" }];
+const errors = [{ messageId: "unexpectedLonelyIf", type: "IfStatement" }];
 
 ruleTester.run("no-lonely-if", rule, {
 

--- a/tests/lib/rules/no-mixed-operators.js
+++ b/tests/lib/rules/no-mixed-operators.js
@@ -64,94 +64,304 @@ ruleTester.run("no-mixed-operators", rule, {
         {
             code: "a && b || c",
             errors: [
-                { column: 3, endColumn: 5, message: "Unexpected mix of '&&' and '||'." },
-                { column: 8, endColumn: 10, message: "Unexpected mix of '&&' and '||'." }
+                {
+                    column: 3,
+                    endColumn: 5,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: "||"
+                    }
+                },
+                {
+                    column: 8,
+                    endColumn: 10,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: "||"
+                    }
+                }
             ]
         },
         {
             code: "a && b > 0 || c",
             options: [{ groups: [["&&", "||", ">"]] }],
             errors: [
-                { column: 3, message: "Unexpected mix of '&&' and '||'." },
-                { column: 3, message: "Unexpected mix of '&&' and '>'." },
-                { column: 8, message: "Unexpected mix of '&&' and '>'." },
-                { column: 12, message: "Unexpected mix of '&&' and '||'." }
+                {
+                    column: 3,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: "||"
+                    }
+                },
+                {
+                    column: 3,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: ">"
+                    }
+                },
+                {
+                    column: 8,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: ">"
+                    }
+                },
+                {
+                    column: 12,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: "||"
+                    }
+                }
             ]
         },
         {
             code: "a && b > 0 || c",
             options: [{ groups: [["&&", "||"]] }],
             errors: [
-                { column: 3, message: "Unexpected mix of '&&' and '||'." },
-                { column: 12, message: "Unexpected mix of '&&' and '||'." }
+                {
+                    column: 3,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: "||"
+                    }
+                },
+                {
+                    column: 12,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: "||"
+                    }
+                }
             ]
         },
         {
             code: "a && b + c - d / e || f",
             options: [{ groups: [["&&", "||"], ["+", "-", "*", "/"]] }],
             errors: [
-                { column: 3, message: "Unexpected mix of '&&' and '||'." },
-                { column: 12, message: "Unexpected mix of '-' and '/'." },
-                { column: 16, message: "Unexpected mix of '-' and '/'." },
-                { column: 20, message: "Unexpected mix of '&&' and '||'." }
+                {
+                    column: 3,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: "||"
+                    }
+                },
+                {
+                    column: 12,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "-",
+                        rightOperator: "/"
+                    }
+                },
+                {
+                    column: 16,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "-",
+                        rightOperator: "/"
+                    }
+                },
+                {
+                    column: 20,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: "||"
+                    }
+                }
             ]
         },
         {
             code: "a && b + c - d / e || f",
             options: [{ groups: [["&&", "||"], ["+", "-", "*", "/"]], allowSamePrecedence: true }],
             errors: [
-                { column: 3, message: "Unexpected mix of '&&' and '||'." },
-                { column: 12, message: "Unexpected mix of '-' and '/'." },
-                { column: 16, message: "Unexpected mix of '-' and '/'." },
-                { column: 20, message: "Unexpected mix of '&&' and '||'." }
+                {
+                    column: 3,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: "||"
+                    }
+                },
+                {
+                    column: 12,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "-",
+                        rightOperator: "/"
+                    }
+                },
+                {
+                    column: 16,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "-",
+                        rightOperator: "/"
+                    }
+                },
+                {
+                    column: 20,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: "||"
+                    }
+                }
             ]
         },
         {
             code: "a + b - c",
             options: [{ allowSamePrecedence: false }],
             errors: [
-                { column: 3, endColumn: 4, message: "Unexpected mix of '+' and '-'." },
-                { column: 7, endColumn: 8, message: "Unexpected mix of '+' and '-'." }
+                {
+                    column: 3,
+                    endColumn: 4,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "+",
+                        rightOperator: "-"
+                    }
+                },
+                {
+                    column: 7,
+                    endColumn: 8,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "+",
+                        rightOperator: "-"
+                    }
+                }
             ]
         },
         {
             code: "a * b / c",
             options: [{ allowSamePrecedence: false }],
             errors: [
-                { column: 3, endColumn: 4, message: "Unexpected mix of '*' and '/'." },
-                { column: 7, endColumn: 8, message: "Unexpected mix of '*' and '/'." }
+                {
+                    column: 3,
+                    endColumn: 4,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "*",
+                        rightOperator: "/"
+                    }
+                },
+                {
+                    column: 7,
+                    endColumn: 8,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "*",
+                        rightOperator: "/"
+                    }
+                }
             ]
         },
         {
             code: "a || b ? c : d",
             options: [{ groups: [["&&", "||", "?:"]] }],
             errors: [
-                { column: 3, endColumn: 5, message: "Unexpected mix of '||' and '?:'." },
-                { column: 8, endColumn: 9, message: "Unexpected mix of '||' and '?:'." }
+                {
+                    column: 3,
+                    endColumn: 5,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "||",
+                        rightOperator: "?:"
+                    }
+                },
+                {
+                    column: 8,
+                    endColumn: 9,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "||",
+                        rightOperator: "?:"
+                    }
+                }
             ]
         },
         {
             code: "a && b ? 1 : 2",
             options: [{ groups: [["&&", "||", "?:"]] }],
             errors: [
-                { column: 3, endColumn: 5, message: "Unexpected mix of '&&' and '?:'." },
-                { column: 8, endColumn: 9, message: "Unexpected mix of '&&' and '?:'." }
+                {
+                    column: 3,
+                    endColumn: 5,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: "?:"
+                    }
+                },
+                {
+                    column: 8,
+                    endColumn: 9,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "&&",
+                        rightOperator: "?:"
+                    }
+                }
             ]
         },
         {
             code: "x ? a && b : 0",
             options: [{ groups: [["&&", "||", "?:"]] }],
             errors: [
-                { column: 3, endColumn: 4, message: "Unexpected mix of '?:' and '&&'." },
-                { column: 7, endColumn: 9, message: "Unexpected mix of '?:' and '&&'." }
+                {
+                    column: 3,
+                    endColumn: 4,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "?:",
+                        rightOperator: "&&"
+                    }
+                },
+                {
+                    column: 7,
+                    endColumn: 9,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "?:",
+                        rightOperator: "&&"
+                    }
+                }
             ]
         },
         {
             code: "x ? 0 : a && b",
             options: [{ groups: [["&&", "||", "?:"]] }],
             errors: [
-                { column: 3, endColumn: 4, message: "Unexpected mix of '?:' and '&&'." },
-                { column: 11, endColumn: 13, message: "Unexpected mix of '?:' and '&&'." }
+                {
+                    column: 3,
+                    endColumn: 4,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "?:",
+                        rightOperator: "&&"
+                    }
+                },
+                {
+                    column: 11,
+                    endColumn: 13,
+                    messageId: "unexpectedMixedOperator",
+                    data: {
+                        leftOperator: "?:",
+                        rightOperator: "&&"
+                    }
+                }
             ]
         }
     ]

--- a/tests/lib/rules/no-mixed-requires.js
+++ b/tests/lib/rules/no-mixed-requires.js
@@ -35,15 +35,85 @@ ruleTester.run("no-mixed-requires", rule, {
         { code: "var async = require('async'), debug = require('diagnostics')('my-module')", options: [{ allowCall: true }] }
     ],
     invalid: [
-        { code: "var fs = require('fs'), foo = 42", options: [false], errors: [{ message: "Do not mix 'require' and other declarations.", type: "VariableDeclaration" }] },
-        { code: "var fs = require('fs'), foo", options: [false], errors: [{ message: "Do not mix 'require' and other declarations.", type: "VariableDeclaration" }] },
-        { code: "var a = require(42), b = require(), c = require('y'), d = require(doStuff())", options: [true], errors: [{ message: "Do not mix core, module, file and computed requires.", type: "VariableDeclaration" }] },
-        { code: "var fs = require('fs'), foo = require('foo')", options: [true], errors: [{ message: "Do not mix core, module, file and computed requires.", type: "VariableDeclaration" }] },
-        { code: "var fs = require('fs'), foo = require('foo')", options: [{ grouping: true }], errors: [{ message: "Do not mix core, module, file and computed requires.", type: "VariableDeclaration" }] },
-        { code: "var exec = require('child_process').exec, foo = require('foo')", options: [true], errors: [{ message: "Do not mix core, module, file and computed requires.", type: "VariableDeclaration" }] },
-        { code: "var fs = require('fs'), foo = require('./foo')", options: [true], errors: [{ message: "Do not mix core, module, file and computed requires.", type: "VariableDeclaration" }] },
-        { code: "var foo = require('foo'), foo2 = require('./foo')", options: [true], errors: [{ message: "Do not mix core, module, file and computed requires.", type: "VariableDeclaration" }] },
-        { code: "var foo = require('foo'), bar = require(getName())", options: [true], errors: [{ message: "Do not mix core, module, file and computed requires.", type: "VariableDeclaration" }] },
-        { code: "var async = require('async'), debug = require('diagnostics').someFun('my-module')", options: [{ allowCall: true }], errors: [{ message: "Do not mix 'require' and other declarations.", type: "VariableDeclaration" }] }
+        {
+            code: "var fs = require('fs'), foo = 42",
+            options: [false],
+            errors: [{
+                messageId: "noMixRequire",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var fs = require('fs'), foo",
+            options: [false],
+            errors: [{
+                messageId: "noMixRequire",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var a = require(42), b = require(), c = require('y'), d = require(doStuff())",
+            options: [true],
+            errors: [{
+                messageId: "noMixCoreModuleFileComputed",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var fs = require('fs'), foo = require('foo')",
+            options: [true],
+            errors: [{
+                messageId: "noMixCoreModuleFileComputed",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var fs = require('fs'), foo = require('foo')",
+            options: [{ grouping: true }],
+            errors: [{
+                messageId: "noMixCoreModuleFileComputed",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var exec = require('child_process').exec, foo = require('foo')",
+            options: [true],
+            errors: [{
+                messageId: "noMixCoreModuleFileComputed",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var fs = require('fs'), foo = require('./foo')",
+            options: [true],
+            errors: [{
+                messageId: "noMixCoreModuleFileComputed",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var foo = require('foo'), foo2 = require('./foo')",
+            options: [true],
+            errors: [{
+                messageId: "noMixCoreModuleFileComputed",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var foo = require('foo'), bar = require(getName())",
+            options: [true],
+            errors: [{
+                messageId: "noMixCoreModuleFileComputed",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var async = require('async'), debug = require('diagnostics').someFun('my-module')",
+            options: [{ allowCall: true }],
+            errors: [{
+                messageId: "noMixRequire",
+                type: "VariableDeclaration"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/tests/lib/rules/no-mixed-spaces-and-tabs.js
@@ -88,7 +88,7 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             code: "function add(x, y) {\n\t return x + y;\n}",
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 2
                 }
@@ -98,7 +98,7 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             code: "\t ;\n/*\n\t * Hello\n\t */",
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 1
                 }
@@ -108,7 +108,7 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             code: " \t/* comment */",
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 1
                 }
@@ -118,7 +118,7 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             code: "\t // comment",
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 1
                 }
@@ -128,7 +128,7 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             code: "\t var a /* comment */ = 1;",
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 1
                 }
@@ -138,7 +138,7 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             code: " \tvar b = 1; // comment",
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 1
                 }
@@ -148,7 +148,7 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             code: "/**/\n \t/*\n \t*/",
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 2
                 }
@@ -158,12 +158,12 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             code: "\t var x = 5, y = 2, z = 5;\n\n\t \tvar j =\t x + y;\nz *= j;",
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 1
                 },
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 3
                 }
@@ -174,7 +174,7 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             options: [true],
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 2
                 }
@@ -185,7 +185,7 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             options: ["smart-tabs"],
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 2
                 }
@@ -197,7 +197,7 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             env: { es6: true },
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 2,
                     column: 2
@@ -209,7 +209,7 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             env: { es6: true },
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 2,
                     column: 2
@@ -220,7 +220,7 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             code: "  \t'';",
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 1
                 }
@@ -230,7 +230,7 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
             code: "''\n\t ",
             errors: [
                 {
-                    message: "Mixed spaces and tabs.",
+                    messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 2
                 }

--- a/tests/lib/rules/no-multi-assign.js
+++ b/tests/lib/rules/no-multi-assign.js
@@ -26,7 +26,7 @@ const rule = require("../../../lib/rules/no-multi-assign"),
  */
 function errorAt(line, column, type) {
     return {
-        message: "Unexpected chained assignment.",
+        messageId: "unexpectedChain",
         type,
         line,
         column

--- a/tests/lib/rules/no-multi-spaces.js
+++ b/tests/lib/rules/no-multi-spaces.js
@@ -111,7 +111,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "function foo(a,  b) {}",
             output: "function foo(a, b) {}",
             errors: [{
-                message: "Multiple spaces found before 'b'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "b" },
                 type: "Identifier",
                 column: 16,
                 endColumn: 18
@@ -122,7 +123,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var foo = (a, b) => {}",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
-                message: "Multiple spaces found before 'b'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "b" },
                 type: "Identifier",
                 column: 14,
                 endColumn: 16
@@ -132,7 +134,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var a =  1",
             output: "var a = 1",
             errors: [{
-                message: "Multiple spaces found before '1'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "1" },
                 type: "Numeric",
                 column: 8,
                 endColumn: 10
@@ -142,7 +145,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var a = 1,  b = 2;",
             output: "var a = 1, b = 2;",
             errors: [{
-                message: "Multiple spaces found before 'b'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "b" },
                 type: "Identifier"
             }]
         },
@@ -150,7 +154,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "a <<  b",
             output: "a << b",
             errors: [{
-                message: "Multiple spaces found before 'b'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "b" },
                 type: "Identifier"
             }]
         },
@@ -158,7 +163,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var arr = {'a': 1,  'b': 2};",
             output: "var arr = {'a': 1, 'b': 2};",
             errors: [{
-                message: "Multiple spaces found before ''b''.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "'b'" },
                 type: "String",
                 column: 19,
                 endColumn: 21
@@ -168,7 +174,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "if (a &  b) { }",
             output: "if (a & b) { }",
             errors: [{
-                message: "Multiple spaces found before 'b'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "b" },
                 type: "Identifier"
             }]
         },
@@ -176,10 +183,12 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "if ( a === 3  &&  b === 4) {}",
             output: "if ( a === 3 && b === 4) {}",
             errors: [{
-                message: "Multiple spaces found before '&&'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "&&" },
                 type: "Punctuator"
             }, {
-                message: "Multiple spaces found before 'b'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "b" },
                 type: "Identifier"
             }]
         },
@@ -187,10 +196,12 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var foo = bar === 1 ?  2:  3",
             output: "var foo = bar === 1 ? 2: 3",
             errors: [{
-                message: "Multiple spaces found before '2'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "2" },
                 type: "Numeric"
             }, {
-                message: "Multiple spaces found before '3'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "3" },
                 type: "Numeric"
             }]
         },
@@ -198,13 +209,16 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var a = [1,  2,  3,  4]",
             output: "var a = [1, 2, 3, 4]",
             errors: [{
-                message: "Multiple spaces found before '2'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "2" },
                 type: "Numeric"
             }, {
-                message: "Multiple spaces found before '3'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "3" },
                 type: "Numeric"
             }, {
-                message: "Multiple spaces found before '4'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "4" },
                 type: "Numeric"
             }]
         },
@@ -212,7 +226,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var arr = [1,  2];",
             output: "var arr = [1, 2];",
             errors: [{
-                message: "Multiple spaces found before '2'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "2" },
                 type: "Numeric"
             }]
         },
@@ -220,22 +235,26 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "[  , 1,  , 3,  ,  ]",
             output: "[ , 1, , 3, , ]",
             errors: [{
-                message: "Multiple spaces found before ','.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "," },
                 type: "Punctuator",
                 column: 2,
                 endColumn: 4
             }, {
-                message: "Multiple spaces found before ','.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "," },
                 type: "Punctuator",
                 column: 8,
                 endColumn: 10
             }, {
-                message: "Multiple spaces found before ','.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "," },
                 type: "Punctuator",
                 column: 14,
                 endColumn: 16
             }, {
-                message: "Multiple spaces found before ']'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "]" },
                 type: "Punctuator",
                 column: 17,
                 endColumn: 19
@@ -245,7 +264,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "a >>>  b",
             output: "a >>> b",
             errors: [{
-                message: "Multiple spaces found before 'b'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "b" },
                 type: "Identifier"
             }]
         },
@@ -253,10 +273,12 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "a = 1,  b =  2;",
             output: "a = 1, b = 2;",
             errors: [{
-                message: "Multiple spaces found before 'b'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "b" },
                 type: "Identifier"
             }, {
-                message: "Multiple spaces found before '2'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "2" },
                 type: "Numeric"
             }]
         },
@@ -264,7 +286,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "(function(a,  b){})",
             output: "(function(a, b){})",
             errors: [{
-                message: "Multiple spaces found before 'b'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "b" },
                 type: "Identifier"
             }]
         },
@@ -272,7 +295,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "function foo(a,  b){}",
             output: "function foo(a, b){}",
             errors: [{
-                message: "Multiple spaces found before 'b'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "b" },
                 type: "Identifier"
             }]
         },
@@ -280,7 +304,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var o = { fetch: function    () {} };",
             output: "var o = { fetch: function () {} };",
             errors: [{
-                message: "Multiple spaces found before '('.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "(" },
                 type: "Punctuator"
             }]
         },
@@ -288,7 +313,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "function foo      () {}",
             output: "function foo () {}",
             errors: [{
-                message: "Multiple spaces found before '('.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "(" },
                 type: "Punctuator",
                 column: 13,
                 endColumn: 19
@@ -298,7 +324,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "if (foo)      {}",
             output: "if (foo) {}",
             errors: [{
-                message: "Multiple spaces found before '{'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "{" },
                 type: "Punctuator"
             }]
         },
@@ -306,7 +333,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "function    foo(){}",
             output: "function foo(){}",
             errors: [{
-                message: "Multiple spaces found before 'foo'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "foo" },
                 type: "Identifier"
             }]
         },
@@ -314,7 +342,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "if    (foo) {}",
             output: "if (foo) {}",
             errors: [{
-                message: "Multiple spaces found before '('.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "(" },
                 type: "Punctuator"
             }]
         },
@@ -322,7 +351,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "try    {} catch(ex) {}",
             output: "try {} catch(ex) {}",
             errors: [{
-                message: "Multiple spaces found before '{'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "{" },
                 type: "Punctuator"
             }]
         },
@@ -330,7 +360,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "try {} catch    (ex) {}",
             output: "try {} catch (ex) {}",
             errors: [{
-                message: "Multiple spaces found before '('.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "(" },
                 type: "Punctuator"
             }]
         },
@@ -338,7 +369,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "throw  error;",
             output: "throw error;",
             errors: [{
-                message: "Multiple spaces found before 'error'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "error" },
                 type: "Identifier"
             }]
         },
@@ -346,7 +378,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "function foo() { return      bar; }",
             output: "function foo() { return bar; }",
             errors: [{
-                message: "Multiple spaces found before 'bar'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "bar" },
                 type: "Identifier"
             }]
         },
@@ -354,7 +387,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "switch   (a) {default: foo(); break;}",
             output: "switch (a) {default: foo(); break;}",
             errors: [{
-                message: "Multiple spaces found before '('.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "(" },
                 type: "Punctuator"
             }]
         },
@@ -362,10 +396,12 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var  answer = 6 *  7;",
             output: "var answer = 6 * 7;",
             errors: [{
-                message: "Multiple spaces found before 'answer'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "answer" },
                 type: "Identifier"
             }, {
-                message: "Multiple spaces found before '7'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "7" },
                 type: "Numeric"
             }]
         },
@@ -373,7 +409,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "({ a:  6  * 7 })",
             output: "({ a:  6 * 7 })",
             errors: [{
-                message: "Multiple spaces found before '*'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "*" },
                 type: "Punctuator"
             }]
         },
@@ -382,7 +419,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "({ a: b })",
             options: [{ exceptions: { Property: false } }],
             errors: [{
-                message: "Multiple spaces found before 'b'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "b" },
                 type: "Identifier"
             }]
         },
@@ -390,7 +428,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var foo = { bar: function() { return 1    + 2; } };",
             output: "var foo = { bar: function() { return 1 + 2; } };",
             errors: [{
-                message: "Multiple spaces found before '+'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "+" },
                 type: "Punctuator"
             }]
         },
@@ -398,7 +437,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "\t\tvar x = 5,\n\t\t    y =  2;",
             output: "\t\tvar x = 5,\n\t\t    y = 2;",
             errors: [{
-                message: "Multiple spaces found before '2'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "2" },
                 type: "Numeric"
             }]
         },
@@ -406,7 +446,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var x =\t  5;",
             output: "var x = 5;",
             errors: [{
-                message: "Multiple spaces found before '5'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "5" },
                 type: "Numeric",
                 column: 8,
                 endColumn: 11
@@ -418,7 +459,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var x =  /* comment */ 5;",
             output: "var x = /* comment */ 5;",
             errors: [{
-                message: "Multiple spaces found before '/* comment */'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "/* comment */" },
                 type: "Block"
             }]
         },
@@ -426,7 +468,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var x = /* comment */  5;",
             output: "var x = /* comment */ 5;",
             errors: [{
-                message: "Multiple spaces found before '5'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "5" },
                 type: "Numeric"
             }]
         },
@@ -434,7 +477,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var x = 5;  // comment",
             output: "var x = 5; // comment",
             errors: [{
-                message: "Multiple spaces found before '// comment'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "// comment" },
                 type: "Line",
                 column: 11,
                 endColumn: 13
@@ -444,7 +488,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var x = 5;  // comment\nvar y = 6;",
             output: "var x = 5; // comment\nvar y = 6;",
             errors: [{
-                message: "Multiple spaces found before '// comment'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "// comment" },
                 type: "Line"
             }]
         },
@@ -452,7 +497,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var x = 5;  /* multiline\n * comment\n */",
             output: "var x = 5; /* multiline\n * comment\n */",
             errors: [{
-                message: "Multiple spaces found before '/* multiline...*/'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "/* multiline...*/" },
                 type: "Block"
             }]
         },
@@ -460,7 +506,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var x = 5;  /* multiline\n * comment\n */\nvar y = 6;",
             output: "var x = 5; /* multiline\n * comment\n */\nvar y = 6;",
             errors: [{
-                message: "Multiple spaces found before '/* multiline...*/'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "/* multiline...*/" },
                 type: "Block"
             }]
         },
@@ -468,7 +515,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "var x = 5;  // this is a long comment",
             output: "var x = 5; // this is a long comment",
             errors: [{
-                message: "Multiple spaces found before '// this is a l...'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "// this is a l..." },
                 type: "Line"
             }]
         },
@@ -477,7 +525,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = /* comment */ 5;",
             options: [{ ignoreEOLComments: false }],
             errors: [{
-                message: "Multiple spaces found before '/* comment */'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "/* comment */" },
                 type: "Block"
             }]
         },
@@ -486,7 +535,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = /* comment */ 5;",
             options: [{ ignoreEOLComments: false }],
             errors: [{
-                message: "Multiple spaces found before '5'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "5" },
                 type: "Numeric"
             }]
         },
@@ -495,7 +545,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = 5; // comment",
             options: [{ ignoreEOLComments: false }],
             errors: [{
-                message: "Multiple spaces found before '// comment'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "// comment" },
                 type: "Line"
             }]
         },
@@ -504,7 +555,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = 5; // comment\nvar y = 6;",
             options: [{ ignoreEOLComments: false }],
             errors: [{
-                message: "Multiple spaces found before '// comment'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "// comment" },
                 type: "Line"
             }]
         },
@@ -513,7 +565,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = 5; /* multiline\n * comment\n */",
             options: [{ ignoreEOLComments: false }],
             errors: [{
-                message: "Multiple spaces found before '/* multiline...*/'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "/* multiline...*/" },
                 type: "Block"
             }]
         },
@@ -522,7 +575,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = 5; /* multiline\n * comment\n */\nvar y = 6;",
             options: [{ ignoreEOLComments: false }],
             errors: [{
-                message: "Multiple spaces found before '/* multiline...*/'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "/* multiline...*/" },
                 type: "Block"
             }]
         },
@@ -531,7 +585,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = 5; // this is a long comment",
             options: [{ ignoreEOLComments: false }],
             errors: [{
-                message: "Multiple spaces found before '// this is a l...'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "// this is a l..." },
                 type: "Line"
             }]
         },
@@ -540,7 +595,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = /* comment */ 5;  // EOL comment",
             options: [{ ignoreEOLComments: true }],
             errors: [{
-                message: "Multiple spaces found before '/* comment */'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "/* comment */" },
                 type: "Block"
             }]
         },
@@ -549,7 +605,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = /* comment */ 5;  // EOL comment\nvar y = 6;",
             options: [{ ignoreEOLComments: true }],
             errors: [{
-                message: "Multiple spaces found before '/* comment */'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "/* comment */" },
                 type: "Block"
             }]
         },
@@ -558,7 +615,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = /* comment */ 5;  /* EOL comment */",
             options: [{ ignoreEOLComments: true }],
             errors: [{
-                message: "Multiple spaces found before '5'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "5" },
                 type: "Numeric"
             }]
         },
@@ -567,7 +625,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = /* comment */ 5;  /* EOL comment */\nvar y = 6;",
             options: [{ ignoreEOLComments: true }],
             errors: [{
-                message: "Multiple spaces found before '5'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "5" },
                 type: "Numeric"
             }]
         },
@@ -576,7 +635,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = /*comment without spaces*/ 5;",
             options: [{ ignoreEOLComments: true }],
             errors: [{
-                message: "Multiple spaces found before '/*comment with...*/'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "/*comment with...*/" },
                 type: "Block"
             }]
         },
@@ -585,7 +645,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = 5; //comment without spaces",
             options: [{ ignoreEOLComments: false }],
             errors: [{
-                message: "Multiple spaces found before '//comment with...'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "//comment with..." },
                 type: "Line"
             }]
         },
@@ -594,7 +655,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = 5; /*comment without spaces*/",
             options: [{ ignoreEOLComments: false }],
             errors: [{
-                message: "Multiple spaces found before '/*comment with...*/'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "/*comment with...*/" },
                 type: "Block"
             }]
         },
@@ -603,7 +665,8 @@ ruleTester.run("no-multi-spaces", rule, {
             output: "var x = 5; /*comment\n without spaces*/",
             options: [{ ignoreEOLComments: false }],
             errors: [{
-                message: "Multiple spaces found before '/*comment...*/'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "/*comment...*/" },
                 type: "Block",
                 column: 11,
                 endColumn: 13
@@ -613,7 +676,8 @@ ruleTester.run("no-multi-spaces", rule, {
             code: "foo\n\f  bar  + baz",
             output: "foo\n\f  bar + baz",
             errors: [{
-                message: "Multiple spaces found before '+'.",
+                messageId: "multipleSpaces",
+                data: { displayValue: "+" },
                 type: "Punctuator"
             }]
         }

--- a/tests/lib/rules/no-multi-str.js
+++ b/tests/lib/rules/no-multi-str.js
@@ -24,10 +24,40 @@ ruleTester.run("no-multi-str", rule, {
         { code: "var a = <div>\n<h1>Wat</h1>\n</div>;", parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } }
     ],
     invalid: [
-        { code: "var x = 'Line 1 \\\n Line 2'", errors: [{ message: "Multiline support is limited to browsers supporting ES5 only.", type: "Literal" }] },
-        { code: "test('Line 1 \\\n Line 2');", errors: [{ message: "Multiline support is limited to browsers supporting ES5 only.", type: "Literal" }] },
-        { code: "'foo\\\rbar';", errors: [{ message: "Multiline support is limited to browsers supporting ES5 only.", type: "Literal" }] },
-        { code: "'foo\\\u2028bar';", errors: [{ message: "Multiline support is limited to browsers supporting ES5 only.", type: "Literal" }] },
-        { code: "'foo\\\u2029ar';", errors: [{ message: "Multiline support is limited to browsers supporting ES5 only.", type: "Literal" }] }
+        {
+            code: "var x = 'Line 1 \\\n Line 2'",
+            errors: [{
+                messageId: "multilineString",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "test('Line 1 \\\n Line 2');",
+            errors: [{
+                messageId: "multilineString",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "'foo\\\rbar';",
+            errors: [{
+                messageId: "multilineString",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "'foo\\\u2028bar';",
+            errors: [{
+                messageId: "multilineString",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "'foo\\\u2029ar';",
+            errors: [{
+                messageId: "multilineString",
+                type: "Literal"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -24,12 +24,12 @@ const ruleTester = new RuleTester();
  * @private
  */
 function getExpectedError(lines) {
-    const message = lines === 1
-        ? "More than 1 blank line not allowed."
-        : `More than ${lines} blank lines not allowed.`;
-
     return {
-        message,
+        messageId: "consecutiveBlank",
+        data: {
+            max: lines,
+            pluralizedLines: lines === 1 ? "line" : "lines"
+        },
         type: "Program",
         column: 1
     };
@@ -43,7 +43,10 @@ function getExpectedError(lines) {
  */
 function getExpectedErrorEOF(lines) {
     return {
-        message: `Too many blank lines at the end of file. Max of ${lines} allowed.`,
+        messageId: "blankEndOfFile",
+        data: {
+            max: lines
+        },
         type: "Program",
         column: 1
     };
@@ -57,7 +60,10 @@ function getExpectedErrorEOF(lines) {
  */
 function getExpectedErrorBOF(lines) {
     return {
-        message: `Too many blank lines at the beginning of file. Max of ${lines} allowed.`,
+        messageId: "blankBeginningOfFile",
+        data: {
+            max: lines
+        },
         type: "Program",
         column: 1
     };
@@ -324,7 +330,11 @@ ruleTester.run("no-multiple-empty-lines", rule, {
             output: "var a;\n\nvar b;",
             options: [{ max: 1 }],
             errors: [{
-                message: "More than 1 blank line not allowed.",
+                messageId: "consecutiveBlank",
+                data: {
+                    max: 1,
+                    pluralizedLines: "line"
+                },
                 type: "Program",
                 line: 3,
                 column: 1
@@ -337,7 +347,11 @@ ruleTester.run("no-multiple-empty-lines", rule, {
             output: "var a;\n\n\nvar b;",
             options: [{ max: 2 }],
             errors: [{
-                message: "More than 2 blank lines not allowed.",
+                messageId: "consecutiveBlank",
+                data: {
+                    max: 2,
+                    pluralizedLines: "lines"
+                },
                 type: "Program",
                 line: 4,
                 column: 1

--- a/tests/lib/rules/no-negated-condition.js
+++ b/tests/lib/rules/no-negated-condition.js
@@ -41,42 +41,42 @@ ruleTester.run("no-negated-condition", rule, {
         {
             code: "if (!a) {;} else {;}",
             errors: [{
-                message: "Unexpected negated condition.",
+                messageId: "unexpectedNegated",
                 type: "IfStatement"
             }]
         },
         {
             code: "if (a != b) {;} else {;}",
             errors: [{
-                message: "Unexpected negated condition.",
+                messageId: "unexpectedNegated",
                 type: "IfStatement"
             }]
         },
         {
             code: "if (a !== b) {;} else {;}",
             errors: [{
-                message: "Unexpected negated condition.",
+                messageId: "unexpectedNegated",
                 type: "IfStatement"
             }]
         },
         {
             code: "!a ? b : c",
             errors: [{
-                message: "Unexpected negated condition.",
+                messageId: "unexpectedNegated",
                 type: "ConditionalExpression"
             }]
         },
         {
             code: "a != b ? c : d",
             errors: [{
-                message: "Unexpected negated condition.",
+                messageId: "unexpectedNegated",
                 type: "ConditionalExpression"
             }]
         },
         {
             code: "a !== b ? c : d",
             errors: [{
-                message: "Unexpected negated condition.",
+                messageId: "unexpectedNegated",
                 type: "ConditionalExpression"
             }]
         }

--- a/tests/lib/rules/no-nested-ternary.js
+++ b/tests/lib/rules/no-nested-ternary.js
@@ -24,7 +24,19 @@ ruleTester.run("no-nested-ternary", rule, {
         "var foo = bar === baz ? qux : quxx;"
     ],
     invalid: [
-        { code: "foo ? bar : baz === qux ? quxx : foobar;", errors: [{ message: "Do not nest ternary expressions.", type: "ConditionalExpression" }] },
-        { code: "foo ? baz === qux ? quxx : foobar : bar;", errors: [{ message: "Do not nest ternary expressions.", type: "ConditionalExpression" }] }
+        {
+            code: "foo ? bar : baz === qux ? quxx : foobar;",
+            errors: [{
+                messageId: "noNestedTernary",
+                type: "ConditionalExpression"
+            }]
+        },
+        {
+            code: "foo ? baz === qux ? quxx : foobar : bar;",
+            errors: [{
+                messageId: "noNestedTernary",
+                type: "ConditionalExpression"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-new-func.js
+++ b/tests/lib/rules/no-new-func.js
@@ -24,7 +24,19 @@ ruleTester.run("no-new-func", rule, {
         "var a = _function(\"b\", \"c\", \"return b+c\");"
     ],
     invalid: [
-        { code: "var a = new Function(\"b\", \"c\", \"return b+c\");", errors: [{ message: "The Function constructor is eval.", type: "NewExpression" }] },
-        { code: "var a = Function(\"b\", \"c\", \"return b+c\");", errors: [{ message: "The Function constructor is eval.", type: "CallExpression" }] }
+        {
+            code: "var a = new Function(\"b\", \"c\", \"return b+c\");",
+            errors: [{
+                messageId: "noFunctionConstructor",
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "var a = Function(\"b\", \"c\", \"return b+c\");",
+            errors: [{
+                messageId: "noFunctionConstructor",
+                type: "CallExpression"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-new-object.js
+++ b/tests/lib/rules/no-new-object.js
@@ -23,6 +23,12 @@ ruleTester.run("no-new-object", rule, {
         "var foo = new foo.Object()"
     ],
     invalid: [
-        { code: "var foo = new Object()", errors: [{ message: "The object literal notation {} is preferrable.", type: "NewExpression" }] }
+        {
+            code: "var foo = new Object()",
+            errors: [{
+                messageId: "preferLiteral",
+                type: "NewExpression"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-new-require.js
+++ b/tests/lib/rules/no-new-require.js
@@ -25,7 +25,19 @@ ruleTester.run("no-new-require", rule, {
         "var AppHeader = new (require('headers').appHeader)"
     ],
     invalid: [
-        { code: "var appHeader = new require('app-header')", errors: [{ message: "Unexpected use of new with require.", type: "NewExpression" }] },
-        { code: "var appHeader = new require('headers').appHeader", errors: [{ message: "Unexpected use of new with require.", type: "NewExpression" }] }
+        {
+            code: "var appHeader = new require('app-header')",
+            errors: [{
+                messageId: "noNewRequire",
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "var appHeader = new require('headers').appHeader",
+            errors: [{
+                messageId: "noNewRequire",
+                type: "NewExpression"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-new-symbol.js
+++ b/tests/lib/rules/no-new-symbol.js
@@ -27,11 +27,11 @@ ruleTester.run("no-new-symbol", rule, {
     invalid: [
         {
             code: "var foo = new Symbol('foo');",
-            errors: [{ message: "`Symbol` cannot be called as a constructor." }]
+            errors: [{ messageId: "noNewSymbol" }]
         },
         {
             code: "function bar() { return function Symbol() {}; } var baz = new Symbol('baz');",
-            errors: [{ message: "`Symbol` cannot be called as a constructor." }]
+            errors: [{ messageId: "noNewSymbol" }]
         }
     ]
 });

--- a/tests/lib/rules/no-new-wrappers.js
+++ b/tests/lib/rules/no-new-wrappers.js
@@ -24,10 +24,55 @@ ruleTester.run("no-new-wrappers", rule, {
         "var a = String('test'), b = String.fromCharCode(32);"
     ],
     invalid: [
-        { code: "var a = new String('hello');", errors: [{ message: "Do not use String as a constructor.", type: "NewExpression" }] },
-        { code: "var a = new Number(10);", errors: [{ message: "Do not use Number as a constructor.", type: "NewExpression" }] },
-        { code: "var a = new Boolean(false);", errors: [{ message: "Do not use Boolean as a constructor.", type: "NewExpression" }] },
-        { code: "var a = new Math();", errors: [{ message: "Do not use Math as a constructor.", type: "NewExpression" }] },
-        { code: "var a = new JSON({ myProp: 10 });", errors: [{ message: "Do not use JSON as a constructor.", type: "NewExpression" }] }
+        {
+            code: "var a = new String('hello');",
+            errors: [{
+                messageId: "noConstructor",
+                data: {
+                    fn: "String"
+                },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "var a = new Number(10);",
+            errors: [{
+                messageId: "noConstructor",
+                data: {
+                    fn: "Number"
+                },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "var a = new Boolean(false);",
+            errors: [{
+                messageId: "noConstructor",
+                data: {
+                    fn: "Boolean"
+                },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "var a = new Math();",
+            errors: [{
+                messageId: "noConstructor",
+                data: {
+                    fn: "Math"
+                },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "var a = new JSON({ myProp: 10 });",
+            errors: [{
+                messageId: "noConstructor",
+                data: {
+                    fn: "JSON"
+                },
+                type: "NewExpression"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-new.js
+++ b/tests/lib/rules/no-new.js
@@ -24,6 +24,12 @@ ruleTester.run("no-new", rule, {
         "var a; if (a === new Date()) { a = false; }"
     ],
     invalid: [
-        { code: "new Date()", errors: [{ message: "Do not use 'new' for side effects.", type: "ExpressionStatement" }] }
+        {
+            code: "new Date()",
+            errors: [{
+                messageId: "noNewStatement",
+                type: "ExpressionStatement"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-octal.js
+++ b/tests/lib/rules/no-octal.js
@@ -28,16 +28,82 @@ ruleTester.run("no-octal", rule, {
         "0.5e1"
     ],
     invalid: [
-        { code: "var a = 01234;", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
-        { code: "a = 1 + 01234;", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
-        { code: "00", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
-        { code: "08", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
-        { code: "09.1", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
-        { code: "09e1", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
-        { code: "09.1e1", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
-        { code: "018", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
-        { code: "019.1", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
-        { code: "019e1", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
-        { code: "019.1e1", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] }
+        {
+            code: "var a = 01234;",
+            errors: [{
+                messageId: "noOcatal",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "a = 1 + 01234;",
+            errors: [{
+                messageId: "noOcatal",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "00",
+            errors: [{
+                messageId: "noOcatal",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "08",
+            errors: [{
+                messageId: "noOcatal",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "09.1",
+            errors: [{
+                messageId: "noOcatal",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "09e1",
+            errors: [{
+                messageId: "noOcatal",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "09.1e1",
+            errors: [{
+                messageId: "noOcatal",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "018",
+            errors: [{
+                messageId: "noOcatal",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "019.1",
+            errors: [{
+                messageId: "noOcatal",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "019e1",
+            errors: [{
+                messageId: "noOcatal",
+                type: "Literal"
+            }]
+        },
+        {
+            code: "019.1e1",
+            errors: [{
+                messageId: "noOcatal",
+                type: "Literal"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -103,125 +103,271 @@ ruleTester.run("no-param-reassign", rule, {
     ],
 
     invalid: [
-        { code: "function foo(bar) { bar = 13; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
-        { code: "function foo(bar) { bar += 13; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
-        { code: "function foo(bar) { (function() { bar = 13; })(); }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
-        { code: "function foo(bar) { ++bar; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
-        { code: "function foo(bar) { bar++; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
-        { code: "function foo(bar) { --bar; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
-        { code: "function foo(bar) { bar--; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
-        { code: "function foo({bar}) { bar = 13; }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Assignment to function parameter 'bar'." }] },
-        { code: "function foo([, {bar}]) { bar = 13; }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Assignment to function parameter 'bar'." }] },
-        { code: "function foo(bar) { ({bar} = {}); }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Assignment to function parameter 'bar'." }] },
-        { code: "function foo(bar) { ({x: [, bar = 0]} = {}); }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Assignment to function parameter 'bar'." }] },
-        { code: "function foo(bar) { for (bar in baz); }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
-        { code: "function foo(bar) { for (bar of baz); }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Assignment to function parameter 'bar'." }] },
+        {
+            code: "function foo(bar) { bar = 13; }",
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "bar" }
+            }]
+        },
+        {
+            code: "function foo(bar) { bar += 13; }",
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "bar" }
+            }]
+        },
+        {
+            code: "function foo(bar) { (function() { bar = 13; })(); }",
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "bar" }
+            }]
+        },
+        {
+            code: "function foo(bar) { ++bar; }",
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "bar" }
+            }]
+        },
+        {
+            code: "function foo(bar) { bar++; }",
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "bar" }
+            }]
+        },
+        {
+            code: "function foo(bar) { --bar; }",
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "bar" }
+            }]
+        },
+        {
+            code: "function foo(bar) { bar--; }",
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "bar" }
+            }]
+        },
+        {
+            code: "function foo({bar}) { bar = 13; }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "bar" }
+            }]
+        },
+        {
+            code: "function foo([, {bar}]) { bar = 13; }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "bar" }
+            }]
+        },
+        {
+            code: "function foo(bar) { ({bar} = {}); }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "bar" }
+            }]
+        },
+        {
+            code: "function foo(bar) { ({x: [, bar = 0]} = {}); }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "bar" }
+            }]
+        },
+        {
+            code: "function foo(bar) { for (bar in baz); }",
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "bar" }
+            }]
+        },
+        {
+            code: "function foo(bar) { for (bar of baz); }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "bar" }
+            }]
+        },
 
         {
             code: "function foo(bar) { bar.a = 0; }",
             options: [{ props: true }],
-            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "bar" }
+            }]
         },
         {
             code: "function foo(bar) { bar.get(0).a = 0; }",
             options: [{ props: true }],
-            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "bar" }
+            }]
         },
         {
             code: "function foo(bar) { delete bar.a; }",
             options: [{ props: true }],
-            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "bar" }
+            }]
         },
         {
             code: "function foo(bar) { ++bar.a; }",
             options: [{ props: true }],
-            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "bar" }
+            }]
         },
         {
             code: "function foo(bar) { for (bar.a in {}); }",
             options: [{ props: true }],
-            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "bar" }
+            }]
         },
         {
             code: "function foo(bar) { for (bar.a of []); }",
             options: [{ props: true }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "bar" }
+            }]
         },
         {
             code: "function foo(bar) { (bar ? bar : [])[0] = 1; }",
             options: [{ props: true }],
-            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "bar" }
+            }]
         },
         {
             code: "function foo(bar) { [bar.a] = []; }",
             options: [{ props: true }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "bar" }
+            }]
         },
         {
             code: "function foo(bar) { [bar.a] = []; }",
             options: [{ props: true, ignorePropertyModificationsFor: ["a"] }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "bar" }
+            }]
         },
         {
             code: "function foo(bar) { [bar.a] = []; }",
             options: [{ props: true, ignorePropertyModificationsForRegex: ["^a.*$"] }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "bar" }
+            }]
         },
         {
             code: "function foo(bar) { [bar.a] = []; }",
             options: [{ props: true, ignorePropertyModificationsForRegex: ["^B.*$"] }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "bar" }
+            }]
         },
         {
             code: "function foo(bar) { ({foo: bar.a} = {}); }",
             options: [{ props: true }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "bar" }
+            }]
         },
         {
             code: "function foo(a) { ({a} = obj); }",
             options: [{ props: true }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Assignment to function parameter 'a'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: {
+                    name: "a"
+                }
+            }]
         },
         {
             code: "function foo(a) { ([...a] = obj); }",
             parserOptions: { ecmaVersion: 2015 },
-            errors: [{ message: "Assignment to function parameter 'a'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: {
+                    name: "a"
+                }
+            }]
         },
         {
             code: "function foo(a) { ({...a} = obj); }",
             parserOptions: { ecmaVersion: 2018 },
-            errors: [{ message: "Assignment to function parameter 'a'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: {
+                    name: "a"
+                }
+            }]
         },
         {
             code: "function foo(a) { ([...a.b] = obj); }",
             options: [{ props: true }],
             parserOptions: { ecmaVersion: 2015 },
-            errors: [{ message: "Assignment to property of function parameter 'a'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "a" }
+            }]
         },
         {
             code: "function foo(a) { ({...a.b} = obj); }",
             options: [{ props: true }],
             parserOptions: { ecmaVersion: 2018 },
-            errors: [{ message: "Assignment to property of function parameter 'a'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "a" }
+            }]
         },
         {
             code: "function foo(a) { for ({bar: a.b} in {}); }",
             options: [{ props: true }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Assignment to property of function parameter 'a'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "a" }
+            }]
         },
         {
             code: "function foo(a) { for ([a.b] of []); }",
             options: [{ props: true }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Assignment to property of function parameter 'a'." }]
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "a" }
+            }]
         }
     ]
 });

--- a/tests/lib/rules/no-path-concat.js
+++ b/tests/lib/rules/no-path-concat.js
@@ -30,28 +30,28 @@ ruleTester.run("no-path-concat", rule, {
         {
             code: "var fullPath = __dirname + \"/foo.js\";",
             errors: [{
-                message: "Use path.join() or path.resolve() instead of + to create paths.",
+                messageId: "usePathFunctions",
                 type: "BinaryExpression"
             }]
         },
         {
             code: "var fullPath = __filename + \"/foo.js\";",
             errors: [{
-                message: "Use path.join() or path.resolve() instead of + to create paths.",
+                messageId: "usePathFunctions",
                 type: "BinaryExpression"
             }]
         },
         {
             code: "var fullPath = \"/foo.js\" + __filename;",
             errors: [{
-                message: "Use path.join() or path.resolve() instead of + to create paths.",
+                messageId: "usePathFunctions",
                 type: "BinaryExpression"
             }]
         },
         {
             code: "var fullPath = \"/foo.js\" + __dirname;",
             errors: [{
-                message: "Use path.join() or path.resolve() instead of + to create paths.",
+                messageId: "usePathFunctions",
                 type: "BinaryExpression"
             }]
         }

--- a/tests/lib/rules/no-plusplus.js
+++ b/tests/lib/rules/no-plusplus.js
@@ -28,12 +28,59 @@ ruleTester.run("no-plusplus", rule, {
     ],
 
     invalid: [
-        { code: "var foo = 0; foo++;", errors: [{ message: "Unary operator '++' used.", type: "UpdateExpression" }] },
-        { code: "var foo = 0; foo--;", errors: [{ message: "Unary operator '--' used.", type: "UpdateExpression" }] },
-        { code: "for (i = 0; i < l; i++) { console.log(i); }", errors: [{ message: "Unary operator '++' used.", type: "UpdateExpression" }] },
+        {
+            code: "var foo = 0; foo++;",
+            errors: [{
+                messageId: "unexpectedUnaryOp",
+                data: {
+                    operator: "++"
+                },
+                type: "UpdateExpression"
+            }]
+        },
+        {
+            code: "var foo = 0; foo--;",
+            errors: [{
+                messageId: "unexpectedUnaryOp",
+                data: {
+                    operator: "--"
+                },
+                type: "UpdateExpression"
+            }]
+        },
+        {
+            code: "for (i = 0; i < l; i++) { console.log(i); }",
+            errors: [{
+                messageId: "unexpectedUnaryOp",
+                data: {
+                    operator: "++"
+                },
+                type: "UpdateExpression"
+            }]
+        },
 
         // With "allowForLoopAfterthoughts" allowed
-        { code: "var foo = 0; foo++;", options: [{ allowForLoopAfterthoughts: true }], errors: [{ message: "Unary operator '++' used.", type: "UpdateExpression" }] },
-        { code: "for (i = 0; i < l; i++) { v++; }", options: [{ allowForLoopAfterthoughts: true }], errors: [{ message: "Unary operator '++' used.", type: "UpdateExpression" }] }
+        {
+            code: "var foo = 0; foo++;",
+            options: [{ allowForLoopAfterthoughts: true }],
+            errors: [{
+                messageId: "unexpectedUnaryOp",
+                data: {
+                    operator: "++"
+                },
+                type: "UpdateExpression"
+            }]
+        },
+        {
+            code: "for (i = 0; i < l; i++) { v++; }",
+            options: [{ allowForLoopAfterthoughts: true }],
+            errors: [{
+                messageId: "unexpectedUnaryOp",
+                data: {
+                    operator: "++"
+                },
+                type: "UpdateExpression"
+            }]
+        }
     ]
 });

--- a/tests/lib/rules/no-restricted-globals.js
+++ b/tests/lib/rules/no-restricted-globals.js
@@ -17,6 +17,7 @@ const rule = require("../../../lib/rules/no-restricted-globals"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester();
+const customMessage = "Use bar instead.";
 
 ruleTester.run("no-restricted-globals", rule, {
     valid: [
@@ -191,29 +192,29 @@ ruleTester.run("no-restricted-globals", rule, {
         },
         {
             code: "foo",
-            options: [{ name: "foo", message: "Use bar instead." }],
+            options: [{ name: "foo", message: customMessage }],
             errors: [{
                 messageId: "customMessage",
-                data: { name: "foo", customMessage: "Use bar instead." },
+                data: { name: "foo", customMessage },
                 type: "Identifier"
             }]
         },
         {
             code: "function fn() { foo; }",
-            options: [{ name: "foo", message: "Use bar instead." }],
+            options: [{ name: "foo", message: customMessage }],
             errors: [{
                 messageId: "customMessage",
-                data: { name: "foo", customMessage: "Use bar instead." },
+                data: { name: "foo", customMessage },
                 type: "Identifier"
             }]
         },
         {
             code: "function fn() { foo; }",
-            options: [{ name: "foo", message: "Use bar instead." }],
+            options: [{ name: "foo", message: customMessage }],
             globals: { foo: false },
             errors: [{
                 messageId: "customMessage",
-                data: { name: "foo", customMessage: "Use bar instead." },
+                data: { name: "foo", customMessage },
                 type: "Identifier"
             }]
         },
@@ -229,29 +230,29 @@ ruleTester.run("no-restricted-globals", rule, {
         },
         {
             code: "foo",
-            options: [{ name: "foo", message: "Use bar instead." }],
+            options: [{ name: "foo", message: customMessage }],
             globals: { foo: false },
             errors: [{
                 messageId: "customMessage",
-                data: { name: "foo", customMessage: "Use bar instead." },
+                data: { name: "foo", customMessage },
                 type: "Identifier"
             }]
         },
         {
             code: "foo()",
-            options: [{ name: "foo", message: "Use bar instead." }],
+            options: [{ name: "foo", message: customMessage }],
             errors: [{
                 messageId: "customMessage",
-                data: { name: "foo", customMessage: "Use bar instead." },
+                data: { name: "foo", customMessage },
                 type: "Identifier"
             }]
         },
         {
             code: "foo.bar()",
-            options: [{ name: "foo", message: "Use bar instead." }],
+            options: [{ name: "foo", message: customMessage }],
             errors: [{
                 messageId: "customMessage",
-                data: { name: "foo", customMessage: "Use bar instead." },
+                data: { name: "foo", customMessage },
                 type: "Identifier"
             }]
         },

--- a/tests/lib/rules/no-restricted-globals.js
+++ b/tests/lib/rules/no-restricted-globals.js
@@ -60,122 +60,210 @@ ruleTester.run("no-restricted-globals", rule, {
         {
             code: "foo",
             options: ["foo"],
-            errors: [{ message: "Unexpected use of 'foo'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function fn() { foo; }",
             options: ["foo"],
-            errors: [{ message: "Unexpected use of 'foo'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function fn() { foo; }",
             options: ["foo"],
             globals: { foo: false },
-            errors: [{ message: "Unexpected use of 'foo'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
         },
         {
             code: "event",
             options: ["foo", "event"],
             env: { browser: true },
-            errors: [{ message: "Unexpected use of 'event'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "event" },
+                type: "Identifier"
+            }]
         },
         {
             code: "foo",
             options: ["foo"],
             globals: { foo: false },
-            errors: [{ message: "Unexpected use of 'foo'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
         },
         {
             code: "foo()",
             options: ["foo"],
-            errors: [{ message: "Unexpected use of 'foo'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
         },
         {
             code: "foo.bar()",
             options: ["foo"],
-            errors: [{ message: "Unexpected use of 'foo'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
         },
         {
             code: "foo",
             options: [{ name: "foo" }],
-            errors: [{ message: "Unexpected use of 'foo'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function fn() { foo; }",
             options: [{ name: "foo" }],
-            errors: [{ message: "Unexpected use of 'foo'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function fn() { foo; }",
             options: [{ name: "foo" }],
             globals: { foo: false },
-            errors: [{ message: "Unexpected use of 'foo'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
         },
         {
             code: "event",
             options: ["foo", { name: "event" }],
             env: { browser: true },
-            errors: [{ message: "Unexpected use of 'event'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "event" },
+                type: "Identifier"
+            }]
         },
         {
             code: "foo",
             options: [{ name: "foo" }],
             globals: { foo: false },
-            errors: [{ message: "Unexpected use of 'foo'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
         },
         {
             code: "foo()",
             options: [{ name: "foo" }],
-            errors: [{ message: "Unexpected use of 'foo'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
         },
         {
             code: "foo.bar()",
             options: [{ name: "foo" }],
-            errors: [{ message: "Unexpected use of 'foo'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
         },
         {
             code: "foo",
             options: [{ name: "foo", message: "Use bar instead." }],
-            errors: [{ message: "Unexpected use of 'foo'. Use bar instead.", type: "Identifier" }]
+            errors: [{
+                messageId: "customMessage",
+                data: { name: "foo", customMessage: "Use bar instead." },
+                type: "Identifier"
+            }]
         },
         {
             code: "function fn() { foo; }",
             options: [{ name: "foo", message: "Use bar instead." }],
-            errors: [{ message: "Unexpected use of 'foo'. Use bar instead.", type: "Identifier" }]
+            errors: [{
+                messageId: "customMessage",
+                data: { name: "foo", customMessage: "Use bar instead." },
+                type: "Identifier"
+            }]
         },
         {
             code: "function fn() { foo; }",
             options: [{ name: "foo", message: "Use bar instead." }],
             globals: { foo: false },
-            errors: [{ message: "Unexpected use of 'foo'. Use bar instead.", type: "Identifier" }]
+            errors: [{
+                messageId: "customMessage",
+                data: { name: "foo", customMessage: "Use bar instead." },
+                type: "Identifier"
+            }]
         },
         {
             code: "event",
             options: ["foo", { name: "event", message: "Use local event parameter." }],
             env: { browser: true },
-            errors: [{ message: "Unexpected use of 'event'. Use local event parameter.", type: "Identifier" }]
+            errors: [{
+                messageId: "customMessage",
+                data: { name: "event", customMessage: "Use local event parameter." },
+                type: "Identifier"
+            }]
         },
         {
             code: "foo",
             options: [{ name: "foo", message: "Use bar instead." }],
             globals: { foo: false },
-            errors: [{ message: "Unexpected use of 'foo'. Use bar instead.", type: "Identifier" }]
+            errors: [{
+                messageId: "customMessage",
+                data: { name: "foo", customMessage: "Use bar instead." },
+                type: "Identifier"
+            }]
         },
         {
             code: "foo()",
             options: [{ name: "foo", message: "Use bar instead." }],
-            errors: [{ message: "Unexpected use of 'foo'. Use bar instead.", type: "Identifier" }]
+            errors: [{
+                messageId: "customMessage",
+                data: { name: "foo", customMessage: "Use bar instead." },
+                type: "Identifier"
+            }]
         },
         {
             code: "foo.bar()",
             options: [{ name: "foo", message: "Use bar instead." }],
-            errors: [{ message: "Unexpected use of 'foo'. Use bar instead.", type: "Identifier" }]
+            errors: [{
+                messageId: "customMessage",
+                data: { name: "foo", customMessage: "Use bar instead." },
+                type: "Identifier"
+            }]
         },
         {
             code: "var foo = obj => hasOwnProperty(obj, 'name');",
             options: ["hasOwnProperty"],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Unexpected use of 'hasOwnProperty'.", type: "Identifier" }]
+            errors: [{
+                messageId: "defaultMessage",
+                data: { name: "hasOwnProperty" },
+                type: "Identifier"
+            }]
         }
     ]
 });

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -63,7 +63,8 @@ ruleTester.run("no-shadow", rule, {
         {
             code: "function a(x) { var b = function c() { var x = 'foo'; }; }",
             errors: [{
-                message: "'x' is already declared in the upper scope.",
+                messageId: "noShadow",
+                data: { name: "x" },
                 type: "Identifier",
                 line: 1,
                 column: 44
@@ -73,7 +74,8 @@ ruleTester.run("no-shadow", rule, {
             code: "var a = (x) => { var b = () => { var x = 'foo'; }; }",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
-                message: "'x' is already declared in the upper scope.",
+                messageId: "noShadow",
+                data: { name: "x" },
                 type: "Identifier",
                 line: 1,
                 column: 38
@@ -82,7 +84,8 @@ ruleTester.run("no-shadow", rule, {
         {
             code: "function a(x) { var b = function () { var x = 'foo'; }; }",
             errors: [{
-                message: "'x' is already declared in the upper scope.",
+                messageId: "noShadow",
+                data: { name: "x" },
                 type: "Identifier",
                 line: 1,
                 column: 43
@@ -91,7 +94,8 @@ ruleTester.run("no-shadow", rule, {
         {
             code: "var x = 1; function a(x) { return ++x; }",
             errors: [{
-                message: "'x' is already declared in the upper scope.",
+                messageId: "noShadow",
+                data: { name: "x" },
                 type: "Identifier",
                 line: 1,
                 column: 23
@@ -99,240 +103,430 @@ ruleTester.run("no-shadow", rule, {
         },
         {
             code: "var a=3; function b() { var a=10; }",
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "var a=3; function b() { var a=10; }; setTimeout(function() { b(); }, 0);",
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "var a=3; function b() { var a=10; var b=0; }; setTimeout(function() { b(); }, 0);",
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }, { message: "'b' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [
+                {
+                    messageId: "noShadow",
+                    data: { name: "a" },
+                    type: "Identifier"
+                }, {
+                    messageId: "noShadow",
+                    data: { name: "b" },
+                    type: "Identifier"
+                }
+            ]
         },
         {
             code: "var x = 1; { let x = 2; }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "x" },
+                type: "Identifier"
+            }]
         },
         {
             code: "let x = 1; { const x = 2; }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "x" },
+                type: "Identifier"
+            }]
         },
         {
             code: "{ let a; } function a() {}",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "{ const a = 0; } function a() {}",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo() { let a; } function a() {}",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo() { var a; } function a() {}",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo(a) { } function a() {}",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "{ let a; } let a;",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "{ let a; } var a;",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "{ let a; } function a() {}",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "{ const a = 0; } const a = 1;",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "{ const a = 0; } var a;",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "{ const a = 0; } function a() {}",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo() { let a; } let a;",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo() { let a; } var a;",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo() { let a; } function a() {}",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo() { var a; } let a;",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo() { var a; } var a;",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo() { var a; } function a() {}",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo(a) { } let a;",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo(a) { } var a;",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo(a) { } function a() {}",
             options: [{ hoist: "all" }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "(function a() { function a(){} })()",
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "(function a() { class a{} })()",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "(function a() { (function a(){}); })()",
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "(function a() { (class a{}); })()",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "(function() { var a = function(a) {}; })()",
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "(function() { var a = function() { function a() {} }; })()",
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "(function() { var a = function() { class a{} }; })()",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "(function() { var a = function() { (function a() {}); }; })()",
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "(function() { var a = function() { (class a{}); }; })()",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "(function() { var a = class { constructor() { class a {} } }; })()",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'a' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
         },
         {
             code: "class A { constructor() { var A; } }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'A' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "A" },
+                type: "Identifier"
+            }]
         },
         {
             code: "(function a() { function a(){ function a(){} } })()",
             errors: [
-                { message: "'a' is already declared in the upper scope.", type: "Identifier", line: 1, column: 26 },
-                { message: "'a' is already declared in the upper scope.", type: "Identifier", line: 1, column: 40 }
+                {
+                    messageId: "noShadow",
+                    data: { name: "a" },
+                    type: "Identifier",
+                    line: 1,
+                    column: 26
+                },
+                {
+                    messageId: "noShadow",
+                    data: { name: "a" },
+                    type: "Identifier",
+                    line: 1,
+                    column: 40
+                }
             ]
         },
         {
             code: "function foo() { var Object = 0; }",
             options: [{ builtinGlobals: true }],
-            errors: [{ message: "'Object' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "Object" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo() { var top = 0; }",
             options: [{ builtinGlobals: true }],
             env: { browser: true },
-            errors: [{ message: "'top' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "top" },
+                type: "Identifier"
+            }]
         },
         {
             code: "var Object = 0;",
             options: [{ builtinGlobals: true }],
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
-            errors: [{ message: "'Object' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "Object" },
+                type: "Identifier"
+            }]
         },
         {
             code: "var top = 0;",
             options: [{ builtinGlobals: true }],
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
             env: { browser: true },
-            errors: [{ message: "'top' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "top" },
+                type: "Identifier"
+            }]
         },
         {
             code: "var Object = 0;",
             options: [{ builtinGlobals: true }],
             parserOptions: { ecmaFeatures: { globalReturn: true } },
-            errors: [{ message: "'Object' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "Object" },
+                type: "Identifier"
+            }]
         },
         {
             code: "var top = 0;",
             options: [{ builtinGlobals: true }],
             parserOptions: { ecmaFeatures: { globalReturn: true } },
             env: { browser: true },
-            errors: [{ message: "'top' is already declared in the upper scope.", type: "Identifier" }]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "top" },
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo(cb) { (function (cb) { cb(42); })(cb); }",
-            errors: [
-                { message: "'cb' is already declared in the upper scope.", type: "Identifier", line: 1, column: 31 }
-            ]
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "cb" },
+                type: "Identifier",
+                line: 1,
+                column: 31
+            }]
         }
     ]
 });

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -59,109 +59,442 @@ ruleTester.run("no-use-before-define", rule, {
         }
     ],
     invalid: [
-        { code: "a++; var a=19;", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "a++; var a=19;", parserOptions: { parserOptions: { ecmaVersion: 6 } }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "a++; var a=19;", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "a(); var a=function() {};", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "alert(a[1]); var a=[1,3];", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "a(); function a() { alert(b); var b=10; a(); }", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }, { message: "'b' was used before it was defined.", type: "Identifier" }] },
-        { code: "a(); var a=function() {};", options: ["nofunc"], errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "(() => { alert(a); var a = 42; })();", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "(() => a())(); function a() { }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "\"use strict\"; a(); { function a() {} }", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "a(); try { throw new Error() } catch (foo) {var a;}", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "var f = () => a; var a;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "new A(); class A {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
-        { code: "function foo() { new A(); } class A {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
-        { code: "new A(); var A = class {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
-        { code: "function foo() { new A(); } var A = class {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
+        {
+            code: "a++; var a=19;",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "a++; var a=19;",
+            parserOptions: { parserOptions: { ecmaVersion: 6 } },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "a++; var a=19;",
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "a(); var a=function() {};",
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "alert(a[1]); var a=[1,3];",
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "a(); function a() { alert(b); var b=10; a(); }",
+            errors: [
+                {
+                    messageId: "usedBeforeDefined",
+                    data: { name: "a" },
+                    type: "Identifier"
+                },
+                {
+                    messageId: "usedBeforeDefined",
+                    data: { name: "b" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "a(); var a=function() {};",
+            options: ["nofunc"],
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "(() => { alert(a); var a = 42; })();",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "(() => a())(); function a() { }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "\"use strict\"; a(); { function a() {} }",
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "a(); try { throw new Error() } catch (foo) {var a;}",
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "var f = () => a; var a;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "new A(); class A {};",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "A" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "function foo() { new A(); } class A {};",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "A" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "new A(); var A = class {};",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "A" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "function foo() { new A(); } var A = class {};",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "A" },
+                type: "Identifier"
+            }]
+        },
 
         // Block-level bindings
-        { code: "a++; { var a; }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "\"use strict\"; { a(); function a() {} }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "{a; let a = 1}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "switch (foo) { case 1: a();\n default: \n let a;}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "if (true) { function foo() { a; } let a;}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        {
+            code: "a++; { var a; }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "\"use strict\"; { a(); function a() {} }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "{a; let a = 1}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "switch (foo) { case 1: a();\n default: \n let a;}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "if (true) { function foo() { a; } let a;}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
 
         // object style options
-        { code: "a(); var a=function() {};", options: [{ functions: false, classes: false }], errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "new A(); class A {};", options: [{ functions: false, classes: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
-        { code: "new A(); var A = class {};", options: [{ classes: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
-        { code: "function foo() { new A(); } var A = class {};", options: [{ classes: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
+        {
+            code: "a(); var a=function() {};",
+            options: [{ functions: false, classes: false }],
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "new A(); class A {};",
+            options: [{ functions: false, classes: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "A" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "new A(); var A = class {};",
+            options: [{ classes: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "A" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "function foo() { new A(); } var A = class {};",
+            options: [{ classes: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "A" },
+                type: "Identifier"
+            }]
+        },
 
         // invalid initializers
-        { code: "var a = a;", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "let a = a + b;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "const a = foo(a);", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "function foo(a = a) {}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "var {a = a} = [];", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "var [a = a] = [];", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "var {b = a, a} = {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "var [b = a, a] = {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "var {a = 0} = a;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "var [a = 0] = a;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "for (var a in a) {}", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "for (var a of a) {}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        {
+            code: "var a = a;",
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "let a = a + b;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "const a = foo(a);",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "function foo(a = a) {}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "var {a = a} = [];",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "var [a = a] = [];",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "var {b = a, a} = {};",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "var [b = a, a] = {};",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "var {a = 0} = a;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "var [a = 0] = a;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "for (var a in a) {}",
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "for (var a of a) {}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "a" },
+                type: "Identifier"
+            }]
+        },
 
         // "variables" option
         {
             code: "function foo() { bar; var bar = 1; } var bar;",
             options: [{ variables: false }],
-            errors: [{ message: "'bar' was used before it was defined.", type: "Identifier" }]
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "bar" },
+                type: "Identifier"
+            }]
         },
         {
             code: "foo; var foo;",
             options: [{ variables: false }],
-            errors: [{ message: "'foo' was used before it was defined.", type: "Identifier" }]
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "foo" },
+                type: "Identifier"
+            }]
         },
 
         // https://github.com/eslint/eslint/issues/10227
         {
             code: "for (let x = x;;); let x = 0",
             parserOptions: { ecmaVersion: 2015 },
-            errors: ["'x' was used before it was defined."]
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "x" }
+            }]
         },
         {
             code: "for (let x in xs); let xs = []",
             parserOptions: { ecmaVersion: 2015 },
-            errors: ["'xs' was used before it was defined."]
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "xs" }
+            }]
         },
         {
             code: "for (let x of xs); let xs = []",
             parserOptions: { ecmaVersion: 2015 },
-            errors: ["'xs' was used before it was defined."]
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "xs" }
+            }]
         },
         {
             code: "try {} catch ({message = x}) {} let x = ''",
             parserOptions: { ecmaVersion: 2015 },
-            errors: ["'x' was used before it was defined."]
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "x" }
+            }]
         },
         {
             code: "with (obj) x; let x = {}",
             parserOptions: { ecmaVersion: 2015 },
-            errors: ["'x' was used before it was defined."]
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "x" }
+            }]
         },
 
         // WithStatements.
         {
             code: "with (x); let x = {}",
             parserOptions: { ecmaVersion: 2015 },
-            errors: ["'x' was used before it was defined."]
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "x" }
+            }]
         },
         {
             code: "with (obj) { x } let x = {}",
             parserOptions: { ecmaVersion: 2015 },
-            errors: ["'x' was used before it was defined."]
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "x" }
+            }]
         },
         {
             code: "with (obj) { if (a) { x } } let x = {}",
             parserOptions: { ecmaVersion: 2015 },
-            errors: ["'x' was used before it was defined."]
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "x" }
+            }]
         },
         {
             code: "with (obj) { (() => { if (a) { x } })() } let x = {}",
             parserOptions: { ecmaVersion: 2015 },
-            errors: ["'x' was used before it was defined."]
+            errors: [{
+                messageId: "usedBeforeDefined",
+                data: { name: "x" }
+            }]
         }
     ]
 });

--- a/tests/lib/rules/no-useless-constructor.js
+++ b/tests/lib/rules/no-useless-constructor.js
@@ -17,7 +17,7 @@ const { RuleTester } = require("../../../lib/rule-tester");
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
-const error = { message: "Useless constructor.", type: "MethodDefinition" };
+const error = { messageId: "noUselessConstructor", type: "MethodDefinition" };
 
 ruleTester.run("no-useless-constructor", rule, {
     valid: [

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -80,13 +80,21 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = 'bar';",
             output: "var foo = \"bar\";",
-            errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = \"bar\";",
             output: "var foo = 'bar';",
             options: ["single"],
-            errors: [{ message: "Strings must use singlequote.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "singlequote" },
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = `bar`;",
@@ -95,27 +103,49 @@ ruleTester.run("quotes", rule, {
             parserOptions: {
                 ecmaVersion: 6
             },
-            errors: [{ message: "Strings must use singlequote.", type: "TemplateLiteral" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "singlequote" },
+                type: "TemplateLiteral"
+            }]
         },
         {
             code: "var foo = 'don\\'t';",
             output: "var foo = \"don't\";",
-            errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "Literal"
+            }]
         },
         {
             code: "var msg = \"Plugin '\" + name + \"' not found\"",
             output: "var msg = 'Plugin \\'' + name + '\\' not found'",
             options: ["single"],
             errors: [
-                { message: "Strings must use singlequote.", type: "Literal", column: 11 },
-                { message: "Strings must use singlequote.", type: "Literal", column: 31 }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "singlequote" },
+                    type: "Literal",
+                    column: 11
+                },
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "singlequote" },
+                    type: "Literal",
+                    column: 31
+                }
             ]
         },
         {
             code: "var foo = 'bar';",
             output: "var foo = \"bar\";",
             options: ["double"],
-            errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = `bar`;",
@@ -124,72 +154,116 @@ ruleTester.run("quotes", rule, {
             parserOptions: {
                 ecmaVersion: 6
             },
-            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
         },
         {
             code: "var foo = \"bar\";",
             output: "var foo = 'bar';",
             options: ["single", { avoidEscape: true }],
-            errors: [{ message: "Strings must use singlequote.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "singlequote" },
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = 'bar';",
             output: "var foo = \"bar\";",
             options: ["double", { avoidEscape: true }],
-            errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = '\\\\';",
             output: "var foo = \"\\\\\";",
             options: ["double", { avoidEscape: true }],
-            errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = \"bar\";",
             output: "var foo = 'bar';",
             options: ["single", { allowTemplateLiterals: true }],
-            errors: [{ message: "Strings must use singlequote.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "singlequote" },
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = 'bar';",
             output: "var foo = \"bar\";",
             options: ["double", { allowTemplateLiterals: true }],
-            errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = 'bar';",
             output: "var foo = `bar`;",
             options: ["backtick"],
             parserOptions: { ecmaVersion: 2015 },
-            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = 'b${x}a$r';",
             output: "var foo = `b\\${x}a$r`;",
             options: ["backtick"],
             parserOptions: { ecmaVersion: 2015 },
-            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = \"bar\";",
             output: "var foo = `bar`;",
             options: ["backtick"],
             parserOptions: { ecmaVersion: 2015 },
-            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = \"bar\";",
             output: "var foo = `bar`;",
             options: ["backtick", { avoidEscape: true }],
             parserOptions: { ecmaVersion: 2015 },
-            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = 'bar';",
             output: "var foo = `bar`;",
             options: ["backtick", { avoidEscape: true }],
             parserOptions: { ecmaVersion: 2015 },
-            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
         },
 
         // "use strict" is *not* a directive prologue in these statements so is subject to the rule
@@ -198,21 +272,33 @@ ruleTester.run("quotes", rule, {
             output: "var foo = `backtick`; `use strict`;",
             options: ["backtick"],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
         },
         {
             code: "{ \"use strict\"; var foo = `backtick`; }",
             output: "{ `use strict`; var foo = `backtick`; }",
             options: ["backtick"],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
         },
         {
             code: "if (1) { \"use strict\"; var foo = `backtick`; }",
             output: "if (1) { `use strict`; var foo = `backtick`; }",
             options: ["backtick"],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
         },
 
         // `backtick` should warn computed property names.
@@ -222,8 +308,16 @@ ruleTester.run("quotes", rule, {
             options: ["backtick"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Strings must use backtick.", type: "Literal" },
-                { message: "Strings must use backtick.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                },
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
             ]
         },
         {
@@ -232,8 +326,16 @@ ruleTester.run("quotes", rule, {
             options: ["backtick"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Strings must use backtick.", type: "Literal" },
-                { message: "Strings must use backtick.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                },
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
             ]
         },
 
@@ -244,7 +346,11 @@ ruleTester.run("quotes", rule, {
             options: ["single"],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [
-                { message: "Strings must use singlequote.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "singlequote" },
+                    type: "Literal"
+                }
             ]
         },
         {
@@ -253,7 +359,11 @@ ruleTester.run("quotes", rule, {
             options: ["double"],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [
-                { message: "Strings must use doublequote.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "doublequote" },
+                    type: "Literal"
+                }
             ]
         },
         {
@@ -262,7 +372,11 @@ ruleTester.run("quotes", rule, {
             options: ["backtick"],
             parserOptions: { ecmaFeatures: { jsx: true }, ecmaVersion: 2015 },
             errors: [
-                { message: "Strings must use backtick.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
             ]
         },
 
@@ -271,37 +385,61 @@ ruleTester.run("quotes", rule, {
             code: "`use strict`;",
             output: null,
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
         },
         {
             code: "function foo() { `use strict`; foo(); }",
             output: null,
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
         },
         {
             code: "foo = function() { `use strict`; foo(); }",
             output: null,
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
         },
         {
             code: "() => { `use strict`; foo(); }",
             output: null,
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
         },
         {
             code: "() => { foo(); `use strict`; }",
             output: "() => { foo(); \"use strict\"; }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
         },
         {
             code: "foo(); `use strict`;",
             output: "foo(); \"use strict\";",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
         },
 
         // https://github.com/eslint/eslint/issues/7646
@@ -309,25 +447,43 @@ ruleTester.run("quotes", rule, {
             code: "var foo = `foo\\nbar`;",
             output: "var foo = \"foo\\nbar\";",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
         },
         {
             code: "var foo = `foo\\\nbar`;", // 1 backslash followed by a newline
             output: "var foo = \"foo\\\nbar\";",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
         },
         {
             code: "var foo = `foo\\\\\\\nbar`;", // 3 backslashes followed by a newline
             output: "var foo = \"foo\\\\\\\nbar\";",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
         },
         {
             code: "````",
             output: "\"\"``",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral", line: 1, column: 1 }]
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral",
+                line: 1,
+                column: 1
+            }]
         },
 
         // Strings containing octal escape sequences. Don't autofix to backticks.
@@ -336,7 +492,11 @@ ruleTester.run("quotes", rule, {
             output: "var foo = '\\1'",
             options: ["single"],
             errors: [
-                { message: "Strings must use singlequote.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "singlequote" },
+                    type: "Literal"
+                }
             ]
         },
         {
@@ -344,7 +504,11 @@ ruleTester.run("quotes", rule, {
             output: "var foo = \"\\1\"",
             options: ["double"],
             errors: [
-                { message: "Strings must use doublequote.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "doublequote" },
+                    type: "Literal"
+                }
             ]
         },
         {
@@ -353,7 +517,11 @@ ruleTester.run("quotes", rule, {
             options: ["backtick"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Strings must use backtick.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
             ]
         },
         {
@@ -362,7 +530,11 @@ ruleTester.run("quotes", rule, {
             options: ["backtick"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Strings must use backtick.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
             ]
         },
         {
@@ -371,7 +543,11 @@ ruleTester.run("quotes", rule, {
             options: ["backtick"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Strings must use backtick.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
             ]
         },
         {
@@ -380,7 +556,11 @@ ruleTester.run("quotes", rule, {
             options: ["backtick"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Strings must use backtick.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
             ]
         },
         {
@@ -389,7 +569,11 @@ ruleTester.run("quotes", rule, {
             options: ["backtick"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Strings must use backtick.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
             ]
         },
         {
@@ -398,7 +582,11 @@ ruleTester.run("quotes", rule, {
             options: ["backtick"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Strings must use backtick.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
             ]
         },
         {
@@ -407,7 +595,11 @@ ruleTester.run("quotes", rule, {
             options: ["backtick"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Strings must use backtick.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
             ]
         },
         {
@@ -416,7 +608,11 @@ ruleTester.run("quotes", rule, {
             options: ["backtick"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Strings must use backtick.", type: "Literal" }
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
             ]
         }
     ]

--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -60,43 +60,73 @@ ruleTester.run("require-await", rule, {
     invalid: [
         {
             code: "async function foo() { doSomething() }",
-            errors: ["Async function 'foo' has no 'await' expression."]
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async function 'foo'" }
+            }]
         },
         {
             code: "(async function() { doSomething() })",
-            errors: ["Async function has no 'await' expression."]
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async function" }
+            }]
         },
         {
             code: "async () => { doSomething() }",
-            errors: ["Async arrow function has no 'await' expression."]
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async arrow function" }
+            }]
         },
         {
             code: "async () => doSomething()",
-            errors: ["Async arrow function has no 'await' expression."]
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async arrow function" }
+            }]
         },
         {
             code: "({ async foo() { doSomething() } })",
-            errors: ["Async method 'foo' has no 'await' expression."]
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async method 'foo'" }
+            }]
         },
         {
             code: "class A { async foo() { doSomething() } }",
-            errors: ["Async method 'foo' has no 'await' expression."]
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async method 'foo'" }
+            }]
         },
         {
             code: "(class { async foo() { doSomething() } })",
-            errors: ["Async method 'foo' has no 'await' expression."]
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async method 'foo'" }
+            }]
         },
         {
             code: "(class { async ''() { doSomething() } })",
-            errors: ["Async method '' has no 'await' expression."]
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async method ''" }
+            }]
         },
         {
             code: "async function foo() { async () => { await doSomething() } }",
-            errors: ["Async function 'foo' has no 'await' expression."]
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async function 'foo'" }
+            }]
         },
         {
             code: "async function foo() { await async () => { doSomething() } }",
-            errors: ["Async arrow function has no 'await' expression."]
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async arrow function" }
+            }]
         }
     ]
 });

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -233,80 +233,629 @@ ruleTester.run("semi", rule, {
         }
     ],
     invalid: [
-        { code: "import * as utils from './utils'", output: "import * as utils from './utils';", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ImportDeclaration", column: 33, endLine: void 0, endColumn: void 0 }] },
-        { code: "import { square, diag } from 'lib'", output: "import { square, diag } from 'lib';", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ImportDeclaration" }] },
-        { code: "import { default as foo } from 'lib'", output: "import { default as foo } from 'lib';", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ImportDeclaration" }] },
-        { code: "import 'src/mylib'", output: "import 'src/mylib';", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ImportDeclaration" }] },
-        { code: "import theDefault, { named1, named2 } from 'src/mylib'", output: "import theDefault, { named1, named2 } from 'src/mylib';", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ImportDeclaration" }] },
-        { code: "function foo() { return [] }", output: "function foo() { return []; }", errors: [{ message: "Missing semicolon.", type: "ReturnStatement" }] },
-        { code: "while(true) { break }", output: "while(true) { break; }", errors: [{ message: "Missing semicolon.", type: "BreakStatement" }] },
-        { code: "while(true) { continue }", output: "while(true) { continue; }", errors: [{ message: "Missing semicolon.", type: "ContinueStatement" }] },
-        { code: "let x = 5", output: "let x = 5;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Missing semicolon.", type: "VariableDeclaration" }] },
-        { code: "var x = 5", output: "var x = 5;", errors: [{ message: "Missing semicolon.", type: "VariableDeclaration" }] },
-        { code: "var x = 5, y", output: "var x = 5, y;", errors: [{ message: "Missing semicolon.", type: "VariableDeclaration" }] },
-        { code: "debugger", output: "debugger;", errors: [{ message: "Missing semicolon.", type: "DebuggerStatement" }] },
-        { code: "foo()", output: "foo();", errors: [{ message: "Missing semicolon.", type: "ExpressionStatement", column: 6, endColumn: void 0 }] },
-        { code: "foo()\n", output: "foo();\n", errors: [{ message: "Missing semicolon.", type: "ExpressionStatement", column: 6, endLine: 2, endColumn: 1 }] },
-        { code: "foo()\nbar();", output: "foo();\nbar();", errors: [{ message: "Missing semicolon.", type: "ExpressionStatement", column: 6, endLine: 2, endColumn: 1 }] },
-        { code: "for (var a in b) var i ", output: "for (var a in b) var i; ", errors: [{ message: "Missing semicolon.", type: "VariableDeclaration" }] },
-        { code: "for (;;){var i}", output: "for (;;){var i;}", errors: [{ message: "Missing semicolon.", type: "VariableDeclaration" }] },
-        { code: "for (;;) var i ", output: "for (;;) var i; ", errors: [{ message: "Missing semicolon.", type: "VariableDeclaration" }] },
-        { code: "for (var j;;) {var i}", output: "for (var j;;) {var i;}", errors: [{ message: "Missing semicolon.", type: "VariableDeclaration" }] },
-        { code: "var foo = {\n bar: baz\n}", output: "var foo = {\n bar: baz\n};", errors: [{ message: "Missing semicolon.", type: "VariableDeclaration", line: 3 }] },
-        { code: "var foo\nvar bar;", output: "var foo;\nvar bar;", errors: [{ message: "Missing semicolon.", type: "VariableDeclaration", line: 1 }] },
-        { code: "throw new Error('foo')", output: "throw new Error('foo');", errors: [{ message: "Missing semicolon.", type: "ThrowStatement", line: 1 }] },
-        { code: "do{}while(true)", output: "do{}while(true);", errors: [{ message: "Missing semicolon.", type: "DoWhileStatement", line: 1 }] },
-        { code: "if (foo) {bar()}", output: "if (foo) {bar();}", errors: [{ message: "Missing semicolon.", column: 16, endColumn: 17 }] },
-        { code: "if (foo) {bar()} ", output: "if (foo) {bar();} ", errors: [{ message: "Missing semicolon.", column: 16, endColumn: 17 }] },
-        { code: "if (foo) {bar()\n}", output: "if (foo) {bar();\n}", errors: [{ message: "Missing semicolon.", column: 16, endLine: 2, endColumn: 1 }] },
+        {
+            code: "import * as utils from './utils'",
+            output: "import * as utils from './utils';",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "ImportDeclaration",
+                column: 33,
+                endLine: void 0,
+                endColumn: void 0
+            }]
+        },
+        {
+            code: "import { square, diag } from 'lib'",
+            output: "import { square, diag } from 'lib';",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import { default as foo } from 'lib'",
+            output: "import { default as foo } from 'lib';",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import 'src/mylib'",
+            output: "import 'src/mylib';",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import theDefault, { named1, named2 } from 'src/mylib'",
+            output: "import theDefault, { named1, named2 } from 'src/mylib';",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "function foo() { return [] }",
+            output: "function foo() { return []; }",
+            errors: [{
+                messageId: "missingSemi",
+                type: "ReturnStatement"
+            }]
+        },
+        {
+            code: "while(true) { break }",
+            output: "while(true) { break; }",
+            errors: [{
+                messageId: "missingSemi",
+                type: "BreakStatement"
+            }]
+        },
+        {
+            code: "while(true) { continue }",
+            output: "while(true) { continue; }",
+            errors: [{
+                messageId: "missingSemi",
+                type: "ContinueStatement"
+            }]
+        },
+        {
+            code: "let x = 5",
+            output: "let x = 5;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "missingSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var x = 5",
+            output: "var x = 5;",
+            errors: [{
+                messageId: "missingSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var x = 5, y",
+            output: "var x = 5, y;",
+            errors: [{
+                messageId: "missingSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "debugger",
+            output: "debugger;",
+            errors: [{
+                messageId: "missingSemi",
+                type: "DebuggerStatement"
+            }]
+        },
+        {
+            code: "foo()",
+            output: "foo();",
+            errors: [{
+                messageId: "missingSemi",
+                type: "ExpressionStatement",
+                column: 6,
+                endColumn: void 0
+            }]
+        },
+        {
+            code: "foo()\n",
+            output: "foo();\n",
+            errors: [{
+                messageId: "missingSemi",
+                type: "ExpressionStatement",
+                column: 6,
+                endLine: 2,
+                endColumn: 1
+            }]
+        },
+        {
+            code: "foo()\nbar();",
+            output: "foo();\nbar();",
+            errors: [{
+                messageId: "missingSemi",
+                type: "ExpressionStatement",
+                column: 6,
+                endLine: 2,
+                endColumn: 1
+            }]
+        },
+        {
+            code: "for (var a in b) var i ",
+            output: "for (var a in b) var i; ",
+            errors: [{
+                messageId: "missingSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "for (;;){var i}",
+            output: "for (;;){var i;}",
+            errors: [{
+                messageId: "missingSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "for (;;) var i ",
+            output: "for (;;) var i; ",
+            errors: [{
+                messageId: "missingSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "for (var j;;) {var i}",
+            output: "for (var j;;) {var i;}",
+            errors: [{
+                messageId: "missingSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var foo = {\n bar: baz\n}",
+            output: "var foo = {\n bar: baz\n};",
+            errors: [{
+                messageId: "missingSemi",
+                type: "VariableDeclaration",
+                line: 3
+            }]
+        },
+        {
+            code: "var foo\nvar bar;",
+            output: "var foo;\nvar bar;",
+            errors: [{
+                messageId: "missingSemi",
+                type: "VariableDeclaration",
+                line: 1
+            }]
+        },
+        {
+            code: "throw new Error('foo')",
+            output: "throw new Error('foo');",
+            errors: [{
+                messageId: "missingSemi",
+                type: "ThrowStatement",
+                line: 1
+            }]
+        },
+        {
+            code: "do{}while(true)",
+            output: "do{}while(true);",
+            errors: [{
+                messageId: "missingSemi",
+                type: "DoWhileStatement",
+                line: 1
+            }]
+        },
+        {
+            code: "if (foo) {bar()}",
+            output: "if (foo) {bar();}",
+            errors: [{
+                messageId: "missingSemi",
+                column: 16,
+                endColumn: 17
+            }]
+        },
+        {
+            code: "if (foo) {bar()} ",
+            output: "if (foo) {bar();} ",
+            errors: [{
+                messageId: "missingSemi",
+                column: 16,
+                endColumn: 17
+            }]
+        },
+        {
+            code: "if (foo) {bar()\n}",
+            output: "if (foo) {bar();\n}",
+            errors: [{
+                messageId: "missingSemi",
+                column: 16,
+                endLine: 2,
+                endColumn: 1
+            }]
+        },
 
-        { code: "throw new Error('foo');", output: "throw new Error('foo')", options: ["never"], errors: [{ message: "Extra semicolon.", type: "ThrowStatement", column: 23 }] },
-        { code: "function foo() { return []; }", output: "function foo() { return [] }", options: ["never"], errors: [{ message: "Extra semicolon.", type: "ReturnStatement" }] },
-        { code: "while(true) { break; }", output: "while(true) { break }", options: ["never"], errors: [{ message: "Extra semicolon.", type: "BreakStatement" }] },
-        { code: "while(true) { continue; }", output: "while(true) { continue }", options: ["never"], errors: [{ message: "Extra semicolon.", type: "ContinueStatement" }] },
-        { code: "let x = 5;", output: "let x = 5", options: ["never"], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Extra semicolon.", type: "VariableDeclaration" }] },
-        { code: "var x = 5;", output: "var x = 5", options: ["never"], errors: [{ message: "Extra semicolon.", type: "VariableDeclaration" }] },
-        { code: "var x = 5, y;", output: "var x = 5, y", options: ["never"], errors: [{ message: "Extra semicolon.", type: "VariableDeclaration" }] },
-        { code: "debugger;", output: "debugger", options: ["never"], errors: [{ message: "Extra semicolon.", type: "DebuggerStatement" }] },
-        { code: "foo();", output: "foo()", options: ["never"], errors: [{ message: "Extra semicolon.", type: "ExpressionStatement" }] },
-        { code: "for (var a in b) var i; ", output: "for (var a in b) var i ", options: ["never"], errors: [{ message: "Extra semicolon.", type: "VariableDeclaration" }] },
-        { code: "for (;;){var i;}", output: "for (;;){var i}", options: ["never"], errors: [{ message: "Extra semicolon.", type: "VariableDeclaration" }] },
-        { code: "for (;;) var i; ", output: "for (;;) var i ", options: ["never"], errors: [{ message: "Extra semicolon.", type: "VariableDeclaration" }] },
-        { code: "for (var j;;) {var i;}", output: "for (var j;;) {var i}", options: ["never"], errors: [{ message: "Extra semicolon.", type: "VariableDeclaration" }] },
-        { code: "var foo = {\n bar: baz\n};", output: "var foo = {\n bar: baz\n}", options: ["never"], errors: [{ message: "Extra semicolon.", type: "VariableDeclaration", line: 3 }] },
-        { code: "import theDefault, { named1, named2 } from 'src/mylib';", output: "import theDefault, { named1, named2 } from 'src/mylib'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ImportDeclaration" }] },
-        { code: "do{}while(true);", output: "do{}while(true)", options: ["never"], errors: [{ message: "Extra semicolon.", type: "DoWhileStatement", line: 1 }] },
+        {
+            code: "throw new Error('foo');",
+            output: "throw new Error('foo')",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "ThrowStatement",
+                column: 23
+            }]
+        },
+        {
+            code: "function foo() { return []; }",
+            output: "function foo() { return [] }",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "ReturnStatement"
+            }]
+        },
+        {
+            code: "while(true) { break; }",
+            output: "while(true) { break }",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "BreakStatement"
+            }]
+        },
+        {
+            code: "while(true) { continue; }",
+            output: "while(true) { continue }",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "ContinueStatement"
+            }]
+        },
+        {
+            code: "let x = 5;",
+            output: "let x = 5",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "extraSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var x = 5;",
+            output: "var x = 5",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var x = 5, y;",
+            output: "var x = 5, y",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "debugger;",
+            output: "debugger",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "DebuggerStatement"
+            }]
+        },
+        {
+            code: "foo();",
+            output: "foo()",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "ExpressionStatement"
+            }]
+        },
+        {
+            code: "for (var a in b) var i; ",
+            output: "for (var a in b) var i ",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "for (;;){var i;}",
+            output: "for (;;){var i}",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "for (;;) var i; ",
+            output: "for (;;) var i ",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "for (var j;;) {var i;}",
+            output: "for (var j;;) {var i}",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var foo = {\n bar: baz\n};",
+            output: "var foo = {\n bar: baz\n}",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "VariableDeclaration",
+                line: 3
+            }]
+        },
+        {
+            code: "import theDefault, { named1, named2 } from 'src/mylib';",
+            output: "import theDefault, { named1, named2 } from 'src/mylib'",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "extraSemi",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "do{}while(true);",
+            output: "do{}while(true)",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                type: "DoWhileStatement",
+                line: 1
+            }]
+        },
 
-        { code: "if (foo) { bar()\n }", output: "if (foo) { bar();\n }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Missing semicolon." }] },
-        { code: "if (foo) {\n bar() }", output: "if (foo) {\n bar(); }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Missing semicolon." }] },
-        { code: "if (foo) {\n bar(); baz() }", output: "if (foo) {\n bar(); baz(); }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Missing semicolon." }] },
-        { code: "if (foo) { bar(); }", output: "if (foo) { bar() }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Extra semicolon." }] },
+        {
+            code: "if (foo) { bar()\n }",
+            output: "if (foo) { bar();\n }",
+            options: ["always", { omitLastInOneLineBlock: true }],
+            errors: [{
+                messageId: "missingSemi"
+            }]
+        },
+        {
+            code: "if (foo) {\n bar() }",
+            output: "if (foo) {\n bar(); }",
+            options: ["always", { omitLastInOneLineBlock: true }],
+            errors: [{
+                messageId: "missingSemi"
+            }]
+        },
+        {
+            code: "if (foo) {\n bar(); baz() }",
+            output: "if (foo) {\n bar(); baz(); }",
+            options: ["always", { omitLastInOneLineBlock: true }],
+            errors: [{
+                messageId: "missingSemi"
+            }]
+        },
+        {
+            code: "if (foo) { bar(); }",
+            output: "if (foo) { bar() }",
+            options: ["always", { omitLastInOneLineBlock: true }],
+            errors: [{
+                messageId: "extraSemi"
+            }]
+        },
 
 
         // exports, "always"
-        { code: "export * from 'foo'", output: "export * from 'foo';", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ExportAllDeclaration" }] },
-        { code: "export { foo } from 'foo'", output: "export { foo } from 'foo';", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ExportNamedDeclaration" }] },
-        { code: "var foo = 0;export { foo }", output: "var foo = 0;export { foo };", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ExportNamedDeclaration" }] },
-        { code: "export var foo", output: "export var foo;", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "VariableDeclaration" }] },
-        { code: "export let foo", output: "export let foo;", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "VariableDeclaration" }] },
-        { code: "export const FOO = 42", output: "export const FOO = 42;", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "VariableDeclaration" }] },
-        { code: "export default foo || bar", output: "export default foo || bar;", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ExportDefaultDeclaration" }] },
-        { code: "export default (foo) => foo.bar()", output: "export default (foo) => foo.bar();", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ExportDefaultDeclaration" }] },
-        { code: "export default foo = 42", output: "export default foo = 42;", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ExportDefaultDeclaration" }] },
-        { code: "export default foo += 42", output: "export default foo += 42;", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ExportDefaultDeclaration" }] },
+        {
+            code: "export * from 'foo'",
+            output: "export * from 'foo';",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "ExportAllDeclaration"
+            }]
+        },
+        {
+            code: "export { foo } from 'foo'",
+            output: "export { foo } from 'foo';",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "ExportNamedDeclaration"
+            }]
+        },
+        {
+            code: "var foo = 0;export { foo }",
+            output: "var foo = 0;export { foo };",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "ExportNamedDeclaration"
+            }]
+        },
+        {
+            code: "export var foo",
+            output: "export var foo;",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "export let foo",
+            output: "export let foo;",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "export const FOO = 42",
+            output: "export const FOO = 42;",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "export default foo || bar",
+            output: "export default foo || bar;",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "ExportDefaultDeclaration"
+            }]
+        },
+        {
+            code: "export default (foo) => foo.bar()",
+            output: "export default (foo) => foo.bar();",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "ExportDefaultDeclaration"
+            }]
+        },
+        {
+            code: "export default foo = 42",
+            output: "export default foo = 42;",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "ExportDefaultDeclaration"
+            }]
+        },
+        {
+            code: "export default foo += 42",
+            output: "export default foo += 42;",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "missingSemi",
+                type: "ExportDefaultDeclaration"
+            }]
+        },
 
         // exports, "never"
-        { code: "export * from 'foo';", output: "export * from 'foo'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ExportAllDeclaration", column: 20, endColumn: 21 }] },
-        { code: "export { foo } from 'foo';", output: "export { foo } from 'foo'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ExportNamedDeclaration" }] },
-        { code: "var foo = 0;export { foo };", output: "var foo = 0;export { foo }", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ExportNamedDeclaration" }] },
-        { code: "export var foo;", output: "export var foo", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "VariableDeclaration" }] },
-        { code: "export let foo;", output: "export let foo", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "VariableDeclaration" }] },
-        { code: "export const FOO = 42;", output: "export const FOO = 42", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "VariableDeclaration" }] },
-        { code: "export default foo || bar;", output: "export default foo || bar", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ExportDefaultDeclaration" }] },
-        { code: "export default (foo) => foo.bar();", output: "export default (foo) => foo.bar()", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ExportDefaultDeclaration" }] },
-        { code: "export default foo = 42;", output: "export default foo = 42", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ExportDefaultDeclaration" }] },
-        { code: "export default foo += 42;", output: "export default foo += 42", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ExportDefaultDeclaration" }] },
-        { code: "a;\n++b", output: "a\n++b", options: ["never"], errors: [{ message: "Extra semicolon.", column: 2, endColumn: 3 }] },
+        {
+            code: "export * from 'foo';",
+            output: "export * from 'foo'",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "extraSemi",
+                type: "ExportAllDeclaration",
+                column: 20,
+                endColumn: 21
+            }]
+        },
+        {
+            code: "export { foo } from 'foo';",
+            output: "export { foo } from 'foo'",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "extraSemi",
+                type: "ExportNamedDeclaration"
+            }]
+        },
+        {
+            code: "var foo = 0;export { foo };",
+            output: "var foo = 0;export { foo }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "extraSemi",
+                type: "ExportNamedDeclaration"
+            }]
+        },
+        {
+            code: "export var foo;",
+            output: "export var foo",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "extraSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "export let foo;",
+            output: "export let foo",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "extraSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "export const FOO = 42;",
+            output: "export const FOO = 42",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "extraSemi",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "export default foo || bar;",
+            output: "export default foo || bar",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "extraSemi",
+                type: "ExportDefaultDeclaration"
+            }]
+        },
+        {
+            code: "export default (foo) => foo.bar();",
+            output: "export default (foo) => foo.bar()",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "extraSemi",
+                type: "ExportDefaultDeclaration"
+            }]
+        },
+        {
+            code: "export default foo = 42;",
+            output: "export default foo = 42",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "extraSemi",
+                type: "ExportDefaultDeclaration"
+            }]
+        },
+        {
+            code: "export default foo += 42;",
+            output: "export default foo += 42",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "extraSemi",
+                type: "ExportDefaultDeclaration"
+            }]
+        },
+        {
+            code: "a;\n++b",
+            output: "a\n++b",
+            options: ["never"],
+            errors: [{
+                messageId: "extraSemi",
+                column: 2,
+                endColumn: 3
+            }]
+        },
 
         // https://github.com/eslint/eslint/issues/7928
         {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other: Helping to bring the codebase closer to standardisation.

**What changes did you make? (Give an overview)**

I went through the rules and added `messages` to a number of older rules.
I picked non-deprecated rules, and rules that could be simply changed (i.e. essentially just a prop change in `context.report`).

I did as many as I could before getting bored 😅 (there's about 71 more rules to go)

There should be no functionality changes at all from this PR.
No new tests have been added, and no tests have been changed (apart from switching from hardcoded `message` to `messageId` + `data`).
Whilst I was at it, I did a little bit of reformatting to standardise on the format style I saw in other rules.

Let me know if you want me to split this up into separate PRs because of its size.