### PR TITLE
Breaking: use-isnan enforceForSwitchCase default `true` (fixes #12810)

### DIFF
--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -45,17 +45,15 @@ if (!isNaN(foo)) {
 
 This rule has an object option, with two options:
 
-* `"enforceForSwitchCase"` when set to `true` disallows `case NaN` and `switch(NaN)` in `switch` statements. Default is `false`, meaning that this rule by default does not warn about `case NaN` or `switch(NaN)`.
-* `"enforceForIndexOf"` when set to `true` disallows the use of `indexOf` and `lastIndexOf` methods with `NaN`. Default is `false`, meaning that this rule by default does not warn about `indexOf(NaN)` or `lastIndexOf(NaN)` method calls.
+* `"enforceForSwitchCase": true` (default) additionally disallows `case NaN` and `switch(NaN)` in `switch` statements.
+* `"enforceForIndexOf": true` additionally disallows the use of `indexOf` and `lastIndexOf` methods with `NaN`. Default is `false`, meaning that this rule by default does not warn about `indexOf(NaN)` or `lastIndexOf(NaN)` method calls.
 
 ### enforceForSwitchCase
 
 The `switch` statement internally uses the `===` comparison to match the expression's value to a case clause.
 Therefore, it can never match `case NaN`. Also, `switch(NaN)` can never match a case clause.
 
-Set `"enforceForSwitchCase"` to `true` if you want this rule to report `case NaN` and `switch(NaN)` in `switch` statements.
-
-Examples of **incorrect** code for this rule with `"enforceForSwitchCase"` option set to `true`:
+Examples of **incorrect** code for this rule with `"enforceForSwitchCase"` option set to `true` (default):
 
 ```js
 /*eslint use-isnan: ["error", {"enforceForSwitchCase": true}]*/
@@ -81,7 +79,7 @@ switch (NaN) {
 }
 ```
 
-Examples of **correct** code for this rule with `"enforceForSwitchCase"` option set to `true`:
+Examples of **correct** code for this rule with `"enforceForSwitchCase"` option set to `true` (default):
 
 ```js
 /*eslint use-isnan: ["error", {"enforceForSwitchCase": true}]*/
@@ -102,6 +100,32 @@ if (Number.isNaN(a)) {
 } else if (Number.isNaN(b)) {
     baz();
 } // ...
+```
+
+Examples of **correct** code for this rule with `"enforceForSwitchCase"` option set to `false`:
+
+```js
+/*eslint use-isnan: ["error", {"enforceForSwitchCase": false}]*/
+
+switch (foo) {
+    case NaN:
+        bar();
+        break;
+    case 1:
+        baz();
+        break;
+    // ...
+}
+
+switch (NaN) {
+    case a:
+        bar();
+        break;
+    case b:
+        baz();
+        break;
+    // ...
+}
 ```
 
 ### enforceForIndexOf

--- a/lib/rules/use-isnan.js
+++ b/lib/rules/use-isnan.js
@@ -45,7 +45,7 @@ module.exports = {
                 properties: {
                     enforceForSwitchCase: {
                         type: "boolean",
-                        default: false
+                        default: true
                     },
                     enforceForIndexOf: {
                         type: "boolean",
@@ -66,7 +66,7 @@ module.exports = {
 
     create(context) {
 
-        const enforceForSwitchCase = context.options[0] && context.options[0].enforceForSwitchCase;
+        const enforceForSwitchCase = !context.options[0] || context.options[0].enforceForSwitchCase;
         const enforceForIndexOf = context.options[0] && context.options[0].enforceForIndexOf;
 
         /**

--- a/tests/lib/rules/use-isnan.js
+++ b/tests/lib/rules/use-isnan.js
@@ -41,16 +41,6 @@ ruleTester.run("use-isnan", rule, {
         // enforceForSwitchCase
         //------------------------------------------------------------------------------
 
-        "switch(NaN) { case foo: break; }",
-        "switch(foo) { case NaN: break; }",
-        {
-            code: "switch(NaN) { case foo: break; }",
-            options: [{}]
-        },
-        {
-            code: "switch(foo) { case NaN: break; }",
-            options: [{}]
-        },
         {
             code: "switch(NaN) { case foo: break; }",
             options: [{ enforceForSwitchCase: false }]
@@ -282,6 +272,24 @@ ruleTester.run("use-isnan", rule, {
         // enforceForSwitchCase
         //------------------------------------------------------------------------------
 
+        {
+            code: "switch(NaN) { case foo: break; }",
+            errors: [{ messageId: "switchNaN", type: "SwitchStatement", column: 1 }]
+        },
+        {
+            code: "switch(foo) { case NaN: break; }",
+            errors: [{ messageId: "caseNaN", type: "SwitchCase", column: 15 }]
+        },
+        {
+            code: "switch(NaN) { case foo: break; }",
+            options: [{}],
+            errors: [{ messageId: "switchNaN", type: "SwitchStatement", column: 1 }]
+        },
+        {
+            code: "switch(foo) { case NaN: break; }",
+            options: [{}],
+            errors: [{ messageId: "caseNaN", type: "SwitchCase", column: 15 }]
+        },
         {
             code: "switch(NaN) {}",
             options: [{ enforceForSwitchCase: true }],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

fixes #12810

Rule: `use-isnan`.

This PR changes  `enforceForSwitchCase` option's default value to `true`.

The rule will now by default disallow `switch (NaN)` and `case NaN`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed default value and updated documentation.

#### Is there anything you'd like reviewers to focus on?
