### PR TITLE
Docs: fix eslint comment in no-inner-declarations examples

### DIFF
--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -134,7 +134,7 @@ if (foo) function f(){}
 Examples of **correct** code for this rule with the `"both"` option:
 
 ```js
-/*eslint no-inner-declarations: "error"*/
+/*eslint no-inner-declarations: ["error", "both"]*/
 /*eslint-env es6*/
 
 var bar = 42;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update

Fixes wrong eslint configuration in correct examples for the `no-inner-declarations` rule with the `"both"` option.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed eslint directive comment.

#### Is there anything you'd like reviewers to focus on?