### PR TITLE
Fix: multiline-comment-style rule add extra space after * (fixes #12785)

### DIFF
--- a/lib/rules/multiline-comment-style.js
+++ b/lib/rules/multiline-comment-style.js
@@ -315,7 +315,7 @@ module.exports = {
                                         const lineTextToAlignWith = sourceCode.lines[firstComment.loc.start.line - 1 + idx];
                                         const [, prefix = "", initialOffset = ""] = lineTextToAlignWith.match(/^(\s*(?:\/?\*)?(\s*))/u) || [];
 
-                                        offset = `${commentTextPrefix.slice(prefix.length)}${initialOffset}`;
+                                        offset = `${commentTextPrefix.slice(prefix.length)}${initialOffset} `;
                                         break;
                                     }
 

--- a/lib/rules/multiline-comment-style.js
+++ b/lib/rules/multiline-comment-style.js
@@ -315,10 +315,10 @@ module.exports = {
                                         const lineTextToAlignWith = sourceCode.lines[firstComment.loc.start.line - 1 + idx];
                                         const [, prefix = "", initialOffset = ""] = lineTextToAlignWith.match(/^(\s*(?:\/?\*)?(\s*))/u) || [];
 
-                                        if (/^\s*\//u.test(lineText)) {
+                                        offset = `${commentTextPrefix.slice(prefix.length)}${initialOffset}`;
+
+                                        if (/^\s*\//u.test(lineText) && offset.length === 0) {
                                             offset = `${commentTextPrefix.slice(prefix.length)}${initialOffset} `;
-                                        } else {
-                                            offset = `${commentTextPrefix.slice(prefix.length)}${initialOffset}`;
                                         }
                                         break;
                                     }

--- a/lib/rules/multiline-comment-style.js
+++ b/lib/rules/multiline-comment-style.js
@@ -315,7 +315,11 @@ module.exports = {
                                         const lineTextToAlignWith = sourceCode.lines[firstComment.loc.start.line - 1 + idx];
                                         const [, prefix = "", initialOffset = ""] = lineTextToAlignWith.match(/^(\s*(?:\/?\*)?(\s*))/u) || [];
 
-                                        offset = `${commentTextPrefix.slice(prefix.length)}${initialOffset} `;
+                                        if (/^\s*\//u.test(lineText)) {
+                                            offset = `${commentTextPrefix.slice(prefix.length)}${initialOffset} `;
+                                        } else {
+                                            offset = `${commentTextPrefix.slice(prefix.length)}${initialOffset}`;
+                                        }
                                         break;
                                     }
 

--- a/lib/rules/multiline-comment-style.js
+++ b/lib/rules/multiline-comment-style.js
@@ -318,7 +318,7 @@ module.exports = {
                                         offset = `${commentTextPrefix.slice(prefix.length)}${initialOffset}`;
 
                                         if (/^\s*\//u.test(lineText) && offset.length === 0) {
-                                            offset = `${commentTextPrefix.slice(prefix.length)}${initialOffset} `;
+                                            offset += " ";
                                         }
                                         break;
                                     }

--- a/tests/lib/rules/multiline-comment-style.js
+++ b/tests/lib/rules/multiline-comment-style.js
@@ -1379,6 +1379,25 @@ ${"                   "}
                 { messageId: "missingStar", line: 4 },
                 { messageId: "endNewline", line: 4 }
             ]
+        },
+        {
+            code: `
+                /*
+                 // a line comment
+                 some.code();
+                 */
+            `,
+            output: `
+                /*
+                 * // a line comment
+                 *some.code();
+                 */
+            `,
+            options: ["starred-block"],
+            errors: [
+                { messageId: "missingStar", line: 3 },
+                { messageId: "missingStar", line: 4 }
+            ]
         }
     ]
 });

--- a/tests/lib/rules/multiline-comment-style.js
+++ b/tests/lib/rules/multiline-comment-style.js
@@ -1447,6 +1447,32 @@ ${"                   "}
             errors: [
                 { messageId: "expectedBlock", line: 2 }
             ]
+        },
+        {
+            code: `
+                /*
+                {
+                \t"foo": 1,
+                \t//"bar": 2
+                }
+                */
+            `,
+            output: `
+                /*
+                 *{
+                 *\t"foo": 1,
+                 *\t//"bar": 2
+                 *}
+                 */
+            `,
+            options: ["starred-block"],
+            errors: [
+                { messageId: "missingStar", line: 3 },
+                { messageId: "missingStar", line: 4 },
+                { messageId: "missingStar", line: 5 },
+                { messageId: "missingStar", line: 6 },
+                { messageId: "alignment", line: 7 }
+            ]
         }
     ]
 });

--- a/tests/lib/rules/multiline-comment-style.js
+++ b/tests/lib/rules/multiline-comment-style.js
@@ -328,6 +328,15 @@ ruleTester.run("multiline-comment-style", rule, {
                  */
             `,
             options: ["separate-lines"]
+        },
+        {
+            code: `
+                /*
+                 * // a line comment
+                 *some.code();
+                 */
+            `,
+            options: ["starred-block"]
         }
     ],
 
@@ -1397,6 +1406,46 @@ ${"                   "}
             errors: [
                 { messageId: "missingStar", line: 3 },
                 { messageId: "missingStar", line: 4 }
+            ]
+        },
+        {
+            code: `
+                /*
+                 // a line comment
+                 * some.code();
+                 */
+            `,
+            output: `
+                /*
+                 * // a line comment
+                 * some.code();
+                 */
+            `,
+            options: ["starred-block"],
+            errors: [
+                { messageId: "missingStar", line: 3 }
+            ]
+        },
+        {
+            code: `
+                ////This comment is in
+                //\`separate-lines\` format.
+            `,
+            output: null,
+            options: ["starred-block"],
+            errors: [
+                { messageId: "expectedBlock", line: 2 }
+            ]
+        },
+        {
+            code: `
+                // // This comment is in
+                // \`separate-lines\` format.
+            `,
+            output: null,
+            options: ["starred-block"],
+            errors: [
+                { messageId: "expectedBlock", line: 2 }
             ]
         }
     ]


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

fixes #12785 

#### What changes did you make? (Give an overview)
Added the extra white space which was removed here https://github.com/eslint/eslint/pull/12316/files#diff-e8cce2004dd5e0386021b0e80370c8ebL190

#### Is there anything you'd like reviewers to focus on?
No