### PR TITLE
Docs: Clarify that node_modules is ignored by default

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -480,7 +480,7 @@ Example:
 
 ESLint supports `.eslintignore` files to exclude files from the linting process when ESLint operates on a directory. Files given as individual CLI arguments will be exempt from exclusion. The `.eslintignore` file is a plain text file containing one pattern per line. It can be located in any of the target directory's ancestors; it will affect files in its containing directory as well as all sub-directories. Here's a simple example of a `.eslintignore` file:
 
-    node_modules/*
+    temp.js
     **/vendor/*.js
 
 A more detailed breakdown of supported patterns and directories ESLint ignores by default can be found in [Configuring ESLint](configuring.md#ignoring-files-and-directories).

--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -1021,7 +1021,7 @@ You can tell ESLint to ignore specific files and directories by `ignorePatterns`
 
 ```json
 {
-    "ignorePatterns": ["temp.js", "node_modules/"],
+    "ignorePatterns": ["temp.js", "**/vendor/*.js"],
     "rules": {
         //...
     }
@@ -1061,12 +1061,13 @@ Of particular note is that like `.gitignore` files, all paths used as patterns f
 
 Please see `.gitignore`'s specification for further examples of valid syntax.
 
-In addition to any patterns in a `.eslintignore` file, ESLint always ignores files in `/**/node_modules/*`.
+In addition to any patterns in a `.eslintignore` file, ESLint ignores files in `/**/node_modules/*` by default. It can still be added using `!`.
 
-For example, placing the following `.eslintignore` file in the current working directory will ignore all of `node_modules/*` and anything in the `build/` directory except `build/index.js`:
+For example, placing the following `.eslintignore` file in the current working directory will not ignore `node_modules/*` and ignore anything in the `build/` directory except `build/index.js`:
 
 ```text
-# node_modules/* are ignored by default
+# node_modules/* is ignored by default, but can be added using !
+!node_modules/*
 
 # Ignore built files except build/index.js
 build/*


### PR DESCRIPTION
Fixes #13006

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [ ] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)
The ```node_modules``` folder is ignored by default. However, in some parts of the documentation it is still included in ignore configs. I removed the ```node_modules``` entries from the examples and clarified in an example ignore config how it can be added back in.

#### Is there anything you'd like reviewers to focus on?
Whether the added/edited documentation is still correct and if ```node_modules/*``` is the correct pattern.