### PR TITLE
Fix markdown for the issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/NEW_RULE.md
+++ b/.github/ISSUE_TEMPLATE/NEW_RULE.md
@@ -24,10 +24,10 @@ assignees: ''
 
 **What category of rule is this? (place an "X" next to just one item)**
 
-[ ] Warns about a potential error (problem)
-[ ] Suggests an alternate way of doing something (suggestion)
-[ ] Enforces code style (layout)
-[ ] Other (please specify:)
+- [ ] Warns about a potential error (problem)
+- [ ] Suggests an alternate way of doing something (suggestion)
+- [ ] Enforces code style (layout)
+- [ ] Other (please specify:)
 
 **Provide 2-3 code examples that this rule will warn about:**
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,14 +11,14 @@
 
 #### What is the purpose of this pull request? (put an "X" next to an item)
 
-[ ] Documentation update
-[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
-[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
-[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
-[ ] Add autofixing to a rule
-[ ] Add a CLI option
-[ ] Add something to the core
-[ ] Other, please explain:
+- [ ] Documentation update
+- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
+- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
+- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
+- [ ] Add autofixing to a rule
+- [ ] Add a CLI option
+- [ ] Add something to the core
+- [ ] Other, please explain:
 
 <!--
     If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)


### PR DESCRIPTION
So that the checkboxes are rendered correctly.

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [ ] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

When opening another PR I noticed that a bunch of lines starting with `[ ]` that came from the github PR template weren't properly rendered as a list of checkboxes. I changed the templates so they do :hugs:
