### PR TITLE
Fix: init error in extending recommended config (fixes #12707)

### DIFF
--- a/lib/init/autoconfig.js
+++ b/lib/init/autoconfig.js
@@ -333,7 +333,7 @@ function extendFromRecommended(config) {
             delete newConfig.rules[ruleId];
         }
     });
-    newConfig.extends.push(RECOMMENDED_CONFIG_NAME);
+    newConfig.extends.unshift(RECOMMENDED_CONFIG_NAME);
     return newConfig;
 }
 

--- a/lib/init/autoconfig.js
+++ b/lib/init/autoconfig.js
@@ -316,7 +316,7 @@ class Registry {
 /**
  * Extract rule configuration into eslint:recommended where possible.
  *
- * This will return a new config with `"extends": "eslint:recommended"` and
+ * This will return a new config with `["extends": [ ..., "eslint:recommended"]` and
  * only the rules which have configurations different from the recommended config.
  * @param   {Object} config config object
  * @returns {Object}        config object using `"extends": ["eslint:recommended"]`
@@ -333,7 +333,7 @@ function extendFromRecommended(config) {
             delete newConfig.rules[ruleId];
         }
     });
-    newConfig.extends = [RECOMMENDED_CONFIG_NAME];
+    newConfig.extends.push(RECOMMENDED_CONFIG_NAME);
     return newConfig;
 }
 

--- a/lib/init/autoconfig.js
+++ b/lib/init/autoconfig.js
@@ -319,7 +319,7 @@ class Registry {
  * This will return a new config with `"extends": "eslint:recommended"` and
  * only the rules which have configurations different from the recommended config.
  * @param   {Object} config config object
- * @returns {Object}        config object using `"extends": "eslint:recommended"`
+ * @returns {Object}        config object using `"extends": ["eslint:recommended"]`
  */
 function extendFromRecommended(config) {
     const newConfig = Object.assign({}, config);
@@ -333,7 +333,7 @@ function extendFromRecommended(config) {
             delete newConfig.rules[ruleId];
         }
     });
-    newConfig.extends = RECOMMENDED_CONFIG_NAME;
+    newConfig.extends = [RECOMMENDED_CONFIG_NAME];
     return newConfig;
 }
 

