### PR TITLE
Update: Add option "ignoreGlobals" to camelcase rule (fixes #11716)

### DIFF
--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -225,9 +225,9 @@ Examples of **incorrect** code for this rule with the default `{ "ignoreGlobals"
 
 ```js
 /*eslint camelcase: ["error", {ignoreGlobals: false}]*/
-/* global some_property */
+/* global no_camelcased */
 
-const property = some_property;
+const foo = no_camelcased;
 ```
 
 ### ignoreGlobals: true
@@ -236,9 +236,9 @@ Examples of **correct** code for this rule with the `{ "ignoreGlobals": true }` 
 
 ```js
 /*eslint camelcase: ["error", {ignoreGlobals: true}]*/
-/* global some_property */
+/* global no_camelcased */
 
-const property = some_property;
+const foo = no_camelcased;
 ```
 
 ## allow

--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -16,6 +16,8 @@ This rule has an object option:
 * `"ignoreDestructuring": true` does not check destructured identifiers (but still checks any use of those identifiers later in the code)
 * `"ignoreImports": false` (default) enforces camelcase style for ES2015 imports
 * `"ignoreImports": true` does not check ES2015 imports (but still checks any use of the imports later in the code except function arguments)
+* `"ignoreGlobals": false` (default) enforces camelcase style for global variables
+* `"ignoreGlobals": true` does not enforce camelcase style for global variables
 * `allow` (`string[]`) list of properties to accept. Accept regex.
 
 ### properties: "always"
@@ -215,6 +217,28 @@ Examples of **correct** code for this rule with the `{ "ignoreImports": true }` 
 /*eslint camelcase: ["error", {ignoreImports: true}]*/
 
 import { snake_cased } from 'mod';
+```
+
+### ignoreGlobals: false
+
+Examples of **incorrect** code for this rule with the default `{ "ignoreGlobals": false }` option:
+
+```js
+/*eslint camelcase: ["error", {ignoreGlobals: false}]*/
+/* global some_property */
+
+const property = some_property;
+```
+
+### ignoreGlobals: true
+
+Examples of **correct** code for this rule with the `{ "ignoreGlobals": true }` option:
+
+```js
+/*eslint camelcase: ["error", {ignoreGlobals: true}]*/
+/* global some_property */
+
+const property = some_property;
 ```
 
 ## allow

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -213,6 +213,11 @@ module.exports = {
                     return;
                 }
 
+                // Check if it's a global variable
+                if (ignoreGlobals && isReferenceToGlobalVariable(node)) {
+                    return;
+                }
+
                 // MemberExpressions get special rules
                 if (node.parent.type === "MemberExpression") {
 
@@ -289,11 +294,6 @@ module.exports = {
                     ) {
                         report(node);
                     }
-
-                // Check if it's a global variable
-                } else if (ignoreGlobals && isReferenceToGlobalVariable(node)) {
-
-                    // no-op (no-useless-return)
 
                 // Report anything that is underscored that isn't a CallExpression
                 } else if (nameIsUnderscored && !ALLOWED_PARENT_TYPES.has(effectiveParent.type)) {

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -6,28 +6,6 @@
 "use strict";
 
 //------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
-const { findVariable } = require("eslint-utils");
-
-//------------------------------------------------------------------------------
-// Helpers
-//------------------------------------------------------------------------------
-
-/**
- * Determines whether the given identifier node is a reference to a global variable.
- * @param {ASTNode} node `Identifier` node to check.
- * @param {Scope} scope Scope to which the node belongs.
- * @returns {boolean} True if the identifier is a reference to a global variable.
- */
-function isGlobalReference(node, scope) {
-    const variable = findVariable(scope, node);
-
-    return variable !== null && variable.scope.type === "global" && variable.defs.length === 0;
-}
-
-//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -89,7 +67,8 @@ module.exports = {
         const ignoreImports = options.ignoreImports;
         const ignoreGlobals = options.ignoreGlobals;
         const allow = options.allow || [];
-        const currentScope = context.getScope();
+
+        let globalScope;
 
         if (properties !== "always" && properties !== "never") {
             properties = "always";
@@ -188,6 +167,19 @@ module.exports = {
         }
 
         /**
+         * Checks whether the given node represents a reference to a global variable that is not declared in the source code.
+         * These identifiers will be allowed, as it is assumed that user has no control over the names of external global variables.
+         * @param {ASTNode} node `Identifier` node to check.
+         * @returns {boolean} `true` if the node is a reference to a global variable.
+         */
+        function isReferenceToGlobalVariable(node) {
+            const variable = globalScope.set.get(node.name);
+
+            return variable && variable.defs.length === 0 &&
+                variable.references.some(ref => ref.identifier === node);
+        }
+
+        /**
          * Reports an AST node as a rule violation.
          * @param {ASTNode} node The node to report.
          * @returns {void}
@@ -201,6 +193,10 @@ module.exports = {
         }
 
         return {
+
+            Program() {
+                globalScope = context.getScope();
+            },
 
             Identifier(node) {
 
@@ -295,16 +291,9 @@ module.exports = {
                     }
 
                 // Check if it's a global variable
-                } else if (isGlobalReference(node, currentScope)) {
+                } else if (ignoreGlobals && isReferenceToGlobalVariable(node)) {
 
-                    if (ignoreGlobals) {
-                        return;
-                    }
-
-                    // Report only if the local imported identifier is underscored
-                    if (nameIsUnderscored) {
-                        report(node);
-                    }
+                    // no-op (no-useless-return)
 
                 // Report anything that is underscored that isn't a CallExpression
                 } else if (nameIsUnderscored && !ALLOWED_PARENT_TYPES.has(effectiveParent.type)) {

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -180,6 +180,24 @@ module.exports = {
         }
 
         /**
+         * Checks whether the given node represents a reference to a property of an object in an object literal expression.
+         * This allows to differentiate between a global variable that is allowed to be used as a reference, and the key
+         * of the expressed object (which shouldn't be allowed).
+         * @param {*} node `Identifier` node to check.
+         * @returns {boolean} `true` if the node is a property name of an object literal expression
+         */
+        function isPropertyNameInObjectLiteral(node) {
+            const parent = node.parent;
+
+            return (
+                parent.type === "Property" &&
+                parent.parent.type === "ObjectExpression" &&
+                !parent.computed &&
+                parent.key === node
+            );
+        }
+
+        /**
          * Reports an AST node as a rule violation.
          * @param {ASTNode} node The node to report.
          * @returns {void}
@@ -214,7 +232,7 @@ module.exports = {
                 }
 
                 // Check if it's a global variable
-                if (ignoreGlobals && isReferenceToGlobalVariable(node)) {
+                if (ignoreGlobals && isReferenceToGlobalVariable(node) && !isPropertyNameInObjectLiteral(node)) {
                     return;
                 }
 

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -6,6 +6,28 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { findVariable } = require("eslint-utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Determines whether the given identifier node is a reference to a global variable.
+ * @param {ASTNode} node `Identifier` node to check.
+ * @param {Scope} scope Scope to which the node belongs.
+ * @returns {boolean} True if the identifier is a reference to a global variable.
+ */
+function isGlobalReference(node, scope) {
+    const variable = findVariable(scope, node);
+
+    return variable !== null && variable.scope.type === "global" && variable.defs.length === 0;
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -29,6 +51,10 @@ module.exports = {
                         default: false
                     },
                     ignoreImports: {
+                        type: "boolean",
+                        default: false
+                    },
+                    ignoreGlobals: {
                         type: "boolean",
                         default: false
                     },
@@ -61,7 +87,9 @@ module.exports = {
         let properties = options.properties || "";
         const ignoreDestructuring = options.ignoreDestructuring;
         const ignoreImports = options.ignoreImports;
+        const ignoreGlobals = options.ignoreGlobals;
         const allow = options.allow || [];
+        const currentScope = context.getScope();
 
         if (properties !== "always" && properties !== "never") {
             properties = "always";
@@ -263,6 +291,18 @@ module.exports = {
                         node.parent.local.name === node.name &&
                         nameIsUnderscored
                     ) {
+                        report(node);
+                    }
+
+                // Check if it's a global variable
+                } else if (isGlobalReference(node, currentScope)) {
+
+                    if (ignoreGlobals) {
+                        return;
+                    }
+
+                    // Report only if the local imported identifier is underscored
+                    if (nameIsUnderscored) {
                         report(node);
                     }
 

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -183,7 +183,7 @@ module.exports = {
          * Checks whether the given node represents a reference to a property of an object in an object literal expression.
          * This allows to differentiate between a global variable that is allowed to be used as a reference, and the key
          * of the expressed object (which shouldn't be allowed).
-         * @param {*} node `Identifier` node to check.
+         * @param {ASTNode} node `Identifier` node to check.
          * @returns {boolean} `true` if the node is a property name of an object literal expression
          */
         function isPropertyNameInObjectLiteral(node) {

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -195,6 +195,79 @@ ruleTester.run("camelcase", rule, {
             globals: { a_global_variable: "readonly" } // eslint-disable-line camelcase
         },
         {
+            code: "var foo = a_global_variable.bar",
+            options: [{ ignoreGlobals: true }],
+            globals: { a_global_variable: "readonly" } // eslint-disable-line camelcase
+        },
+        {
+            code: "a_global_variable.foo = bar",
+            options: [{ ignoreGlobals: true }],
+            globals: { a_global_variable: "readonly" } // eslint-disable-line camelcase
+        },
+        {
+            code: "( { foo: a_global_variable.bar } = baz )",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "readonly" } // eslint-disable-line camelcase
+        },
+        {
+            code: "a_global_variable = foo",
+            options: [{ ignoreGlobals: true }],
+            globals: { a_global_variable: "writable" } // eslint-disable-line camelcase
+        },
+        {
+            code: "a_global_variable = foo",
+            options: [{ ignoreGlobals: true }],
+            globals: { a_global_variable: "readonly" } // eslint-disable-line camelcase
+        },
+        {
+            code: "({ a_global_variable } = foo)",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "writable" } // eslint-disable-line camelcase
+        },
+        {
+            code: "({ snake_cased: a_global_variable } = foo)",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "writable" } // eslint-disable-line camelcase
+        },
+        {
+            code: "({ snake_cased: a_global_variable = foo } = bar)",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "writable" } // eslint-disable-line camelcase
+        },
+        {
+            code: "[a_global_variable] = bar",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "writable" } // eslint-disable-line camelcase
+        },
+        {
+            code: "[a_global_variable = foo] = bar",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "writable" } // eslint-disable-line camelcase
+        },
+        {
+            code: "foo[a_global_variable] = bar",
+            options: [{ ignoreGlobals: true }],
+            globals: { a_global_variable: "readonly" } // eslint-disable-line camelcase
+        },
+        {
+            code: "var foo = { [a_global_variable]: bar }",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "readonly" } // eslint-disable-line camelcase
+        },
+        {
+            code: "var { [a_global_variable]: foo } = bar",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "readonly" } // eslint-disable-line camelcase
+        },
+        {
             code: "function foo({ no_camelcased: camelCased }) {};",
             parserOptions: { ecmaVersion: 6 }
         },

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -170,14 +170,29 @@ ruleTester.run("camelcase", rule, {
             parserOptions: { ecmaVersion: 6, sourceType: "module" }
         },
         {
-            code: "var _camelCased = camelCased",
+            code: "var _camelCased = aGlobalVariable",
             options: [{ ignoreGlobals: false }],
-            globals: { camelCased: false }
+            globals: { aGlobalVariable: false }
         },
         {
-            code: "var camelCased = snake_cased",
+            code: "var camelCased = _aGlobalVariable",
+            options: [{ ignoreGlobals: false }],
+            globals: { _aGlobalVariable: false }
+        },
+        {
+            code: "var camelCased = a_global_variable",
             options: [{ ignoreGlobals: true }],
-            globals: { snake_cased: false } // eslint-disable-line camelcase
+            globals: { a_global_variable: false } // eslint-disable-line camelcase
+        },
+        {
+            code: "a_global_variable.foo()",
+            options: [{ ignoreGlobals: true }],
+            globals: { a_global_variable: false } // eslint-disable-line camelcase
+        },
+        {
+            code: "a_global_variable[undefined]",
+            options: [{ ignoreGlobals: true }],
+            globals: { a_global_variable: "readonly" } // eslint-disable-line camelcase
         },
         {
             code: "function foo({ no_camelcased: camelCased }) {};",
@@ -674,6 +689,31 @@ ruleTester.run("camelcase", rule, {
                 }
             ]
         },
+        {
+            code: "a_global_variable.foo()",
+            options: [{ ignoreGlobals: false }],
+            globals: { a_global_variable: false }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "a_global_variable[undefined]",
+            options: [{ ignoreGlobals: false }],
+            globals: { a_global_variable: false }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier"
+                }
+            ]
+        },
+
         {
             code: "export * as snake_cased from 'mod'",
             parserOptions: { ecmaVersion: 2020, sourceType: "module" },

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -172,22 +172,22 @@ ruleTester.run("camelcase", rule, {
         {
             code: "var _camelCased = aGlobalVariable",
             options: [{ ignoreGlobals: false }],
-            globals: { aGlobalVariable: false }
+            globals: { aGlobalVariable: "readonly" }
         },
         {
             code: "var camelCased = _aGlobalVariable",
             options: [{ ignoreGlobals: false }],
-            globals: { _aGlobalVariable: false }
+            globals: { _aGlobalVariable: "readonly" }
         },
         {
             code: "var camelCased = a_global_variable",
             options: [{ ignoreGlobals: true }],
-            globals: { a_global_variable: false } // eslint-disable-line camelcase
+            globals: { a_global_variable: "readonly" } // eslint-disable-line camelcase
         },
         {
             code: "a_global_variable.foo()",
             options: [{ ignoreGlobals: true }],
-            globals: { a_global_variable: false } // eslint-disable-line camelcase
+            globals: { a_global_variable: "readonly" } // eslint-disable-line camelcase
         },
         {
             code: "a_global_variable[undefined]",
@@ -753,7 +753,7 @@ ruleTester.run("camelcase", rule, {
         {
             code: "var camelCased = snake_cased",
             options: [{ ignoreGlobals: false }],
-            globals: { snake_cased: false }, // eslint-disable-line camelcase
+            globals: { snake_cased: "readonly" }, // eslint-disable-line camelcase
             errors: [
                 {
                     messageId: "notCamelCase",
@@ -765,7 +765,7 @@ ruleTester.run("camelcase", rule, {
         {
             code: "a_global_variable.foo()",
             options: [{ ignoreGlobals: false }],
-            globals: { a_global_variable: false }, // eslint-disable-line camelcase
+            globals: { snake_cased: "readonly" }, // eslint-disable-line camelcase
             errors: [
                 {
                     messageId: "notCamelCase",
@@ -777,7 +777,7 @@ ruleTester.run("camelcase", rule, {
         {
             code: "a_global_variable[undefined]",
             options: [{ ignoreGlobals: false }],
-            globals: { a_global_variable: false }, // eslint-disable-line camelcase
+            globals: { snake_cased: "readonly" }, // eslint-disable-line camelcase
             errors: [
                 {
                     messageId: "notCamelCase",
@@ -786,7 +786,208 @@ ruleTester.run("camelcase", rule, {
                 }
             ]
         },
-
+        {
+            code: "var camelCased = snake_cased",
+            globals: { snake_cased: "readonly" }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "snake_cased" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "var camelCased = snake_cased",
+            options: [{}],
+            globals: { snake_cased: "readonly" }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "snake_cased" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "foo.a_global_variable = bar",
+            options: [{ ignoreGlobals: true }],
+            globals: { a_global_variable: "writable" }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "var foo = { a_global_variable: bar }",
+            options: [{ ignoreGlobals: true }],
+            globals: { a_global_variable: "writable" }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "var foo = { a_global_variable: a_global_variable }",
+            options: [{ ignoreGlobals: true }],
+            globals: { a_global_variable: "writable" }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier",
+                    column: 13
+                }
+            ]
+        },
+        {
+            code: "var foo = { a_global_variable() {} }",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "writable" }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "class Foo { a_global_variable() {} }",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "writable" }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "a_global_variable: for (;;);",
+            options: [{ ignoreGlobals: true }],
+            globals: { a_global_variable: "writable" }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "if (foo) { let a_global_variable; a_global_variable = bar; }",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "writable" }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier",
+                    column: 16
+                },
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier",
+                    column: 35
+                }
+            ]
+        },
+        {
+            code: "function foo(a_global_variable) { foo = a_global_variable; }",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "writable" }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier",
+                    column: 14
+                },
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier",
+                    column: 41
+                }
+            ]
+        },
+        {
+            code: "var a_global_variable",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "function a_global_variable () {}",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "const a_global_variable = foo; bar = a_global_variable",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "writable" }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier",
+                    column: 7
+                },
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier",
+                    column: 38
+                }
+            ]
+        },
+        {
+            code: "bar = a_global_variable; var a_global_variable;",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "writable" }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier",
+                    column: 7
+                },
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier",
+                    column: 30
+                }
+            ]
+        },
         {
             code: "export * as snake_cased from 'mod'",
             parserOptions: { ecmaVersion: 2020, sourceType: "module" },

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -989,6 +989,19 @@ ruleTester.run("camelcase", rule, {
             ]
         },
         {
+            code: "var foo = { a_global_variable }",
+            options: [{ ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            globals: { a_global_variable: "readonly" }, // eslint-disable-line camelcase
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "a_global_variable" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
             code: "export * as snake_cased from 'mod'",
             parserOptions: { ecmaVersion: 2020, sourceType: "module" },
             errors: [

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -170,6 +170,16 @@ ruleTester.run("camelcase", rule, {
             parserOptions: { ecmaVersion: 6, sourceType: "module" }
         },
         {
+            code: "var _camelCased = camelCased",
+            options: [{ ignoreGlobals: false }],
+            globals: { camelCased: false }
+        },
+        {
+            code: "var camelCased = snake_cased",
+            options: [{ ignoreGlobals: true }],
+            globals: { snake_cased: false } // eslint-disable-line camelcase
+        },
+        {
             code: "function foo({ no_camelcased: camelCased }) {};",
             parserOptions: { ecmaVersion: 6 }
         },
@@ -644,6 +654,18 @@ ruleTester.run("camelcase", rule, {
             code: "import * as snake_cased from 'mod'",
             options: [{ ignoreImports: false }],
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "snake_cased" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "var camelCased = snake_cased",
+            options: [{ ignoreGlobals: false }],
+            globals: { snake_cased: false }, // eslint-disable-line camelcase
             errors: [
                 {
                     messageId: "notCamelCase",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added an option to ignore global variables in the camelcase rule.

**Is there anything you'd like reviewers to focus on?**
Testing the change and add tests.

**What rule do you want to change?**
camelcase

**Does this change cause the rule to produce more or fewer warnings?**
fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option

**Please provide some example code that this change will affect:**


Examples of **incorrect** code for this rule with the default `{ "ignoreGlobals": false }` option:

```js
/*eslint camelcase: ["error", {ignoreGlobals: false}]*/
/* global some_property */

const property = some_property;
```


Examples of **correct** code for this rule with the `{ "ignoreGlobals": true }` option:

```js
/*eslint camelcase: ["error", {ignoreGlobals: true}]*/
/* global some_property */

const property = some_property;
```

**What does the rule currently do for this code?**
Returns an error.

**What will the rule do after it's changed?**
Offer an option to ignore the error.