### PR TITLE
Fix: improve report location for computed-property-spacing

### DIFF
--- a/lib/rules/computed-property-spacing.js
+++ b/lib/rules/computed-property-spacing.js
@@ -67,7 +67,7 @@ module.exports = {
         function reportNoBeginningSpace(node, token, tokenAfter) {
             context.report({
                 node,
-                loc: token.loc.start,
+                loc: { start: token.loc.end, end: tokenAfter.loc.start },
                 messageId: "unexpectedSpaceAfter",
                 data: {
                     tokenValue: token.value
@@ -88,7 +88,7 @@ module.exports = {
         function reportNoEndingSpace(node, token, tokenBefore) {
             context.report({
                 node,
-                loc: token.loc.start,
+                loc: { start: tokenBefore.loc.end, end: token.loc.start },
                 messageId: "unexpectedSpaceBefore",
                 data: {
                     tokenValue: token.value
@@ -108,7 +108,7 @@ module.exports = {
         function reportRequiredBeginningSpace(node, token) {
             context.report({
                 node,
-                loc: token.loc.start,
+                loc: token.loc,
                 messageId: "missingSpaceAfter",
                 data: {
                     tokenValue: token.value
@@ -128,7 +128,7 @@ module.exports = {
         function reportRequiredEndingSpace(node, token) {
             context.report({
                 node,
-                loc: token.loc.start,
+                loc: token.loc,
                 messageId: "missingSpaceBefore",
                 data: {
                     tokenValue: token.value

--- a/tests/lib/rules/computed-property-spacing.js
+++ b/tests/lib/rules/computed-property-spacing.js
@@ -184,6 +184,8 @@ ruleTester.run("computed-property-spacing", rule, {
             options: ["always", { enforceForClassMembers: true }],
             parserOptions: { ecmaVersion: 6 }
         },
+
+        // handling of parens and comments
         {
             code: [
                 "const foo = {",
@@ -277,8 +279,11 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MemberExpression",
+                    line: 1,
                     column: 17,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 18
+
                 }
             ]
         },
@@ -291,8 +296,10 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MemberExpression",
+                    line: 1,
                     column: 14,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 15
                 }
             ]
         },
@@ -305,8 +312,10 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MemberExpression",
-                    column: 14,
-                    line: 1
+                    line: 1,
+                    column: 15,
+                    endLine: 1,
+                    endColumn: 16
                 }
             ]
         },
@@ -318,7 +327,11 @@ ruleTester.run("computed-property-spacing", rule, {
                 {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
-                    type: "MemberExpression"
+                    type: "MemberExpression",
+                    line: 1,
+                    column: 16,
+                    endLine: 1,
+                    endColumn: 17
                 }
             ]
         },
@@ -331,15 +344,19 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MemberExpression",
-                    column: 4,
-                    line: 1
+                    line: 1,
+                    column: 5,
+                    endLine: 1,
+                    endColumn: 6
                 },
                 {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MemberExpression",
-                    column: 10,
-                    line: 1
+                    line: 1,
+                    column: 9,
+                    endLine: 1,
+                    endColumn: 10
                 }
             ]
         },
@@ -352,8 +369,10 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MemberExpression",
-                    column: 9,
-                    line: 1
+                    line: 1,
+                    column: 8,
+                    endLine: 1,
+                    endColumn: 9
                 }
             ]
         },
@@ -366,8 +385,10 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MemberExpression",
-                    column: 4,
-                    line: 1
+                    line: 1,
+                    column: 5,
+                    endLine: 1,
+                    endColumn: 6
                 }
             ]
         },
@@ -380,15 +401,128 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MemberExpression",
+                    line: 1,
                     column: 14,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 15
                 },
                 {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MemberExpression",
+                    line: 1,
                     column: 16,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 17
+                }
+            ]
+        },
+
+        // multiple spaces
+        {
+            code: "obj[    foo]",
+            output: "obj[foo]",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MemberExpression",
+                    line: 1,
+                    column: 5,
+                    endLine: 1,
+                    endColumn: 9
+                }
+            ]
+        },
+        {
+            code: "obj[  foo  ]",
+            output: "obj[foo]",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MemberExpression",
+                    line: 1,
+                    column: 5,
+                    endLine: 1,
+                    endColumn: 7
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MemberExpression",
+                    line: 1,
+                    column: 10,
+                    endLine: 1,
+                    endColumn: 12
+                }
+            ]
+        },
+        {
+            code: "obj[   foo ]",
+            output: "obj[foo]",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MemberExpression",
+                    line: 1,
+                    column: 5,
+                    endLine: 1,
+                    endColumn: 8
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MemberExpression",
+                    line: 1,
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
+                }
+            ]
+        },
+        {
+            code: "obj[ foo + \n  bar   ]",
+            output: "obj[foo + \n  bar]",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MemberExpression",
+                    line: 1,
+                    column: 5,
+                    endLine: 1,
+                    endColumn: 6
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MemberExpression",
+                    line: 2,
+                    column: 6,
+                    endLine: 2,
+                    endColumn: 9
+                }
+            ]
+        },
+        {
+            code: "obj[\n foo  ]",
+            output: "obj[\n foo]",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MemberExpression",
+                    line: 2,
+                    column: 5,
+                    endLine: 2,
+                    endColumn: 7
                 }
             ]
         },
