### PR TITLE
Fix: Newline before eof when creating config via --init

### DIFF
--- a/lib/init/config-file.js
+++ b/lib/init/config-file.js
@@ -45,7 +45,7 @@ function sortByKey(a, b) {
 function writeJSONConfigFile(config, filePath) {
     debug(`Writing JSON config file: ${filePath}`);
 
-    const content = stringify(config, { cmp: sortByKey, space: 4 });
+    const content = `${stringify(config, { cmp: sortByKey, space: 4 })}\n`;
 
     fs.writeFileSync(filePath, content, "utf8");
 }
@@ -80,7 +80,7 @@ function writeJSConfigFile(config, filePath) {
     debug(`Writing JS config file: ${filePath}`);
 
     let contentToWrite;
-    const stringifiedContent = `module.exports = ${stringify(config, { cmp: sortByKey, space: 4 })};`;
+    const stringifiedContent = `module.exports = ${stringify(config, { cmp: sortByKey, space: 4 })};\n`;
 
     try {
         const { CLIEngine } = require("../cli-engine");

--- a/tests/lib/init/config-file.js
+++ b/tests/lib/init/config-file.js
@@ -71,7 +71,7 @@ describe("ConfigFile", () => {
 
                 sinon.mock(fakeFS).expects("writeFileSync").withExactArgs(
                     filename,
-                    sinon.match(value => !!validate(value)),
+                    sinon.match(value => !!validate(value) && value.endsWith("\n")),
                     "utf8"
                 );
 
@@ -81,7 +81,6 @@ describe("ConfigFile", () => {
 
                 StubbedConfigFile.write(config, filename);
             });
-
         });
 
         it("should make sure js config files match linting rules", () => {

--- a/tests/lib/init/config-file.js
+++ b/tests/lib/init/config-file.js
@@ -71,7 +71,23 @@ describe("ConfigFile", () => {
 
                 sinon.mock(fakeFS).expects("writeFileSync").withExactArgs(
                     filename,
-                    sinon.match(value => !!validate(value) && value.endsWith("\n")),
+                    sinon.match(value => !!validate(value)),
+                    "utf8"
+                );
+
+                const StubbedConfigFile = proxyquire("../../../lib/init/config-file", {
+                    fs: fakeFS
+                });
+
+                StubbedConfigFile.write(config, filename);
+            });
+
+            it("should include a newline character at EOF", () => {
+                const fakeFS = leche.fake(fs);
+
+                sinon.mock(fakeFS).expects("writeFileSync").withExactArgs(
+                    filename,
+                    sinon.match(value => value.endsWith("\n")),
                     "utf8"
                 );
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [ ] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Include a newline character before EOF when writing out a .js or .json-based config in `eslint --init`. Previously only the .yaml mode did this.
