### PR TITLE
Update: check template literal in yoda (fixes #12863)

### DIFF
--- a/docs/rules/yoda.md
+++ b/docs/rules/yoda.md
@@ -51,6 +51,14 @@ if ("red" === color) {
     // ...
 }
 
+if (`red` === color) {
+    // ...
+}
+
+if (`red` === `${color}`) {
+    // ...
+}
+
 if (true == flag) {
     // ...
 }
@@ -80,6 +88,14 @@ if (5 & value) {
 if (value === "red") {
     // ...
 }
+
+if (value === `red`) {
+    // ...
+}
+
+if (`${value}` === `red`) {
+
+}
 ```
 
 ### exceptRange
@@ -101,6 +117,10 @@ if (count < 10 && (0 <= rand && rand < 1)) {
     // ...
 }
 
+if (`blue` < x && x < `green`) {
+    // ...
+}
+
 function howLong(arr) {
     return (0 <= arr.length && arr.length < 10) ? "short" : "long";
 }
@@ -118,6 +138,9 @@ if (x < -1 || 9 < x) {
 
 if (x !== 'foo' && 'bar' != x) {
 }
+
+if (x !== `foo` && `bar` != x) {
+}
 ```
 
 ### always
@@ -130,6 +153,10 @@ Examples of **incorrect** code for the `"always"` option:
 if (color == "blue") {
     // ...
 }
+
+if (color == `blue`) {
+    // ...
+}
 ```
 
 Examples of **correct** code for the `"always"` option:
@@ -138,6 +165,14 @@ Examples of **correct** code for the `"always"` option:
 /*eslint yoda: ["error", "always"]*/
 
 if ("blue" == value) {
+    // ...
+}
+
+if (`blue` == value) {
+    // ...
+}
+
+if (`blue` == `${value}`) {
     // ...
 }
 

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -49,11 +49,30 @@ function isRangeTestOperator(operator) {
  * @returns {boolean} True if the node is a negative number that looks like a
  *                    real literal and should be treated as such.
  */
-function looksLikeLiteral(node) {
+function isNegativeNumericLiteral(node) {
     return (node.type === "UnaryExpression" &&
         node.operator === "-" &&
         node.prefix &&
         astUtils.isNumericLiteral(node.argument));
+}
+
+/**
+ * Determines whether a node is a Template Literal which can be determined statically.
+ * @param {*} node Node to test
+ * @returns {boolean} True if the node is a Template Literal without expression.
+ */
+function isStaticTemplateLiteral(node) {
+    return node.type === "TemplateLiteral" && node.expressions.length === 0;
+}
+
+/**
+ * Determines whether a non-Literal type node should be treated as a single Literal node.
+ * @param {*} node Node to test
+ * @returns {boolean} True if the node should be treated as a sinle Literal Node.
+ */
+function looksLikeLiteral(node) {
+    return isNegativeNumericLiteral(node) ||
+        isStaticTemplateLiteral(node);
 }
 
 /**
@@ -73,11 +92,19 @@ function getNormalizedLiteral(node, defaultValue) {
         return node;
     }
 
-    if (looksLikeLiteral(node)) {
+    if (isNegativeNumericLiteral(node)) {
         return {
             type: "Literal",
             value: -node.argument.value,
             raw: `-${node.argument.value}`
+        };
+    }
+
+    if (isStaticTemplateLiteral(node)) {
+        return {
+            type: "Literal",
+            value: node.quasis[0].value.cooked,
+            raw: node.quasis[0].value.raw
         };
     }
 

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -58,7 +58,7 @@ function isNegativeNumericLiteral(node) {
 
 /**
  * Determines whether a node is a Template Literal which can be determined statically.
- * @param {*} node Node to test
+ * @param {ASTNode} node Node to test
  * @returns {boolean} True if the node is a Template Literal without expression.
  */
 function isStaticTemplateLiteral(node) {
@@ -66,9 +66,9 @@ function isStaticTemplateLiteral(node) {
 }
 
 /**
- * Determines whether a non-Literal type node should be treated as a single Literal node.
- * @param {*} node Node to test
- * @returns {boolean} True if the node should be treated as a sinle Literal Node.
+ * Determines whether a non-Literal node should be treated as a single Literal node.
+ * @param {ASTNode} node Node to test
+ * @returns {boolean} True if the node should be treated as a single Literal node.
  */
 function looksLikeLiteral(node) {
     return isNegativeNumericLiteral(node) ||

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -84,8 +84,10 @@ function looksLikeLiteral(node) {
  *  1. The original node if the node is already a Literal
  *  2. A normalized Literal node with the negative number as the value if the
  *     node represents a negative number literal.
- *  3. The Literal node which has the `defaultValue` argument if it exists.
- *  4. Otherwise `null`.
+ *  3. A normalized Literal node with the string as the value if the node is
+ *     a Template Literal without expression.
+ *  4. The Literal node which has the `defaultValue` argument if it exists.
+ *  5. Otherwise `null`.
  */
 function getNormalizedLiteral(node, defaultValue) {
     if (node.type === "Literal") {

--- a/tests/lib/rules/yoda.js
+++ b/tests/lib/rules/yoda.js
@@ -260,6 +260,19 @@ ruleTester.run("yoda", rule, {
             ]
         },
         {
+            code: "if (`red` <= `${\"red\"}`) {}",
+            output: "if (`${\"red\"}` >= `red`) {}",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: "<=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
             code: "if (true >= value) {}",
             output: "if (value <= true) {}",
             options: ["never"],
@@ -353,6 +366,19 @@ ruleTester.run("yoda", rule, {
                 {
                     messageId: "expected",
                     data: { expectedSide: "left", operator: "===" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (`${\"red\"}` <= `red`) {}",
+            output: "if (`red` >= `${\"red\"}`) {}",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "left", operator: "<=" },
                     type: "BinaryExpression"
                 }
             ]

--- a/tests/lib/rules/yoda.js
+++ b/tests/lib/rules/yoda.js
@@ -26,6 +26,12 @@ ruleTester.run("yoda", rule, {
         { code: "if (value != 5) {}", options: ["never"] },
         { code: "if (5 & foo) {}", options: ["never"] },
         { code: "if (5 === 4) {}", options: ["never"] },
+        { code: "if (value === `red`) {}", options: ["never"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "if (`red` === `red`) {}", options: ["never"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "if (`${foo}` === `red`) {}", options: ["never"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "if (`${\"\"}` === `red`) {}", options: ["never"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "if (b > `a` && b > `a`) {}", options: ["never"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "if (`b` > `a` && \"b\" > \"a\") {}", options: ["never"], parserOptions: { ecmaVersion: 2015 } },
 
         // "always" mode
         { code: "if (\"blue\" === value) {}", options: ["always"] },
@@ -33,6 +39,11 @@ ruleTester.run("yoda", rule, {
         { code: "if (4 != value) {}", options: ["always"] },
         { code: "if (foo & 4) {}", options: ["always"] },
         { code: "if (5 === 4) {}", options: ["always"] },
+        { code: "if (`red` === value) {}", options: ["always"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "if (`red` === `red`) {}", options: ["always"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "if (`red` === `${foo}`) {}", options: ["always"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "if (`red` === `${\"\"}`) {}", options: ["always"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "if (`a` > b && `a` > b) {}", options: ["always"], parserOptions: { ecmaVersion: 2015 } },
 
         // Range exception
         {
@@ -92,6 +103,10 @@ ruleTester.run("yoda", rule, {
             code: "if (0 <= a.b && a[\"b\"] <= 100) {}",
             options: ["never", { exceptRange: true }]
         }, {
+            code: "if (0 <= a.b && a[`b`] <= 100) {}",
+            options: ["never", { exceptRange: true }],
+            parserOptions: { ecmaVersion: 2015 }
+        }, {
             code: "if (-1n < x && x <= 1n) {}",
             options: ["never", { exceptRange: true }],
             parserOptions: { ecmaVersion: 2020 }
@@ -108,15 +123,37 @@ ruleTester.run("yoda", rule, {
             options: ["always", { exceptRange: true }],
             parserOptions: { ecmaVersion: 2020 }
         }, {
+            code: "if (x < `1` || `1` < x) {}",
+            options: ["always", { exceptRange: true }],
+            parserOptions: { ecmaVersion: 2020 }
+        }, {
             code: "if (1 <= a['/(?<zero>0)/'] && a[/(?<zero>0)/] <= 100) {}",
             options: ["never", { exceptRange: true }],
             parserOptions: { ecmaVersion: 2018 }
+        }, {
+            code: "if (x <= `bar` || `foo` < x) {}",
+            options: ["always", { exceptRange: true }],
+            parserOptions: { ecmaVersion: 2015 }
+        }, {
+            code: "if (`blue` < x.y && x.y < `green`) {}",
+            options: ["never", { exceptRange: true }],
+            parserOptions: { ecmaVersion: 2015 }
+        }, {
+            code: "if (0 <= x[`y`] && x[`y`] <= 100) {}",
+            options: ["never", { exceptRange: true }],
+            parserOptions: { ecmaVersion: 2015 }
+        }, {
+            code: "if (0 <= x[`y`] && x[\"y\"] <= 100) {}",
+            options: ["never", { exceptRange: true }],
+            parserOptions: { ecmaVersion: 2015 }
         },
 
         // onlyEquality
         { code: "if (0 < x && x <= 1) {}", options: ["never", { onlyEquality: true }] },
         { code: "if (x !== 'foo' && 'foo' !== x) {}", options: ["never", { onlyEquality: true }] },
-        { code: "if (x < 2 && x !== -3) {}", options: ["always", { onlyEquality: true }] }
+        { code: "if (x < 2 && x !== -3) {}", options: ["always", { onlyEquality: true }] },
+        { code: "if (x !== `foo` && `foo` !== x) {}", options: ["never", { onlyEquality: true }], parserOptions: { ecmaVersion: 2015 } },
+        { code: "if (x < `2` && x !== `-3`) {}", options: ["always", { onlyEquality: true }], parserOptions: { ecmaVersion: 2015 } }
     ],
     invalid: [
 
@@ -194,6 +231,32 @@ ruleTester.run("yoda", rule, {
             ]
         },
         {
+            code: "if (`red` <= value) {}",
+            output: "if (value >= `red`) {}",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: "<=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (`red` <= `${foo}`) {}",
+            output: "if (`${foo}` >= `red`) {}",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: "<=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
             code: "if (true >= value) {}",
             output: "if (value <= true) {}",
             options: ["never"],
@@ -245,6 +308,19 @@ ruleTester.run("yoda", rule, {
             code: "if (value == \"red\") {}",
             output: "if (\"red\" == value) {}",
             options: ["always"],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "left", operator: "==" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (value == `red`) {}",
+            output: "if (`red` == value) {}",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2015 },
             errors: [
                 {
                     messageId: "expected",
@@ -363,9 +439,48 @@ ruleTester.run("yoda", rule, {
             ]
         },
         {
+            code: "var a = (b < `0` && `0` <= b);",
+            output: "var a = (`0` > b && `0` <= b);",
+            options: ["always", { exceptRange: true }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "left", operator: "<" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
             code: "if (0 <= a[b] && a['b'] < 1) {}",
             output: "if (a[b] >= 0 && a['b'] < 1) {}",
             options: ["never", { exceptRange: true }],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: "<=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (0 <= a[b] && a[`b`] < 1) {}",
+            output: "if (a[b] >= 0 && a[`b`] < 1) {}",
+            options: ["never", { exceptRange: true }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: "<=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (`0` <= a[b] && a[`b`] < `1`) {}",
+            output: "if (a[b] >= `0` && a[`b`] < `1`) {}",
+            options: ["never", { exceptRange: true }],
+            parserOptions: { ecmaVersion: 2015 },
             errors: [
                 {
                     messageId: "expected",
@@ -423,6 +538,19 @@ ruleTester.run("yoda", rule, {
             ]
         },
         {
+            code: "if (0 <= a[``] && a[null] < 1) {}",
+            output: "if (a[``] >= 0 && a[null] < 1) {}",
+            options: ["never", { exceptRange: true }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: "<=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
             code: "if (0 <= a[''] && a[b] < 1) {}",
             output: "if (a[''] >= 0 && a[b] < 1) {}",
             options: ["never", { exceptRange: true }],
@@ -438,6 +566,19 @@ ruleTester.run("yoda", rule, {
             code: "if (0 <= a[''] && a[b()] < 1) {}",
             output: "if (a[''] >= 0 && a[b()] < 1) {}",
             options: ["never", { exceptRange: true }],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: "<=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (0 <= a[``] && a[b()] < 1) {}",
+            output: "if (a[``] >= 0 && a[b()] < 1) {}",
+            options: ["never", { exceptRange: true }],
+            parserOptions: { ecmaVersion: 2015 },
             errors: [
                 {
                     messageId: "expected",
@@ -499,6 +640,19 @@ ruleTester.run("yoda", rule, {
             code: "foo(a === 3);",
             output: "foo(3 === a);",
             options: ["always", { onlyEquality: true }],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "left", operator: "===" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "foo(a === `3`);",
+            output: "foo(`3` === a);",
+            options: ["always", { onlyEquality: true }],
+            parserOptions: { ecmaVersion: 2015 },
             errors: [
                 {
                     messageId: "expected",

--- a/tests/lib/rules/yoda.js
+++ b/tests/lib/rules/yoda.js
@@ -642,6 +642,19 @@ ruleTester.run("yoda", rule, {
             ]
         },
         {
+            code: "if (`green` < x.y && x.y < `blue`) {}",
+            output: "if (x.y > `green` && x.y < `blue`) {}",
+            options: ["never", { exceptRange: true }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: "<" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
             code: "if (3 == a) {}",
             output: "if (a == 3) {}",
             options: ["never", { onlyEquality: true }],

--- a/tests/lib/rules/yoda.js
+++ b/tests/lib/rules/yoda.js
@@ -30,6 +30,7 @@ ruleTester.run("yoda", rule, {
         { code: "if (`red` === `red`) {}", options: ["never"], parserOptions: { ecmaVersion: 2015 } },
         { code: "if (`${foo}` === `red`) {}", options: ["never"], parserOptions: { ecmaVersion: 2015 } },
         { code: "if (`${\"\"}` === `red`) {}", options: ["never"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "if (`${\"red\"}` === foo) {}", options: ["never"], parserOptions: { ecmaVersion: 2015 } },
         { code: "if (b > `a` && b > `a`) {}", options: ["never"], parserOptions: { ecmaVersion: 2015 } },
         { code: "if (`b` > `a` && \"b\" > \"a\") {}", options: ["never"], parserOptions: { ecmaVersion: 2015 } },
 
@@ -43,7 +44,9 @@ ruleTester.run("yoda", rule, {
         { code: "if (`red` === `red`) {}", options: ["always"], parserOptions: { ecmaVersion: 2015 } },
         { code: "if (`red` === `${foo}`) {}", options: ["always"], parserOptions: { ecmaVersion: 2015 } },
         { code: "if (`red` === `${\"\"}`) {}", options: ["always"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "if (foo === `${\"red\"}`) {}", options: ["always"], parserOptions: { ecmaVersion: 2015 } },
         { code: "if (`a` > b && `a` > b) {}", options: ["always"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "if (`b` > `a` && \"b\" > \"a\") {}", options: ["always"], parserOptions: { ecmaVersion: 2015 } },
 
         // Range exception
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I added checking for template literals, which have no expressions.

#### Is there anything you'd like reviewers to focus on?


In the actual version(`v6.8.0`), a comparison between a literal and expression is warned, even if operands in the expressions are consist of literals only.

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgeW9kYTogW1wiZXJyb3JcIiwgXCJuZXZlclwiXSovXG5cbmlmICgxIDwgMSArIDEpIHsgLy8gRXJyb3Jcbn1cblxuaWYgKFwiYVwiID09PSBcImFcIiArIFwiYlwiKSB7IC8vIEVycm9yXG59XG5cbmlmICgxIDwgKzEpIHsgLy8gRXJyb3JcblxufSIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6MTEsInNvdXJjZVR5cGUiOiJtb2R1bGUiLCJlY21hRmVhdHVyZXMiOnsianN4Ijp0cnVlfX0sInJ1bGVzIjp7fSwiZW52Ijp7ImJyb3dzZXIiOmZhbHNlLCJlczIwMjAiOnRydWV9fX0=)
```js
/*eslint yoda: ["error", "never"]*/

if (1 < 1 + 1) { // Error
}

if ("a" === "a" + "b") { // Error
}

if (1 < +1) {

}
```

From this point of view, I think template literal with only literal expressions should be warned, so added these test cases. 

```js
{
        code: "if (`${\"red\"}` <= `red`) {}",
        output: "if (`red` >= `${\"red\"}`) {}",
        options: ["always"],
        parserOptions: { ecmaVersion: 2015 },
        errors: [
            {
                messageId: "expected",
                data: { expectedSide: "left", operator: "<=" },
                type: "BinaryExpression"
            }
        ]
}
```

But I'm not sure whether it is intended behavior or not.


