### PR TITLE
Fix: remove type arguments in prefer-object-spread (fixes #13058)

### DIFF
--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -181,8 +181,8 @@ function defineFixer(node, sourceCode) {
         const leftParen = sourceCode.getTokenAfter(node.callee, isOpeningParenToken);
         const rightParen = sourceCode.getLastToken(node);
 
-        // Remove the callee `Object.assign`
-        yield fixer.remove(node.callee);
+        // Remove everything before the opening paren: callee `Object.assign`, type arguments, and whitespace between the callee and the paren.
+        yield fixer.removeRange([node.range[0], leftParen.range[0]]);
 
         // Replace the parens of argument list to braces.
         if (needsParens(node, sourceCode)) {

--- a/tests/fixtures/parsers/typescript-parsers/object-assign-with-generic/object-assign-with-generic-1.js
+++ b/tests/fixtures/parsers/typescript-parsers/object-assign-with-generic/object-assign-with-generic-1.js
@@ -1,0 +1,343 @@
+"use strict";
+
+/**
+ * Parser: @typescript-eslint/parser@2.24.0
+ * Source code:
+ * const obj = Object.assign<{}, Record<string, string[]>>({}, getObject());
+ */
+
+exports.parse = () => ({
+  type: "Program",
+  body: [
+    {
+      type: "VariableDeclaration",
+      declarations: [
+        {
+          type: "VariableDeclarator",
+          id: {
+            type: "Identifier",
+            name: "obj",
+            range: [6, 9],
+            loc: { start: { line: 1, column: 6 }, end: { line: 1, column: 9 } }
+          },
+          init: {
+            type: "CallExpression",
+            callee: {
+              type: "MemberExpression",
+              object: {
+                type: "Identifier",
+                name: "Object",
+                range: [12, 18],
+                loc: {
+                  start: { line: 1, column: 12 },
+                  end: { line: 1, column: 18 }
+                }
+              },
+              property: {
+                type: "Identifier",
+                name: "assign",
+                range: [19, 25],
+                loc: {
+                  start: { line: 1, column: 19 },
+                  end: { line: 1, column: 25 }
+                }
+              },
+              computed: false,
+              optional: false,
+              range: [12, 25],
+              loc: {
+                start: { line: 1, column: 12 },
+                end: { line: 1, column: 25 }
+              }
+            },
+            arguments: [
+              {
+                type: "ObjectExpression",
+                properties: [],
+                range: [56, 58],
+                loc: {
+                  start: { line: 1, column: 56 },
+                  end: { line: 1, column: 58 }
+                }
+              },
+              {
+                type: "CallExpression",
+                callee: {
+                  type: "Identifier",
+                  name: "getObject",
+                  range: [60, 69],
+                  loc: {
+                    start: { line: 1, column: 60 },
+                    end: { line: 1, column: 69 }
+                  }
+                },
+                arguments: [],
+                optional: false,
+                range: [60, 71],
+                loc: {
+                  start: { line: 1, column: 60 },
+                  end: { line: 1, column: 71 }
+                }
+              }
+            ],
+            optional: false,
+            range: [12, 72],
+            loc: {
+              start: { line: 1, column: 12 },
+              end: { line: 1, column: 72 }
+            },
+            typeParameters: {
+              type: "TSTypeParameterInstantiation",
+              range: [25, 55],
+              params: [
+                {
+                  type: "TSTypeLiteral",
+                  members: [],
+                  range: [26, 28],
+                  loc: {
+                    start: { line: 1, column: 26 },
+                    end: { line: 1, column: 28 }
+                  }
+                },
+                {
+                  type: "TSTypeReference",
+                  typeName: {
+                    type: "Identifier",
+                    name: "Record",
+                    range: [30, 36],
+                    loc: {
+                      start: { line: 1, column: 30 },
+                      end: { line: 1, column: 36 }
+                    }
+                  },
+                  typeParameters: {
+                    type: "TSTypeParameterInstantiation",
+                    range: [36, 54],
+                    params: [
+                      {
+                        type: "TSStringKeyword",
+                        range: [37, 43],
+                        loc: {
+                          start: { line: 1, column: 37 },
+                          end: { line: 1, column: 43 }
+                        }
+                      },
+                      {
+                        type: "TSArrayType",
+                        elementType: {
+                          type: "TSStringKeyword",
+                          range: [45, 51],
+                          loc: {
+                            start: { line: 1, column: 45 },
+                            end: { line: 1, column: 51 }
+                          }
+                        },
+                        range: [45, 53],
+                        loc: {
+                          start: { line: 1, column: 45 },
+                          end: { line: 1, column: 53 }
+                        }
+                      }
+                    ],
+                    loc: {
+                      start: { line: 1, column: 36 },
+                      end: { line: 1, column: 54 }
+                    }
+                  },
+                  range: [30, 54],
+                  loc: {
+                    start: { line: 1, column: 30 },
+                    end: { line: 1, column: 54 }
+                  }
+                }
+              ],
+              loc: {
+                start: { line: 1, column: 25 },
+                end: { line: 1, column: 55 }
+              }
+            }
+          },
+          range: [6, 72],
+          loc: { start: { line: 1, column: 6 }, end: { line: 1, column: 72 } }
+        }
+      ],
+      kind: "const",
+      range: [0, 73],
+      loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 73 } }
+    }
+  ],
+  sourceType: "script",
+  range: [0, 73],
+  loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 73 } },
+  tokens: [
+    {
+      type: "Keyword",
+      value: "const",
+      range: [0, 5],
+      loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } }
+    },
+    {
+      type: "Identifier",
+      value: "obj",
+      range: [6, 9],
+      loc: { start: { line: 1, column: 6 }, end: { line: 1, column: 9 } }
+    },
+    {
+      type: "Punctuator",
+      value: "=",
+      range: [10, 11],
+      loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 11 } }
+    },
+    {
+      type: "Identifier",
+      value: "Object",
+      range: [12, 18],
+      loc: { start: { line: 1, column: 12 }, end: { line: 1, column: 18 } }
+    },
+    {
+      type: "Punctuator",
+      value: ".",
+      range: [18, 19],
+      loc: { start: { line: 1, column: 18 }, end: { line: 1, column: 19 } }
+    },
+    {
+      type: "Identifier",
+      value: "assign",
+      range: [19, 25],
+      loc: { start: { line: 1, column: 19 }, end: { line: 1, column: 25 } }
+    },
+    {
+      type: "Punctuator",
+      value: "<",
+      range: [25, 26],
+      loc: { start: { line: 1, column: 25 }, end: { line: 1, column: 26 } }
+    },
+    {
+      type: "Punctuator",
+      value: "{",
+      range: [26, 27],
+      loc: { start: { line: 1, column: 26 }, end: { line: 1, column: 27 } }
+    },
+    {
+      type: "Punctuator",
+      value: "}",
+      range: [27, 28],
+      loc: { start: { line: 1, column: 27 }, end: { line: 1, column: 28 } }
+    },
+    {
+      type: "Punctuator",
+      value: ",",
+      range: [28, 29],
+      loc: { start: { line: 1, column: 28 }, end: { line: 1, column: 29 } }
+    },
+    {
+      type: "Identifier",
+      value: "Record",
+      range: [30, 36],
+      loc: { start: { line: 1, column: 30 }, end: { line: 1, column: 36 } }
+    },
+    {
+      type: "Punctuator",
+      value: "<",
+      range: [36, 37],
+      loc: { start: { line: 1, column: 36 }, end: { line: 1, column: 37 } }
+    },
+    {
+      type: "Identifier",
+      value: "string",
+      range: [37, 43],
+      loc: { start: { line: 1, column: 37 }, end: { line: 1, column: 43 } }
+    },
+    {
+      type: "Punctuator",
+      value: ",",
+      range: [43, 44],
+      loc: { start: { line: 1, column: 43 }, end: { line: 1, column: 44 } }
+    },
+    {
+      type: "Identifier",
+      value: "string",
+      range: [45, 51],
+      loc: { start: { line: 1, column: 45 }, end: { line: 1, column: 51 } }
+    },
+    {
+      type: "Punctuator",
+      value: "[",
+      range: [51, 52],
+      loc: { start: { line: 1, column: 51 }, end: { line: 1, column: 52 } }
+    },
+    {
+      type: "Punctuator",
+      value: "]",
+      range: [52, 53],
+      loc: { start: { line: 1, column: 52 }, end: { line: 1, column: 53 } }
+    },
+    {
+      type: "Punctuator",
+      value: ">",
+      range: [53, 54],
+      loc: { start: { line: 1, column: 53 }, end: { line: 1, column: 54 } }
+    },
+    {
+      type: "Punctuator",
+      value: ">",
+      range: [54, 55],
+      loc: { start: { line: 1, column: 54 }, end: { line: 1, column: 55 } }
+    },
+    {
+      type: "Punctuator",
+      value: "(",
+      range: [55, 56],
+      loc: { start: { line: 1, column: 55 }, end: { line: 1, column: 56 } }
+    },
+    {
+      type: "Punctuator",
+      value: "{",
+      range: [56, 57],
+      loc: { start: { line: 1, column: 56 }, end: { line: 1, column: 57 } }
+    },
+    {
+      type: "Punctuator",
+      value: "}",
+      range: [57, 58],
+      loc: { start: { line: 1, column: 57 }, end: { line: 1, column: 58 } }
+    },
+    {
+      type: "Punctuator",
+      value: ",",
+      range: [58, 59],
+      loc: { start: { line: 1, column: 58 }, end: { line: 1, column: 59 } }
+    },
+    {
+      type: "Identifier",
+      value: "getObject",
+      range: [60, 69],
+      loc: { start: { line: 1, column: 60 }, end: { line: 1, column: 69 } }
+    },
+    {
+      type: "Punctuator",
+      value: "(",
+      range: [69, 70],
+      loc: { start: { line: 1, column: 69 }, end: { line: 1, column: 70 } }
+    },
+    {
+      type: "Punctuator",
+      value: ")",
+      range: [70, 71],
+      loc: { start: { line: 1, column: 70 }, end: { line: 1, column: 71 } }
+    },
+    {
+      type: "Punctuator",
+      value: ")",
+      range: [71, 72],
+      loc: { start: { line: 1, column: 71 }, end: { line: 1, column: 72 } }
+    },
+    {
+      type: "Punctuator",
+      value: ";",
+      range: [72, 73],
+      loc: { start: { line: 1, column: 72 }, end: { line: 1, column: 73 } }
+    }
+  ],
+  comments: []
+});

