### PR TITLE
Fix confusing error message.

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -708,7 +708,7 @@ class RuleTester {
                                      */
                                     function assertSuggestionKeyEquals(key) {
                                         if (hasOwnProperty(expectedSuggestion, key)) {
-                                            assert.deepStrictEqual(actualSuggestion[key], expectedSuggestion[key], `Error suggestion at index: ${index} should have desc of: "${actualSuggestion[key]}"`);
+                                            assert.deepStrictEqual(actualSuggestion[key], expectedSuggestion[key], `Error suggestion at index: ${index} should have ${key} of: "${actualSuggestion[key]}"`);
                                         }
                                     }
                                     assertSuggestionKeyEquals("desc");


### PR DESCRIPTION
the problem here was even if the assertion on `messageId` fails in the error it reads `should have desc of`:


#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request?
- [x] Other, please explain:

this PR fixes a small naming issue in RuleTester suggestions test error output.