### PR TITLE
Update: func-names `as-needed` false negative with AssignmentPattern

### DIFF
--- a/lib/rules/func-names.js
+++ b/lib/rules/func-names.js
@@ -119,7 +119,7 @@ module.exports = {
                 (parent.type === "VariableDeclarator" && parent.id.type === "Identifier" && parent.init === node) ||
                 (parent.type === "Property" && parent.value === node) ||
                 (parent.type === "AssignmentExpression" && parent.left.type === "Identifier" && parent.right === node) ||
-                (parent.type === "AssignmentPattern" && parent.right === node);
+                (parent.type === "AssignmentPattern" && parent.left.type === "Identifier" && parent.right === node);
         }
 
         /**

--- a/tests/lib/rules/func-names.js
+++ b/tests/lib/rules/func-names.js
@@ -393,6 +393,54 @@ ruleTester.run("func-names", rule, {
             }]
         },
         {
+            code: "({ a: obj.prop = function(){} } = foo);",
+            options: ["as-needed"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unnamed",
+                type: "FunctionExpression",
+                line: 1,
+                column: 18,
+                endColumn: 26
+            }]
+        },
+        {
+            code: "[obj.prop = function(){}] = foo;",
+            options: ["as-needed"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unnamed",
+                type: "FunctionExpression",
+                line: 1,
+                column: 13,
+                endColumn: 21
+            }]
+        },
+        {
+            code: "var { a: [b] = function(){} } = foo;",
+            options: ["as-needed"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unnamed",
+                type: "FunctionExpression",
+                line: 1,
+                column: 16,
+                endColumn: 24
+            }]
+        },
+        {
+            code: "function foo({ a } = function(){}) {};",
+            options: ["as-needed"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unnamed",
+                type: "FunctionExpression",
+                line: 1,
+                column: 22,
+                endColumn: 30
+            }]
+        },
+        {
             code: "var x = function foo() {};",
             options: ["never"],
             errors: [{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

This bug fix produces **more** warnings.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.0.0-alpha.1
* **Node Version:** v12.14.0
* **npm Version:** v6.13.4

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: 2015
    }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IGZ1bmMtbmFtZXM6IFtcImVycm9yXCIsIFwiYXMtbmVlZGVkXCJdICovXG5cbltvYmoucHJvcCA9IGZ1bmN0aW9uKCl7fV0gPSBmb287XG5cbih7IGE6IG9iai5wcm9wID0gZnVuY3Rpb24oKXt9IH0gPSBmb28pOyIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js
/* eslint func-names: ["error", "as-needed"] */

[obj.prop = function(){}] = foo;

({ a: obj.prop = function(){} } = foo);
```

**What did you expect to happen?**

2 errors.

> "as-needed" requires function expressions to have a name, if the name cannot be assigned automatically in an ES6 environment

By the [ES6 specification](http://www.ecma-international.org/ecma-262/6.0/), in all cases where the function is estree's `AssigmentPattern#right`, [SetFunctionName](http://www.ecma-international.org/ecma-262/6.0/#sec-setfunctionname) is called only when estree's `AssigmentPattern#left` is `Identifier`:

* [DestructuringAssignmentEvaluation](http://www.ecma-international.org/ecma-262/6.0/#sec-runtime-semantics-destructuringassignmentevaluation) (_AssignmentProperty : IdentifierReference Initializer_)
* [IteratorDestructuringAssignmentEvaluation](http://www.ecma-international.org/ecma-262/6.0/#sec-runtime-semantics-iteratordestructuringassignmentevaluation) (_AssignmentElement: DestructuringAssignmentTarget Initializer_ has _IsIdentifierRef_ condition).
* [KeyedDestructuringAssignmentEvaluation](http://www.ecma-international.org/ecma-262/6.0/#sec-runtime-semantics-keyeddestructuringassignmentevaluation) (same as previous).
* [IteratorBindingInitialization](http://www.ecma-international.org/ecma-262/6.0/#sec-destructuring-binding-patterns-runtime-semantics-iteratorbindinginitialization) (_SingleNameBinding : BindingIdentifier Initializer_)
* [KeyedBindingInitialization](http://www.ecma-international.org/ecma-262/6.0/#sec-runtime-semantics-keyedbindinginitialization) (same as previous)

**What actually happened? Please include the actual, raw output from ESLint.**

no errors

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`hasInferredName` will return `true` for a function that is `right` of an `AssignmentPattern` only if its `left` is `Identifier`.

#### Is there anything you'd like reviewers to focus on?
