### PR TITLE
Update: fix operator-linebreak overrides schema

### DIFF
--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -22,7 +22,7 @@ This rule enforces a consistent linebreak style for operators.
 
 ## Options
 
-This rule has one option, which can be a string option or an object option.
+This rule has two options, a string option and an object option.
 
 String option:
 

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -35,11 +35,8 @@ module.exports = {
                 properties: {
                     overrides: {
                         type: "object",
-                        properties: {
-                            anyOf: {
-                                type: "string",
-                                enum: ["after", "before", "none", "ignore"]
-                            }
+                        additionalProperties: {
+                            enum: ["after", "before", "none", "ignore"]
                         }
                     }
                 },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.0.0-alpha.3
* **Node Version:** v12.14.0
* **npm Version:** v6.13.4

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: 2015
    }
}
```
</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgb3BlcmF0b3ItbGluZWJyZWFrOiBbXCJlcnJvclwiLCBcImFmdGVyXCIsIHsgXCJvdmVycmlkZXNcIjogeyBcIitcIjogdHJ1ZSB9IH1dKi9cbiIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js
/*eslint operator-linebreak: ["error", "after", { "overrides": { "+": true } }]*/

```

**What did you expect to happen?**

ESLint to report invalid configuration on `true`. This value should be one of `["after", "before", "none", "ignore"]`.

**What actually happened? Please include the actual, raw output from ESLint.**

no warnings

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the schema for `overrides` in the `operator-linebreak` rule. The previous schema actually defined allowed enum for the value of a property named `"anyOf"` (which doesn't make sense).

Also fixed the documentation. This rule has two options, not one option that can be either string or object.

#### Is there anything you'd like reviewers to focus on?

This invalid configuration had specific behavior, different from the 4 valid options. It works mostly as `"ignore"`, but it also disallows cases where linebreaks are on both sides of the specified operator. Nevertheless, this isn't documented and it doesn't look it was intentional.
