### PR TITLE
Fix: func-call-spacing "never" reports wrong message (fixes #13190)

### DIFF
--- a/lib/rules/func-call-spacing.js
+++ b/lib/rules/func-call-spacing.js
@@ -63,7 +63,8 @@ module.exports = {
         },
 
         messages: {
-            unexpected: "Unexpected newline between function name and paren.",
+            unexpectedWhitespace: "Unexpected whitespace between function name and paren.",
+            unexpectedNewline: "Unexpected newline between function name and paren.",
             missing: "Missing space between function name and paren."
         }
     },
@@ -116,7 +117,7 @@ module.exports = {
                 context.report({
                     node,
                     loc: leftToken.loc.start,
-                    messageId: "unexpected",
+                    messageId: "unexpectedWhitespace",
                     fix(fixer) {
 
                         /*
@@ -143,7 +144,7 @@ module.exports = {
                 context.report({
                     node,
                     loc: leftToken.loc.start,
-                    messageId: "unexpected",
+                    messageId: "unexpectedNewline",
                     fix(fixer) {
                         return fixer.replaceTextRange([leftToken.range[1], rightToken.range[0]], " ");
                     }

--- a/tests/lib/rules/func-call-spacing.js
+++ b/tests/lib/rules/func-call-spacing.js
@@ -226,99 +226,99 @@ ruleTester.run("func-call-spacing", rule, {
         {
             code: "f ();",
             output: "f();",
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "f (a, b);",
             output: "f(a, b);",
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "f.b ();",
             output: "f.b();",
-            errors: [{ messageId: "unexpected", type: "CallExpression", column: 3 }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression", column: 3 }]
         },
         {
             code: "f.b().c ();",
             output: "f.b().c();",
-            errors: [{ messageId: "unexpected", type: "CallExpression", column: 7 }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression", column: 7 }]
         },
         {
             code: "f() ()",
             output: "f()()",
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "(function() {} ())",
             output: "(function() {}())",
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "var f = new Foo ()",
             output: "var f = new Foo()",
-            errors: [{ messageId: "unexpected", type: "NewExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "NewExpression" }]
         },
         {
             code: "f ( (0) )",
             output: "f( (0) )",
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "f(0) (1)",
             output: "f(0)(1)",
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "(f) (0)",
             output: "(f)(0)",
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "f ();\n t   ();",
             output: "f();\n t();",
             errors: [
-                { messageId: "unexpected", type: "CallExpression" },
-                { messageId: "unexpected", type: "CallExpression" }
+                { messageId: "unexpectedWhitespace", type: "CallExpression" },
+                { messageId: "unexpectedWhitespace", type: "CallExpression" }
             ]
         },
         {
             code: "import (source);",
             output: "import(source);",
             parserOptions: { ecmaVersion: 2020 },
-            errors: [{ messageId: "unexpected", type: "ImportExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "ImportExpression" }]
         },
 
         // https://github.com/eslint/eslint/issues/7787
         {
             code: "f\n();",
             output: null, // no change
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "f\r();",
             output: null, // no change
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "f\u2028();",
             output: null, // no change
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "f\u2029();",
             output: null, // no change
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "f\r\n();",
             output: null, // no change
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "import\n(source);",
             output: null,
             parserOptions: { ecmaVersion: 2020 },
-            errors: [{ messageId: "unexpected", type: "ImportExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "ImportExpression" }]
         },
 
         // "never"
@@ -326,69 +326,69 @@ ruleTester.run("func-call-spacing", rule, {
             code: "f ();",
             output: "f();",
             options: ["never"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "f (a, b);",
             output: "f(a, b);",
             options: ["never"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "f.b ();",
             output: "f.b();",
             options: ["never"],
-            errors: [{ messageId: "unexpected", type: "CallExpression", column: 3 }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression", column: 3 }]
         },
         {
             code: "f.b().c ();",
             output: "f.b().c();",
             options: ["never"],
-            errors: [{ messageId: "unexpected", type: "CallExpression", column: 7 }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression", column: 7 }]
         },
         {
             code: "f() ()",
             output: "f()()",
             options: ["never"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "(function() {} ())",
             output: "(function() {}())",
             options: ["never"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "var f = new Foo ()",
             output: "var f = new Foo()",
             options: ["never"],
-            errors: [{ messageId: "unexpected", type: "NewExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "NewExpression" }]
         },
         {
             code: "f ( (0) )",
             output: "f( (0) )",
             options: ["never"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "f(0) (1)",
             output: "f(0)(1)",
             options: ["never"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "(f) (0)",
             output: "(f)(0)",
             options: ["never"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]
         },
         {
             code: "f ();\n t   ();",
             output: "f();\n t();",
             options: ["never"],
             errors: [
-                { messageId: "unexpected", type: "CallExpression" },
-                { messageId: "unexpected", type: "CallExpression" }
+                { messageId: "unexpectedWhitespace", type: "CallExpression" },
+                { messageId: "unexpectedWhitespace", type: "CallExpression" }
             ]
         },
         {
@@ -396,7 +396,7 @@ ruleTester.run("func-call-spacing", rule, {
             output: "import(source);",
             options: ["never"],
             parserOptions: { ecmaVersion: 2020 },
-            errors: [{ messageId: "unexpected", type: "ImportExpression" }]
+            errors: [{ messageId: "unexpectedWhitespace", type: "ImportExpression" }]
         },
 
         // https://github.com/eslint/eslint/issues/7787
@@ -406,7 +406,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    messageId: "unexpected",
+                    messageId: "unexpectedWhitespace",
                     type: "CallExpression"
                 }
             ]
@@ -421,7 +421,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    messageId: "unexpected",
+                    messageId: "unexpectedWhitespace",
                     type: "CallExpression",
                     line: 2,
                     column: 23
@@ -437,7 +437,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    messageId: "unexpected",
+                    messageId: "unexpectedWhitespace",
                     type: "CallExpression",
                     line: 1,
                     column: 9
@@ -453,7 +453,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    messageId: "unexpected",
+                    messageId: "unexpectedWhitespace",
                     type: "CallExpression",
                     line: 1,
                     column: 9
@@ -466,7 +466,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    messageId: "unexpected",
+                    messageId: "unexpectedWhitespace",
                     type: "CallExpression"
                 }
             ]
@@ -477,7 +477,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    messageId: "unexpected",
+                    messageId: "unexpectedWhitespace",
                     type: "CallExpression"
                 }
             ]
@@ -488,7 +488,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    messageId: "unexpected",
+                    messageId: "unexpectedWhitespace",
                     type: "CallExpression"
                 }
             ]
@@ -499,7 +499,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    messageId: "unexpected",
+                    messageId: "unexpectedWhitespace",
                     type: "CallExpression"
                 }
             ]
@@ -516,7 +516,7 @@ ruleTester.run("func-call-spacing", rule, {
             code: "f\n();",
             output: "f ();",
             options: ["always"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedNewline", type: "CallExpression" }]
         },
         {
             code: "f(a, b);",
@@ -528,7 +528,7 @@ ruleTester.run("func-call-spacing", rule, {
             code: "f\n(a, b);",
             output: "f (a, b);",
             options: ["always"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedNewline", type: "CallExpression" }]
         },
         {
             code: "f.b();",
@@ -540,7 +540,7 @@ ruleTester.run("func-call-spacing", rule, {
             code: "f.b\n();",
             output: "f.b ();",
             options: ["always"],
-            errors: [{ messageId: "unexpected", type: "CallExpression", column: 3 }]
+            errors: [{ messageId: "unexpectedNewline", type: "CallExpression", column: 3 }]
         },
         {
             code: "f.b().c ();",
@@ -552,7 +552,7 @@ ruleTester.run("func-call-spacing", rule, {
             code: "f.b\n().c ();",
             output: "f.b ().c ();",
             options: ["always"],
-            errors: [{ messageId: "unexpected", type: "CallExpression", column: 3 }]
+            errors: [{ messageId: "unexpectedNewline", type: "CallExpression", column: 3 }]
         },
         {
             code: "f() ()",
@@ -564,14 +564,14 @@ ruleTester.run("func-call-spacing", rule, {
             code: "f\n() ()",
             output: "f () ()",
             options: ["always"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedNewline", type: "CallExpression" }]
         },
         {
             code: "f\n()()",
             output: "f () ()",
             options: ["always"],
             errors: [
-                { messageId: "unexpected", type: "CallExpression" },
+                { messageId: "unexpectedNewline", type: "CallExpression" },
                 { messageId: "missing", type: "CallExpression" }
             ]
         },
@@ -625,25 +625,25 @@ ruleTester.run("func-call-spacing", rule, {
             code: "f\r();",
             output: "f ();",
             options: ["always"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedNewline", type: "CallExpression" }]
         },
         {
             code: "f\u2028();",
             output: "f ();",
             options: ["always"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedNewline", type: "CallExpression" }]
         },
         {
             code: "f\u2029();",
             output: "f ();",
             options: ["always"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedNewline", type: "CallExpression" }]
         },
         {
             code: "f\r\n();",
             output: "f ();",
             options: ["always"],
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
+            errors: [{ messageId: "unexpectedNewline", type: "CallExpression" }]
         },
 
         // "always", "allowNewlines": true


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix


fixes #13190
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`func-call-spacing` will be reporting the following messages:

* "Unexpected whitespace between function name and paren." if the option is `"never"` and there is any whitespace (including spaces and newlines) between function name and paren.
* "Unexpected newline between function name and paren." if the option is `"always"`, `"allowNewlines"` is set to `false`, and there is a newline between function name and paren. 

#### Is there anything you'd like reviewers to focus on?

This reverts change in the message text made in #10764, plus changes "space" to "whitespace" in the message for `"never"`.
