### PR TITLE
Fix: remove custom plugins from replacedBy metadata

### DIFF
--- a/lib/rules/callback-return.js
+++ b/lib/rules/callback-return.js
@@ -12,7 +12,7 @@ module.exports = {
     meta: {
         deprecated: true,
 
-        replacedBy: ["node/callback-return"],
+        replacedBy: [],
 
         type: "suggestion",
 

--- a/lib/rules/global-require.js
+++ b/lib/rules/global-require.js
@@ -50,7 +50,7 @@ module.exports = {
     meta: {
         deprecated: true,
 
-        replacedBy: ["node/global-require"],
+        replacedBy: [],
 
         type: "suggestion",
 

--- a/lib/rules/handle-callback-err.js
+++ b/lib/rules/handle-callback-err.js
@@ -13,7 +13,7 @@ module.exports = {
     meta: {
         deprecated: true,
 
-        replacedBy: ["node/handle-callback-err"],
+        replacedBy: [],
 
         type: "suggestion",
 

--- a/lib/rules/no-buffer-constructor.js
+++ b/lib/rules/no-buffer-constructor.js
@@ -12,7 +12,7 @@ module.exports = {
     meta: {
         deprecated: true,
 
-        replacedBy: ["node/no-deprecated-api"],
+        replacedBy: [],
 
         type: "problem",
 

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -13,7 +13,7 @@ module.exports = {
     meta: {
         deprecated: true,
 
-        replacedBy: ["node/no-mixed-requires"],
+        replacedBy: [],
 
         type: "suggestion",
 

--- a/lib/rules/no-new-require.js
+++ b/lib/rules/no-new-require.js
@@ -13,7 +13,7 @@ module.exports = {
     meta: {
         deprecated: true,
 
-        replacedBy: ["node/no-new-require"],
+        replacedBy: [],
 
         type: "suggestion",
 

--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -12,7 +12,7 @@ module.exports = {
     meta: {
         deprecated: true,
 
-        replacedBy: ["node/no-path-concat"],
+        replacedBy: [],
 
         type: "suggestion",
 

--- a/lib/rules/no-process-env.js
+++ b/lib/rules/no-process-env.js
@@ -12,7 +12,7 @@ module.exports = {
     meta: {
         deprecated: true,
 
-        replacedBy: ["node/no-process-env"],
+        replacedBy: [],
 
         type: "suggestion",
 

--- a/lib/rules/no-process-exit.js
+++ b/lib/rules/no-process-exit.js
@@ -12,7 +12,7 @@ module.exports = {
     meta: {
         deprecated: true,
 
-        replacedBy: ["node/no-process-exit"],
+        replacedBy: [],
 
         type: "suggestion",
 

--- a/lib/rules/no-restricted-modules.js
+++ b/lib/rules/no-restricted-modules.js
@@ -42,7 +42,7 @@ module.exports = {
     meta: {
         deprecated: true,
 
-        replacedBy: ["node/no-restricted-require"],
+        replacedBy: [],
 
         type: "suggestion",
 

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -15,7 +15,7 @@ module.exports = {
     meta: {
         deprecated: true,
 
-        replacedBy: ["node/no-sync"],
+        replacedBy: [],
 
         type: "suggestion",
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
The [deprecated rules](https://eslint.org/docs/rules/#deprecated) currently link to broken links. 

Following up on https://github.com/eslint/website/pull/727 (which fixes the site immediately), and since we don't want to be in the business of keeping track of custom plugins, this PR removes the `replacedBy` elements for the deprecated Node.js/CommonJS to be consistent with the deprecated JSDoc rules.


#### Is there anything you'd like reviewers to focus on?
Nothing in particular.