### PR TITLE
Update: Improve report location for array-callback-return (refs #12334)

### DIFF
--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -30,22 +30,6 @@ function isReachable(segment) {
 }
 
 /**
- * Gets a readable location.
- *
- * - FunctionExpression -> the function name or `function` keyword.
- * - ArrowFunctionExpression -> `=>` token.
- * @param {ASTNode} node A function node to get.
- * @param {SourceCode} sourceCode A source code to get tokens.
- * @returns {ASTNode|Token} The node or the token of a location.
- */
-function getLocation(node, sourceCode) {
-    if (node.type === "ArrowFunctionExpression") {
-        return sourceCode.getTokenBefore(node.body);
-    }
-    return node.id || node;
-}
-
-/**
  * Checks a given node is a MemberExpression node which has the specified name's
  * property.
  * @param {ASTNode} node A node to check.
@@ -179,6 +163,7 @@ module.exports = {
     create(context) {
 
         const options = context.options[0] || { allowImplicit: false, checkForEach: false };
+        const sourceCode = context.getSourceCode();
 
         let funcInfo = {
             arrayMethodName: null,
@@ -217,12 +202,12 @@ module.exports = {
             }
 
             if (messageId) {
-                let name = astUtils.getFunctionNameWithKind(funcInfo.node);
+                let name = astUtils.getFunctionNameWithKind(node);
 
                 name = messageId === "expectedNoReturnValue" ? lodash.upperFirst(name) : name;
                 context.report({
                     node,
-                    loc: getLocation(node, context.getSourceCode()).loc.start,
+                    loc: astUtils.getFunctionHeadLoc(node, sourceCode),
                     messageId,
                     data: { name }
                 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #12334

Change reported location in the `array-callback-return` rule.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The rule will now use `astUtils.getFunctionHeadLoc` instead of its own code for the reported function's location.

Differences:

* Arrow functions
  * Start loc is unchanged (start loc of `=>`).
  * End loc will be the end loc of `=>`, instead of nothing.
* Anonymous function expressions 
  * Start loc is unchanged (start loc of the function node).
  * End loc will be start loc of the opening paren of params, instead of nothing.
* Named function expression: 
  * Start loc will be start loc of the function node, instead of the function's name. 
  * End loc will be start loc of the opening paren of params, instead of nothing.


#### Is there anything you'd like reviewers to focus on?

In edge cases where `function` and its name are not on the same line this change can produce more warnings in the existing code, based on location of `eslint-disable-*` comments:

```js
/* eslint array-callback-return: error*/

foo.filter(function 
    bar() {} // eslint-disable-line array-callback-return
)
```
