### PR TITLE
Breaking: class default `true` computed-property-spacing (fixes #12812)

### DIFF
--- a/docs/rules/computed-property-spacing.md
+++ b/docs/rules/computed-property-spacing.md
@@ -34,7 +34,7 @@ String option:
 
 Object option:
 
-* `"enforceForClassMembers": true` additionally applies this rule to class members (default is `false`)
+* `"enforceForClassMembers": true` (default) additionally applies this rule to class members.
 
 ### never
 
@@ -92,13 +92,9 @@ obj[ foo[ bar ] ]
 
 #### enforceForClassMembers
 
-By default, this rule does not check class declarations and class expressions,
-as the default value for `enforceForClassMembers` is `false`.
+With `enforceForClassMembers` set to `true` (default), the rule also disallows/enforces spaces inside of computed keys of class methods, getters and setters.
 
-When `enforceForClassMembers` is set to `true`, the rule will also disallow/enforce spaces inside of
-computed keys of class methods, getters and setters.
-
-Examples of **incorrect** code for this rule with `"never"` and `{ "enforceForClassMembers": true }`:
+Examples of **incorrect** code for this rule with `"never"` and `{ "enforceForClassMembers": true }` (default):
 
 ```js
 /*eslint computed-property-spacing: ["error", "never", { "enforceForClassMembers": true }]*/
@@ -118,7 +114,7 @@ const Bar = class {
 }
 ```
 
-Examples of **correct** code for this rule with `"never"` and `{ "enforceForClassMembers": true }`:
+Examples of **correct** code for this rule with `"never"` and `{ "enforceForClassMembers": true }` (default):
 
 ```js
 /*eslint computed-property-spacing: ["error", "never", { "enforceForClassMembers": true }]*/
@@ -135,6 +131,26 @@ const Bar = class {
   static [b]() {}
   static get [c]() {}
   static set [c](value) {}
+}
+```
+
+Examples of **correct** code for this rule with `"never"` and `{ "enforceForClassMembers": false }`:
+
+```js
+/*eslint computed-property-spacing: ["error", "never", { "enforceForClassMembers": false }]*/
+/*eslint-env es6*/
+
+class Foo {
+  [a ]() {}
+  get [b ]() {}
+  set [b ](value) {}
+}
+
+const Bar = class {
+  [ a](){}
+  static [ b]() {}
+  static get [ c ]() {}
+  static set [ c ](value) {}
 }
 ```
 

--- a/lib/rules/computed-property-spacing.js
+++ b/lib/rules/computed-property-spacing.js
@@ -32,7 +32,7 @@ module.exports = {
                 properties: {
                     enforceForClassMembers: {
                         type: "boolean",
-                        default: false
+                        default: true
                     }
                 },
                 additionalProperties: false
@@ -51,7 +51,7 @@ module.exports = {
     create(context) {
         const sourceCode = context.getSourceCode();
         const propertyNameMustBeSpaced = context.options[0] === "always"; // default is "never"
-        const enforceForClassMembers = context.options[1] && context.options[1].enforceForClassMembers;
+        const enforceForClassMembers = !context.options[1] || context.options[1].enforceForClassMembers;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/tests/lib/rules/computed-property-spacing.js
+++ b/tests/lib/rules/computed-property-spacing.js
@@ -78,37 +78,6 @@ ruleTester.run("computed-property-spacing", rule, {
         // Classes
         //------------------------------------------------------------------------------
 
-        // test default settings
-        {
-            code: "class A { [ a ](){} }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }",
-            options: ["never"],
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "A = class { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }",
-            options: ["never", {}],
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "A = class { [a](){} }",
-            options: ["always"],
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "A = class { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }",
-            options: ["always"],
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }",
-            options: ["always", {}],
-            parserOptions: { ecmaVersion: 6 }
-        },
-
         // explicitly disabled option
         {
             code: "class A { [ a ](){} }",
@@ -664,6 +633,523 @@ ruleTester.run("computed-property-spacing", rule, {
                     column: 11,
                     endLine: 1,
                     endColumn: 12
+                }
+            ]
+        },
+
+        // test default settings for classes
+        {
+            code: "class A { [ a ](){} }",
+            output: "class A { [a](){} }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 13
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 14,
+                    endLine: 1,
+                    endColumn: 15
+                }
+            ]
+        },
+        {
+            code: "class A { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }",
+            output: "class A { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 13
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 14,
+                    endLine: 1,
+                    endColumn: 15
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 26,
+                    endLine: 1,
+                    endColumn: 27
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 28,
+                    endLine: 1,
+                    endColumn: 29
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 40,
+                    endLine: 1,
+                    endColumn: 41
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 42,
+                    endLine: 1,
+                    endColumn: 43
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 60,
+                    endLine: 1,
+                    endColumn: 61
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 62,
+                    endLine: 1,
+                    endColumn: 63
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 81,
+                    endLine: 1,
+                    endColumn: 82
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 83,
+                    endLine: 1,
+                    endColumn: 84
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 102,
+                    endLine: 1,
+                    endColumn: 103
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 104,
+                    endLine: 1,
+                    endColumn: 105
+                }
+            ]
+        },
+        {
+            code: "A = class { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }",
+            output: "A = class { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }",
+            options: ["never", {}],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 14,
+                    endLine: 1,
+                    endColumn: 15
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 16,
+                    endLine: 1,
+                    endColumn: 17
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 28,
+                    endLine: 1,
+                    endColumn: 29
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 30,
+                    endLine: 1,
+                    endColumn: 31
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 42,
+                    endLine: 1,
+                    endColumn: 43
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 44,
+                    endLine: 1,
+                    endColumn: 45
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 62,
+                    endLine: 1,
+                    endColumn: 63
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 64,
+                    endLine: 1,
+                    endColumn: 65
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 83,
+                    endLine: 1,
+                    endColumn: 84
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 85,
+                    endLine: 1,
+                    endColumn: 86
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 104,
+                    endLine: 1,
+                    endColumn: 105
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 106,
+                    endLine: 1,
+                    endColumn: 107
+                }
+            ]
+        },
+        {
+            code: "A = class { [a](){} }",
+            output: "A = class { [ a ](){} }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 13,
+                    endLine: 1,
+                    endColumn: 14
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 15,
+                    endLine: 1,
+                    endColumn: 16
+                }
+            ]
+        },
+        {
+            code: "A = class { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }",
+            output: "A = class { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 13,
+                    endLine: 1,
+                    endColumn: 14
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 15,
+                    endLine: 1,
+                    endColumn: 16
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 25,
+                    endLine: 1,
+                    endColumn: 26
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 27,
+                    endLine: 1,
+                    endColumn: 28
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 37,
+                    endLine: 1,
+                    endColumn: 38
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 39,
+                    endLine: 1,
+                    endColumn: 40
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 55,
+                    endLine: 1,
+                    endColumn: 56
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 57,
+                    endLine: 1,
+                    endColumn: 58
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 74,
+                    endLine: 1,
+                    endColumn: 75
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 76,
+                    endLine: 1,
+                    endColumn: 77
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 93,
+                    endLine: 1,
+                    endColumn: 94
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 95,
+                    endLine: 1,
+                    endColumn: 96
+                }
+            ]
+        },
+        {
+            code: "class A { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }",
+            output: "class A { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }",
+            options: ["always", {}],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 13,
+                    endLine: 1,
+                    endColumn: 14
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 23,
+                    endLine: 1,
+                    endColumn: 24
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 25,
+                    endLine: 1,
+                    endColumn: 26
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 35,
+                    endLine: 1,
+                    endColumn: 36
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 37,
+                    endLine: 1,
+                    endColumn: 38
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 53,
+                    endLine: 1,
+                    endColumn: 54
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 55,
+                    endLine: 1,
+                    endColumn: 56
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 72,
+                    endLine: 1,
+                    endColumn: 73
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 74,
+                    endLine: 1,
+                    endColumn: 75
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 91,
+                    endLine: 1,
+                    endColumn: 92
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 93,
+                    endLine: 1,
+                    endColumn: 94
                 }
             ]
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

fixes #12812

Rule: `computed-property-spacing`.

This PR changes  `enforceForClassMembers` option's default value to `true`.

The rule will now by default apply to classes, too.

#### What changes did you make? (Give an overview)

Changed default value and updated documentation.

#### Is there anything you'd like reviewers to focus on?
