### PR TITLE
Update: Improve report location for comma-style

### DIFF
--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -146,10 +146,7 @@ module.exports = {
                 // lone comma
                 context.report({
                     node: reportItem,
-                    loc: {
-                        line: commaToken.loc.end.line,
-                        column: commaToken.loc.start.column
-                    },
+                    loc: commaToken.loc,
                     messageId: "unexpectedLineBeforeAndAfterComma",
                     fix: getFixerFunction(styleType, previousItemToken, commaToken, currentItemToken)
                 });
@@ -158,6 +155,7 @@ module.exports = {
 
                 context.report({
                     node: reportItem,
+                    loc: commaToken.loc,
                     messageId: "expectedCommaFirst",
                     fix: getFixerFunction(style, previousItemToken, commaToken, currentItemToken)
                 });
@@ -166,10 +164,7 @@ module.exports = {
 
                 context.report({
                     node: reportItem,
-                    loc: {
-                        line: commaToken.loc.end.line,
-                        column: commaToken.loc.end.column
-                    },
+                    loc: commaToken.loc,
                     messageId: "expectedCommaLast",
                     fix: getFixerFunction(style, previousItemToken, commaToken, currentItemToken)
                 });

--- a/tests/lib/rules/comma-style.js
+++ b/tests/lib/rules/comma-style.js
@@ -292,7 +292,9 @@ ruleTester.run("comma-style", rule, {
             output: "var foo = 1,\nbar = 2;",
             errors: [{
                 messageId: "expectedCommaLast",
-                type: "VariableDeclarator"
+                type: "VariableDeclarator",
+                column: 1,
+                endColumn: 2
             }]
         },
         {
@@ -473,7 +475,9 @@ ruleTester.run("comma-style", rule, {
             options: ["first"],
             errors: [{
                 messageId: "expectedCommaFirst",
-                type: "VariableDeclarator"
+                type: "VariableDeclarator",
+                column: 12,
+                endColumn: 13
             }]
         },
         {
@@ -590,7 +594,9 @@ ruleTester.run("comma-style", rule, {
             output: "var foo = [\n(bar\n),\nbaz\n];",
             errors: [{
                 messageId: "unexpectedLineBeforeAndAfterComma",
-                type: "Identifier"
+                type: "Identifier",
+                column: 1,
+                endColumn: 2
             }]
         },
         {


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #12334

#### What changes did you make? (Give an overview)
Change the reported location in the comma-style rule. The rule will now report the full location of the comma token with `start` and `end`, instead of only `end` location. 

#### Is there anything you'd like reviewers to focus on?
