### PR TITLE
Update: Make `space-in-parens` more strict for single line statements.

### DIFF
--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -39,6 +39,8 @@ Examples of **incorrect** code for this rule with the default `"never"` option:
 foo( 'bar');
 foo('bar' );
 foo( 'bar' );
+foo(bar()
+);
 
 var foo = ( 1 + 2 ) * 3;
 ( function () { return 'bar'; }() );
@@ -52,6 +54,7 @@ Examples of **correct** code for this rule with the default `"never"` option:
 foo();
 
 foo('bar');
+foo(bar())
 
 var foo = (1 + 2) * 3;
 (function () { return 'bar'; }());

--- a/lib/rules/space-in-parens.js
+++ b/lib/rules/space-in-parens.js
@@ -193,14 +193,22 @@ module.exports = {
          * Determines if a closer paren is immediately preceeded by a disallowed space
          * @param {Object} tokenBeforeClosingParen The token before the paren
          * @param {Object} closingParenToken The paren token
+         * @param {Object} openingParenToken The opening paren token
          * @returns {boolean} True if the closing paren has a disallowed space
          */
-        function closerRejectsSpace(tokenBeforeClosingParen, closingParenToken) {
-            if (!astUtils.isTokenOnSameLine(tokenBeforeClosingParen, closingParenToken)) {
+        function closerRejectsSpace(tokenBeforeClosingParen, closingParenToken, openingParenToken) {
+            const isTokenOnSameLine = astUtils.isTokenOnSameLine(tokenBeforeClosingParen, closingParenToken);
+            const isSpaceBetweenTokens = sourceCode.isSpaceBetweenTokens(tokenBeforeClosingParen, closingParenToken);
+            const isSingleLineAndHasNewlinesOrSpaces = (
+                openingParenToken.loc.start.line === tokenBeforeClosingParen.loc.start.line &&
+                (!isTokenOnSameLine || isSpaceBetweenTokens)
+            );
+
+            if (!isTokenOnSameLine && !isSingleLineAndHasNewlinesOrSpaces) {
                 return false;
             }
 
-            if (!sourceCode.isSpaceBetweenTokens(tokenBeforeClosingParen, closingParenToken)) {
+            if (!isSpaceBetweenTokens && !isSingleLineAndHasNewlinesOrSpaces) {
                 return false;
             }
 
@@ -218,6 +226,7 @@ module.exports = {
             Program: function checkParenSpaces(node) {
                 exceptions = getExceptions();
                 const tokens = sourceCode.tokensAndComments;
+                const openingParens = [];
 
                 tokens.forEach((token, i) => {
                     const prevToken = tokens[i - 1];
@@ -227,6 +236,12 @@ module.exports = {
                     if (!astUtils.isOpeningParenToken(token) && !astUtils.isClosingParenToken(token)) {
                         return;
                     }
+
+                    // Get the matching open paren
+                    if (astUtils.isOpeningParenToken(token)) {
+                        openingParens.push(token);
+                    }
+                    const openingParen = (astUtils.isClosingParenToken(token)) ? openingParens.pop() : void 0;
 
                     // if token is an opening paren and is not followed by a required space
                     if (token.value === "(" && openerMissingSpace(token, nextToken)) {
@@ -265,7 +280,7 @@ module.exports = {
                     }
 
                     // if token is a closing paren and is preceded by a disallowed space
-                    if (token.value === ")" && closerRejectsSpace(prevToken, token)) {
+                    if (token.value === ")" && closerRejectsSpace(prevToken, token, openingParen)) {
                         context.report({
                             node,
                             loc: { start: prevToken.loc.end, end: token.loc.start },

--- a/tests/lib/rules/space-in-parens.js
+++ b/tests/lib/rules/space-in-parens.js
@@ -38,6 +38,7 @@ ruleTester.run("space-in-parens", rule, {
         { code: "var foo = `(bar ${( 1 + 2 )})`;", options: ["always"], parserOptions: { ecmaVersion: 6 } },
         { code: "bar(baz)", options: ["never"] },
         { code: "var x = (4 + 5) * 6", options: ["never"] },
+        { code: "foo(\nbar()\n)\n", options: ["never"] },
         { code: "foo\n(\nbar\n)\n", options: ["never"] },
         { code: "foo\n(  \nbar\n )\n", options: ["never"] },
         { code: "foo\n(\n bar  \n)\n", options: ["never"] },
@@ -164,6 +165,12 @@ ruleTester.run("space-in-parens", rule, {
             output: "foo(bar())",
             options: ["never"],
             errors: [{ messageId: "rejectedClosingSpace" }]
+        },
+        {
+            code: "foo(bar()\n)\n",
+            output: "foo(bar())\n",
+            options: ["never"],
+            errors: [{ messageId: "rejectedClosingSpace", line: 1, column: 10 }]
         },
         {
             code: "foo\n(\nbar )",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**
`space-in-parens`

**Does this change cause the rule to produce more or fewer warnings?**
More warnings

**How will the change be implemented? (New option, new default behavior, etc.)?**
New default behavior

**Please provide some example code that this change will affect:**

Before, if the the opening paren and everything between its closing paren was on the same line and the closing paren was not, no warning would be reported.

```js
// Before -- no warnings reported
const result = someArray.map((item) => item.prop
);
```

**What does the rule currently do for this code?**

Before, if the the opening paren and everything between its closing paren was on the same line and the closing paren was not, no warning would be reported.

**What will the rule do after it's changed?**

This change now correctly enforces the closing paren will be on the same line for single-line statements.

```js
// Now -- warnings reported
const result = someArray.map((item) => item.prop
);

// Now -- after auto fix
const result = someArray.map((item) => item.prop);
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The rule now tracks the line the opening paren is on, and compares it to the line the token before the closing paren is on. If they match, we can assume the statement is on a single line, and expect the closing paren to also be on that line.

**Is there anything you'd like reviewers to focus on?**

Nope.
