### PR TITLE
Update: Improve report location newline-per-chained-call (refs #12334)

### DIFF
--- a/lib/rules/newline-per-chained-call.js
+++ b/lib/rules/newline-per-chained-call.js
@@ -90,16 +90,16 @@ module.exports = {
                 }
 
                 if (depth > ignoreChainWithDepth && astUtils.isTokenOnSameLine(callee.object, callee.property)) {
+                    const firstTokenAfterObject = sourceCode.getTokenAfter(callee.object, astUtils.isNotClosingParenToken);
+
                     context.report({
                         node: callee.property,
-                        loc: callee.property.loc.start,
+                        loc: firstTokenAfterObject.loc,
                         messageId: "expected",
                         data: {
                             callee: getPropertyText(callee)
                         },
                         fix(fixer) {
-                            const firstTokenAfterObject = sourceCode.getTokenAfter(callee.object, astUtils.isNotClosingParenToken);
-
                             return fixer.insertTextBefore(firstTokenAfterObject, "\n");
                         }
                     });

--- a/lib/rules/newline-per-chained-call.js
+++ b/lib/rules/newline-per-chained-call.js
@@ -94,7 +94,10 @@ module.exports = {
 
                     context.report({
                         node: callee.property,
-                        loc: firstTokenAfterObject.loc,
+                        loc: {
+                            start: firstTokenAfterObject.loc.start,
+                            end: callee.loc.end
+                        },
                         messageId: "expected",
                         data: {
                             callee: getPropertyText(callee)

--- a/tests/lib/rules/newline-per-chained-call.js
+++ b/tests/lib/rules/newline-per-chained-call.js
@@ -35,14 +35,14 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 2,
             column: 20,
             endLine: 2,
-            endColumn: 21
+            endColumn: 27
         }, {
             messageId: "expected",
             data: { callee: ".value" },
             line: 2,
             column: 32,
             endLine: 2,
-            endColumn: 33
+            endColumn: 38
         }]
     }, {
         code: "_\n.chain({})\n.map(foo)\n.filter(bar).value();",
@@ -53,7 +53,7 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 4,
             column: 13,
             endLine: 4,
-            endColumn: 14
+            endColumn: 19
         }]
     }, {
         code: "a().b().c().e.d()",
@@ -64,7 +64,7 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 1,
             column: 8,
             endLine: 1,
-            endColumn: 9
+            endColumn: 10
         }]
     }, {
         code: "a.b.c().e().d()",
@@ -75,7 +75,7 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 1,
             column: 12,
             endLine: 1,
-            endColumn: 13
+            endColumn: 14
         }]
     }, {
         code: "_.chain({}).map(a).value(); ",
@@ -86,7 +86,7 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 1,
             column: 19,
             endLine: 1,
-            endColumn: 20
+            endColumn: 25
         }]
     }, {
         code: "var a = m1.m2();\n var b = m1.m2().m3().m4().m5();",
@@ -97,14 +97,14 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 2,
             column: 22,
             endLine: 2,
-            endColumn: 23
+            endColumn: 25
         }, {
             messageId: "expected",
             data: { callee: ".m5" },
             line: 2,
             column: 27,
             endLine: 2,
-            endColumn: 28
+            endColumn: 30
         }]
     }, {
         code: "var a = m1.m2();\n var b = m1.m2().m3()\n.m4().m5();",
@@ -115,7 +115,7 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 3,
             column: 6,
             endLine: 3,
-            endColumn: 7
+            endColumn: 9
         }]
     }, {
         code: "var a = m1().m2\n.m3().m4().m5().m6().m7();",
@@ -129,14 +129,14 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 2,
             column: 16,
             endLine: 2,
-            endColumn: 17
+            endColumn: 19
         }, {
             messageId: "expected",
             data: { callee: ".m7" },
             line: 2,
             column: 21,
             endLine: 2,
-            endColumn: 22
+            endColumn: 24
         }]
     }, {
         code: [
@@ -205,14 +205,14 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 16,
             column: 3,
             endLine: 16,
-            endColumn: 4
+            endColumn: 6
         }, {
             messageId: "expected",
             data: { callee: ".end" },
             line: 27,
             column: 3,
             endLine: 27,
-            endColumn: 4
+            endColumn: 7
         }]
     }, {
         code: [
@@ -233,14 +233,14 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 1,
             column: 29,
             endLine: 1,
-            endColumn: 30
+            endColumn: 43
         }, {
             messageId: "expected",
             data: { callee: "[aCondition ?" },
             line: 1,
             column: 45,
-            endLine: 1,
-            endColumn: 46
+            endLine: 3,
+            endColumn: 15
         }]
     }, {
         code: "foo.bar()['foo' + \u2029 + 'bar']()",
@@ -251,8 +251,8 @@ ruleTester.run("newline-per-chained-call", rule, {
             data: { callee: "['foo' + " },
             line: 1,
             column: 10,
-            endLine: 1,
-            endColumn: 11
+            endLine: 2,
+            endColumn: 10
         }]
     }, {
         code: "foo.bar()[(biz)]()",
@@ -264,7 +264,7 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 1,
             column: 10,
             endLine: 1,
-            endColumn: 11
+            endColumn: 17
         }]
     }, {
         code: "(foo).bar().biz()",
@@ -276,7 +276,7 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 1,
             column: 12,
             endLine: 1,
-            endColumn: 13
+            endColumn: 16
         }]
     }, {
         code: "foo.bar(). /* comment */ biz()",
@@ -288,7 +288,7 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 1,
             column: 10,
             endLine: 1,
-            endColumn: 11
+            endColumn: 29
         }]
     }, {
         code: "foo.bar() /* comment */ .biz()",
@@ -300,7 +300,7 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 1,
             column: 25,
             endLine: 1,
-            endColumn: 26
+            endColumn: 29
         }]
     }, {
         code: "((foo.bar()) . baz()).quux();",
@@ -312,14 +312,14 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 1,
             column: 14,
             endLine: 1,
-            endColumn: 15
+            endColumn: 19
         }, {
             messageId: "expected",
             data: { callee: ".quux" },
             line: 1,
             column: 22,
             endLine: 1,
-            endColumn: 23
+            endColumn: 27
         }]
     }, {
         code: "((foo.bar()) [a + b] ()) [(c + d)]()",
@@ -331,14 +331,14 @@ ruleTester.run("newline-per-chained-call", rule, {
             line: 1,
             column: 14,
             endLine: 1,
-            endColumn: 15
+            endColumn: 21
         }, {
             messageId: "expected",
             data: { callee: "[c + d]" },
             line: 1,
             column: 26,
             endLine: 1,
-            endColumn: 27
+            endColumn: 35
         }]
     }]
 });

