### PR TITLE
Docs: removed correct code from incorrect eg section

### DIFF
--- a/docs/rules/quote-props.md
+++ b/docs/rules/quote-props.md
@@ -61,8 +61,7 @@ Examples of **incorrect** code for this rule with the default `"always"` option:
 
 var object = {
     foo: "bar",
-    baz: 42,
-    "qux-lorem": true
+    baz: 42
 };
 ```
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Removed the code from snippet which is correct but placed in the section for incorrect example
for `quote-prop` rule's `always` example in docs

[check the snippet for `incorrect`](https://github.com/eslint/eslint/blob/master/docs/rules/quote-props.md#always)
```js
{
 "qux-lorem": true  // correct code
}
```


#### Is there anything you'd like reviewers to focus on?
[`demo`](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgcXVvdGUtcHJvcHM6IFtcImVycm9yXCIsIFwiYWx3YXlzXCJdKi9cblxudmFyIG9iamVjdCA9IHtcbiAgICBmb286IFwiYmFyXCIsXG4gICAgYmF6OiA0MixcbiAgXHRcInF1eC1sb3JlbVwiOiB0cnVlIC8vIHRoaXMgaXMgYSBjb3JyZWN0IGV4YW1wbGVcbn07Iiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo1LCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7InF1b3RlLXByb3BzIjoyfSwiZW52Ijp7fX19)