### PR TITLE
Chore: update space-before-function-paren in eslint-config-eslint

### DIFF
--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -188,7 +188,11 @@ rules:
     semi-spacing: ["error", {before: false, after: true}]
     semi-style: "error"
     space-before-blocks: "error"
-    space-before-function-paren: ["error", "never"]
+    space-before-function-paren: ["error", {
+        "anonymous": "never",
+        "named": "never",
+        "asyncArrow": "always"
+    }]
     space-in-parens: "error"
     space-infix-ops: "error"
     space-unary-ops: ["error", {words: true, nonwords: false}]

--- a/tests/lib/cli-engine/cascading-config-array-factory.js
+++ b/tests/lib/cli-engine/cascading-config-array-factory.js
@@ -160,7 +160,7 @@ describe("CascadingConfigArrayFactory", () => {
 
                 // no warning.
                 describe("when it lints 'subdir/exist-with-root/test.js'", () => {
-                    beforeEach(async() => {
+                    beforeEach(async () => {
                         config = factory.getConfigArrayForFile("exist-with-root/test.js");
                         await delay();
                     });
@@ -179,7 +179,7 @@ describe("CascadingConfigArrayFactory", () => {
 
                 // no warning.
                 describe("when it lints 'subdir/exist/test.js'", () => {
-                    beforeEach(async() => {
+                    beforeEach(async () => {
                         config = factory.getConfigArrayForFile("exist/test.js");
                         await delay();
                     });
@@ -198,7 +198,7 @@ describe("CascadingConfigArrayFactory", () => {
 
                 // no warning
                 describe("when it lints 'subdir/not-exist/test.js'", () => {
-                    beforeEach(async() => {
+                    beforeEach(async () => {
                         config = factory.getConfigArrayForFile("not-exist/test.js");
                         await delay();
                     });
@@ -240,7 +240,7 @@ describe("CascadingConfigArrayFactory", () => {
 
                 // Project's config file has `root:true`, then no warning.
                 describe("when it lints 'subdir/exist-with-root/test.js'", () => {
-                    beforeEach(async() => {
+                    beforeEach(async () => {
                         config = factory.getConfigArrayForFile("exist-with-root/test.js");
                         await delay();
                     });
@@ -259,7 +259,7 @@ describe("CascadingConfigArrayFactory", () => {
 
                 // Project's config file doesn't have `root:true` and home is ancestor, then ESLINT_PERSONAL_CONFIG_SUPPRESS.
                 describe("when it lints 'subdir/exist/test.js'", () => {
-                    beforeEach(async() => {
+                    beforeEach(async () => {
                         config = factory.getConfigArrayForFile("exist/test.js");
                         await delay();
                     });
@@ -286,7 +286,7 @@ describe("CascadingConfigArrayFactory", () => {
                  * In this case, ESLint will continue to use `~/.eslintrc.json` even if personal config file feature is removed.
                  */
                 describe("when it lints 'subdir/not-exist/test.js'", () => {
-                    beforeEach(async() => {
+                    beforeEach(async () => {
                         config = factory.getConfigArrayForFile("not-exist/test.js");
                         await delay();
                     });
@@ -328,7 +328,7 @@ describe("CascadingConfigArrayFactory", () => {
 
                 // Project's config file has `root:true`, then no warning.
                 describe("when it lints 'exist-with-root/test.js'", () => {
-                    beforeEach(async() => {
+                    beforeEach(async () => {
                         config = factory.getConfigArrayForFile("exist-with-root/test.js");
                         await delay();
                     });
@@ -347,7 +347,7 @@ describe("CascadingConfigArrayFactory", () => {
 
                 // Project's config file doesn't have `root:true` but home is not ancestor, then no warning.
                 describe("when it lints 'exist/test.js'", () => {
-                    beforeEach(async() => {
+                    beforeEach(async () => {
                         config = factory.getConfigArrayForFile("exist/test.js");
                         await delay();
                     });
@@ -366,7 +366,7 @@ describe("CascadingConfigArrayFactory", () => {
 
                 // Project's config file doesn't exist and home is not ancestor, then ESLINT_PERSONAL_CONFIG_LOAD.
                 describe("when it lints 'not-exist/test.js'", () => {
-                    beforeEach(async() => {
+                    beforeEach(async () => {
                         config = factory.getConfigArrayForFile("not-exist/test.js");
                         await delay();
                     });
@@ -407,7 +407,7 @@ describe("CascadingConfigArrayFactory", () => {
                 });
 
                 describe("when it lints 'subdir/exist/test.js'", () => {
-                    beforeEach(async() => {
+                    beforeEach(async () => {
                         config = factory.getConfigArrayForFile("exist/test.js");
                         await delay();
                     });
@@ -436,7 +436,7 @@ describe("CascadingConfigArrayFactory", () => {
                 });
 
                 describe("when it lints 'not-exist/test.js'", () => {
-                    beforeEach(async() => {
+                    beforeEach(async () => {
                         config = factory.getConfigArrayForFile("not-exist/test.js", { ignoreNotFoundError: true });
                         await delay();
                     });
@@ -1514,7 +1514,7 @@ describe("CascadingConfigArrayFactory", () => {
                     process.removeListener("warning", onWarning);
                 });
 
-                it("should emit a deprecation warning if 'ecmaFeatures' is given.", async() => {
+                it("should emit a deprecation warning if 'ecmaFeatures' is given.", async () => {
                     getConfig(factory, "ecma-features/test.js");
 
                     // Wait for "warning" event.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Updating `eslint-config-eslint`

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Working on https://github.com/eslint/eslint/pull/12939, I noticed that we currently enforce no spaces between the `async` keyword and the parens of an async arrow function.
This PR updates our `space-before-function-paren` configuration to require a space in this case (leaving everything else unchanged).

#### Is there anything you'd like reviewers to focus on?

We have a few existing cases of `async` arrow functions in our codebase, but they're all in our tests. Does this seem desirable to everyone? I personally find it easier to parse visually.

