### PR TITLE
Fix: Check division operator in astUtils.canTokensBeAdjacent

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -307,13 +307,13 @@ module.exports = {
          */
         function requiresLeadingSpace(node) {
             const leftParenToken = sourceCode.getTokenBefore(node);
-            const tokenBeforeLeftParen = sourceCode.getTokenBefore(node, 1);
-            const firstToken = sourceCode.getFirstToken(node);
+            const tokenBeforeLeftParen = sourceCode.getTokenBefore(leftParenToken, { includeComments: true });
+            const tokenAfterLeftParen = sourceCode.getTokenAfter(leftParenToken, { includeComments: true });
 
             return tokenBeforeLeftParen &&
                 tokenBeforeLeftParen.range[1] === leftParenToken.range[0] &&
-                leftParenToken.range[1] === firstToken.range[0] &&
-                !astUtils.canTokensBeAdjacent(tokenBeforeLeftParen, firstToken);
+                leftParenToken.range[1] === tokenAfterLeftParen.range[0] &&
+                !astUtils.canTokensBeAdjacent(tokenBeforeLeftParen, tokenAfterLeftParen);
         }
 
         /**

--- a/lib/rules/operator-assignment.js
+++ b/lib/rules/operator-assignment.js
@@ -214,12 +214,12 @@ module.exports = {
                             ) {
                                 rightText = `${sourceCode.text.slice(operatorToken.range[1], node.right.range[0])}(${sourceCode.getText(node.right)})`;
                             } else {
-                                const firstRightToken = sourceCode.getFirstToken(node.right);
+                                const tokenAfterOperator = sourceCode.getTokenAfter(operatorToken, { includeComments: true });
                                 let rightTextPrefix = "";
 
                                 if (
-                                    operatorToken.range[1] === firstRightToken.range[0] &&
-                                    !astUtils.canTokensBeAdjacent({ type: "Punctuator", value: newOperator }, firstRightToken)
+                                    operatorToken.range[1] === tokenAfterOperator.range[0] &&
+                                    !astUtils.canTokensBeAdjacent({ type: "Punctuator", value: newOperator }, tokenAfterOperator)
                                 ) {
                                     rightTextPrefix = " "; // foo+=+bar -> foo= foo+ +bar
                                 }

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1357,17 +1357,43 @@ module.exports = {
      * next to each other, behavior is undefined (although it should return `true` in most cases).
      */
     canTokensBeAdjacent(leftValue, rightValue) {
+        const espreeOptions = { ecmaVersion: 2020, comment: true, range: true };
+
         let leftToken;
 
         if (typeof leftValue === "string") {
-            const leftTokens = espree.tokenize(leftValue, { ecmaVersion: 2015 });
+            const tokens = espree.tokenize(leftValue, espreeOptions);
+            const comments = tokens.comments;
 
-            leftToken = leftTokens[leftTokens.length - 1];
+            leftToken = tokens[tokens.length - 1];
+            if (comments.length) {
+                const lastComment = comments[comments.length - 1];
+
+                if (lastComment.range[0] > leftToken.range[0]) {
+                    leftToken = lastComment;
+                }
+            }
         } else {
             leftToken = leftValue;
         }
 
-        const rightToken = typeof rightValue === "string" ? espree.tokenize(rightValue, { ecmaVersion: 2015 })[0] : rightValue;
+        let rightToken;
+
+        if (typeof rightValue === "string") {
+            const tokens = espree.tokenize(rightValue, espreeOptions);
+            const comments = tokens.comments;
+
+            rightToken = tokens[0];
+            if (comments.length) {
+                const firstComment = comments[0];
+
+                if (firstComment.range[0] < rightToken.range[0]) {
+                    rightToken = firstComment;
+                }
+            }
+        } else {
+            rightToken = rightValue;
+        }
 
         if (leftToken.type === "Punctuator" || rightToken.type === "Punctuator") {
             if (leftToken.type === "Punctuator" && rightToken.type === "Punctuator") {
@@ -1378,6 +1404,9 @@ module.exports = {
                     PLUS_TOKENS.has(leftToken.value) && PLUS_TOKENS.has(rightToken.value) ||
                     MINUS_TOKENS.has(leftToken.value) && MINUS_TOKENS.has(rightToken.value)
                 );
+            }
+            if (leftToken.type === "Punctuator" && leftToken.value === "/") {
+                return !["Block", "Line", "RegularExpression"].includes(rightToken.type);
             }
             return true;
         }
@@ -1390,6 +1419,10 @@ module.exports = {
         }
 
         if (leftToken.type !== "Numeric" && rightToken.type === "Numeric" && rightToken.value.startsWith(".")) {
+            return true;
+        }
+
+        if (leftToken.type === "Block" || rightToken.type === "Block" || rightToken.type === "Line") {
             return true;
         }
 

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1357,7 +1357,11 @@ module.exports = {
      * next to each other, behavior is undefined (although it should return `true` in most cases).
      */
     canTokensBeAdjacent(leftValue, rightValue) {
-        const espreeOptions = { ecmaVersion: 2020, comment: true, range: true };
+        const espreeOptions = {
+            ecmaVersion: espree.latestEcmaVersion,
+            comment: true,
+            range: true
+        };
 
         let leftToken;
 

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1362,7 +1362,14 @@ module.exports = {
         let leftToken;
 
         if (typeof leftValue === "string") {
-            const tokens = espree.tokenize(leftValue, espreeOptions);
+            let tokens;
+
+            try {
+                tokens = espree.tokenize(leftValue, espreeOptions);
+            } catch (e) {
+                return false;
+            }
+
             const comments = tokens.comments;
 
             leftToken = tokens[tokens.length - 1];
@@ -1377,10 +1384,21 @@ module.exports = {
             leftToken = leftValue;
         }
 
+        if (leftToken.type === "Shebang") {
+            return false;
+        }
+
         let rightToken;
 
         if (typeof rightValue === "string") {
-            const tokens = espree.tokenize(rightValue, espreeOptions);
+            let tokens;
+
+            try {
+                tokens = espree.tokenize(rightValue, espreeOptions);
+            } catch (e) {
+                return false;
+            }
+
             const comments = tokens.comments;
 
             rightToken = tokens[0];

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-scope": "^5.0.0",
     "eslint-utils": "^1.4.3",
     "eslint-visitor-keys": "^1.1.0",
-    "espree": "^6.1.2",
+    "espree": "^6.2.0",
     "esquery": "^1.0.1",
     "esutils": "^2.0.2",
     "file-entry-cache": "^5.0.1",

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -2192,6 +2192,20 @@ ruleTester.run("no-extra-parens", rule, {
             code: "var foo = { [((bar1, bar2))]: baz };",
             output: "var foo = { [(bar1, bar2)]: baz };",
             errors: [{ messageId: "unexpected" }]
-        }
+        },
+
+        // adjacent tokens tests for division operator, comments and regular expressions
+        invalid("a+/**/(/**/b)", "a+/**//**/b", "Identifier"),
+        invalid("a+/**/(//\nb)", "a+/**///\nb", "Identifier"),
+        invalid("a in(/**/b)", "a in/**/b", "Identifier"),
+        invalid("a in(//\nb)", "a in//\nb", "Identifier"),
+        invalid("a+(/**/b)", "a+/**/b", "Identifier"),
+        invalid("a+/**/(b)", "a+/**/b", "Identifier"),
+        invalid("a+(//\nb)", "a+//\nb", "Identifier"),
+        invalid("a+//\n(b)", "a+//\nb", "Identifier"),
+        invalid("a+(/^b$/)", "a+/^b$/", "Literal"),
+        invalid("a/(/**/b)", "a/ /**/b", "Identifier"),
+        invalid("a/(//\nb)", "a/ //\nb", "Identifier"),
+        invalid("a/(/^b$/)", "a/ /^b$/", "Literal")
     ]
 });

--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -345,6 +345,16 @@ ruleTester.run("no-implicit-coercion", rule, {
                 data: { recommendation: "Number(foo)" },
                 type: "UnaryExpression"
             }]
+        },
+        {
+            code: "let x ='' + 1n;",
+            output: "let x =String(1n);",
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(1n)" },
+                type: "BinaryExpression"
+            }]
         }
     ]
 });

