### PR TITLE
Remove format assumptions from rule-tester deepClone/deepFreeze funct…

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -148,43 +148,17 @@ const friendlySuggestionObjectParameterList = `[${[...suggestionObjectParameters
 const hasOwnProperty = Function.call.bind(Object.hasOwnProperty);
 
 /**
- * Clones a given value deeply.
- * Note: This ignores `parent` property.
- * @param {any} x A value to clone.
- * @returns {any} A cloned value.
- */
-function cloneDeeplyExcludesParent(x) {
-    if (typeof x === "object" && x !== null) {
-        if (Array.isArray(x)) {
-            return x.map(cloneDeeplyExcludesParent);
-        }
-
-        const retv = {};
-
-        for (const key in x) {
-            if (key !== "parent" && hasOwnProperty(x, key)) {
-                retv[key] = cloneDeeplyExcludesParent(x[key]);
-            }
-        }
-
-        return retv;
-    }
-
-    return x;
-}
-
-/**
  * Freezes a given value deeply.
  * @param {any} x A value to freeze.
  * @returns {void}
  */
 function freezeDeeply(x) {
-    if (typeof x === "object" && x !== null) {
+    if (typeof x === "object" && x !== null && !Object.isFrozen(x)) {
         if (Array.isArray(x)) {
             x.forEach(freezeDeeply);
         } else {
             for (const key in x) {
-                if (key !== "parent" && hasOwnProperty(x, key)) {
+                if (hasOwnProperty(x, key)) {
                     freezeDeeply(x[key]);
                 }
             }
@@ -440,7 +414,7 @@ class RuleTester {
              */
             linter.defineRule("rule-tester/validate-ast", () => ({
                 Program(node) {
-                    beforeAST = cloneDeeplyExcludesParent(node);
+                    beforeAST = lodash.cloneDeep(node);
                 },
                 "Program:exit"(node) {
                     afterAST = node;
@@ -504,7 +478,7 @@ class RuleTester {
                 messages,
                 output,
                 beforeAST,
-                afterAST: cloneDeeplyExcludesParent(afterAST)
+                afterAST: lodash.cloneDeep(afterAST)
             };
         }
 


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What parser (default, Babel-ESLint, etc.) are you using?**
   > Any custom parser that introduces additional recursion in the AST (IE: not the "parent" key)

**What did you do? Please include the actual source code causing the issue.**
  > Used an AST format that introduced recursion on a key other than `parent`. 

**What did you expect to happen?**
  > Rule-tester execute without exception 

**What actually happened? Please include the actual, raw output from ESLint.**
  > A Stack Overflow exception

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Removed infinite recursion edge cases from rules-tester.js: 

1. Modified `freezeDeeply` to prevent infinite recursion by checking `Object.isFrozen()` instead of giving a special exception to the `parent` key. 
2. Replaced `cloneDeeply` with `lodash.cloneDeep`.

_Please note: `Object.isFrozen`is a new addition to the eslint codebase. It appears to have the same support as `Object.freeze`._ 