--- a/tests/fixtures/parsers/typescript-parsers/object-assign-with-generic/object-assign-with-generic-2.js
+++ b/tests/fixtures/parsers/typescript-parsers/object-assign-with-generic/object-assign-with-generic-2.js
@@ -1,0 +1,198 @@
+"use strict";
+
+/**
+ * Parser: @typescript-eslint/parser@2.24.0
+ * Source code:
+ * Object.assign<{}, A>({}, foo);
+ */
+
+exports.parse = () => ({
+  type: "Program",
+  body: [
+    {
+      type: "ExpressionStatement",
+      expression: {
+        type: "CallExpression",
+        callee: {
+          type: "MemberExpression",
+          object: {
+            type: "Identifier",
+            name: "Object",
+            range: [0, 6],
+            loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 6 } }
+          },
+          property: {
+            type: "Identifier",
+            name: "assign",
+            range: [7, 13],
+            loc: { start: { line: 1, column: 7 }, end: { line: 1, column: 13 } }
+          },
+          computed: false,
+          optional: false,
+          range: [0, 13],
+          loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 13 } }
+        },
+        arguments: [
+          {
+            type: "ObjectExpression",
+            properties: [],
+            range: [21, 23],
+            loc: {
+              start: { line: 1, column: 21 },
+              end: { line: 1, column: 23 }
+            }
+          },
+          {
+            type: "Identifier",
+            name: "foo",
+            range: [25, 28],
+            loc: {
+              start: { line: 1, column: 25 },
+              end: { line: 1, column: 28 }
+            }
+          }
+        ],
+        optional: false,
+        range: [0, 29],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 29 } },
+        typeParameters: {
+          type: "TSTypeParameterInstantiation",
+          range: [13, 20],
+          params: [
+            {
+              type: "TSTypeLiteral",
+              members: [],
+              range: [14, 16],
+              loc: {
+                start: { line: 1, column: 14 },
+                end: { line: 1, column: 16 }
+              }
+            },
+            {
+              type: "TSTypeReference",
+              typeName: {
+                type: "Identifier",
+                name: "A",
+                range: [18, 19],
+                loc: {
+                  start: { line: 1, column: 18 },
+                  end: { line: 1, column: 19 }
+                }
+              },
+              range: [18, 19],
+              loc: {
+                start: { line: 1, column: 18 },
+                end: { line: 1, column: 19 }
+              }
+            }
+          ],
+          loc: { start: { line: 1, column: 13 }, end: { line: 1, column: 20 } }
+        }
+      },
+      range: [0, 30],
+      loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 30 } }
+    }
+  ],
+  sourceType: "script",
+  range: [0, 30],
+  loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 30 } },
+  tokens: [
+    {
+      type: "Identifier",
+      value: "Object",
+      range: [0, 6],
+      loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 6 } }
+    },
+    {
+      type: "Punctuator",
+      value: ".",
+      range: [6, 7],
+      loc: { start: { line: 1, column: 6 }, end: { line: 1, column: 7 } }
+    },
+    {
+      type: "Identifier",
+      value: "assign",
+      range: [7, 13],
+      loc: { start: { line: 1, column: 7 }, end: { line: 1, column: 13 } }
+    },
+    {
+      type: "Punctuator",
+      value: "<",
+      range: [13, 14],
+      loc: { start: { line: 1, column: 13 }, end: { line: 1, column: 14 } }
+    },
+    {
+      type: "Punctuator",
+      value: "{",
+      range: [14, 15],
+      loc: { start: { line: 1, column: 14 }, end: { line: 1, column: 15 } }
+    },
+    {
+      type: "Punctuator",
+      value: "}",
+      range: [15, 16],
+      loc: { start: { line: 1, column: 15 }, end: { line: 1, column: 16 } }
+    },
+    {
+      type: "Punctuator",
+      value: ",",
+      range: [16, 17],
+      loc: { start: { line: 1, column: 16 }, end: { line: 1, column: 17 } }
+    },
+    {
+      type: "Identifier",
+      value: "A",
+      range: [18, 19],
+      loc: { start: { line: 1, column: 18 }, end: { line: 1, column: 19 } }
+    },
+    {
+      type: "Punctuator",
+      value: ">",
+      range: [19, 20],
+      loc: { start: { line: 1, column: 19 }, end: { line: 1, column: 20 } }
+    },
+    {
+      type: "Punctuator",
+      value: "(",
+      range: [20, 21],
+      loc: { start: { line: 1, column: 20 }, end: { line: 1, column: 21 } }
+    },
+    {
+      type: "Punctuator",
+      value: "{",
+      range: [21, 22],
+      loc: { start: { line: 1, column: 21 }, end: { line: 1, column: 22 } }
+    },
+    {
+      type: "Punctuator",
+      value: "}",
+      range: [22, 23],
+      loc: { start: { line: 1, column: 22 }, end: { line: 1, column: 23 } }
+    },
+    {
+      type: "Punctuator",
+      value: ",",
+      range: [23, 24],
+      loc: { start: { line: 1, column: 23 }, end: { line: 1, column: 24 } }
+    },
+    {
+      type: "Identifier",
+      value: "foo",
+      range: [25, 28],
+      loc: { start: { line: 1, column: 25 }, end: { line: 1, column: 28 } }
+    },
+    {
+      type: "Punctuator",
+      value: ")",
+      range: [28, 29],
+      loc: { start: { line: 1, column: 28 }, end: { line: 1, column: 29 } }
+    },
+    {
+      type: "Punctuator",
+      value: ";",
+      range: [29, 30],
+      loc: { start: { line: 1, column: 29 }, end: { line: 1, column: 30 } }
+    }
+  ],
+  comments: []
+});

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -103,7 +103,18 @@ ruleTester.run("prefer-object-spread", rule, {
                 }
             ]
         },
