### PR TITLE
Fix: no-extra-parens export default sequence expression false positive

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -560,7 +560,11 @@ module.exports = {
                 tokensToIgnore.add(secondToken);
             }
 
-            if (hasExcessParens(node)) {
+            const hasExtraParens = node.parent.type === "ExportDefaultDeclaration"
+                ? hasExcessParensWithPrecedence(node, PRECEDENCE_OF_ASSIGNMENT_EXPR)
+                : hasExcessParens(node);
+
+            if (hasExtraParens) {
                 report(node);
             }
         }

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -531,12 +531,16 @@ ruleTester.run("no-extra-parens", rule, {
         "() => ({ foo: 1 }.foo().bar).baz.qux()",
         "() => ({ foo: 1 }.foo().bar + baz)",
         {
+            code: "export default (a, b)",
+            parserOptions: { sourceType: "module" }
+        },
+        {
             code: "export default (function(){}).foo",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+            parserOptions: { sourceType: "module" }
         },
         {
             code: "export default (class{}).foo",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+            parserOptions: { sourceType: "module" }
         },
         "({}).hasOwnProperty.call(foo, bar)",
         "({}) ? foo() : bar()",
@@ -1357,6 +1361,55 @@ ruleTester.run("no-extra-parens", rule, {
             "class A extends (++foo) {}",
             "UpdateExpression",
             1
+        ),
+        invalid(
+            "export default ((a, b))",
+            "export default (a, b)",
+            "SequenceExpression",
+            1,
+            { parserOptions: { sourceType: "module" } }
+        ),
+        invalid(
+            "export default (() => {})",
+            "export default () => {}",
+            "ArrowFunctionExpression",
+            1,
+            { parserOptions: { sourceType: "module" } }
+        ),
+        invalid(
+            "export default ((a, b) => a + b)",
+            "export default (a, b) => a + b",
+            "ArrowFunctionExpression",
+            1,
+            { parserOptions: { sourceType: "module" } }
+        ),
+        invalid(
+            "export default (a => a)",
+            "export default a => a",
+            "ArrowFunctionExpression",
+            1,
+            { parserOptions: { sourceType: "module" } }
+        ),
+        invalid(
+            "export default (a = b)",
+            "export default a = b",
+            "AssignmentExpression",
+            1,
+            { parserOptions: { sourceType: "module" } }
+        ),
+        invalid(
+            "export default (a ? b : c)",
+            "export default a ? b : c",
+            "ConditionalExpression",
+            1,
+            { parserOptions: { sourceType: "module" } }
+        ),
+        invalid(
+            "export default (a)",
+            "export default a",
+            "Identifier",
+            1,
+            { parserOptions: { sourceType: "module" } }
         ),
         invalid(
             "for (foo of(bar));",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.0.0-alpha.2
* **Node Version:** v12.14.0
* **npm Version:** v6.13.4

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: 2015,
        sourceType: "module"
    }
};

```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWV4dHJhLXBhcmVuczogXCJlcnJvclwiKi9cblxuZXhwb3J0IGRlZmF1bHQgKGEsIGIpOyIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6Im1vZHVsZSIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==) (v6.8.0)

```js
/* eslint no-extra-parens: "error"*/

export default (a, b);
```

**What did you expect to happen?**

No errors.

[ExportDeclaration](https://www.ecma-international.org/ecma-262/10.0/index.html#prod-ExportDeclaration) allows only HoistableDeclaration, ClassDeclaration or AssignmentExpression after `export default`.

`a, b` is neither of them, it's [Expression](https://www.ecma-international.org/ecma-262/10.0/index.html#prod-Expression).

**What actually happened? Please include the actual, raw output from ESLint.**

Autofix to:

```js
/* eslint no-extra-parens: "error"*/

export default a, b;
```

Parsing error on the fixed code:

```
  3:17  error  Parsing error: Unexpected token ,
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added precedence check for `ExportDefaultDeclaration`'s `declaration` node.

#### Is there anything you'd like reviewers to focus on?
