### PR TITLE
Update: add checking static value in no-throw-literal

### DIFF
--- a/lib/rules/no-throw-literal.js
+++ b/lib/rules/no-throw-literal.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const astUtils = require("./utils/ast-utils");
+const { getStaticValue } = require("eslint-utils");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -35,7 +36,9 @@ module.exports = {
         return {
 
             ThrowStatement(node) {
-                if (!astUtils.couldBeError(node.argument)) {
+                const isStaticValue = node.argument && getStaticValue(node.argument, context.getScope());
+
+                if (!astUtils.couldBeError(node.argument) || isStaticValue) {
                     context.report({ node, messageId: "object" });
                 } else if (node.argument.type === "Identifier") {
                     if (node.argument.name === "undefined") {

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1284,7 +1284,7 @@ module.exports = {
         return sourceCode.getText().slice(leftToken.range[0], rightToken.range[1]);
     },
 
-    /*
+    /**
      * Determine if a node has a possiblity to be an Error object
      * @param  {ASTNode} node  ASTNode to check
      * @returns {boolean} True if there is a chance it contains an Error obj

--- a/tests/lib/rules/no-throw-literal.js
+++ b/tests/lib/rules/no-throw-literal.js
@@ -25,6 +25,11 @@ ruleTester.run("no-throw-literal", rule, {
         "throw Error('error');",
         "var e = new Error(); throw e;",
         "try {throw new Error();} catch (e) {throw e;};",
+        { code: "const err = Error('err'); throw err;", parserOptions: { ecmaVersion: 6 } },
+        { code: "const err = new Error('err'); throw err;", parserOptions: { ecmaVersion: 6 } },
+        { code: "const String = Error; throw String('err');", parserOptions: { ecmaVersion: 6 } },
+        "throw new CustomError();",
+        "throw CustomError();",
         "throw a;", // Identifier
         "throw foo();", // CallExpression
         "throw new foo();", // NewExpression
@@ -41,6 +46,16 @@ ruleTester.run("no-throw-literal", rule, {
         { code: "async function foo() { throw await bar; }", parserOptions: { ecmaVersion: 8 } } // AwaitExpression
     ],
     invalid: [
+        {
+            code: "function foo() { const foo = 'str'; throw foo; }",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [{
+                messageId: "object",
+                type: "ThrowStatement"
+            }]
+        },
         {
             code: "throw 'error';",
             errors: [{
@@ -79,7 +94,24 @@ ruleTester.run("no-throw-literal", rule, {
         {
             code: "throw undefined;",
             errors: [{
+                messageId: "object",
+                type: "ThrowStatement"
+            }]
+        },
+        {
+            code: "function foo(undefined) {throw undefined;}",
+            errors: [{
                 messageId: "undef",
+                type: "ThrowStatement"
+            }]
+        },
+        {
+            code: "const foo = 'foo'; throw foo;",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [{
+                messageId: "object",
                 type: "ThrowStatement"
             }]
         },
@@ -139,6 +171,59 @@ ruleTester.run("no-throw-literal", rule, {
         // TemplateLiteral
         {
             code: "throw `${err}`;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "object",
+                type: "ThrowStatement"
+
+            }]
+        },
+
+        {
+            code: "const err = 'error'; throw err;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "object",
+                type: "ThrowStatement"
+
+            }]
+        },
+        {
+            code: "throw new String('error');",
+            errors: [{
+                messageId: "object",
+                type: "ThrowStatement"
+
+            }]
+        },
+        {
+            code: "throw String('error');",
+            errors: [{
+                messageId: "object",
+                type: "ThrowStatement"
+
+            }]
+        },
+        {
+            code: "const foo = { bar: 'err' }; throw foo.bar;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "object",
+                type: "ThrowStatement"
+
+            }]
+        },
+        {
+            code: "const Error = 'err'; throw Error;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "object",
+                type: "ThrowStatement"
+
+            }]
+        },
+        {
+            code: "throw new Object();",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "object",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I added static value checking in no-throw-literal using eslint-utils -getStaticValue.

#### Is there anything you'd like reviewers to focus on?

It will generate more warning so I labeled it `Update`.

> When it was first created, it only prevented literals from being thrown (hence the name), but it has now been expanded to only allow expressions which have a possibility of being an Error object.

This rule's name is `no-throw-literal` which pretends to check only literal. But, as mentioned in the docs, I think this change can be accepted.

Also, this PR contains small [jsdoc fix](https://github.com/eslint/eslint/compare/updateNoThrowLiteral?expand=1#diff-60bc8a6f0c57ce4fbfa4b794e7efc7d3R1287) in ast-utils 