### PR TITLE
Update: treat comment tokens in template-curly-spacing (fixes #12744)

### DIFF
--- a/lib/rules/template-curly-spacing.js
+++ b/lib/rules/template-curly-spacing.js
@@ -57,7 +57,7 @@ module.exports = {
          * @returns {void}
          */
         function checkSpacingBefore(token) {
-            const prevToken = sourceCode.getTokenBefore(token);
+            const prevToken = sourceCode.getTokenBefore(token, { includeComments: true });
 
             if (prevToken &&
                 CLOSE_PAREN.test(token.value) &&
@@ -86,7 +86,7 @@ module.exports = {
          * @returns {void}
          */
         function checkSpacingAfter(token) {
-            const nextToken = sourceCode.getTokenAfter(token);
+            const nextToken = sourceCode.getTokenAfter(token, { includeComments: true });
 
             if (nextToken &&
                 OPEN_PAREN.test(token.value) &&

--- a/tests/lib/rules/template-curly-spacing.js
+++ b/tests/lib/rules/template-curly-spacing.js
@@ -26,7 +26,31 @@ ruleTester.run("template-curly-spacing", rule, {
         { code: "`${ foo } ${ bar } ${\n  baz\n}`", options: ["always"] },
         "tag`${foo} ${bar}`",
         { code: "tag`${foo} ${bar} ${\n  baz\n}`", options: ["never"] },
-        { code: "tag`${ foo } ${ bar } ${\n  baz\n}`", options: ["always"] }
+        { code: "tag`${ foo } ${ bar } ${\n  baz\n}`", options: ["always"] },
+
+        "`${/*  */ foo} ${bar /*  */}`",
+        "`${/*  */foo/*  */} ${/*  */  bar  /*  */}`",
+        "`${\n  /*  */  foo  /*  */  \n} ${/*\n  */  bar  /*  \n*/}`",
+        "tag`${/*  */ foo} ${bar /*  */}}`",
+        "tag`${/*  */foo/*  */} ${/*  */  bar  /*  */}`",
+        "tag`${\n  /*  */  foo  /*  */  \n} ${/*\n  */  bar  /*  \n*/}`",
+        "`${// comment\n foo} ${bar // comment \n}`",
+
+        { code: "`${/*  */ foo} ${bar /*  */}`", options: ["never"] },
+        { code: "`${/*  */foo/*  */} ${/*  */  bar  /*  */}`", options: ["never"] },
+        { code: "`${\n  /*  */  foo  /*  */  \n} ${/*\n  */  bar  /*  \n*/}`", options: ["never"] },
+        { code: "tag`${/*  */ foo} ${bar /*  */}}`", options: ["never"] },
+        { code: "tag`${/*  */foo/*  */} ${/*  */  bar  /*  */}`", options: ["never"] },
+        { code: "tag`${\n  /*  */  foo  /*  */  \n} ${/*\n  */  bar  /*  \n*/}`", options: ["never"] },
+        { code: "`${// comment\n foo} ${bar // comment \n}`", options: ["never"] },
+
+        { code: "`${ /*  */ foo } ${ bar /*  */ }`", options: ["always"] },
+        { code: "`${ /*  */foo/*  */ } ${ /*  */  bar  /*  */ }`", options: ["always"] },
+        { code: "`${\n  /*  */  foo  /*  */  \n} ${ /*\n  */  bar  /*  \n*/ }`", options: ["always"] },
+        { code: "tag`${ /*  */ foo } ${ bar /*  */ }`", options: ["always"] },
+        { code: "tag`${ /*  */foo/*  */ } ${ /*  */  bar  /*  */ }`", options: ["always"] },
+        { code: "tag`${\n  /*  */  foo  /*  */  \n} ${ /*\n  */  bar  /*  \n*/ }`", options: ["always"] },
+        { code: "`${ // comment\n foo } ${ bar // comment \n}`", options: ["always"] }
     ],
     invalid: [
         {
@@ -91,6 +115,157 @@ ruleTester.run("template-curly-spacing", rule, {
                 { messageId: "expectedBefore", column: 10 },
                 { messageId: "expectedAfter", column: 12 },
                 { messageId: "expectedBefore", column: 17 }
+            ]
+        },
+        {
+            code: "`${ /*  */foo } ${ bar/*  */ }`",
+            output: "`${/*  */foo} ${bar/*  */}`",
+            errors: [
+                { messageId: "unexpectedAfter", column: 2 },
+                { messageId: "unexpectedBefore", column: 15 },
+                { messageId: "unexpectedAfter", column: 17 },
+                { messageId: "unexpectedBefore", column: 30 }
+            ]
+        },
+        {
+            code: "`${ /*\n  */foo } ${ bar/*  \n*/ }`",
+            output: "`${/*\n  */foo} ${bar/*  \n*/}`",
+            errors: [
+                { messageId: "unexpectedAfter", line: 1, column: 2 },
+                { messageId: "unexpectedBefore", line: 2, column: 9 },
+                { messageId: "unexpectedAfter", line: 2, column: 11 },
+                { messageId: "unexpectedBefore", line: 3, column: 4 }
+            ]
+        },
+        {
+            code: "`${ /*  */ foo } ${ bar /*  */ }`",
+            output: "`${/*  */ foo} ${bar /*  */}`",
+            options: ["never"],
+            errors: [
+                { messageId: "unexpectedAfter", column: 2 },
+                { messageId: "unexpectedBefore", column: 16 },
+                { messageId: "unexpectedAfter", column: 18 },
+                { messageId: "unexpectedBefore", column: 32 }
+            ]
+        },
+        {
+            code: "`${ /*\n  */ foo } ${ bar /*  \n*/ }`",
+            output: "`${/*\n  */ foo} ${bar /*  \n*/}`",
+            options: ["never"],
+            errors: [
+                { messageId: "unexpectedAfter", line: 1, column: 2 },
+                { messageId: "unexpectedBefore", line: 2, column: 10 },
+                { messageId: "unexpectedAfter", line: 2, column: 12 },
+                { messageId: "unexpectedBefore", line: 3, column: 4 }
+            ]
+        },
+        {
+            code: "`${/*  */foo} ${bar/*  */}`",
+            output: "`${ /*  */foo } ${ bar/*  */ }`",
+            options: ["always"],
+            errors: [
+                { messageId: "expectedAfter", column: 2 },
+                { messageId: "expectedBefore", column: 13 },
+                { messageId: "expectedAfter", column: 15 },
+                { messageId: "expectedBefore", column: 26 }
+            ]
+        },
+        {
+            code: "`${/*\n  */foo} ${bar/*  \n*/}`",
+            output: "`${ /*\n  */foo } ${ bar/*  \n*/ }`",
+            options: ["always"],
+            errors: [
+                { messageId: "expectedAfter", line: 1, column: 2 },
+                { messageId: "expectedBefore", line: 2, column: 8 },
+                { messageId: "expectedAfter", line: 2, column: 10 },
+                { messageId: "expectedBefore", line: 3, column: 3 }
+            ]
+        },
+        {
+            code: "tag`${ /*  */foo } ${ bar/*  */ }`",
+            output: "tag`${/*  */foo} ${bar/*  */}`",
+            errors: [
+                { messageId: "unexpectedAfter", column: 5 },
+                { messageId: "unexpectedBefore", column: 18 },
+                { messageId: "unexpectedAfter", column: 20 },
+                { messageId: "unexpectedBefore", column: 33 }
+            ]
+        },
+        {
+            code: "tag`${ /*\n  */foo } ${ bar/*  \n*/ }`",
+            output: "tag`${/*\n  */foo} ${bar/*  \n*/}`",
+            errors: [
+                { messageId: "unexpectedAfter", line: 1, column: 5 },
+                { messageId: "unexpectedBefore", line: 2, column: 9 },
+                { messageId: "unexpectedAfter", line: 2, column: 11 },
+                { messageId: "unexpectedBefore", line: 3, column: 4 }
+            ]
+        },
+        {
+            code: "tag`${ /*  */foo } ${ bar/*  */ }`",
+            output: "tag`${/*  */foo} ${bar/*  */}`",
+            options: ["never"],
+            errors: [
+                { messageId: "unexpectedAfter", column: 5 },
+                { messageId: "unexpectedBefore", column: 18 },
+                { messageId: "unexpectedAfter", column: 20 },
+                { messageId: "unexpectedBefore", column: 33 }
+            ]
+        },
+        {
+            code: "tag`${ /*\n  */foo } ${ bar/*  \n*/ }`",
+            output: "tag`${/*\n  */foo} ${bar/*  \n*/}`",
+            options: ["never"],
+            errors: [
+                { messageId: "unexpectedAfter", line: 1, column: 5 },
+                { messageId: "unexpectedBefore", line: 2, column: 9 },
+                { messageId: "unexpectedAfter", line: 2, column: 11 },
+                { messageId: "unexpectedBefore", line: 3, column: 4 }
+            ]
+        },
+        {
+            code: "tag`${/*  */foo} ${bar/*  */}`",
+            output: "tag`${ /*  */foo } ${ bar/*  */ }`",
+            options: ["always"],
+            errors: [
+                { messageId: "expectedAfter", column: 5 },
+                { messageId: "expectedBefore", column: 16 },
+                { messageId: "expectedAfter", column: 18 },
+                { messageId: "expectedBefore", column: 29 }
+            ]
+        },
+        {
+            code: "tag`${/*\n  */foo} ${bar/*  \n*/}`",
+            output: "tag`${ /*\n  */foo } ${ bar/*  \n*/ }`",
+            options: ["always"],
+            errors: [
+                { messageId: "expectedAfter", line: 1, column: 5 },
+                { messageId: "expectedBefore", line: 2, column: 8 },
+                { messageId: "expectedAfter", line: 2, column: 10 },
+                { messageId: "expectedBefore", line: 3, column: 3 }
+            ]
+        },
+        {
+            code: "`${ // comment\n foo} ${bar // comment \n}`",
+            output: "`${// comment\n foo} ${bar // comment \n}`",
+            errors: [
+                { messageId: "unexpectedAfter", line: 1, column: 2 }
+            ]
+        },
+        {
+            code: "`${ // comment\n foo} ${bar // comment \n}`",
+            output: "`${// comment\n foo} ${bar // comment \n}`",
+            options: ["never"],
+            errors: [
+                { messageId: "unexpectedAfter", line: 1, column: 2 }
+            ]
+        },
+        {
+            code: "`${// comment\n foo } ${ bar // comment \n}`",
+            output: "`${ // comment\n foo } ${ bar // comment \n}`",
+            options: ["always"],
+            errors: [
+                { messageId: "expectedAfter", line: 1, column: 2 }
             ]
         }
     ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

fix #12744 by treating comments as tokens.

**Is there anything you'd like reviewers to focus on?**

This change will produce new warnings in the cases below.
Can this change be a semver-minor bug fix? Or is it breaking change?

```js
/*eslint template-curly-spacing: ["error", "always"]*/

`${/**/ foo /* */}`
```
