### PR TITLE
Upgrade: levn@0.4.1 (fixes #9366)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "is-glob": "^4.0.0",
     "js-yaml": "^3.13.1",
     "json-stable-stringify-without-jsonify": "^1.0.1",
-    "levn": "^0.3.0",
+    "levn": "^0.4.1",
     "lodash": "^4.17.14",
     "minimatch": "^3.0.4",
     "natural-compare": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "lodash": "^4.17.14",
     "minimatch": "^3.0.4",
     "natural-compare": "^1.4.0",
-    "optionator": "^0.8.3",
+    "optionator": "^0.9.1",
     "progress": "^2.0.0",
     "regexpp": "^3.0.0",
     "semver": "^7.1.1",

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -2734,7 +2734,7 @@ describe("Linter", () => {
 
     describe("when evaluating code with comments which have colon in its value", () => {
         const code = String.raw`
-/* eslint max-len: [2, 100, 2, {ignoreUrls: true, ignorePattern: "data:image\/|\\s*require\\s*\\(|^\\s*loader\\.lazy|-\\*-"}] */
+/* eslint max-len: [2, 100, 2, {ignoreUrls: true, ignorePattern: "data:image\\/|\\s*require\\s*\\(|^\\s*loader\\.lazy|-\\*-"}] */
 alert('test');
 `;
 
@@ -2743,29 +2743,35 @@ alert('test');
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "max-len");
-            assert.strictEqual(messages[0].message, "This line has a length of 128. Maximum allowed is 100.");
+            assert.strictEqual(messages[0].message, "This line has a length of 129. Maximum allowed is 100.");
             assert.include(messages[0].nodeType, "Program");
         });
     });
 
     describe("when evaluating code with comments that contain escape sequences", () => {
         const code = String.raw`
-/* eslint max-len: ["error", 1, { ignoreComments: true, ignorePattern: "console\.log\\(" }] */
+/* eslint max-len: ["error", 1, { ignoreComments: true, ignorePattern: "console\\.log\\(" }] */
 console.log("test");
+consolexlog("test2");
 var a = "test2";
 `;
 
         it("should validate correctly", () => {
             const config = { rules: {} };
-
             const messages = linter.verify(code, config, filename);
+            const [message1, message2] = messages;
 
-            assert.strictEqual(messages.length, 1);
-            assert.strictEqual(messages[0].ruleId, "max-len");
-            assert.strictEqual(messages[0].message, "This line has a length of 16. Maximum allowed is 1.");
-            assert.strictEqual(messages[0].line, 4);
-            assert.strictEqual(messages[0].column, 1);
-            assert.include(messages[0].nodeType, "Program");
+            assert.strictEqual(messages.length, 2);
+            assert.strictEqual(message1.ruleId, "max-len");
+            assert.strictEqual(message1.message, "This line has a length of 21. Maximum allowed is 1.");
+            assert.strictEqual(message1.line, 4);
+            assert.strictEqual(message1.column, 1);
+            assert.include(message1.nodeType, "Program");
+            assert.strictEqual(message2.ruleId, "max-len");
+            assert.strictEqual(message2.message, "This line has a length of 16. Maximum allowed is 1.");
+            assert.strictEqual(message2.line, 5);
+            assert.strictEqual(message2.column, 1);
+            assert.include(message2.nodeType, "Program");
         });
     });
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -2733,7 +2733,10 @@ describe("Linter", () => {
     });
 
     describe("when evaluating code with comments which have colon in its value", () => {
-        const code = "/* eslint max-len: [2, 100, 2, {ignoreUrls: true, ignorePattern: \"data:image\\/|\\\\s*require\\\\s*\\\\(|^\\\\s*loader\\\\.lazy|-\\\\*-\"}] */\nalert('test');";
+        const code = String.raw`
+/* eslint max-len: [2, 100, 2, {ignoreUrls: true, ignorePattern: "data:image\/|\\s*require\\s*\\(|^\\s*loader\\.lazy|-\\*-"}] */
+alert('test');
+`;
 
         it("should not parse errors, should report a violation", () => {
             const messages = linter.verify(code, {}, filename);
@@ -2746,7 +2749,11 @@ describe("Linter", () => {
     });
 
     describe("when evaluating code with comments that contain escape sequences", () => {
-        const code = '/* eslint max-len: ["error", 1, { ignoreComments: true, ignorePattern: "console\\.log\\\\(" }] */\nconsole.log("test");\nvar a = "test2";';
+        const code = String.raw`
+/* eslint max-len: ["error", 1, { ignoreComments: true, ignorePattern: "console\.log\\(" }] */
+console.log("test");
+var a = "test2";
+`;
 
         it("should validate correctly", () => {
             const config = { rules: {} };
@@ -2756,7 +2763,7 @@ describe("Linter", () => {
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "max-len");
             assert.strictEqual(messages[0].message, "This line has a length of 16. Maximum allowed is 1.");
-            assert.strictEqual(messages[0].line, 3);
+            assert.strictEqual(messages[0].line, 4);
             assert.strictEqual(messages[0].column, 1);
             assert.include(messages[0].nodeType, "Program");
         });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

fixes #9366

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR upgrades `levn` to `0.4.1` to fix the issue of backslashes in strings not being escaped correctly in inline directive comments.

#### Is there anything you'd like reviewers to focus on?

Am I missing anything? Apologies - I know the tests are difficult to read.