--- a/tests/lib/init/autoconfig.js
+++ b/tests/lib/init/autoconfig.js
@@ -331,7 +331,15 @@ describe("autoconfig", () => {
     });
 
     describe("extendFromRecommended()", () => {
-        it("should return a configuration which includes `eslint:recommended` in `extends`", () => {
+        it("should return a configuration which has `extends` key with Array type value", () => {
+            const oldConfig = { extends: [], rules: {} };
+            const newConfig = autoconfig.extendFromRecommended(oldConfig);
+
+            assert.exists(newConfig.extends);
+            assert.isArray(newConfig.extends);
+        });
+
+        it("should return a configuration which has array property `extends`", () => {
             const oldConfig = { extends: [], rules: {} };
             const newConfig = autoconfig.extendFromRecommended(oldConfig);
 
@@ -339,14 +347,14 @@ describe("autoconfig", () => {
         });
 
         it("should return a configuration which preserves the previous extending configurations", () => {
-            const oldConfig = { extends: ["pevious:configuration1", "previous:configuration2"], rules: {} };
+            const oldConfig = { extends: ["previous:configuration1", "previous:configuration2"], rules: {} };
             const newConfig = autoconfig.extendFromRecommended(oldConfig);
 
             assert.includeMembers(newConfig.extends, oldConfig.extends);
         });
 
         it("should return a configuration which has `eslint:recommended` at the last of `extends`", () => {
-            const oldConfig = { extends: ["pevious:configuration1", "previous:configuration2"], rules: {} };
+            const oldConfig = { extends: ["previous:configuration1", "previous:configuration2"], rules: {} };
             const newConfig = autoconfig.extendFromRecommended(oldConfig);
             const lastExtendInNewConfig = newConfig.extends[newConfig.extends.length - 1];
 

--- a/tests/lib/init/autoconfig.js
+++ b/tests/lib/init/autoconfig.js
@@ -328,4 +328,28 @@ describe("autoconfig", () => {
             });
         });
     });
+
+    describe("extendFromRecommended()", () => {
+        it("should return a configuration which includes `eslint:recommended` in `extends`", () => {
+            const oldConfig = { extends: [], rules: {} };
+            const newConfig = autoconfig.extendFromRecommended(oldConfig);
+
+            assert.include(newConfig.extends, "eslint:recommended");
+        });
+
+        it("should return a configuration which preserves the previous extending configurations", () => {
+            const oldConfig = { extends: ["pevious:configuration1", "previous:configuration2"], rules: {} };
+            const newConfig = autoconfig.extendFromRecommended(oldConfig);
+
+            assert.includeMembers(newConfig.extends, oldConfig.extends);
+        });
+
+        it("should return a configuration which has `eslint:recommended` at the last of `extends`", () => {
+            const oldConfig = { extends: ["pevious:configuration1", "previous:configuration2"], rules: {} };
+            const newConfig = autoconfig.extendFromRecommended(oldConfig);
+            const lastExtendInNewConfig = newConfig.extends[newConfig.extends.length - 1];
+
+            assert.strictEqual(lastExtendInNewConfig, "eslint:recommended");
+        });
+    });
 });

--- a/tests/lib/init/autoconfig.js
+++ b/tests/lib/init/autoconfig.js
@@ -12,7 +12,8 @@
 const assert = require("chai").assert,
     autoconfig = require("../../../lib/init/autoconfig"),
     sourceCodeUtils = require("../../../lib/init/source-code-utils"),
-    baseDefaultOptions = require("../../../conf/default-cli-options");
+    baseDefaultOptions = require("../../../conf/default-cli-options"),
+    recommendedConfig = require("../../conf/eslint-recommended");
 
 const defaultOptions = Object.assign({}, baseDefaultOptions, { cwd: process.cwd() });
 
@@ -350,6 +351,13 @@ describe("autoconfig", () => {
             const lastExtendInNewConfig = newConfig.extends[newConfig.extends.length - 1];
 
             assert.strictEqual(lastExtendInNewConfig, "eslint:recommended");
+        });
+
+        it("should return a configuration which not includes rules configured in `eslint:recommended`", () => {
+            const oldConfig = { extends: [], rules: { ...recommendedConfig.rules } };
+            const newConfig = autoconfig.extendFromRecommended(oldConfig);
+
+            assert.notInclude(newConfig.rules, oldConfig.rules);
         });
     });
 });

--- a/tests/lib/init/autoconfig.js
+++ b/tests/lib/init/autoconfig.js
@@ -353,12 +353,12 @@ describe("autoconfig", () => {
             assert.includeMembers(newConfig.extends, oldConfig.extends);
         });
 
-        it("should return a configuration which has `eslint:recommended` at the last of `extends`", () => {
+        it("should return a configuration which has `eslint:recommended` at the first of `extends`", () => {
             const oldConfig = { extends: ["previous:configuration1", "previous:configuration2"], rules: {} };
             const newConfig = autoconfig.extendFromRecommended(oldConfig);
-            const lastExtendInNewConfig = newConfig.extends[newConfig.extends.length - 1];
+            const [firstExtendInNewConfig] = newConfig.extends;
 
-            assert.strictEqual(lastExtendInNewConfig, "eslint:recommended");
+            assert.strictEqual(firstExtendInNewConfig, "eslint:recommended");
         });
 
         it("should return a configuration which not includes rules configured in `eslint:recommended`", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fix #12707. It still has a `triage label` but I can reproduce it 
reproduced - https://github.com/yeonjuan/autoconfbug

**Is there anything you'd like reviewers to focus on?**

The cause of the problem is precisely what [here](https://github.com/eslint/eslint/issues/12707#issue-541987711) mentioned.
> RECOMMENDED_CONFIG_NAME is a string, after extendFromRecommended return, the parent scope expect config.extends is an array