### PR TITLE
Update: added empty error array check for false negative

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -645,7 +645,7 @@ class RuleTester {
                 `Did not specify errors for an invalid test of ${ruleName}`);
 
             if (Array.isArray(item.errors) && item.errors.length === 0) {
-                assert.fail("errors array should have at least one element otherwise its a valid case");
+                assert.fail("Invalid cases must have at least one error");
             }
 
             const ruleHasMetaMessages = hasOwnProperty(rule, "meta") && hasOwnProperty(rule.meta, "messages");
@@ -657,7 +657,7 @@ class RuleTester {
             if (typeof item.errors === "number") {
 
                 if (item.errors === 0) {
-                    assert.fail("errors of type `number` should not have value `0`");
+                    assert.fail("Invalid cases must have value greater than 0");
                 }
 
                 assert.strictEqual(messages.length, item.errors, util.format("Should have %d error%s but had %d: %s",

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -657,7 +657,7 @@ class RuleTester {
             if (typeof item.errors === "number") {
 
                 if (item.errors === 0) {
-                    assert.fail("Invalid cases must have value greater than 0");
+                    assert.fail("Invalid cases must have 'error' value greater than 0");
                 }
 
                 assert.strictEqual(messages.length, item.errors, util.format("Should have %d error%s but had %d: %s",

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -644,6 +644,10 @@ class RuleTester {
             assert.ok(item.errors || item.errors === 0,
                 `Did not specify errors for an invalid test of ${ruleName}`);
 
+            if (Array.isArray(item.errors) && item.errors.length === 0) {
+                assert.fail("errors array should have atleast one element otherwise its a valid case");
+            }
+
             const ruleHasMetaMessages = hasOwnProperty(rule, "meta") && hasOwnProperty(rule.meta, "messages");
             const friendlyIDList = ruleHasMetaMessages ? `[${Object.keys(rule.meta.messages).map(key => `'${key}'`).join(", ")}]` : null;
 

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -645,7 +645,7 @@ class RuleTester {
                 `Did not specify errors for an invalid test of ${ruleName}`);
 
             if (Array.isArray(item.errors) && item.errors.length === 0) {
-                assert.fail("errors array should have atleast one element otherwise its a valid case");
+                assert.fail("errors array should have at least one element otherwise its a valid case");
             }
 
             const ruleHasMetaMessages = hasOwnProperty(rule, "meta") && hasOwnProperty(rule.meta, "messages");

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -655,6 +655,11 @@ class RuleTester {
             const messages = result.messages;
 
             if (typeof item.errors === "number") {
+
+                if (item.errors === 0) {
+                    assert.fail("errors of type `number` should not have value `0`");
+                }
+
                 assert.strictEqual(messages.length, item.errors, util.format("Should have %d error%s but had %d: %s",
                     item.errors, item.errors === 1 ? "" : "s", messages.length, util.inspect(messages)));
             } else {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -472,7 +472,7 @@ describe("RuleTester", () => {
                     errors: []
                 }]
             });
-        }, /errors array should have atleast one element otherwise its a valid case/u);
+        }, /errors array should have at least one element otherwise its a valid case/u);
     });
 
     it("should not skip column assertion if column is a falsy value", () => {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -463,6 +463,18 @@ describe("RuleTester", () => {
         }, expectedErrorMessage);
     });
 
+    it("should throw error for empty error array", () => {
+        assert.throws(() => {
+            ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+                valid: [],
+                invalid: [{
+                    code: "var foo;",
+                    errors: []
+                }]
+            });
+        }, /errors array should have atleast one element otherwise its a valid case/u);
+    });
+
     it("should not skip column assertion if column is a falsy value", () => {
         assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
@@ -732,7 +744,7 @@ describe("RuleTester", () => {
                 {
                     code: "eval(foo)",
                     parser: require.resolve("esprima"),
-                    errors: [{}]
+                    errors: [{ line: 1 }]
                 }
             ]
         });
@@ -1893,4 +1905,5 @@ describe("RuleTester", () => {
         });
 
     });
+
 });

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -475,6 +475,25 @@ describe("RuleTester", () => {
         }, /errors array should have at least one element otherwise its a valid case/u);
     });
 
+    it("should throw error for errors : 0", () => {
+        assert.throws(() => {
+            ruleTester.run(
+                "suggestions-messageIds",
+                require("../../fixtures/testers/rule-tester/suggestions")
+                    .withMessageIds,
+                {
+                    valid: [],
+                    invalid: [
+                        {
+                            code: "var foo;",
+                            errors: 0
+                        }
+                    ]
+                }
+            );
+        }, /errors of type `number` should not have value `0`/u);
+    });
+
     it("should not skip column assertion if column is a falsy value", () => {
         assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -491,7 +491,7 @@ describe("RuleTester", () => {
                     ]
                 }
             );
-        }, /Invalid cases must have value greater than 0/u);
+        }, /Invalid cases must have 'error' value greater than 0/u);
     });
 
     it("should not skip column assertion if column is a falsy value", () => {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -472,7 +472,7 @@ describe("RuleTester", () => {
                     errors: []
                 }]
             });
-        }, /errors array should have at least one element otherwise its a valid case/u);
+        }, /Invalid cases must have at least one error/u);
     });
 
     it("should throw error for errors : 0", () => {
@@ -491,7 +491,7 @@ describe("RuleTester", () => {
                     ]
                 }
             );
-        }, /errors of type `number` should not have value `0`/u);
+        }, /Invalid cases must have value greater than 0/u);
     });
 
     it("should not skip column assertion if column is a falsy value", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Currently in test files for rules and internal rules, if a valid test case in added to invalid test case and have `errors` set to an empty array, it simply passes the test which should be an error as it is false negative. 
Added a check for empty-ness of the array and it will throw  error if the `errors` is empty array

#### Is there anything you'd like reviewers to focus on?
~None~
not sure whether it is of type `Fix` or `Chore` cause I think it is addressing false negative of test cases. let me know 👍 