### PR TITLE
Update: Backticks as an escape for both of the single and double-quote

### DIFF
--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -109,6 +109,7 @@ Examples of additional **correct** code for this rule with the `"double", { "avo
 /*eslint quotes: ["error", "double", { "avoidEscape": true }]*/
 
 var single = 'a string containing "double" quotes';
+var backtick = `a string containing 'single' and "double" quotes`;
 ```
 
 Examples of additional **correct** code for this rule with the `"single", { "avoidEscape": true }` options:
@@ -117,6 +118,7 @@ Examples of additional **correct** code for this rule with the `"single", { "avo
 /*eslint quotes: ["error", "single", { "avoidEscape": true }]*/
 
 var double = "a string containing 'single' quotes";
+var backtick = `a string containing 'single' and "double" quotes`;
 ```
 
 Examples of additional **correct** code for this rule with the `"backtick", { "avoidEscape": true }` options:

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -259,6 +259,25 @@ module.exports = {
             return false;
         }
 
+        /**
+         * Checks whether or not a given TemplateLiteral node is actually escaping both of the singlequote and doublequote.
+         * @param {ASTNode} node A TemplateLiteral node to check.
+         * @returns {boolean} Whether or not a given TemplateLiteral node is actually escaping both of the singlequote and doublequote.
+         * @private
+         */
+        function isEscapingBothQuotes(node) {
+            const val = node.quasis[0].value.raw;
+
+            if (typeof val === "string" &&
+                val.indexOf(QUOTE_SETTINGS.double.quote) >= 0 &&
+                val.indexOf(QUOTE_SETTINGS.single.quote) >= 0
+            ) {
+                return true;
+            }
+
+            return false;
+        }
+
         return {
 
             Literal(node) {
@@ -303,6 +322,10 @@ module.exports = {
                     quoteOption === "backtick" ||
                     isUsingFeatureOfTemplateLiteral(node)
                 ) {
+                    return;
+                }
+
+                if (avoidEscape && isEscapingBothQuotes(node)) {
                     return;
                 }
 

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -22,7 +22,9 @@ ruleTester.run("quotes", rule, {
         { code: "var foo = 1;", options: ["single"] },
         { code: "var foo = 1;", options: ["double"] },
         { code: "var foo = \"'\";", options: ["single", { avoidEscape: true }] },
+        { code: "var foo = `\"'`;", options: ["single", { avoidEscape: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "var foo = '\"';", options: ["double", { avoidEscape: true }] },
+        { code: "var foo = `\"'`;", options: ["double", { avoidEscape: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "var foo = <>Hello world</>;", options: ["single"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
         { code: "var foo = <>Hello world</>;", options: ["double"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
         { code: "var foo = <>Hello world</>;", options: ["double", { avoidEscape: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
@@ -188,6 +190,50 @@ ruleTester.run("quotes", rule, {
                 messageId: "wrongQuotes",
                 data: { description: "doublequote" },
                 type: "Literal"
+            }]
+        },
+        {
+            code: "var foo = `bar'baz`;",
+            output: "var foo = 'bar\\'baz';",
+            options: ["single", { avoidEscape: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "singlequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "var foo = `bar'\"baz`;",
+            output: "var foo = 'bar\\'\"baz';",
+            options: ["single"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "singlequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "var foo = `bar\"baz`;",
+            output: "var foo = \"bar\\\"baz\";",
+            options: ["double", { avoidEscape: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "var foo = `bar'\"baz`;",
+            output: "var foo = \"bar'\\\"baz\";",
+            options: ["double"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
             }]
         },
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**
[quotes](https://eslint.org/docs/rules/quotes)

**Does this change cause the rule to produce more or fewer warnings?**
Fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**
New behavior when using `avoidEscape: true`. Allow to use backticks as an escape for both of the singlequote and doublequote.

**Please provide some example code that this change will affect:**

```js
const foo = `a string containing both 'single' and "double" quotes`;
```

**What does the rule currently do for this code?**
Give the warning when you want t use backticks as a escape for quotes.

**What will the rule do after it's changed?**
Allow to use backticks as an escape for both of the singlequote and doublequote when using `avoidEscape: true`.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Just checking if the string include both singlequote and doublequote to allow escaping by the backticks.

#### Is there anything you'd like reviewers to focus on?
Fixes #10627

