### PR TITLE
Fix: getNameLocationInGlobalDirectiveComment end location (refs #12334)

### DIFF
--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1468,11 +1468,17 @@ module.exports = {
         const match = namePattern.exec(comment.value);
 
         // Convert the index to loc.
-        return sourceCode.getLocFromIndex(
+        const start = sourceCode.getLocFromIndex(
             comment.range[0] +
             "/*".length +
             (match ? match.index + 1 : 0)
         );
+        const end = {
+            line: start.line,
+            column: start.column + (match ? name.length : 1)
+        };
+
+        return { start, end };
     },
 
     /**

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -3816,7 +3816,9 @@ describe("Linter", () => {
                     messages,
                     [{
                         column: 30,
+                        endColumn: 33,
                         line: 2,
+                        endLine: 2,
                         message: "'aaa' is already defined by a variable declaration.",
                         messageId: "redeclaredBySyntax",
                         nodeType: "Block",
@@ -3838,7 +3840,9 @@ describe("Linter", () => {
                     messages,
                     [{
                         column: 31,
+                        endColumn: 34,
                         line: 2,
+                        endLine: 2,
                         message: "'aaa' is already defined by a variable declaration.",
                         messageId: "redeclaredBySyntax",
                         nodeType: "Block",

--- a/tests/lib/rules/no-redeclare.js
+++ b/tests/lib/rules/no-redeclare.js
@@ -145,16 +145,26 @@ ruleTester.run("no-redeclare", rule, {
         {
             code: "/*global b:false*/ var b = 1;",
             options: [{ builtinGlobals: true }],
-            errors: [
-                { message: "'b' is already defined by a variable declaration.", type: "Block" }
-            ]
+            errors: [{
+                message: "'b' is already defined by a variable declaration.",
+                type: "Block",
+                line: 1,
+                column: 10,
+                endLine: 1,
+                endColumn: 11
+            }]
         },
         {
             code: "/*global b:true*/ var b = 1;",
             options: [{ builtinGlobals: true }],
-            errors: [
-                { message: "'b' is already defined by a variable declaration.", type: "Block" }
-            ]
+            errors: [{
+                message: "'b' is already defined by a variable declaration.",
+                type: "Block",
+                line: 1,
+                column: 10,
+                endLine: 1,
+                endColumn: 11
+            }]
         },
         {
             code: "function f() { var a; var a; }",
@@ -305,40 +315,213 @@ ruleTester.run("no-redeclare", rule, {
         {
             code: "/*globals Array */",
             options: [{ builtinGlobals: true }],
-            errors: [
-                { message: "'Array' is already defined as a built-in global variable.", type: "Block" }
-            ]
+            errors: [{
+                message: "'Array' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 1,
+                column: 11,
+                endLine: 1,
+                endColumn: 16
+            }]
+        },
+        {
+            code: "/*globals parseInt */",
+            options: [{ builtinGlobals: true }],
+            errors: [{
+                message: "'parseInt' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 1,
+                column: 11,
+                endLine: 1,
+                endColumn: 19
+            }]
+        },
+        {
+            code: "/*globals foo, Array */",
+            options: [{ builtinGlobals: true }],
+            errors: [{
+                message: "'Array' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 1,
+                column: 16,
+                endLine: 1,
+                endColumn: 21
+            }]
+        },
+        {
+            code: "/* globals foo, Array, baz */",
+            options: [{ builtinGlobals: true }],
+            errors: [{
+                message: "'Array' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 1,
+                column: 17,
+                endLine: 1,
+                endColumn: 22
+            }]
+        },
+        {
+            code: "/*global foo, Array, baz*/",
+            options: [{ builtinGlobals: true }],
+            errors: [{
+                message: "'Array' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 1,
+                column: 15,
+                endLine: 1,
+                endColumn: 20
+            }]
+        },
+        {
+            code: "/*global array, Array*/",
+            options: [{ builtinGlobals: true }],
+            errors: [{
+                message: "'Array' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 1,
+                column: 17,
+                endLine: 1,
+                endColumn: 22
+            }]
+        },
+        {
+            code: "/*globals a,Array*/",
+            options: [{ builtinGlobals: true }],
+            errors: [{
+                message: "'Array' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 1,
+                column: 13,
+                endLine: 1,
+                endColumn: 18
+            }]
+        },
+        {
+            code: "/*globals a:readonly, Array:writable */",
+            options: [{ builtinGlobals: true }],
+            errors: [{
+                message: "'Array' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 1,
+                column: 23,
+                endLine: 1,
+                endColumn: 28
+            }]
+        },
+        {
+            code: "\n/*globals Array */",
+            options: [{ builtinGlobals: true }],
+            errors: [{
+                message: "'Array' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 2,
+                column: 11,
+                endLine: 2,
+                endColumn: 16
+            }]
+        },
+        {
+            code: "/*globals\nArray */",
+            options: [{ builtinGlobals: true }],
+            errors: [{
+                message: "'Array' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 2,
+                column: 1,
+                endLine: 2,
+                endColumn: 6
+            }]
+        },
+        {
+            code: "\n/*globals\n\nArray*/",
+            options: [{ builtinGlobals: true }],
+            errors: [{
+                message: "'Array' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 4,
+                column: 1,
+                endLine: 4,
+                endColumn: 6
+            }]
+        },
+        {
+            code: "/*globals foo,\n    Array */",
+            options: [{ builtinGlobals: true }],
+            errors: [{
+                message: "'Array' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 2,
+                column: 5,
+                endLine: 2,
+                endColumn: 10
+            }]
         },
         {
             code: "/*globals a */",
             options: [{ builtinGlobals: true }],
             globals: { a: "readonly" },
-            errors: [
-                { message: "'a' is already defined as a built-in global variable.", type: "Block" }
-            ]
+            errors: [{
+                message: "'a' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 1,
+                column: 11,
+                endLine: 1,
+                endColumn: 12
+            }]
         },
         {
             code: "/*globals a */",
             options: [{ builtinGlobals: true }],
             globals: { a: "writable" },
-            errors: [
-                { message: "'a' is already defined as a built-in global variable.", type: "Block" }
-            ]
+            errors: [{
+                message: "'a' is already defined as a built-in global variable.",
+                type: "Block",
+                line: 1,
+                column: 11,
+                endLine: 1,
+                endColumn: 12
+            }]
         },
         {
             code: "/*globals a */ /*globals a */",
-            errors: [
-                { message: "'a' is already defined.", type: "Block", column: 26 }
-            ]
+            errors: [{
+                message: "'a' is already defined.",
+                type: "Block",
+                line: 1,
+                column: 26,
+                endLine: 1,
+                endColumn: 27
+            }]
         },
         {
             code: "/*globals a */ /*globals a */ var a = 0",
             options: [{ builtinGlobals: true }],
             globals: { a: "writable" },
             errors: [
-                { message: "'a' is already defined as a built-in global variable.", type: "Block", column: 11 },
-                { message: "'a' is already defined as a built-in global variable.", type: "Block", column: 26 },
-                { message: "'a' is already defined as a built-in global variable.", type: "Identifier", column: 35 }
+                {
+                    message: "'a' is already defined as a built-in global variable.",
+                    type: "Block",
+                    line: 1,
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
+                },
+                {
+                    message: "'a' is already defined as a built-in global variable.",
+                    type: "Block",
+                    line: 1,
+                    column: 26,
+                    endLine: 1,
+                    endColumn: 27
+                },
+                {
+                    message: "'a' is already defined as a built-in global variable.",
+                    type: "Identifier",
+                    line: 1,
+                    column: 35,
+                    endLine: 1,
+                    endColumn: 36
+                }
             ]
         }
     ]

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -486,7 +486,9 @@ ruleTester.run("no-unused-vars", rule, {
             errors: [
                 {
                     line: 2,
+                    endLine: 2,
                     column: 19,
+                    endColumn: 22,
                     messageId: "unusedVar",
                     data: {
                         varName: "foo",
@@ -496,7 +498,9 @@ ruleTester.run("no-unused-vars", rule, {
                 },
                 {
                     line: 2,
+                    endLine: 2,
                     column: 24,
+                    endColumn: 27,
                     messageId: "unusedVar",
                     data: {
                         varName: "bar",
@@ -512,6 +516,8 @@ ruleTester.run("no-unused-vars", rule, {
                 {
                     line: 3,
                     column: 4,
+                    endLine: 3,
+                    endColumn: 7,
                     messageId: "unusedVar",
                     data: {
                         varName: "foo",
@@ -522,6 +528,8 @@ ruleTester.run("no-unused-vars", rule, {
                 {
                     line: 4,
                     column: 4,
+                    endLine: 4,
+                    endColumn: 7,
                     messageId: "unusedVar",
                     data: {
                         varName: "bar",
@@ -638,6 +646,8 @@ ruleTester.run("no-unused-vars", rule, {
                 {
                     line: 1,
                     column: 18,
+                    endLine: 1,
+                    endColumn: 22,
                     messageId: "unusedVar",
                     data: {
                         varName: "$foo",
@@ -653,6 +663,8 @@ ruleTester.run("no-unused-vars", rule, {
                 {
                     line: 1,
                     column: 20,
+                    endLine: 1,
+                    endColumn: 21,
                     messageId: "unusedVar",
                     data: {
                         varName: "$",
@@ -668,6 +680,8 @@ ruleTester.run("no-unused-vars", rule, {
                 {
                     line: 1,
                     column: 11,
+                    endLine: 1,
+                    endColumn: 15,
                     messageId: "unusedVar",
                     data: {
                         varName: "$foo",
@@ -683,6 +697,8 @@ ruleTester.run("no-unused-vars", rule, {
                 {
                     line: 1,
                     column: 11,
+                    endLine: 1,
+                    endColumn: 17,
                     messageId: "unusedVar",
                     data: {
                         varName: "global",
@@ -698,6 +714,8 @@ ruleTester.run("no-unused-vars", rule, {
                 {
                     line: 1,
                     column: 10,
+                    endLine: 1,
+                    endColumn: 13,
                     messageId: "unusedVar",
                     data: {
                         varName: "foo",
@@ -715,6 +733,8 @@ ruleTester.run("no-unused-vars", rule, {
                 {
                     line: 1,
                     column: 14,
+                    endLine: 1,
+                    endColumn: 15,
                     messageId: "unusedVar",
                     data: {
                         varName: "数",
@@ -733,6 +753,8 @@ ruleTester.run("no-unused-vars", rule, {
                 {
                     line: 1,
                     column: 16,
+                    endLine: 1,
+                    endColumn: 18,
                     messageId: "unusedVar",
                     data: {
                         varName: "𠮷",
@@ -910,6 +932,8 @@ ruleTester.run("no-unused-vars", rule, {
             errors: [{
                 line: 2,
                 column: 1,
+                endLine: 2,
+                endColumn: 4,
                 messageId: "unusedVar",
                 data: {
                     varName: "foo",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #12334

This PR modifies `astUtils.getNameLocationInGlobalDirectiveComment` in order to add end location to reports in two rules:

* `no-redeclare`
* `no-unused-vars`

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`astUtils.getNameLocationInGlobalDirectiveComment` used to return `{ line, column }`.

After this change, return value will be `{ start: { line, column }, end: { line, column }  }`


#### Is there anything you'd like reviewers to focus on?
