### PR TITLE
Docs: improve documentation of no-return-await

### DIFF
--- a/docs/rules/no-return-await.md
+++ b/docs/rules/no-return-await.md
@@ -2,7 +2,7 @@
 
 Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited have resolved. You can take a shortcut and just return the Promise right away to avoid this, saving an extra microtask before resolving the overarching Promise. `return await` can also be  used in a try/catch statement to catch errors from another Promise-based function.
 
-The only visible change when doing this is that the function will no longer be a part of the stack trace, if an error is thrown asyncrously from the Promise being returned.
+The only visible change when doing this is that the function will no longer be a part of the stack trace, if an error is thrown asynchronously from the Promise being returned.
 
 ## Rule Details
 

--- a/docs/rules/no-return-await.md
+++ b/docs/rules/no-return-await.md
@@ -1,8 +1,8 @@
 # Disallows unnecessary `return await` (no-return-await)
 
-Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited have resolved. You can take a shortcut and just return the Promise right away to avoid this, saving an extra microtask before resolving the overarching Promise. `return await` can also be  used in a try/catch statement to catch errors from another Promise-based function.
+Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited has resolved, at the cost of an extra microtask before resolving the outer Promise. `return await` can also be used in a try/catch statement to catch errors from another function that returns a Promise.
 
-The only visible change when doing this is that the function will no longer be a part of the stack trace, if an error is thrown asynchronously from the Promise being returned.
+You can avoid the extra microtask by not awaiting the return value, with the trade off of the function no longer being a part of the stack trace if an error is thrown asynchronously from the Promise being returned. This can make debugging more difficult.
 
 ## Rule Details
 
@@ -48,7 +48,7 @@ There are a few reasons you might want to turn this rule off:
 
 - If you want to use `await` to denote a value that is a thenable
 - If you do not want the performance benefit of avoiding `return await`
-- If you still want the functions to show up in stack traces
+- If you want the functions to show up in stack traces (useful for debugging purposes)
 
 ## Further Reading
 

--- a/docs/rules/no-return-await.md
+++ b/docs/rules/no-return-await.md
@@ -1,6 +1,8 @@
 # Disallows unnecessary `return await` (no-return-await)
 
-Inside an `async function`, `return await` is seldom useful. Since the return value of an `async function` is always wrapped in `Promise.resolve`, `return await` doesn’t actually do anything except add extra time before the overarching Promise resolves or rejects. The only valid exception is if `return await` is used in a try/catch statement to catch errors from another Promise-based function.
+Using `return await` inside an `async function`keeps the current function in the call stack until the Promise that is being awaited have resolved. You can take a shortcut and just return the Promise right away to avoid this, saving an extra microtask before resolving the overarching Promise.
+
+The only visible change when doing this is that the function will no longer be a part of the stack trace, if an error is thrown asyncrously from the Promise being returned.
 
 ## Rule Details
 
@@ -42,7 +44,11 @@ In the last example the `await` is necessary to be able to catch errors thrown f
 
 ## When Not To Use It
 
-If you want to use `await` to denote a value that is a thenable, even when it is not necessary; or if you do not want the performance benefit of avoiding `return await`, you can turn off this rule.
+There are a few reasons you might want to turn this rule off:
+
+- If you want to use `await` to denote a value that is a thenable
+- If you do not want the performance benefit of avoiding `return await`
+- If you still want the functions to show up in stack traces
 
 ## Further Reading
 

--- a/docs/rules/no-return-await.md
+++ b/docs/rules/no-return-await.md
@@ -1,6 +1,6 @@
 # Disallows unnecessary `return await` (no-return-await)
 
-Using `return await` inside an `async function`keeps the current function in the call stack until the Promise that is being awaited have resolved. You can take a shortcut and just return the Promise right away to avoid this, saving an extra microtask before resolving the overarching Promise.
+Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited have resolved. You can take a shortcut and just return the Promise right away to avoid this, saving an extra microtask before resolving the overarching Promise. `return await` can also be  used in a try/catch statement to catch errors from another Promise-based function.
 
 The only visible change when doing this is that the function will no longer be a part of the stack trace, if an error is thrown asyncrously from the Promise being returned.
 


### PR DESCRIPTION
this is a resubmit of https://github.com/eslint/website/pull/716 but to the correct repo ☺️ 

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [ ] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

First of all, I know that there have been a lot of discussions on wether this rule is a good one or not. I do not want to bring up that discussion here at all. I just want to clarify the documentation to better explain the implications, I don't want to advocate for either turning this rule on or off.

-----

I've had some team member asking why we are using `return await`, especially after reading the current version of the documentation for `no-return-await`. The reason we are using `return await` is because otherwise the functions are missing from the stack traces if an error is thrown asynchronously in the promise that is being returned.

My intention with this change is to document that pitfall, and to clarify exactly what is being skipped when not using `return await` (that is, that the function is either still on the call stack, or not)

I'm very open to suggestion on more improvements that we can do here! ❤️ 

#### Is there anything you'd like reviewers to focus on?

n/a