@@ -404,15 +538,19 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "Property",
+                    line: 1,
                     column: 10,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 11
                 },
                 {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "Property",
+                    line: 1,
                     column: 12,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 13
                 }
             ]
         },
@@ -426,8 +564,10 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "Property",
+                    line: 1,
                     column: 10,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 11
                 }
             ]
         },
@@ -441,8 +581,10 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "Property",
+                    line: 1,
                     column: 13,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 14
                 }
             ]
         },
@@ -458,15 +600,19 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "Property",
-                    column: 10,
-                    line: 1
+                    line: 1,
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 },
                 {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "Property",
-                    column: 14,
-                    line: 1
+                    line: 1,
+                    column: 13,
+                    endLine: 1,
+                    endColumn: 14
                 }
             ]
         },
@@ -480,8 +626,10 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "Property",
-                    column: 13,
-                    line: 1
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 13
                 }
             ]
         },
@@ -495,8 +643,10 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "Property",
-                    column: 10,
-                    line: 1
+                    line: 1,
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 }
             ]
         },
@@ -510,17 +660,15 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "Property",
-                    column: 10,
-                    line: 1
+                    line: 1,
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 }
             ]
         },
 
-        //------------------------------------------------------------------------------
-        // Classes
-        //------------------------------------------------------------------------------
-
-        // never
+        // never - classes
         {
             code: "class A { [ a](){} }",
             output: "class A { [a](){} }",
@@ -531,8 +679,10 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
-                    column: 11,
-                    line: 1
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 13
                 }
             ]
         },
@@ -546,8 +696,10 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
-                    column: 37,
-                    line: 1
+                    line: 1,
+                    column: 36,
+                    endLine: 1,
+                    endColumn: 37
                 }
             ]
         },
@@ -561,29 +713,37 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
-                    column: 18,
-                    line: 1
+                    line: 1,
+                    column: 17,
+                    endLine: 1,
+                    endColumn: 18
                 },
                 {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
-                    column: 28,
-                    line: 1
+                    line: 1,
+                    column: 29,
+                    endLine: 1,
+                    endColumn: 30
                 },
                 {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
-                    column: 81,
-                    line: 1
+                    line: 1,
+                    column: 82,
+                    endLine: 1,
+                    endColumn: 83
                 },
                 {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
-                    column: 104,
-                    line: 1
+                    line: 1,
+                    column: 103,
+                    endLine: 1,
+                    endColumn: 104
                 }
             ]
         },
