### PR TITLE
Update: fix no-extra-parens CallExpression#callee false negatives

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -418,11 +418,10 @@ module.exports = {
                     hasDoubleExcessParens(callee) ||
                     !isIIFE(node) && !hasNewParensException && !(
 
-                        /*
-                         * Allow extra parens around a new expression if
-                         * there are intervening parentheses.
-                         */
-                        (callee.type === "MemberExpression" && doesMemberExpressionContainCallExpression(callee))
+                        // Allow extra parens around a new expression if they are intervening parentheses.
+                        node.type === "NewExpression" &&
+                        callee.type === "MemberExpression" &&
+                        doesMemberExpressionContainCallExpression(callee)
                     )
                 ) {
                     report(node.callee);

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -673,6 +673,12 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("(new foo.bar()).baz", "new foo.bar().baz", "NewExpression"),
         invalid("(new foo.bar()).baz()", "new foo.bar().baz()", "NewExpression"),
 
+        invalid("(a)()", "a()", "Identifier"),
+        invalid("(a.b)()", "a.b()", "MemberExpression"),
+        invalid("(a())()", "a()()", "CallExpression"),
+        invalid("(a.b())()", "a.b()()", "CallExpression"),
+        invalid("(a().b)()", "a().b()", "MemberExpression"),
+        invalid("(a().b.c)()", "a().b.c()", "MemberExpression"),
         invalid("new (A)", "new A", "Identifier"),
         invalid("(new A())()", "new A()()", "NewExpression"),
         invalid("(new A(1))()", "new A(1)()", "NewExpression"),


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

This bug fix produces **more** warnings.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v6.8.0
* **Node Version:** v12.14.0
* **npm Version:** v6.13.4

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: 2015
    },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWV4dHJhLXBhcmVuczogXCJlcnJvclwiICovXG5cbihhKCkuYikoKTtcbiIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6NSwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js
/* eslint no-extra-parens: "error" */

(a().b)();
```

**What did you expect to happen?**

Error and auto-fix to:

```js
/* eslint no-extra-parens: "error" */

a().b();
```

**What actually happened? Please include the actual, raw output from ESLint.**

No errors.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fixed the condition that prevents reporting code such as `new (a().b)()`, but it didn't account for the fact that the same `checkCallNew()` function is also used to check `CallExpression` nodes.

**Is there anything you'd like reviewers to focus on?**

These tests were already `invalid`. Added them because it seems that the existing tests were mostly for `NewExpression`:

```js
invalid("(a)()", "a()", "Identifier"),
invalid("(a.b)()", "a.b()", "MemberExpression"),
invalid("(a())()", "a()()", "CallExpression"),
invalid("(a.b())()", "a.b()()", "CallExpression"),
```

These are new errors after this PR:

```js
invalid("(a().b)()", "a().b()", "MemberExpression"),
invalid("(a().b.c)()", "a().b.c()", "MemberExpression"),
```
