### PR TITLE
Fix: curly removes necessary braces between if and else (fixes #12928)

### DIFF
--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -336,6 +336,89 @@ ruleTester.run("curly", rule, {
             // https://github.com/feross/standard/issues/664
             code: "if (true) foo()\n;[1, 2, 3].bar()",
             options: ["multi-line"]
+        },
+
+        // https://github.com/eslint/eslint/issues/12928 (also in invalid[])
+        {
+            code: "if (x) for (var i in x) { if (i > 0) console.log(i); } else console.log('whoops');",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) { if (b) foo(); } else bar();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) { if (b) foo(); } else bar();",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "if (a) { if (b) foo(); } else { bar(); }",
+            options: ["multi", "consistent"]
+        },
+        {
+            code: "if (a) { if (b) foo(); } else { bar(); }",
+            options: ["multi-or-nest", "consistent"]
+        },
+        {
+            code: "if (a) { if (b) { foo(); bar(); } } else baz();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) foo(); else if (b) { if (c) bar(); } else baz();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) { if (b) foo(); else if (c) bar(); } else baz();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) if (b) foo(); else { if (c) bar(); } else baz();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) { lbl:if (b) foo(); } else bar();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) { lbl1:lbl2:if (b) foo(); } else bar();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) { for (;;) if (b) foo(); } else bar();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) { for (key in obj) if (b) foo(); } else bar();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) { for (elem of arr) if (b) foo(); } else bar();",
+            options: ["multi"],
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "if (a) { with (obj) if (b) foo(); } else bar();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) { while (cond) if (b) foo(); } else bar();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) { while (cond) for (;;) for (key in obj) if (b) foo(); } else bar();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) while (cond) { for (;;) for (key in obj) if (b) foo(); } else bar();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) while (cond) for (;;) { for (key in obj) if (b) foo(); } else bar();",
+            options: ["multi"]
+        },
+        {
+            code: "if (a) while (cond) for (;;) for (key in obj) { if (b) foo(); } else bar();",
+            options: ["multi"]
         }
     ],
     invalid: [
@@ -1091,6 +1174,114 @@ ruleTester.run("curly", rule, {
             output: "do \ndoSomething()\n;\n while (foo)",
             options: ["multi-or-nest"],
             errors: [{ messageId: "unexpectedCurlyAfter", data: { name: "do" }, type: "DoWhileStatement" }]
+        },
+
+        // https://github.com/eslint/eslint/issues/12928 (also in valid[])
+        {
+            code: "if (a) { if (b) foo(); }",
+            output: "if (a)  if (b) foo(); ",
+            options: ["multi"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (a) { if (b) foo(); else bar(); }",
+            output: "if (a)  if (b) foo(); else bar(); ",
+            options: ["multi"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (a) { if (b) foo(); else bar(); } baz();",
+            output: "if (a)  if (b) foo(); else bar();  baz();",
+            options: ["multi"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (a) { while (cond) if (b) foo(); }",
+            output: "if (a)  while (cond) if (b) foo(); ",
+            options: ["multi"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (a) while (cond) { if (b) foo(); }",
+            output: "if (a) while (cond)  if (b) foo(); ",
+            options: ["multi"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "while" }, type: "WhileStatement" }]
+        },
+        {
+            code: "if (a) while (cond) { if (b) foo(); else bar(); }",
+            output: "if (a) while (cond)  if (b) foo(); else bar(); ",
+            options: ["multi"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "while" }, type: "WhileStatement" }]
+        },
+        {
+            code: "if (a) { while (cond) { if (b) foo(); } bar(); baz() } else quux();",
+            output: "if (a) { while (cond)  if (b) foo();  bar(); baz() } else quux();",
+            options: ["multi"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "while" }, type: "WhileStatement" }]
+        },
+        {
+            code: "if (a) { if (b) foo(); } bar();",
+            output: "if (a)  if (b) foo();  bar();",
+            options: ["multi"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if(a) { if (b) foo(); } if (c) bar(); else baz();",
+            output: "if(a)  if (b) foo();  if (c) bar(); else baz();",
+            options: ["multi-or-nest"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (a) { do if (b) foo(); while (cond); } else bar();",
+            output: "if (a)  do if (b) foo(); while (cond);  else bar();",
+            options: ["multi"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (a) do { if (b) foo(); } while (cond); else bar();",
+            output: "if (a) do  if (b) foo();  while (cond); else bar();",
+            options: ["multi"],
+            errors: [{ messageId: "unexpectedCurlyAfter", data: { name: "do" }, type: "DoWhileStatement" }]
+        },
+        {
+            code: "if (a) { if (b) foo(); else bar(); } else baz();",
+            output: "if (a)  if (b) foo(); else bar();  else baz();",
+            options: ["multi"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (a) while (cond) { bar(); } else baz();",
+            output: "if (a) while (cond)  bar();  else baz();",
+            options: ["multi"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "while" }, type: "WhileStatement" }]
+        },
+        {
+            code: "if (a) { for (;;); } else bar();",
+            output: "if (a)  for (;;);  else bar();",
+            options: ["multi"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (a) { while (cond) if (b) foo() } else bar();",
+            output: "if (a) { while (cond) if (b) foo() } else {bar();}",
+            options: ["multi", "consistent"],
+            errors: [{ messageId: "missingCurlyAfter", data: { name: "else" }, type: "IfStatement" }]
+        },
+        {
+
+            /**
+             * Reports 2 errors, but one pair of braces is necessary if the other pair gets removed.
+             * Auto-fix will remove only outer braces in the first iteration.
+             * After that, the inner braces will become valid and won't be removed in the second iteration.
+             * If user manually removes inner braces first, the outer braces will become valid.
+             */
+            code: "if (a) { while (cond) { if (b) foo(); } } else bar();",
+            output: "if (a)  while (cond) { if (b) foo(); }  else bar();",
+            options: ["multi"],
+            errors: [
+                { messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" },
+                { messageId: "unexpectedCurlyAfterCondition", data: { name: "while" }, type: "WhileStatement" }
+            ]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

Fixes #12928

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Implemented a more generic check than the existing `requiresBraceOfConsequent`, to account for more cases when an `if` can become associated with an unrelated `else`.

#### Is there anything you'd like reviewers to focus on?

In the following case, the rule will still report 2 errors although only 1 pair of braces can be removed:

```js
/* eslint curly: ["error", "multi"] */

if (a) {
    while (b) { 
        if (c) foo(); 
    }  
} else 
    bar();
```

Auto-fix will remove the outer braces only. After that, the inner braces will become valid.

User can manually remove either of these. After that, the error for the other braces will disappear.