-
+        {
+            code: "Object.assign  ({}, foo)",
+            output: "({ ...foo})",
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        },
         {
             code: "Object.assign({}, { foo: 'bar' })",
             output: "({ foo: 'bar'})",
@@ -463,6 +474,18 @@ ruleTester.run("prefer-object-spread", rule, {
         },
         {
             code: "let a = Object.assign({}, a)",
+            output: "let a = { ...a}",
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 1,
+                    column: 9
+                }
+            ]
+        },
+        {
+            code: "let a = Object.assign   ({}, a)",
             output: "let a = { ...a}",
             errors: [
                 {
@@ -935,6 +958,34 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useLiteralMessage",
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        },
+
+        // https://github.com/eslint/eslint/issues/13058
+        {
+            code: "const obj = Object.assign<{}, Record<string, string[]>>({}, getObject());",
+            output: "const obj = { ...getObject()};",
+            parser: require.resolve("../../fixtures/parsers/typescript-parsers/object-assign-with-generic/object-assign-with-generic-1"),
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 1,
+                    column: 13
+                }
+            ]
+        },
+        {
+            code: "Object.assign<{}, A>({}, foo);",
+            output: "({ ...foo});",
+            parser: require.resolve("../../fixtures/parsers/typescript-parsers/object-assign-with-generic/object-assign-with-generic-2"),
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
                     type: "CallExpression",
                     line: 1,
                     column: 1


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

fixes #13058

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed `prefer-object-spread` fixer to remove everything before the opening paren of the argument list, instead of just `callee`. This should remove TypeScript's type arguments as well.

#### Is there anything you'd like reviewers to focus on?

This looks like a correct change even without TS, because it removes whitespace between `Object.assign` and the opening paren of arguments, which is what similar rules usually do (via `fixer.replaceText` on the whole `CallExpression`).
