### PR TITLE
Update: no-inner-declarations false negative in non-block (fixes #12222)

### DIFF
--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -137,6 +137,10 @@ if (test) {
 function doAnotherThing() {
     var baz = 81;
 }
+
+if (foo) var a;
+
+if (foo) function f(){}
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -81,6 +81,8 @@ function doSomethingElse() {
         function doAnotherThing() { }
     }
 }
+
+if (foo) function f(){}
 ```
 
 Examples of **correct** code for this rule with the default `"functions"` option:
@@ -102,6 +104,8 @@ var fn;
 if (test) {
     fn = function fnExpression() { };
 }
+
+if (foo) var a;
 ```
 
 ### both
@@ -120,6 +124,11 @@ function doAnotherThing() {
         var bar = 81;
     }
 }
+
+
+if (foo) var a;
+
+if (foo) function f(){}
 ```
 
 Examples of **correct** code for this rule with the `"both"` option:
@@ -137,10 +146,6 @@ if (test) {
 function doAnotherThing() {
     var baz = 81;
 }
-
-if (foo) var a;
-
-if (foo) function f(){}
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -67,7 +67,7 @@ module.exports = {
         function check(node) {
             const body = nearestBody(),
                 valid = ((body.type === "Program" && body.distance === 1) ||
-                    body.distance === 2);
+                    (body.type !== "Program" && body.distance === 2));
 
             if (!valid) {
                 context.report({

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -9,6 +9,9 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const validParent = ["Program", "ExportNamedDeclaration", "ExportDefaultDeclaration"];
+const validBlockStatementParent = ["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"];
+
 module.exports = {
     meta: {
         type: "problem",
@@ -34,52 +37,47 @@ module.exports = {
     create(context) {
 
         /**
-         * Find the nearest Program or Function ancestor node.
-         * @returns {Object} Ancestor's type and distance from node.
-         */
-        function nearestBody() {
-            const ancestors = context.getAncestors();
-            let ancestor = ancestors.pop(),
-                generation = 1;
-
-            while (ancestor && ["Program", "FunctionDeclaration",
-                "FunctionExpression", "ArrowFunctionExpression", "ExportNamedDeclaration", "ExportDefaultDeclaration"
-            ].indexOf(ancestor.type) < 0) {
-                generation += 1;
-                ancestor = ancestors.pop();
-            }
-
-            return {
-
-                // Type of containing ancestor
-                type: ancestor.type,
-
-                // Separation between ancestor and node
-                distance: generation
-            };
-        }
-
-        /**
          * Ensure that a given node is at a program or function body's root.
          * @param {ASTNode} node Declaration node to check.
          * @returns {void}
          */
         function check(node) {
-            const body = nearestBody(),
-                valid = ((!!~["Program", "ExportNamedDeclaration", "ExportDefaultDeclaration"].indexOf(body.type) && body.distance === 1) ||
-                    (body.type !== "Program" && body.distance === 2));
+            const ancestors = context.getAncestors();
+            let ancestor = ancestors.pop();
 
-            if (!valid) {
-                context.report({
-                    node,
-                    messageId: "moveDeclToRoot",
-                    data: {
-                        type: (node.type === "FunctionDeclaration" ? "function" : "variable"),
-                        body: (body.type === "Program" ? "program" : "function body")
-                    }
-                });
+            if (
+                ancestor.type === "BlockStatement" &&
+            !!~validBlockStatementParent.indexOf(ancestor.parent.type)
+            ) {
+                return;
             }
+
+            if ((~validParent.indexOf(ancestor.type))) {
+                return;
+            }
+
+            let parentsListToCheck = ancestor.type === "BlockStatement" ? validBlockStatementParent : validParent;
+
+            while (ancestor && !~parentsListToCheck.indexOf(ancestor.type)) {
+                ancestor = ancestors.pop();
+                if (ancestor.type === "BlockStatement") {
+                    ancestor = ancestor.parent;
+                    parentsListToCheck = validBlockStatementParent;
+                } else {
+                    parentsListToCheck = validParent;
+                }
+            }
+
+            context.report({
+                node,
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: (node.type === "FunctionDeclaration" ? "function" : "variable"),
+                    body: (ancestor.type === "Program" ? "program" : "function body")
+                }
+            });
         }
+
 
         return {
 

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("./utils/ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -43,7 +49,7 @@ module.exports = {
          */
         function check(node) {
             const ancestors = context.getAncestors();
-            let ancestor = ancestors.pop();
+            const ancestor = ancestors.pop();
 
             if (
                 ancestor.type === "BlockStatement" && validBlockStatementParent.has(ancestor.parent.type)
@@ -55,19 +61,14 @@ module.exports = {
                 return;
             }
 
-            while (ancestor &&
-                !["Program", "FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"]
-                    .includes(ancestor.type)
-            ) {
-                ancestor = ancestors.pop();
-            }
+            const body = astUtils.getUpperFunction(ancestor);
 
             context.report({
                 node,
                 messageId: "moveDeclToRoot",
                 data: {
                     type: (node.type === "FunctionDeclaration" ? "function" : "variable"),
-                    body: (ancestor.type === "Program" ? "program" : "function body")
+                    body: (body === null ? "program" : "function body")
                 }
             });
         }

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -43,7 +43,7 @@ module.exports = {
                 generation = 1;
 
             while (ancestor && ["Program", "FunctionDeclaration",
-                "FunctionExpression", "ArrowFunctionExpression"
+                "FunctionExpression", "ArrowFunctionExpression", "ExportNamedDeclaration", "ExportDefaultDeclaration"
             ].indexOf(ancestor.type) < 0) {
                 generation += 1;
                 ancestor = ancestors.pop();
@@ -66,7 +66,7 @@ module.exports = {
          */
         function check(node) {
             const body = nearestBody(),
-                valid = ((body.type === "Program" && body.distance === 1) ||
+                valid = ((!!~["Program", "ExportNamedDeclaration", "ExportDefaultDeclaration"].indexOf(body.type) && body.distance === 1) ||
                     (body.type !== "Program" && body.distance === 2));
 
             if (!valid) {

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -48,27 +48,26 @@ module.exports = {
          * @returns {void}
          */
         function check(node) {
-            const ancestors = context.getAncestors();
-            const ancestor = ancestors.pop();
+            const parent = node.parent;
 
             if (
-                ancestor.type === "BlockStatement" && validBlockStatementParent.has(ancestor.parent.type)
+                parent.type === "BlockStatement" && validBlockStatementParent.has(parent.parent.type)
             ) {
                 return;
             }
 
-            if ((validParent.has(ancestor.type))) {
+            if (validParent.has(parent.type)) {
                 return;
             }
 
-            const body = astUtils.getUpperFunction(ancestor);
+            const upperFunction = astUtils.getUpperFunction(parent);
 
             context.report({
                 node,
                 messageId: "moveDeclToRoot",
                 data: {
                     type: (node.type === "FunctionDeclaration" ? "function" : "variable"),
-                    body: (body === null ? "program" : "function body")
+                    body: (upperFunction === null ? "program" : "function body")
                 }
             });
         }

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -9,8 +9,8 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const validParent = ["Program", "ExportNamedDeclaration", "ExportDefaultDeclaration"];
-const validBlockStatementParent = ["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"];
+const validParent = new Set(["Program", "ExportNamedDeclaration", "ExportDefaultDeclaration"]);
+const validBlockStatementParent = new Set(["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"]);
 
 module.exports = {
     meta: {
@@ -46,26 +46,20 @@ module.exports = {
             let ancestor = ancestors.pop();
 
             if (
-                ancestor.type === "BlockStatement" &&
-            !!~validBlockStatementParent.indexOf(ancestor.parent.type)
+                ancestor.type === "BlockStatement" && validBlockStatementParent.has(ancestor.parent.type)
             ) {
                 return;
             }
 
-            if ((~validParent.indexOf(ancestor.type))) {
+            if ((validParent.has(ancestor.type))) {
                 return;
             }
 
-            let parentsListToCheck = ancestor.type === "BlockStatement" ? validBlockStatementParent : validParent;
-
-            while (ancestor && !~parentsListToCheck.indexOf(ancestor.type)) {
+            while (ancestor &&
+                !["Program", "FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"]
+                    .includes(ancestor.type)
+            ) {
                 ancestor = ancestors.pop();
-                if (ancestor.type === "BlockStatement") {
-                    ancestor = ancestor.parent;
-                    parentsListToCheck = validBlockStatementParent;
-                } else {
-                    parentsListToCheck = validParent;
-                }
             }
 
             context.report({

--- a/tests/lib/rules/no-inner-declarations.js
+++ b/tests/lib/rules/no-inner-declarations.js
@@ -62,6 +62,65 @@ ruleTester.run("no-inner-declarations", rule, {
             type: "FunctionDeclaration"
         }]
     }, {
+        code: "if (foo) var a; ",
+        options: ["both"],
+        errors: [{
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "variable",
+                body: "program"
+            },
+            type: "VariableDeclaration"
+        }]
+    },
+    {
+        code: "if (foo)  function f(){} ",
+        options: ["both"],
+        errors: [{
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "function",
+                body: "program"
+            },
+            type: "FunctionDeclaration"
+        }]
+    },
+    {
+        code: "function bar() { if (foo) function f(){}; }",
+        options: ["both"],
+        errors: [{
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "function",
+                body: "function body"
+            },
+            type: "FunctionDeclaration"
+        }]
+    },
+    {
+        code: "function bar() { if (foo) var a; }",
+        options: ["both"],
+        errors: [{
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "variable",
+                body: "function body"
+            },
+            type: "VariableDeclaration"
+        }]
+    },
+    {
+        code: "if (foo){ var a; }",
+        options: ["both"],
+        errors: [{
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "variable",
+                body: "program"
+            },
+            type: "VariableDeclaration"
+        }]
+    }, {
         code: "function doSomething() { do { function somethingElse() { } } while (test); }",
         errors: [{
             messageId: "moveDeclToRoot",

--- a/tests/lib/rules/no-inner-declarations.js
+++ b/tests/lib/rules/no-inner-declarations.js
@@ -72,6 +72,64 @@ ruleTester.run("no-inner-declarations", rule, {
             },
             type: "VariableDeclaration"
         }]
+    }, {
+        code: "if (foo) /* some comments */ var a; ",
+        options: ["both"],
+        errors: [{
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "variable",
+                body: "program"
+            },
+            type: "VariableDeclaration"
+        }]
+    }, {
+        code: "if (foo){ function f(){ if(bar){ var a; } } }",
+        options: ["both"],
+        errors: [{
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "function",
+                body: "program"
+            },
+            type: "FunctionDeclaration"
+        }, {
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "variable",
+                body: "function body"
+            },
+            type: "VariableDeclaration"
+        }]
+    }, {
+        code: "if (foo) function f(){ if(bar) var a; } ",
+        options: ["both"],
+        errors: [{
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "function",
+                body: "program"
+            },
+            type: "FunctionDeclaration"
+        }, {
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "variable",
+                body: "function body"
+            },
+            type: "VariableDeclaration"
+        }]
+    }, {
+        code: "if (foo) { var fn = function(){} } ",
+        options: ["both"],
+        errors: [{
+            messageId: "moveDeclToRoot",
+            data: {
+                type: "variable",
+                body: "program"
+            },
+            type: "VariableDeclaration"
+        }]
     },
     {
         code: "if (foo)  function f(){} ",

--- a/tests/lib/rules/no-inner-declarations.js
+++ b/tests/lib/rules/no-inner-declarations.js
@@ -45,191 +45,223 @@ ruleTester.run("no-inner-declarations", rule, {
             code: "var x = {doSomething() {var foo;}}",
             options: ["both"],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "export var foo;",
+            options: ["both"],
+            parserOptions: { sourceType: "module", ecmaVersion: 6 }
+        },
+        {
+            code: "export function bar() {}",
+            options: ["both"],
+            parserOptions: { sourceType: "module", ecmaVersion: 6 }
+        },
+        {
+            code: "export default function baz() {}",
+            options: ["both"],
+            parserOptions: { sourceType: "module", ecmaVersion: 6 }
+        },
+        {
+            code: "exports.foo = () => {}",
+            options: ["both"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "exports.foo = function(){}",
+            options: ["both"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "module.exports = function foo(){}",
+            options: ["both"],
+            parserOptions: { ecmaVersion: 6 }
         }
 
     ],
 
     // Examples of code that should trigger the rule
-    invalid: [{
-        code: "if (test) { function doSomething() { } }",
-        options: ["both"],
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "function",
-                body: "program"
-            },
-            type: "FunctionDeclaration"
-        }]
-    }, {
-        code: "if (foo) var a; ",
-        options: ["both"],
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "variable",
-                body: "program"
-            },
-            type: "VariableDeclaration"
-        }]
-    }, {
-        code: "if (foo) /* some comments */ var a; ",
-        options: ["both"],
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "variable",
-                body: "program"
-            },
-            type: "VariableDeclaration"
-        }]
-    }, {
-        code: "if (foo){ function f(){ if(bar){ var a; } } }",
-        options: ["both"],
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "function",
-                body: "program"
-            },
-            type: "FunctionDeclaration"
+    invalid: [
+        {
+            code: "if (test) { function doSomething() { } }",
+            options: ["both"],
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "function",
+                    body: "program"
+                },
+                type: "FunctionDeclaration"
+            }]
         }, {
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "variable",
-                body: "function body"
-            },
-            type: "VariableDeclaration"
-        }]
-    }, {
-        code: "if (foo) function f(){ if(bar) var a; } ",
-        options: ["both"],
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "function",
-                body: "program"
-            },
-            type: "FunctionDeclaration"
+            code: "if (foo) var a; ",
+            options: ["both"],
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "program"
+                },
+                type: "VariableDeclaration"
+            }]
         }, {
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "variable",
-                body: "function body"
-            },
-            type: "VariableDeclaration"
-        }]
-    }, {
-        code: "if (foo) { var fn = function(){} } ",
-        options: ["both"],
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "variable",
-                body: "program"
-            },
-            type: "VariableDeclaration"
-        }]
-    },
-    {
-        code: "if (foo)  function f(){} ",
-        options: ["both"],
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "function",
-                body: "program"
-            },
-            type: "FunctionDeclaration"
-        }]
-    },
-    {
-        code: "function bar() { if (foo) function f(){}; }",
-        options: ["both"],
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "function",
-                body: "function body"
-            },
-            type: "FunctionDeclaration"
-        }]
-    },
-    {
-        code: "function bar() { if (foo) var a; }",
-        options: ["both"],
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "variable",
-                body: "function body"
-            },
-            type: "VariableDeclaration"
-        }]
-    },
-    {
-        code: "if (foo){ var a; }",
-        options: ["both"],
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "variable",
-                body: "program"
-            },
-            type: "VariableDeclaration"
-        }]
-    }, {
-        code: "function doSomething() { do { function somethingElse() { } } while (test); }",
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "function",
-                body: "function body"
-            },
-            type: "FunctionDeclaration"
-        }]
-    }, {
-        code: "(function() { if (test) { function doSomething() { } } }());",
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "function",
-                body: "function body"
-            },
-            type: "FunctionDeclaration"
-        }]
-    }, {
-        code: "while (test) { var foo; }",
-        options: ["both"],
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "variable",
-                body: "program"
-            },
-            type: "VariableDeclaration"
-        }]
-    }, {
-        code: "function doSomething() { if (test) { var foo = 42; } }",
-        options: ["both"],
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "variable",
-                body: "function body"
-            },
-            type: "VariableDeclaration"
-        }]
-    }, {
-        code: "(function() { if (test) { var foo; } }());",
-        options: ["both"],
-        errors: [{
-            messageId: "moveDeclToRoot",
-            data: {
-                type: "variable",
-                body: "function body"
-            },
-            type: "VariableDeclaration"
-        }]
-    }]
+            code: "if (foo) /* some comments */ var a; ",
+            options: ["both"],
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "program"
+                },
+                type: "VariableDeclaration"
+            }]
+        }, {
+            code: "if (foo){ function f(){ if(bar){ var a; } } }",
+            options: ["both"],
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "function",
+                    body: "program"
+                },
+                type: "FunctionDeclaration"
+            }, {
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "function body"
+                },
+                type: "VariableDeclaration"
+            }]
+        }, {
+            code: "if (foo) function f(){ if(bar) var a; } ",
+            options: ["both"],
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "function",
+                    body: "program"
+                },
+                type: "FunctionDeclaration"
+            }, {
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "function body"
+                },
+                type: "VariableDeclaration"
+            }]
+        }, {
+            code: "if (foo) { var fn = function(){} } ",
+            options: ["both"],
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "program"
+                },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "if (foo)  function f(){} ",
+            options: ["both"],
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "function",
+                    body: "program"
+                },
+                type: "FunctionDeclaration"
+            }]
+        },
+        {
+            code: "function bar() { if (foo) function f(){}; }",
+            options: ["both"],
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "function",
+                    body: "function body"
+                },
+                type: "FunctionDeclaration"
+            }]
+        },
+        {
+            code: "function bar() { if (foo) var a; }",
+            options: ["both"],
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "function body"
+                },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "if (foo){ var a; }",
+            options: ["both"],
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "program"
+                },
+                type: "VariableDeclaration"
+            }]
+        }, {
+            code: "function doSomething() { do { function somethingElse() { } } while (test); }",
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "function",
+                    body: "function body"
+                },
+                type: "FunctionDeclaration"
+            }]
+        }, {
+            code: "(function() { if (test) { function doSomething() { } } }());",
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "function",
+                    body: "function body"
+                },
+                type: "FunctionDeclaration"
+            }]
+        }, {
+            code: "while (test) { var foo; }",
+            options: ["both"],
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "program"
+                },
+                type: "VariableDeclaration"
+            }]
+        }, {
+            code: "function doSomething() { if (test) { var foo = 42; } }",
+            options: ["both"],
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "function body"
+                },
+                type: "VariableDeclaration"
+            }]
+        }, {
+            code: "(function() { if (test) { var foo; } }());",
+            options: ["both"],
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "function body"
+                },
+                type: "VariableDeclaration"
+            }]
+        }
+    ]
 });

--- a/tests/lib/rules/no-inner-declarations.js
+++ b/tests/lib/rules/no-inner-declarations.js
@@ -68,13 +68,11 @@ ruleTester.run("no-inner-declarations", rule, {
         },
         {
             code: "exports.foo = function(){}",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "module.exports = function foo(){}",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         }
 
     ],

--- a/tests/lib/rules/no-inner-declarations.js
+++ b/tests/lib/rules/no-inner-declarations.js
@@ -164,7 +164,6 @@ ruleTester.run("no-inner-declarations", rule, {
         },
         {
             code: "if (foo)  function f(){} ",
-            options: ["both"],
             errors: [{
                 messageId: "moveDeclToRoot",
                 data: {
@@ -262,6 +261,19 @@ ruleTester.run("no-inner-declarations", rule, {
                 },
                 type: "VariableDeclaration"
             }]
+        }, {
+            code: "const doSomething = () => { if (test) { var foo = 42; } }",
+            options: ["both"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "function body"
+                },
+                type: "VariableDeclaration"
+            }]
         }
+
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
fixes https://github.com/eslint/eslint/issues/12222
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Currently whenever the distance is more than 1, it was not showing error cause it was considering ancestor as any (`Program` included). 
it will be valid only if ancestor is not `Program` for distance equal to 2

example

```js
if(foo){
  var a;
}
```
this will result in distance 1 for the ancestor `Program`

```js
if(foo)
  var a;
```
This will be distance 2 for the ancestor `Program`. 
here both calculations for distance and ancestor are correct but not valid. (the `master` is considering it as valid)

So in this PR, whenever distance is 2, it should not check if from `Program`.


#### Is there anything you'd like reviewers to focus on?
#12222