### PR TITLE
Chore: add missing `ecmaVersion` 2020/11 type value

### DIFF
--- a/lib/shared/types.js
+++ b/lib/shared/types.js
@@ -21,7 +21,7 @@ module.exports = {};
 /**
  * @typedef {Object} ParserOptions
  * @property {EcmaFeatures} [ecmaFeatures] The optional features.
- * @property {3|5|6|7|8|9|10|2015|2016|2017|2018|2019} [ecmaVersion] The ECMAScript version (or revision number).
+ * @property {3|5|6|7|8|9|10|11|2015|2016|2017|2018|2019|2020} [ecmaVersion] The ECMAScript version (or revision number).
  * @property {"script"|"module"} [sourceType] The source code type.
  */
 


### PR DESCRIPTION
This is minor fix for shared type definition.

Thanks!

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.
- [x] Other, please explain: fixes missing type value