### PR TITLE
Fix: id-match with onlyDeclarations should ignore imports

### DIFF
--- a/lib/rules/id-match.js
+++ b/lib/rules/id-match.js
@@ -209,7 +209,7 @@ module.exports = {
                 } else if (IMPORT_TYPES.has(parent.type)) {
 
                     // Report only if the local imported identifier is invalid
-                    if (parent.local && parent.local.name === node.name && isInvalid(name)) {
+                    if (parent.local && parent.local.name === node.name && shouldReport(parent, name) && isInvalid(name)) {
                         report(node);
                     }
 


### PR DESCRIPTION
id-match rule should ignore imports when onlyDeclarations=true

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment**

* **ESLint Version: 6.7.2**
* **Node Version: v12.13.0**
* **npm Version: 6.12.0**

**What parser (default, Babel-ESLint, etc.) are you using?**
@typescript-eslint/parser

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
{
	"env": {
		"browser": true,
		"es6": true
	},
	"extends": [
		"eslint:recommended",
		"plugin:@typescript-eslint/eslint-recommended",
		"plugin:@typescript-eslint/recommended",
		"plugin:@typescript-eslint/recommended-requiring-type-checking"
	],
	"parser": "@typescript-eslint/parser",
	"parserOptions": {
		"project": "tsconfig.json"
	},
	"plugins": ["@typescript-eslint"],
	"settings": {
		"react": {
			"version": "detect"
		}
	},
	"rules": {
		"id-match": ["error", "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]+)*$", { "onlyDeclarations": true }],
		"@typescript-eslint/member-delimiter-style": ["error", { "multiline": { "delimiter": "none" } }]
	}
}
```

</details>

**What did you do? Please include the actual source code causing the issue.**
```js
import { CurrencyConfig } from '../../models/CurrencyConfig'

interface Pattern {
	gSize: number
	lgSize: number
	maxFrac: number
	minFrac: number
	minInt: number
	negPre: string
	negSuf: string
	posPre: string
	posSuf: string
}
```

**What did you expect to happen?**
First line (import statement) should not be reported as violating rule id-match because onlyDeclarations set to true.
Output should be:
```
$ eslint --cache -f visualstudio src/Pattern.ts
C:\Users\boris\Projects\restaurantcashier-frontend\src\Pattern.ts(1,10): warning @typescript-eslint/no-unused-vars : 'CurrencyConfig' is defined but never used.
...
```

**What actually happened? Please include the actual, raw output from ESLint.**
```
$ eslint --cache -f visualstudio src/Pattern.ts
C:\Users\boris\Projects\restaurantcashier-frontend\src\Pattern.ts(1,10): error id-match : Identifier 'CurrencyConfig' does not match the pattern '^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]+)*$'.
C:\Users\boris\Projects\restaurantcashier-frontend\src\Pattern.ts(1,10): error id-match : Identifier 'CurrencyConfig' does not match the pattern '^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]+)*$'.
C:\Users\boris\Projects\restaurantcashier-frontend\src\Pattern.ts(1,10): warning @typescript-eslint/no-unused-vars : 'CurrencyConfig' is defined but never used.

3 problems
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
There is correct logic in shouldReport method. It's called on all conditional branches of core check login except one checking imports. So, imports are checked ALWAYS despite of options.
I've added call to shouldReport to branch with imports.

**Is there anything you'd like reviewers to focus on?**
