### PR TITLE
Chore: enable exceptRange option in the yoda rule

### DIFF
--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -201,4 +201,4 @@ rules:
     unicode-bom: "error"
     wrap-iife: "error"
     yield-star-spacing: "error"
-    yoda: ["error", "never"]
+    yoda: ["error", "never", { exceptRange: true }]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Set `exceptRange: true` for the `yoda` rule in  eslint-config-eslint.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Enabled the option in order to allow code such as this:

```js
0 <= value && value < MAX_ARRAY_LENGTH
```

#### Is there anything you'd like reviewers to focus on?

I'm not entirely familiar with the semver policy for eslint-config-eslint. Just to note that this option doesn't enforce anything, so enabling it can produce only fewer warnings.