### PR TITLE
Update: prefer-regex-literal detects regex literals passed to RegExp (fixes #12840)

### DIFF
--- a/docs/rules/prefer-regex-literals.md
+++ b/docs/rules/prefer-regex-literals.md
@@ -88,6 +88,38 @@ RegExp(`${prefix}abc`);
 new RegExp(String.raw`^\d\. ${suffix}`);
 ```
 
+## Options
+
+This rule has an object option:
+
+* `disallowRedundantWrapping` set to `true` additionally checks for unnecessarily wrapped regex literals (Default `false`).
+
+### `disallowRedundantWrapping`
+
+By default, this rule doesn’t check when a regex literal is unnecessarily wrapped in a `RegExp` constructor call. When the option `disallowRedundantWrapping` is set to `true`, the rule will also disallow such unnecessary patterns.
+
+Examples of `incorrect` code for `{ "disallowRedundantWrapping": true }`
+
+```js
+/*eslint prefer-regex-literals: ["error", {"disallowRedundantWrapping": true}]*/
+
+new RegExp(/abc/);
+
+new RegExp(/abc/, 'u');
+```
+
+Examples of `correct` code for `{ "disallowRedundantWrapping": true }`
+
+```js
+/*eslint prefer-regex-literals: ["error", {"disallowRedundantWrapping": true}]*/
+
+/abc/;
+
+/abc/u;
+
+new RegExp(/abc/, flags);
+```
+
 ## Further Reading
 
 * [MDN: Regular Expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)

--- a/tests/lib/rules/prefer-regex-literals.js
+++ b/tests/lib/rules/prefer-regex-literals.js
@@ -23,6 +23,7 @@ ruleTester.run("prefer-regex-literals", rule, {
         "/abc/",
         "/abc/g",
 
+
         // considered as dynamic
         "new RegExp(pattern)",
         "RegExp(pattern, 'g')",
@@ -41,6 +42,26 @@ ruleTester.run("prefer-regex-literals", rule, {
         "new RegExp(String.raw`a${''}c`);",
         "new RegExp('a' + 'b')",
         "RegExp(1)",
+        "new RegExp(/a/, 'u');",
+        "new RegExp(/a/);",
+        {
+            code: "new RegExp(/a/, flags);",
+            options: [{ disallowRedundantWrapping: true }]
+        },
+        {
+            code: "new RegExp(/a/, `u${flags}`);",
+            options: [{ disallowRedundantWrapping: true }]
+        },
+
+        // redundant wrapping is allowed
+        {
+            code: "new RegExp(/a/);",
+            options: [{}]
+        },
+        {
+            code: "new RegExp(/a/);",
+            options: [{ disallowRedundantWrapping: false }]
+        },
 
         // invalid number of arguments
         "new RegExp;",
@@ -52,6 +73,10 @@ ruleTester.run("prefer-regex-literals", rule, {
         "RegExp(`a`, `g`, `b`);",
         "new RegExp(String.raw`a`, String.raw`g`, String.raw`b`);",
         "RegExp(String.raw`a`, String.raw`g`, String.raw`b`);",
+        {
+            code: "new RegExp(/a/, 'u', 'foo');",
+            options: [{ disallowRedundantWrapping: true }]
+        },
 
         // not String.raw``
         "new RegExp(String`a`);",
@@ -196,6 +221,26 @@ ruleTester.run("prefer-regex-literals", rule, {
             code: "globalThis.RegExp('a');",
             env: { es2020: true },
             errors: [{ messageId: "unexpectedRegExp", type: "CallExpression" }]
+        },
+        {
+            code: "new RegExp(/a/);",
+            options: [{ disallowRedundantWrapping: true }],
+            errors: [{ messageId: "unexpectedRedundantRegExp", type: "NewExpression", line: 1, column: 1 }]
+        },
+        {
+            code: "new RegExp(/a/, 'u');",
+            options: [{ disallowRedundantWrapping: true }],
+            errors: [{ messageId: "unexpectedRedundantRegExpWithFlags", type: "NewExpression", line: 1, column: 1 }]
+        },
+        {
+            code: "new RegExp(/a/, `u`);",
+            options: [{ disallowRedundantWrapping: true }],
+            errors: [{ messageId: "unexpectedRedundantRegExpWithFlags", type: "NewExpression", line: 1, column: 1 }]
+        },
+        {
+            code: "new RegExp('a');",
+            options: [{ disallowRedundantWrapping: true }],
+            errors: [{ messageId: "unexpectedRegExp", type: "NewExpression", line: 1, column: 1 }]
         }
     ]
 });


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [ ] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

I’ve changed the rule `prefer-regex-literal` so that it detects regex literals that are passed to the `RegExp` constructor.

#### Is there anything you'd like reviewers to focus on?

* I decided to implement an autofix yet, since the whole rule is not autofixable yet. I think it makes more sense to address this separately 
* ~~I have implemented the rule change as the new default behavior. Once a decision has been made in #12840 I’m happy to change the if necessary and move the new behavior behind an option~~ The new behavior is now implemented behind an option.