### PR TITLE
Update: Improve error message for fatal fixer errors

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -563,7 +563,12 @@ class RuleTester {
                 output = SourceCodeFixer.applyFixes(code, messages).output;
                 const errorMessageInFix = linter.verify(output, config, filename).find(m => m.fatal);
 
-                assert(!errorMessageInFix, `A fatal parsing error occurred in autofix: ${errorMessageInFix && errorMessageInFix.message}`);
+                assert(!errorMessageInFix, [
+                    "A fatal parsing error occurred in autofix.",
+                    `Error: ${errorMessageInFix && errorMessageInFix.message}`,
+                    "Autofix output:",
+                    output
+                ].join("\n"));
             } else {
                 output = code;
             }

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1829,7 +1829,7 @@ describe("RuleTester", () => {
                     invalid: []
                 }
             );
-        }, /A fatal parsing error occurred in autofix/u);
+        }, /A fatal parsing error occurred in autofix.\nError: .+\nAutofix output:\n.+/u);
     });
 
     describe("sanitize test cases", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

When the autofixer outputs broken code, the rule tester rightfully hard fails the test.
However, the error current message can be pretty vague as it relies upon the error message from the parser. Some of the parser errors can be explicit and easy to trace, and others can be useless without an error location.

For example, the following invalid code
```js
'const a = "1";`'`
```
Produces this error message in both espree and typescript-eslint
```
Unterminated template literal.
```

Which results in this test failure:
```
A fatal parsing error occurred in autofix: Parsing error: Unterminated template literal.
```

This is especially problematic for fixer failure, because you cannot actually see the fixer output anywhere. So the above error message is impossible to action.

Usually I just patch my local eslint install to `console.log` the fixer output, but I finally figured it was probably just better if this was part of core.

This change simply includes the code in the output so it's possible to see what code caused the error:
```
A fatal parsing error occurred in autofix.
Error: Parsing error: Unterminated template literal.
Autofix output:
'const a = "1";`'`
```