### PR TITLE
Update: Allows for grouped sort-imports (fixes #12951)

### DIFF
--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -36,6 +36,7 @@ This rule accepts an object with its properties as
 * `ignoreCase` (default: `false`)
 * `ignoreDeclarationSort` (default: `false`)
 * `ignoreMemberSort` (default: `false`)
+* `ignoreBlankLines` (default: `true`)
 * `memberSyntaxSortOrder` (default: `["none", "all", "multiple", "single"]`); all 4 items must be present in the array, but you can change the order:
     * `none` = import module without exported bindings.
     * `all` = import all members provided by exported bindings.
@@ -50,6 +51,7 @@ Default option settings are:
         "ignoreCase": false,
         "ignoreDeclarationSort": false,
         "ignoreMemberSort": false,
+        "ignoreBlankLines": true,
         "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
     }]
 }
@@ -84,6 +86,13 @@ import c from 'qux.js';
 
 /*eslint sort-imports: "error"*/
 import {a, b, c} from 'foo.js'
+
+/*eslint sort-imports: "error"*/
+import a from 'bar.js';
+
+import b from 'foo.js';
+
+import c from 'baz.js';
 ```
 
 Examples of **incorrect** code for this rule when using default options:
@@ -91,6 +100,11 @@ Examples of **incorrect** code for this rule when using default options:
 ```js
 /*eslint sort-imports: "error"*/
 import b from 'foo.js';
+import a from 'bar.js';
+
+/*eslint sort-imports: "error"*/
+import b from 'foo.js';
+
 import a from 'bar.js';
 
 /*eslint sort-imports: "error"*/
@@ -185,6 +199,45 @@ import {b, a, c} from 'foo.js'
 ```
 
 Default is `false`.
+
+### `ignoreBlankLines`
+
+When `true` the rule ignores the blank lines between the imports.
+
+Examples of **incorrect** code for this rule with the default `{ "ignoreBlankLines": true }` option:
+
+```js
+/*eslint sort-imports: ["error", { "ignoreBlankLines": true }]*/
+import b from 'foo.js'
+
+import a from 'bar.js'
+
+
+/*eslint sort-imports: ["error", { "ignoreBlankLines": true }]*/
+import b from 'foo.js';
+import c from 'baz.js';
+
+import a from 'bar.js';
+import x from 'qux.js';
+```
+
+Examples of **correct** code for this rule with the `{ "ignoreBlankLines": false }` option:
+
+```js
+/*eslint sort-imports: ["error", { "ignoreDeclarationSort": true }]*/
+import b from 'bar.js'
+
+import a from 'foo.js'
+
+/*eslint sort-imports: ["error", { "ignoreBlankLines": false }]*/
+import b from 'foo.js';
+import c from 'baz.js';
+
+import a from 'bar.js';
+import x from 'qux.js';
+```
+
+Default is `true`.
 
 ### `memberSyntaxSortOrder`
 

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -44,6 +44,10 @@ module.exports = {
                     ignoreMemberSort: {
                         type: "boolean",
                         default: false
+                    },
+                    ignoreBlankLines: {
+                        type: "boolean",
+                        default: true
                     }
                 },
                 additionalProperties: false
@@ -65,6 +69,7 @@ module.exports = {
             ignoreCase = configuration.ignoreCase || false,
             ignoreDeclarationSort = configuration.ignoreDeclarationSort || false,
             ignoreMemberSort = configuration.ignoreMemberSort || false,
+            ignoreBlankLines = configuration.ignoreBlankLines !== false,
             memberSyntaxSortOrder = configuration.memberSyntaxSortOrder || ["none", "all", "multiple", "single"],
             sourceCode = context.getSourceCode();
         let previousDeclaration = null;
@@ -112,7 +117,16 @@ module.exports = {
                 return node.specifiers[0].local.name;
             }
             return null;
+        }
 
+        /**
+         * Gets the number of lines between the given declarations.
+         * @param {ASTNode} node1 the ImportDeclaration node.
+         * @param {ASTNode} node2 the ImportDeclaration node.
+         * @returns {number} number of lines.
+         */
+        function getLinesBetweenMembers(node1, node2) {
+            return node1.loc.start.line - node2.loc.end.line - 1;
         }
 
         return {
@@ -120,7 +134,8 @@ module.exports = {
                 if (!ignoreDeclarationSort) {
                     if (previousDeclaration) {
                         const currentMemberSyntaxGroupIndex = getMemberParameterGroupIndex(node),
-                            previousMemberSyntaxGroupIndex = getMemberParameterGroupIndex(previousDeclaration);
+                            previousMemberSyntaxGroupIndex = getMemberParameterGroupIndex(previousDeclaration),
+                            linesBetweenMembers = getLinesBetweenMembers(node, previousDeclaration);
                         let currentLocalMemberName = getFirstLocalMemberName(node),
                             previousLocalMemberName = getFirstLocalMemberName(previousDeclaration);
 
@@ -148,7 +163,8 @@ module.exports = {
                         } else {
                             if (previousLocalMemberName &&
                                 currentLocalMemberName &&
-                                currentLocalMemberName < previousLocalMemberName
+                                currentLocalMemberName < previousLocalMemberName &&
+                                (ignoreBlankLines || linesBetweenMembers < 1)
                             ) {
                                 context.report({
                                     node,

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -101,7 +101,17 @@ ruleTester.run("sort-imports", rule, {
         },
 
         // https://github.com/eslint/eslint/issues/5305
-        "import React, {Component} from 'react';"
+        "import React, {Component} from 'react';",
+
+        // https://github.com/eslint/eslint/issues/12951
+        {
+            code:
+                "import b from 'foo.js';\n\n" +
+                "import a from 'bar.js';",
+            options: [{
+                ignoreBlankLines: false
+            }]
+        }
     ],
     invalid: [
         {
@@ -287,6 +297,15 @@ ruleTester.run("sort-imports", rule, {
                 data: { memberName: "qux" },
                 type: "ImportSpecifier"
             }]
+        },
+
+        // https://github.com/eslint/eslint/issues/12951
+        {
+            code:
+                "import b from 'foo.js';\n\n" +
+                "import a from 'bar.js';",
+            output: null,
+            errors: [expectedError]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [ ] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

- [x] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
I've added a new option to the `sort-imports` rule, called `ignoreBlankLines`, which is `true` by default. When set to `false`, the alphabetical sort error will be surpassed if there is a blank line before the statement. Meaning that there could be grouped imports, like mentioned in the [issue](https://github.com/eslint/eslint/issues/12951).

#### Is there anything you'd like reviewers to focus on?
Maybe the default to `true` option could be done better, but the tests are working nice, so I suppose it's fine.
