### PR TITLE
Fix: astUtils.getNextLocation returns invalid location after CRLF

### DIFF
--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -673,6 +673,21 @@ ruleTester.run("comma-dangle", rule, {
             ]
         },
         {
+            code: "var foo = {\nbar: 'baz'\r\n}",
+            output: "var foo = {\nbar: 'baz',\r\n}",
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "missing",
+                    type: "Property",
+                    line: 2,
+                    column: 11,
+                    endLine: 3,
+                    endColumn: 1
+                }
+            ]
+        },
+        {
             code: "foo({ bar: 'baz', qux: 'quux' });",
             output: "foo({ bar: 'baz', qux: 'quux', });",
             options: ["always"],

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -360,8 +360,30 @@ ruleTester.run("semi", rule, {
             }]
         },
         {
+            code: "foo()\r\n",
+            output: "foo();\r\n",
+            errors: [{
+                messageId: "missingSemi",
+                type: "ExpressionStatement",
+                column: 6,
+                endLine: 2,
+                endColumn: 1
+            }]
+        },
+        {
             code: "foo()\nbar();",
             output: "foo();\nbar();",
+            errors: [{
+                messageId: "missingSemi",
+                type: "ExpressionStatement",
+                column: 6,
+                endLine: 2,
+                endColumn: 1
+            }]
+        },
+        {
+            code: "foo()\r\nbar();",
+            output: "foo();\r\nbar();",
             errors: [{
                 messageId: "missingSemi",
                 type: "ExpressionStatement",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.0.0
* **Node Version:** v12.14.0
* **npm Version:** v6.13.4

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
      ecmaVersion: 2015
  }
}
```

</details>

**What did you do? Please include the actual source code causing the issue.**

CRLF after `foo` and `bar`

```js
/*eslint semi: error*/

foo
bar

```

**What did you expect to happen?**

Two errors with the following locations (1-based lines and 1-based columns):

* `foo`: "line":3,"column":4, "endLine":4,"endColumn":1
* `bar`: "line":4,"column":4, "endLine":5,"endColumn":1

**What actually happened? Please include the actual, raw output from ESLint.**

Two errors with the following locations (1-based lines and 1-based columns):

* `foo`: "line":3,"column":4, "endLine":3,"endColumn":5
* `bar`: "line":4,"column":4, "endLine":4,"endColumn":5

`endColumn: 5` would be a position between CR and LF.

VS Code treats this as if no endColumn was given, and underlines word before the start column:

![image](https://user-images.githubusercontent.com/44349756/81466665-a0cae580-91d3-11ea-988c-57d3431b02e9.png)

Atom explicitly reports invalid position:

![image](https://user-images.githubusercontent.com/44349756/81466787-7e859780-91d4-11ea-82c2-33ae76764278.png)

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed `astUtils.getNextLocation` to return the start of the next line instead of an invalid location between CR and LF.

This affects the following rules at the moment:

* `semi`
* `comma-dangle`

#### Is there anything you'd like reviewers to focus on?
