### PR TITLE
Fix: Ignore re-export all in no-duplicate-imports (fixes #12760)

### DIFF
--- a/docs/rules/no-duplicate-imports.md
+++ b/docs/rules/no-duplicate-imports.md
@@ -37,9 +37,31 @@ import something from 'another-module';
 
 This rule takes one optional argument, an object with a single key, `includeExports` which is a `boolean`. It defaults to `false`.
 
-If re-exporting from an imported module, you should add the imports to the `import`-statement, and export that directly, not use `export ... from`.
+### includeExports
+
+If the `includeExports` option is set to `true`, this rule will also require that all named re-exports from a single module exist in a single `export` statement.
 
 Example of **incorrect** code for this rule with the `{ "includeExports": true }` option:
+
+```js
+/*eslint no-duplicate-imports: ["error", { "includeExports": true }]*/
+
+export { merge } from 'module';
+
+export { find } from 'module';
+```
+
+Example of **correct** code for this rule with the `{ "includeExports": true }` option:
+
+```js
+/*eslint no-duplicate-imports: ["error", { "includeExports": true }]*/
+
+export { merge, find } from 'module';
+```
+
+Additionally, if re-exporting from an imported module, you should add the imports to the `import`-statement, and export that directly, not use `export ... from`.
+
+Example of additional **incorrect** code for this rule with the `{ "includeExports": true }` option:
 
 ```js
 /*eslint no-duplicate-imports: ["error", { "includeExports": true }]*/
@@ -49,7 +71,7 @@ import { merge } from 'module';
 export { find } from 'module';
 ```
 
-Example of **correct** code for this rule with the `{ "includeExports": true }` option:
+Example of additional **correct** code for this rule with the `{ "includeExports": true }` option:
 
 ```js
 /*eslint no-duplicate-imports: ["error", { "includeExports": true }]*/

--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -134,7 +134,6 @@ module.exports = {
 
         if (includeExports) {
             handlers.ExportNamedDeclaration = handleExports(context, importsInFile, exportsInFile);
-            handlers.ExportAllDeclaration = handleExports(context, importsInFile, exportsInFile);
         }
 
         return handlers;

--- a/tests/lib/rules/no-duplicate-imports.js
+++ b/tests/lib/rules/no-duplicate-imports.js
@@ -45,6 +45,34 @@ ruleTester.run("no-duplicate-imports", rule, {
         {
             code: "import { merge } from \"lodash-es\";\nexport { merge as lodashMerge }",
             options: [{ includeExports: true }]
+        },
+
+        // ignore `export * from` declarations, they cannot be merged with any other import/export declarations
+        {
+            code: "import os from 'os'; export * from 'os';",
+            options: [{ includeExports: true }]
+        },
+        {
+            code: "export * from 'os'; import { a } from 'os';",
+            options: [{ includeExports: true }]
+        },
+        {
+            code: "import * as ns from 'os'; export * from 'os';",
+            options: [{ includeExports: true }]
+        },
+        {
+            code: "export * from 'os'; export { a } from 'os';",
+            options: [{ includeExports: true }]
+        },
+        {
+            code: "export { a as b } from 'os'; export * from 'os';",
+            options: [{ includeExports: true }]
+        },
+
+        // this is probably an exporting error, but that isn't a responsibility of this rule
+        {
+            code: "export * from 'os'; export * from 'os';",
+            options: [{ includeExports: true }]
         }
     ],
     invalid: [
@@ -80,9 +108,9 @@ ruleTester.run("no-duplicate-imports", rule, {
             errors: [{ messageId: "exportAs", data: { module: "os" }, type: "ExportNamedDeclaration" }]
         },
         {
-            code: "import os from \"os\";\nexport * from \"os\";",
+            code: "import os from 'os'; export * from 'os'; export { a } from 'os';",
             options: [{ includeExports: true }],
-            errors: [{ messageId: "exportAs", data: { module: "os" }, type: "ExportAllDeclaration" }]
+            errors: [{ messageId: "exportAs", data: { module: "os" }, type: "ExportNamedDeclaration" }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #12760

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

After this PR, `no-duplicate-imports` will ignore `export * from "mod"`, since it isn't possible to merge these exports with any other imports/exports. 

I believe it's actually even impossible to rewrite such code in any other way, so it seems that taking into account these declarations was a bug.

Also, documentation was missing the explanation for the `includeExports`  option. There was just a special case with both `import` and `export` declarations.

**Is there anything you'd like reviewers to focus on?**

Yes. Ignoring `export * from` will also ignore duplicates:

```js
export * from "mod";
export * from "mod";
```

This looks like a possible error in exporting rather than a stylistic issue in importing (which is what this rule is about?). So, this indeed might not belong here, but after this fix there will be no rule to report it.