--- a/tests/lib/rules/newline-per-chained-call.js
+++ b/tests/lib/rules/newline-per-chained-call.js
@@ -30,47 +30,92 @@ ruleTester.run("newline-per-chained-call", rule, {
         code: "_\n.chain({}).map(foo).filter(bar).value();",
         output: "_\n.chain({}).map(foo)\n.filter(bar)\n.value();",
         errors: [{
-            messageId: "expected", data: { callee: ".filter" }
+            messageId: "expected",
+            data: { callee: ".filter" },
+            line: 2,
+            column: 20,
+            endLine: 2,
+            endColumn: 21
         }, {
-            messageId: "expected", data: { callee: ".value" }
+            messageId: "expected",
+            data: { callee: ".value" },
+            line: 2,
+            column: 32,
+            endLine: 2,
+            endColumn: 33
         }]
     }, {
         code: "_\n.chain({})\n.map(foo)\n.filter(bar).value();",
         output: "_\n.chain({})\n.map(foo)\n.filter(bar)\n.value();",
         errors: [{
-            messageId: "expected", data: { callee: ".value" }
+            messageId: "expected",
+            data: { callee: ".value" },
+            line: 4,
+            column: 13,
+            endLine: 4,
+            endColumn: 14
         }]
     }, {
         code: "a().b().c().e.d()",
         output: "a().b()\n.c().e.d()",
         errors: [{
-            messageId: "expected", data: { callee: ".c" }
+            messageId: "expected",
+            data: { callee: ".c" },
+            line: 1,
+            column: 8,
+            endLine: 1,
+            endColumn: 9
         }]
     }, {
         code: "a.b.c().e().d()",
         output: "a.b.c().e()\n.d()",
         errors: [{
-            messageId: "expected", data: { callee: ".d" }
+            messageId: "expected",
+            data: { callee: ".d" },
+            line: 1,
+            column: 12,
+            endLine: 1,
+            endColumn: 13
         }]
     }, {
         code: "_.chain({}).map(a).value(); ",
         output: "_.chain({}).map(a)\n.value(); ",
         errors: [{
-            messageId: "expected", data: { callee: ".value" }
+            messageId: "expected",
+            data: { callee: ".value" },
+            line: 1,
+            column: 19,
+            endLine: 1,
+            endColumn: 20
         }]
     }, {
         code: "var a = m1.m2();\n var b = m1.m2().m3().m4().m5();",
         output: "var a = m1.m2();\n var b = m1.m2().m3()\n.m4()\n.m5();",
         errors: [{
-            messageId: "expected", data: { callee: ".m4" }
+            messageId: "expected",
+            data: { callee: ".m4" },
+            line: 2,
+            column: 22,
+            endLine: 2,
+            endColumn: 23
         }, {
-            messageId: "expected", data: { callee: ".m5" }
+            messageId: "expected",
+            data: { callee: ".m5" },
+            line: 2,
+            column: 27,
+            endLine: 2,
+            endColumn: 28
         }]
     }, {
         code: "var a = m1.m2();\n var b = m1.m2().m3()\n.m4().m5();",
         output: "var a = m1.m2();\n var b = m1.m2().m3()\n.m4()\n.m5();",
         errors: [{
-            messageId: "expected", data: { callee: ".m5" }
+            messageId: "expected",
+            data: { callee: ".m5" },
+            line: 3,
+            column: 6,
+            endLine: 3,
+            endColumn: 7
         }]
     }, {
         code: "var a = m1().m2\n.m3().m4().m5().m6().m7();",
@@ -79,9 +124,19 @@ ruleTester.run("newline-per-chained-call", rule, {
             ignoreChainWithDepth: 3
         }],
         errors: [{
-            messageId: "expected", data: { callee: ".m6" }
+            messageId: "expected",
+            data: { callee: ".m6" },
+            line: 2,
+            column: 16,
+            endLine: 2,
+            endColumn: 17
         }, {
-            messageId: "expected", data: { callee: ".m7" }
+            messageId: "expected",
+            data: { callee: ".m7" },
+            line: 2,
+            column: 21,
+            endLine: 2,
+            endColumn: 22
         }]
     }, {
         code: [
@@ -145,9 +200,19 @@ ruleTester.run("newline-per-chained-call", rule, {
             ".end();"
         ].join("\n"),
         errors: [{
-            messageId: "expected", data: { callee: ".on" }
+            messageId: "expected",
+            data: { callee: ".on" },
+            line: 16,
+            column: 3,
+            endLine: 16,
+            endColumn: 4
         }, {
-            messageId: "expected", data: { callee: ".end" }
+            messageId: "expected",
+            data: { callee: ".end" },
+            line: 27,
+            column: 3,
+            endLine: 27,
+            endColumn: 4
         }]
     }, {
         code: [
@@ -163,34 +228,117 @@ ruleTester.run("newline-per-chained-call", rule, {
             "    'method4']()"
         ].join("\n"),
         errors: [{
-            messageId: "expected", data: { callee: "['method' + n]" }
+            messageId: "expected",
+            data: { callee: "['method' + n]" },
+            line: 1,
+            column: 29,
+            endLine: 1,
+            endColumn: 30
         }, {
-            messageId: "expected", data: { callee: "[aCondition ?" }
+            messageId: "expected",
+            data: { callee: "[aCondition ?" },
+            line: 1,
+            column: 45,
+            endLine: 1,
+            endColumn: 46
         }]
     }, {
         code: "foo.bar()['foo' + \u2029 + 'bar']()",
         output: "foo.bar()\n['foo' + \u2029 + 'bar']()",
         options: [{ ignoreChainWithDepth: 1 }],
-        errors: [{ messageId: "expected", data: { callee: "['foo' + " } }]
+        errors: [{
+            messageId: "expected",
+            data: { callee: "['foo' + " },
+            line: 1,
+            column: 10,
+            endLine: 1,
+            endColumn: 11
+        }]
     }, {
         code: "foo.bar()[(biz)]()",
         output: "foo.bar()\n[(biz)]()",
         options: [{ ignoreChainWithDepth: 1 }],
-        errors: [{ messageId: "expected", data: { callee: "[biz]" } }]
+        errors: [{
+            messageId: "expected",
+            data: { callee: "[biz]" },
+            line: 1,
+            column: 10,
+            endLine: 1,
+            endColumn: 11
+        }]
     }, {
         code: "(foo).bar().biz()",
         output: "(foo).bar()\n.biz()",
         options: [{ ignoreChainWithDepth: 1 }],
-        errors: [{ messageId: "expected", data: { callee: ".biz" } }]
+        errors: [{
+            messageId: "expected",
+            data: { callee: ".biz" },
+            line: 1,
+            column: 12,
+            endLine: 1,
+            endColumn: 13
+        }]
     }, {
         code: "foo.bar(). /* comment */ biz()",
         output: "foo.bar()\n. /* comment */ biz()",
         options: [{ ignoreChainWithDepth: 1 }],
-        errors: [{ messageId: "expected", data: { callee: ".biz" } }]
+        errors: [{
+            messageId: "expected",
+            data: { callee: ".biz" },
+            line: 1,
+            column: 10,
+            endLine: 1,
+            endColumn: 11
+        }]
     }, {
         code: "foo.bar() /* comment */ .biz()",
         output: "foo.bar() /* comment */ \n.biz()",
         options: [{ ignoreChainWithDepth: 1 }],
-        errors: [{ messageId: "expected", data: { callee: ".biz" } }]
+        errors: [{
+            messageId: "expected",
+            data: { callee: ".biz" },
+            line: 1,
+            column: 25,
+            endLine: 1,
+            endColumn: 26
+        }]
+    }, {
+        code: "((foo.bar()) . baz()).quux();",
+        output: "((foo.bar()) \n. baz())\n.quux();",
+        options: [{ ignoreChainWithDepth: 1 }],
+        errors: [{
+            messageId: "expected",
+            data: { callee: ".baz" },
+            line: 1,
+            column: 14,
+            endLine: 1,
+            endColumn: 15
+        }, {
+            messageId: "expected",
+            data: { callee: ".quux" },
+            line: 1,
+            column: 22,
+            endLine: 1,
+            endColumn: 23
+        }]
+    }, {
+        code: "((foo.bar()) [a + b] ()) [(c + d)]()",
+        output: "((foo.bar()) \n[a + b] ()) \n[(c + d)]()",
+        options: [{ ignoreChainWithDepth: 1 }],
+        errors: [{
+            messageId: "expected",
+            data: { callee: "[a + b]" },
+            line: 1,
+            column: 14,
+            endLine: 1,
+            endColumn: 15
+        }, {
+            messageId: "expected",
+            data: { callee: "[c + d]" },
+            line: 1,
+            column: 26,
+            endLine: 1,
+            endColumn: 27
+        }]
     }]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #12334

Change reported location in the `newline-per-chained-call` rule.

This shouldn't produce any new warnings because it doesn't change the start line.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed location to the full location of `.` or `[`, instead of start location of the `property` node.

Before:

![image](https://user-images.githubusercontent.com/44349756/77836936-40b83c80-715b-11ea-96dd-f63ca9d911fb.png)

After:

![image](https://user-images.githubusercontent.com/44349756/77836963-87a63200-715b-11ea-9bcc-126c1cad3d8b.png)

#### Is there anything you'd like reviewers to focus on?

This looks like a big visual change. I chose this among many alternatives because it matches the place where the fixer inserts newline, and it's a common place to insert the newline manually (either on the left or on the right side). Also, the message starts with `.`/`[`
