### PR TITLE
Fix: add end location to report in no-extra-bind (refs #12334)

### DIFF
--- a/lib/rules/no-extra-bind.js
+++ b/lib/rules/no-extra-bind.js
@@ -64,7 +64,7 @@ module.exports = {
             context.report({
                 node: node.parent.parent,
                 messageId: "unexpected",
-                loc: node.parent.property.loc.start,
+                loc: node.parent.property.loc,
                 fix(fixer) {
                     if (node.parent.parent.arguments.length && !isSideEffectFree(node.parent.parent.arguments[0])) {
                         return null;

--- a/tests/lib/rules/no-extra-bind.js
+++ b/tests/lib/rules/no-extra-bind.js
@@ -36,18 +36,39 @@ ruleTester.run("no-extra-bind", rule, {
         {
             code: "var a = function() { return 1; }.bind(b)",
             output: "var a = function() { return 1; }",
-            errors
+            errors: [{
+                messageId: "unexpected",
+                type: "CallExpression",
+                line: 1,
+                column: 34,
+                endLine: 1,
+                endColumn: 38
+            }]
         },
         {
             code: "var a = function() { return 1; }['bind'](b)",
             output: "var a = function() { return 1; }",
-            errors
+            errors: [{
+                messageId: "unexpected",
+                type: "CallExpression",
+                line: 1,
+                column: 34,
+                endLine: 1,
+                endColumn: 40
+            }]
         },
         {
             code: "var a = function() { return 1; }[`bind`](b)",
             output: "var a = function() { return 1; }",
             parserOptions: { ecmaVersion: 6 },
-            errors
+            errors: [{
+                messageId: "unexpected",
+                type: "CallExpression",
+                line: 1,
+                column: 34,
+                endLine: 1,
+                endColumn: 40
+            }]
         },
         {
             code: "var a = (() => { return 1; }).bind(b)",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #12334

This PR adds `loc.end` to reports in `no-extra-bind`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Just a small change from `loc.start` to `loc`.

#### Is there anything you'd like reviewers to focus on?
