### PR TITLE
Fix: consistencies with docs default and rule

### DIFF
--- a/lib/rules/computed-property-spacing.js
+++ b/lib/rules/computed-property-spacing.js
@@ -32,7 +32,7 @@ module.exports = {
                 properties: {
                     enforceForClassMembers: {
                         type: "boolean",
-                        default: true
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/use-isnan.js
+++ b/lib/rules/use-isnan.js
@@ -45,7 +45,7 @@ module.exports = {
                 properties: {
                     enforceForSwitchCase: {
                         type: "boolean",
-                        default: true
+                        default: false
                     },
                     enforceForIndexOf: {
                         type: "boolean",

--- a/tests/lib/rules/computed-property-spacing.js
+++ b/tests/lib/rules/computed-property-spacing.js
@@ -153,6 +153,238 @@ ruleTester.run("computed-property-spacing", rule, {
             options: ["always", { enforceForClassMembers: true }],
             parserOptions: { ecmaVersion: 6 }
         },
+        {
+            code: "A = class { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }",
+            output: "A = class { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }",
+            options: ["never", {}],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 14,
+                    endLine: 1,
+                    endColumn: 15
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 16,
+                    endLine: 1,
+                    endColumn: 17
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 28,
+                    endLine: 1,
+                    endColumn: 29
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 30,
+                    endLine: 1,
+                    endColumn: 31
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 42,
+                    endLine: 1,
+                    endColumn: 43
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 44,
+                    endLine: 1,
+                    endColumn: 45
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 62,
+                    endLine: 1,
+                    endColumn: 63
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 64,
+                    endLine: 1,
+                    endColumn: 65
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 83,
+                    endLine: 1,
+                    endColumn: 84
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 85,
+                    endLine: 1,
+                    endColumn: 86
+                },
+                {
+                    messageId: "unexpectedSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 104,
+                    endLine: 1,
+                    endColumn: 105
+                },
+                {
+                    messageId: "unexpectedSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 106,
+                    endLine: 1,
+                    endColumn: 107
+                }
+            ]
+        },
+        {
+            code: "class A { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }",
+            output: "class A { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }",
+            options: ["always", {}],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 13,
+                    endLine: 1,
+                    endColumn: 14
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 23,
+                    endLine: 1,
+                    endColumn: 24
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 25,
+                    endLine: 1,
+                    endColumn: 26
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 35,
+                    endLine: 1,
+                    endColumn: 36
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 37,
+                    endLine: 1,
+                    endColumn: 38
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 53,
+                    endLine: 1,
+                    endColumn: 54
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 55,
+                    endLine: 1,
+                    endColumn: 56
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 72,
+                    endLine: 1,
+                    endColumn: 73
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 74,
+                    endLine: 1,
+                    endColumn: 75
+                },
+                {
+                    messageId: "missingSpaceAfter",
+                    data: { tokenValue: "[" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 91,
+                    endLine: 1,
+                    endColumn: 92
+                },
+                {
+                    messageId: "missingSpaceBefore",
+                    data: { tokenValue: "]" },
+                    type: "MethodDefinition",
+                    line: 1,
+                    column: 93,
+                    endLine: 1,
+                    endColumn: 94
+                }
+            ]
+        },
 
         // handling of parens and comments
         {
@@ -780,122 +1012,6 @@ ruleTester.run("computed-property-spacing", rule, {
             ]
         },
         {
-            code: "A = class { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }",
-            output: "A = class { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }",
-            options: ["never", {}],
-            parserOptions: { ecmaVersion: 6 },
-            errors: [
-                {
-                    messageId: "unexpectedSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 14,
-                    endLine: 1,
-                    endColumn: 15
-                },
-                {
-                    messageId: "unexpectedSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 16,
-                    endLine: 1,
-                    endColumn: 17
-                },
-                {
-                    messageId: "unexpectedSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 28,
-                    endLine: 1,
-                    endColumn: 29
-                },
-                {
-                    messageId: "unexpectedSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 30,
-                    endLine: 1,
-                    endColumn: 31
-                },
-                {
-                    messageId: "unexpectedSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 42,
-                    endLine: 1,
-                    endColumn: 43
-                },
-                {
-                    messageId: "unexpectedSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 44,
-                    endLine: 1,
-                    endColumn: 45
-                },
-                {
-                    messageId: "unexpectedSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 62,
-                    endLine: 1,
-                    endColumn: 63
-                },
-                {
-                    messageId: "unexpectedSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 64,
-                    endLine: 1,
-                    endColumn: 65
-                },
-                {
-                    messageId: "unexpectedSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 83,
-                    endLine: 1,
-                    endColumn: 84
-                },
-                {
-                    messageId: "unexpectedSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 85,
-                    endLine: 1,
-                    endColumn: 86
-                },
-                {
-                    messageId: "unexpectedSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 104,
-                    endLine: 1,
-                    endColumn: 105
-                },
-                {
-                    messageId: "unexpectedSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 106,
-                    endLine: 1,
-                    endColumn: 107
-                }
-            ]
-        },
-        {
             code: "A = class { [a](){} }",
             output: "A = class { [ a ](){} }",
             options: ["always"],
@@ -1034,122 +1150,6 @@ ruleTester.run("computed-property-spacing", rule, {
                     column: 95,
                     endLine: 1,
                     endColumn: 96
-                }
-            ]
-        },
-        {
-            code: "class A { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }",
-            output: "class A { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }",
-            options: ["always", {}],
-            parserOptions: { ecmaVersion: 6 },
-            errors: [
-                {
-                    messageId: "missingSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 11,
-                    endLine: 1,
-                    endColumn: 12
-                },
-                {
-                    messageId: "missingSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 13,
-                    endLine: 1,
-                    endColumn: 14
-                },
-                {
-                    messageId: "missingSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 23,
-                    endLine: 1,
-                    endColumn: 24
-                },
-                {
-                    messageId: "missingSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 25,
-                    endLine: 1,
-                    endColumn: 26
-                },
-                {
-                    messageId: "missingSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 35,
-                    endLine: 1,
-                    endColumn: 36
-                },
-                {
-                    messageId: "missingSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 37,
-                    endLine: 1,
-                    endColumn: 38
-                },
-                {
-                    messageId: "missingSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 53,
-                    endLine: 1,
-                    endColumn: 54
-                },
-                {
-                    messageId: "missingSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 55,
-                    endLine: 1,
-                    endColumn: 56
-                },
-                {
-                    messageId: "missingSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 72,
-                    endLine: 1,
-                    endColumn: 73
-                },
-                {
-                    messageId: "missingSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 74,
-                    endLine: 1,
-                    endColumn: 75
-                },
-                {
-                    messageId: "missingSpaceAfter",
-                    data: { tokenValue: "[" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 91,
-                    endLine: 1,
-                    endColumn: 92
-                },
-                {
-                    messageId: "missingSpaceBefore",
-                    data: { tokenValue: "]" },
-                    type: "MethodDefinition",
-                    line: 1,
-                    column: 93,
-                    endLine: 1,
-                    endColumn: 94
                 }
             ]
         },

--- a/tests/lib/rules/use-isnan.js
+++ b/tests/lib/rules/use-isnan.js
@@ -50,6 +50,16 @@ ruleTester.run("use-isnan", rule, {
             options: [{ enforceForSwitchCase: false }]
         },
         {
+            code: "switch(NaN) { case foo: break; }",
+            options: [{}],
+            errors: [{ messageId: "switchNaN", type: "SwitchStatement", column: 1 }]
+        },
+        {
+            code: "switch(foo) { case NaN: break; }",
+            options: [{}],
+            errors: [{ messageId: "caseNaN", type: "SwitchCase", column: 15 }]
+        },
+        {
             code: "switch(NaN) { case NaN: break; }",
             options: [{ enforceForSwitchCase: false }]
         },
@@ -278,16 +288,6 @@ ruleTester.run("use-isnan", rule, {
         },
         {
             code: "switch(foo) { case NaN: break; }",
-            errors: [{ messageId: "caseNaN", type: "SwitchCase", column: 15 }]
-        },
-        {
-            code: "switch(NaN) { case foo: break; }",
-            options: [{}],
-            errors: [{ messageId: "switchNaN", type: "SwitchStatement", column: 1 }]
-        },
-        {
-            code: "switch(foo) { case NaN: break; }",
-            options: [{}],
             errors: [{ messageId: "caseNaN", type: "SwitchCase", column: 15 }]
         },
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->
There is an inconsistency with the default mentioned in docs and in the rule schema for  rule

- `use-isnan`
- `computed-property-spacing`

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
- `use-isnan`:    [`In docs`](https://eslint.org/docs/rules/use-isnan#top) check the `enforceForSwitchCase` which is mentioned `false` in docs but `true` in [`rule schema`](https://github.com/eslint/eslint/blob/master/lib/rules/use-isnan.js#L48)

- `computed-property-spacing` : [`In docs`](https://eslint.org/docs/rules/computed-property-spacing#top) check the `enforceForClassMembers` which is mentioned as `false` in docs but true in [`rule schema`](https://github.com/eslint/eslint/blob/master/lib/rules/computed-property-spacing.js#L35)

I did change the rule schema and the required tests as the docs were correct in there place.

#### Is there anything you'd like reviewers to focus on?
This was noticed when I was working in this https://github.com/eslint/eslint/pull/13034 
