### PR TITLE
Breaking: no-dupe-class-members checks some computed keys (fixes #12808)

### DIFF
--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -74,11 +74,12 @@ module.exports = {
 
             // Reports the node if its name has been declared already.
             MethodDefinition(node) {
-                if (node.computed) {
+                const name = astUtils.getStaticPropertyName(node);
+
+                if (name === null) {
                     return;
                 }
 
-                const name = astUtils.getStaticPropertyName(node) || "";
                 const state = getState(name, node.static);
                 let isDuplicate = false;
 

--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -76,7 +76,7 @@ module.exports = {
             MethodDefinition(node) {
                 const name = astUtils.getStaticPropertyName(node);
 
-                if (name === null) {
+                if (name === null || node.kind === "constructor") {
                     return;
                 }
 

--- a/tests/lib/rules/no-dupe-class-members.js
+++ b/tests/lib/rules/no-dupe-class-members.js
@@ -36,6 +36,14 @@ ruleTester.run("no-dupe-class-members", rule, {
         "class A { [1.0]() {} ['1.0']() {} }",
         "class A { [0x1]() {} [`0x1`]() {} }",
         "class A { [null]() {} ['']() {} }",
+        "class A { get ['foo']() {} set ['foo'](value) {} }",
+        "class A { ['foo']() {} static ['foo']() {} }",
+
+        // computed "constructor" key doesn't create constructor
+        "class A { ['constructor']() {} constructor() {} }",
+        "class A { 'constructor'() {} [`constructor`]() {} }",
+        "class A { constructor() {} get [`constructor`]() {} }",
+        "class A { 'constructor'() {} set ['constructor'](value) {} }",
 
         // not assumed to be statically-known values
         "class A { ['foo' + '']() {} ['foo']() {} }",
@@ -83,6 +91,12 @@ ruleTester.run("no-dupe-class-members", rule, {
             ]
         },
         {
+            code: "class A { set 'foo'(value) {} set ['foo'](val) {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 31, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
             code: "class A { ''() {} ['']() {} }",
             errors: [
                 { type: "MethodDefinition", line: 1, column: 19, messageId: "unexpected", data: { name: "" } }
@@ -95,9 +109,9 @@ ruleTester.run("no-dupe-class-members", rule, {
             ]
         },
         {
-            code: "class A { [`foo`]() {} ['foo']() {} }",
+            code: "class A { static get [`foo`]() {} static get ['foo']() {} }",
             errors: [
-                { type: "MethodDefinition", line: 1, column: 24, messageId: "unexpected", data: { name: "foo" } }
+                { type: "MethodDefinition", line: 1, column: 35, messageId: "unexpected", data: { name: "foo" } }
             ]
         },
         {
@@ -107,9 +121,33 @@ ruleTester.run("no-dupe-class-members", rule, {
             ]
         },
         {
+            code: "class A { get [`foo`]() {} 'foo'() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 28, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
             code: "class A { static 'foo'() {} static [`foo`]() {} }",
             errors: [
                 { type: "MethodDefinition", line: 1, column: 29, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { ['constructor']() {} ['constructor']() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 32, messageId: "unexpected", data: { name: "constructor" } }
+            ]
+        },
+        {
+            code: "class A { static [`constructor`]() {} static constructor() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 39, messageId: "unexpected", data: { name: "constructor" } }
+            ]
+        },
+        {
+            code: "class A { static constructor() {} static 'constructor'() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 35, messageId: "unexpected", data: { name: "constructor" } }
             ]
         },
         {

--- a/tests/lib/rules/no-dupe-class-members.js
+++ b/tests/lib/rules/no-dupe-class-members.js
@@ -29,7 +29,21 @@ ruleTester.run("no-dupe-class-members", rule, {
         "class A { 'foo'() {} 'bar'() {} baz() {} }",
         "class A { *'foo'() {} *'bar'() {} *baz() {} }",
         "class A { get 'foo'() {} get 'bar'() {} get baz() {} }",
-        "class A { 1() {} 2() {} }"
+        "class A { 1() {} 2() {} }",
+        "class A { ['foo']() {} ['bar']() {} }",
+        "class A { [`foo`]() {} [`bar`]() {} }",
+        "class A { [12]() {} [123]() {} }",
+        "class A { [1.0]() {} ['1.0']() {} }",
+        "class A { [0x1]() {} [`0x1`]() {} }",
+        "class A { [null]() {} ['']() {} }",
+
+        // not assumed to be statically-known values
+        "class A { ['foo' + '']() {} ['foo']() {} }",
+        "class A { [`foo${''}`]() {} [`foo`]() {} }",
+        "class A { [-1]() {} ['-1']() {} }",
+
+        // not supported by this rule
+        "class A { [foo]() {} [foo]() {} }"
     ],
     invalid: [
         {
@@ -54,6 +68,91 @@ ruleTester.run("no-dupe-class-members", rule, {
             code: "class A { 10() {} 1e1() {} }",
             errors: [
                 { type: "MethodDefinition", line: 1, column: 19, messageId: "unexpected", data: { name: "10" } }
+            ]
+        },
+        {
+            code: "class A { ['foo']() {} ['foo']() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 24, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { static ['foo']() {} static foo() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 31, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { ''() {} ['']() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 19, messageId: "unexpected", data: { name: "" } }
+            ]
+        },
+        {
+            code: "class A { [`foo`]() {} [`foo`]() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 24, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { [`foo`]() {} ['foo']() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 24, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { foo() {} [`foo`]() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 20, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { static 'foo'() {} static [`foo`]() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 29, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { [123]() {} [123]() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 22, messageId: "unexpected", data: { name: "123" } }
+            ]
+        },
+        {
+            code: "class A { [0x10]() {} 16() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 23, messageId: "unexpected", data: { name: "16" } }
+            ]
+        },
+        {
+            code: "class A { [100]() {} [1e2]() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 22, messageId: "unexpected", data: { name: "100" } }
+            ]
+        },
+        {
+            code: "class A { [123.00]() {} [`123`]() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 25, messageId: "unexpected", data: { name: "123" } }
+            ]
+        },
+        {
+            code: "class A { static '65'() {} static [0o101]() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 28, messageId: "unexpected", data: { name: "65" } }
+            ]
+        },
+        {
+            code: "class A { [123n]() {} 123() {} }",
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 23, messageId: "unexpected", data: { name: "123" } }
+            ]
+        },
+        {
+            code: "class A { [null]() {} 'null'() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 23, messageId: "unexpected", data: { name: "null" } }
             ]
         },
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to item)

[X] Changes an existing rule #12808

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`no-dupe-class-members` was ignoring all computed keys.

After this PR, this rule will also check those class members for which `astUtils.getStaticPropertyName` returns a string value. This is new default behavior.

```js
/*eslint no-dupe-class-members: ["error"]*/

class A {

  ["a"](){}
  ["a"](){} // error

  ["b"](){}
  b(){} // error

  "c"(){}
  [`c`](){} // error
  
  [123](){}
  123(){} // error

}
```

The rule will still ignore computed keys with values that are not statically known:

```js
/*eslint no-dupe-class-members: ["error"]*/

class A {

  [a](){}
  [a](){} // no error

}
```

#### Is there anything you'd like reviewers to focus on?
