### PR TITLE
Fix: Backport removal of mkdirp to 6.x (fixes #13050)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,7 +17,6 @@
 
 const fs = require("fs"),
     path = require("path"),
-    mkdirp = require("mkdirp"),
     { CLIEngine } = require("./cli-engine"),
     options = require("./options"),
     log = require("./shared/logging"),
@@ -115,7 +114,7 @@ function printResults(engine, results, format, outputFile) {
             }
 
             try {
-                mkdirp.sync(path.dirname(filePath));
+                fs.mkdirSync(path.dirname(filePath), { recursive: true });
                 fs.writeFileSync(filePath, output);
             } catch (ex) {
                 log.error("There was a problem writing the output file:\n%s", ex);

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "levn": "^0.3.0",
     "lodash": "^4.17.14",
     "minimatch": "^3.0.4",
-    "mkdirp": "^0.5.1",
     "natural-compare": "^1.4.0",
     "optionator": "^0.8.3",
     "progress": "^2.0.0",


### PR DESCRIPTION
* the CVE is caused by the mkdirp dependency
* mkdirp is no longer supported
* mkdirp has been removed as of 7.0.0-alpha0
* this back-ports the change to v6.x

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Other:
This PR removes the `mkdirp` dependency reflecting a change made in #12753 and included in the 7.0.0-alpha0 tag. This change fixes the security vulnerability CVE-2020-7598. Specifics are outlined in issue #13050.

Patching this into the v6.x line will ensure that users who still depend on v6.x can reliably update ESLint, thereby removing the security vulnerability and related security audit notices.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- remove the `mkdirp` dependency from `package.json`
- remove the `require("mkdirp")` statement in `/lib/cli.js`
- replace the call to `mkdirp.sync` with a call to the node built-in `fs.mkdirSync()` in `/lib/cli.js` 

These changes were extracted from the #12753 diff

#### Is there anything you'd like reviewers to focus on?

Guess I should start with the obvious question. Does ESLint support back-porting security fixes to previous versions? If so, is this the right way to handle it?

This change has been tested with the `pkg.engines` specified in the v6.8.0 tag (ie "^8.10.0 || ^10.13.0 || >=11.10.1"). Double-check to make sure this change doesn't break anything.

From what I could gather from the git history, it looks like all changes after v6.8.0 apply to the new 7.x series. I wasn't sure if I should build off a specific commit following v6.8.0 so I branched directly off the tag. If the change needs to be rebased on top of a later commit, let me know.