### PR TITLE
Fix: add end location to report in no-useless-concat (refs #12334)

### DIFF
--- a/lib/rules/no-useless-concat.js
+++ b/lib/rules/no-useless-concat.js
@@ -105,7 +105,7 @@ module.exports = {
 
                     context.report({
                         node,
-                        loc: operatorToken.loc.start,
+                        loc: operatorToken.loc,
                         messageId: "unexpectedConcat"
                     });
                 }

--- a/tests/lib/rules/no-useless-concat.js
+++ b/tests/lib/rules/no-useless-concat.js
@@ -42,7 +42,25 @@ ruleTester.run("no-useless-concat", rule, {
         {
             code: "'a' + 'b'",
             errors: [
-                { messageId: "unexpectedConcat" }
+                {
+                    messageId: "unexpectedConcat",
+                    line: 1,
+                    column: 5,
+                    endLine: 1,
+                    endColumn: 6
+                }
+            ]
+        },
+        {
+            code: "'a' +\n'b' + 'c'",
+            errors: [
+                {
+                    messageId: "unexpectedConcat",
+                    line: 2,
+                    column: 5,
+                    endLine: 2,
+                    endColumn: 6
+                }
             ]
         },
         {
@@ -57,12 +75,16 @@ ruleTester.run("no-useless-concat", rule, {
                 {
                     messageId: "unexpectedConcat",
                     line: 1,
-                    column: 5
+                    column: 5,
+                    endLine: 1,
+                    endColumn: 6
                 },
                 {
                     messageId: "unexpectedConcat",
                     line: 1,
-                    column: 11
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 }
             ]
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #12334

This PR adds `loc.end` to reports in `no-useless-concat`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Just a small change from `loc.start` to `loc`.

#### Is there anything you'd like reviewers to focus on?
