### PR TITLE
Fix: fix no-shadow false-positives (fixes #12687)

### DIFF
--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -165,6 +165,81 @@ module.exports = {
                     !isOnInitializer(variable, shadowed) &&
                     !(options.hoist !== "all" && isInTdz(variable, shadowed))
                 ) {
+                    if (shadowed.defs[0]) {
+                        const shadowedNode = shadowed.defs[0].node;
+                        const shadowNode = variable.defs[0].node;
+
+                        // Skip variable declaration
+                        if (
+                            (shadowedNode.type === "VariableDeclarator" || shadowedNode.type === "ArrowFunctionExpression") &&
+                            (shadowNode.type === "FunctionDeclaration" || shadowNode.type === "ArrowFunctionExpression") &&
+                            shadowNode.parent.type !== "BlockStatement" &&
+                            shadowNode.parent.parent
+                        ) {
+                            if (
+                                shadowedNode.range[0] === shadowNode.parent.parent.range[0] &&
+                                shadowedNode.range[1] === shadowNode.parent.parent.range[1]
+                            ) {
+                                continue;
+                            }
+                        }
+
+                        // Skip assignment in variable declaration
+                        if (
+                            shadowedNode.type === "VariableDeclarator" &&
+                            (shadowNode.type === "ArrowFunctionExpression" || shadowNode.type === "FunctionDeclaration") &&
+                            shadowNode.parent &&
+                            shadowNode.parent.parent &&
+                            shadowNode.parent.parent.parent &&
+                            shadowNode.parent.parent.parent.parent &&
+                            shadowedNode.range[0] === shadowNode.parent.parent.parent.parent.range[0] &&
+                            shadowedNode.range[1] === shadowNode.parent.parent.parent.parent.range[1]
+                        ) {
+                            continue;
+                        }
+                        if (
+                            shadowedNode.type === "VariableDeclarator" &&
+                            (shadowNode.type === "ArrowFunctionExpression" || shadowNode.type === "FunctionDeclaration") &&
+                            shadowNode.parent &&
+                            shadowNode.parent.parent &&
+                            shadowNode.parent.parent.parent &&
+                            shadowNode.parent.parent.parent.parent &&
+                            shadowNode.parent.parent.parent.parent.parent &&
+                            shadowedNode.range[0] === shadowNode.parent.parent.parent.parent.parent.range[0] &&
+                            shadowedNode.range[1] === shadowNode.parent.parent.parent.parent.parent.range[1]
+                        ) {
+                            continue;
+                        }
+
+                        // Skip for loop
+                        if (
+                            shadowedNode.parent &&
+                            shadowedNode.parent.parent &&
+                            (shadowedNode.parent.parent.type === "ForOfStatement" || shadowedNode.parent.parent.type === "ForInStatement") &&
+                            shadowNode.parent &&
+                            shadowNode.parent.parent &&
+                            (shadowNode.parent.parent.type === "ForOfStatement" || shadowNode.parent.parent.type === "ForInStatement")
+                        ) {
+                            if (
+                                shadowedNode.parent.parent.range[0] === shadowNode.parent.parent.range[0] &&
+                                shadowedNode.parent.parent.range[1] === shadowNode.parent.parent.range[1]) {
+                                continue;
+                            }
+                        }
+
+                        // Skip function declaration;
+                        if (
+                            shadowedNode.type === "FunctionDeclaration" &&
+                            (shadowNode.type === "ArrowFunctionExpression" || shadowNode.type === "FunctionDeclaration") &&
+                            shadowNode.parent &&
+                            shadowNode.parent.parent &&
+                            shadowNode.parent.parent.parent &&
+                            shadowedNode.range[0] === shadowNode.parent.parent.parent.range[0] &&
+                            shadowedNode.range[1] === shadowNode.parent.parent.parent.range[1]
+                        ) {
+                            continue;
+                        }
+                    }
                     context.report({
                         node: variable.identifiers[0],
                         messageId: "noShadow",

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -57,7 +57,13 @@ ruleTester.run("no-shadow", rule, {
         { code: "function foo() { var top = 0; }", env: { browser: true } },
         { code: "var Object = 0;", options: [{ builtinGlobals: true }] },
         { code: "var top = 0;", options: [{ builtinGlobals: true }], env: { browser: true } },
-        { code: "function foo(cb) { (function (cb) { cb(42); })(cb); }", options: [{ allow: ["cb"] }] }
+        { code: "function foo(cb) { (function (cb) { cb(42); })(cb); }", options: [{ allow: ["cb"] }] },
+        { code: "const a = [].find(a=>a)", parserOptions: { ecmaVersion: 6 } },
+        { code: "const [a = [].find(a => true)] = dummy", parserOptions: { ecmaVersion: 6 } },
+        { code: "const { a = [].find(a => true) } = dummy", parserOptions: { ecmaVersion: 6 } },
+        { code: "function func(a = [].find(a => true)) {}", parserOptions: { ecmaVersion: 6 } },
+        { code: "for (const a in [].find(a => true)) {}", parserOptions: { ecmaVersion: 6 } },
+        { code: "for (const a of [].find(a => true)) {}", parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**What rule do you want to change?**
no-shadow

**Does this change cause the rule to produce more or fewer warnings?**
fewer warnings

**How will the change be implemented? (New option, new default behavior, etc.)?**
more strict condition

**Please provide some example code that this change will affect:**
const person = people.find(person => person.name === "John");
previously incorrectly gave a no-shadow warning, this PR will fix this, along side other examples given in #12687

```js
<!-- example code here -->
const person = people.find(person => person.name === "John");

```

**What does the rule currently do for this code?**
incorrectly give no-shadow warning

**What will the rule do after it's changed?**
show no warnings

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added more conditions on the main checker for the rule no-shadow.
These conditions simply check the examples given in #12687 in a case by case basis.
Added tests cases for said examples.

#### Is there anything you'd like reviewers to focus on?
If it would be possible to generalize the case by case basis condition into a single, more compact condition.
