### PR TITLE
Update: new option singleline-if in padding-line-between-statements

### DIFF
--- a/docs/rules/padding-line-between-statements.md
+++ b/docs/rules/padding-line-between-statements.md
@@ -76,6 +76,7 @@ You can supply any number of configurations. If a statement pair matches multipl
     - `"singleline-const"` is single-line `const` variable declarations.
     - `"singleline-let"` is single-line `let` variable declarations.
     - `"singleline-var"` is single-line `var` variable declarations.
+    - `"singleline-if"` is single-line `if` statements.
     - `"switch"` is `switch` statements.
     - `"throw"` is `throw` statements.
     - `"try"` is `try` statements.

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -395,6 +395,8 @@ const StatementTypes = {
     "singleline-let": newSinglelineKeywordTester("let"),
     "singleline-var": newSinglelineKeywordTester("var"),
 
+    "singleline-if": newSinglelineKeywordTester("if"),
+
     block: newNodeTypeTester("BlockStatement"),
     empty: newNodeTypeTester("EmptyStatement"),
     function: newNodeTypeTester("FunctionDeclaration"),


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist



- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
New option to allow specify preferences for padding lines between single-line if's

<img width="440" alt="impr" src="https://user-images.githubusercontent.com/1401931/77300581-5662d780-6cff-11ea-9ae1-0d37a0a095f7.PNG">


#### Is there anything you'd like reviewers to focus on?



**What rule do you want to change?**
padding-line-between-statements

**Does this change cause the rule to produce more or fewer warnings?**
No, only with special configuration with 'singleline-if' 

**How will the change be implemented? (New option, new default behavior, etc.)?**
            { blankLine: "never", prev: ["singleline-if"], next: ["if"]},


**Please provide some example code that this change will affect:**
```js
/*eslint padding-line-between-statements: [
    "error",
    { blankLine: "never", prev: ["singleline-if"], next: ["singleline-if"]},
    { blankLine: "always", prev: ["singleline-if"], next: ["if"]},
]*/

/* correct */
function foo(error, a, b)
   if (error) return bar(error);
   if (!a) return bar(a);
   if (!b) return bar(b);

   if (a > b) {
      boo(a);
   }
}

/* incorrect */
function foo(error, a, b)
   if (error) return bar(error);

   if (!a) return bar(a);

   if (!b) return bar(b);
   if (a > b) {
      boo(a);
   }
}

```

**What does the rule currently do for this code?**
There is no way now to specify rule config for that case, only always/never spaces between all if's

**What will the rule do after it's changed?**
Same things but only will have additional option. 



