### PR TITLE
add handling of lone commas when destructuring arrays

### DIFF
--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -124,10 +124,11 @@ module.exports = {
          * @param {Token} commaToken The token representing the comma.
          * @param {Token} currentItemToken The first token of the current item.
          * @param {Token} reportItem The item to use when reporting an error.
+         * @param {boolean} arrayLiteral whether the comma is in a destructuring assignment.
          * @returns {void}
          * @private
          */
-        function validateCommaItemSpacing(previousItemToken, commaToken, currentItemToken, reportItem) {
+        function validateCommaItemSpacing(previousItemToken, commaToken, currentItemToken, reportItem, arrayLiteral) {
 
             // if single line
             if (astUtils.isTokenOnSameLine(commaToken, currentItemToken) &&
@@ -144,15 +145,21 @@ module.exports = {
                     : "between";
 
                 // lone comma
-                context.report({
-                    node: reportItem,
-                    loc: {
-                        line: commaToken.loc.end.line,
-                        column: commaToken.loc.start.column
-                    },
-                    messageId: "unexpectedLineBeforeAndAfterComma",
-                    fix: getFixerFunction(styleType, previousItemToken, commaToken, currentItemToken)
-                });
+                if (arrayLiteral) {
+
+                    // ignored element, move on.
+
+                } else {
+                    context.report({
+                        node: reportItem,
+                        loc: {
+                            line: commaToken.loc.end.line,
+                            column: commaToken.loc.start.column
+                        },
+                        messageId: "unexpectedLineBeforeAndAfterComma",
+                        fix: getFixerFunction(styleType, previousItemToken, commaToken, currentItemToken)
+                    });
+                }
 
             } else if (style === "first" && !astUtils.isTokenOnSameLine(commaToken, currentItemToken)) {
 
@@ -213,7 +220,7 @@ module.exports = {
                      */
                     if (astUtils.isCommaToken(commaToken)) {
                         validateCommaItemSpacing(previousItemToken, commaToken,
-                            currentItemToken, reportItem);
+                            currentItemToken, reportItem, arrayLiteral);
                     }
 
                     if (item) {
@@ -232,7 +239,6 @@ module.exports = {
                  * dangling comma.
                  */
                 if (arrayLiteral) {
-
                     const lastToken = sourceCode.getLastToken(node),
                         nextToLastToken = sourceCode.getTokenBefore(lastToken);
 

--- a/tests/lib/rules/comma-style.js
+++ b/tests/lib/rules/comma-style.js
@@ -586,19 +586,6 @@ ruleTester.run("comma-style", rule, {
             errors: [{ messageId: "expectedCommaFirst" }]
         },
         {
-            code: "var foo = [\n(bar\n)\n,\nbaz\n];",
-            output: "var foo = [\n(bar\n),\nbaz\n];",
-            errors: [{
-                messageId: "unexpectedLineBeforeAndAfterComma",
-                type: "Identifier"
-            }]
-        },
-        {
-            code: "[(foo),\n,\nbar]",
-            output: "[(foo),,\nbar]",
-            errors: [{ messageId: "unexpectedLineBeforeAndAfterComma" }]
-        },
-        {
             code: "new Foo(a\n,b);",
             output: "new Foo(a,\nb);",
             options: ["last", {
@@ -607,11 +594,6 @@ ruleTester.run("comma-style", rule, {
                 }
             }],
             errors: [{ messageId: "expectedCommaLast" }]
-        },
-        {
-            code: "[\n[foo(3)],\n,\nbar\n];",
-            output: "[\n[foo(3)],,\nbar\n];",
-            errors: [{ messageId: "unexpectedLineBeforeAndAfterComma" }]
         },
         {
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Details about the bug and my environment are as seen in the issue**

Closes #12756. This handles ignored elements as per [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Ignoring_some_returned_values)

**Tell us about your environment**

* **ESLint Version:** 6.8.0
* **Node Version:** 13.6.0
* **NPM Version:** 6.13.4
* **Parser** @typescript-eslint

**What changes did you make? (Give an overview)**

I've split the checks for ArrayPatterns from ArrayLiterals, as LHS allows ignoring elements, whereas RHS would be invalid code. This results in null nodes using AST, which the existing validation code could not handle coherently. Thus, if there are any commas without element, it doesn't report them.  Honestly, I'm not sure my approach is the most adequate, yet it seems to get the job done based on my tests.

I've noticed with this change you can have as many commas in a single line as you want.
I am not sure what space between consecutive commas should be required, if any. 
That is to be discussed in a separate issue.

For the time being, my next step will be modifying "array-element-newline" to respond accordingly (pending issue to discuss implementation with the community, will add a link here for reference.)

**Is there anything you'd like reviewers to focus on?**
I didn't go the whole ten yards checking for other overlapping rules.

