### PR TITLE
Fix: Respect --resolve-plugins-relative-to flag for parser.

### DIFF
--- a/lib/cli-engine/config-array-factory.js
+++ b/lib/cli-engine/config-array-factory.js
@@ -897,8 +897,7 @@ class ConfigArrayFactory {
     _loadParser(nameOrPath, ctx) {
         debug("Loading parser %j from %s", nameOrPath, ctx.filePath);
 
-        const { cwd } = internalSlotsMap.get(this);
-        const relativeTo = ctx.filePath || path.join(cwd, "__placeholder__.js");
+        const relativeTo = path.join(ctx.pluginBasePath, "__placeholder__.js");
 
         try {
             const filePath = ModuleResolver.resolve(nameOrPath, relativeTo);

--- a/lib/cli-engine/config-array-factory.js
+++ b/lib/cli-engine/config-array-factory.js
@@ -703,7 +703,7 @@ class ConfigArrayFactory {
         }
 
         // Load parser & plugins.
-        const parser = parserName && this._loadParser(parserName, ctx);
+        const parser = parserName && ConfigArrayFactory.loadParser(parserName, ctx);
         const plugins = pluginList && this._loadPlugins(pluginList, ctx);
 
         // Yield pseudo config data for file extension processors.
@@ -894,7 +894,7 @@ class ConfigArrayFactory {
      * @param {ConfigArrayFactoryLoadingContext} ctx The loading context.
      * @returns {DependentParser} The loaded parser.
      */
-    _loadParser(nameOrPath, ctx) {
+    static loadParser(nameOrPath, ctx) {
         debug("Loading parser %j from %s", nameOrPath, ctx.filePath);
 
         const relativeTo = path.join(ctx.pluginBasePath, "__placeholder__.js");


### PR DESCRIPTION
The configuration to say that plugins should be loaded
from a relative path should also apply to the parser.

If i dont want to install my plugins locally then i dont
want to install my parser locally either.

This allows me to install both the eslint/typescript plugin as well as the eslint/typescript parser somewhere else and not in `./node_modules`.

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [ ] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Respect the cli `--resolve-plugins-relative-to` option when attempting the find the parser.

#### Is there anything you'd like reviewers to focus on?

I made the method static because the linter complained about no usage of `this` in the method body.