### PR TITLE
Fix: operator-assignment crash on adjacent division assignment

### DIFF
--- a/lib/rules/operator-assignment.js
+++ b/lib/rules/operator-assignment.js
@@ -219,7 +219,7 @@ module.exports = {
 
                                 if (
                                     operatorToken.range[1] === firstRightToken.range[0] &&
-                                    !astUtils.canTokensBeAdjacent(newOperator, firstRightToken)
+                                    !astUtils.canTokensBeAdjacent({ type: "Punctuator", value: newOperator }, firstRightToken)
                                 ) {
                                     rightTextPrefix = " "; // foo+=+bar -> foo= foo+ +bar
                                 }

--- a/tests/lib/rules/operator-assignment.js
+++ b/tests/lib/rules/operator-assignment.js
@@ -359,6 +359,11 @@ ruleTester.run("operator-assignment", rule, {
         options: ["never"],
         errors: UNEXPECTED_OPERATOR_ASSIGNMENT
     }, {
+        code: "foo/=bar",
+        output: "foo= foo/bar", // tokens can be adjacent
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
         code: "foo+=+bar",
         output: "foo= foo+ +bar", // tokens cannot be adjacent, insert a space between
         options: ["never"],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to item)

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 7.0.0-alpha.0
* **Node Version:** v12.14.0
* **npm Version:** v6.13.4

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: 2015
    },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint operator-assignment: ["error", "never"]*/

foo/=bar
```

[Online Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgb3BlcmF0b3ItYXNzaWdubWVudDogW1wiZXJyb3JcIiwgXCJuZXZlclwiXSovXG5cbmZvby89YmFyXG4iLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjYsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=) (v6.8.0 actual)

**What did you expect to happen?**

Not to crash.

**What actually happened? Please include the actual, raw output from ESLint.**

```
SyntaxError: Unterminated regular expression
...
at Espree.tokenize
at Object.tokenize
at Object.canTokensBeAdjacent
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`astUtils.canTokensBeAdjacent` passes source code `/` to `Espree.tokenize`, which throws on that seeing a lone slash as an unterminated regex literal.

I changed the `operator-assignment` rule to pass a token-like object instead of a source code made up of an operator only.

#### Is there anything you'd like reviewers to focus on?

`astUtils.canTokensBeAdjacent` should be also fixed to account for `/` on the left side and comments or regex literals on the right side, as these cannot be adjacent (it would turn everything into a `//` line comment). I'll work on that in another PR.
