### PR TITLE
Update: added max depth option to newline-per-chained-call (fixes #12970)

### DIFF
--- a/docs/rules/newline-per-chained-call.md
+++ b/docs/rules/newline-per-chained-call.md
@@ -1,14 +1,14 @@
-# require a newline after each call in a method chain (newline-per-chained-call)
+# Require a newline after each call in a method chain (newline-per-chained-call)
 
 Chained method calls on a single line without line breaks are harder to read, so some developers place a newline character after each method call in the chain to make it more readable and easy to maintain.
 
-Let's look at the following perfectly valid (but single line) code.
+Let's look at the following perfectly valid (but single line) code:
 
 ```js
 d3.select("body").selectAll("p").data([4, 8, 15, 16, 23, 42 ]).enter().append("p").text(function(d) { return "I'm number " + d + "!"; });
 ```
 
-However, with appropriate new lines, it becomes easy to read and understand. Look at the same code written below with line breaks after each call.
+However, with appropriate new lines, it becomes easy to read and understand. Look at the same code written below with line breaks after each call:
 
 ```js
 d3
@@ -29,7 +29,7 @@ d3
     });
 ```
 
-Another argument in favor of this style is that it improves the clarity of diffs when something in the method chain is changed:
+Another argument in favor of this style is that it improves the clarity of diffs when something in the method chain is changed.
 
 Less clear:
 
@@ -44,26 +44,36 @@ More clear:
 d3
     .select("body")
     .selectAll("p")
--    .style("color", "white");
-+    .style("color", "blue");
+-   .style("color", "white");
++   .style("color", "blue");
 ```
 
 ## Rule Details
 
-This rule requires a newline after each call in a method chain or deep member access. Computed property accesses such as `instance[something]` are excluded.
+This rule requires a newline after each call in a method chain or deep member access. Computed property accesses such as `instance[something]` are optionally excluded with `includeBracketedProperties: false`.
 
 ## Options
 
-This rule has an object option:
-
-* `"ignoreChainWithDepth"` (default: `2`) allows chains up to a specified depth.
+* `"depthCalculationStyle"` (default: `"trailingMembers"`) changes the algorithm used to calculate depth is calculated.
+    * `all`: once the depth of all chained members excluding invalid members exceeds `ignoreChainWithDepth`, all chained properties are dropped to newlines.
+    * `trailingMembers` (default): once the depth of chained members up to an invalid member exceeds `ignoreChainWithDepth`, only properties past the `ignoreChainWithDepth` are dropped to newlines.
+* `"ignoreChainWithDepth"` (default: `2`) allows chains of calls up to a specified depth.
+* `"includeBracketedProperties"` (default: `true`) drop chained properties with array bracket syntax to new lines such as `array[0]`, `array['length']`, and `array['map']()`. Using this along with `includeMethodCalls` or `includeProperties` changes the behavior of which bracket syntax is included respective to those options.
+* `"includeMethodCalls"` (default: `true`) drop method calls to new lines such as `array.map()`.
+* `"includeProperties"` (default: `false`) drop bare properties to new lines such as `array.length`.
+* `"multilineBreakStyle"` (default: `"never"`) ignore `ignoreChainWithDepth` when statement spans more than a single line.
+    * `never` (default): Doesn't enforce newlines regardless of how many lines are spanned by the chain.
+    * `object`: If the object beginning the chain spans more than a single line, force chained members, excluding invalid members, to newlines.
+    * `statement`: If the object beginning the chain or any property in the chain itself spans more than a single line, force chained members, excluding invalid members, to newlines.
 
 ### ignoreChainWithDepth
 
-Examples of **incorrect** code for this rule with the default `{ "ignoreChainWithDepth": 2 }` option:
+#### depthCalculationStyle: trailingMembers
+
+Examples of **incorrect** code for this rule with the default `{ ignoreChainWithDepth: 2 }`:
 
 ```js
-/*eslint newline-per-chained-call: ["error", { "ignoreChainWithDepth": 2 }]*/
+/* eslint newline-per-chained-call: ["error"] */
 
 _.chain({}).map(foo).filter(bar).value();
 
@@ -76,13 +86,16 @@ _
   .filter(bar);
 
 // Or
-obj.method().method2().method3();
+obj.method1().method2().method3();
+
+// Or
+obj.prop.method1()['prop']['method2']().method3().method4().prop;
 ```
 
-Examples of **correct** code for this rule with the default `{ "ignoreChainWithDepth": 2 }` option:
+Examples of **correct** code for this rule with the default `{ ignoreChainWithDepth: 2 }`:
 
 ```js
-/*eslint newline-per-chained-call: ["error", { "ignoreChainWithDepth": 2 }]*/
+/* eslint newline-per-chained-call: ["error"] */
 
 _
   .chain({})
@@ -104,13 +117,333 @@ _.chain({})
 // Or
 obj
   .prop
-  .method().prop;
+  .method1().prop;
+
+// Or
+obj.prop.method1()
+  .method2()
+  .method3().prop;
 
 // Or
 obj
-  .prop.method()
+  .prop.method1()
   .method2()
   .method3().prop;
+
+// Or
+obj.prop.method1()['prop']['method2']().method3()
+  .method4().prop;
+```
+
+#### depthCalculationStyle: all
+
+Examples of **incorrect** code for this rule with `{ depthCalculationStyle: "all", ignoreChainWithDepth: 2 }`:
+
+```js
+/* eslint newline-per-chained-call: ["error", { depthCalculationStyle: "all" }] */
+
+_.chain({}).map(foo).filter(bar).value();
+
+// Or
+_.chain({}).map(foo).filter(bar);
+
+// Or
+_
+  .chain({}).map(foo)
+  .filter(bar);
+
+// Or
+obj.method1().method2().method3();
+
+// Or
+obj.prop.method1()['prop']['method2']().method3().method4().prop;
+```
+
+Examples of **correct** code for this rule with `{ depthCalculationStyle: "all", ignoreChainWithDepth: 2 }`:
+
+```js
+/* eslint newline-per-chained-call: ["error", { depthCalculationStyle: "all" }] */
+
+Object.keys(object);
+
+// Or
+Object
+.keys(object);
+
+// Or
+_
+  .chain({})
+  .map(foo)
+  .filter(bar)
+  .value();
+
+// Or
+obj
+  .prop
+  .method()
+  .prop;
+
+// Or
+obj
+  .prop
+  .method1()
+  .method2()
+  .method3()
+  .prop;
+
+
+// Or
+obj
+  .prop
+  .method1()
+  ['prop']
+  ['method2']()
+  .method3()
+  .method4()
+  .prop;
+```
+
+### multilineBreakStyle
+
+This rule doesn't care about which options are enabled, it only cares if the statement itself spans multiple lines.
+
+#### multilineBreakStyle: statement
+
+Examples of **incorrect** code for this rule with `{ ignoreChainWithDepth: 2, multilineBreakStyle: "statement" }`:
+
+```js
+/* eslint newline-per-chained-call: ["error", { multilineBreakStyle: "statement" }] */
+
+Object
+.keys(object);
+
+// Or
+_
+  .chain({}).map(foo).filter(bar).value();
+
+// Or
+_
+  .chain({}).map(foo)
+  .filter(bar);
+
+// Or
+obj
+  .method1()
+  .method2().method3();
+
+// Or
+obj.method1()
+  .method2()
+  .method3();
+
+// Or
+void [
+  1,
+  2,
+  3
+].forEach(func)
+
+// Or
+void [1, 2, 3].forEach(() => {
+  return
+})
+```
+
+Examples of **correct** code for this rule with `{ ignoreChainWithDepth: 2, multilineBreakStyle: "statement" }`:
+
+```js
+/* eslint newline-per-chained-call: ["error", { multilineBreakStyle: "statement" }] */
+
+Object.keys(object);
+
+// Or
+Object
+.keys(object);
+
+// Or
+_
+  .chain({})
+  .map(foo)
+  .filter(bar)
+  .value();
+
+// Or
+_
+  .chain({})
+  .map(foo)
+  .filter(bar);
+
+// Or
+obj
+  .method1()
+  .method2()
+  .method3();
+
+// Or
+obj
+  .method1()
+  .method2()
+  .method3();
+
+// Or
+void [
+  1,
+  2,
+  3
+]
+.forEach(func)
+
+// Or
+void [1, 2, 3]
+.forEach(() => {
+  return
+})
+```
+
+#### multilineBreakStyle: object
+
+Examples of **incorrect** code for this rule with `{ ignoreChainWithDepth: 2, multilineBreakStyle: "object" }`:
+
+```js
+/* eslint newline-per-chained-call: ["error", { multilineBreakStyle: "object" }] */
+
+// Or
+void [
+  1,
+  2,
+  3
+].forEach(func)
+```
+
+Examples of **correct** code for this rule with `{ ignoreChainWithDepth: 2, multilineBreakStyle: "object" }`:
+
+```js
+/* eslint newline-per-chained-call: ["error", { multilineBreakStyle: "object" }] */
+
+Object.keys(object);
+
+// Or
+obj
+  .method1().method2();
+
+// Or
+obj.method1()
+  .method2();
+
+// Or
+void [
+  1,
+  2,
+  3
+]
+.forEach(func)
+
+// Or
+void [1, 2, 3].forEach(() => {
+  return
+})
+```
+
+### All `include` Options
+
+#### depthCalculationStyle: trailingMembers
+
+```js
+{
+  breakIfMultilineStyle: false // default,
+  depthCalculationStyle: "trailingMembers", // default
+  ignoreChainWithDepth: 2, // default
+  includeBracketedProperties: true, // default
+  includeMethodCalls: true, // default
+  includeProperties: true,
+}
+```
+
+Examples of **incorrect** code for these options:
+
+```js
+/* eslint newline-per-chained-call: ["error", { ignoreChainWithDepth: 2 }] */
+
+array[a][b][c].length;
+
+// Or
+obj.method1().method2().method3()[0];
+
+// Or
+obj.method1()['foo']['bar']().method2();
+```
+
+Examples of **correct** code for these options:
+
+```js
+/* eslint newline-per-chained-call: ["error", { ignoreChainWithDepth: 2 }] */
+
+array[a]
+  [b][c].length;
+
+// Or
+obj.method1()
+.method2()
+.method3()
+[0];
+
+// Or
+obj.method1()
+['foo']
+['bar']()
+.method2();
+```
+
+#### depthCalculationStyle: all
+
+```js
+{
+  depthCalculationStyle: "all",
+  ignoreChainWithDepth: 2, // default
+  includeBracketedProperties: true, // default
+  includeMethodCalls: true, // default
+  includeProperties: true,
+}
+```
+
+Examples of **incorrect** code with these options:
+
+```js
+/* eslint newline-per-chained-call: ["error", { ignoreChainWithDepth: 2 }] */
+
+array[a][b][c].length;
+
+// Or
+obj.method1().method2().method3()[0];
+
+// Or
+obj.method1()['foo']['bar']().method2();
+```
+
+Examples of **correct** code with these options:
+
+```js
+/* eslint newline-per-chained-call: ["error", { ignoreChainWithDepth: 2 }] */
+
+array
+[a]
+[b]
+[c]
+.length;
+
+// Or
+obj
+.method1()
+.method2()
+.method3()
+[0];
+
+// Or
+obj
+.method1()
+['foo']
+['bar']()
+.method2();
 ```
 
 ## When Not To Use It

--- a/lib/rules/newline-per-chained-call.js
+++ b/lib/rules/newline-per-chained-call.js
@@ -28,24 +28,62 @@ module.exports = {
         schema: [{
             type: "object",
             properties: {
+                depthCalculationStyle: {
+                    type: "string",
+                    enum: ["all", "trailingMembers"],
+                    default: "trailingMembers"
+                },
                 ignoreChainWithDepth: {
                     type: "integer",
-                    minimum: 1,
-                    maximum: 10,
+                    minimum: 0,
                     default: 2
+                },
+                includeBracketedProperties: {
+                    type: "boolean",
+                    default: true
+                },
+                includeMethodCalls: {
+                    type: "boolean",
+                    default: true
+                },
+                includeProperties: {
+                    type: "boolean",
+                    default: false
+                },
+                multilineBreakStyle: {
+                    type: "string",
+                    enum: ["never", "object", "statement"],
+                    default: "never"
                 }
             },
             additionalProperties: false
         }],
+
         messages: {
-            expected: "Expected line break before `{{callee}}`."
+            expectedLineBreak: "Expected line break before `{{propertyName}}`."
         }
     },
 
     create(context) {
-
         const options = context.options[0] || {},
-            ignoreChainWithDepth = options.ignoreChainWithDepth || 2;
+            depthCalculationStyle = options.depthCalculationStyle || "trailingMembers",
+            ignoreChainWithDepth = options.ignoreChainWithDepth || 2,
+            includeBracketedProperties = (
+                typeof options.includeBracketedProperties !== "undefined"
+                    ? options.includeBracketedProperties
+                    : true
+            ),
+            includeMethodCalls = (
+                typeof options.includeMethodCalls !== "undefined"
+                    ? options.includeMethodCalls
+                    : true
+            ),
+            includeProperties = (
+                typeof options.includeProperties !== "undefined"
+                    ? options.includeProperties
+                    : false
+            ),
+            multilineBreakStyle = options.multilineBreakStyle || "never";
 
         const sourceCode = context.getSourceCode();
 
@@ -74,37 +112,204 @@ module.exports = {
             return prefix + lines[0] + suffix;
         }
 
-        return {
-            "CallExpression:exit"(node) {
-                if (!node.callee || node.callee.type !== "MemberExpression") {
-                    return;
-                }
+        /**
+         * Checks if the object and property of a given MemberExpression node are on the same line.
+         * @param {ASTNode} node A CallExpression node to validate.
+         * @returns {bool} The result of the object and property being on the same line.
+         */
+        function hasObjectAndPropertyOnSameLine({ object, property }) {
+            return (
+                astUtils.isTokenOnSameLine(
+                    object,
+                    property
+                )
+            );
+        }
 
-                const callee = node.callee;
-                let parent = callee.object;
-                let depth = 1;
+        /**
+         * Checks if a given ASTNode spans multiple lines.
+         * @param {ASTNode} node An ASTNode to validate.
+         * @returns {bool} Is the ASTNode spanning multiple lines?
+         */
+        function isSpanningMultipleLines(node) {
+            return !astUtils.isTokenOnSameLine(node, node);
+        }
 
-                while (parent && parent.callee) {
-                    depth += 1;
-                    parent = parent.callee.object;
-                }
+        /**
+         * Gets the top-most CallExpression or MemberExpression of a given ASTNode.
+         * @param {ASTNode} node A MemberExpression node to validate.
+         * @returns {bool} The final MemberExpression node.
+         */
+        function getStatementChildNode(node) {
+            let currentNode = node.parent;
 
-                if (depth > ignoreChainWithDepth && astUtils.isTokenOnSameLine(callee.object, callee.property)) {
-                    context.report({
-                        node: callee.property,
-                        loc: callee.property.loc.start,
-                        messageId: "expected",
-                        data: {
-                            callee: getPropertyText(callee)
-                        },
-                        fix(fixer) {
-                            const firstTokenAfterObject = sourceCode.getTokenAfter(callee.object, astUtils.isNotClosingParenToken);
+            while (
+                currentNode.type === "CallExpression" ||
+                currentNode.type === "MemberExpression"
+            ) {
+                currentNode = currentNode.parent;
+            }
 
-                            return fixer.insertTextBefore(firstTokenAfterObject, "\n");
+            return currentNode;
+        }
+
+        /**
+         * Checks if parent of a given MemberExpression is the final node in the statement.
+         * @param {ASTNode} node A MemberExpression node to validate.
+         * @returns {bool} The result of the parent's type not being a MemberExpression.
+         */
+        function isFinalMemberExpression(node) {
+            let { parent } = node;
+
+            if (parent.type === "CallExpression") {
+                parent = parent.parent;
+            }
+
+            return parent.type !== "MemberExpression";
+        }
+
+        /**
+         * Reports when CallExpression or MemberExpression count is greater than the max total when two nodes are on the same line.
+         * @param {ASTNode} node A MemberExpression or CallExpression node to validate.
+         * @returns {void} The result of the object and property being on the same line.
+         */
+        function validateChainDepth(node) {
+            if (
+                depthCalculationStyle === "all" &&
+                !isFinalMemberExpression(node)
+            ) {
+                return;
+            }
+
+            const memberExpressions = [];
+
+            let currentNode = node;
+
+            while (currentNode) {
+                if (currentNode.type === "CallExpression") {
+                    currentNode = currentNode.callee;
+                } else if (
+                    (
+                        includeMethodCalls &&
+                        currentNode.parent.type === "CallExpression"
+                    ) || (
+                        includeProperties &&
+                        currentNode.parent.type !== "CallExpression"
+                    )
+                ) {
+                    if (currentNode.type === "MemberExpression") {
+                        if (
+                            includeBracketedProperties || (
+                                currentNode.property.type === "Identifier" &&
+                                !currentNode.computed
+                            )
+                        ) {
+                            memberExpressions.push(currentNode);
                         }
-                    });
+                    } else {
+                        memberExpressions.push({
+                            object: currentNode.parent,
+                            property: currentNode
+                        });
+                    }
+
+                    currentNode = currentNode.object;
+                } else if (depthCalculationStyle === "all") {
+                    currentNode = currentNode.object;
+                } else {
+                    break;
                 }
             }
+
+            if (
+                isFinalMemberExpression(node) && (
+                    (
+                        memberExpressions.length > 0 &&
+                        memberExpressions.length <= ignoreChainWithDepth && (
+                            (
+                                multilineBreakStyle === "object" &&
+                                isSpanningMultipleLines(
+                                    (memberExpressions[memberExpressions.length - 1] || {}).property
+                                )
+                            ) || (
+                                multilineBreakStyle === "statement" &&
+                                isSpanningMultipleLines(getStatementChildNode(node))
+                            )
+                        )
+                    ) || (
+                        depthCalculationStyle === "all" &&
+                        memberExpressions.length > ignoreChainWithDepth &&
+                        memberExpressions.some(hasObjectAndPropertyOnSameLine)
+                    )
+                )
+            ) {
+                memberExpressions
+                    .filter(({ type }) => type)
+                    .filter(hasObjectAndPropertyOnSameLine)
+                    .forEach(memberExpression => {
+                        context.report({
+                            node: memberExpression.property,
+                            loc: memberExpression.property.loc.start,
+                            messageId: "expectedLineBreak",
+                            data: {
+                                propertyName: getPropertyText(memberExpression)
+                            },
+                            fix(fixer) {
+                                const firstTokenAfterObject = (
+                                    sourceCode.getTokenAfter(
+                                        memberExpression.object,
+                                        astUtils.isNotClosingParenToken
+                                    )
+                                );
+
+                                return fixer.insertTextBefore(firstTokenAfterObject, "\n");
+                            }
+                        });
+                    });
+            } else if (
+                (
+                    memberExpressions.length > 0 &&
+                    memberExpressions.length <= ignoreChainWithDepth && (
+                        (
+                            multilineBreakStyle === "object" &&
+                            isSpanningMultipleLines(
+                                (memberExpressions[memberExpressions.length - 1] || {}).property
+                            )
+                        ) || (
+                            multilineBreakStyle === "statement" &&
+                            isSpanningMultipleLines(getStatementChildNode(node))
+                        )
+                    )
+                ) || (
+                    depthCalculationStyle === "trailingMembers" && (
+                        memberExpressions.length > ignoreChainWithDepth &&
+                        hasObjectAndPropertyOnSameLine(node)
+                    )
+                )
+            ) {
+                context.report({
+                    node: node.property,
+                    loc: node.property.loc.start,
+                    messageId: "expectedLineBreak",
+                    data: {
+                        propertyName: getPropertyText(node)
+                    },
+                    fix(fixer) {
+                        const firstTokenAfterObject = (
+                            sourceCode.getTokenAfter(
+                                node.object,
+                                astUtils.isNotClosingParenToken
+                            )
+                        );
+
+                        return fixer.insertTextBefore(firstTokenAfterObject, "\n");
+                    }
+                });
+            }
+        }
+
+        return {
+            "MemberExpression:exit": validateChainDepth
         };
     }
 };

--- a/tests/lib/rules/newline-per-chained-call.js
+++ b/tests/lib/rules/newline-per-chained-call.js
@@ -15,62 +15,151 @@ const rule = require("../../../lib/rules/newline-per-chained-call"),
 const ruleTester = new RuleTester();
 
 ruleTester.run("newline-per-chained-call", rule, {
-    valid: ["_\n.chain({})\n.map(foo)\n.filter(bar)\n.value();", "a.b.c.d.e.f", "a()\n.b()\n.c\n.e", "var a = m1.m2(); var b = m1.m2();\nvar c = m1.m2()", "var a = m1()\n.m2();", "var a = m1();", "a()\n.b().c.e.d()", "a().b().c.e.d()", "a.b.c.e.d()", "var a = window\n.location\n.href\n.match(/(^[^#]*)/)[0];", "var a = window['location']\n.href\n.match(/(^[^#]*)/)[0];", "var a = window['location'].href.match(/(^[^#]*)/)[0];", {
-        code: "var a = m1().m2.m3();",
-        options: [{
-            ignoreChainWithDepth: 3
+    valid: [
+        "_\n.chain({}).map(foo).length\n.filter(bar).value();",
+        "_\n.chain({})\n.map(foo)\n.filter(bar)\n.value();",
+        "a.b.c.d.e.f",
+        "a()\n.b()\n.c\n.e",
+        "var a = m1.m2(); var b = m1.m2();\nvar c = m1.m2()",
+        "var a = m1()\n.m2();",
+        "var a = m1();",
+        "a()\n.b().c.e.d()",
+        "a().b().c.e.d()",
+        "a.b.c.e.d()",
+        "var a = window\n.location\n.href\n.match(/(^[^#]*)/)[0];",
+        "var a = window['location']\n.href\n.match(/(^[^#]*)/)[0];",
+        "var a = window['location'].href.match(/(^[^#]*)/)[0];",
+        {
+            code: "var a = m1().m2.m3();",
+            options: [{
+                ignoreChainWithDepth: 3
+            }]
+        }, {
+            code: "var a = m1().m2.m3().m4.m5().m6.m7().m8;",
+            options: [{
+                ignoreChainWithDepth: 8
+            }]
+        },
+
+        /*
+         * depthCalculationStyle: "all"
+         * ignoreChainWithDepth: 3
+         * includeBracketedProperties: false
+         * includeMethodCalls: true (default)
+         * includeProperties: true
+         */
+        {
+            code: "foo.bar()['foo' + \u2029 + 'bar']()",
+            options: [{
+                depthCalculationStyle: "all",
+                ignoreChainWithDepth: 3,
+                includeBracketedProperties: false,
+                includeProperties: true
+            }]
+        }, {
+            code: "foo.bar()[(biz)]()",
+            options: [{
+                depthCalculationStyle: "all",
+                ignoreChainWithDepth: 3,
+                includeBracketedProperties: false,
+                includeProperties: true
+            }]
+        }, {
+            code: "(foo).bar().biz()",
+            options: [{
+                depthCalculationStyle: "all",
+                ignoreChainWithDepth: 3,
+                includeBracketedProperties: false,
+                includeProperties: true
+            }]
+        }, {
+            code: "foo.bar(). /* comment */ biz()",
+            options: [{
+                depthCalculationStyle: "all",
+                ignoreChainWithDepth: 3,
+                includeBracketedProperties: false,
+                includeProperties: true
+            }]
+        }, {
+            code: "foo.bar() /* comment */ .biz()",
+            options: [{
+                depthCalculationStyle: "all",
+                ignoreChainWithDepth: 3,
+                includeBracketedProperties: false,
+                includeProperties: true
+            }]
+        }, {
+            code: "foo\n.bar() /* comment */ .biz()",
+            options: [{
+                depthCalculationStyle: "all",
+                ignoreChainWithDepth: 3,
+                includeBracketedProperties: false,
+                includeProperties: true
+            }]
+        }
+    ],
+
+    /*
+     * depthCalculationStyle: "trailingMembers" (default)
+     * ignoreChainWithDepth: 2 (default)
+     * includeBracketedProperties: true (default)
+     * includeMethodCalls: true (default)
+     * includeProperties: false (default)
+     * multilineBreakStyle: "never" (default)
+     */
+    invalid: [{
+        code: "_.chain({}).map(foo).filter(bar).value();",
+        output: "_.chain({}).map(foo)\n.filter(bar)\n.value();",
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".filter" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".value" }
         }]
     }, {
-        code: "var a = m1().m2.m3().m4.m5().m6.m7().m8;",
-        options: [{
-            ignoreChainWithDepth: 8
-        }]
-    }],
-    invalid: [{
         code: "_\n.chain({}).map(foo).filter(bar).value();",
         output: "_\n.chain({}).map(foo)\n.filter(bar)\n.value();",
         errors: [{
-            messageId: "expected", data: { callee: ".filter" }
+            messageId: "expectedLineBreak", data: { propertyName: ".filter" }
         }, {
-            messageId: "expected", data: { callee: ".value" }
+            messageId: "expectedLineBreak", data: { propertyName: ".value" }
         }]
     }, {
         code: "_\n.chain({})\n.map(foo)\n.filter(bar).value();",
         output: "_\n.chain({})\n.map(foo)\n.filter(bar)\n.value();",
         errors: [{
-            messageId: "expected", data: { callee: ".value" }
+            messageId: "expectedLineBreak", data: { propertyName: ".value" }
         }]
     }, {
         code: "a().b().c().e.d()",
         output: "a().b()\n.c().e.d()",
         errors: [{
-            messageId: "expected", data: { callee: ".c" }
+            messageId: "expectedLineBreak", data: { propertyName: ".c" }
         }]
     }, {
         code: "a.b.c().e().d()",
         output: "a.b.c().e()\n.d()",
         errors: [{
-            messageId: "expected", data: { callee: ".d" }
+            messageId: "expectedLineBreak", data: { propertyName: ".d" }
         }]
     }, {
         code: "_.chain({}).map(a).value(); ",
         output: "_.chain({}).map(a)\n.value(); ",
         errors: [{
-            messageId: "expected", data: { callee: ".value" }
+            messageId: "expectedLineBreak", data: { propertyName: ".value" }
         }]
     }, {
-        code: "var a = m1.m2();\n var b = m1.m2().m3().m4().m5();",
-        output: "var a = m1.m2();\n var b = m1.m2().m3()\n.m4()\n.m5();",
+        code: "var a = m1.m2();\nvar b = m1.m2().m3().m4().m5();",
+        output: "var a = m1.m2();\nvar b = m1.m2().m3()\n.m4()\n.m5();",
         errors: [{
-            messageId: "expected", data: { callee: ".m4" }
+            messageId: "expectedLineBreak", data: { propertyName: ".m4" }
         }, {
-            messageId: "expected", data: { callee: ".m5" }
+            messageId: "expectedLineBreak", data: { propertyName: ".m5" }
         }]
     }, {
-        code: "var a = m1.m2();\n var b = m1.m2().m3()\n.m4().m5();",
-        output: "var a = m1.m2();\n var b = m1.m2().m3()\n.m4()\n.m5();",
+        code: "var a = m1.m2();\nvar b = m1.m2().m3()\n.m4().m5();",
+        output: "var a = m1.m2();\nvar b = m1.m2().m3()\n.m4()\n.m5();",
         errors: [{
-            messageId: "expected", data: { callee: ".m5" }
+            messageId: "expectedLineBreak", data: { propertyName: ".m5" }
         }]
     }, {
         code: "var a = m1().m2\n.m3().m4().m5().m6().m7();",
@@ -79,9 +168,9 @@ ruleTester.run("newline-per-chained-call", rule, {
             ignoreChainWithDepth: 3
         }],
         errors: [{
-            messageId: "expected", data: { callee: ".m6" }
+            messageId: "expectedLineBreak", data: { propertyName: ".m6" }
         }, {
-            messageId: "expected", data: { callee: ".m7" }
+            messageId: "expectedLineBreak", data: { propertyName: ".m7" }
         }]
     }, {
         code: [
@@ -145,9 +234,9 @@ ruleTester.run("newline-per-chained-call", rule, {
             ".end();"
         ].join("\n"),
         errors: [{
-            messageId: "expected", data: { callee: ".on" }
+            messageId: "expectedLineBreak", data: { propertyName: ".on" }
         }, {
-            messageId: "expected", data: { callee: ".end" }
+            messageId: "expectedLineBreak", data: { propertyName: ".end" }
         }]
     }, {
         code: [
@@ -163,34 +252,865 @@ ruleTester.run("newline-per-chained-call", rule, {
             "    'method4']()"
         ].join("\n"),
         errors: [{
-            messageId: "expected", data: { callee: "['method' + n]" }
+            messageId: "expectedLineBreak", data: { propertyName: "['method' + n]" }
         }, {
-            messageId: "expected", data: { callee: "[aCondition ?" }
+            messageId: "expectedLineBreak", data: { propertyName: "[aCondition ?" }
         }]
+    },
+
+    /*
+     * depthCalculationStyle: "trailingMembers" (default)
+     * ignoreChainWithDepth: 1
+     * includeBracketedProperties: true (default)
+     * includeMethodCalls: true (default)
+     * includeProperties: false (default)
+     * multilineBreakStyle: "never" (default)
+     */
+    {
+        code: "foo.bar()['foo' + \u2029 + 'bar']",
+        output: null,
+        options: [{ ignoreChainWithDepth: 1 }],
+        errors: []
     }, {
         code: "foo.bar()['foo' + \u2029 + 'bar']()",
         output: "foo.bar()\n['foo' + \u2029 + 'bar']()",
         options: [{ ignoreChainWithDepth: 1 }],
-        errors: [{ messageId: "expected", data: { callee: "['foo' + " } }]
+        errors: [{ messageId: "expectedLineBreak", data: { propertyName: "['foo' + " } }]
     }, {
         code: "foo.bar()[(biz)]()",
         output: "foo.bar()\n[(biz)]()",
         options: [{ ignoreChainWithDepth: 1 }],
-        errors: [{ messageId: "expected", data: { callee: "[biz]" } }]
+        errors: [{ messageId: "expectedLineBreak", data: { propertyName: "[biz]" } }]
     }, {
         code: "(foo).bar().biz()",
         output: "(foo).bar()\n.biz()",
         options: [{ ignoreChainWithDepth: 1 }],
-        errors: [{ messageId: "expected", data: { callee: ".biz" } }]
+        errors: [{ messageId: "expectedLineBreak", data: { propertyName: ".biz" } }]
     }, {
         code: "foo.bar(). /* comment */ biz()",
         output: "foo.bar()\n. /* comment */ biz()",
         options: [{ ignoreChainWithDepth: 1 }],
-        errors: [{ messageId: "expected", data: { callee: ".biz" } }]
+        errors: [{ messageId: "expectedLineBreak", data: { propertyName: ".biz" } }]
     }, {
         code: "foo.bar() /* comment */ .biz()",
         output: "foo.bar() /* comment */ \n.biz()",
         options: [{ ignoreChainWithDepth: 1 }],
-        errors: [{ messageId: "expected", data: { callee: ".biz" } }]
+        errors: [{ messageId: "expectedLineBreak", data: { propertyName: ".biz" } }]
+    }, {
+        code: "obj.prop.method1()['prop']['method2']().method3().method4().prop;",
+        output: "obj.prop.method1()['prop']['method2']().method3()\n.method4().prop;",
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".method4" }
+        }]
+    },
+
+    /*
+     * depthCalculationStyle: "all"
+     * ignoreChainWithDepth: 1
+     * includeBracketedProperties: true (default)
+     * includeMethodCalls: true (default)
+     * includeProperties: true
+     * multilineBreakStyle: "never" (default)
+     */
+    {
+        code: "a.b",
+        output: "a\n.b",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".b" }
+        }]
+    }, {
+        code: "a.b()",
+        output: "a\n.b()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".b" }
+        }]
+    }, {
+        code: "a().b()",
+        output: "a()\n.b()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".b" }
+        }]
+    }, {
+        code: "a['propertyNameString']",
+        output: "a\n['propertyNameString']",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: "['propertyNameString']" }
+        }]
+    }, {
+        code: "a()['propertyNameString']",
+        output: "a()\n['propertyNameString']",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: "['propertyNameString']" }
+        }]
+    }, {
+        code: "a['propertyNameString'].b()",
+        output: "a\n['propertyNameString']\n.b()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: "['propertyNameString']" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".b" }
+        }]
+    }, {
+        code: "a[propertyNameVariable]",
+        output: "a\n[propertyNameVariable]",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: "[propertyNameVariable]" }
+        }]
+    }, {
+        code: "a()[propertyNameVariable]",
+        output: "a()\n[propertyNameVariable]",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: "[propertyNameVariable]" }
+        }]
+    }, {
+        code: "void [1, 2, 3].forEach(func)",
+        output: "void [1, 2, 3]\n.forEach(func)",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".forEach" }
+        }]
+    }, {
+        code: "test ? condition : [1, 2, 3].forEach(func)",
+        output: "test ? condition : [1, 2, 3]\n.forEach(func)",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".forEach" }
+        }]
+    }, {
+        code: "test ? condition : a[1, 2, 3].forEach(func)",
+        output: "test ? condition : a\n[1, 2, 3]\n.forEach(func)",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: "[1, 2, 3]" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".forEach" }
+        }]
+    }, {
+        code: "test ? condition : a[1, 2, 3].forEach(func).length",
+        output: "test ? condition : a\n[1, 2, 3]\n.forEach(func)\n.length",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: "[1, 2, 3]" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".forEach" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".length" }
+        }]
+    }, {
+        code: "obj.prop.method1()['prop']['method2']().method3().method4().prop;",
+        output: "obj\n.prop\n.method1()\n['prop']\n['method2']()\n.method3()\n.method4()\n.prop;",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".prop" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".method1" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: "['prop']" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: "['method2']" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".method3" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".method4" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".prop" }
+        }]
+    },
+
+    /*
+     * depthCalculationStyle: "all"
+     * ignoreChainWithDepth: 1
+     * includeBracketedProperties: true (default)
+     * includeMethodCalls: false
+     * includeProperties: true
+     * multilineBreakStyle: "never" (default)
+     */
+    {
+        code: "a.b",
+        output: "a\n.b",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeMethodCalls: false,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".b" }
+        }]
+    }, {
+        code: "a.b()",
+        output: null,
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeMethodCalls: false,
+            includeProperties: true
+        }],
+        errors: []
+    }, {
+        code: "a().b()",
+        output: null,
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeMethodCalls: false,
+            includeProperties: true
+        }],
+        errors: []
+    }, {
+        code: "a['propertyNameString']",
+        output: "a\n['propertyNameString']",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeMethodCalls: false,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: "['propertyNameString']" }
+        }]
+    }, {
+        code: "a()['propertyNameString']",
+        output: null,
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeMethodCalls: false,
+            includeProperties: true
+        }],
+        errors: []
+    }, {
+        code: "a['propertyNameString'].b()",
+        output: "a\n['propertyNameString'].b()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeMethodCalls: false,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: "['propertyNameString']" }
+        }]
+    },
+    {
+        code: "a['propertyNameString'].b().c",
+        output: "a\n['propertyNameString'].b()\n.c",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeMethodCalls: false,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: "['propertyNameString']" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".c" }
+        }]
+    },
+    {
+        code: "a[propertyNameVariable]",
+        output: "a\n[propertyNameVariable]",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeMethodCalls: false,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: "[propertyNameVariable]" }
+        }]
+    }, {
+        code: "a()[propertyNameVariable]",
+        output: null,
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 1,
+            includeMethodCalls: false,
+            includeProperties: true
+        }],
+        errors: []
+    },
+
+    /*
+     * depthCalculationStyle: "all"
+     * ignoreChainWithDepth: 2 (default)
+     * includeBracketedProperties: true (default)
+     * includeMethodCalls: true (default)
+     * includeProperties: true
+     * multilineBreakStyle: "never" (default)
+     */
+    {
+        code: "_\n.chain({}).map(foo).filter(bar).value();",
+        output: "_\n.chain({})\n.map(foo)\n.filter(bar)\n.value();",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".map" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".filter" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".value" }
+        }]
+    }, {
+        code: "_\n.chain({})\n.map(foo)\n.filter(bar).value();",
+        output: "_\n.chain({})\n.map(foo)\n.filter(bar)\n.value();",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".value" }
+        }]
+    }, {
+        code: "a().b().c().e.d()",
+        output: "a()\n.b()\n.c()\n.e\n.d()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".b" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".c" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".e" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".d" }
+        }]
+    }, {
+        code: "a.b.c().e().d()",
+        output: "a\n.b\n.c()\n.e()\n.d()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".b" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".c" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".e" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".d" }
+        }]
+    }, {
+        code: "_.chain({}).map(a).value(); ",
+        output: "_\n.chain({})\n.map(a)\n.value(); ",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".chain" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".map" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".value" }
+        }]
+    }, {
+        code: "var a = m1.m2();\nvar b = m1.m2().m3().m4().m5();",
+        output: "var a = m1.m2();\nvar b = m1\n.m2()\n.m3()\n.m4()\n.m5();",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".m2" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".m3" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".m4" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".m5" }
+        }]
+    }, {
+        code: "var a = m1.m2();\nvar b = m1.m2().m3()\n.m4().m5();",
+        output: "var a = m1.m2();\nvar b = m1\n.m2()\n.m3()\n.m4()\n.m5();",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".m2" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".m3" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".m5" }
+        }]
+    }, {
+        code: "var a = m1().m2\n.m3().m4().m5().m6().m7();",
+        output: "var a = m1()\n.m2\n.m3()\n.m4()\n.m5()\n.m6()\n.m7();",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".m2" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".m4" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".m5" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".m6" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".m7" }
+        }]
+    }, {
+        code: [
+            "http.request({",
+            "    // Param",
+            "    // Param",
+            "    // Param",
+            "}).on('response', function(response) {",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "}).on('error', function(error) {",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "}).end();"
+        ].join("\n"),
+        output: [
+            "http",
+            ".request({",
+            "    // Param",
+            "    // Param",
+            "    // Param",
+            "})",
+            ".on('response', function(response) {",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "    // Do something with response.",
+            "})",
+            ".on('error', function(error) {",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "    // Do something with error.",
+            "})",
+            ".end();"
+        ].join("\n"),
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".request" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".on" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".on" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".end" }
+        }]
+    }, {
+        code: [
+            "anObject.method1().method2()['method' + n]()[aCondition ?",
+            "    'method3' :",
+            "    'method4']()"
+        ].join("\n"),
+        output: [
+            "anObject",
+            ".method1()",
+            ".method2()",
+            "['method' + n]()",
+            "[aCondition ?",
+            "    'method3' :",
+            "    'method4']()"
+        ].join("\n"),
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".method1" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".method2" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: "['method' + n]" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: "[aCondition ?" }
+        }]
+    }, {
+        code: "foo.bar()['foo' + \u2029 + 'bar']()",
+        output: "foo\n.bar()\n['foo' + \u2029 + 'bar']()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [
+            { messageId: "expectedLineBreak", data: { propertyName: ".bar" } },
+            { messageId: "expectedLineBreak", data: { propertyName: "['foo' + " } }
+        ]
+    }, {
+        code: "foo.bar()[(biz)]()",
+        output: "foo\n.bar()\n[(biz)]()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [
+            { messageId: "expectedLineBreak", data: { propertyName: ".bar" } },
+            { messageId: "expectedLineBreak", data: { propertyName: "[biz]" } }
+        ]
+    }, {
+        code: "(foo).bar().biz()",
+        output: "(foo)\n.bar()\n.biz()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [
+            { messageId: "expectedLineBreak", data: { propertyName: ".bar" } },
+            { messageId: "expectedLineBreak", data: { propertyName: ".biz" } }
+        ]
+    }, {
+        code: "foo.bar(). /* comment */ biz()",
+        output: "foo\n.bar()\n. /* comment */ biz()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [
+            { messageId: "expectedLineBreak", data: { propertyName: ".bar" } },
+            { messageId: "expectedLineBreak", data: { propertyName: ".biz" } }
+        ]
+    }, {
+        code: "foo.bar() /* comment */ .biz()",
+        output: "foo\n.bar() /* comment */ \n.biz()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [
+            { messageId: "expectedLineBreak", data: { propertyName: ".bar" } },
+            { messageId: "expectedLineBreak", data: { propertyName: ".biz" } }
+        ]
+    }, {
+        code: "foo\n.bar() /* comment */ .biz()",
+        output: "foo\n.bar() /* comment */ \n.biz()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: [{ messageId: "expectedLineBreak", data: { propertyName: ".biz" } }]
+    }, {
+        code: "test ? condition : [1, 2, 3].forEach(func)",
+        output: null,
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true
+        }],
+        errors: []
+    },
+
+    /*
+     * depthCalculationStyle: "all"
+     * ignoreChainWithDepth: 2 (default)
+     * includeBracketedProperties: true (default)
+     * includeMethodCalls: false
+     * includeProperties: true
+     * multilineBreakStyle: "never" (default)
+     */
+    {
+        code: "a['propertyNameString'].b().c",
+        output: "a\n['propertyNameString'].b()\n.c",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeMethodCalls: false,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: "['propertyNameString']" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".c" }
+        }]
+    },
+
+    /*
+     * depthCalculationStyle: "all"
+     * ignoreChainWithDepth: 2 (default)
+     * includeBracketedProperties: false
+     * includeMethodCalls: true (default)
+     * includeProperties: true
+     * multilineBreakStyle: "never" (default)
+     */
+    {
+        code: [
+            "anObject.method1().method2()['method' + n]()[aCondition ?",
+            "    'method3' :",
+            "    'method4']()"
+        ].join("\n"),
+        output: [
+            "anObject",
+            ".method1()",
+            ".method2()['method' + n]()[aCondition ?",
+            "    'method3' :",
+            "    'method4']()"
+        ].join("\n"),
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeBracketedProperties: false,
+            includeProperties: true
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".method1" }
+        }, {
+            messageId: "expectedLineBreak", data: { propertyName: ".method2" }
+        }]
+    }, {
+        code: "foo.bar()['foo' + \u2029 + 'bar']()",
+        output: null,
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeBracketedProperties: false,
+            includeProperties: true
+        }],
+        errors: []
+    }, {
+        code: "foo.bar()[(biz)]()",
+        output: null,
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeBracketedProperties: false,
+            includeProperties: true
+        }],
+        errors: []
+    }, {
+        code: "(foo).bar().biz()",
+        output: "(foo)\n.bar()\n.biz()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeBracketedProperties: false,
+            includeProperties: true
+        }],
+        errors: [
+            { messageId: "expectedLineBreak", data: { propertyName: ".bar" } },
+            { messageId: "expectedLineBreak", data: { propertyName: ".biz" } }
+        ]
+    }, {
+        code: "foo.bar(). /* comment */ biz()",
+        output: "foo\n.bar()\n. /* comment */ biz()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeBracketedProperties: false,
+            includeProperties: true
+        }],
+        errors: [
+            { messageId: "expectedLineBreak", data: { propertyName: ".bar" } },
+            { messageId: "expectedLineBreak", data: { propertyName: ".biz" } }
+        ]
+    }, {
+        code: "foo.bar() /* comment */ .biz()",
+        output: "foo\n.bar() /* comment */ \n.biz()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeBracketedProperties: false,
+            includeProperties: true
+        }],
+        errors: [
+            { messageId: "expectedLineBreak", data: { propertyName: ".bar" } },
+            { messageId: "expectedLineBreak", data: { propertyName: ".biz" } }
+        ]
+    }, {
+        code: "foo\n.bar() /* comment */ .biz()",
+        output: "foo\n.bar() /* comment */ \n.biz()",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeBracketedProperties: false,
+            includeProperties: true
+        }],
+        errors: [{ messageId: "expectedLineBreak", data: { propertyName: ".biz" } }]
+    },
+
+    /*
+     * depthCalculationStyle: "all"
+     * ignoreChainWithDepth: 2 (default)
+     * includeBracketedProperties: true (default)
+     * includeMethodCalls: false
+     * includeProperties: true
+     * multilineBreakStyle: "object"
+     */
+    {
+        code: "test ? condition : [1, 2, 3].forEach(func)",
+        output: null,
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true,
+            multilineBreakStyle: "object"
+        }],
+        errors: []
+    }, {
+        code: "test ? condition : [\n  1,\n  2,\n  3\n].forEach(func)",
+        output: "test ? condition : [\n  1,\n  2,\n  3\n]\n.forEach(func)",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true,
+            multilineBreakStyle: "object"
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".forEach" }
+        }]
+    },
+
+    /*
+     * depthCalculationStyle: "all"
+     * ignoreChainWithDepth: 2 (default)
+     * includeBracketedProperties: true (default)
+     * includeMethodCalls: false
+     * includeProperties: true
+     * multilineBreakStyle: "statement"
+     */
+    {
+        code: "test ? condition : [1, 2, 3].forEach(func)",
+        output: null,
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true,
+            multilineBreakStyle: "statement"
+        }],
+        errors: []
+    }, {
+        code: "test ? condition : [1, 2, 3].forEach(function() {\n  return\n})",
+        output: "test ? condition : [1, 2, 3]\n.forEach(function() {\n  return\n})",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true,
+            multilineBreakStyle: "statement"
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".forEach" }
+        }]
+    }, {
+        code: "test ? condition : [\n  1,\n  2,\n  3\n].forEach(func)",
+        output: "test ? condition : [\n  1,\n  2,\n  3\n]\n.forEach(func)",
+        options: [{
+            depthCalculationStyle: "all",
+            ignoreChainWithDepth: 2,
+            includeProperties: true,
+            multilineBreakStyle: "statement"
+        }],
+        errors: [{
+            messageId: "expectedLineBreak", data: { propertyName: ".forEach" }
+        }]
     }]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
Issue: https://github.com/eslint/eslint/issues/12970

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added a new option `maxTotalChainDepth` to `newline-per-chained-call` to re-add previously regressed functionality in ESLint v2. This functionality allowed ignoring a total chain depth and forcing newlines on all values if the chained members were greater than the total chain depth.

The code which has been added was written from scratch and unit tests were added accordingly. This way, whatever was being fixed in the previous PR where the regression occurred (#5365) won't also be an issue in this PR.

This PR does **not** remove the regressed functionality that currently exists.

#### Is there anything you'd like reviewers to focus on?
This re-added functionality is technically a completely different rule: `newline-per-chained-member` but would conflict with `newline-per-chained-call`.

The schema has been written such that you're either using the option `ignoreChainWithDepth` or `maxTotalChainDepth` but not both.

This is because both options are in conflict with one another and are based on completely different logic. `ignoreChainWithDepth` only looks at individual `CallExpression` types while `maxTotalChainDepth` looks at both `MemberExpression` and `CallExpression` types.