### PR TITLE
Fix: id-blacklist false positives on renamed imports

### DIFF
--- a/tests/lib/rules/id-blacklist.js
+++ b/tests/lib/rules/id-blacklist.js
@@ -42,6 +42,16 @@ ruleTester.run("id-blacklist", rule, {
             options: ["f", "fo", "fooo", "bar"]
         },
         {
+            code: "import { foo as bar } from 'mod'",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code: "export { foo as bar } from 'mod'",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
             code: "foo.bar()",
             options: ["f", "fo", "fooo", "b", "ba", "baz"]
         },
@@ -146,6 +156,260 @@ ruleTester.run("id-blacklist", rule, {
             errors: [
                 error
             ]
+        },
+        {
+            code: "import foo from 'mod'",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                error
+            ]
+        },
+        {
+            code: "import * as foo from 'mod'",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                error
+            ]
+        },
+        {
+            code: "import { foo } from 'mod'",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                error
+            ]
+        },
+        {
+            code: "import { foo as bar } from 'mod'",
+            options: ["bar"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "blacklisted",
+                data: { name: "bar" },
+                type: "Identifier",
+                column: 17
+            }]
+        },
+        {
+            code: "import { foo as bar } from 'mod'",
+            options: ["foo", "bar"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "blacklisted",
+                data: { name: "bar" },
+                type: "Identifier",
+                column: 17
+            }]
+        },
+        {
+            code: "import { foo as foo } from 'mod'",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "blacklisted",
+                data: { name: "foo" },
+                type: "Identifier",
+                column: 17
+            }]
+        },
+        {
+            code: "import { foo, foo as bar } from 'mod'",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "blacklisted",
+                data: { name: "foo" },
+                type: "Identifier",
+                column: 10
+            }]
+        },
+        {
+            code: "import { foo as bar, foo } from 'mod'",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "blacklisted",
+                data: { name: "foo" },
+                type: "Identifier",
+                column: 22
+            }]
+        },
+        {
+            code: "import foo, { foo as bar } from 'mod'",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "blacklisted",
+                data: { name: "foo" },
+                type: "Identifier",
+                column: 8
+            }]
+        },
+        {
+            code: "var foo; export { foo as bar };",
+            options: ["bar"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "blacklisted",
+                data: { name: "bar" },
+                type: "Identifier",
+                column: 26
+            }]
+        },
+        {
+            code: "var foo; export { foo };",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    messageId: "blacklisted",
+                    data: { name: "foo" },
+                    type: "Identifier",
+                    column: 5
+                },
+                {
+                    messageId: "blacklisted",
+                    data: { name: "foo" },
+                    type: "Identifier",
+                    column: 19
+                }
+            ]
+        },
+        {
+            code: "var foo; export { foo as bar };",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    messageId: "blacklisted",
+                    data: { name: "foo" },
+                    type: "Identifier",
+                    column: 5
+                },
+
+                // reports each occurence of local identifier, although it's renamed in this export specifier
+                {
+                    messageId: "blacklisted",
+                    data: { name: "foo" },
+                    type: "Identifier",
+                    column: 19
+                }
+            ]
+        },
+        {
+            code: "var foo; export { foo as foo };",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    messageId: "blacklisted",
+                    data: { name: "foo" },
+                    type: "Identifier",
+                    column: 5
+                },
+                {
+                    messageId: "blacklisted",
+                    data: { name: "foo" },
+                    type: "Identifier",
+                    column: 19
+                },
+                {
+                    messageId: "blacklisted",
+                    data: { name: "foo" },
+                    type: "Identifier",
+                    column: 26
+                }
+            ]
+        },
+        {
+            code: "var foo; export { foo as bar };",
+            options: ["foo", "bar"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    messageId: "blacklisted",
+                    data: { name: "foo" },
+                    type: "Identifier",
+                    column: 5
+                },
+                {
+                    messageId: "blacklisted",
+                    data: { name: "foo" },
+                    type: "Identifier",
+                    column: 19
+                },
+                {
+                    messageId: "blacklisted",
+                    data: { name: "bar" },
+                    type: "Identifier",
+                    column: 26
+                }
+            ]
+        },
+        {
+            code: "export { foo } from 'mod'",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                error
+            ]
+        },
+        {
+            code: "export { foo as bar } from 'mod'",
+            options: ["bar"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "blacklisted",
+                data: { name: "bar" },
+                type: "Identifier",
+                column: 17
+            }]
+        },
+        {
+            code: "export { foo as bar } from 'mod'",
+            options: ["foo", "bar"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "blacklisted",
+                data: { name: "bar" },
+                type: "Identifier",
+                column: 17
+            }]
+        },
+        {
+            code: "export { foo as foo } from 'mod'",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "blacklisted",
+                data: { name: "foo" },
+                type: "Identifier",
+                column: 17
+            }]
+        },
+        {
+            code: "export { foo, foo as bar } from 'mod'",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "blacklisted",
+                data: { name: "foo" },
+                type: "Identifier",
+                column: 10
+            }]
+        },
+        {
+            code: "export { foo as bar, foo } from 'mod'",
+            options: ["foo"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "blacklisted",
+                data: { name: "foo" },
+                type: "Identifier",
+                column: 22
+            }]
         },
         {
             code: "foo.bar()",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to item)

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 7.0.0-alpha.0
* **Node Version:** v12.14.0
* **npm Version:** v6.13.4

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: 2015,
        sourceType: "module"
    },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint id-blacklist: ["error", "foo"] */

