### PR TITLE
Update: no-void add an option to allow at start of concise arrow functions

### DIFF
--- a/docs/rules/no-void.md
+++ b/docs/rules/no-void.md
@@ -92,6 +92,36 @@ void foo;
 void someFunction();
 ```
 
+### allowAtStartOfConciseArrowFunctions
+
+When `allowAtStartOfConciseArrowFunctions` is set to true, the rule will not error if the void operator is used at the start of concise arrow functions.
+This can be used as a way of explicitly marking concise arrow functions as not returning a value without having to add braces, which formatters often expand
+with newlines.
+
+Examples of **incorrect** code for `{ "allowAtStartOfConciseArrowFunctions": true }`:
+
+```js
+const log = function(message) { return void console.log(message); };
+
+const warn = message => {
+  return void console.warn(message);
+};
+
+const error = message => void (message ? console.error(message) : void 0);
+```
+
+Examples of **correct** code for `{ "allowAtStartOfConciseArrowFunctions": true }`:
+
+```js
+const log = message => void console.log(message);
+
+const warn = message => {
+  console.warn(message);
+}
+
+const error = message => void (message ? console.error(message) : 0);
+```
+
 ## When Not To Use It
 
 If you intentionally use the `void` operator then you can disable this rule.

--- a/lib/rules/no-void.js
+++ b/lib/rules/no-void.js
@@ -30,6 +30,10 @@ module.exports = {
                     allowAsStatement: {
                         type: "boolean",
                         default: false
+                    },
+                    allowAtStartOfConciseArrowFunctions: {
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -38,8 +42,10 @@ module.exports = {
     },
 
     create(context) {
-        const allowAsStatement =
-            context.options[0] && context.options[0].allowAsStatement;
+        const {
+            allowAsStatement,
+            allowAtStartOfConciseArrowFunctions
+        } = context.options[0] || {};
 
         //--------------------------------------------------------------------------
         // Public
@@ -54,6 +60,16 @@ module.exports = {
                 ) {
                     return;
                 }
+
+                if (
+                    allowAtStartOfConciseArrowFunctions &&
+                    node.parent &&
+                    node.parent.type === "ArrowFunctionExpression" &&
+                    node.parent.expression
+                ) {
+                    return;
+                }
+
                 context.report({
                     node,
                     messageId: "noVoid"

--- a/tests/lib/rules/no-void.js
+++ b/tests/lib/rules/no-void.js
@@ -15,7 +15,7 @@ const { RuleTester } = require("../../../lib/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("no-void", rule, {
     valid: [
@@ -30,6 +30,10 @@ ruleTester.run("no-void", rule, {
         {
             code: "void(0)",
             options: [{ allowAsStatement: true }]
+        },
+        {
+            code: "const log = x => void console.log(x);",
+            options: [{ allowAtStartOfConciseArrowFunctions: true }]
         }
     ],
 
@@ -59,6 +63,25 @@ ruleTester.run("no-void", rule, {
         {
             code: "var foo = void 0",
             options: [{ allowAsStatement: true }],
+            errors: [{ messageId: "noVoid" }]
+        },
+        {
+            code: "const log = x => void console.log(x);",
+            options: [{ allowAtStartOfConciseArrowFunctions: false }],
+            errors: [{ messageId: "noVoid" }]
+        },
+        {
+            code: "const log = x => void (x ? console.log(x) : void 0);",
+            options: [{ allowAtStartOfConciseArrowFunctions: true }],
+            errors: [{ messageId: "noVoid" }]
+        },
+        {
+            code: `
+              const log = x => {
+                return void console.log(x);
+              }
+            `,
+            options: [{ allowAtStartOfConciseArrowFunctions: true }],
             errors: [{ messageId: "noVoid" }]
         }
     ]


### PR DESCRIPTION
fixes #13020
fixes #13299

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
I changed `no-void` to support an option that allows using `void `at the start of single line arrow functions.

This allows for the use of `void` to ignore any side effects an expression may produce, as described in the docs for the `no-void` rule.

#### Is there anything you'd like reviewers to focus on?
Nothing in particular.