### PR TITLE
Fix: require-await ignore async generators (fixes #12459)

### DIFF
--- a/docs/rules/require-await.md
+++ b/docs/rules/require-await.md
@@ -18,7 +18,7 @@ async function fetchData(processDataItem) {
 
 Asynchronous functions that don't use `await` might not need to be asynchronous functions and could be the unintentional result of refactoring.
 
-> This rule doesnt report for non `await` async generator functions
+Note: this rule ignores async generator functions. This is because generators yield rather than return a value and async generator might yield all the values of another async generator without ever actually needing to use await.
 
 ## Rule Details
 

--- a/docs/rules/require-await.md
+++ b/docs/rules/require-await.md
@@ -18,7 +18,7 @@ async function fetchData(processDataItem) {
 
 Asynchronous functions that don't use `await` might not need to be asynchronous functions and could be the unintentional result of refactoring.
 
-Note: this rule ignores async generator functions. This is because generators yield rather than return a value and async generator might yield all the values of another async generator without ever actually needing to use await.
+Note: this rule ignores async generator functions. This is because generators yield rather than return a value and async generators might yield all the values of another async generator without ever actually needing to use await.
 
 ## Rule Details
 

--- a/docs/rules/require-await.md
+++ b/docs/rules/require-await.md
@@ -18,6 +18,7 @@ async function fetchData(processDataItem) {
 
 Asynchronous functions that don't use `await` might not need to be asynchronous functions and could be the unintentional result of refactoring.
 
+> This rule doesnt report for non `await` async generator functions
 
 ## Rule Details
 

--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -68,7 +68,7 @@ module.exports = {
          * @returns {void}
          */
         function exitFunction(node) {
-            if (node.async && !scopeInfo.hasAwait && !astUtils.isEmptyFunction(node)) {
+            if (!node.generator && node.async && !scopeInfo.hasAwait && !astUtils.isEmptyFunction(node)) {
                 context.report({
                     node,
                     loc: astUtils.getFunctionHeadLoc(node, sourceCode),

--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -57,7 +57,7 @@ ruleTester.run("require-await", rule, {
             parser: require.resolve("../../fixtures/parsers/typescript-parsers/global-for-await-of")
         },
         {
-            code: "async function* run() { anotherAsyncGenerator() }",
+            code: "async function* run() { yield * anotherAsyncGenerator() }",
             parserOptions: { ecmaVersion: 9 }
         },
         {

--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -55,6 +55,19 @@ ruleTester.run("require-await", rule, {
                 }
             `,
             parser: require.resolve("../../fixtures/parsers/typescript-parsers/global-for-await-of")
+        },
+        {
+            code: "async function* run() { anotherAsyncGenerator() }",
+            parserOptions: { ecmaVersion: 9 }
+        },
+        {
+            code: `async function* run() {
+                await new Promise(resolve => setTimeout(resolve, 100));
+                yield 'Hello';
+                console.log('World');
+            }
+            `,
+            parserOptions: { ecmaVersion: 9 }
         }
     ],
     invalid: [

--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -68,7 +68,24 @@ ruleTester.run("require-await", rule, {
             }
             `,
             parserOptions: { ecmaVersion: 9 }
+        },
+        {
+            code: "async function* run() { }",
+            parserOptions: { ecmaVersion: 9 }
+        },
+        {
+            code: "const foo = async function *(){}",
+            parserOptions: { ecmaVersion: 9 }
+        },
+        {
+            code: 'const foo = async function *(){ console.log("bar") }',
+            parserOptions: { ecmaVersion: 9 }
+        },
+        {
+            code: 'async function* run() { console.log("bar") }',
+            parserOptions: { ecmaVersion: 9 }
         }
+
     ],
     invalid: [
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
Fixes https://github.com/eslint/eslint/issues/12459
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

after this change, `require-await` rule won't check for async generator functions . So an async generator function having no await wont report any error

#### Is there anything you'd like reviewers to focus on?
https://github.com/eslint/eslint/issues/12459