### PR TITLE
Fix: wrap-iife autofix removes mandatory parentheses

### DIFF
--- a/tests/lib/rules/wrap-iife.js
+++ b/tests/lib/rules/wrap-iife.js
@@ -65,6 +65,137 @@ ruleTester.run("wrap-iife", rule, {
             options: ["any"]
         },
         {
+            code: "var a = ((function(){return 1;})());", // always allows existing extra parens (parens both inside and outside)
+            options: ["any"]
+        },
+        {
+            code: "var a = ((function(){return 1;})());", // always allows existing extra parens (parens both inside and outside)
+            options: ["inside"]
+        },
+        {
+            code: "var a = ((function(){return 1;})());", // always allows existing extra parens (parens both inside and outside)
+            options: ["outside"]
+        },
+        {
+            code: "if (function (){}()) {}",
+            options: ["any"]
+        },
+        {
+            code: "while (function (){}()) {}",
+            options: ["any"]
+        },
+        {
+            code: "do {} while (function (){}())",
+            options: ["any"]
+        },
+        {
+            code: "switch (function (){}()) {}",
+            options: ["any"]
+        },
+        {
+            code: "with (function (){}()) {}",
+            options: ["any"]
+        },
+        {
+            code: "foo(function (){}());",
+            options: ["any"]
+        },
+        {
+            code: "new foo(function (){}());",
+            options: ["any"]
+        },
+        {
+            code: "import(function (){}());",
+            options: ["any"],
+            parserOptions: { ecmaVersion: 2020 }
+        },
+        {
+            code: "if ((function (){})()) {}",
+            options: ["any"]
+        },
+        {
+            code: "while (((function (){})())) {}",
+            options: ["any"]
+        },
+        {
+            code: "if (function (){}()) {}",
+            options: ["outside"]
+        },
+        {
+            code: "while (function (){}()) {}",
+            options: ["outside"]
+        },
+        {
+            code: "do {} while (function (){}())",
+            options: ["outside"]
+        },
+        {
+            code: "switch (function (){}()) {}",
+            options: ["outside"]
+        },
+        {
+            code: "with (function (){}()) {}",
+            options: ["outside"]
+        },
+        {
+            code: "foo(function (){}());",
+            options: ["outside"]
+        },
+        {
+            code: "new foo(function (){}());",
+            options: ["outside"]
+        },
+        {
+            code: "import(function (){}());",
+            options: ["outside"],
+            parserOptions: { ecmaVersion: 2020 }
+        },
+        {
+            code: "if ((function (){})()) {}",
+            options: ["outside"]
+        },
+        {
+            code: "while (((function (){})())) {}",
+            options: ["outside"]
+        },
+        {
+            code: "if ((function (){})()) {}",
+            options: ["inside"]
+        },
+        {
+            code: "while ((function (){})()) {}",
+            options: ["inside"]
+        },
+        {
+            code: "do {} while ((function (){})())",
+            options: ["inside"]
+        },
+        {
+            code: "switch ((function (){})()) {}",
+            options: ["inside"]
+        },
+        {
+            code: "with ((function (){})()) {}",
+            options: ["inside"]
+        },
+        {
+            code: "foo((function (){})());",
+            options: ["inside"]
+        },
+        {
+            code: "new foo((function (){})());",
+            options: ["inside"]
+        },
+        {
+            code: "import((function (){})());",
+            options: ["inside"],
+            parserOptions: { ecmaVersion: 2020 }
+        },
+        {
+            code: "while (((function (){})())) {}",
+            options: ["inside"]
+        },
+        {
             code: "window.bar = (function() { return 3; }.call(this, arg1));",
             options: ["outside", { functionPrototypeMethods: true }]
         },
@@ -83,6 +214,10 @@ ruleTester.run("wrap-iife", rule, {
         {
             code: "window.bar = function() { return 3; }.call(this, arg1);",
             options: ["inside"]
+        },
+        {
+            code: "window.bar = function() { return 3; }.call(this, arg1);",
+            options: ["inside", {}]
         },
         {
             code: "window.bar = function() { return 3; }.call(this, arg1);",
@@ -106,6 +241,137 @@ ruleTester.run("wrap-iife", rule, {
         },
         {
             code: "var a = function(){return 1;}.bind(this).apply(that);",
+            options: ["inside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "var a = ((function(){return 1;}).call());", // always allows existing extra parens (parens both inside and outside)
+            options: ["any", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "var a = ((function(){return 1;}).call());", // always allows existing extra parens (parens both inside and outside)
+            options: ["inside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "var a = ((function(){return 1;}).call());", // always allows existing extra parens (parens both inside and outside)
+            options: ["outside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "if (function (){}.call()) {}",
+            options: ["any", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "while (function (){}.call()) {}",
+            options: ["any", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "do {} while (function (){}.call())",
+            options: ["any", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "switch (function (){}.call()) {}",
+            options: ["any", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "with (function (){}.call()) {}",
+            options: ["any", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "foo(function (){}.call())",
+            options: ["any", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "new foo(function (){}.call())",
+            options: ["any", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "import(function (){}.call())",
+            options: ["any", { functionPrototypeMethods: true }],
+            parserOptions: { ecmaVersion: 2020 }
+        },
+        {
+            code: "if ((function (){}).call()) {}",
+            options: ["any", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "while (((function (){}).call())) {}",
+            options: ["any", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "if (function (){}.call()) {}",
+            options: ["outside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "while (function (){}.call()) {}",
+            options: ["outside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "do {} while (function (){}.call())",
+            options: ["outside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "switch (function (){}.call()) {}",
+            options: ["outside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "with (function (){}.call()) {}",
+            options: ["outside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "foo(function (){}.call())",
+            options: ["outside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "new foo(function (){}.call())",
+            options: ["outside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "import(function (){}.call())",
+            options: ["outside", { functionPrototypeMethods: true }],
+            parserOptions: { ecmaVersion: 2020 }
+        },
+        {
+            code: "if ((function (){}).call()) {}",
+            options: ["outside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "while (((function (){}).call())) {}",
+            options: ["outside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "if ((function (){}).call()) {}",
+            options: ["inside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "while ((function (){}).call()) {}",
+            options: ["inside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "do {} while ((function (){}).call())",
+            options: ["inside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "switch ((function (){}).call()) {}",
+            options: ["inside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "with ((function (){}).call()) {}",
+            options: ["inside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "foo((function (){}).call())",
+            options: ["inside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "new foo((function (){}).call())",
+            options: ["inside", { functionPrototypeMethods: true }]
+        },
+        {
+            code: "import((function (){}).call())",
+            options: ["inside", { functionPrototypeMethods: true }],
+            parserOptions: { ecmaVersion: 2020 }
+        },
+        {
+            code: "if (((function (){}).call())) {}",
             options: ["inside", { functionPrototypeMethods: true }]
         }
     ],
@@ -140,6 +406,79 @@ ruleTester.run("wrap-iife", rule, {
             code: "(function a(){ }());",
             output: "(function a(){ })();",
             options: ["inside"],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "new foo((function (){}()))",
+            output: "new foo((function (){})())",
+            options: ["inside"],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "new (function (){}())",
+            output: "new ((function (){})())", // wrap function expression, but don't remove necessary grouping parens
+            options: ["inside"],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "new (function (){}())()",
+            output: "new ((function (){})())()", // wrap function expression, but don't remove necessary grouping parens
+            options: ["inside"],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "if (function (){}()) {}",
+            output: "if ((function (){})()) {}", // wrap function expression, but don't remove mandatory parens
+            options: ["inside"],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "if ((function (){}())) {}",
+            output: "if ((function (){})()) {}", // wrap function expression and remove unnecessary grouping parens aroung the call expression
+            options: ["inside"],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "while (function (){}()) {}",
+            output: "while ((function (){})()) {}", // wrap function expression, but don't remove mandatory parens
+            options: ["inside"],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "do {} while (function (){}())",
+            output: "do {} while ((function (){})())", // wrap function expression, but don't remove mandatory parens
+            options: ["inside"],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "switch (function (){}()) {}",
+            output: "switch ((function (){})()) {}", // wrap function expression, but don't remove mandatory parens
+            options: ["inside"],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "with (function (){}()) {}",
+            output: "with ((function (){})()) {}", // wrap function expression, but don't remove mandatory parens
+            options: ["inside"],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "foo(function (){}())",
+            output: "foo((function (){})())", // wrap function expression, but don't remove mandatory parens
+            options: ["inside"],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "new foo(function (){}())",
+            output: "new foo((function (){})())", // wrap function expression, but don't remove mandatory parens
+            options: ["inside"],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "import(function (){}())",
+            output: "import((function (){})())", // wrap function expression, but don't remove mandatory parens
+            options: ["inside"],
+            parserOptions: { ecmaVersion: 2020 },
             errors: [wrapExpressionError]
         },
         {
@@ -197,6 +536,73 @@ ruleTester.run("wrap-iife", rule, {
             output: "window.bar = (function() { return 3; }.call(this, arg1));",
             options: ["outside", { functionPrototypeMethods: true }],
             errors: [moveInvocationError]
+        },
+        {
+            code: "new (function (){}.call())",
+            output: "new ((function (){}).call())", // wrap function expression, but don't remove necessary grouping parens
+            options: ["inside", { functionPrototypeMethods: true }],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "new (function (){}.call())()",
+            output: "new ((function (){}).call())()", // wrap function expression, but don't remove necessary grouping parens
+            options: ["inside", { functionPrototypeMethods: true }],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "if (function (){}.call()) {}",
+            output: "if ((function (){}).call()) {}", // wrap function expression, but don't remove mandatory parens
+            options: ["inside", { functionPrototypeMethods: true }],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "if ((function (){}.call())) {}",
+            output: "if ((function (){}).call()) {}", // wrap function expression and remove unnecessary grouping parens aroung the call expression
+            options: ["inside", { functionPrototypeMethods: true }],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "while (function (){}.call()) {}",
+            output: "while ((function (){}).call()) {}", // wrap function expression, but don't remove mandatory parens
+            options: ["inside", { functionPrototypeMethods: true }],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "do {} while (function (){}.call())",
+            output: "do {} while ((function (){}).call())", // wrap function expression, but don't remove mandatory parens
+            options: ["inside", { functionPrototypeMethods: true }],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "switch (function (){}.call()) {}",
+            output: "switch ((function (){}).call()) {}", // wrap function expression, but don't remove mandatory parens
+            options: ["inside", { functionPrototypeMethods: true }],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "with (function (){}.call()) {}",
+            output: "with ((function (){}).call()) {}", // wrap function expression, but don't remove mandatory parens
+            options: ["inside", { functionPrototypeMethods: true }],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "foo(function (){}.call())",
+            output: "foo((function (){}).call())", // wrap function expression, but don't remove mandatory parens
+            options: ["inside", { functionPrototypeMethods: true }],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "new foo(function (){}.call())",
+            output: "new foo((function (){}).call())", // wrap function expression, but don't remove mandatory parens
+            options: ["inside", { functionPrototypeMethods: true }],
+            errors: [wrapExpressionError]
+        },
+        {
+            code: "import(function (){}.call())",
+            output: "import((function (){}).call())", // wrap function expression, but don't remove mandatory parens
+            options: ["inside", { functionPrototypeMethods: true }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [wrapExpressionError]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

**Tell us about your environment**

* **ESLint Version:** 7.0.0-alpha.0
* **Node Version:** v12.14.0
* **npm Version:** v6.13.4

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: 2020
    },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint wrap-iife: ["error", "inside"]*/

if (function (){}()) {}

while (function (){}()) {}

do {} while (function (){}())

switch (function (){}()) {}

with (function (){}()) {}

foo(function (){}());

new foo(function (){}());

import(function (){}());

new (function (){}())();
```

[Online Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgd3JhcC1paWZlOiBbXCJlcnJvclwiLCBcImluc2lkZVwiXSovXG5cbmlmIChmdW5jdGlvbiAoKXt9KCkpIHt9XG5cbndoaWxlIChmdW5jdGlvbiAoKXt9KCkpIHt9XG5cbmRvIHt9IHdoaWxlIChmdW5jdGlvbiAoKXt9KCkpXG5cbnN3aXRjaCAoZnVuY3Rpb24gKCl7fSgpKSB7fVxuXG53aXRoIChmdW5jdGlvbiAoKXt9KCkpIHt9XG5cbmZvbyhmdW5jdGlvbiAoKXt9KCkpO1xuXG5uZXcgZm9vKGZ1bmN0aW9uICgpe30oKSk7XG5cbmltcG9ydChmdW5jdGlvbiAoKXt9KCkpO1xuXG5uZXcgKGZ1bmN0aW9uICgpe30oKSkoKTsiLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjExLCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7fSwiZW52Ijp7fX19) (v6.8.0 actual)

**What did you expect to happen?**

Autofix to just parenthesize function expressions, without removing mandatory parentheses in constructs and necessary grouping parentheses after `new`.

**What actually happened? Please include the actual, raw output from ESLint.**

Autofix:

```js
/*eslint wrap-iife: ["error", "inside"]*/

if (function (){})() {} // syntax error

while (function (){})() {} // syntax error

do {} while (function (){})() // syntax error

switch (function (){})() {} // syntax error

with (function (){})() {} // syntax error

foo(function (){})(); // changed behavior

new foo(function (){})(); // changed behavior

import(function (){})(); // changed behavior

new (function (){})()(); // changed behavior
```

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the auto-fix to just add new parens around `FunctionExpression` when the existing parens around `CallExpression` cannot be removed.

#### Is there anything you'd like reviewers to focus on?
