### PR TITLE
Update: report backtick loc in no-unexpected-multiline (refs #12334)

### DIFF
--- a/tests/lib/rules/no-unexpected-multiline.js
+++ b/tests/lib/rules/no-unexpected-multiline.js
@@ -43,6 +43,18 @@ ruleTester.run("no-unexpected-multiline", rule, {
             code: "x\n.y\nz `Valid Test Case`",
             parserOptions: { ecmaVersion: 6 }
         },
+        {
+            code: "f(x\n)`Valid Test Case`",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "x.\ny `Valid Test Case`",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "(x\n)`Valid Test Case`",
+            parserOptions: { ecmaVersion: 6 }
+        },
         `
             foo
             / bar /2
@@ -118,8 +130,9 @@ ruleTester.run("no-unexpected-multiline", rule, {
             errors: [{
                 messageId: "function",
                 line: 2,
-                column: 1
-
+                column: 1,
+                endLine: 2,
+                endColumn: 2
             }]
         },
         {
@@ -127,6 +140,8 @@ ruleTester.run("no-unexpected-multiline", rule, {
             errors: [{
                 line: 2,
                 column: 1,
+                endLine: 2,
+                endColumn: 2,
                 messageId: "function"
             }]
         },
@@ -135,6 +150,8 @@ ruleTester.run("no-unexpected-multiline", rule, {
             errors: [{
                 line: 2,
                 column: 1,
+                endLine: 2,
+                endColumn: 2,
                 messageId: "function"
             }]
         },
@@ -143,6 +160,8 @@ ruleTester.run("no-unexpected-multiline", rule, {
             errors: [{
                 line: 2,
                 column: 1,
+                endLine: 2,
+                endColumn: 2,
                 messageId: "property"
             }]
         },
@@ -151,6 +170,8 @@ ruleTester.run("no-unexpected-multiline", rule, {
             errors: [{
                 line: 2,
                 column: 5,
+                endLine: 2,
+                endColumn: 6,
                 messageId: "function"
             }]
         },
@@ -159,6 +180,8 @@ ruleTester.run("no-unexpected-multiline", rule, {
             errors: [{
                 line: 2,
                 column: 3,
+                endLine: 2,
+                endColumn: 4,
                 messageId: "property"
             }]
         },
@@ -166,8 +189,10 @@ ruleTester.run("no-unexpected-multiline", rule, {
             code: "let x = function() {}\n `hello`",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
-                line: 1,
-                column: 9,
+                line: 2,
+                column: 2,
+                endLine: 2,
+                endColumn: 3,
                 messageId: "taggedTemplate"
             }]
         },
@@ -175,8 +200,10 @@ ruleTester.run("no-unexpected-multiline", rule, {
             code: "let x = function() {}\nx\n`hello`",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
-                line: 2,
+                line: 3,
                 column: 1,
+                endLine: 3,
+                endColumn: 2,
                 messageId: "taggedTemplate"
             }]
         },
@@ -184,8 +211,10 @@ ruleTester.run("no-unexpected-multiline", rule, {
             code: "x\n.y\nz\n`Invalid Test Case`",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
-                line: 3,
+                line: 4,
                 column: 1,
+                endLine: 4,
+                endColumn: 2,
                 messageId: "taggedTemplate"
             }]
         },
@@ -197,6 +226,8 @@ ruleTester.run("no-unexpected-multiline", rule, {
             errors: [{
                 line: 3,
                 column: 17,
+                endLine: 3,
+                endColumn: 18,
                 messageId: "division"
             }]
         },
@@ -208,6 +239,8 @@ ruleTester.run("no-unexpected-multiline", rule, {
             errors: [{
                 line: 3,
                 column: 17,
+                endLine: 3,
+                endColumn: 18,
                 messageId: "division"
             }]
         },
@@ -219,6 +252,8 @@ ruleTester.run("no-unexpected-multiline", rule, {
             errors: [{
                 line: 3,
                 column: 17,
+                endLine: 3,
+                endColumn: 18,
                 messageId: "division"
             }]
         },
@@ -230,6 +265,8 @@ ruleTester.run("no-unexpected-multiline", rule, {
             errors: [{
                 line: 3,
                 column: 17,
+                endLine: 3,
+                endColumn: 18,
                 messageId: "division"
             }]
         },
@@ -241,24 +278,28 @@ ruleTester.run("no-unexpected-multiline", rule, {
             errors: [{
                 line: 3,
                 column: 17,
+                endLine: 3,
+                endColumn: 18,
                 messageId: "division"
             }]
         },
 
         // https://github.com/eslint/eslint/issues/11650
         {
-            code: `
-                const x = aaaa<
-                    test
-                >/*
-                test
-                */\`foo\`
-            `,
+            code: [
+                "const x = aaaa<",
+                "  test",
+                ">/*",
+                "test",
+                "*/`foo`"
+            ].join("\n"),
             parser: require.resolve("../../fixtures/parsers/typescript-parsers/tagged-template-with-generic/tagged-template-with-generic-and-comment"),
             errors: [
                 {
-                    line: 1,
-                    column: 11,
+                    line: 5,
+                    column: 3,
+                    endLine: 5,
+                    endColumn: 4,
                     messageId: "taggedTemplate"
                 }
             ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #12334

Change reported location in the `no-unexpected-multiline` rule.

For tagged template literals, this change can produce **more** warnings in existing code, depending on the location of `eslint-disable-*` comments.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Tagged template literals: rule will now report template literal's backtick location, instead of tag's start location. This is consistent with other node types.
* All other nodes: rule will now report the full location of `(`, `[`, `/`, instead of just their start locations.

Before:

![image](https://user-images.githubusercontent.com/44349756/78462203-2a1c6300-76d0-11ea-9f84-4f0de247007f.png)

After:

![image](https://user-images.githubusercontent.com/44349756/78462267-a8790500-76d0-11ea-9cbe-624ab9950abd.png)

#### Is there anything you'd like reviewers to focus on?

An existing code like the following will have a `no-unexpected-multiline` error after this change:

```js
/* eslint no-unexpected-multiline: ["error"] */

// eslint-disable-next-line no-unexpected-multiline
a
`b`
```

Other changes:

* `data` isn't used in error messages, so it's removed.
* `if (node.tag.loc.end.line === node.quasi.loc.start.line)` conditional was redundant, so it's removed.
* Formatting for the last test case (tagged-template-with-generic-and-comment) was wrong, so it's fixed to match the actual input (which is observable from the reported location).