### PR TITLE
Update: Improve report location for template-tag-spacing (refs #12334)

### DIFF
--- a/lib/rules/template-tag-spacing.js
+++ b/lib/rules/template-tag-spacing.js
@@ -71,7 +71,10 @@ module.exports = {
             } else if (!never && !hasWhitespace) {
                 context.report({
                     node,
-                    loc: tagToken.loc,
+                    loc: {
+                        start: node.loc.start,
+                        end: literalToken.loc.start
+                    },
                     messageId: "missing",
                     fix(fixer) {
                         return fixer.insertTextAfter(tagToken, " ");

--- a/lib/rules/template-tag-spacing.js
+++ b/lib/rules/template-tag-spacing.js
@@ -49,7 +49,10 @@ module.exports = {
             if (never && hasWhitespace) {
                 context.report({
                     node,
-                    loc: tagToken.loc.start,
+                    loc: {
+                        start: tagToken.loc.end,
+                        end: literalToken.loc.start
+                    },
                     messageId: "unexpected",
                     fix(fixer) {
                         const comments = sourceCode.getCommentsBefore(node.quasi);
@@ -68,7 +71,7 @@ module.exports = {
             } else if (!never && !hasWhitespace) {
                 context.report({
                     node,
-                    loc: tagToken.loc.start,
+                    loc: tagToken.loc,
                     messageId: "missing",
                     fix(fixer) {
                         return fixer.insertTextAfter(tagToken, " ");

--- a/tests/lib/rules/template-tag-spacing.js
+++ b/tests/lib/rules/template-tag-spacing.js
@@ -118,7 +118,7 @@ ruleTester.run("template-tag-spacing", rule, {
                 line: 1,
                 column: 1,
                 endLine: 1,
-                endColumn: 4
+                endColumn: 24
             }]
         },
         {
@@ -279,7 +279,7 @@ ruleTester.run("template-tag-spacing", rule, {
             errors: [{
                 messageId: "missing",
                 line: 1,
-                column: 5,
+                column: 1,
                 endLine: 1,
                 endColumn: 6
             }]
@@ -314,7 +314,7 @@ ruleTester.run("template-tag-spacing", rule, {
             errors: [{
                 messageId: "missing",
                 line: 1,
-                column: 5,
+                column: 1,
                 endLine: 1,
                 endColumn: 6
             }]
@@ -349,7 +349,7 @@ ruleTester.run("template-tag-spacing", rule, {
             errors: [{
                 messageId: "missing",
                 line: 1,
-                column: 9,
+                column: 5,
                 endLine: 1,
                 endColumn: 10
             }]
@@ -384,7 +384,7 @@ ruleTester.run("template-tag-spacing", rule, {
             errors: [{
                 messageId: "missing",
                 line: 1,
-                column: 9,
+                column: 5,
                 endLine: 1,
                 endColumn: 10
             }]
@@ -435,6 +435,30 @@ ruleTester.run("template-tag-spacing", rule, {
                 column: 4,
                 endLine: 3,
                 endColumn: 1
+            }]
+        },
+        {
+            code: "foo\n  .bar`Hello world`",
+            output: "foo\n  .bar `Hello world`",
+            options: ["always"],
+            errors: [{
+                messageId: "missing",
+                line: 1,
+                column: 1,
+                endLine: 2,
+                endColumn: 7
+            }]
+        },
+        {
+            code: "foo(\n  bar\n)`Hello world`",
+            output: "foo(\n  bar\n) `Hello world`",
+            options: ["always"],
+            errors: [{
+                messageId: "missing",
+                line: 1,
+                column: 1,
+                endLine: 3,
+                endColumn: 2
             }]
         }
     ]

--- a/tests/lib/rules/template-tag-spacing.js
+++ b/tests/lib/rules/template-tag-spacing.js
@@ -17,8 +17,6 @@ const rule = require("../../../lib/rules/template-tag-spacing"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
-const unexpectedError = { messageId: "unexpected" };
-const missingError = { messageId: "missing" };
 
 ruleTester.run("template-tag-spacing", rule, {
     valid: [
@@ -55,167 +53,389 @@ ruleTester.run("template-tag-spacing", rule, {
         {
             code: "tag `name`",
             output: "tag`name`",
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 4,
+                endLine: 1,
+                endColumn: 5
+            }]
         },
         {
             code: "tag `name`",
             output: "tag`name`",
             options: ["never"],
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 4,
+                endLine: 1,
+                endColumn: 5
+            }]
         },
         {
             code: "tag`name`",
             output: "tag `name`",
             options: ["always"],
-            errors: [missingError]
+            errors: [{
+                messageId: "missing",
+                line: 1,
+                column: 1,
+                endLine: 1,
+                endColumn: 4
+            }]
         },
         {
             code: "tag /*here's a comment*/`Hello world`",
             output: "tag/*here's a comment*/`Hello world`",
             options: ["never"],
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 4,
+                endLine: 1,
+                endColumn: 25
+            }]
         },
         {
             code: "tag/*here's a comment*/ `Hello world`",
             output: "tag/*here's a comment*/`Hello world`",
             options: ["never"],
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 4,
+                endLine: 1,
+                endColumn: 25
+            }]
         },
         {
             code: "tag/*here's a comment*/`Hello world`",
             output: "tag /*here's a comment*/`Hello world`",
             options: ["always"],
-            errors: [missingError]
+            errors: [{
+                messageId: "missing",
+                line: 1,
+                column: 1,
+                endLine: 1,
+                endColumn: 4
+            }]
         },
         {
             code: "tag // here's a comment \n`bar`",
             output: null,
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 4,
+                endLine: 2,
+                endColumn: 1
+            }]
         },
         {
             code: "tag // here's a comment \n`bar`",
             output: null,
             options: ["never"],
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 4,
+                endLine: 2,
+                endColumn: 1
+            }]
         },
         {
             code: "tag `hello ${name}`",
             output: "tag`hello ${name}`",
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 4,
+                endLine: 1,
+                endColumn: 5
+            }]
         },
         {
             code: "tag `hello ${name}`",
             output: "tag`hello ${name}`",
             options: ["never"],
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 4,
+                endLine: 1,
+                endColumn: 5
+            }]
         },
         {
             code: "tag`hello ${name}`",
             output: "tag `hello ${name}`",
             options: ["always"],
-            errors: [missingError]
+            errors: [{
+                messageId: "missing",
+                line: 1,
+                column: 1,
+                endLine: 1,
+                endColumn: 4
+            }]
         },
         {
             code: "new tag `name`",
             output: "new tag`name`",
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 8,
+                endLine: 1,
+                endColumn: 9
+            }]
         },
         {
             code: "new tag `name`",
             output: "new tag`name`",
             options: ["never"],
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 8,
+                endLine: 1,
+                endColumn: 9
+            }]
         },
         {
             code: "new tag`name`",
             output: "new tag `name`",
             options: ["always"],
-            errors: [missingError]
+            errors: [{
+                messageId: "missing",
+                line: 1,
+                column: 5,
+                endLine: 1,
+                endColumn: 8
+            }]
         },
         {
             code: "new tag `hello ${name}`",
             output: "new tag`hello ${name}`",
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 8,
+                endLine: 1,
+                endColumn: 9
+            }]
         },
         {
             code: "new tag `hello ${name}`",
             output: "new tag`hello ${name}`",
             options: ["never"],
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 8,
+                endLine: 1,
+                endColumn: 9
+            }]
         },
         {
             code: "new tag`hello ${name}`",
             output: "new tag `hello ${name}`",
             options: ["always"],
-            errors: [missingError]
+            errors: [{
+                messageId: "missing",
+                line: 1,
+                column: 5,
+                endLine: 1,
+                endColumn: 8
+            }]
         },
         {
             code: "(tag) `name`",
             output: "(tag)`name`",
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 6,
+                endLine: 1,
+                endColumn: 7
+            }]
         },
         {
             code: "(tag) `name`",
             output: "(tag)`name`",
             options: ["never"],
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 6,
+                endLine: 1,
+                endColumn: 7
+            }]
         },
         {
             code: "(tag)`name`",
             output: "(tag) `name`",
             options: ["always"],
-            errors: [missingError]
+            errors: [{
+                messageId: "missing",
+                line: 1,
+                column: 5,
+                endLine: 1,
+                endColumn: 6
+            }]
         },
         {
             code: "(tag) `hello ${name}`",
             output: "(tag)`hello ${name}`",
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 6,
+                endLine: 1,
+                endColumn: 7
+            }]
         },
         {
             code: "(tag) `hello ${name}`",
             output: "(tag)`hello ${name}`",
             options: ["never"],
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 6,
+                endLine: 1,
+                endColumn: 7
+            }]
         },
         {
             code: "(tag)`hello ${name}`",
             output: "(tag) `hello ${name}`",
             options: ["always"],
-            errors: [missingError]
+            errors: [{
+                messageId: "missing",
+                line: 1,
+                column: 5,
+                endLine: 1,
+                endColumn: 6
+            }]
         },
         {
             code: "new (tag) `name`",
             output: "new (tag)`name`",
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 10,
+                endLine: 1,
+                endColumn: 11
+            }]
         },
         {
             code: "new (tag) `name`",
             output: "new (tag)`name`",
             options: ["never"],
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 10,
+                endLine: 1,
+                endColumn: 11
+            }]
         },
         {
             code: "new (tag)`name`",
             output: "new (tag) `name`",
             options: ["always"],
-            errors: [missingError]
+            errors: [{
+                messageId: "missing",
+                line: 1,
+                column: 9,
+                endLine: 1,
+                endColumn: 10
+            }]
         },
         {
             code: "new (tag) `hello ${name}`",
             output: "new (tag)`hello ${name}`",
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 10,
+                endLine: 1,
+                endColumn: 11
+            }]
         },
         {
             code: "new (tag) `hello ${name}`",
             output: "new (tag)`hello ${name}`",
             options: ["never"],
-            errors: [unexpectedError]
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 10,
+                endLine: 1,
+                endColumn: 11
+            }]
         },
         {
             code: "new (tag)`hello ${name}`",
             output: "new (tag) `hello ${name}`",
             options: ["always"],
-            errors: [missingError]
+            errors: [{
+                messageId: "missing",
+                line: 1,
+                column: 9,
+                endLine: 1,
+                endColumn: 10
+            }]
+        },
+        {
+            code: "tag   `name`",
+            output: "tag`name`",
+            options: ["never"],
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 4,
+                endLine: 1,
+                endColumn: 7
+            }]
+        },
+        {
+            code: "tag\n`name`",
+            output: "tag`name`",
+            options: ["never"],
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 4,
+                endLine: 2,
+                endColumn: 1
+            }]
+        },
+        {
+            code: "tag \n  `name`",
+            output: "tag`name`",
+            options: ["never"],
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 4,
+                endLine: 2,
+                endColumn: 3
+            }]
+        },
+        {
+            code: "tag\n\n`name`",
+            output: "tag`name`",
+            options: ["never"],
+            errors: [{
+                messageId: "unexpected",
+                line: 1,
+                column: 4,
+                endLine: 3,
+                endColumn: 1
+            }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)
[X] Other, please explain:

refs #12334

Change reported location in the `template-tag-spacing` rule.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

For `"always"`, the rule will now report the full location of the first token before the template literal, instead of just its start.

For `"never"`, the rule will now report range between the first token before the template literal and the template literal, instead of start of the first token before the template literal,

`"always"` before this change:

![image](https://user-images.githubusercontent.com/44349756/79803104-a1edbd00-8361-11ea-988b-6a8d5e24d160.png)

`"always"` after this change:

![image](https://user-images.githubusercontent.com/44349756/79803390-30fad500-8362-11ea-810d-c50255e8f6c1.png)

`"never"` before this change:

![image](https://user-images.githubusercontent.com/44349756/79803177-ca75b700-8361-11ea-8e9c-9387bbfd658c.png)

`"never"` after this change:

![image](https://user-images.githubusercontent.com/44349756/79803311-06108100-8362-11ea-84b7-684739d81e33.png)

#### Is there anything you'd like reviewers to focus on?