--- a/tests/lib/rules/operator-assignment.js
+++ b/tests/lib/rules/operator-assignment.js
@@ -364,6 +364,21 @@ ruleTester.run("operator-assignment", rule, {
         options: ["never"],
         errors: UNEXPECTED_OPERATOR_ASSIGNMENT
     }, {
+        code: "foo/=/**/bar",
+        output: "foo= foo/ /**/bar", // // tokens cannot be adjacent, insert a space between
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "foo/=//\nbar",
+        output: "foo= foo/ //\nbar", // // tokens cannot be adjacent, insert a space between
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "foo/=/^bar$/",
+        output: "foo= foo/ /^bar$/", // // tokens cannot be adjacent, insert a space between
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
         code: "foo+=+bar",
         output: "foo= foo+ +bar", // tokens cannot be adjacent, insert a space between
         options: ["never"],

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -1356,13 +1356,26 @@ describe("ast-utils", () => {
             [["a", "/**/b"], true],
             [["a", "b/**/"], false],
             [["a", "//\nb"], true],
-            [["a", "b//"], false]
+            [["a", "b//"], false],
+            [["#!/usr/bin/env node", "("], false],
+            [["123invalidtoken", "("], false],
+            [["(", "123invalidtoken"], false]
         ]);
 
         CASES.forEach((expectedResult, tokenStrings) => {
             it(tokenStrings.join(", "), () => {
                 assert.strictEqual(astUtils.canTokensBeAdjacent(tokenStrings[0], tokenStrings[1]), expectedResult);
             });
+        });
+
+        it("#!/usr/bin/env node, (", () => {
+            assert.strictEqual(
+                astUtils.canTokensBeAdjacent(
+                    { type: "Shebang", value: "#!/usr/bin/env node" },
+                    { type: "Punctuator", value: "(" }
+                ),
+                false
+            );
         });
     });
 

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -1342,7 +1342,21 @@ describe("ast-utils", () => {
             [["++", "+"], false],
             [["--", "-"], false],
             [["+", "++"], false],
-            [["-", "--"], false]
+            [["-", "--"], false],
+            [["a/", "b"], true],
+            [["a/", "+b"], true],
+            [["a+", "/^regex$/"], true],
+            [["a/", "/^regex$/"], false],
+            [["a+", "/**/b"], true],
+            [["a/", "/**/b"], false],
+            [["a+", "//\nb"], true],
+            [["a/", "//\nb"], false],
+            [["a/**/", "b"], true],
+            [["/**/a", "b"], false],
+            [["a", "/**/b"], true],
+            [["a", "b/**/"], false],
+            [["a", "//\nb"], true],
+            [["a", "b//"], false]
         ]);
 
         CASES.forEach((expectedResult, tokenStrings) => {

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -1359,7 +1359,10 @@ describe("ast-utils", () => {
             [["a", "b//"], false],
             [["#!/usr/bin/env node", "("], false],
             [["123invalidtoken", "("], false],
-            [["(", "123invalidtoken"], false]
+            [["(", "123invalidtoken"], false],
+            [["(", "1n"], true],
+            [["1n", "+"], true],
+            [["1n", "in"], false]
         ]);
 
         CASES.forEach((expectedResult, tokenStrings) => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 7.0.0-alpha.0
* **Node Version:** v12.14.0
* **npm Version:** v6.13.4

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: 2015
    },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint no-extra-parens: ["error"] */
/* eslint operator-assignment: ["error", "never"] */

a/(/**/b);

a/(//
  b);

a/(/regex/);

a/=/**/b;
```

[Online Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWV4dHJhLXBhcmVuczogW1wiZXJyb3JcIl0gKi9cbi8qIGVzbGludCBvcGVyYXRvci1hc3NpZ25tZW50OiBbXCJlcnJvclwiLCBcIm5ldmVyXCJdICovXG5cbmEvKC8qKi9iKTtcblxuYS8oLy9cbiAgYik7XG5cbmEvKC9yZWdleC8pO1xuXG5hLz0vKiovYjsiLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjYsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=) (v6.8.0 actual)

**What did you expect to happen?**

4 errors and auto-fix that would not comment out some code.

**What actually happened? Please include the actual, raw output from ESLint.**

4 errors and auto-fix to:

```js
/* eslint no-extra-parens: ["error"] */
/* eslint operator-assignment: ["error", "never"] */

a//**/b;

a///
  b;

a//regex/;

a= a//**/b;
```

In all 4 lines `/` becomes start of a line comment.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Fixed `astUtils.canTokensBeAdjacent` to account for the `/` operator on the left side and block comment, line comment or regex on the right side.
* Fixed `no-extra-parens` and `operator-assignment` rules to get and pass possible comment tokens as well.
* Since there are now rules that can pass comment tokens to `astUtils.canTokensBeAdjacent`, had to also add the logic for comments (I believe they can be adjacent with everything except for `/` on the left side).
* Fixed part of the code in `astUtils.canTokensBeAdjacent` that deals with string input (using `espree.tokenize`) to handle comments as well. I don't think this will affect the rules that are using this feature at the moment, but it should be a correct change and it also allowed testing this function with comments (all tests actually pass strings, maybe we should add some tests with tokens at some point since it's the most common case).
* Also upgraded `espree` in order to pass `espree.latestEcmaVersion` instead of a hard-coded version to `espree.tokenize()`, and added `try-catch` around `espree.tokenize()`. This should fix partially or entirely #12291 (edited to prevent auto-closing #12291),

#### Is there anything you'd like reviewers to focus on?

* Is this the correct way to get comments from `espree.tokenize`?

This can also happen in `operator-linebreak` in some edge cases. That rule has its own code to handle adjacent tokens, I'll see if it is possible to switch to `astUtils.canTokensBeAdjacent` (or fix the same issue there if it isn't) in a follow-up PR.

Marked as accepted since it's an obvious autofix bug.