### PR TITLE
Fix: camelcase false positive with computed property (fixes #13022)

### DIFF
--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -186,7 +186,7 @@ module.exports = {
 
                         const assignmentKeyEqualsValue = node.parent.key.name === node.parent.value.name;
 
-                        if (isUnderscored(name) && node.parent.computed) {
+                        if (nameIsUnderscored && node.parent.computed) {
                             report(node);
                         }
 

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -92,6 +92,14 @@ ruleTester.run("camelcase", rule, {
             options: [{ properties: "never" }]
         },
         {
+            code: "const { ['foo']: _foo } = obj;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "const { [_foo_]: foo } = obj;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "var { category_id } = query;",
             options: [{ ignoreDestructuring: true }],
             parserOptions: { ecmaVersion: 6 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

fixes #13022

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In the branch for computed pattern properties, the `camelcase`  rule should check for inner underscores only, like in all other branches.

#### Is there anything you'd like reviewers to focus on?
