### PR TITLE
New: add `maxDepth` option to `sort-keys` rule

### DIFF
--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -74,6 +74,7 @@ The 2nd option is an object which has 3 properties.
 
 * `caseSensitive` - if `true`, enforce properties to be in case-sensitive order. Default is `true`.
 * `minKeys` - Specifies the minimum number of keys that an object should have in order for the object's unsorted keys to produce an error. Default is `2`, which means by default all objects with unsorted keys will result in lint errors.
+* `maxDepth` - Specifies the maximum depth of nested objects to check for sorted keys. `1` means that only the top-level object will be checked. Default is `Infinity`, which means all objects with unsorted keys, regardless of nesting, will result in lint errors.
 * `natural` - if `true`, enforce properties to be in natural order. Default is `false`. Natural Order compares strings containing combination of letters and numbers in the way a human being would sort. It basically sorts numerically, instead of sorting alphabetically. So the number 10 comes after the number 3 in Natural Sorting.
 
 Example for a list:
@@ -211,6 +212,40 @@ let obj = {
 let obj = {
     2: 'b',
     1: 'a',
+};
+```
+
+### maxDepth
+
+Examples of **incorrect** code for the `{maxDepth: 2}` option:
+
+```js
+/*eslint sort-keys: ["error", "asc", {maxDepth: 2}]*/
+/*eslint-env es6*/
+
+let obj = {
+    a: 1,
+    b: 1,
+    c: {
+        e: 1,
+        d: 1, // not sorted correctly, reported as violation because current depth (2) <= maxDepth (2)
+    },
+};
+```
+
+Examples of **correct** code for the `{maxDepth: 1}` option:
+
+```js
+/*eslint sort-keys: ["error", "asc", {maxDepth: 1}]*/
+/*eslint-env es6*/
+
+let obj = {
+    a: 1,
+    b: 1,
+    c: {
+        e: 1,
+        d: 1, // not sorted correctly, but ignored because current depth (2) > maxDepth (1)
+    },
 };
 ```
 

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -105,6 +105,10 @@ module.exports = {
                         type: "integer",
                         minimum: 2,
                         default: 2
+                    },
+                    maxDepth: {
+                        type: "integer",
+                        minimum: 1
                     }
                 },
                 additionalProperties: false
@@ -124,12 +128,16 @@ module.exports = {
         const insensitive = options && options.caseSensitive === false;
         const natural = options && options.natural;
         const minKeys = options && options.minKeys;
+        const maxDepth = (options && options.maxDepth) || Infinity;
         const isValidOrder = isValidOrders[
             order + (insensitive ? "I" : "") + (natural ? "N" : "")
         ];
 
         // The stack to save the previous property's name for each object literals.
         let stack = null;
+
+        // Current depth.
+        let depth = 0;
 
         return {
             ObjectExpression(node) {
@@ -138,10 +146,12 @@ module.exports = {
                     prevName: null,
                     numKeys: node.properties.length
                 };
+                depth++;
             },
 
             "ObjectExpression:exit"() {
                 stack = stack.upper;
+                depth--;
             },
 
             SpreadElement(node) {
@@ -152,6 +162,10 @@ module.exports = {
 
             Property(node) {
                 if (node.parent.type === "ObjectPattern") {
+                    return;
+                }
+
+                if (depth > maxDepth) {
                     return;
                 }
 

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -163,7 +163,11 @@ ruleTester.run("sort-keys", rule, {
         { code: "var obj = {è:4, À:3, 'Z':2, '#':1}", options: ["desc", { natural: true, caseSensitive: false }] },
 
         // desc, natural, insensitive, minKeys should ignore unsorted keys when number of keys is less than minKeys
-        { code: "var obj = {a:1, _:2, b:3}", options: ["desc", { natural: true, caseSensitive: false, minKeys: 4 }] }
+        { code: "var obj = {a:1, _:2, b:3}", options: ["desc", { natural: true, caseSensitive: false, minKeys: 4 }] },
+
+        // maxDepth
+        { code: "var obj = {a:1, b:1, c:{e:1, d:1}}", options: ["asc", { maxDepth: 1 }] }, // maxDepth is 1, 2nd level is out-of-order but ignored.
+        { code: "var obj = {a:1, b:1, c:{d:1, e:{g:1, f:1}}}", options: ["asc", { maxDepth: 2 }] } // maxDepth is 2, 3rd level is out-of-order but ignored.
     ],
     invalid: [
 
@@ -1758,6 +1762,78 @@ ruleTester.run("sort-keys", rule, {
                         order: "desc",
                         thisName: "b",
                         prevName: "_"
+                    }
+                }
+            ]
+        },
+
+        // maxDepth to check is 1, 1st level out-of-order after a nested object.
+        {
+            code: "var obj = {a:1, b:{d:1, c:1}, f:1, e:1}",
+            options: ["asc", { maxDepth: 1 }],
+            errors: [
+                {
+                    messageId: "sortKeys",
+                    data: {
+                        natural: "",
+                        insensitive: "",
+                        order: "asc",
+                        thisName: "e",
+                        prevName: "f"
+                    }
+                }
+            ]
+        },
+
+        // maxDepth to check is 2, and 1st level is out-of-order.
+        {
+            code: "var obj = {b:1, a:1, c:{d:1, e:1}}",
+            options: ["asc", { maxDepth: 2 }],
+            errors: [
+                {
+                    messageId: "sortKeys",
+                    data: {
+                        natural: "",
+                        insensitive: "",
+                        order: "asc",
+                        thisName: "a",
+                        prevName: "b"
+                    }
+                }
+            ]
+        },
+
+        // maxDepth to check is 2, and 2nd level is out-of-order.
+        {
+            code: "var obj = {a:1, b:1, c:{e:1, d:1}}",
+            options: ["asc", { maxDepth: 2 }],
+            errors: [
+                {
+                    messageId: "sortKeys",
+                    data: {
+                        natural: "",
+                        insensitive: "",
+                        order: "asc",
+                        thisName: "d",
+                        prevName: "e"
+                    }
+                }
+            ]
+        },
+
+        // maxDepth to check is 3, and 3rd level is out-of-order. 4th level is also out-of-order but ignored.
+        {
+            code: "var obj = {a:1, b:1, c:{d:1, e:{g:1, f:{i:1, h:1}}}}",
+            options: ["asc", { maxDepth: 3 }],
+            errors: [
+                {
+                    messageId: "sortKeys",
+                    data: {
+                        natural: "",
+                        insensitive: "",
+                        order: "asc",
+                        thisName: "f",
+                        prevName: "g"
                     }
                 }
             ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What rule do you want to change?**

[sort-keys](https://eslint.org/docs/rules/sort-keys)

**Does this change cause the rule to produce more or fewer warnings?**

Potentially less warnings when using the new option.

**How will the change be implemented? (New option, new default behavior, etc.)?**

New option: `maxDepth`

**Please provide some example code that this change will affect:**

```js
/*eslint sort-keys: ["error", "asc", {maxDepth: 1}]*/
/*eslint-env es6*/

let obj = {
    a: 1,
    b: 1,
    c: {
        e: 1,
        d: 1, // not sorted correctly, but ignored because current depth (2) > maxDepth (1)
    },
};
```

**What does the rule currently do for this code?**

Currently, the rule checks for sorted object keys, regardless of how many levels of nesting there are in an object.

**What will the rule do after it's changed?**

The `maxDepth` option can be used to control how many levels of nested objects should be validated for having sorted keys. For example, a `maxDepth` of `1` means only the top-level of an object should be validated.

#### Is there anything you'd like reviewers to focus on?

Not in particular.