### PR TITLE
New: Unsafe integer rule

### DIFF
--- a/docs/rules/no-unsafe-integer.md
+++ b/docs/rules/no-unsafe-integer.md
@@ -1,0 +1,40 @@
+# disallow unsafe integers (no-unsafe-integer)
+
+Due to IEEE-754 double precision, integers with a value higher or equal to 2^53 cannot properly be represented in JavaScript and are therefore considered unsafe.
+Use the [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) object or the `10n` literal instead.
+
+See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger.
+
+## Rule Details
+
+This rule disallows usage of unsafe integer literals. It also checks `parseInt()` and `Number.parseInt()` function calls with unsafe integers.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-unsafe-integer: "error"*/
+
+var num1 = 9223372036854775807; // INT64_MAX_NUMBER
+var num2 = 0x7FFFFFFFFFFFFFFF; // INT64_MAX_NUMBER in hex
+var num3 = 9007199254740992; // MAX_SAFE_INTEGER + 1
+foo(9007199254740992);
+parseInt("9007199254740992");
+parseInt("9007199254740992", 10);
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-empty: "error"*/
+
+var num1 = 0;
+var num2 = 1;
+var num3 = 123456789;
+var num4 = 9007199254740991; // MAX_SAFE_INTEGER
+var num5 = 0x1FFFFFFFFFFFFF; // MAX_SAFE_INTEGER in hex
+foo(9007199254740991);
+parseInt("9007199254740991");
+parseInt("9007199254740991", 10);
+parseInt("1234567891011121315", 8); // 342391
+```

--- a/lib/rules/no-unsafe-integer.js
+++ b/lib/rules/no-unsafe-integer.js
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview Rule to flag use of a probable unsafe integer
+ * @author Joshua Westerheide
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks to see if a CallExpression's callee node is `parseInt` or
+ * `Number.parseInt`.
+ * @param {ASTNode} calleeNode The callee node to evaluate.
+ * @returns {boolean} True if the callee is `parseInt` or `Number.parseInt`,
+ * false otherwise.
+ */
+function isParseInt(calleeNode) {
+    switch (calleeNode.type) {
+        case "Identifier":
+            return calleeNode.name === "parseInt";
+        case "MemberExpression":
+            return calleeNode.object.type === "Identifier" &&
+                calleeNode.object.name === "Number" &&
+                calleeNode.property.type === "Identifier" &&
+                calleeNode.property.name === "parseInt";
+
+        // no default
+    }
+
+    return false;
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        type: "problem",
+
+        docs: {
+            description: "disallow unsafe integers",
+            category: "Possible Errors",
+            recommended: true,
+            url: "https://eslint.org/docs/rules/no-unsafe-integer"
+        },
+
+        schema: [],
+
+        messages: {
+            unsafe: "Possible unsafe integer {{value}}.",
+            "unsafe-parsing": "Possible unsafe integer {{value}} parsing."
+        }
+    },
+
+    create(context) {
+        return {
+            Literal(node) {
+                if (typeof node.value === "number" && !Number.isSafeInteger(node.value)) {
+                    context.report({ node, messageId: "unsafe", data: { value: node.raw } });
+                }
+            },
+
+            "CallExpression[arguments.length>=1]"(node) {
+                const strNode = node.arguments[0];
+
+                if (
+                    strNode.type === "Literal" &&
+                    typeof strNode.value === "string" &&
+                    isParseInt(node.callee)
+                ) {
+                    let radix = 10;
+
+                    if (node.arguments.length === 2) {
+                        radix = node.arguments[1].value;
+                    }
+
+                    const num = Number.parseInt(strNode.value, radix);
+
+                    if (!Number.isSafeInteger(num)) {
+                        context.report({ node, messageId: "unsafe-parsing", data: { value: strNode.value } });
+                    }
+                }
+            }
+        };
+    }
+};

--- a/tests/lib/rules/no-unsafe-integer.js
+++ b/tests/lib/rules/no-unsafe-integer.js
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Test for no-unsafe-integer rule
+ * @author Joshua Westerheide
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-unsafe-integer"),
+    { RuleTester } = require("../../../lib/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-unsafe-integer", rule, {
+    valid: [
+        "var num1 = 0",
+        "var num2 = 1",
+        "var num3 = 123456789",
+        "var num4 = 9007199254740991",
+        "var num5 = 0x1FFFFFFFFFFFFF",
+        "parseInt(\"9007199254740991\")",
+        "parseInt(\"9007199254740991\", 10)",
+        "parseInt(\"1234567891011121315\", 8)",
+        "foo(9007199254740991)"
+    ],
+    invalid: [
+        { code: "var num1 = 9223372036854775807", errors: [{ messageId: "unsafe", data: { value: "9223372036854775807" }, type: "Literal" }] },
+        { code: "var num2 = 0x7FFFFFFFFFFFFFFF", errors: [{ messageId: "unsafe", data: { value: "0x7FFFFFFFFFFFFFFF" }, type: "Literal" }] },
+        { code: "var num3 = 9007199254740992", errors: [{ messageId: "unsafe", data: { value: "9007199254740992" }, type: "Literal" }] },
+        { code: "parseInt(\"9007199254740992\")", errors: [{ messageId: "unsafe-parsing", data: { value: "9007199254740992" }, type: "CallExpression" }] },
+        { code: "parseInt(\"9007199254740992\", 10)", errors: [{ messageId: "unsafe-parsing", data: { value: "9007199254740992" }, type: "CallExpression" }] },
+        { code: "foo(9007199254740992)", errors: [{ messageId: "unsafe", data: { value: "9007199254740992" }, type: "Literal" }] }
+    ]
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [ ] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

## New Rule

**Please describe what the rule should do:**
Due to IEEE-754 double precision, integers with a value higher or equal to 2^53 cannot properly be represented in JavaScript and are therefore considered unsafe.

**What category of rule is this? (place an "X" next to just one item)**

- [x] Warns about a potential error (problem)
- [ ] Suggests an alternate way of doing something (suggestion)
- [ ] Enforces code style (layout)
- [ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**

<!-- Put your code examples here -->
```js
/*eslint no-unsafe-integer: "error"*/

var num1 = 9223372036854775807; // INT64_MAX_NUMBER
var num2 = 0x7FFFFFFFFFFFFFFF; // INT64_MAX_NUMBER in hex
parseInt("9007199254740992");

```

**Why should this rule be included in ESLint (instead of a plugin)?**
It is a very minimal and simple rule which does not produce much overhead. Although I'd guess this rule does not apply to all code bases, when detected it could save a few minutes and quickly resolve confusion about JavaScript's Number object.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
1. Add new rule definition in `lib/rules/`,
2. add tests for that rule,
3. add documentation for the rule.

#### Is there anything you'd like reviewers to focus on?
Documentation: Rule Description.