import { foo as bar } from "mod";
export { foo as bar } from "mod";

import { foo } from "mod";
```

[Online Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IGlkLWJsYWNrbGlzdDogW1wiZXJyb3JcIiwgXCJmb29cIl0gKi9cblxuaW1wb3J0IHsgZm9vIGFzIGJhciB9IGZyb20gXCJtb2RcIjtcbmV4cG9ydCB7IGZvbyBhcyBiYXIgfSBmcm9tIFwibW9kXCI7XG5cbmltcG9ydCB7IGZvbyB9IGZyb20gXCJtb2RcIjsiLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjYsInNvdXJjZVR5cGUiOiJtb2R1bGUiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnsibm8tZXh0cmEtYm9vbGVhbi1jYXN0IjoyfSwiZW52Ijp7fX19) - the actual demo is v6.8.0, but it's the same behavior regarding this issue.

**What did you expect to happen?**

Not to report `foo` in `import { foo as bar }` and `export { foo as bar }`. 

This is a stylistic rule and shouldn't restrict imports of existing external names (and thus basically their use, that's the responsibility of the `no-restricted-imports` rule). 

On the other hand, the rule should report `import { foo }` and enforce renaming, but it shouldn't report the same identifier twice.

**What actually happened? Please include the actual, raw output from ESLint.**

```
  3:10  error  Identifier 'foo' is blacklisted  id-blacklist
  4:10  error  Identifier 'foo' is blacklisted  id-blacklist
  6:10  error  Identifier 'foo' is blacklisted  id-blacklist
  6:10  error  Identifier 'foo' is blacklisted  id-blacklist
```

These are two different bugs: 

* The first two errors are false positives.
* One of the other two errors is a duplicate.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Fixed the rule to not report renamed imports/re-exports.
* Fixed the rule to avoid reporting same nodes multiple times.
* Refactoring
  - `if (node.parent.type === "Property")` branch was same as the next branch, so it's removed.
  - `effectiveParent` was different than `node.parent` just for member expressions, so it's moved to that branch to simplify the rest of the code.

#### Is there anything you'd like reviewers to focus on?

* Refactoring, did I miss something.
* Local names in exports (not re-exports) will be still reported:

```js
/* eslint id-blacklist: ["error", "foo"] */

var foo; // error

export { foo as bar }; // also error, although it's renamed here
```

That seemed consistent with how this rule works: it reports all references, not just declarations.
