### PR TITLE
Fix: `--no-ignore` does not work with `--stdin-filename` (fixes #12745)

### DIFF
--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -863,7 +863,10 @@ class CLIEngine {
         // Clear the last used config arrays.
         lastConfigArrays.length = 0;
 
-        if (resolvedFilename && this.isPathIgnored(resolvedFilename)) {
+        const dotfilesPattern = /(?:(?:^\.)|(?:[/\\]\.))[^/\\.].*/u;
+        const isDot = dotfilesPattern.test(resolvedFilename);
+
+        if (resolvedFilename && this.isPathIgnored(resolvedFilename, isDot)) {
             if (warnIgnored) {
                 results.push(createIgnoreResult(resolvedFilename, cwd));
             }
@@ -934,9 +937,10 @@ class CLIEngine {
     /**
      * Checks if a given path is ignored by ESLint.
      * @param {string} filePath The path of the file to check.
+     * @param {boolean} isDot is the file a dot file.
      * @returns {boolean} Whether or not the given path is ignored.
      */
-    isPathIgnored(filePath) {
+    isPathIgnored(filePath, isDot) {
         const {
             configArrayFactory,
             defaultIgnores,
@@ -950,10 +954,9 @@ class CLIEngine {
                 .extractConfig(absolutePath);
             const ignores = config.ignores || defaultIgnores;
 
-            return ignores(absolutePath);
+            return ignores(absolutePath, isDot);
         }
-
-        return defaultIgnores(absolutePath);
+        return defaultIgnores(absolutePath, isDot);
     }
 
     /**


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [ ] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

#### What changes did you make? (Give an overview)
Added a pattern match check for execute on text  to test if the stdin filename is a dot file just like how it's being tested if eslint is called on files.

#### Is there anything you'd like reviewers to focus on?
Any side effects to core logic.