@@ -597,90 +757,114 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
-                    column: 13,
-                    line: 1
+                    line: 1,
+                    column: 14,
+                    endLine: 1,
+                    endColumn: 15
                 },
                 {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
-                    column: 17,
-                    line: 1
+                    line: 1,
+                    column: 16,
+                    endLine: 1,
+                    endColumn: 17
                 },
                 {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
-                    column: 27,
-                    line: 1
+                    line: 1,
+                    column: 28,
+                    endLine: 1,
+                    endColumn: 29
                 },
                 {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
-                    column: 31,
-                    line: 1
+                    line: 1,
+                    column: 30,
+                    endLine: 1,
+                    endColumn: 31
                 },
                 {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
-                    column: 41,
-                    line: 1
+                    line: 1,
+                    column: 42,
+                    endLine: 1,
+                    endColumn: 43
                 },
                 {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
-                    column: 45,
-                    line: 1
+                    line: 1,
+                    column: 44,
+                    endLine: 1,
+                    endColumn: 45
                 },
                 {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
-                    column: 61,
-                    line: 1
+                    line: 1,
+                    column: 62,
+                    endLine: 1,
+                    endColumn: 63
                 },
                 {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
-                    column: 65,
-                    line: 1
+                    line: 1,
+                    column: 64,
+                    endLine: 1,
+                    endColumn: 65
                 },
                 {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
-                    column: 82,
-                    line: 1
+                    line: 1,
+                    column: 83,
+                    endLine: 1,
+                    endColumn: 84
                 },
                 {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
-                    column: 86,
-                    line: 1
+                    line: 1,
+                    column: 85,
+                    endLine: 1,
+                    endColumn: 86
                 },
                 {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
-                    column: 103,
-                    line: 1
+                    line: 1,
+                    column: 104,
+                    endLine: 1,
+                    endColumn: 105
                 },
                 {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
-                    column: 107,
-                    line: 1
+                    line: 1,
+                    column: 106,
+                    endLine: 1,
+                    endColumn: 107
                 }
             ]
         },
 
-        // always
+        // always - classes
         {
             code: "class A { [ a](){} }",
             output: "class A { [ a ](){} }",
@@ -691,8 +875,10 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 14,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 15
                 }
             ]
         },
@@ -706,8 +892,10 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 36,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 37
                 }
             ]
         },
@@ -721,29 +909,37 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 15,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 16
                 },
                 {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 31,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 32
                 },
                 {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 84,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 85
                 },
                 {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 101,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 102
                 }
             ]
         },
@@ -757,88 +953,114 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 13,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 14
                 },
                 {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 15,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 16
                 },
                 {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 25,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 26
                 },
                 {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 27,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 28
                 },
                 {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 37,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 38
                 },
                 {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 39,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 40
                 },
                 {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 55,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 56
                 },
                 {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 57,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 58
                 },
                 {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 74,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 75
                 },
                 {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 76,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 77
                 },
                 {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 93,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 94
                 },
                 {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MethodDefinition",
+                    line: 1,
                     column: 95,
-                    line: 1
+                    endLine: 1,
+                    endColumn: 96
                 }
             ]
         },
+
+        // handling of parens and comments
         {
             code: [
                 "const foo = {",
@@ -857,15 +1079,19 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "Property",
+                    line: 2,
                     column: 3,
-                    line: 2
+                    endLine: 2,
+                    endColumn: 4
                 },
                 {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "Property",
+                    line: 2,
                     column: 7,
-                    line: 2
+                    endLine: 2,
+                    endColumn: 8
                 }
             ]
         },
@@ -887,15 +1113,19 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "Property",
+                    line: 2,
                     column: 3,
-                    line: 2
+                    endLine: 2,
+                    endColumn: 4
                 },
                 {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "Property",
+                    line: 2,
                     column: 9,
-                    line: 2
+                    endLine: 2,
+                    endColumn: 10
                 }
             ]
         },
