### PR TITLE
Fix: fix inconsistently works option in no-extra-parens (fixes #12717)

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -702,8 +702,7 @@ module.exports = {
                 }
 
                 if (node.body.type === "ConditionalExpression" &&
-                    IGNORE_ARROW_CONDITIONALS &&
-                    !isParenthesisedTwice(node.body)
+                    IGNORE_ARROW_CONDITIONALS
                 ) {
                     return;
                 }

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -244,12 +244,19 @@ ruleTester.run("no-extra-parens", rule, {
 
         // "functions" enables reports for function nodes only
         { code: "(0)", options: ["functions"] },
+        { code: "((0))", options: ["functions"] },
         { code: "a + (b * c)", options: ["functions"] },
+        { code: "a + ((b * c))", options: ["functions"] },
         { code: "(a)(b)", options: ["functions"] },
+        { code: "((a))(b)", options: ["functions"] },
         { code: "a, (b = c)", options: ["functions"] },
+        { code: "a, ((b = c))", options: ["functions"] },
         { code: "for(a in (0));", options: ["functions"] },
+        { code: "for(a in ((0)));", options: ["functions"] },
         { code: "var a = (b = c)", options: ["functions"] },
+        { code: "var a = ((b = c))", options: ["functions"] },
         { code: "_ => (a = 0)", options: ["functions"] },
+        { code: "_ => ((a = 0))", options: ["functions"] },
 
         // ["all", { conditionalAssign: false }] enables extra parens around conditional assignments
         { code: "while ((foo = bar())) {}", options: ["all", { conditionalAssign: false }] },
@@ -257,6 +264,8 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "do; while ((foo = bar()))", options: ["all", { conditionalAssign: false }] },
         { code: "for (;(a = b););", options: ["all", { conditionalAssign: false }] },
         { code: "var a = ((b = c)) ? foo : bar;", options: ["all", { conditionalAssign: false }] },
+        { code: "while (((foo = bar()))) {}", options: ["all", { conditionalAssign: false }] },
+        { code: "var a = (((b = c))) ? foo : bar;", options: ["all", { conditionalAssign: false }] },
 
         // ["all", { nestedBinaryExpressions: false }] enables extra parens around conditional assignments
         { code: "a + (b * c)", options: ["all", { nestedBinaryExpressions: false }] },
@@ -369,11 +378,20 @@ ruleTester.run("no-extra-parens", rule, {
 
         // ["all", { ignoreJSX: "all" }]
         { code: "const Component = (<div />)", options: ["all", { ignoreJSX: "all" }] },
+        { code: "const Component = ((<div />))", options: ["all", { ignoreJSX: "all" }] },
         {
             code: [
                 "const Component = (<>",
                 "  <p />",
                 "</>);"
+            ].join("\n"),
+            options: ["all", { ignoreJSX: "all" }]
+        },
+        {
+            code: [
+                "const Component = ((<>",
+                "  <p />",
+                "</>));"
             ].join("\n"),
             options: ["all", { ignoreJSX: "all" }]
         },
@@ -403,6 +421,7 @@ ruleTester.run("no-extra-parens", rule, {
 
         // ["all", { ignoreJSX: "single-line" }]
         { code: "const Component = (<div />);", options: ["all", { ignoreJSX: "single-line" }] },
+        { code: "const Component = ((<div />));", options: ["all", { ignoreJSX: "single-line" }] },
         {
             code: [
                 "const Component = (",
@@ -427,6 +446,16 @@ ruleTester.run("no-extra-parens", rule, {
                 "  <p />",
                 "</div>",
                 ");"
+            ].join("\n"),
+            options: ["all", { ignoreJSX: "multi-line" }]
+        },
+        {
+            code: [
+                "const Component = ((",
+                "<div>",
+                "  <p />",
+                "</div>",
+                "));"
             ].join("\n"),
             options: ["all", { ignoreJSX: "multi-line" }]
         },
@@ -459,6 +488,7 @@ ruleTester.run("no-extra-parens", rule, {
         // ["all", { enforceForArrowConditionals: false }]
         { code: "var a = b => 1 ? 2 : 3", options: ["all", { enforceForArrowConditionals: false }] },
         { code: "var a = (b) => (1 ? 2 : 3)", options: ["all", { enforceForArrowConditionals: false }] },
+        { code: "var a = (b) => ((1 ? 2 : 3))", options: ["all", { enforceForArrowConditionals: false }] },
 
         // ["all", { enforceForSequenceExpressions: false }]
         { code: "(a, b)", options: ["all", { enforceForSequenceExpressions: false }] },
@@ -466,6 +496,7 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "(foo(), bar());", options: ["all", { enforceForSequenceExpressions: false }] },
         { code: "((foo(), bar()));", options: ["all", { enforceForSequenceExpressions: false }] },
         { code: "if((a, b)){}", options: ["all", { enforceForSequenceExpressions: false }] },
+        { code: "if(((a, b))){}", options: ["all", { enforceForSequenceExpressions: false }] },
         { code: "while ((val = foo(), val < 10));", options: ["all", { enforceForSequenceExpressions: false }] },
 
         // ["all", { enforceForNewInMemberExpressions: false }]
@@ -1122,12 +1153,10 @@ ruleTester.run("no-extra-parens", rule, {
                 }
             ]
         },
-
-        // ["all", { enforceForArrowConditionals: false }]
         {
             code: "var a = (b) => ((1 ? 2 : 3))",
             output: "var a = (b) => (1 ? 2 : 3)",
-            options: ["all", { enforceForArrowConditionals: false }],
+            options: ["all", { enforceForArrowConditionals: true }],
             errors: [
                 {
                     messageId: "unexpected"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md)) fixes #12717
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

1. Removed `!isParenthesisedTwice(node.body)` for fixing #12717.
   - It will make this rule to ignore checking "double extra parens" if the option (`enforceForNewInMemberExpressions : false`) is specified.

2. Added some tests for checks whether they ignore "double extra parens" when the option is specified.
   - Other options which not added test in this PR already have test cases ensuring it.
   - returnAssign, nestedBinaryExpressions, enforceForSequenceExpressions, enforceForNewInMemberExpressions.
#### Is there anything you'd like reviewers to focus on?

In my understanding, an arrow function's block statement body can't be parenthesized`()`, because it will change the body's type `BlockStatement` to `ObjectExpression`.

```js
var a = () => {  }; // BlockStatement
var a = () => ({ }); // ObjectExpression
```
And there is a checking about "double extra parens" when body type is not a `BlockStatement`.
```
if (node.body.type !== "BlockStatement") {
   // ...
    if (hasExcessParensWithPrecedence()) { 
 
   }
   // ...
```
So, I think `!isParenthesisedTwice(node.body)` can be removed without another effect.
