### PR TITLE
Fix: ignore unmergable imports when checking no-duplicate-imports (fixes #13180)

### DIFF
--- a/docs/rules/no-duplicate-imports.md
+++ b/docs/rules/no-duplicate-imports.md
@@ -12,7 +12,9 @@ import { find } from 'module';
 
 ## Rule Details
 
-This rule requires that all imports from a single module exists in a single `import` statement.
+An import that can be merged with another is a duplicate of that other.
+
+This rule requires that all imports from a single module that can be merged exists in a single `import` statement.
 
 Example of **incorrect** code for this rule:
 
@@ -32,6 +34,27 @@ Example of **correct** code for this rule:
 import { merge, find } from 'module';
 import something from 'another-module';
 ```
+
+The following examples explains **can be merged** in detail:
+
+```js
+// mergable, as parsers1 & parsers2 hold the same reference, and so their identifiers can be replaced.
+import * as parsers1 from 'parsers';
+import * as parsers2 from 'parsers';
+
+// mergable, as they can be combined without changing behaviour & remaining syntactically valid.
+import defaultValue from 'parsers';
+import { anotherValue } from 'parsers';
+
+// mergable as they will both trigger any side effects the module has.
+import * as parsers2 from 'parsers';
+import 'parsers';
+
+// not mergable, as they would require new nodes to be created.
+import { anotherValue } from 'parsers';
+import * as parsers1 from 'parsers';
+```
+
 
 ## Options
 

--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -22,17 +22,106 @@ function getValue(node) {
 }
 
 /**
+ * Checks if the import's type is the given type import.
+ * @param {ASTNode} node The import to be checked.
+ * @param {type} type the type to be checked.
+ *
+ * @returns {boolean} Whether or not the import's type is type.
+ */
+function checkImportType(node, type) {
+    return (
+        node.specifiers &&
+        node.specifiers[0] &&
+        node.specifiers[0].type === type
+    );
+}
+
+
+/**
+ * Checks whether a node has the given value.
+ * @param {string} value the value to be checked.
+ *
+ * @returns {Function} the predicate function, return true if the parameter ASTNode has the given value.
+ */
+function hasValue(value) {
+    return function(node) {
+        return getValue(node) === value;
+    };
+}
+
+/**
+ * Checks if two nodes can be merged.
+ * @param {ASTNode} node1 one of the two nodes to be checked.
+ * @param {ASTNode} node2 the other node to be checked.
+ *
+ * @returns {boolean} true where only one ImportNamespaceSpecifier and one ImportSpecifier, otherwise, false.
+ */
+function isTwoNodesCanMerge(node1, node2) {
+    return (
+        (
+            checkImportType(node1, "ImportNamespaceSpecifier") &&
+            checkImportType(node2, "ImportSpecifier")
+        ) ||
+        (
+            checkImportType(node1, "ImportSpecifier") &&
+            checkImportType(node2, "ImportNamespaceSpecifier")
+        )
+    );
+}
+
+/**
+ * Checks if one node cannot be merged into the imports, which means a duplication.
+ * @param {ASTNode} node the node to be checked.
+ * @param {ASTNode[]} importsInFile the imports to be checked.
+ *
+ * @returns {boolean} true if the node can be merged.
+ */
+function canBeMerged(node, importsInFile) {
+    const sameSourceImports = importsInFile.filter(hasValue(getValue(node)));
+
+    return !(
+        !sameSourceImports.length ||
+        (
+            sameSourceImports.length === 1 &&
+            isTwoNodesCanMerge(node, sameSourceImports[0])
+        )
+    );
+}
+
+/**
  * Checks if the name of the import or export exists in the given array, and reports if so.
  * @param {RuleContext} context The ESLint rule context object.
  * @param {ASTNode} node A node to get.
  * @param {string} value The name of the imported or exported module.
- * @param {string[]} array The array containing other imports or exports in the file.
+ * @param {ASTNode[]} importsInFile The array containing other imports or exports in the file.
+ * @param {string} messageId A messageId to be reported after the name of the module
+ *
+ * @returns {void} No return value
+ */
+function checkAndReportImport(context, node, value, importsInFile, messageId) {
+    if (canBeMerged(node, importsInFile)) {
+        context.report({
+            node,
+            messageId,
+            data: {
+                module: value
+            }
+        });
+    }
+}
+
+/**
+ * Checks if the name of the import or export exists in the given array, and reports if so.
+ * @param {RuleContext} context The ESLint rule context object.
+ * @param {ASTNode} node A node to get.
+ * @param {string} value The name of the imported or exported module.
+ * @param {ASTNode[]} array The array containing other imports or exports in the file.
  * @param {string} messageId A messageId to be reported after the name of the module
  *
  * @returns {void} No return value
  */
 function checkAndReport(context, node, value, array, messageId) {
-    if (array.indexOf(value) !== -1) {
+    if (array.map(getValue).indexOf(value) !== -1) {
         context.report({
             node,
             messageId,
@@ -52,8 +141,8 @@ function checkAndReport(context, node, value, array, messageId) {
  * Returns a function handling the imports of a given file
  * @param {RuleContext} context The ESLint rule context object.
  * @param {boolean} includeExports Whether or not to check for exports in addition to imports.
- * @param {string[]} importsInFile The array containing other imports in the file.
- * @param {string[]} exportsInFile The array containing other exports in the file.
+ * @param {ASTNode[]} importsInFile The array containing other imports in the file.
+ * @param {ASTNode[]} exportsInFile The array containing other exports in the file.
  *
  * @returns {nodeCallback} A function passed to ESLint to handle the statement.
  */
@@ -62,13 +151,13 @@ function handleImports(context, includeExports, importsInFile, exportsInFile) {
         const value = getValue(node);
 
         if (value) {
-            checkAndReport(context, node, value, importsInFile, "import");
+            checkAndReportImport(context, node, value, importsInFile, "import");
 
             if (includeExports) {
                 checkAndReport(context, node, value, exportsInFile, "importAs");
             }
 
-            importsInFile.push(value);
+            importsInFile.push(node);
         }
     };
 }
@@ -76,8 +165,8 @@ function handleImports(context, includeExports, importsInFile, exportsInFile) {
 /**
  * Returns a function handling the exports of a given file
  * @param {RuleContext} context The ESLint rule context object.
- * @param {string[]} importsInFile The array containing other imports in the file.
- * @param {string[]} exportsInFile The array containing other exports in the file.
+ * @param {ASTNode[]} importsInFile The array containing other imports in the file.
+ * @param {ASTNode[]} exportsInFile The array containing other exports in the file.
  *
  * @returns {nodeCallback} A function passed to ESLint to handle the statement.
  */
@@ -89,7 +178,7 @@ function handleExports(context, importsInFile, exportsInFile) {
             checkAndReport(context, node, value, exportsInFile, "export");
             checkAndReport(context, node, value, importsInFile, "exportAs");
 
-            exportsInFile.push(value);
+            exportsInFile.push(node);
         }
     };
 }

--- a/tests/lib/rules/no-duplicate-imports.js
+++ b/tests/lib/rules/no-duplicate-imports.js
@@ -26,6 +26,7 @@ ruleTester.run("no-duplicate-imports", rule, {
         "import * as Foobar from \"async\";",
         "import \"foo\"",
         "import os from \"os\";\nexport { something } from \"os\";",
+        "import * as Lodash from \"lodash-es\";import { merge } from \"lodash-es\";",
         {
             code: "import os from \"os\";\nexport { hello } from \"hello\";",
             options: [{ includeExports: true }]
@@ -48,6 +49,18 @@ ruleTester.run("no-duplicate-imports", rule, {
         }
     ],
     invalid: [
+        {
+            code: "import * as Foo from \"os\";\nimport * as Bar from \"os\"",
+            errors: [{ messageId: "import", data: { module: "os" }, type: "ImportDeclaration" }]
+        },
+        {
+            code: "import os from \"os\";\nimport { arch } from \"os\"",
+            errors: [{ messageId: "import", data: { module: "os" }, type: "ImportDeclaration" }]
+        },
+        {
+            code: "import * as Foobar from \"os\";\nimport \"os\"",
+            errors: [{ messageId: "import", data: { module: "os" }, type: "ImportDeclaration" }]
+        },
         {
             code: "import \"fs\";\nimport \"fs\"",
             errors: [{ messageId: "import", data: { module: "fs" }, type: "ImportDeclaration" }]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fix the issue here: https://github.com/eslint/eslint/issues/12758

#### Is there anything you'd like reviewers to focus on?
1. I thought two nodes are mergable only when one is ImportNamespaceSpecifier and one is ImportSpecifier, is that true?
2. I thought only in handleImports when checking importsInFile should I change the `checkAndReport` function, is that true?