### PR TITLE
Update: fix no-restricted-imports export * false negative (fixes #12737)

### DIFF
--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -91,6 +91,7 @@ module.exports = {
     },
 
     create(context) {
+        const sourceCode = context.getSourceCode();
         const options = Array.isArray(context.options) ? context.options : [];
         const isPathAndPatternsObject =
             typeof options[0] === "object" &&
@@ -216,30 +217,36 @@ module.exports = {
          */
         function checkNode(node) {
             const importSource = node.source.value.trim();
-            const importNames = node.specifiers ? node.specifiers.reduce((map, specifier) => {
-                let name;
-                const specifierData = { loc: specifier.loc };
+            const importNames = new Map();
 
-                if (specifier.type === "ImportDefaultSpecifier") {
-                    name = "default";
-                } else if (specifier.type === "ImportNamespaceSpecifier") {
-                    name = "*";
-                } else if (specifier.imported) {
-                    name = specifier.imported.name;
-                } else if (specifier.local) {
-                    name = specifier.local.name;
-                }
+            if (node.type === "ExportAllDeclaration") {
+                const starToken = sourceCode.getFirstToken(node, 1);
 
-                if (name) {
-                    if (map.has(name)) {
-                        map.get(name).push(specifierData);
-                    } else {
-                        map.set(name, [specifierData]);
+                importNames.set("*", [{ loc: starToken.loc }]);
+            } else if (node.specifiers) {
+                for (const specifier of node.specifiers) {
+                    let name;
+                    const specifierData = { loc: specifier.loc };
+
+                    if (specifier.type === "ImportDefaultSpecifier") {
+                        name = "default";
+                    } else if (specifier.type === "ImportNamespaceSpecifier") {
+                        name = "*";
+                    } else if (specifier.imported) {
+                        name = specifier.imported.name;
+                    } else if (specifier.local) {
+                        name = specifier.local.name;
+                    }
+
+                    if (name) {
+                        if (importNames.has(name)) {
+                            importNames.get(name).push(specifierData);
+                        } else {
+                            importNames.set(name, [specifierData]);
+                        }
                     }
                 }
-
-                return map;
-            }, new Map()) : new Map();
+            }
 
             checkRestrictedPathAndReport(importSource, importNames, node);
 

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -168,6 +168,17 @@ ruleTester.run("no-restricted-imports", rule, {
         {
             code: "import {\nAllowedObject,\nDisallowedObject, // eslint-disable-line\n} from \"foo\";",
             options: [{ paths: [{ name: "foo", importNames: ["DisallowedObject"] }] }]
+        },
+        {
+            code: "export * from \"foo\";",
+            options: ["bar"]
+        },
+        {
+            code: "export * from \"foo\";",
+            options: [{
+                name: "bar",
+                importNames: ["DisallowedObject"]
+            }]
         }
     ],
     invalid: [{
@@ -354,6 +365,37 @@ ruleTester.run("no-restricted-imports", rule, {
             line: 1,
             column: 8,
             endColumn: 16
+        }]
+    },
+    {
+        code: "export * from \"foo\";",
+        options: [{
+            paths: [{
+                name: "foo",
+                importNames: ["DisallowedObject"],
+                message: "Please import 'DisallowedObject' from /bar/ instead."
+            }]
+        }],
+        errors: [{
+            message: "* import is invalid because 'DisallowedObject' from 'foo' is restricted. Please import 'DisallowedObject' from /bar/ instead.",
+            type: "ExportAllDeclaration",
+            line: 1,
+            column: 8,
+            endColumn: 9
+        }]
+    },
+    {
+        code: "export * from \"foo\";",
+        options: [{
+            name: "foo",
+            importNames: ["DisallowedObject1, DisallowedObject2"]
+        }],
+        errors: [{
+            message: "* import is invalid because 'DisallowedObject1, DisallowedObject2' from 'foo' is restricted.",
+            type: "ExportAllDeclaration",
+            line: 1,
+            column: 8,
+            endColumn: 9
         }]
     },
     {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #12737

This bug fix produces **more** warnings by default.
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The previous behavior was to disallow `export * from "foo"` just when the whole module `"foo"` is restricted.

After this fix, the rule will disallow `export * from "foo"` even if only some names from `"foo"` are restricted but not the whole module (i.e., configuration for `"foo"` has `importNames` option).

**Is there anything you'd like reviewers to focus on?**


