### PR TITLE
Chore: use espree.latestEcmaVersion in config-initializer

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -15,6 +15,7 @@ const util = require("util"),
     inquirer = require("inquirer"),
     ProgressBar = require("progress"),
     semver = require("semver"),
+    espree = require("espree"),
     recConfig = require("../../conf/eslint-recommended"),
     ConfigOps = require("../shared/config-ops"),
     log = require("../shared/logging"),
@@ -30,8 +31,6 @@ const debug = require("debug")("eslint:config-initializer");
 //------------------------------------------------------------------------------
 // Private
 //------------------------------------------------------------------------------
-
-const DEFAULT_ECMA_VERSION = 2018;
 
 /* istanbul ignore next: hard to test fs function */
 /**
@@ -265,8 +264,7 @@ function processAnswers(answers) {
         extends: []
     };
 
-    // set the latest ECMAScript version
-    config.parserOptions.ecmaVersion = DEFAULT_ECMA_VERSION;
+    config.parserOptions.ecmaVersion = espree.latestEcmaVersion;
     config.env.es6 = true;
     config.globals = {
         Atomics: "readonly",

--- a/tests/lib/init/config-initializer.js
+++ b/tests/lib/init/config-initializer.js
@@ -15,6 +15,7 @@ const assert = require("chai").assert,
     os = require("os"),
     sinon = require("sinon"),
     sh = require("shelljs"),
+    espree = require("espree"),
     autoconfig = require("../../../lib/init/autoconfig"),
     npmUtils = require("../../../lib/init/npm-utils");
 
@@ -138,7 +139,7 @@ describe("configInitializer", () => {
                 assert.strictEqual(config.env.es6, true);
                 assert.strictEqual(config.globals.Atomics, "readonly");
                 assert.strictEqual(config.globals.SharedArrayBuffer, "readonly");
-                assert.strictEqual(config.parserOptions.ecmaVersion, 2018);
+                assert.strictEqual(config.parserOptions.ecmaVersion, espree.latestEcmaVersion);
                 assert.strictEqual(config.parserOptions.sourceType, "module");
                 assert.strictEqual(config.env.browser, true);
                 assert.strictEqual(config.extends, "eslint:recommended");
@@ -156,7 +157,7 @@ describe("configInitializer", () => {
                 const config = init.processAnswers(answers);
 
                 assert.strictEqual(config.parserOptions.ecmaFeatures.jsx, true);
-                assert.strictEqual(config.parserOptions.ecmaVersion, 2018);
+                assert.strictEqual(config.parserOptions.ecmaVersion, espree.latestEcmaVersion);
                 assert.deepStrictEqual(config.plugins, ["react"]);
             });
 
@@ -164,7 +165,7 @@ describe("configInitializer", () => {
                 answers.framework = "vue";
                 const config = init.processAnswers(answers);
 
-                assert.strictEqual(config.parserOptions.ecmaVersion, 2018);
+                assert.strictEqual(config.parserOptions.ecmaVersion, espree.latestEcmaVersion);
                 assert.deepStrictEqual(config.plugins, ["vue"]);
                 assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:vue/essential"]);
             });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Chore

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This is a small PR that utilizes `espree.latestEcmaVersion` in the config initializer so that we don't have to manually update this each time we add a new version to the parser.

#### Is there anything you'd like reviewers to focus on?

This value will change as soon as we update to a version of Espree with a new supported `ecmaVersion`. Is that undesirable for any reason? Since the intention is to always use the latest version and since this is intended to only be used once by new users, I don't think this is an issue, but just wanted to check with the rest of the team.