### PR TITLE
Update: Improve report location for new-cap (refs #12334)

### DIFF
--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -235,7 +235,7 @@ module.exports = {
                 callee = callee.property;
             }
 
-            context.report({ node, loc: callee.loc.start, messageId });
+            context.report({ node, loc: callee.loc, messageId });
         }
 
         //--------------------------------------------------------------------------

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -74,15 +74,105 @@ ruleTester.run("new-cap", rule, {
         { code: "var x = foo.Bar(42);", options: [{ capIsNew: false, properties: false }] }
     ],
     invalid: [
-        { code: "var x = new c();", errors: [{ messageId: "lower", type: "NewExpression" }] },
-        { code: "var x = new φ;", errors: [{ messageId: "lower", type: "NewExpression" }] },
-        { code: "var x = new a.b.c;", errors: [{ messageId: "lower", type: "NewExpression" }] },
-        { code: "var x = new a.b['c'];", errors: [{ messageId: "lower", type: "NewExpression" }] },
-        { code: "var b = Foo();", errors: [{ messageId: "upper", type: "CallExpression" }] },
-        { code: "var b = a.Foo();", errors: [{ messageId: "upper", type: "CallExpression" }] },
-        { code: "var b = a['Foo']();", errors: [{ messageId: "upper", type: "CallExpression" }] },
-        { code: "var b = a.Date.UTC();", errors: [{ messageId: "upper", type: "CallExpression" }] },
-        { code: "var b = UTC();", errors: [{ messageId: "upper", type: "CallExpression" }] },
+        {
+            code: "var x = new c();",
+            errors: [{
+                messageId: "lower",
+                type: "NewExpression",
+                line: 1,
+                column: 13,
+                endLine: 1,
+                endColumn: 14
+            }]
+        },
+        {
+            code: "var x = new φ;",
+            errors: [{
+                messageId: "lower",
+                type: "NewExpression",
+                line: 1,
+                column: 13,
+                endLine: 1,
+                endColumn: 14
+            }]
+        },
+        {
+            code: "var x = new a.b.c;",
+            errors: [{
+                messageId: "lower",
+                type: "NewExpression",
+                line: 1,
+                column: 17,
+                endLine: 1,
+                endColumn: 18
+            }]
+        },
+        {
+            code: "var x = new a.b['c'];",
+            errors: [{
+                messageId: "lower",
+                type: "NewExpression",
+                line: 1,
+                column: 17,
+                endLine: 1,
+                endColumn: 20
+            }]
+        },
+        {
+            code: "var b = Foo();",
+            errors: [{
+                messageId: "upper",
+                type: "CallExpression",
+                line: 1,
+                column: 9,
+                endLine: 1,
+                endColumn: 12
+            }]
+        },
+        {
+            code: "var b = a.Foo();",
+            errors: [{
+                messageId: "upper",
+                type: "CallExpression",
+                line: 1,
+                column: 11,
+                endLine: 1,
+                endColumn: 14
+            }]
+        },
+        {
+            code: "var b = a['Foo']();",
+            errors: [{
+                messageId: "upper",
+                type: "CallExpression",
+                line: 1,
+                column: 11,
+                endLine: 1,
+                endColumn: 16
+            }]
+        },
+        {
+            code: "var b = a.Date.UTC();",
+            errors: [{
+                messageId: "upper",
+                type: "CallExpression",
+                line: 1,
+                column: 16,
+                endLine: 1,
+                endColumn: 19
+            }]
+        },
+        {
+            code: "var b = UTC();",
+            errors: [{
+                messageId: "upper",
+                type: "CallExpression",
+                line: 1,
+                column: 9,
+                endLine: 1,
+                endColumn: 12
+            }]
+        },
         {
             code: "var a = B.C();",
             errors: [
@@ -90,7 +180,9 @@ ruleTester.run("new-cap", rule, {
                     messageId: "upper",
                     type: "CallExpression",
                     line: 1,
-                    column: 11
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 }
             ]
         },
@@ -101,7 +193,9 @@ ruleTester.run("new-cap", rule, {
                     messageId: "upper",
                     type: "CallExpression",
                     line: 2,
-                    column: 2
+                    column: 2,
+                    endLine: 2,
+                    endColumn: 3
                 }
             ]
         },
@@ -112,7 +206,9 @@ ruleTester.run("new-cap", rule, {
                     messageId: "lower",
                     type: "NewExpression",
                     line: 1,
-                    column: 15
+                    column: 15,
+                    endLine: 1,
+                    endColumn: 16
                 }
             ]
         },
@@ -123,7 +219,9 @@ ruleTester.run("new-cap", rule, {
                     messageId: "lower",
                     type: "NewExpression",
                     line: 2,
-                    column: 1
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 2
                 }
             ]
         },
@@ -134,7 +232,51 @@ ruleTester.run("new-cap", rule, {
                     messageId: "lower",
                     type: "NewExpression",
                     line: 1,
-                    column: 13
+                    column: 13,
+                    endLine: 1,
+                    endColumn: 14
+                }
+            ]
+        },
+        {
+            code: "var a = new b[ ( 'foo' ) ]();",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "lower",
+                    type: "NewExpression",
+                    line: 1,
+                    column: 18,
+                    endLine: 1,
+                    endColumn: 23
+                }
+            ]
+        },
+        {
+            code: "var a = new b[`foo`];",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "lower",
+                    type: "NewExpression",
+                    line: 1,
+                    column: 15,
+                    endLine: 1,
+                    endColumn: 20
+                }
+            ]
+        },
+        {
+            code: "var a = b[`\\\nFoo`]();",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "upper",
+                    type: "CallExpression",
+                    line: 1,
+                    column: 11,
+                    endLine: 2,
+                    endColumn: 5
                 }
             ]
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #12334

Add end location to reports in the `new-cap` rule.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed location to the full location of `callee` (or callee's `property` if it is a `MemberExpression`), instead of just their start locations.

In VS Code, this change is observable with computed properties:

Before:

![image](https://user-images.githubusercontent.com/44349756/78307160-93bc3600-7545-11ea-9282-f0c7c4d77aa9.png)

After:

![image](https://user-images.githubusercontent.com/44349756/78307264-cebe6980-7545-11ea-8b76-a231e88229e5.png)


#### Is there anything you'd like reviewers to focus on?