### PR TITLE
Chore: fix invalid syntax in require-await tests

### DIFF
--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -31,7 +31,7 @@ ruleTester.run("require-await", rule, {
         "({ async foo() { await doSomething() } })",
         "class A { async foo() { await doSomething() } }",
         "(class { async foo() { await doSomething() } })",
-        "async function foo() { await async () => { await doSomething() } }",
+        "async function foo() { await (async () => { await doSomething() }) }",
 
         // empty functions are ok.
         "async function foo() {}",
@@ -152,7 +152,7 @@ ruleTester.run("require-await", rule, {
             }]
         },
         {
-            code: "async function foo() { await async () => { doSomething() } }",
+            code: "async function foo() { await (async () => { doSomething() }) }",
             errors: [{
                 messageId: "missingAwait",
                 data: { name: "Async arrow function" }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

Fixes syntax error in two test cases for `require-await`.

These errors are causing build failure with the latest acorn v7.2.0, see PR #13275.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added parens around arrow function in `await`.

#### Is there anything you'd like reviewers to focus on?
