### PR TITLE
Breaking: change default ignore pattern (eslint/rfcs#51)

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -1061,19 +1061,17 @@ Of particular note is that like `.gitignore` files, all paths used as patterns f
 
 Please see `.gitignore`'s specification for further examples of valid syntax.
 
-In addition to any patterns in a `.eslintignore` file, ESLint always ignores files in `/node_modules/*` and `/bower_components/*`.
+In addition to any patterns in a `.eslintignore` file, ESLint always ignores files in `/**/node_modules/*`.
 
-For example, placing the following `.eslintignore` file in the current working directory will ignore all of `node_modules`, `bower_components` in the project root and anything in the `build/` directory except `build/index.js`:
+For example, placing the following `.eslintignore` file in the current working directory will ignore all of `node_modules/*` and anything in the `build/` directory except `build/index.js`:
 
 ```text
-# /node_modules/* and /bower_components/* in the project root are ignored by default
+# node_modules/* are ignored by default
 
 # Ignore built files except build/index.js
 build/*
 !build/index.js
 ```
-
-**Important**: Note that `node_modules` directories in, for example, a `packages` directory in a mono repo are *not* ignored by default and need to be added to `.eslintignore` explicitly.
 
 ### Using an Alternate File
 

--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -278,14 +278,11 @@ function createIgnoreResult(filePath, baseDir) {
     let message;
     const isHidden = /^\./u.test(path.basename(filePath));
     const isInNodeModules = baseDir && path.relative(baseDir, filePath).startsWith("node_modules");
-    const isInBowerComponents = baseDir && path.relative(baseDir, filePath).startsWith("bower_components");
 
     if (isHidden) {
         message = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override.";
     } else if (isInNodeModules) {
         message = "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override.";
-    } else if (isInBowerComponents) {
-        message = "File ignored by default. Use \"--ignore-pattern '!bower_components/*'\" to override.";
     } else {
         message = "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override.";
     }

--- a/lib/cli-engine/config-array/ignore-pattern.js
+++ b/lib/cli-engine/config-array/ignore-pattern.js
@@ -103,8 +103,8 @@ function dirSuffix(filePath) {
     return isDir ? "/" : "";
 }
 
-const DefaultPatterns = Object.freeze(["/node_modules/*", "/bower_components/*"]);
-const DotPatterns = Object.freeze([".*", "!../"]);
+const DefaultPatterns = Object.freeze(["/**/node_modules/*"]);
+const DotPatterns = Object.freeze([".*", "!.eslintrc.*", "!../"]);
 
 //------------------------------------------------------------------------------
 // Public

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -3796,24 +3796,16 @@ describe("CLIEngine", () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ cwd });
 
-                assert(engine.isPathIgnored(getFixturePath("ignored-paths", "bower_components/package/file.js")));
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "node_modules/package/file.js")));
+                assert(engine.isPathIgnored(getFixturePath("ignored-paths", "subdir/node_modules/package/file.js")));
             });
 
             it("should still apply defaultPatterns if ignore option is is false", () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ ignore: false, cwd });
 
-                assert(engine.isPathIgnored(getFixturePath("ignored-paths", "bower_components/package/file.js")));
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "node_modules/package/file.js")));
-            });
-
-            it("should not ignore files in defaultPatterns within a subdirectory", () => {
-                const cwd = getFixturePath("ignored-paths");
-                const engine = new CLIEngine({ cwd });
-
-                assert(!engine.isPathIgnored(getFixturePath("ignored-paths", "subdir/bower_components/package/file.js")));
-                assert(!engine.isPathIgnored(getFixturePath("ignored-paths", "subdir/node_modules/package/file.js")));
+                assert(engine.isPathIgnored(getFixturePath("ignored-paths", "subdir/node_modules/package/file.js")));
             });
 
             it("should allow subfolders of defaultPatterns to be unignored by ignorePattern", () => {
@@ -3869,20 +3861,20 @@ describe("CLIEngine", () => {
                 assert(!engine.isPathIgnored(`${getFixturePath("ignored-paths", "foo")}/../unignored.js`));
             });
 
-            it("should ignore /node_modules/ at top level relative to .eslintignore when loaded", () => {
+            it("should ignore /node_modules/ relative to .eslintignore when loaded", () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new CLIEngine({ ignorePath: getFixturePath("ignored-paths", ".eslintignore"), cwd });
 
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "node_modules", "existing.js")));
-                assert(!engine.isPathIgnored(getFixturePath("ignored-paths", "foo", "node_modules", "existing.js")));
+                assert(engine.isPathIgnored(getFixturePath("ignored-paths", "foo", "node_modules", "existing.js")));
             });
 
-            it("should ignore /node_modules/ at top level relative to cwd without an .eslintignore", () => {
+            it("should ignore /node_modules/ relative to cwd without an .eslintignore", () => {
                 const cwd = getFixturePath("ignored-paths", "no-ignore-file");
                 const engine = new CLIEngine({ cwd });
 
                 assert(engine.isPathIgnored(getFixturePath("ignored-paths", "no-ignore-file", "node_modules", "existing.js")));
-                assert(!engine.isPathIgnored(getFixturePath("ignored-paths", "no-ignore-file", "foo", "node_modules", "existing.js")));
+                assert(engine.isPathIgnored(getFixturePath("ignored-paths", "no-ignore-file", "foo", "node_modules", "existing.js")));
             });
         });
 