@@ -917,163 +1147,191 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "Property",
-                    column: 3,
-                    line: 2
+                    line: 2,
+                    column: 4,
+                    endLine: 2,
+                    endColumn: 5
                 },
                 {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "Property",
-                    column: 11,
-                    line: 2
-                }
-            ]
-        },
-        {
-            code: [
-                "const foo = {",
-                "  [/**/ a /**/]: 1",
-                "}"
-            ].join("\n"),
-            output: [
-                "const foo = {",
-                "  [ /**/ a /**/ ]: 1",
-                "}"
-            ].join("\n"),
-            options: ["always"],
-            parserOptions: { ecmaVersion: 6 },
-            errors: [
-                {
-                    messageId: "missingSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "Property",
-                    column: 3,
-                    line: 2
-                },
-                {
-                    messageId: "missingSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "Property",
-                    column: 15,
-                    line: 2
-                }
-            ]
-        },
-        {
-            code: [
-                "const foo = {",
-                "  [ /**/ a /**/ ]: 1",
-                "}"
-            ].join("\n"),
-            output: [
-                "const foo = {",
-                "  [/**/ a /**/]: 1",
-                "}"
-            ].join("\n"),
-            options: ["never"],
-            parserOptions: { ecmaVersion: 6 },
-            errors: [
-                {
-                    messageId: "unexpectedSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "Property",
-                    column: 3,
-                    line: 2
-                },
-                {
-                    messageId: "unexpectedSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "Property",
-                    column: 17,
-                    line: 2
-                }
-            ]
-        },
-        {
-            code: [
-                "const foo = {",
-                "  [a[b]]: 1",
-                "}"
-            ].join("\n"),
-            output: [
-                "const foo = {",
-                "  [ a[ b ] ]: 1",
-                "}"
-            ].join("\n"),
-            options: ["always"],
-            parserOptions: { ecmaVersion: 6 },
-            errors: [
-                {
-                    messageId: "missingSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "Property",
-                    column: 3,
-                    line: 2
-                },
-                {
-                    messageId: "missingSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MemberExpression",
-                    column: 5,
-                    line: 2
-                },
-                {
-                    messageId: "missingSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MemberExpression",
-                    column: 7,
-                    line: 2
-                },
-                {
-                    messageId: "missingSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "Property",
-                    column: 8,
-                    line: 2
-                }
-            ]
-        },
-        {
-            code: [
-                "const foo = {",
-                "  [ a[ b ] ]: 1",
-                "}"
-            ].join("\n"),
-            output: [
-                "const foo = {",
-                "  [a[b]]: 1",
-                "}"
-            ].join("\n"),
-            options: ["never"],
-            parserOptions: { ecmaVersion: 6 },
-            errors: [
-                {
-                    messageId: "unexpectedSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "Property",
-                    column: 3,
-                    line: 2
-                },
-                {
-                    messageId: "unexpectedSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MemberExpression",
-                    column: 6,
-                    line: 2
-                },
-                {
-                    messageId: "unexpectedSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MemberExpression",
+                    line: 2,
                     column: 10,
-                    line: 2
+                    endLine: 2,
+                    endColumn: 11
+                }
+            ]
+        },
+        {
+            code: [
+                "const foo = {",
+                "  [/**/ a /**/]: 1",
+                "}"
+            ].join("\n"),
+            output: [
+                "const foo = {",
+                "  [ /**/ a /**/ ]: 1",
+                "}"
+            ].join("\n"),
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "Property",
+                    line: 2,
+                    column: 3,
+                    endLine: 2,
+                    endColumn: 4
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "Property",
+                    line: 2,
+                    column: 15,
+                    endLine: 2,
+                    endColumn: 16
+                }
+            ]
+        },
+        {
+            code: [
+                "const foo = {",
+                "  [ /**/ a /**/ ]: 1",
+                "}"
+            ].join("\n"),
+            output: [
+                "const foo = {",
+                "  [/**/ a /**/]: 1",
+                "}"
+            ].join("\n"),
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "Property",
+                    line: 2,
+                    column: 4,
+                    endLine: 2,
+                    endColumn: 5
                 },
                 {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "Property",
-                    column: 12,
-                    line: 2
+                    line: 2,
+                    column: 16,
+                    endLine: 2,
+                    endColumn: 17
+                }
+            ]
+        },
+        {
+            code: [
+                "const foo = {",
+                "  [a[b]]: 1",
+                "}"
+            ].join("\n"),
+            output: [
+                "const foo = {",
+                "  [ a[ b ] ]: 1",
+                "}"
+            ].join("\n"),
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "Property",
+                    line: 2,
+                    column: 3,
+                    endLine: 2,
+                    endColumn: 4
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MemberExpression",
+                    line: 2,
+                    column: 5,
+                    endLine: 2,
+                    endColumn: 6
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MemberExpression",
+                    line: 2,
+                    column: 7,
+                    endLine: 2,
+                    endColumn: 8
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "Property",
+                    line: 2,
+                    column: 8,
+                    endLine: 2,
+                    endColumn: 9
+                }
+            ]
+        },
+        {
+            code: [
+                "const foo = {",
+                "  [ a[ b ] ]: 1",
+                "}"
+            ].join("\n"),
+            output: [
+                "const foo = {",
+                "  [a[b]]: 1",
+                "}"
+            ].join("\n"),
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "Property",
+                    line: 2,
+                    column: 4,
+                    endLine: 2,
+                    endColumn: 5
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MemberExpression",
+                    line: 2,
+                    column: 7,
+                    endLine: 2,
+                    endColumn: 8
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MemberExpression",
+                    line: 2,
+                    column: 9,
+                    endLine: 2,
+                    endColumn: 10
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "Property",
+                    line: 2,
+                    column: 11,
+                    endLine: 2,
+                    endColumn: 12
                 }
             ]
         },
