### PR TITLE
Update: curly should check consequent `if` statements

### DIFF
--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -373,11 +373,18 @@ module.exports = {
 
         return {
             IfStatement(node) {
-                if (node.parent.type !== "IfStatement") {
+                const parent = node.parent;
+                const isElseIf = parent.type === "IfStatement" && parent.alternate === node;
+
+                if (!isElseIf) {
+
+                    // This is a top `if`, check the whole `if-else-if` chain
                     prepareIfChecks(node).forEach(preparedCheck => {
                         preparedCheck.check();
                     });
                 }
+
+                // Skip `else if`, it's already checked (when the top `if` was visited)
             },
 
             WhileStatement(node) {

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -453,6 +453,30 @@ ruleTester.run("curly", rule, {
             ]
         },
         {
+            code: "if (foo) if (bar) { baz() }",
+            output: "if (foo) if (bar)  baz() ",
+            options: ["multi"],
+            errors: [
+                {
+                    messageId: "unexpectedCurlyAfterCondition",
+                    data: { name: "if" },
+                    type: "IfStatement"
+                }
+            ]
+        },
+        {
+            code: "if (foo) if (bar) baz(); else if (quux) { quuux(); }",
+            output: "if (foo) if (bar) baz(); else if (quux)  quuux(); ",
+            options: ["multi"],
+            errors: [
+                {
+                    messageId: "unexpectedCurlyAfterCondition",
+                    data: { name: "if" },
+                    type: "IfStatement"
+                }
+            ]
+        },
+        {
             code: "while (foo) { bar() }",
             output: "while (foo)  bar() ",
             options: ["multi"],
@@ -467,6 +491,18 @@ ruleTester.run("curly", rule, {
         {
             code: "if (foo) baz(); else { bar() }",
             output: "if (foo) baz(); else  bar() ",
+            options: ["multi"],
+            errors: [
+                {
+                    messageId: "unexpectedCurlyAfter",
+                    data: { name: "else" },
+                    type: "IfStatement"
+                }
+            ]
+        },
+        {
+            code: "if (foo) if (bar); else { baz() }",
+            output: "if (foo) if (bar); else  baz() ",
             options: ["multi"],
             errors: [
                 {
@@ -891,6 +927,18 @@ ruleTester.run("curly", rule, {
                     data: { name: "if" },
                     type: "IfStatement"
                 },
+                {
+                    messageId: "missingCurlyAfterCondition",
+                    data: { name: "if" },
+                    type: "IfStatement"
+                }
+            ]
+        },
+        {
+            code: "if (true) if (true) foo(); else { bar(); baz(); }",
+            output: "if (true) if (true) {foo();} else { bar(); baz(); }",
+            options: ["multi", "consistent"],
+            errors: [
                 {
                     messageId: "missingCurlyAfterCondition",
                     data: { name: "if" },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

This bug fix produces **more** warnings.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.0.0-alpha.1
* **Node Version:** v12.14.0
* **npm Version:** v6.13.4

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: 2015
    }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IGN1cmx5OiBbXCJlcnJvclwiLCBcIm11bHRpXCJdICovXG5cbmlmIChhKVxuICAgIGlmIChiKSB7XG4gICAgICAgIGZvbygpO1xuICAgIH1cblxuaWYgKGEpXG4gICAgaWYgKGIpXG4gICAgICAgIGZvbygpO1xuICAgIGVsc2Uge1xuICAgICAgICBiYXIoKTtcbiAgICB9IFxuXG5pZiAoYSlcbiAgICBpZiAoYilcbiAgICAgICAgZm9vKCk7XG4gICAgZWxzZSBpZiAoYykge1xuICAgICAgICBiYXIoKTtcbiAgICB9Iiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo2LCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7fSwiZW52Ijp7fX19) (v.6.8.0)

```js
/* eslint curly: ["error", "multi"] */

if (a)
    if (b) {
        foo();
    }

if (a)
    if (b)
        foo();
    else {
        bar();
    } 

if (a)
    if (b)
        foo();
    else if (c) {
        bar();
    }
```

**What did you expect to happen?**

3 errors.

**What actually happened? Please include the actual, raw output from ESLint.**

No errors.

The whole chain is ignored if it happens to be in another if's consequent.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `IfStatement` visitor to skip only those `if` statements that are `alternate` of another `if` (because they were already processed as a chain), but not `if` statements that are `consequent` of another `if`.

#### Is there anything you'd like reviewers to focus on?
