### PR TITLE
Upgrade: esquery@1.2.0

### DIFF
--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -159,8 +159,8 @@ function tryParseSelector(rawSelector) {
     try {
         return esquery.parse(rawSelector.replace(/:exit$/u, ""));
     } catch (err) {
-        if (typeof err.offset === "number") {
-            throw new SyntaxError(`Syntax error in selector "${rawSelector}" at position ${err.offset}: ${err.message}`);
+        if (err.location && err.location.start && typeof err.location.start.offset === "number") {
+            throw new SyntaxError(`Syntax error in selector "${rawSelector}" at position ${err.location.start.offset}: ${err.message}`);
         }
         throw err;
     }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-utils": "^2.0.0",
     "eslint-visitor-keys": "^1.1.0",
     "espree": "^6.2.1",
-    "esquery": "^1.0.1",
+    "esquery": "^1.2.0",
     "esutils": "^2.0.2",
     "file-entry-cache": "^5.0.1",
     "functional-red-black-tree": "^1.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,5 +42,8 @@ module.exports = {
             }
         ]
     },
+    resolve: {
+        mainFields: ["main", "module"]
+    },
     stats: "errors-only"
 };


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

Upgrade `esquery` to `1.2.0`

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Upgraded `esquery` to `1.2.0` and fixed some problems.

This version has been released today and is causing ESLint builds to fail, for two reasons:

1. Errors thrown by `esquery.parse` do not have `offset` property anymore, I think this was a change in [pegjs](https://github.com/pegjs/pegjs).

Some tests were (correctly) failing because of this. It's fixed by using `err.location.start.offset`.

2. `esquery` now distributes ESM modules, too.

Webpack by default looks for `"module"` (ESM) first. Unfortunately, [that module](https://github.com/estools/esquery/blob/master/esquery.js) is using `export default`, which turns `require("esquery")` into something like:

```js
{ default: { parse, match, matches, query } }
```

instead of expected:

```js
{ parse, match, matches, query }
```

This produces an invalid `build/eslint.js` bundle.

Might be relevant issue: webpack/webpack#4742

It's fixed by configuring webpack to always look for `"main"` first.

#### Is there anything you'd like reviewers to focus on?

The size of `build/eslint.js` increased by only ~1KB.
