### PR TITLE
Docs: add missing eslint comments in prefer-regex-literals examples

### DIFF
--- a/docs/rules/prefer-regex-literals.md
+++ b/docs/rules/prefer-regex-literals.md
@@ -45,6 +45,8 @@ dynamically generated regular expressions.
 Examples of **incorrect** code for this rule:
 
 ```js
+/*eslint prefer-regex-literals: "error"*/
+
 new RegExp("abc");
 
 new RegExp("abc", "u");
@@ -63,6 +65,8 @@ new RegExp(String.raw`^\d\.$`);
 Examples of **correct** code for this rule:
 
 ```js
+/*eslint prefer-regex-literals: "error"*/
+
 /abc/;
 
 /abc/u;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added `/*eslint prefer-regex-literals: "error"*/` in the examples, missed that in the original PR.

#### Is there anything you'd like reviewers to focus on?
