### PR TITLE
Fix: prefer-object-spread false positives with accessors (fixes #12086)

### DIFF
--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -59,7 +59,19 @@ ruleTester.run("prefer-object-spread", rule, {
         `
         import { Object, Array } from 'globals';
         Object.assign({ foo: 'bar' });
-        `
+        `,
+
+        // ignore Object.assign() with > 1 arguments if any of the arguments is an object expression with a getter/setter
+        "Object.assign({ get a() {} }, {})",
+        "Object.assign({ set a(val) {} }, {})",
+        "Object.assign({ get a() {} }, foo)",
+        "Object.assign({ set a(val) {} }, foo)",
+        "Object.assign({ foo: 'bar', get a() {}, baz: 'quux' }, quuux)",
+        "Object.assign({ foo: 'bar', set a(val) {} }, { baz: 'quux' })",
+        "Object.assign({}, { get a() {} })",
+        "Object.assign({}, { set a(val) {} })",
+        "Object.assign({}, { foo: 'bar', get a() {} }, {})",
+        "Object.assign({ foo }, bar, {}, { baz: 'quux', set a(val) {}, quuux }, {})"
     ],
 
     invalid: [
@@ -826,6 +838,20 @@ ruleTester.run("prefer-object-spread", rule, {
         {
             code: "Object.assign({\n});",
             output: "({});",
+            errors: [
+                {
+                    messageId: "useLiteralMessage",
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        },
+
+        // report Object.assign() with getters/setters if the function call has only 1 argument
+        {
+            code: "Object.assign({ get a() {}, set b(val) {} })",
+            output: "({get a() {}, set b(val) {}})",
             errors: [
                 {
                     messageId: "useLiteralMessage",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #12086

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The rule will now ignore `Object.assign()` with 2 or more arguments if any of the arguments is an object expression with at least one getter or setter.

**Is there anything you'd like reviewers to focus on?**


