### PR TITLE
Breaking: classes default `true` in accessor-pairs (fixes #12811)

### DIFF
--- a/docs/rules/accessor-pairs.md
+++ b/docs/rules/accessor-pairs.md
@@ -32,14 +32,13 @@ This rule enforces a style where it requires to have a getter for every property
 
 By activating the option `getWithoutSet` it enforces the presence of a setter for every property which has a getter defined.
 
-By default, this rule checks only object literals and property descriptors. If you want this rule
-to also check class declarations and class expressions, activate the option `enforceForClassMembers`.
+This rule always checks object literals and property descriptors. By default, it also checks class declarations and class expressions.
 
 ## Options
 
 * `setWithoutGet` set to `true` will warn for setters without getters (Default `true`).
 * `getWithoutSet` set to `true` will warn for getters without setters (Default `false`).
-* `enforceForClassMembers` set to `true` additionally applies this rule to class getters/setters (Default `false`).
+* `enforceForClassMembers` set to `true` additionally applies this rule to class getters/setters (Default `true`). Set `enforceForClassMembers` to `false` if you want this rule to ignore class declarations and class expressions.
 
 ### setWithoutGet
 
@@ -149,10 +148,7 @@ Object.defineProperty(o, 'c', {
 
 ### enforceForClassMembers
 
-By default, this rule does not enforce getter/setter pairs in class declarations and class expressions,
-as the default value for `enforceForClassMembers` is `false`.
-
-When `enforceForClassMembers` is set to `true`:
+When `enforceForClassMembers` is set to `true` (default):
 
 * `"getWithoutSet": true` will also warn for getters without setters in classes.
 * `"setWithoutGet": true` will also warn for setters without getters in classes.
@@ -201,6 +197,41 @@ const Bar = class {
     }
 }
 ```
+
+When `enforceForClassMembers` is set to `false`, this rule ignores classes.
+
+Examples of **correct** code for `{ "getWithoutSet": true, "setWithoutGet": true, "enforceForClassMembers": false }`:
+
+```js
+/*eslint accessor-pairs: ["error", {
+    "getWithoutSet": true, "setWithoutGet": true, "enforceForClassMembers": false
+}]*/
+
+class Foo {
+    get a() {
+        return this.val;
+    }
+}
+
+class Bar {
+    static set a(value) {
+        this.val = value;
+    }
+}
+
+const Baz = class {
+    static get a() {
+        return this.val;
+    }
+}
+
+const Quux = class {
+    set a(value) {
+        this.val = value;
+    }
+}
+```
+
 
 ## Known Limitations
 

--- a/lib/rules/accessor-pairs.js
+++ b/lib/rules/accessor-pairs.js
@@ -171,7 +171,7 @@ module.exports = {
                 },
                 enforceForClassMembers: {
                     type: "boolean",
-                    default: false
+                    default: true
                 }
             },
             additionalProperties: false
@@ -190,7 +190,7 @@ module.exports = {
         const config = context.options[0] || {};
         const checkGetWithoutSet = config.getWithoutSet === true;
         const checkSetWithoutGet = config.setWithoutGet !== false;
-        const enforceForClassMembers = config.enforceForClassMembers === true;
+        const enforceForClassMembers = config.enforceForClassMembers !== false;
         const sourceCode = context.getSourceCode();
 
         /**

--- a/tests/lib/rules/accessor-pairs.js
+++ b/tests/lib/rules/accessor-pairs.js
@@ -331,47 +331,8 @@ ruleTester.run("accessor-pairs", rule, {
 
         // Test default settings
         {
-            code: "class A { set a(foo) {} }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A { get a() {} set b(foo) {} }",
-            options: [{}],
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
             code: "class A { get a() {} }",
             options: [{ enforceForClassMembers: true }],
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A { get a() {} }",
-            options: [{ setWithoutGet: true, getWithoutSet: true }],
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A { set a(foo) {} }",
-            options: [{ setWithoutGet: true, getWithoutSet: true }],
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A { static get a() {} }",
-            options: [{ setWithoutGet: true, getWithoutSet: true }],
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A { static set a(foo) {} }",
-            options: [{ setWithoutGet: true, getWithoutSet: true }],
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "A = class { get a() {} };",
-            options: [{ setWithoutGet: true, getWithoutSet: true }],
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "A = class { get a() {} set b(foo) {} };",
-            options: [{ setWithoutGet: true, getWithoutSet: true }],
             parserOptions: { ecmaVersion: 6 }
         },
 
@@ -1132,6 +1093,56 @@ ruleTester.run("accessor-pairs", rule, {
         //------------------------------------------------------------------------------
 
         // Test default settings
+        {
+            code: "class A { set a(foo) {} }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Getter is not present for class setter 'a'.", type: "MethodDefinition" }]
+        },
+        {
+            code: "class A { get a() {} set b(foo) {} }",
+            options: [{}],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Getter is not present for class setter 'b'.", type: "MethodDefinition" }]
+        },
+        {
+            code: "class A { get a() {} }",
+            options: [{ setWithoutGet: true, getWithoutSet: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Setter is not present for class getter 'a'.", type: "MethodDefinition" }]
+        },
+        {
+            code: "class A { set a(foo) {} }",
+            options: [{ setWithoutGet: true, getWithoutSet: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Getter is not present for class setter 'a'.", type: "MethodDefinition" }]
+        },
+        {
+            code: "class A { static get a() {} }",
+            options: [{ setWithoutGet: true, getWithoutSet: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Setter is not present for class static getter 'a'.", type: "MethodDefinition" }]
+        },
+        {
+            code: "class A { static set a(foo) {} }",
+            options: [{ setWithoutGet: true, getWithoutSet: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Getter is not present for class static setter 'a'.", type: "MethodDefinition" }]
+        },
+        {
+            code: "A = class { get a() {} };",
+            options: [{ setWithoutGet: true, getWithoutSet: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Setter is not present for class getter 'a'.", type: "MethodDefinition" }]
+        },
+        {
+            code: "A = class { get a() {} set b(foo) {} };",
+            options: [{ setWithoutGet: true, getWithoutSet: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { message: "Setter is not present for class getter 'a'.", type: "MethodDefinition" },
+                { message: "Getter is not present for class setter 'b'.", type: "MethodDefinition" }
+            ]
+        },
         {
             code: "class A { set a(value) {} }",
             options: [{ enforceForClassMembers: true }],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

fixes #12811

Rule: `accessor-pairs`.

This PR changes  `enforceForClassMembers` option's default value to `true`.

The rule will now by default apply to classes, too.

#### What changes did you make? (Give an overview)

Changed default value and updated documentation.

#### Is there anything you'd like reviewers to focus on?
