### PR TITLE
Handle throw with no arguments in no-throw-literal

### DIFF
--- a/lib/rules/no-throw-literal.js
+++ b/lib/rules/no-throw-literal.js
@@ -35,7 +35,7 @@ module.exports = {
         return {
 
             ThrowStatement(node) {
-                if (!astUtils.couldBeError(node.argument)) {
+                if (node.argument === null || !astUtils.couldBeError(node.argument)) {
                     context.report({ node, messageId: "object" });
                 } else if (node.argument.type === "Identifier") {
                     if (node.argument.name === "undefined") {


### PR DESCRIPTION

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request?

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))


#### Repro for the bug

```
throw
```

Yep, that's it. Empty file with that will crash ESLint.

Here's the stack trace from ESLint output channel in VSCode

```
[Error - 1:41:32 PM] TypeError: Cannot read property 'type' of null
Occurred while linting [fileName].ts:132
    at Object.couldBeError (eslint/lib/rules/utils/ast-utils.js:1262:22)
    at ThrowStatement (eslint/lib/rules/no-throw-literal.js:38:31)
    at eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (eslint/lib/linter/node-event-generator.js:254:26)
    at NodeEventGenerator.applySelectors (eslint/lib/linter/node-event-generator.js:283:22)
    at NodeEventGenerator.enterNode (eslint/lib/linter/node-event-generator.js:297:14)
    at CodePathAnalyzer.enterNode (eslint/lib/linter/code-path-analysis/code-path-analyzer.js:634:23)
    at eslint/lib/linter/linter.js:936:32
```

I'm using the `@typescript-eslint` parser if that's relevant.