### PR TITLE
Fix: Remove default .js from --ext CLI option

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -46,7 +46,6 @@ module.exports = optionator({
         {
             option: "ext",
             type: "[String]",
-            default: ".js",
             description: "Specify JavaScript file extensions"
         },
         {

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -79,11 +79,10 @@ describe("options", () => {
             assert.strictEqual(currentOptions.ext[1], ".js");
         });
 
-        it("should return an array one item when not passed", () => {
+        it("should not exist when not passed", () => {
             const currentOptions = options.parse("");
 
-            assert.isArray(currentOptions.ext);
-            assert.strictEqual(currentOptions.ext[0], ".js");
+            assert.notProperty(currentOptions, "ext");
         });
     });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** `7.0.0-alpha.3`
* **Node Version:** `13.11.0`
* **npm Version:** `6.13.7`

**What parser (default, Babel-ESLint, etc.) are you using?** default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
"use strict";

module.exports = {
    root: true,
    plugins: [
        "markdown",
        "react"
    ],
    extends: ["eslint:recommended"],
    overrides: [
        {
            files: [".eslintrc.js"],
            env: {
                node: true
            }
        },
        {
            files: ["**/*.md"],
            processor: "markdown/markdown"
        },
        {
            files: ["**/*.md/*.jsx"],
            env: {
                browser: true,
                es6: true
            },
            globals: {
                React: false
            },
            extends: ["plugin:react/recommended"],
            parserOptions: {
                ecmaFeatures: {
                    jsx: true
                },
                ecmaVersion: 2015,
                sourceType: "module"
            },
        }
    ]
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

````md
# README.md

```jsx
!@#$%^
```
````

```sh
$ eslint README.md
```

**What did you expect to happen?**

Because I included `md` and `jsx` `overrides` in `.eslintrc.js`, ESLint should have seen the syntax error in the Markdown file's JSX code block.

**What actually happened? Please include the actual, raw output from ESLint.**

No errors were reported.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

PR #12677, `Breaking: lint overrides files`, removed the default `.js` value from the  default CLIEngine options. However, it did not remove the same default value from the `--ext` option parsed by Optionator. Because of this, when running `eslint .` without the `--ext` option, Optionator would insert a default `--ext .js` value that would be passed on to the CLIEngine. ESLint only lints `overrides` files if the `--ext` CLI option is not passed, so the default `--ext .js` option prevented ESLint from ever reaching the `overrides` file path checking flow.

#### Is there anything you'd like reviewers to focus on?

Is this a `Fix:` or a `Breaking:`? It's a bug fix because it enables behavior that was supposed to be working already, but it's also a breaking change because it removes a CLI option's default value. Since we're still in prereleases, I went with `Breaking:` since it won't prevent us from doing anything.
