### PR TITLE
Fix: [no-duplicate-imports] ignore namespace imports (fixes #12758)

### DIFF
--- a/docs/rules/no-duplicate-imports.md
+++ b/docs/rules/no-duplicate-imports.md
@@ -12,7 +12,9 @@ import { find } from 'module';
 
 ## Rule Details
 
-This rule requires that all imports from a single module exists in a single `import` statement.
+an import that can be merged with another is a duplicate of that other
+
+This rule requires that all imports from a single module that can be merged exists in a single `import` statement.
 
 Example of **incorrect** code for this rule:
 
@@ -30,6 +32,16 @@ Example of **correct** code for this rule:
 /*eslint no-duplicate-imports: "error"*/
 
 import { merge, find } from 'module';
+import something from 'another-module';
+```
+
+Example of **correct** code for this rule (namespace imports can't be merged):
+
+```js
+/*eslint no-duplicate-imports: "error"*/
+
+import * as Namespace from 'module';
+import { merge } from 'module';
 import something from 'another-module';
 ```
 

--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -22,6 +22,20 @@ function getValue(node) {
 }
 
 /**
+ * Checks if the import's type is a namespace import.
+ * @param {ASTNode} node A node to get.
+ *
+ * @returns {boolean} Whether or not the import's type is "ImportNamespaceSpecifier".
+ */
+function isNamespaceImport(node) {
+    return (
+        node.specifiers &&
+        node.specifiers[0] &&
+        node.specifiers[0].type === "ImportNamespaceSpecifier"
+    );
+}
+
+/**
  * Checks if the name of the import or export exists in the given array, and reports if so.
  * @param {RuleContext} context The ESLint rule context object.
  * @param {ASTNode} node A node to get.
@@ -61,7 +75,7 @@ function handleImports(context, includeExports, importsInFile, exportsInFile) {
     return function(node) {
         const value = getValue(node);
 
-        if (value) {
+        if (value && !isNamespaceImport(node)) {
             checkAndReport(context, node, value, importsInFile, "import");
 
             if (includeExports) {

--- a/tests/lib/rules/no-duplicate-imports.js
+++ b/tests/lib/rules/no-duplicate-imports.js
@@ -20,6 +20,7 @@ const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6, sourceType:
 
 ruleTester.run("no-duplicate-imports", rule, {
     valid: [
+        "import * as Lodash from \"lodash-es\";import { merge } from \"lodash-es\";;",
         "import os from \"os\";\nimport fs from \"fs\";",
         "import { merge } from \"lodash-es\";",
         "import _, { merge } from \"lodash-es\";",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Solve [this issue](https://github.com/eslint/eslint/issues/12758).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Fix a bug on [no-duplicate-imports] rule.
It shouldn't throw an error when the duplicated import is a namespace import such as `import * as Namespace from 'module'`


**What did you do? Please include the actual source code causing the issue.**
Fix a bug on [no-duplicate-imports] rule.

**What did you expect to happen?**
It shouldn't throw an error when the duplicated import is a namespace import such as `import * as namespace from 'module'`. Because namespace imports can't be merged.

Example of correct code:
```js
import { anotherValue } from 'parsers';
import * as parsers1 from 'parsers';
```

**What actually happened? Please include the actual, raw output from ESLint.**
It was considered as incorrect.

#### Is there anything you'd like reviewers to focus on?
I'm wondering if it could be helpful to extract `isNamespaceImport()` function's content inside an util. WDYT?

Transforming it a bit to be more generic, it should look like this:
```js
/**
 * Checks the specifier's type.
 * @param {ASTNode} node A node to check.
 * @param {string} the type of the import we want to check .
 *
 * @returns {boolean} Whether or not the specifier's type matchs the "type" param.
 */
function checkSpecifierType(node, type) {
    return (
        node.specifiers &&
        node.specifiers[0] &&
        node.specifiers[0].type === type 
    );
}
```