### PR TITLE
Update: Improve report location for space-before-function-paren

### DIFF
--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -127,7 +127,10 @@ module.exports = {
             if (hasSpacing && functionConfig === "never") {
                 context.report({
                     node,
-                    loc: leftToken.loc.end,
+                    loc: {
+                        start: leftToken.loc.end,
+                        end: rightToken.loc.start
+                    },
                     messageId: "unexpectedSpace",
                     fix(fixer) {
                         const comments = sourceCode.getCommentsBefore(rightToken);
@@ -145,7 +148,7 @@ module.exports = {
             } else if (!hasSpacing && functionConfig === "always") {
                 context.report({
                     node,
-                    loc: leftToken.loc.end,
+                    loc: rightToken.loc,
                     messageId: "missingSpace",
                     fix: fixer => fixer.insertTextAfter(leftToken, " ")
                 });

--- a/tests/lib/rules/space-before-function-paren.js
+++ b/tests/lib/rules/space-before-function-paren.js
@@ -136,7 +136,8 @@ ruleTester.run("space-before-function-paren", rule, {
                     type: "FunctionDeclaration",
                     messageId: "missingSpace",
                     line: 1,
-                    column: 13
+                    column: 13,
+                    endColumn: 14
                 }
             ]
         },
@@ -148,7 +149,8 @@ ruleTester.run("space-before-function-paren", rule, {
                     type: "FunctionDeclaration",
                     messageId: "missingSpace",
                     line: 1,
-                    column: 13
+                    column: 18,
+                    endColumn: 19
                 }
             ]
         },
@@ -230,7 +232,8 @@ ruleTester.run("space-before-function-paren", rule, {
                     type: "FunctionDeclaration",
                     messageId: "unexpectedSpace",
                     line: 1,
-                    column: 13
+                    column: 13,
+                    endColumn: 14
                 }
             ]
         },
@@ -274,6 +277,20 @@ ruleTester.run("space-before-function-paren", rule, {
             ]
         },
         {
+            code: "function foo  () {}",
+            output: "function foo() {}",
+            options: ["never"],
+            errors: [
+                {
+                    type: "FunctionDeclaration",
+                    messageId: "unexpectedSpace",
+                    line: 1,
+                    column: 13,
+                    endColumn: 15
+                }
+            ]
+        },
+        {
             code: "function foo//\n() {}",
             output: null,
             options: ["never"],
@@ -282,7 +299,9 @@ ruleTester.run("space-before-function-paren", rule, {
                     type: "FunctionDeclaration",
                     messageId: "unexpectedSpace",
                     line: 1,
-                    column: 13
+                    column: 13,
+                    endLine: 2,
+                    endColumn: 1
                 }
             ]
         },
@@ -321,7 +340,8 @@ ruleTester.run("space-before-function-paren", rule, {
                     type: "FunctionExpression",
                     messageId: "unexpectedSpace",
                     line: 1,
-                    column: 19
+                    column: 19,
+                    endColumn: 20
                 }
             ]
         },


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Other, please explain:

refs #12334.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
1. Add end location for cases with extra space.
2. Change the report location to that of opening parenthesis for cases with missing space.


```js
// Before
/* eslint space-before-function-paren: [2, 'never'] */
function foo () {}
//       ~~~   vscode highlight

/* eslint space-before-function-paren: [2, 'always'] */
function foo() {}
//       ~~~   vscode highlight

// Now
/* eslint space-before-function-paren: [2, 'never'] */
function foo () {}
//          ~   vscode highlight

/* eslint space-before-function-paren: [2, 'always'] */
function foo() {}
//          ~   vscode highlight

```

#### Is there anything you'd like reviewers to focus on?
