### PR TITLE
Update: disallow multiple options in comma-dangle schema (fixes #13165)

### DIFF
--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -124,7 +124,8 @@ module.exports = {
                         }
                     ]
                 }
-            ]
+            ],
+            additionalItems: false
         },
 
         messages: {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

fixes #13165

`comma-dangle` schema mistakenly allows specifying multiple options.

User might expect that this rule allows string option + specific overrides in an additional object option, because some other rules indeed have such configuration.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added `additionalItems: false` in order to allow specifying only 1 option.

#### Is there anything you'd like reviewers to focus on?

This change can break a build with an invalid configuration, which should be a good thing since it wasn't working as expected.

A similar change was treated as a semver-patch bug fix (#12639).
