### PR TITLE
Fix: arrow-body-style fixer for `in` wrap (fixes #11849)

### DIFF
--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -189,7 +189,7 @@ module.exports = {
                              */
                             if (astUtils.isOpeningBraceToken(firstValueToken) || blockBody[0].argument.type === "SequenceExpression" || (n.type === "ForStatement" && isInOp)) {
 
-                                if (firstValueToken.value !== "(") {
+                                if (!astUtils.isParenthesised(sourceCode, blockBody[0].argument)) {
                                     fixes.push(
                                         fixer.insertTextBefore(firstValueToken, "("),
                                         fixer.insertTextAfter(lastValueToken, ")")
@@ -257,10 +257,13 @@ module.exports = {
         }
 
         return {
+            "BinaryExpression[operator='in'] > *:exit"() {
+                isInOp = false;
+            },
             "BinaryExpression[operator='in']:exit"() {
                 isInOp = true;
             },
-            "BinaryExpression[operator='in'] > *:exit"() {
+            "ArrowFunctionExpression"() {
                 isInOp = false;
             },
             "ArrowFunctionExpression:exit": validate

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -260,6 +260,9 @@ module.exports = {
             "BinaryExpression[operator='in']:exit"() {
                 isInOp = true;
             },
+            "BinaryExpression[operator='in'] > *:exit"() {
+                isInOp = false;
+            },
             "ArrowFunctionExpression:exit": validate
         };
     }

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -101,16 +101,18 @@ module.exports = {
         }
 
         /**
-         * Check whether the node is inside of a for loop
+         * Check whether the node is inside of a for loop's init
          * @param {ASTNode} node node is inside for loop
          * @returns {boolean} `true` if the node is inside of a for loop, else `false`
          */
         function isInsideForLoopInitializer(node) {
-            if (node.type !== "ForStatement" && node.parent && (node.parent.type !== "BlockStatement" || node.parent.type !== "Program")) {
+            if (node && node.parent) {
+                if (node.parent.type === "ForStatement" && node.parent.init === node) {
+                    return true;
+                }
                 return isInsideForLoopInitializer(node.parent);
             }
-
-            return node.type === "ForStatement";
+            return false;
         }
 
         /**
@@ -193,7 +195,6 @@ module.exports = {
                              * enclose the return value by parentheses to avoid syntax error.
                              */
                             if (astUtils.isOpeningBraceToken(firstValueToken) || blockBody[0].argument.type === "SequenceExpression" || (funcInfo.hasInOperator && isInsideForLoopInitializer(node))) {
-
                                 if (!astUtils.isParenthesised(sourceCode, blockBody[0].argument)) {
                                     fixes.push(
                                         fixer.insertTextBefore(firstValueToken, "("),

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -75,6 +75,7 @@ module.exports = {
         const never = options[0] === "never";
         const requireReturnForObjectLiteral = options[1] && options[1].requireReturnForObjectLiteral;
         const sourceCode = context.getSourceCode();
+        let isInOp = false;
 
         /**
          * Checks whether the given node has ASI problem or not.
@@ -97,24 +98,6 @@ module.exports = {
                 node = node.parent;
             }
             return sourceCode.getTokenAfter(node);
-        }
-
-        /**
-         * Checks if a node has `in` operator or not
-         * @param {Node} node The argument node which needs to be checked
-         * @returns {boolean} `true` if there is an `in` operator else `false`.
-         */
-        function isIn(node) {
-            if (
-                node.type === "BinaryExpression" ||
-                node.type === "LogicalExpression"
-            ) {
-                if (node.operator === "in") {
-                    return true;
-                }
-                return isIn(node.left) || isIn(node.right);
-            }
-            return false;
         }
 
         /**
@@ -175,8 +158,6 @@ module.exports = {
                                 sourceCode.commentsExistBetween(openingBrace, firstValueToken) ||
                                 sourceCode.commentsExistBetween(lastValueToken, closingBrace);
 
-                            const isInOp = isIn(blockBody[0].argument);
-
                             /*
                              * Remove tokens around the return value.
                              * If comments don't exist, remove extra spaces as well.
@@ -202,7 +183,6 @@ module.exports = {
                                 }
                             }
 
-
                             /*
                              * If the first token of the reutrn value is `{` or the return value is a sequence expression,
                              * enclose the return value by parentheses to avoid syntax error.
@@ -215,7 +195,6 @@ module.exports = {
                                         fixer.insertTextAfter(lastValueToken, ")")
                                     );
                                 }
-
                             }
 
                             /*
@@ -278,6 +257,9 @@ module.exports = {
         }
 
         return {
+            "BinaryExpression[operator='in']:exit"() {
+                isInOp = true;
+            },
             "ArrowFunctionExpression:exit": validate
         };
     }

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -196,19 +196,26 @@ module.exports = {
 
                             let n = node;
 
-                            while (n.type !== "ForStatement" && n.parent && (n.parent.type !== "BlockStatement" || n.parent.type !== "Program")) {
-                                n = n.parent;
+                            if (isInOp) {
+                                while (n.type !== "ForStatement" && n.parent && (n.parent.type !== "BlockStatement" || n.parent.type !== "Program")) {
+                                    n = n.parent;
+                                }
                             }
+
 
                             /*
                              * If the first token of the reutrn value is `{` or the return value is a sequence expression,
                              * enclose the return value by parentheses to avoid syntax error.
                              */
                             if (astUtils.isOpeningBraceToken(firstValueToken) || blockBody[0].argument.type === "SequenceExpression" || (n.type === "ForStatement" && isInOp)) {
-                                fixes.push(
-                                    fixer.insertTextBefore(firstValueToken, "("),
-                                    fixer.insertTextAfter(lastValueToken, ")")
-                                );
+
+                                if (firstValueToken.value !== "(") {
+                                    fixes.push(
+                                        fixer.insertTextBefore(firstValueToken, "("),
+                                        fixer.insertTextAfter(lastValueToken, ")")
+                                    );
+                                }
+
                             }
 
                             /*

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -101,6 +101,19 @@ module.exports = {
         }
 
         /**
+         * Check whether the node is inside of a for loop
+         * @param {ASTNode} node node is inside for loop
+         * @returns {boolean} `true` if the node is inside of a for loop, else `false`
+         */
+        function isInsideForLoopInitializer(node) {
+            if (node.type !== "ForStatement" && node.parent && (node.parent.type !== "BlockStatement" || node.parent.type !== "Program")) {
+                return isInsideForLoopInitializer(node.parent);
+            }
+
+            return node.type === "ForStatement";
+        }
+
+        /**
          * Determines whether a arrow function body needs braces
          * @param {ASTNode} node The arrow function node.
          * @returns {void}
@@ -179,7 +192,7 @@ module.exports = {
                              * If the first token of the reutrn value is `{` or the return value is a sequence expression,
                              * enclose the return value by parentheses to avoid syntax error.
                              */
-                            if (astUtils.isOpeningBraceToken(firstValueToken) || blockBody[0].argument.type === "SequenceExpression" || funcInfo.hasInOperator) {
+                            if (astUtils.isOpeningBraceToken(firstValueToken) || blockBody[0].argument.type === "SequenceExpression" || (funcInfo.hasInOperator && isInsideForLoopInitializer(node))) {
 
                                 if (!astUtils.isParenthesised(sourceCode, blockBody[0].argument)) {
                                     fixes.push(

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -100,6 +100,24 @@ module.exports = {
         }
 
         /**
+         * check if node has `in` operator or not
+         * @param {Node} node The argument node which needs to be checked
+         * @returns {boolean} `true` if there is an `in` operator else `false`.
+         */
+        function isIn(node) {
+            if (
+                node.type === "BinaryExpression" ||
+                node.type === "LogicalExpression"
+            ) {
+                if (node.operator === "in") {
+                    return true;
+                }
+                return isIn(node.left) || isIn(node.right);
+            }
+            return false;
+        }
+
+        /**
          * Determines whether a arrow function body needs braces
          * @param {ASTNode} node The arrow function node.
          * @returns {void}
@@ -157,6 +175,8 @@ module.exports = {
                                 sourceCode.commentsExistBetween(openingBrace, firstValueToken) ||
                                 sourceCode.commentsExistBetween(lastValueToken, closingBrace);
 
+                            const isInOp = isIn(blockBody[0].argument);
+
                             /*
                              * Remove tokens around the return value.
                              * If comments don't exist, remove extra spaces as well.
@@ -178,7 +198,7 @@ module.exports = {
                              * If the first token of the reutrn value is `{` or the return value is a sequence expression,
                              * enclose the return value by parentheses to avoid syntax error.
                              */
-                            if (astUtils.isOpeningBraceToken(firstValueToken) || blockBody[0].argument.type === "SequenceExpression") {
+                            if (astUtils.isOpeningBraceToken(firstValueToken) || blockBody[0].argument.type === "SequenceExpression" || isInOp) {
                                 fixes.push(
                                     fixer.insertTextBefore(firstValueToken, "("),
                                     fixer.insertTextAfter(lastValueToken, ")")

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -75,7 +75,7 @@ module.exports = {
         const never = options[0] === "never";
         const requireReturnForObjectLiteral = options[1] && options[1].requireReturnForObjectLiteral;
         const sourceCode = context.getSourceCode();
-        let isInOp = false;
+        let funcInfo = null;
 
         /**
          * Checks whether the given node has ASI problem or not.
@@ -175,19 +175,11 @@ module.exports = {
                                 );
                             }
 
-                            let n = node;
-
-                            if (isInOp) {
-                                while (n.type !== "ForStatement" && n.parent && (n.parent.type !== "BlockStatement" || n.parent.type !== "Program")) {
-                                    n = n.parent;
-                                }
-                            }
-
                             /*
                              * If the first token of the reutrn value is `{` or the return value is a sequence expression,
                              * enclose the return value by parentheses to avoid syntax error.
                              */
-                            if (astUtils.isOpeningBraceToken(firstValueToken) || blockBody[0].argument.type === "SequenceExpression" || (n.type === "ForStatement" && isInOp)) {
+                            if (astUtils.isOpeningBraceToken(firstValueToken) || blockBody[0].argument.type === "SequenceExpression" || funcInfo.hasInOperator) {
 
                                 if (!astUtils.isParenthesised(sourceCode, blockBody[0].argument)) {
                                     fixes.push(
@@ -257,16 +249,24 @@ module.exports = {
         }
 
         return {
-            "BinaryExpression[operator='in'] > *:exit"() {
-                isInOp = false;
+            "BinaryExpression[operator='in']"() {
+                let info = funcInfo;
+
+                while (info) {
+                    info.hasInOperator = true;
+                    info = info.upper;
+                }
             },
-            "BinaryExpression[operator='in']:exit"() {
-                isInOp = true;
+            ArrowFunctionExpression() {
+                funcInfo = {
+                    upper: funcInfo,
+                    hasInOperator: false
+                };
             },
-            "ArrowFunctionExpression"() {
-                isInOp = false;
-            },
-            "ArrowFunctionExpression:exit": validate
+            "ArrowFunctionExpression:exit"(node) {
+                validate(node);
+                funcInfo = funcInfo.upper;
+            }
         };
     }
 };

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -194,11 +194,17 @@ module.exports = {
                                 );
                             }
 
+                            let n = node;
+
+                            while (n.type !== "ForStatement" && n.parent && (n.parent.type !== "BlockStatement" || n.parent.type !== "Program")) {
+                                n = n.parent;
+                            }
+
                             /*
                              * If the first token of the reutrn value is `{` or the return value is a sequence expression,
                              * enclose the return value by parentheses to avoid syntax error.
                              */
-                            if (astUtils.isOpeningBraceToken(firstValueToken) || blockBody[0].argument.type === "SequenceExpression" || isInOp) {
+                            if (astUtils.isOpeningBraceToken(firstValueToken) || blockBody[0].argument.type === "SequenceExpression" || (n.type === "ForStatement" && isInOp)) {
                                 fixes.push(
                                     fixer.insertTextBefore(firstValueToken, "("),
                                     fixer.insertTextAfter(lastValueToken, ")")

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -46,8 +46,30 @@ ruleTester.run("arrow-body-style", rule, {
         { code: "var foo = () => { return { bar: 0 }; };", options: ["as-needed", { requireReturnForObjectLiteral: true }] }
     ],
     invalid: [
-
-
+        {
+            code: "for (a = b => { return c in d ? e : f } ;;);",
+            output: "for (a = b => (c in d ? e : f) ;;);",
+            options: ["as-needed"],
+            errors: [
+                {
+                    line: 1,
+                    column: 15,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
+            code: "for (a = b => { return c = d in e } ;;);",
+            output: "for (a = b => (c = d in e) ;;);",
+            options: ["as-needed"],
+            errors: [
+                {
+                    line: 1,
+                    column: 15,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
         {
             code: "for (let a = (b, c, d) => { return vb && c in d; }; ;);",
             output: "for (let a = (b, c, d) => (vb && c in d); ;);",

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -19,6 +19,7 @@ const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("arrow-body-style", rule, {
     valid: [
+
         "var foo = () => {};",
         "var foo = () => 0;",
         "var addToB = (a) => { b =  b + a };",
@@ -45,6 +46,8 @@ ruleTester.run("arrow-body-style", rule, {
         { code: "var foo = () => { return { bar: 0 }; };", options: ["as-needed", { requireReturnForObjectLiteral: true }] }
     ],
     invalid: [
+
+
         {
             code: "for (let a = (b, c, d) => { return vb && c in d; }; ;);",
             output: "for (let a = (b, c, d) => (vb && c in d); ;);",
@@ -63,6 +66,28 @@ ruleTester.run("arrow-body-style", rule, {
                 {
                     line: 1,
                     column: 27,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
+            code: "function foo(){ for (let a = (b, c, d) => { return v in b && c in d; }; ;); }",
+            output: "function foo(){ for (let a = (b, c, d) => (v in b && c in d); ;); }",
+            errors: [
+                {
+                    line: 1,
+                    column: 43,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
+            code: "for ( a = (b, c, d) => { return v in b && c in d; }; ;);",
+            output: "for ( a = (b, c, d) => (v in b && c in d); ;);",
+            errors: [
+                {
+                    line: 1,
+                    column: 24,
                     messageId: "unexpectedSingleBlock"
                 }
             ]
@@ -91,7 +116,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "do{let a = () => {return f in ff}}while(true){}",
-            output: "do{let a = () => (f in ff)}while(true){}",
+            output: "do{let a = () => f in ff}while(true){}",
             errors: [{
                 line: 1,
                 column: 18,
@@ -99,8 +124,17 @@ ruleTester.run("arrow-body-style", rule, {
             }]
         },
         {
+            code: "do{for (let a = (b, c, d) => { return vb in c in dd ; }; ;);}while(true){}",
+            output: "do{for (let a = (b, c, d) => (vb in c in dd ); ;);}while(true){}",
+            errors: [{
+                line: 1,
+                column: 30,
+                messageId: "unexpectedSingleBlock"
+            }]
+        },
+        {
             code: "scores.map(score => { return x in +(score / maxScore).toFixed(2)});",
-            output: "scores.map(score => (x in +(score / maxScore).toFixed(2)));",
+            output: "scores.map(score => x in +(score / maxScore).toFixed(2));",
             errors: [{
                 line: 1,
                 column: 21,
@@ -109,7 +143,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "const fn = (a, b) => { return a + x in Number(b) };",
-            output: "const fn = (a, b) => (a + x in Number(b));",
+            output: "const fn = (a, b) => a + x in Number(b);",
             errors: [{
                 line: 1,
                 column: 22,
@@ -439,8 +473,8 @@ ruleTester.run("arrow-body-style", rule, {
 
             // Not fixed; fixing would cause ASI issues.
             code:
-            "var foo = () => { return bar }\n" +
-            "[1, 2, 3].map(foo)",
+        "var foo = () => { return bar }\n" +
+        "[1, 2, 3].map(foo)",
             output: null,
             options: ["never"],
             errors: [
@@ -449,10 +483,11 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
 
+
             // Not fixed; fixing would cause ASI issues.
             code:
-            "var foo = () => { return bar }\n" +
-            "(1).toString();",
+        "var foo = () => { return bar }\n" +
+        "(1).toString();",
             output: null,
             options: ["never"],
             errors: [

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -90,6 +90,33 @@ ruleTester.run("arrow-body-style", rule, {
             ]
         },
         {
+            code: "do{let a = () => {return f in ff}}while(true){}",
+            output: "do{let a = () => (f in ff)}while(true){}",
+            errors: [{
+                line: 1,
+                column: 18,
+                messageId: "unexpectedSingleBlock"
+            }]
+        },
+        {
+            code: "scores.map(score => { return x in +(score / maxScore).toFixed(2)});",
+            output: "scores.map(score => (x in +(score / maxScore).toFixed(2)));",
+            errors: [{
+                line: 1,
+                column: 21,
+                messageId: "unexpectedSingleBlock"
+            }]
+        },
+        {
+            code: "const fn = (a, b) => { return a + x in Number(b) };",
+            output: "const fn = (a, b) => (a + x in Number(b));",
+            errors: [{
+                line: 1,
+                column: 22,
+                messageId: "unexpectedSingleBlock"
+            }]
+        },
+        {
             code: "var foo = () => 0",
             output: "var foo = () => {return 0}",
             options: ["always"],

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -197,7 +197,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "do{let a = () => {return f in ff}}while(true){}",
-            output: "do{let a = () => (f in ff)}while(true){}",
+            output: "do{let a = () => f in ff}while(true){}",
             errors: [{
                 line: 1,
                 column: 18,
@@ -215,7 +215,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "scores.map(score => { return x in +(score / maxScore).toFixed(2)});",
-            output: "scores.map(score => (x in +(score / maxScore).toFixed(2)));",
+            output: "scores.map(score => x in +(score / maxScore).toFixed(2));",
             errors: [{
                 line: 1,
                 column: 21,
@@ -224,7 +224,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "const fn = (a, b) => { return a + x in Number(b) };",
-            output: "const fn = (a, b) => (a + x in Number(b));",
+            output: "const fn = (a, b) => a + x in Number(b);",
             errors: [{
                 line: 1,
                 column: 22,

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -93,6 +93,17 @@ ruleTester.run("arrow-body-style", rule, {
             ]
         },
         {
+            code: "for ( a = (b) => { return (c in d) }; ;);",
+            output: "for ( a = (b) => (c in d); ;);",
+            errors: [
+                {
+                    line: 1,
+                    column: 18,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
             code: "for (let a = (b, c, d) => { return vb in dd ; }; ;);",
             output: "for (let a = (b, c, d) => (vb in dd ); ;);",
             errors: [

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -47,6 +47,18 @@ ruleTester.run("arrow-body-style", rule, {
     ],
     invalid: [
         {
+            code: "for (var foo = () => { return a in b ? bar : () => {} } ;;);",
+            output: "for (var foo = () => (a in b ? bar : () => {}) ;;);",
+            options: ["as-needed"],
+            errors: [
+                {
+                    line: 1,
+                    column: 22,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
             code: "a in b; for (var f = () => { return c };;);",
             output: "a in b; for (var f = () => c;;);",
             options: ["as-needed"],
@@ -185,7 +197,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "do{let a = () => {return f in ff}}while(true){}",
-            output: "do{let a = () => f in ff}while(true){}",
+            output: "do{let a = () => (f in ff)}while(true){}",
             errors: [{
                 line: 1,
                 column: 18,
@@ -203,7 +215,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "scores.map(score => { return x in +(score / maxScore).toFixed(2)});",
-            output: "scores.map(score => x in +(score / maxScore).toFixed(2));",
+            output: "scores.map(score => (x in +(score / maxScore).toFixed(2)));",
             errors: [{
                 line: 1,
                 column: 21,
@@ -212,7 +224,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "const fn = (a, b) => { return a + x in Number(b) };",
-            output: "const fn = (a, b) => a + x in Number(b);",
+            output: "const fn = (a, b) => (a + x in Number(b));",
             errors: [{
                 line: 1,
                 column: 22,

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -19,7 +19,6 @@ const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("arrow-body-style", rule, {
     valid: [
-
         "var foo = () => {};",
         "var foo = () => 0;",
         "var addToB = (a) => { b =  b + a };",
@@ -95,6 +94,18 @@ ruleTester.run("arrow-body-style", rule, {
             ]
         },
         {
+            code: "for (var f;f = () => { return a };);",
+            output: "for (var f;f = () => a;);",
+            options: ["as-needed"],
+            errors: [
+                {
+                    line: 1,
+                    column: 22,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
             code: "for (var f = () => { return a in c };;);",
             output: "for (var f = () => (a in c);;);",
             options: ["as-needed"],
@@ -107,6 +118,30 @@ ruleTester.run("arrow-body-style", rule, {
             ]
         },
         {
+            code: "for (var f;f = () => { return a in c };);",
+            output: "for (var f;f = () => a in c;);",
+            options: ["as-needed"],
+            errors: [
+                {
+                    line: 1,
+                    column: 22,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
+            code: "for (;;){var f = () => { return a in c }}",
+            output: "for (;;){var f = () => a in c}",
+            options: ["as-needed"],
+            errors: [
+                {
+                    line: 1,
+                    column: 24,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
             code: "for (a = b => { return c = d in e } ;;);",
             output: "for (a = b => (c = d in e) ;;);",
             options: ["as-needed"],
@@ -114,6 +149,18 @@ ruleTester.run("arrow-body-style", rule, {
                 {
                     line: 1,
                     column: 15,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
+            code: "for (var a;;a = b => { return c = d in e } );",
+            output: "for (var a;;a = b => c = d in e );",
+            options: ["as-needed"],
+            errors: [
+                {
+                    line: 1,
+                    column: 22,
                     messageId: "unexpectedSingleBlock"
                 }
             ]

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -47,6 +47,18 @@ ruleTester.run("arrow-body-style", rule, {
     ],
     invalid: [
         {
+            code: "a in b; for (var f = () => { return c };;);",
+            output: "a in b; for (var f = () => c;;);",
+            options: ["as-needed"],
+            errors: [
+                {
+                    line: 1,
+                    column: 28,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
             code: "for (a = b => { return c in d ? e : f } ;;);",
             output: "for (a = b => (c in d ? e : f) ;;);",
             options: ["as-needed"],

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -59,6 +59,30 @@ ruleTester.run("arrow-body-style", rule, {
             ]
         },
         {
+            code: "for (var f = () => { return a };;);",
+            output: "for (var f = () => a;;);",
+            options: ["as-needed"],
+            errors: [
+                {
+                    line: 1,
+                    column: 20,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
+            code: "for (var f = () => { return a in c };;);",
+            output: "for (var f = () => (a in c);;);",
+            options: ["as-needed"],
+            errors: [
+                {
+                    line: 1,
+                    column: 20,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
             code: "for (a = b => { return c = d in e } ;;);",
             output: "for (a = b => (c = d in e) ;;);",
             options: ["as-needed"],

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -46,6 +46,50 @@ ruleTester.run("arrow-body-style", rule, {
     ],
     invalid: [
         {
+            code: "for (let a = (b, c, d) => { return vb && c in d; }; ;);",
+            output: "for (let a = (b, c, d) => (vb && c in d); ;);",
+            errors: [
+                {
+                    line: 1,
+                    column: 27,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
+            code: "for (let a = (b, c, d) => { return v in b && c in d; }; ;);",
+            output: "for (let a = (b, c, d) => (v in b && c in d); ;);",
+            errors: [
+                {
+                    line: 1,
+                    column: 27,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
+            code: "for (let a = (b, c, d) => { return vb in dd ; }; ;);",
+            output: "for (let a = (b, c, d) => (vb in dd ); ;);",
+            errors: [
+                {
+                    line: 1,
+                    column: 27,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
+            code: "for (let a = (b, c, d) => { return vb in c in dd ; }; ;);",
+            output: "for (let a = (b, c, d) => (vb in c in dd ); ;);",
+            errors: [
+                {
+                    line: 1,
+                    column: 27,
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
             code: "var foo = () => 0",
             output: "var foo = () => {return 0}",
             options: ["always"],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Fixed the fixer for `in` operator being wrongly fixed. wrapping the whole body when there is an `in` operator. `inIn` method will check if the body has `in` operator or not. wrapping the whole as mentioned in the issue was decided.


#### Is there anything you'd like reviewers to focus on?

fixes #11849