### PR TITLE
Fix: Display pipe character correctly in test output

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -174,7 +174,7 @@ function freezeDeeply(x) {
  */
 function sanitize(text) {
     return text.replace(
-        /[\u0000-\u0009|\u000b-\u001a]/gu, // eslint-disable-line no-control-regex
+        /[\u0000-\u0009\u000b-\u001a]/gu, // eslint-disable-line no-control-regex
         c => `\\u${c.codePointAt(0).toString(16).padStart(4, "0")}`
     );
 }

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1281,6 +1281,20 @@ describe("RuleTester", () => {
             });
             sinon.assert.calledWith(spyRuleTesterIt, "\\u0000");
         });
+        it("should present the pipe character correctly", () => {
+            const code = "var foo = bar || baz;";
+
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [],
+                invalid: [
+                    {
+                        code,
+                        errors: [/^Bad var/u]
+                    }
+                ]
+            });
+            sinon.assert.calledWith(spyRuleTesterIt, code);
+        });
 
     });
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

#12031 introduced an invalid regex, which caused the `|` character to be displayed as `\u007c` in test output.
This ofc ruins any output with an OR (`||` / `|`). I finally got annoyed enough to look into a fix.

![image](https://user-images.githubusercontent.com/7462525/72175521-2f983480-3391-11ea-9bb8-da7182244c47.png)

This just fixes the output and adds a test to make sure it doesn't happen again.
