### PR TITLE
Docs: fix curly multi-or-nest examples with comments (refs #12972)

### DIFF
--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -181,10 +181,6 @@ while (true) {
 for (var i = 0; foo; i++) {
     doSomething();
 }
-
-if (foo)
-    // some comment
-    bar();
 ```
 
 Examples of **correct** code for the `"multi-or-nest"` option:
@@ -214,6 +210,18 @@ while (true)
 
 for (var i = 0; foo; i++)
     doSomething();
+```
+
+For single-line statements preceded by a comment, braces are allowed but not required.
+
+Examples of additional **correct** code for the `"multi-or-nest"` option:
+
+```js
+/*eslint curly: ["error", "multi-or-nest"]*/
+
+if (foo)
+    // some comment
+    bar();
 
 if (foo) {
     // some comment


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update

refs #12972

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed `multi-or-nest` examples with preceding comments in the `curly` rule to match the actual behavior and added a note to clarify the logic.

#### Is there anything you'd like reviewers to focus on?
