### PR TITLE
Fix: no-plusplus allow comma operands in for afterthought (fixes #13005)

### DIFF
--- a/docs/rules/no-plusplus.md
+++ b/docs/rules/no-plusplus.md
@@ -71,10 +71,30 @@ Examples of **correct** code for this rule with the `{ "allowForLoopAfterthought
 /*eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }]*/
 
 for (i = 0; i < l; i++) {
-    return;
+    doSomething(i);
 }
 
-for (i = 0; i < l; i--) {
-    return;
+for (i = l; i >= 0; i--) {
+    doSomething(i);
 }
+
+for (i = 0, j = l; i < l; i++, j--) {
+    doSomething(i, j);
+}
+```
+
+Examples of **incorrect** code for this rule with the `{ "allowForLoopAfterthoughts": true }` option:
+
+```js
+/*eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }]*/
+
+for (i = 0; i < l; j = i++) {
+    doSomething(i, j);
+}
+
+for (i = l; i--;) {
+    doSomething(i);
+}
+
+for (i = 0; i < l;) i++;
 ```

--- a/lib/rules/no-plusplus.js
+++ b/lib/rules/no-plusplus.js
@@ -23,15 +23,22 @@ function isForStatementUpdate(node) {
 
 /**
  * Determines whether the given node is considered to be a for loop "afterthought" by the logic of this rule.
- * In particular, if it is the update node of a `ForStatement`, or an operand of a sequence expression that is the update node.
+ * In particular, it returns `true` if the given node is either:
+ *   - The update node of a `ForStatement`: for (;; i++) {}
+ *   - An operand of a sequence expression that is the update node: for (;; foo(), i++) {}
+ *   - An operand of a sequence expression that is child of another sequence expression, etc.,
+ *     up to the sequence expression that is the update node: for (;; foo(), (bar(), (baz(), i++))) {}
  * @param {ASTNode} node The node to check.
  * @returns {boolean} `true` if the node is a for loop afterthought.
  */
 function isForLoopAfterthought(node) {
     const parent = node.parent;
 
-    return isForStatementUpdate(node) ||
-        parent.type === "SequenceExpression" && isForStatementUpdate(parent);
+    if (parent.type === "SequenceExpression") {
+        return isForLoopAfterthought(parent);
+    }
+
+    return isForStatementUpdate(node);
 }
 
 //------------------------------------------------------------------------------

--- a/lib/rules/no-plusplus.js
+++ b/lib/rules/no-plusplus.js
@@ -7,6 +7,34 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Determines whether the given node is the update node of a `ForStatement`.
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is `ForStatement` update.
+ */
+function isForStatementUpdate(node) {
+    const parent = node.parent;
+
+    return parent.type === "ForStatement" && parent.update === node;
+}
+
+/**
+ * Determines whether the given node is considered to be a for loop "afterthought" by the logic of this rule.
+ * In particular, if it is the update node of a `ForStatement`, or an operand of a sequence expression that is the update node.
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is a for loop afterthought.
+ */
+function isForLoopAfterthought(node) {
+    const parent = node.parent;
+
+    return isForStatementUpdate(node) ||
+        parent.type === "SequenceExpression" && isForStatementUpdate(parent);
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -42,18 +70,19 @@ module.exports = {
     create(context) {
 
         const config = context.options[0];
-        let allowInForAfterthought = false;
+        let allowForLoopAfterthoughts = false;
 
         if (typeof config === "object") {
-            allowInForAfterthought = config.allowForLoopAfterthoughts === true;
+            allowForLoopAfterthoughts = config.allowForLoopAfterthoughts === true;
         }
 
         return {
 
             UpdateExpression(node) {
-                if (allowInForAfterthought && node.parent.type === "ForStatement") {
+                if (allowForLoopAfterthoughts && isForLoopAfterthought(node)) {
                     return;
                 }
+
                 context.report({
                     node,
                     messageId: "unexpectedUnaryOp",

--- a/tests/lib/rules/no-plusplus.js
+++ b/tests/lib/rules/no-plusplus.js
@@ -24,7 +24,11 @@ ruleTester.run("no-plusplus", rule, {
 
         // With "allowForLoopAfterthoughts" allowed
         { code: "var foo = 0; foo=+1;", options: [{ allowForLoopAfterthoughts: true }] },
-        { code: "for (i = 0; i < l; i++) { console.log(i); }", options: [{ allowForLoopAfterthoughts: true }] }
+        { code: "for (i = 0; i < l; i++) { console.log(i); }", options: [{ allowForLoopAfterthoughts: true }] },
+        { code: "for (var i = 0, j = i + 1; j < example.length; i++, j++) {}", options: [{ allowForLoopAfterthoughts: true }] },
+        { code: "for (;; i--, foo());", options: [{ allowForLoopAfterthoughts: true }] },
+        { code: "for (;; foo(), --i);", options: [{ allowForLoopAfterthoughts: true }] },
+        { code: "for (;; foo(), ++i, bar);", options: [{ allowForLoopAfterthoughts: true }] }
     ],
 
     invalid: [
@@ -78,6 +82,61 @@ ruleTester.run("no-plusplus", rule, {
                 messageId: "unexpectedUnaryOp",
                 data: {
                     operator: "++"
+                },
+                type: "UpdateExpression"
+            }]
+        },
+        {
+            code: "for (i++;;);",
+            options: [{ allowForLoopAfterthoughts: true }],
+            errors: [{
+                messageId: "unexpectedUnaryOp",
+                data: {
+                    operator: "++"
+                },
+                type: "UpdateExpression"
+            }]
+        },
+        {
+            code: "for (;--i;);",
+            options: [{ allowForLoopAfterthoughts: true }],
+            errors: [{
+                messageId: "unexpectedUnaryOp",
+                data: {
+                    operator: "--"
+                },
+                type: "UpdateExpression"
+            }]
+        },
+        {
+            code: "for (;;) ++i;",
+            options: [{ allowForLoopAfterthoughts: true }],
+            errors: [{
+                messageId: "unexpectedUnaryOp",
+                data: {
+                    operator: "++"
+                },
+                type: "UpdateExpression"
+            }]
+        },
+        {
+            code: "for (;; i = j++);",
+            options: [{ allowForLoopAfterthoughts: true }],
+            errors: [{
+                messageId: "unexpectedUnaryOp",
+                data: {
+                    operator: "++"
+                },
+                type: "UpdateExpression"
+            }]
+        },
+        {
+            code: "for (;; i++, f(--j));",
+            options: [{ allowForLoopAfterthoughts: true }],
+            errors: [{
+                messageId: "unexpectedUnaryOp",
+                data: {
+                    operator: "--"
                 },
                 type: "UpdateExpression"
             }]

--- a/tests/lib/rules/no-plusplus.js
+++ b/tests/lib/rules/no-plusplus.js
@@ -28,7 +28,11 @@ ruleTester.run("no-plusplus", rule, {
         { code: "for (var i = 0, j = i + 1; j < example.length; i++, j++) {}", options: [{ allowForLoopAfterthoughts: true }] },
         { code: "for (;; i--, foo());", options: [{ allowForLoopAfterthoughts: true }] },
         { code: "for (;; foo(), --i);", options: [{ allowForLoopAfterthoughts: true }] },
-        { code: "for (;; foo(), ++i, bar);", options: [{ allowForLoopAfterthoughts: true }] }
+        { code: "for (;; foo(), ++i, bar);", options: [{ allowForLoopAfterthoughts: true }] },
+        { code: "for (;; i++, (++j, k--));", options: [{ allowForLoopAfterthoughts: true }] },
+        { code: "for (;; foo(), (bar(), i++), baz());", options: [{ allowForLoopAfterthoughts: true }] },
+        { code: "for (;; (--i, j += 2), bar = j + 1);", options: [{ allowForLoopAfterthoughts: true }] },
+        { code: "for (;; a, (i--, (b, ++j, c)), d);", options: [{ allowForLoopAfterthoughts: true }] }
     ],
 
     invalid: [
@@ -54,6 +58,16 @@ ruleTester.run("no-plusplus", rule, {
         },
         {
             code: "for (i = 0; i < l; i++) { console.log(i); }",
+            errors: [{
+                messageId: "unexpectedUnaryOp",
+                data: {
+                    operator: "++"
+                },
+                type: "UpdateExpression"
+            }]
+        },
+        {
+            code: "for (i = 0; i < l; foo, i++) { console.log(i); }",
             errors: [{
                 messageId: "unexpectedUnaryOp",
                 data: {
@@ -137,6 +151,17 @@ ruleTester.run("no-plusplus", rule, {
                 messageId: "unexpectedUnaryOp",
                 data: {
                     operator: "--"
+                },
+                type: "UpdateExpression"
+            }]
+        },
+        {
+            code: "for (;; foo + (i++, bar));",
+            options: [{ allowForLoopAfterthoughts: true }],
+            errors: [{
+                messageId: "unexpectedUnaryOp",
+                data: {
+                    operator: "++"
                 },
                 type: "UpdateExpression"
             }]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

fixes #13005

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`allowForLoopAfterthoughts` in the `no-plusplus` rule will now additionally allow `++` and `--` in sequence expressions:

```js
/*eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }]*/

for (i = 0, j = 0; i < l; i++, j++); // ok
```

Also fixed false negatives when the node isn't the `update` node:

```js
for (i++;;);

for (; i++;);
```

#### Is there anything you'd like reviewers to focus on?
