### PR TITLE
Fix: arrow-body-style crash with object literal body (fixes #12884)

### DIFF
--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -46,6 +46,19 @@ ruleTester.run("arrow-body-style", rule, {
     ],
     invalid: [
         {
+            code: "var foo = () => 0",
+            output: "var foo = () => {return 0}",
+            options: ["always"],
+            errors: [
+                {
+                    line: 1,
+                    column: 17,
+                    type: "ArrowFunctionExpression",
+                    messageId: "expectedBlock"
+                }
+            ]
+        },
+        {
             code: "var foo = () => 0;",
             output: "var foo = () => {return 0};",
             options: ["always"],
@@ -66,6 +79,45 @@ ruleTester.run("arrow-body-style", rule, {
                 {
                     line: 1,
                     column: 18,
+                    type: "ArrowFunctionExpression",
+                    messageId: "expectedBlock"
+                }
+            ]
+        },
+        {
+            code: "var foo = () => (  {});",
+            output: "var foo = () => {return   {}};",
+            options: ["always"],
+            errors: [
+                {
+                    line: 1,
+                    column: 20,
+                    type: "ArrowFunctionExpression",
+                    messageId: "expectedBlock"
+                }
+            ]
+        },
+        {
+            code: "(() => ({}))",
+            output: "(() => {return {}})",
+            options: ["always"],
+            errors: [
+                {
+                    line: 1,
+                    column: 9,
+                    type: "ArrowFunctionExpression",
+                    messageId: "expectedBlock"
+                }
+            ]
+        },
+        {
+            code: "(() => ( {}))",
+            output: "(() => {return  {}})",
+            options: ["always"],
+            errors: [
+                {
+                    line: 1,
+                    column: 10,
                     type: "ArrowFunctionExpression",
                     messageId: "expectedBlock"
                 }
@@ -470,6 +522,48 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => ({foo: 1}.foo());",
             output: "var foo = () => {return {foo: 1}.foo()};",
+            options: ["always"],
+            errors: [{ messageId: "expectedBlock" }]
+        },
+        {
+            code: "var foo = () => ( {foo: 1} ).foo();",
+            output: "var foo = () => {return  {foo: 1} .foo()};",
+            options: ["always"],
+            errors: [{ messageId: "expectedBlock" }]
+        },
+        {
+            code: `
+              var foo = () => ({
+                  bar: 1,
+                  baz: 2
+                });
+            `,
+            output: `
+              var foo = () => {return {
+                  bar: 1,
+                  baz: 2
+                }};
+            `,
+            options: ["always"],
+            errors: [{ messageId: "expectedBlock" }]
+        },
+        {
+            code: `
+              parsedYears = _map(years, (year) => (
+                  {
+                      index : year,
+                      title : splitYear(year)
+                  }
+              ));
+            `,
+            output: `
+              parsedYears = _map(years, (year) => {
+                  return {
+                      index : year,
+                      title : splitYear(year)
+                  }
+              });
+            `,
             options: ["always"],
             errors: [{ messageId: "expectedBlock" }]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Bug fix 

Fixes #12884

`arrow-body-style` autofix crashes or produces invalid code while trying to convert object literal expression body to a block body, whenever `(` and `{` are not adjacent:

* This works well: `() => ({})`
* This throws (there's a space between): `() => ( {})` [Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50ICBcImFycm93LWJvZHktc3R5bGVcIjogW1wiZXJyb3JcIiwgXCJhbHdheXNcIl0gKi9cblxuKCkgPT4gKCB7fSkiLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjgsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=)
* This removes the wrong closing paren: `(() => ( {}))` fixed to `(() => {return  {})}` [Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50ICBcImFycm93LWJvZHktc3R5bGVcIjogW1wiZXJyb3JcIiwgXCJhbHdheXNcIl0gKi9cblxuKCgpID0+ICgge30pKSIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6OCwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed to code to pass the brace token instead of the paren token to `sourceCode#getNodeByRangeIndex`

#### Is there anything you'd like reviewers to focus on?

In this branch, auto-fixer has also to account for the ASI (it used to crash in all situations where ASI can happen, so it wasn't observable). In particular, for a code where `(` and `{` are not on the same line. This is solved by replacing `(` with a block `{` and inserting `return ` before the object's `{`. Is it okay?

The code from the original issue:

```js
/* eslint  "arrow-body-style": ["error", "always"] */

parsedYears     = _map(years, (year) => (
      {
          index : year,
          title : splitYear(year)
      }
));
```

will be auto-fixed to:

```js
/* eslint  "arrow-body-style": ["error", "always"] */

parsedYears     = _map(years, (year) => {
      return {
          index : year,
          title : splitYear(year)
      }
});
```