### PR TITLE
Fix: check template literal in prefer-numeric-literals (fixes #13045)

### DIFF
--- a/docs/rules/prefer-numeric-literals.md
+++ b/docs/rules/prefer-numeric-literals.md
@@ -17,6 +17,7 @@ Examples of **incorrect** code for this rule:
 /*eslint prefer-numeric-literals: "error"*/
 
 parseInt("111110111", 2) === 503;
+parseInt(`111110111`, 2) === 503;
 parseInt("767", 8) === 503;
 parseInt("1F7", 16) === 503;
 Number.parseInt("111110111", 2) === 503;

--- a/lib/rules/prefer-numeric-literals.js
+++ b/lib/rules/prefer-numeric-literals.js
@@ -79,13 +79,13 @@ module.exports = {
 
             "CallExpression[arguments.length=2]"(node) {
                 const [strNode, radixNode] = node.arguments,
-                    str = strNode.value,
+                    str = astUtils.getStaticStringValue(strNode),
                     radix = radixNode.value;
 
                 if (
-                    strNode.type === "Literal" &&
+                    str !== null &&
+                    astUtils.isStringLiteral(strNode) &&
                     radixNode.type === "Literal" &&
-                    typeof str === "string" &&
                     typeof radix === "number" &&
                     radixMap.has(radix) &&
                     isParseInt(node.callee)

--- a/tests/lib/rules/prefer-numeric-literals.js
+++ b/tests/lib/rules/prefer-numeric-literals.js
@@ -37,6 +37,7 @@ ruleTester.run("prefer-numeric-literals", rule, {
         "parseInt(1e5, 16);",
         "parseInt('11', '2');",
         "Number.parseInt('11', '8');",
+        "parseInt(/foo/, 2);",
         {
             code: "parseInt('11', 2n);",
             parserOptions: { ecmaVersion: 2020 }
@@ -50,8 +51,16 @@ ruleTester.run("prefer-numeric-literals", rule, {
             parserOptions: { ecmaVersion: 2020 }
         },
         {
+            code: "parseInt(`11`, 16n);",
+            parserOptions: { ecmaVersion: 2020 }
+        },
+        {
             code: "parseInt(1n, 2);",
             parserOptions: { ecmaVersion: 2020 }
+        },
+        {
+            code: "parseInt(`11${foo}`, 2);",
+            parserOptions: { ecmaVersion: 2016 }
         }
     ],
     invalid: [
@@ -111,6 +120,42 @@ ruleTester.run("prefer-numeric-literals", rule, {
             code: "Number.parseInt('1️⃣3️⃣3️⃣7️⃣', 16);",
             output: null, // not fixed, javascript doesn't support emoji literals
             errors: [{ message: "Use hexadecimal literals instead of Number.parseInt()." }]
+        },
+        {
+            code: "parseInt(`111110111`, 2) === 503;",
+            output: "0b111110111 === 503;",
+            errors: [{ message: "Use binary literals instead of parseInt()." }]
+        }, {
+            code: "parseInt(`767`, 8) === 503;",
+            output: "0o767 === 503;",
+            errors: [{ message: "Use octal literals instead of parseInt()." }]
+        }, {
+            code: "parseInt(`1F7`, 16) === 255;",
+            output: "0x1F7 === 255;",
+            errors: [{ message: "Use hexadecimal literals instead of parseInt()." }]
+        },
+        {
+            code: "parseInt('', 8);",
+            output: null, // not fixed, it's empty string
+            errors: [{ message: "Use octal literals instead of parseInt()." }]
+        },
+        {
+            code: "parseInt(``, 8);",
+            output: null, // not fixed, it's empty string
+            errors: [{ message: "Use octal literals instead of parseInt()." }]
+        },
+        {
+            code: "parseInt(`7999`, 8);",
+            output: null, // not fixed, unexpected 9 in parseInt string
+            errors: [{ message: "Use octal literals instead of parseInt()." }]
+        }, {
+            code: "parseInt(`1234`, 2);",
+            output: null, // not fixed, invalid binary string
+            errors: [{ message: "Use binary literals instead of parseInt()." }]
+        }, {
+            code: "parseInt(`1234.5`, 8);",
+            output: null, // not fixed, this isn't an integer
+            errors: [{ message: "Use octal literals instead of parseInt()." }]
         },
 
         // Adjacent tokens tests
@@ -259,6 +304,11 @@ ruleTester.run("prefer-numeric-literals", rule, {
         },
         {
             code: "parseInt('11'/**/, 2);",
+            output: null,
+            errors: 1
+        },
+        {
+            code: "parseInt(`11`/**/, 2);",
             output: null,
             errors: 1
         },

--- a/tests/lib/rules/prefer-numeric-literals.js
+++ b/tests/lib/rules/prefer-numeric-literals.js
@@ -38,6 +38,7 @@ ruleTester.run("prefer-numeric-literals", rule, {
         "parseInt('11', '2');",
         "Number.parseInt('11', '8');",
         "parseInt(/foo/, 2);",
+        "parseInt(`11${foo}`, 2);",
         {
             code: "parseInt('11', 2n);",
             parserOptions: { ecmaVersion: 2020 }
@@ -57,10 +58,6 @@ ruleTester.run("prefer-numeric-literals", rule, {
         {
             code: "parseInt(1n, 2);",
             parserOptions: { ecmaVersion: 2020 }
-        },
-        {
-            code: "parseInt(`11${foo}`, 2);",
-            parserOptions: { ecmaVersion: 2016 }
         }
     ],
     invalid: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I changed it to check literal with using `astUtils.getStaticValue` and `astUtils.isStringLiteral`

#### Is there anything you'd like reviewers to focus on?

This PR will Fixes #13045
