### PR TITLE
Update: Report constructor calls in no-obj-calls

### DIFF
--- a/docs/rules/no-obj-calls.md
+++ b/docs/rules/no-obj-calls.md
@@ -18,27 +18,45 @@ And the [ECMAScript 2017 specification](https://www.ecma-international.org/ecma-
 
 This rule disallows calling the `Math`, `JSON`, `Reflect` and `Atomics` objects as functions.
 
+This rule also disallows using these objects as constructors with the `new` operator.
+
 Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-obj-calls: "error"*/
+/*eslint-env es2017*/
 
 var math = Math();
+
+var newMath = new Math();
+
 var json = JSON();
+
+var newJSON = new JSON();
+
 var reflect = Reflect();
+
+var newReflect = new Reflect();
+
 var atomics = Atomics();
+
+var newAtomics = new Atomics();
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-obj-calls: "error"*/
+/*eslint-env es2017*/
 
 function area(r) {
     return Math.PI * r * r;
 }
+
 var object = JSON.parse("{}");
+
 var value = Reflect.get({ x: 1, y: 2 }, "x");
+
 var first = Atomics.load(foo, 0);
 ```
 

--- a/lib/rules/no-new-wrappers.js
+++ b/lib/rules/no-new-wrappers.js
@@ -32,7 +32,7 @@ module.exports = {
         return {
 
             NewExpression(node) {
-                const wrapperObjects = ["String", "Number", "Boolean", "Math", "JSON"];
+                const wrapperObjects = ["String", "Number", "Boolean"];
 
                 if (wrapperObjects.indexOf(node.callee.name) > -1) {
                     context.report({

--- a/lib/rules/no-obj-calls.js
+++ b/lib/rules/no-obj-calls.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const { CALL, ReferenceTracker } = require("eslint-utils");
+const { CALL, CONSTRUCT, ReferenceTracker } = require("eslint-utils");
 const getPropertyName = require("./utils/ast-utils").getStaticPropertyName;
 
 //------------------------------------------------------------------------------
@@ -63,7 +63,8 @@ module.exports = {
 
                 for (const g of nonCallableGlobals) {
                     traceMap[g] = {
-                        [CALL]: true
+                        [CALL]: true,
+                        [CONSTRUCT]: true
                     };
                 }
 

--- a/tests/lib/rules/no-new-wrappers.js
+++ b/tests/lib/rules/no-new-wrappers.js
@@ -53,26 +53,6 @@ ruleTester.run("no-new-wrappers", rule, {
                 },
                 type: "NewExpression"
             }]
-        },
-        {
-            code: "var a = new Math();",
-            errors: [{
-                messageId: "noConstructor",
-                data: {
-                    fn: "Math"
-                },
-                type: "NewExpression"
-            }]
-        },
-        {
-            code: "var a = new JSON({ myProp: 10 });",
-            errors: [{
-                messageId: "noConstructor",
-                data: {
-                    fn: "JSON"
-                },
-                type: "NewExpression"
-            }]
         }
     ]
 });

--- a/tests/lib/rules/no-obj-calls.js
+++ b/tests/lib/rules/no-obj-calls.js
@@ -24,9 +24,27 @@ ruleTester.run("no-obj-calls", rule, {
         "var x = Math.random();",
         "var x = Math.PI;",
         "var x = foo.Math();",
+        "var x = new foo.Math();",
+        "var x = new Math.foo;",
+        "var x = new Math.foo();",
         "JSON.parse(foo)",
-        "Reflect.get(foo, 'x')",
-        "Atomics.load(foo, 0)",
+        "new JSON.parse",
+        {
+            code: "Reflect.get(foo, 'x')",
+            env: { es6: true }
+        },
+        {
+            code: "new Reflect.foo(a, b)",
+            env: { es6: true }
+        },
+        {
+            code: "Atomics.load(foo, 0)",
+            env: { es2017: true }
+        },
+        {
+            code: "new Atomics.foo()",
+            env: { es2017: true }
+        },
 
         { code: "globalThis.Math();", env: { es6: true } },
         { code: "var x = globalThis.Math();", env: { es6: true } },
@@ -43,12 +61,19 @@ ruleTester.run("no-obj-calls", rule, {
 
         // non-existing variables
         "/*globals Math: off*/ Math();",
+        "/*globals Math: off*/ new Math();",
         {
             code: "JSON();",
             globals: { JSON: "off" }
         },
+        {
+            code: "new JSON();",
+            globals: { JSON: "off" }
+        },
         "Reflect();",
         "Atomics();",
+        "new Reflect();",
+        "new Atomics();",
         {
             code: "Atomics();",
             env: { es6: true }
@@ -56,8 +81,13 @@ ruleTester.run("no-obj-calls", rule, {
 
         // shadowed variables
         "var Math; Math();",
+        "var Math; new Math();",
         {
             code: "let JSON; JSON();",
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "let JSON; new JSON();",
             parserOptions: { ecmaVersion: 2015 }
         },
         {
@@ -65,9 +95,20 @@ ruleTester.run("no-obj-calls", rule, {
             parserOptions: { ecmaVersion: 2015 },
             env: { es6: true }
         },
+        {
+            code: "if (foo) { const Reflect = 1; new Reflect(); }",
+            parserOptions: { ecmaVersion: 2015 },
+            env: { es6: true }
+        },
         "function foo(Math) { Math(); }",
+        "function foo(JSON) { new JSON(); }",
         {
             code: "function foo(Atomics) { Atomics(); }",
+            env: { es2017: true }
+        },
+        {
+            code: "function foo() { if (bar) { let Atomics; if (baz) { new Atomics(); } } }",
+            parserOptions: { ecmaVersion: 2015 },
             env: { es2017: true }
         },
         "function foo() { var JSON; JSON(); }",
@@ -81,12 +122,10 @@ ruleTester.run("no-obj-calls", rule, {
         }
     ],
     invalid: [
-
         {
             code: "Math();",
             errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "CallExpression" }]
         },
-
         {
             code: "var x = Math();",
             errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "CallExpression" }]
@@ -100,12 +139,36 @@ ruleTester.run("no-obj-calls", rule, {
             errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "CallExpression", column: 1, endColumn: 7 }]
         },
         {
+            code: "new Math;",
+            errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "NewExpression" }]
+        },
+        {
+            code: "new Math();",
+            errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "NewExpression" }]
+        },
+        {
+            code: "new Math(foo);",
+            errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "NewExpression" }]
+        },
+        {
+            code: "new Math().foo;",
+            errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "NewExpression" }]
+        },
+        {
+            code: "(new Math).foo();",
+            errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "NewExpression" }]
+        },
+        {
             code: "var x = JSON();",
             errors: [{ messageId: "unexpectedCall", data: { name: "JSON" }, type: "CallExpression" }]
         },
         {
             code: "x = JSON(str);",
             errors: [{ messageId: "unexpectedCall", data: { name: "JSON" }, type: "CallExpression" }]
+        },
+        {
+            code: "var x = new JSON();",
+            errors: [{ messageId: "unexpectedCall", data: { name: "JSON" }, type: "NewExpression" }]
         },
         {
             code: "Math( JSON() );",
@@ -120,6 +183,11 @@ ruleTester.run("no-obj-calls", rule, {
             errors: [{ messageId: "unexpectedCall", data: { name: "Reflect" }, type: "CallExpression" }]
         },
         {
+            code: "var x = new Reflect();",
+            env: { es6: true },
+            errors: [{ messageId: "unexpectedCall", data: { name: "Reflect" }, type: "NewExpression" }]
+        },
+        {
             code: "var x = Reflect();",
             env: { es2017: true },
             errors: [{ messageId: "unexpectedCall", data: { name: "Reflect" }, type: "CallExpression" }]
@@ -129,9 +197,18 @@ ruleTester.run("no-obj-calls", rule, {
             errors: [{ messageId: "unexpectedCall", data: { name: "Reflect" }, type: "CallExpression" }]
         },
         {
+            code: "/*globals Reflect: true*/ new Reflect();",
+            errors: [{ messageId: "unexpectedCall", data: { name: "Reflect" }, type: "NewExpression" }]
+        },
+        {
             code: "var x = Atomics();",
             env: { es2017: true },
             errors: [{ messageId: "unexpectedCall", data: { name: "Atomics" }, type: "CallExpression" }]
+        },
+        {
+            code: "var x = new Atomics();",
+            env: { es2017: true },
+            errors: [{ messageId: "unexpectedCall", data: { name: "Atomics" }, type: "NewExpression" }]
         },
         {
             code: "var x = Atomics();",
@@ -142,6 +219,11 @@ ruleTester.run("no-obj-calls", rule, {
             code: "var x = Atomics();",
             globals: { Atomics: false },
             errors: [{ messageId: "unexpectedCall", data: { name: "Atomics" }, type: "CallExpression" }]
+        },
+        {
+            code: "var x = new Atomics();",
+            globals: { Atomics: "writable" },
+            errors: [{ messageId: "unexpectedCall", data: { name: "Atomics" }, type: "NewExpression" }]
         },
         {
             code: "var x = globalThis.Math();",

--- a/tests/lib/rules/no-obj-calls.js
+++ b/tests/lib/rules/no-obj-calls.js
@@ -231,6 +231,11 @@ ruleTester.run("no-obj-calls", rule, {
             errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "CallExpression" }]
         },
         {
+            code: "var x = new globalThis.Math();",
+            env: { es2020: true },
+            errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "NewExpression" }]
+        },
+        {
             code: "f(globalThis.Math());",
             env: { es2020: true },
             errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "CallExpression", column: 3, endColumn: 20 }]
@@ -239,6 +244,11 @@ ruleTester.run("no-obj-calls", rule, {
             code: "globalThis.Math().foo;",
             env: { es2020: true },
             errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "CallExpression", column: 1, endColumn: 18 }]
+        },
+        {
+            code: "new globalThis.Math().foo;",
+            env: { es2020: true },
+            errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "NewExpression", column: 1, endColumn: 22 }]
         },
         {
             code: "var x = globalThis.JSON();",
@@ -264,6 +274,11 @@ ruleTester.run("no-obj-calls", rule, {
             errors: [{ messageId: "unexpectedCall", data: { name: "Reflect" }, type: "CallExpression" }]
         },
         {
+            code: "var x = new globalThis.Reflect;",
+            env: { es2020: true },
+            errors: [{ messageId: "unexpectedCall", data: { name: "Reflect" }, type: "NewExpression" }]
+        },
+        {
             code: "/*globals Reflect: true*/ Reflect();",
             env: { es2020: true },
             errors: [{ messageId: "unexpectedCall", data: { name: "Reflect" }, type: "CallExpression" }]
@@ -278,14 +293,28 @@ ruleTester.run("no-obj-calls", rule, {
             errors: [{ messageId: "unexpectedRefCall", data: { name: "foo", ref: "JSON" }, type: "CallExpression" }]
         },
         {
+            code: "var foo = bar ? baz: JSON; new foo();",
+            errors: [{ messageId: "unexpectedRefCall", data: { name: "foo", ref: "JSON" }, type: "NewExpression" }]
+        },
+        {
             code: "var foo = bar ? baz: globalThis.JSON; foo();",
             env: { es2020: true },
             errors: [{ messageId: "unexpectedRefCall", data: { name: "foo", ref: "JSON" }, type: "CallExpression" }]
         },
         {
+            code: "var foo = bar ? baz: globalThis.JSON; new foo();",
+            env: { es2020: true },
+            errors: [{ messageId: "unexpectedRefCall", data: { name: "foo", ref: "JSON" }, type: "NewExpression" }]
+        },
+        {
             code: "var foo = window.Atomics; foo();",
             env: { es2020: true, browser: true },
             errors: [{ messageId: "unexpectedRefCall", data: { name: "foo", ref: "Atomics" }, type: "CallExpression" }]
+        },
+        {
+            code: "var foo = window.Atomics; new foo;",
+            env: { es2020: true, browser: true },
+            errors: [{ messageId: "unexpectedRefCall", data: { name: "foo", ref: "Atomics" }, type: "NewExpression" }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Changes an existing rule

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Note: this PR also removes `Math` and `JSON` from the `no-new-wrappers` rule.

**What rule do you want to change?**

`no-obj-calls`

**Does this change cause the rule to produce more or fewer warnings?**

more

**How will the change be implemented? (New option, new default behavior, etc.)?**

new default behavior

**Please provide some example code that this change will affect:**

```js
/*eslint no-obj-calls: "error"*/
/*eslint-env es2017*/

var newMath = new Math();

var newJSON = new JSON();

var newReflect = new Reflect();

var newAtomics = new Atomics();
```

**What does the rule currently do for this code?**

no errors

**What will the rule do after it's changed?**

4 errors

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `no-obj-calls` to warn on `NewExpression` as well.

#### Is there anything you'd like reviewers to focus on?

As suggested in [#11984 (comment)](https://github.com/eslint/eslint/pull/11984#issuecomment-583545886), `no-obj-calls` instead of `no-new-wrappers` should report `new Math()` and `new JSON()`. I guess it makes sense to report all 4 objects when used with `new`, it's always a runtime error.

I think there is no need for a new messageId.