@@ -1095,22 +1353,28 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "Property",
+                    line: 2,
                     column: 3,
-                    line: 2
+                    endLine: 2,
+                    endColumn: 4
                 },
                 {
                     messageId: "missingSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MemberExpression",
+                    line: 2,
                     column: 5,
-                    line: 2
+                    endLine: 2,
+                    endColumn: 6
                 },
                 {
                     messageId: "missingSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "Property",
+                    line: 2,
                     column: 18,
-                    line: 2
+                    endLine: 2,
+                    endColumn: 19
                 }
             ]
         },
@@ -1132,22 +1396,28 @@ ruleTester.run("computed-property-spacing", rule, {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "Property",
-                    column: 3,
-                    line: 2
+                    line: 2,
+                    column: 4,
+                    endLine: 2,
+                    endColumn: 5
                 },
                 {
                     messageId: "unexpectedSpaceAfter",
                     data: { tokenValue: "[" },
                     type: "MemberExpression",
-                    column: 10,
-                    line: 2
+                    line: 2,
+                    column: 11,
+                    endLine: 2,
+                    endColumn: 12
                 },
                 {
                     messageId: "unexpectedSpaceBefore",
                     data: { tokenValue: "]" },
                     type: "MemberExpression",
-                    column: 19,
-                    line: 2
+                    line: 2,
+                    column: 18,
+                    endLine: 2,
+                    endColumn: 19
                 }
             ]
         }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain:

Changes `computed-property-spacing` report locations.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

* For missing spaces the rule will now report `loc` instead of just `loc.start`.
* For disallowed spaces the rule will now report the location of spaces (the range that should be removed) instead of the location of the brackets.

before this change:

![image](https://user-images.githubusercontent.com/44349756/72494512-63a5a680-3824-11ea-810f-0291b0b00fe5.png)

after this change:

![image](https://user-images.githubusercontent.com/44349756/72494580-95b70880-3824-11ea-9742-3515a3fea988.png)


**Is there anything you'd like reviewers to focus on?**


