### PR TITLE
Docs: Mention TypeScript's compiler check

### DIFF
--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -71,4 +71,4 @@ This rule should not be used in ES3/5 environments.
 
 In ES2015 (ES6) or later, if you don't want to be notified about duplicate names in class members, you can safely disable this rule.
 
-It's also safe to disable when using TypeScript because TypeScript's compiler already checks for duplicate function implementations.
+It's also safe to disable this rule when using TypeScript because TypeScript's compiler already checks for duplicate function implementations.

--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -70,3 +70,5 @@ class Foo {
 This rule should not be used in ES3/5 environments.
 
 In ES2015 (ES6) or later, if you don't want to be notified about duplicate names in class members, you can safely disable this rule.
+
+It's also safe to disable when using TypeScript because TypeScript's compiler already checks for duplicate function implementations.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I mentioned that TypeScript has the "no-dupe-class-members" rule built in. TypeScript will throw error TS2393 (Duplicate function implementation) if there are problems with the naming. Turning on ESLint's "no-dupe-class-members" rule can lead to false positives because it won't allow function overloading. The "typescript-eslint" project also has that [rule turned off](https://github.com/typescript-eslint/typescript-eslint/pull/520).

#### Is there anything you'd like reviewers to focus on?

Especially the negative impact on using the "no-dupe-class-members" rule with TypeScript should be a reason to highlight that it is safe to turn off the rule when using TypeScript.