@@ -5052,12 +5044,12 @@ describe("CLIEngine", () => {
                 InMemoryCLIEngine = defineCLIEngineWithInMemoryFileSystem({
                     cwd: () => root,
                     files: {
-                        ".eslintrc.js": `module.exports = ${JSON.stringify({
+                        ".eslintrc.json": JSON.stringify({
                             ignorePatterns: "foo.js"
-                        })}`,
-                        "subdir/.eslintrc.js": `module.exports = ${JSON.stringify({
+                        }),
+                        "subdir/.eslintrc.json": JSON.stringify({
                             ignorePatterns: "bar.js"
-                        })}`,
+                        }),
                         "foo.js": "",
                         "bar.js": "",
                         "subdir/foo.js": "",
@@ -5107,12 +5099,12 @@ describe("CLIEngine", () => {
                 InMemoryCLIEngine = defineCLIEngineWithInMemoryFileSystem({
                     cwd: () => root,
                     files: {
-                        ".eslintrc.js": `module.exports = ${JSON.stringify({
+                        ".eslintrc.json": JSON.stringify({
                             ignorePatterns: "foo.js"
-                        })}`,
-                        "subdir/.eslintrc.js": `module.exports = ${JSON.stringify({
+                        }),
+                        "subdir/.eslintrc.json": JSON.stringify({
                             ignorePatterns: "!foo.js"
-                        })}`,
+                        }),
                         "foo.js": "",
                         "subdir/foo.js": ""
                     }
@@ -5193,13 +5185,13 @@ describe("CLIEngine", () => {
                 InMemoryCLIEngine = defineCLIEngineWithInMemoryFileSystem({
                     cwd: () => root,
                     files: {
-                        ".eslintrc.js": `module.exports = ${JSON.stringify({
+                        ".eslintrc.json": JSON.stringify({
                             ignorePatterns: "foo.js"
-                        })}`,
-                        "subdir/.eslintrc.js": `module.exports = ${JSON.stringify({
+                        }),
+                        "subdir/.eslintrc.json": JSON.stringify({
                             root: true,
                             ignorePatterns: "bar.js"
-                        })}`,
+                        }),
                         "foo.js": "",
                         "bar.js": "",
                         "subdir/foo.js": "",
@@ -5251,11 +5243,11 @@ describe("CLIEngine", () => {
                 InMemoryCLIEngine = defineCLIEngineWithInMemoryFileSystem({
                     cwd: () => root,
                     files: {
-                        ".eslintrc.js": `module.exports = ${JSON.stringify({})}`,
-                        "subdir/.eslintrc.js": `module.exports = ${JSON.stringify({
+                        ".eslintrc.json": JSON.stringify({}),
+                        "subdir/.eslintrc.json": JSON.stringify({
                             root: true,
                             ignorePatterns: "bar.js"
-                        })}`,
+                        }),
                         ".eslintignore": "foo.js",
                         "foo.js": "",
                         "bar.js": "",
@@ -5305,9 +5297,9 @@ describe("CLIEngine", () => {
                         "node_modules/eslint-config-one/index.js": `module.exports = ${JSON.stringify({
                             ignorePatterns: "foo.js"
                         })}`,
-                        ".eslintrc.js": `module.exports = ${JSON.stringify({
+                        ".eslintrc.json": JSON.stringify({
                             extends: "one"
-                        })}`,
+                        }),
                         "foo.js": "",
                         "bar.js": ""
                     }
@@ -5347,9 +5339,9 @@ describe("CLIEngine", () => {
                         "node_modules/eslint-config-one/index.js": `module.exports = ${JSON.stringify({
                             ignorePatterns: "/foo.js"
                         })}`,
-                        ".eslintrc.js": `module.exports = ${JSON.stringify({
+                        ".eslintrc.json": JSON.stringify({
                             extends: "one"
-                        })}`,
+                        }),
                         "foo.js": "",
                         "subdir/foo.js": ""
                     }
@@ -5389,10 +5381,10 @@ describe("CLIEngine", () => {
                         "node_modules/eslint-config-one/index.js": `module.exports = ${JSON.stringify({
                             ignorePatterns: "*.js"
                         })}`,
-                        ".eslintrc.js": `module.exports = ${JSON.stringify({
+                        ".eslintrc.json": JSON.stringify({
                             extends: "one",
                             ignorePatterns: "!bar.js"
-                        })}`,
+                        }),
                         "foo.js": "",
                         "bar.js": ""
                     }
@@ -5429,9 +5421,9 @@ describe("CLIEngine", () => {
                 InMemoryCLIEngine = defineCLIEngineWithInMemoryFileSystem({
                     cwd: () => root,
                     files: {
-                        ".eslintrc.js": `module.exports = ${JSON.stringify({
+                        ".eslintrc.json": JSON.stringify({
                             ignorePatterns: "*.js"
-                        })}`,
+                        }),
                         "foo.js": ""
                     }
                 }).CLIEngine;


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain: change an existing core feature.

#### What changes did you make? (Give an overview)

This PR implements RFC51 -- changes the default ignore patterns.

- unignore `.eslintrc.js`
- unignore `/bower_components/*`
- ignore `node_modules/*` in subdirectories.

This PR fixes some tests for the unignoring `.eslintrc.js`.

#### Is there anything you'd like reviewers to focus on?

Nothing in particular.