### PR TITLE
Update: Add ignorePattern to no-inline-comments

### DIFF
--- a/docs/rules/no-inline-comments.md
+++ b/docs/rules/no-inline-comments.md
@@ -87,3 +87,25 @@ var quux = (
     </div>
 )
 ```
+
+## Options
+
+### ignorePattern
+
+A regular expression can be provided to make this rule ignore specific comments.
+
+Examples of **correct** code for the `ignorePattern` option:
+
+```js
+/*eslint no-inline-comments: ["error", { "ignorePattern": "webpackChunkName:\\s.+" }]*/
+
+import(/* webpackChunkName: "my-chunk-name" */ './locale/en');
+```
+
+Examples of **incorrect** code for the `ignorePattern` option:
+
+```js
+/*eslint no-inline-comments: ["error", { "ignorePattern": "something" }] */
+
+var foo = 4; // other thing
+```

--- a/tests/lib/rules/no-inline-comments.js
+++ b/tests/lib/rules/no-inline-comments.js
@@ -88,7 +88,24 @@ ruleTester.run("no-inline-comments", rule, {
                comment
             */}
             </div>
-        )`
+        )`,
+        {
+            code: "import(/* webpackChunkName: \"my-chunk-name\" */ './locale/en');",
+            options: [
+                {
+                    ignorePattern: "(?:webpackChunkName):\\s.+"
+                }
+            ],
+            parserOptions: { ecmaVersion: 2020 }
+        },
+        {
+            code: "var foo = 2; // Note: This comment is legal.",
+            options: [
+                {
+                    ignorePattern: "Note: "
+                }
+            ]
+        }
     ],
 
     invalid: [
@@ -101,11 +118,29 @@ ruleTester.run("no-inline-comments", rule, {
             errors: [blockError]
         },
         {
+            code: "/* something */ var a = 2;",
+            options: [
+                {
+                    ignorePattern: "otherthing"
+                }
+            ],
+            errors: [blockError]
+        },
+        {
             code: "var a = 3; //A comment inline with code",
             errors: [lineError]
         },
         {
             code: "var a = 3; // someday use eslint-disable-line here",
+            errors: [lineError]
+        },
+        {
+            code: "var a = 3; // other line comment",
+            options: [
+                {
+                    ignorePattern: "something"
+                }
+            ],
             errors: [lineError]
         },
         {


### PR DESCRIPTION
Update: Add filtering to no-inline-comments and allow Webpack magic comments 

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [ ] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request?

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule 
- [X] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

**What rule do you want to change?**
no-inline-comments 

**Does this change cause the rule to produce more or fewer warnings?**
Fewer

**How will the change be implemented?**
New default behaviour. 

**Please provide some example code that this change will affect:**

```js
const language = import(/* webpackChunkName: "my-chunk-name" */'./locale/language');
```

**What does the rule currently do for this code?**
Reports error/warning: `Unexpected comment inline with code.(no-inline-comments)`

**What will the rule do after it's changed?**
Not report on this kind of comment anymore.

#### What changes did you make?
I added all the [Webpack magic comments](https://webpack.js.org/api/module-methods/#magic-comments] keywords to the `astUtils.COMMENTS_IGNORE_PATTERN` regex. It looks like this now:

```js
// From this:
/^\s*(?:eslint|jshint\s+|jslint\s+|istanbul\s+|globals?\s+|exported\s+|jscs)/u
// To this:
/^\s*(?:eslint|jshint\s+|jslint\s+|istanbul\s+|globals?\s+|exported\s+|jscs|webpackInclude:|webpackExclude:|webpackChunkName:|webpackMode:|webpackPrefetch:|webpackPreload:)/u
```
This affects the following rules:
* no-inline-comments
* capitalized-comments (+ This is a big plus as it would break the keywords)
* line-comment-position (- Likely not necessary)
* lines-around-comment (- Likely not necessary)
* multiline-comment-style (- Likely not necessary)

I added a filter to the `sourceCode.getAllComments()` call in the `Program` method of the rule's definition so these comments (and the ones that were already present in `COMMENTS_IGNORE_PATTERN`) will be ignored.

#### Is there anything you'd like reviewers to focus on?
Is the `astUtils.COMMENTS_IGNORE_PATTERN` is the correct place for the new exceptions? If so, I will update the docs in every place it applies.
Should this be the new default behaviour?