### PR TITLE
Update: fix camelcase not checking quoted properties (fixes #13041)

### DIFF
--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -12,6 +12,8 @@ This rule has an object option:
 
 * `"properties": "always"` (default) enforces camelcase style for property names
 * `"properties": "never"` does not check property names
+* `"ignoreQuotedProperties": true` (default) does not check quoted property names
+* `"ignoreQuotedProperties": false` enforces camelcase style for all property names
 * `"ignoreDestructuring": false` (default) enforces camelcase style for destructured identifiers
 * `"ignoreDestructuring": true` does not check destructured identifiers (but still checks any use of those identifiers later in the code)
 * `"ignoreImports": false` (default) enforces camelcase style for ES2015 imports
@@ -110,6 +112,48 @@ Examples of **correct** code for this rule with the `{ "properties": "never" }` 
 var obj = {
     my_pref: 1
 };
+```
+
+### ignoreQuotedProperties: true
+
+Examples of **incorrect** code for this rule with the default `{ "ignoreQuotedProperties": true }` option:
+
+```js
+/*eslint camelcase: "error"*/
+
+var foo = {
+    qux_quux: 2
+};
+
+foo.snake_cased = 11;
+```
+
+Examples of **correct** code for this rule with the default `{ "ignoreQuotedProperties": true }` option:
+
+```js
+/*eslint camelcase: "error"*/
+
+var foo = {
+    barBaz: 1,
+    "qux_quux": 2
+};
+
+foo.camelCased = 10;
+foo["snake_cased"] = 11;
+```
+
+### ignoreQuotedProperties: false
+
+Examples of **correct** code for this rule with the `{ "ignoreQuotedProperties": false }` option:
+
+```js
+/*eslint camelcase: ["error", {ignoreQuotedProperties: false}]*/
+
+var foo = {
+    barBaz: 1,
+};
+
+foo.camelCased = 10;
 ```
 
 ### ignoreDestructuring: false

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -32,6 +32,10 @@ module.exports = {
                         type: "boolean",
                         default: false
                     },
+                    ignoreQuotedProperties: {
+                        type: "boolean",
+                        default: true
+                    },
                     properties: {
                         enum: ["always", "never"]
                     },
@@ -59,8 +63,9 @@ module.exports = {
 
         const options = context.options[0] || {};
         let properties = options.properties || "";
-        const ignoreDestructuring = options.ignoreDestructuring;
-        const ignoreImports = options.ignoreImports;
+        const ignoreDestructuring = !!options.ignoreDestructuring;
+        const ignoreImports = !!options.ignoreImports;
+        const ignoreQuotedProperties = options.ignoreQuotedProperties !== false;
         const allow = options.allow || [];
 
         if (properties !== "always" && properties !== "never") {
@@ -133,14 +138,14 @@ module.exports = {
          *    ([a.foo] = b);     // => true for `foo`
          *    ([a.foo = 1] = b); // => true for `foo`
          *    ({...a.foo} = b);  // => true for `foo`
-         * @param {ASTNode} node An Identifier node to check
+         * @param {ASTNode} node An Identifier/Literal node to check
          * @returns {boolean} True if the node is an assignment target property in destructuring.
          */
         function isAssignmentTargetPropertyInDestructuring(node) {
             if (
                 node.parent.type === "MemberExpression" &&
                 node.parent.property === node &&
-                !node.parent.computed
+                (node.type === "Literal" || !node.parent.computed)
             ) {
                 const effectiveParent = node.parent.parent;
 
@@ -167,112 +172,142 @@ module.exports = {
          */
         function report(node) {
             if (!reported.includes(node)) {
+                const name = node.type === "Literal" ? node.value : node.name;
+
                 reported.push(node);
-                context.report({ node, messageId: "notCamelCase", data: { name: node.name } });
+                context.report({ node, messageId: "notCamelCase", data: { name } });
             }
         }
 
-        return {
+        /**
+         * Checks the Identifier/Literal for camelcase.
+         * @param {ASTNode} node The Identifier or Literal AST node to check.
+         * @returns {void}
+         */
+        function checkCamelcase(node) {
+            const isLiteral = node.type === "Literal",
+                nameKey = isLiteral ? "value" : "name",
+                name = node[nameKey],
+                effectiveParent = (node.parent.type === "MemberExpression") ? node.parent.parent : node.parent;
 
-            Identifier(node) {
+            /*
+             * Leading and trailing underscores are commonly used to flag
+             * private/protected identifiers, strip them before checking if underscored
+             */
+            const nameIsUnderscored = isUnderscored(name.replace(/^_+|_+$/gu, ""));
 
-                /*
-                 * Leading and trailing underscores are commonly used to flag
-                 * private/protected identifiers, strip them before checking if underscored
-                 */
-                const name = node.name,
-                    nameIsUnderscored = isUnderscored(name.replace(/^_+|_+$/gu, "")),
-                    effectiveParent = (node.parent.type === "MemberExpression") ? node.parent.parent : node.parent;
+            // First, we ignore the node if it match the ignore list
+            if (isAllowed(name)) {
+                return;
+            }
 
-                // First, we ignore the node if it match the ignore list
-                if (isAllowed(name)) {
+            // MemberExpressions get special rules
+            if (node.parent.type === "MemberExpression") {
+
+                // "never" check properties
+                if (properties === "never") {
                     return;
                 }
 
-                // MemberExpressions get special rules
-                if (node.parent.type === "MemberExpression") {
+                // ignore string literals as the object of a MemberExpression
+                if (isLiteral && node.parent.object === node) {
+                    return;
+                }
 
-                    // "never" check properties
-                    if (properties === "never") {
-                        return;
-                    }
+                // Always report underscored object names
+                if (node.parent.object.type === "Identifier" && node.parent.object.name === node.name && nameIsUnderscored) {
+                    report(node);
 
-                    // Always report underscored object names
-                    if (node.parent.object.type === "Identifier" && node.parent.object.name === node.name && nameIsUnderscored) {
-                        report(node);
+                // Report AssignmentExpressions only if they are the left side of the assignment
+                } else if (effectiveParent.type === "AssignmentExpression" && nameIsUnderscored && (effectiveParent.right.type !== "MemberExpression" || effectiveParent.left.type === "MemberExpression" && effectiveParent.left.property[nameKey] === node[nameKey])) {
+                    report(node);
 
-                    // Report AssignmentExpressions only if they are the left side of the assignment
-                    } else if (effectiveParent.type === "AssignmentExpression" && nameIsUnderscored && (effectiveParent.right.type !== "MemberExpression" || effectiveParent.left.type === "MemberExpression" && effectiveParent.left.property.name === node.name)) {
-                        report(node);
-
-                    } else if (isAssignmentTargetPropertyInDestructuring(node) && nameIsUnderscored) {
-                        report(node);
-                    }
-
-                /*
-                 * Properties have their own rules, and
-                 * AssignmentPattern nodes can be treated like Properties:
-                 * e.g.: const { no_camelcased = false } = bar;
-                 */
-                } else if (node.parent.type === "Property" || node.parent.type === "AssignmentPattern") {
-
-                    if (node.parent.parent && node.parent.parent.type === "ObjectPattern") {
-                        if (node.parent.shorthand && node.parent.value.left && nameIsUnderscored) {
-                            report(node);
-                        }
-
-                        const assignmentKeyEqualsValue = node.parent.key.name === node.parent.value.name;
-
-                        if (nameIsUnderscored && node.parent.computed) {
-                            report(node);
-                        }
-
-                        // prevent checking righthand side of destructured object
-                        if (node.parent.key === node && node.parent.value !== node) {
-                            return;
-                        }
-
-                        const valueIsUnderscored = node.parent.value.name && nameIsUnderscored;
-
-                        // ignore destructuring if the option is set, unless a new identifier is created
-                        if (valueIsUnderscored && !(assignmentKeyEqualsValue && ignoreDestructuring)) {
-                            report(node);
-                        }
-                    }
-
-                    // "never" check properties or always ignore destructuring
-                    if (properties === "never" || (ignoreDestructuring && isInsideObjectPattern(node))) {
-                        return;
-                    }
-
-                    // don't check right hand side of AssignmentExpression to prevent duplicate warnings
-                    if (nameIsUnderscored && !ALLOWED_PARENT_TYPES.has(effectiveParent.type) && !(node.parent.right === node)) {
-                        report(node);
-                    }
-
-                // Check if it's an import specifier
-                } else if (["ImportSpecifier", "ImportNamespaceSpecifier", "ImportDefaultSpecifier"].includes(node.parent.type)) {
-
-                    if (node.parent.type === "ImportSpecifier" && ignoreImports) {
-                        return;
-                    }
-
-                    // Report only if the local imported identifier is underscored
-                    if (
-                        node.parent.local &&
-                        node.parent.local.name === node.name &&
-                        nameIsUnderscored
-                    ) {
-                        report(node);
-                    }
-
-                // Report anything that is underscored that isn't a CallExpression
-                } else if (nameIsUnderscored && !ALLOWED_PARENT_TYPES.has(effectiveParent.type)) {
+                } else if (isAssignmentTargetPropertyInDestructuring(node) && nameIsUnderscored) {
                     report(node);
                 }
-            }
 
+
+            /*
+             * Properties have their own rules, and
+             * AssignmentPattern nodes can be treated like Properties:
+             * e.g.: const { no_camelcased = false } = bar;
+             */
+            } else if (node.parent.type === "Property" || node.parent.type === "AssignmentPattern") {
+
+                // ignore literals not used as property names
+                if (isLiteral && node.parent.value === node) {
+                    return;
+                }
+
+                if (node.parent.parent && node.parent.parent.type === "ObjectPattern") {
+                    if (node.parent.shorthand && node.parent.value.left && nameIsUnderscored) {
+                        report(node);
+                    }
+
+                    if (!isLiteral && nameIsUnderscored && node.parent.computed) {
+                        report(node);
+                    }
+
+                    // prevent checking righthand side of destructured object
+                    if (node.parent.key === node && node.parent.value !== node) {
+                        return;
+                    }
+
+                    const assignmentKeyEqualsValue = node.parent.key.name === node.parent.value.name;
+                    const valueIsUnderscored = node.parent.value.name && nameIsUnderscored;
+
+                    // ignore destructuring if the option is set, unless a new identifier is created
+                    if (valueIsUnderscored && !(assignmentKeyEqualsValue && ignoreDestructuring)) {
+                        report(node);
+                    }
+                }
+
+                // "never" check properties or always ignore destructuring
+                if (properties === "never" || (ignoreDestructuring && isInsideObjectPattern(node))) {
+                    return;
+                }
+
+                // don't check right hand side of AssignmentExpression to prevent duplicate warnings
+                if (nameIsUnderscored && !ALLOWED_PARENT_TYPES.has(effectiveParent.type) && !(node.parent.right === node)) {
+                    report(node);
+                }
+
+            // Check if it's an import specifier
+            } else if (["ImportSpecifier", "ImportNamespaceSpecifier", "ImportDefaultSpecifier"].includes(node.parent.type)) {
+
+                if (node.parent.type === "ImportSpecifier" && ignoreImports) {
+                    return;
+                }
+
+                // Report only if the local imported identifier is underscored
+                if (
+                    node.parent.local &&
+                    node.parent.local.name === node.name &&
+                    nameIsUnderscored
+                ) {
+                    report(node);
+                }
+
+            // Report anything that is underscored that isn't a CallExpression
+            } else if (nameIsUnderscored && !ALLOWED_PARENT_TYPES.has(effectiveParent.type)) {
+                report(node);
+            }
+        }
+
+        const listeners = {
+            Identifier(node) {
+                checkCamelcase(node);
+            }
         };
 
+        if (properties === "always" && !ignoreQuotedProperties) {
+            listeners.Literal = function(node) {
+                if (typeof node.value === "string" && (node.parent.type === "MemberExpression" || node.parent.type === "Property")) {
+                    checkCamelcase(node);
+                }
+            };
+        }
+
+        return listeners;
     }
 };

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -39,6 +39,8 @@ ruleTester.run("camelcase", rule, {
         "var arr = [foo.bar_baz.qux];",
         "[foo.bar_baz.nesting]",
         "if (foo.bar_baz === boom.bam_pow) { [foo.baz_boom] }",
+        "\"foo_bar\".baz = qux",
+        "var foo = { bar: \"baz_qux\" }",
         {
             code: "var o = {key: 1}",
             options: [{ properties: "always" }]
@@ -92,6 +94,14 @@ ruleTester.run("camelcase", rule, {
             options: [{ properties: "never" }]
         },
         {
+            code: "obj[\"a_b\"] = 2;",
+            options: [{ properties: "always", ignoreQuotedProperties: true }]
+        },
+        {
+            code: "var o = {\"bar_baz\": 1}",
+            options: [{ properties: "always", ignoreQuotedProperties: true }]
+        },
+        {
             code: "const { ['foo']: _foo } = obj;",
             parserOptions: { ecmaVersion: 6 }
         },
@@ -121,6 +131,14 @@ ruleTester.run("camelcase", rule, {
         },
         {
             code: "var { category_id: category } = query;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var { \"category_id\": category } = query;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var { [\"category_id\"]: category } = query;",
             parserOptions: { ecmaVersion: 6 }
         },
         {
@@ -278,6 +296,11 @@ ruleTester.run("camelcase", rule, {
             code: "([obj.foo = obj.fo_o] = bar);",
             options: [{ properties: "always" }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "({ a: obj[\"fo_o\"] } = bar);",
+            options: [{ ignoreQuotedProperties: false, allow: ["fo_o"] }],
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
     invalid: [
@@ -415,6 +438,39 @@ ruleTester.run("camelcase", rule, {
             ]
         },
         {
+            code: "\"foo_bar\".baz_qux = quux",
+            options: [{ properties: "always" }],
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "baz_qux" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "var foo = { \"bar_baz\": 1 }",
+            options: [{ properties: "always", ignoreQuotedProperties: false }],
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "bar_baz" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "foo[\"bar_baz\"] = 1",
+            options: [{ properties: "always", ignoreQuotedProperties: false }],
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "bar_baz" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
             code: "var { category_id: category_alias } = query;",
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -496,6 +552,17 @@ ruleTester.run("camelcase", rule, {
         },
         {
             code: "var { category_id = 1 } = query;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "category_id" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "var { \"category_id\": category_id } = query;",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -944,6 +1011,54 @@ ruleTester.run("camelcase", rule, {
                     messageId: "notCamelCase",
                     data: { name: "fo_o" },
                     type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "({ a: obj[\"fo_o\"] } = bar);",
+            options: [{ properties: "always", ignoreQuotedProperties: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "fo_o" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "([obj[\"fo_o\"]] = bar);",
+            options: [{ properties: "always", ignoreQuotedProperties: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "fo_o" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "({ a: [obj[\"fo_o\"]] } = bar);",
+            options: [{ properties: "always", ignoreQuotedProperties: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "fo_o" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "({...obj[\"fo_o\"]} = baz);",
+            options: [{ properties: "always", ignoreQuotedProperties: false }],
+            parserOptions: { ecmaVersion: 9 },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "fo_o" },
+                    type: "Literal"
                 }
             ]
         }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix: ~~#9470~~ #13041

**What changes did you make? (Give an overview)**

This PR changes the camelcase rule to detect the assignment of non-camelcase properties using quotes when the properties option is set to "always". I kept the old behavior as an option by adding a third possible value for the properties option, "unquoted". This can be useful when non-camelcase property names are required, such as using an API like terser's or using paths as property names (as in eslint's own tests, `tests/lib/cli-engine/cli-engine.js` and `tests/lib/cli-engine/config-array-factory.js`).

**Is there anything you'd like reviewers to focus on?**

Should the old behavior (now the properties: "unquoted" option) be the default? I did not do so because this was deemed a bug in the issue.