### PR TITLE
Update: Improve report location for getter-return (refs #12334)

### DIFF
--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -25,17 +25,6 @@ function isReachable(segment) {
     return segment.reachable;
 }
 
-/**
- * Gets a readable location.
- *
- * - FunctionExpression -> the function name or `function` keyword.
- * @param {ASTNode} node A function node to get.
- * @returns {ASTNode|Token} The node or the token of a location.
- */
-function getId(node) {
-    return node.id || node;
-}
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -75,6 +64,7 @@ module.exports = {
     create(context) {
 
         const options = context.options[0] || { allowImplicit: false };
+        const sourceCode = context.getSourceCode();
 
         let funcInfo = {
             upper: null,
@@ -99,7 +89,7 @@ module.exports = {
             ) {
                 context.report({
                     node,
-                    loc: getId(node).loc.start,
+                    loc: astUtils.getFunctionHeadLoc(node, sourceCode),
                     messageId: funcInfo.hasReturn ? "expectedAlways" : "expected",
                     data: {
                         name: astUtils.getFunctionNameWithKind(funcInfo.node)

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -81,9 +81,56 @@ ruleTester.run("getter-return", rule, {
          * test obj: get
          * option: {allowImplicit: false}
          */
-        { code: "var foo = { get bar() {} };", errors: [expectedError] },
-        { code: "var foo = { get bar(){if(baz) {return true;}} };", errors: [expectedAlwaysError] },
-        { code: "var foo = { get bar() { ~function () {return true;}} };", errors: [expectedError] },
+        {
+            code: "var foo = { get bar() {} };",
+            errors: [{
+                ...expectedError,
+                line: 1,
+                column: 13,
+                endLine: 1,
+                endColumn: 20
+            }]
+        },
+        {
+            code: "var foo = { get\n bar () {} };",
+            errors: [{
+                ...expectedError,
+                line: 1,
+                column: 13,
+                endLine: 2,
+                endColumn: 6
+            }]
+        },
+        {
+            code: "var foo = { get bar(){if(baz) {return true;}} };",
+            errors: [{
+                ...expectedAlwaysError,
+                line: 1,
+                column: 13,
+                endLine: 1,
+                endColumn: 20
+            }]
+        },
+        {
+            code: "var foo = { get bar() { ~function () {return true;}} };",
+            errors: [{
+                ...expectedError,
+                line: 1,
+                column: 13,
+                endLine: 1,
+                endColumn: 20
+            }]
+        },
+        {
+            code: "var foo = { get bar() { return; } };",
+            errors: [{
+                ...expectedError,
+                line: 1,
+                column: 25,
+                endLine: 1,
+                endColumn: 32
+            }]
+        },
 
         // option: {allowImplicit: true}
         { code: "var foo = { get bar() {} };", options, errors: [expectedError] },
@@ -93,7 +140,27 @@ ruleTester.run("getter-return", rule, {
          * test class: get
          * option: {allowImplicit: false}
          */
-        { code: "class foo { get bar(){} }", errors: [expectedError] },
+        {
+            code: "class foo { get bar(){} }",
+            errors: [{
+                ...expectedError,
+                line: 1,
+                column: 13,
+                endLine: 1,
+                endColumn: 20
+            }]
+        },
+        {
+            code: "var foo = class {\n  static get\nbar(){} }",
+            errors: [{
+                messageId: "expected",
+                data: { name: "static getter 'bar'" },
+                line: 2,
+                column: 3,
+                endLine: 3,
+                endColumn: 4
+            }]
+        },
         { code: "class foo { get bar(){ if (baz) { return true; }}}", errors: [expectedAlwaysError] },
         { code: "class foo { get bar(){ ~function () { return true; }()}}", errors: [expectedError] },
 
@@ -105,8 +172,50 @@ ruleTester.run("getter-return", rule, {
          * test object.defineProperty(s)
          * option: {allowImplicit: false}
          */
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", errors: [{ messageId: "expected", data: { name: "method 'get'" } }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: () => {}});", errors: [{ messageId: "expected", data: { name: "arrow function 'get'" } }] },
+        {
+            code: "Object.defineProperty(foo, 'bar', { get: function (){}});",
+            errors: [{
+                messageId: "expected",
+                data: { name: "method 'get'" },
+                line: 1,
+                column: 37,
+                endLine: 1,
+                endColumn: 51
+            }]
+        },
+        {
+            code: "Object.defineProperty(foo, 'bar', { get: function getfoo (){}});",
+            errors: [{
+                messageId: "expected",
+                data: { name: "method 'getfoo'" },
+                line: 1,
+                column: 37,
+                endLine: 1,
+                endColumn: 58
+            }]
+        },
+        {
+            code: "Object.defineProperty(foo, 'bar', { get(){} });",
+            errors: [{
+                messageId: "expected",
+                data: { name: "method 'get'" },
+                line: 1,
+                column: 37,
+                endLine: 1,
+                endColumn: 40
+            }]
+        },
+        {
+            code: "Object.defineProperty(foo, 'bar', { get: () => {}});",
+            errors: [{
+                messageId: "expected",
+                data: { name: "arrow function 'get'" },
+                line: 1,
+                column: 45,
+                endLine: 1,
+                endColumn: 47
+            }]
+        },
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ messageId: "expectedAlways" }] },
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){ ~function () { return true; }()}});", errors: [{ messageId: "expected" }] },
         { code: "Object.defineProperties(foo, { bar: { get: function () {}} });", options, errors: [{ messageId: "expected" }] },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #12334

Change reported location in the `getter-return` rule.

This change can produce **more** warnings in existing code, depending on the location of `eslint-disable-*` comments.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The rule will now use `astUtils.getFunctionHeadLoc` instead of its own code for the reported getter's location.

Some notable differences

Before:

![image](https://user-images.githubusercontent.com/44349756/78832172-18e29780-79eb-11ea-9bc9-94f65ee5d981.png)

After:

![image](https://user-images.githubusercontent.com/44349756/78832507-a6be8280-79eb-11ea-9149-c1a07bf9b086.png)

#### Is there anything you'd like reviewers to focus on?

In edge cases where `get` and the opening paren are not on the same line, this change can produce more warnings. For example, the following code will be invalid now:

```js
/* eslint getter-return: error */

var x = {
  get 
    foo () {} // eslint-disable-line getter-return 
};
```
