### PR TITLE
Update: add enforceForFunctionPrototypeMethods option to no-extra-parens

### DIFF
--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -7,7 +7,7 @@ This rule restricts the use of parentheses to only where they are necessary.
 This rule always ignores extra parentheses around the following:
 
 * RegExp literals such as `(/abc/).test(var)` to avoid conflicts with the [wrap-regex](wrap-regex.md) rule
-* immediately-invoked function expressions (also known as IIFEs) such as `var x = (function () {})();` and `((function foo() {return 1;})())` to avoid conflicts with the [wrap-iife](wrap-iife.md) rule
+* immediately-invoked function expressions (also known as IIFEs) such as `var x = (function () {})();` and `var x = (function () {}());` to avoid conflicts with the [wrap-iife](wrap-iife.md) rule
 * arrow function arguments to avoid conflicts with the [arrow-parens](arrow-parens.md) rule
 
 ## Options
@@ -26,6 +26,7 @@ This rule has an object option for exceptions to the `"all"` option:
 * `"enforceForArrowConditionals": false` allows extra parentheses around ternary expressions which are the body of an arrow function
 * `"enforceForSequenceExpressions": false` allows extra parentheses around sequence expressions
 * `"enforceForNewInMemberExpressions": false` allows extra parentheses around `new` expressions in member expressions
+* `"enforceForFunctionPrototypeMethods": false` allows extra parentheses around immediate `.call` and `.apply` method calls on function expressions and around function expressions in the same context.
 
 ### all
 
@@ -220,6 +221,22 @@ const foo = (new Bar()).baz;
 const quux = (new Bar())[baz];
 
 (new Bar()).doSomething();
