### PR TITLE
Fix: add end location to report in no-prototype-builtins (refs #12334)

### DIFF
--- a/lib/rules/no-prototype-builtins.js
+++ b/lib/rules/no-prototype-builtins.js
@@ -47,7 +47,7 @@ module.exports = {
             if (DISALLOWED_PROPS.indexOf(propName) > -1) {
                 context.report({
                     messageId: "prototypeBuildIn",
-                    loc: node.callee.property.loc.start,
+                    loc: node.callee.property.loc,
                     data: { prop: propName },
                     node
                 });

--- a/tests/lib/rules/no-prototype-builtins.js
+++ b/tests/lib/rules/no-prototype-builtins.js
@@ -41,6 +41,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 5,
+            endLine: 1,
+            endColumn: 19,
             messageId: "prototypeBuildIn",
             data: { prop: "hasOwnProperty" },
             type: "CallExpression"
@@ -51,6 +53,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 5,
+            endLine: 1,
+            endColumn: 18,
             messageId: "prototypeBuildIn",
             data: { prop: "isPrototypeOf" },
             type: "CallExpression"
@@ -61,6 +65,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 5,
+            endLine: 1,
+            endColumn: 25,
             messageId: "prototypeBuildIn",
             data: { prop: "propertyIsEnumerable" }
         }]
@@ -70,6 +76,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 9,
+            endLine: 1,
+            endColumn: 23,
             messageId: "prototypeBuildIn",
             data: { prop: "hasOwnProperty" },
             type: "CallExpression"
@@ -80,6 +88,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 13,
+            endLine: 1,
+            endColumn: 26,
             messageId: "prototypeBuildIn",
             data: { prop: "isPrototypeOf" },
             type: "CallExpression"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #12334

This PR adds `loc.end` to reports in `no-prototype-builtins`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Just a small change from `loc.start` to `loc`.

#### Is there anything you'd like reviewers to focus on?
