### PR TITLE
Update: Improve report location for no-empty-function (refs #12334)

### DIFF
--- a/lib/rules/no-empty-function.js
+++ b/lib/rules/no-empty-function.js
@@ -151,7 +151,7 @@ module.exports = {
             ) {
                 context.report({
                     node,
-                    loc: node.body.loc.start,
+                    loc: node.body.loc,
                     messageId: "unexpected",
                     data: { name }
                 });

--- a/tests/lib/rules/no-empty-function.js
+++ b/tests/lib/rules/no-empty-function.js
@@ -312,5 +312,66 @@ ruleTester.run("no-empty-function", rule, [
         }
 
     ],
-    invalid: []
+    invalid: [
+
+        // location tests
+        {
+            code: "function foo() {}",
+            errors: [{
+                messageId: "unexpected",
+                data: { name: "function 'foo'" },
+                line: 1,
+                column: 16,
+                endLine: 1,
+                endColumn: 18
+            }]
+        },
+        {
+            code: "var foo = function () {\n}",
+            errors: [{
+                messageId: "unexpected",
+                data: { name: "function" },
+                line: 1,
+                column: 23,
+                endLine: 2,
+                endColumn: 2
+            }]
+        },
+        {
+            code: "var foo = () => { \n\n  }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unexpected",
+                data: { name: "arrow function" },
+                line: 1,
+                column: 17,
+                endLine: 3,
+                endColumn: 4
+            }]
+        },
+        {
+            code: "var obj = {\n\tfoo() {\n\t}\n}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unexpected",
+                data: { name: "method 'foo'" },
+                line: 2,
+                column: 8,
+                endLine: 3,
+                endColumn: 3
+            }]
+        },
+        {
+            code: "class A { foo() { } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unexpected",
+                data: { name: "method 'foo'" },
+                line: 1,
+                column: 17,
+                endLine: 1,
+                endColumn: 20
+            }]
+        }
+    ]
 }));


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #12334

Change reported location in the `no-empty-function` rule.

This shouldn't produce any new warnings because it doesn't change the start line.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The rule will now report the full function's body location (highlights the whole empty block), instead of just its start.

Before:

![image](https://user-images.githubusercontent.com/44349756/77863311-a3740b80-7221-11ea-86bd-b8d648431cb4.png)

After:

![image](https://user-images.githubusercontent.com/44349756/77863265-52fcae00-7221-11ea-819d-c7e895f73439.png)

#### Is there anything you'd like reviewers to focus on?

This is consistent with the `no-empty` rule.

An alternative could be to report the location of `{` only.