+```
+
+### enforceForFunctionPrototypeMethods
+
+Examples of **correct** code for this rule with the `"all"` and `{ "enforceForFunctionPrototypeMethods": false }` options:
+
+```js
+/* eslint no-extra-parens: ["error", "all", { "enforceForFunctionPrototypeMethods": false }] */
+
+const foo = (function () {}).call();
+
+const bar = (function () {}).apply();
+
+const baz = (function () {}.call());
+
+const quux = (function () {}.apply());
 ```
 
 ### functions

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -51,7 +51,8 @@ module.exports = {
                                 ignoreJSX: { enum: ["none", "all", "single-line", "multi-line"] },
                                 enforceForArrowConditionals: { type: "boolean" },
                                 enforceForSequenceExpressions: { type: "boolean" },
-                                enforceForNewInMemberExpressions: { type: "boolean" }
+                                enforceForNewInMemberExpressions: { type: "boolean" },
+                                enforceForFunctionPrototypeMethods: { type: "boolean" }
                             },
                             additionalProperties: false
                         }
@@ -83,11 +84,27 @@ module.exports = {
             context.options[1].enforceForSequenceExpressions === false;
         const IGNORE_NEW_IN_MEMBER_EXPR = ALL_NODES && context.options[1] &&
             context.options[1].enforceForNewInMemberExpressions === false;
+        const IGNORE_FUNCTION_PROTOTYPE_METHODS = ALL_NODES && context.options[1] &&
+            context.options[1].enforceForFunctionPrototypeMethods === false;
 
         const PRECEDENCE_OF_ASSIGNMENT_EXPR = precedence({ type: "AssignmentExpression" });
         const PRECEDENCE_OF_UPDATE_EXPR = precedence({ type: "UpdateExpression" });
 
         let reportsBuffer;
+
+        /**
+         * Determines whether the given node is a `call` or `apply` method call, invoked directly on a `FunctionExpression` node.
+         * Example: function(){}.call()
+         * @param {ASTNode} node The node to be checked.
+         * @returns {boolean} True if the node is an immediate `call` or `apply` method call.
+         * @private
+         */
+        function isImmediateFunctionPrototypeMethodCall(node) {
+            return node.type === "CallExpression" &&
+                node.callee.type === "MemberExpression" &&
+                node.callee.object.type === "FunctionExpression" &&
+                ["call", "apply"].includes(astUtils.getStaticPropertyName(node.callee));
+        }
 
         /**
          * Determines if this rule should be enforced for a node given the current configuration.
@@ -122,6 +139,10 @@ module.exports = {
             }
 
             if (node.type === "SequenceExpression" && IGNORE_SEQUENCE_EXPRESSIONS) {
+                return false;
+            }
+
+            if (isImmediateFunctionPrototypeMethodCall(node) && IGNORE_FUNCTION_PROTOTYPE_METHODS) {
                 return false;
             }
 
@@ -924,7 +945,12 @@ module.exports = {
             LogicalExpression: checkBinaryLogical,
 
             MemberExpression(node) {
-                const nodeObjHasExcessParens = hasExcessParens(node.object);
+                const nodeObjHasExcessParens = hasExcessParens(node.object) &&
+                    !(
+                        isImmediateFunctionPrototypeMethodCall(node.parent) &&
+                        node.parent.callee === node &&
+                        IGNORE_FUNCTION_PROTOTYPE_METHODS
+                    );
 
                 if (
                     nodeObjHasExcessParens &&

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -477,6 +477,27 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "(new foo.bar()).baz()", options: ["all", { enforceForNewInMemberExpressions: false }] },
         { code: "((new foo.bar())).baz()", options: ["all", { enforceForNewInMemberExpressions: false }] },
 
+        // ["all", { enforceForFunctionPrototypeMethods: false }]
+        { code: "var foo = (function(){}).call()", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "var foo = (function(){}).apply()", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "var foo = (function(){}.call())", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "var foo = (function(){}.apply())", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "var foo = (function(){}).call(arg)", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "var foo = (function(){}.apply(arg))", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "var foo = (function(){}['call']())", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "var foo = (function(){})[`apply`]()", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "var foo = ((function(){})).call()", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "var foo = ((function(){}).apply())", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "var foo = ((function(){}.call()))", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "var foo = ((((function(){})).apply()))", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "foo((function(){}).call().bar)", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "foo = (function(){}).call()()", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "foo = (function(){}.call())()", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "var foo = { bar: (function(){}.call()) }", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "var foo = { [(function(){}.call())]: bar  }", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "if((function(){}).call()){}", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+        { code: "while((function(){}.apply())){}", options: ["all", { enforceForFunctionPrototypeMethods: false }] },
+
         "let a = [ ...b ]",
         "let a = { ...b }",
         {
@@ -1256,6 +1277,316 @@ ruleTester.run("no-extra-parens", rule, {
                 {
                     messageId: "unexpected",
                     type: "NewExpression"
+                }
+            ]
+        },
+
+        // enforceForFunctionPrototypeMethods
+        {
+            code: "var foo = (function(){}).call()",
+            output: "var foo = function(){}.call()",
+            options: ["all"],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "FunctionExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}.apply())",
+            output: "var foo = function(){}.apply()",
+            options: ["all"],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}).apply()",
+            output: "var foo = function(){}.apply()",
+            options: ["all", {}],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "FunctionExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}.call())",
+            output: "var foo = function(){}.call()",
+            options: ["all", {}],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}).call()",
+            output: "var foo = function(){}.call()",
+            options: ["all", { enforceForFunctionPrototypeMethods: true }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "FunctionExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}).apply()",
+            output: "var foo = function(){}.apply()",
+            options: ["all", { enforceForFunctionPrototypeMethods: true }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "FunctionExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}.call())",
+            output: "var foo = function(){}.call()",
+            options: ["all", { enforceForFunctionPrototypeMethods: true }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}.apply())",
+            output: "var foo = function(){}.apply()",
+            options: ["all", { enforceForFunctionPrototypeMethods: true }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}.call)()", // removing these parens does not cause any conflicts with wrap-iife
+            output: "var foo = function(){}.call()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "MemberExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}.apply)()", // removing these parens does not cause any conflicts with wrap-iife
+            output: "var foo = function(){}.apply()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "MemberExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}).call",
+            output: "var foo = function(){}.call",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "FunctionExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}.call)",
+            output: "var foo = function(){}.call",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "MemberExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = new (function(){}).call()",
+            output: "var foo = new function(){}.call()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "FunctionExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (new function(){}.call())",
+            output: "var foo = new function(){}.call()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "NewExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){})[call]()",
+            output: "var foo = function(){}[call]()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "FunctionExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}[apply]())",
+            output: "var foo = function(){}[apply]()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}).bar()",
+            output: "var foo = function(){}.bar()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "FunctionExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}.bar())",
+            output: "var foo = function(){}.bar()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}).call.call()",
+            output: "var foo = function(){}.call.call()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "FunctionExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (function(){}.call.call())",
+            output: "var foo = function(){}.call.call()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (call())",
+            output: "var foo = call()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (apply())",
+            output: "var foo = apply()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = (bar).call()",
+            output: "var foo = bar.call()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "var foo = (bar.call())",
+            output: "var foo = bar.call()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "((() => {}).call())",
+            output: "(() => {}).call()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = function(){}.call((a.b))",
+            output: "var foo = function(){}.call(a.b)",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "MemberExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = function(){}.call((a).b)",
+            output: "var foo = function(){}.call(a.b)",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "var foo = function(){}[('call')]()",
+            output: "var foo = function(){}['call']()",
+            options: ["all", { enforceForFunctionPrototypeMethods: false }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    type: "Literal"
                 }
             ]
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix
[X] Changes an existing rule

Fixes #12870

This PR adds `enforceForFunctionPrototypeMethods` option to the `no-extra-parens` rule in order to avoid conflicts with `wrap-iife` `"functionPrototypeMethods": true`.

Examples of **correct** code:

```js
/* eslint no-extra-parens: ["error", "all", { "enforceForFunctionPrototypeMethods": false }] */

const foo = (function () {}).call();

const bar = (function () {}).apply();

const baz = (function () {}.call());

const quux = (function () {}.apply());
```

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Added the option.
* Also fixed the wrong IIFE example in the docs.

#### Is there anything you'd like reviewers to focus on?

Yes! Should we add this option to `"functions"` schema, too? It doesn't have any options at the moment. That used to be a separate rule, but got merged in `no-extra-parens` at some point?

This is also a conflict:

```js
/* eslint wrap-iife: ["error", "inside", { functionPrototypeMethods: true }] */
/* eslint no-extra-parens: ["error", "functions"] */

var foo = function () {}.call(); // wrap-iife error

var foo = (function () {}).call(); // no-extra-parens error
```