### PR TITLE
Update: reporting location for semi-spacing (refs #12334)

### DIFF
--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -136,11 +136,9 @@ module.exports = {
          */
         function checkSemicolonSpacing(token, node) {
             if (astUtils.isSemicolonToken(token)) {
-
                 if (hasLeadingSpace(token)) {
-                    const tokenBefore = sourceCode.getTokenBefore(token);
-
                     if (!requireSpaceBefore) {
+                        const tokenBefore = sourceCode.getTokenBefore(token);
                         const loc = {
                             start: tokenBefore.loc.end,
                             end: token.loc.start

--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -117,6 +117,18 @@ module.exports = {
         }
 
         /**
+         * Report location example :
+         *
+         * for unexpected space `before`
+         *
+         * var a = 'b'   ;
+         *            ^^^
+         *
+         * for unexpected space `after`
+         *
+         * var a = 'b';  c = 10;
+         *             ^^
+         *
          * Reports if the given token has invalid spacing.
          * @param {Token} token The semicolon token to check.
          * @param {ASTNode} node The corresponding node of the token.
@@ -124,16 +136,24 @@ module.exports = {
          */
         function checkSemicolonSpacing(token, node) {
             if (astUtils.isSemicolonToken(token)) {
-                const location = token.loc.start;
 
+                // console.log(token.loc)
                 if (hasLeadingSpace(token)) {
+                    const tokenBefore = sourceCode.getTokenBefore(token);
+                    const loc = {
+                        start: tokenBefore.loc.end,
+                        end: {
+                            line: token.loc.start.line,
+                            column: token.loc.start.column - 1
+                        }
+                    };
+
                     if (!requireSpaceBefore) {
                         context.report({
                             node,
-                            loc: location,
+                            loc,
                             messageId: "unexpectedWhitespaceBefore",
                             fix(fixer) {
-                                const tokenBefore = sourceCode.getTokenBefore(token);
 
                                 return fixer.removeRange([tokenBefore.range[1], token.range[0]]);
                             }
@@ -141,9 +161,11 @@ module.exports = {
                     }
                 } else {
                     if (requireSpaceBefore) {
+                        const loc = token.loc.start;
+
                         context.report({
                             node,
-                            loc: location,
+                            loc,
                             messageId: "missingWhitespaceBefore",
                             fix(fixer) {
                                 return fixer.insertTextBefore(token, " ");
@@ -155,12 +177,20 @@ module.exports = {
                 if (!isFirstTokenInCurrentLine(token) && !isLastTokenInCurrentLine(token) && !isBeforeClosingParen(token)) {
                     if (hasTrailingSpace(token)) {
                         if (!requireSpaceAfter) {
+                            const tokenAfter = sourceCode.getTokenAfter(token);
+                            const loc = {
+                                start: token.loc.end,
+                                end: {
+                                    line: tokenAfter.loc.start.line,
+                                    column: tokenAfter.loc.start.column - 1
+                                }
+                            };
+
                             context.report({
                                 node,
-                                loc: location,
+                                loc,
                                 messageId: "unexpectedWhitespaceAfter",
                                 fix(fixer) {
-                                    const tokenAfter = sourceCode.getTokenAfter(token);
 
                                     return fixer.removeRange([token.range[1], tokenAfter.range[0]]);
                                 }
@@ -168,9 +198,11 @@ module.exports = {
                         }
                     } else {
                         if (requireSpaceAfter) {
+                            const loc = token.loc.start;
+
                             context.report({
                                 node,
-                                loc: location,
+                                loc,
                                 messageId: "missingWhitespaceAfter",
                                 fix(fixer) {
                                     return fixer.insertTextAfter(token, " ");

--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -139,12 +139,13 @@ module.exports = {
 
                 if (hasLeadingSpace(token)) {
                     const tokenBefore = sourceCode.getTokenBefore(token);
-                    const loc = {
-                        start: tokenBefore.loc.end,
-                        end: token.loc.start
-                    };
 
                     if (!requireSpaceBefore) {
+                        const loc = {
+                            start: tokenBefore.loc.end,
+                            end: token.loc.start
+                        };
+
                         context.report({
                             node,
                             loc,

--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -141,10 +141,7 @@ module.exports = {
                     const tokenBefore = sourceCode.getTokenBefore(token);
                     const loc = {
                         start: tokenBefore.loc.end,
-                        end: {
-                            line: token.loc.start.line,
-                            column: token.loc.start.column - 1
-                        }
+                        end: token.loc.start
                     };
 
                     if (!requireSpaceBefore) {

--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -176,10 +176,7 @@ module.exports = {
                             const tokenAfter = sourceCode.getTokenAfter(token);
                             const loc = {
                                 start: token.loc.end,
-                                end: {
-                                    line: tokenAfter.loc.start.line,
-                                    column: tokenAfter.loc.start.column - 1
-                                }
+                                end: tokenAfter.loc.start
                             };
 
                             context.report({

--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -137,7 +137,6 @@ module.exports = {
         function checkSemicolonSpacing(token, node) {
             if (astUtils.isSemicolonToken(token)) {
 
-                // console.log(token.loc)
                 if (hasLeadingSpace(token)) {
                     const tokenBefore = sourceCode.getTokenBefore(token);
                     const loc = {
@@ -161,7 +160,7 @@ module.exports = {
                     }
                 } else {
                     if (requireSpaceBefore) {
-                        const loc = token.loc.start;
+                        const loc = token.loc;
 
                         context.report({
                             node,
@@ -198,7 +197,7 @@ module.exports = {
                         }
                     } else {
                         if (requireSpaceAfter) {
-                            const loc = token.loc.start;
+                            const loc = token.loc;
 
                             context.report({
                                 node,

--- a/tests/lib/rules/semi-spacing.js
+++ b/tests/lib/rules/semi-spacing.js
@@ -165,8 +165,8 @@ ruleTester.run("semi-spacing", rule, {
                     type: "VariableDeclaration",
                     line: 1,
                     column: 13,
-                    endColumn: 13,
-                    endLine: 1
+                    endLine: 1,
+                    endColumn: 14
                 }
             ]
         },
@@ -180,8 +180,8 @@ ruleTester.run("semi-spacing", rule, {
                     type: "VariableDeclaration",
                     line: 1,
                     column: 13,
-                    endColumn: 15,
-                    endLine: 1
+                    endLine: 1,
+                    endColumn: 16
                 }
             ]
         },
@@ -267,6 +267,7 @@ ruleTester.run("semi-spacing", rule, {
                     type: "ContinueStatement",
                     line: 1,
                     column: 21,
+                    endLine: 1,
                     endColumn: 24
                 }
             ]
@@ -282,6 +283,7 @@ ruleTester.run("semi-spacing", rule, {
                     type: "ThrowStatement",
                     line: 1,
                     column: 27,
+                    endLine: 1,
                     endColumn: 30
                 }
             ]
@@ -292,20 +294,20 @@ ruleTester.run("semi-spacing", rule, {
             options: [{ before: false, after: false }],
             parserOptions: { ecmaVersion: 6 },
             errors: [{
-                line: 1,
-                column: 6,
                 type: "ForStatement",
                 messageId: "unexpectedWhitespaceBefore",
+                line: 1,
+                column: 6,
                 endLine: 1,
                 endColumn: 7
             },
             {
-                line: 1,
-                column: 8,
                 type: "ForStatement",
                 messageId: "unexpectedWhitespaceAfter",
+                line: 1,
+                column: 8,
                 endLine: 1,
-                endColumn: 8
+                endColumn: 9
             }]
         },
         {
@@ -314,10 +316,10 @@ ruleTester.run("semi-spacing", rule, {
             options: [{ before: false, after: false }],
             parserOptions: { ecmaVersion: 6 },
             errors: [{
-                line: 1,
-                column: 6,
                 type: "ForStatement",
                 messageId: "unexpectedWhitespaceBefore",
+                line: 1,
+                column: 6,
                 endLine: 1,
                 endColumn: 7
             }

--- a/tests/lib/rules/semi-spacing.js
+++ b/tests/lib/rules/semi-spacing.js
@@ -147,13 +147,31 @@ ruleTester.run("semi-spacing", rule, {
         {
             code: "var a = 'b';c = 'd';",
             output: "var a = 'b'; c = 'd';",
-            errors: [{ messageId: "missingWhitespaceAfter", type: "VariableDeclaration", line: 1, column: 12 }]
+            errors: [
+                {
+                    messageId: "missingWhitespaceAfter",
+                    type: "VariableDeclaration",
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 13
+                }
+            ]
         },
         {
             code: "var a = 'b';",
             output: "var a = 'b' ;",
             options: [{ before: true, after: true }],
-            errors: [{ messageId: "missingWhitespaceBefore", type: "VariableDeclaration", line: 1, column: 12 }]
+            errors: [
+                {
+                    messageId: "missingWhitespaceBefore",
+                    type: "VariableDeclaration",
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 13
+                }
+            ]
         },
         {
             code: "var a = 'b'; c = 'd';",
@@ -189,8 +207,22 @@ ruleTester.run("semi-spacing", rule, {
             code: "for (var i = 0;i < 10;i++) {}",
             output: "for (var i = 0; i < 10; i++) {}",
             errors: [
-                { messageId: "missingWhitespaceAfter", type: "ForStatement", line: 1, column: 15 },
-                { messageId: "missingWhitespaceAfter", type: "ForStatement", line: 1, column: 22 }
+                {
+                    messageId: "missingWhitespaceAfter",
+                    type: "ForStatement",
+                    line: 1,
+                    column: 15,
+                    endLine: 1,
+                    endColumn: 16
+                },
+                {
+                    messageId: "missingWhitespaceAfter",
+                    type: "ForStatement",
+                    line: 1,
+                    column: 22,
+                    endLine: 1,
+                    endColumn: 23
+                }
             ]
         },
         {
@@ -198,8 +230,22 @@ ruleTester.run("semi-spacing", rule, {
             output: "for (var i = 0 ; i < 10 ; i++) {}",
             options: [{ before: true, after: true }],
             errors: [
-                { messageId: "missingWhitespaceBefore", type: "ForStatement", line: 1, column: 15 },
-                { messageId: "missingWhitespaceBefore", type: "ForStatement", line: 1, column: 23 }
+                {
+                    messageId: "missingWhitespaceBefore",
+                    type: "ForStatement",
+                    line: 1,
+                    column: 15,
+                    endLine: 1,
+                    endColumn: 16
+                },
+                {
+                    messageId: "missingWhitespaceBefore",
+                    type: "ForStatement",
+                    line: 1,
+                    column: 23,
+                    endLine: 1,
+                    endColumn: 24
+                }
             ]
         },
         {

--- a/tests/lib/rules/semi-spacing.js
+++ b/tests/lib/rules/semi-spacing.js
@@ -59,66 +59,89 @@ ruleTester.run("semi-spacing", rule, {
     ],
     invalid: [
         {
+            code: "var a = 'b'  ;",
+            output: "var a = 'b';",
+            errors: [
+                {
+                    messageId: "unexpectedWhitespaceBefore",
+                    type: "VariableDeclaration",
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 13
+                }
+            ]
+        },
+        {
             code: "var a = 'b' ;",
             output: "var a = 'b';",
-            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "VariableDeclaration", line: 1, column: 13 }]
+            errors: [
+                {
+                    messageId: "unexpectedWhitespaceBefore",
+                    type: "VariableDeclaration",
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 12
+                }
+            ]
         },
         {
             code: "var a = 'b',\nc = 'd' ;",
             output: "var a = 'b',\nc = 'd';",
-            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "VariableDeclaration", line: 2, column: 9 }]
+            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "VariableDeclaration", line: 2, column: 8 }]
         },
         {
             code: "var a = function() {} ;",
             output: "var a = function() {};",
-            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "VariableDeclaration", line: 1, column: 23 }]
+            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "VariableDeclaration", line: 1, column: 22 }]
         },
         {
             code: "var a = function() {\n} ;",
             output: "var a = function() {\n};",
-            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "VariableDeclaration", line: 2, column: 3 }]
+            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "VariableDeclaration", line: 2, column: 2 }]
         },
         {
             code: "/^a$/.test('b') ;",
             output: "/^a$/.test('b');",
-            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "ExpressionStatement", line: 1, column: 17 }]
+            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "ExpressionStatement", line: 1, column: 16 }]
         },
         {
             code: ";(function(){}()) ;",
             output: ";(function(){}());",
-            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "ExpressionStatement", line: 1, column: 19 }]
+            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "ExpressionStatement", line: 1, column: 18 }]
         },
         {
             code: "while (true) { break ; }",
             output: "while (true) { break; }",
-            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "BreakStatement", line: 1, column: 22 }]
+            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "BreakStatement", line: 1, column: 21 }]
         },
         {
             code: "while (true) { continue ; }",
             output: "while (true) { continue; }",
-            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "ContinueStatement", line: 1, column: 25 }]
+            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "ContinueStatement", line: 1, column: 24 }]
         },
         {
             code: "debugger ;",
             output: "debugger;",
-            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "DebuggerStatement", line: 1, column: 10 }]
+            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "DebuggerStatement", line: 1, column: 9 }]
         },
         {
             code: "function foo() { return ; }",
             output: "function foo() { return; }",
-            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "ReturnStatement", line: 1, column: 25 }]
+            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "ReturnStatement", line: 1, column: 24 }]
         },
         {
             code: "throw new Error('foo') ;",
             output: "throw new Error('foo');",
-            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "ThrowStatement", line: 1, column: 24 }]
+            errors: [{ messageId: "unexpectedWhitespaceBefore", type: "ThrowStatement", line: 1, column: 23 }]
         },
         {
             code: "for (var i = 0 ; i < 10 ; i++) {}",
             output: "for (var i = 0; i < 10; i++) {}",
             errors: [
-                { messageId: "unexpectedWhitespaceBefore", type: "ForStatement", line: 1, column: 16 },
-                { messageId: "unexpectedWhitespaceBefore", type: "ForStatement", line: 1, column: 25 }
+                { messageId: "unexpectedWhitespaceBefore", type: "ForStatement", line: 1, column: 15 },
+                { messageId: "unexpectedWhitespaceBefore", type: "ForStatement", line: 1, column: 24 }
             ]
         },
         {
@@ -136,7 +159,31 @@ ruleTester.run("semi-spacing", rule, {
             code: "var a = 'b'; c = 'd';",
             output: "var a = 'b';c = 'd';",
             options: [{ before: false, after: false }],
-            errors: [{ messageId: "unexpectedWhitespaceAfter", type: "VariableDeclaration", line: 1, column: 12 }]
+            errors: [
+                {
+                    messageId: "unexpectedWhitespaceAfter",
+                    type: "VariableDeclaration",
+                    line: 1,
+                    column: 13,
+                    endColumn: 13,
+                    endLine: 1
+                }
+            ]
+        },
+        {
+            code: "var a = 'b';   c = 'd';",
+            output: "var a = 'b';c = 'd';",
+            options: [{ before: false, after: false }],
+            errors: [
+                {
+                    messageId: "unexpectedWhitespaceAfter",
+                    type: "VariableDeclaration",
+                    line: 1,
+                    column: 13,
+                    endColumn: 15,
+                    endLine: 1
+                }
+            ]
         },
         {
             code: "for (var i = 0;i < 10;i++) {}",
@@ -160,8 +207,8 @@ ruleTester.run("semi-spacing", rule, {
             output: "for (var i = 0;i < 10;i++) {}",
             options: [{ before: false, after: false }],
             errors: [
-                { messageId: "unexpectedWhitespaceAfter", type: "ForStatement", line: 1, column: 15 },
-                { messageId: "unexpectedWhitespaceAfter", type: "ForStatement", line: 1, column: 23 }
+                { messageId: "unexpectedWhitespaceAfter", type: "ForStatement", line: 1, column: 16 },
+                { messageId: "unexpectedWhitespaceAfter", type: "ForStatement", line: 1, column: 24 }
             ]
         },
         {
@@ -170,7 +217,7 @@ ruleTester.run("semi-spacing", rule, {
             options: [{ before: false, after: true }],
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: [
-                { messageId: "unexpectedWhitespaceBefore", type: "ImportDeclaration", line: 1, column: 23 }
+                { messageId: "unexpectedWhitespaceBefore", type: "ImportDeclaration", line: 1, column: 22 }
             ]
         },
         {
@@ -179,7 +226,7 @@ ruleTester.run("semi-spacing", rule, {
             options: [{ before: false, after: true }],
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: [
-                { messageId: "unexpectedWhitespaceBefore", type: "ImportDeclaration", line: 1, column: 28 }
+                { messageId: "unexpectedWhitespaceBefore", type: "ImportDeclaration", line: 1, column: 27 }
             ]
         },
         {
@@ -188,7 +235,7 @@ ruleTester.run("semi-spacing", rule, {
             options: [{ before: false, after: true }],
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: [
-                { messageId: "unexpectedWhitespaceBefore", type: "ExportNamedDeclaration", line: 1, column: 27 }
+                { messageId: "unexpectedWhitespaceBefore", type: "ExportNamedDeclaration", line: 1, column: 26 }
             ]
         },
         {
@@ -197,7 +244,7 @@ ruleTester.run("semi-spacing", rule, {
             options: [{ before: false, after: true }],
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: [
-                { messageId: "unexpectedWhitespaceBefore", type: "ExportAllDeclaration", line: 1, column: 21 }
+                { messageId: "unexpectedWhitespaceBefore", type: "ExportAllDeclaration", line: 1, column: 20 }
             ]
         },
         {
@@ -206,7 +253,74 @@ ruleTester.run("semi-spacing", rule, {
             options: [{ before: false, after: true }],
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: [
-                { messageId: "unexpectedWhitespaceBefore", type: "ExportDefaultDeclaration", line: 1, column: 20 }
+                { messageId: "unexpectedWhitespaceBefore", type: "ExportDefaultDeclaration", line: 1, column: 19 }
+            ]
+        },
+        {
+            code: "while(foo) {continue   ;}",
+            output: "while(foo) {continue;}",
+            options: [{ before: false, after: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedWhitespaceBefore",
+                    type: "ContinueStatement",
+                    line: 1,
+                    column: 21,
+                    endColumn: 23
+                }
+            ]
+        },
+        {
+            code: "if(foo) {throw new Error()   ;  }",
+            output: "if(foo) {throw new Error();  }",
+            options: [{ before: false, after: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedWhitespaceBefore",
+                    type: "ThrowStatement",
+                    line: 1,
+                    column: 27,
+                    endColumn: 29
+                }
+            ]
+        },
+        {
+            code: "for(a ; ; );",
+            output: "for(a;; );",
+            options: [{ before: false, after: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                line: 1,
+                column: 6,
+                type: "ForStatement",
+                messageId: "unexpectedWhitespaceBefore",
+                endLine: 1,
+                endColumn: 6
+            },
+            {
+                line: 1,
+                column: 8,
+                type: "ForStatement",
+                messageId: "unexpectedWhitespaceAfter",
+                endLine: 1,
+                endColumn: 8
+            }]
+        },
+        {
+            code: "for(a ; \n ; );",
+            output: "for(a; \n ; );",
+            options: [{ before: false, after: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                line: 1,
+                column: 6,
+                type: "ForStatement",
+                messageId: "unexpectedWhitespaceBefore",
+                endLine: 1,
+                endColumn: 6
+            }
             ]
         }
     ]

--- a/tests/lib/rules/semi-spacing.js
+++ b/tests/lib/rules/semi-spacing.js
@@ -68,7 +68,7 @@ ruleTester.run("semi-spacing", rule, {
                     line: 1,
                     column: 12,
                     endLine: 1,
-                    endColumn: 13
+                    endColumn: 14
                 }
             ]
         },
@@ -82,7 +82,7 @@ ruleTester.run("semi-spacing", rule, {
                     line: 1,
                     column: 12,
                     endLine: 1,
-                    endColumn: 12
+                    endColumn: 13
                 }
             ]
         },
@@ -267,7 +267,7 @@ ruleTester.run("semi-spacing", rule, {
                     type: "ContinueStatement",
                     line: 1,
                     column: 21,
-                    endColumn: 23
+                    endColumn: 24
                 }
             ]
         },
@@ -282,7 +282,7 @@ ruleTester.run("semi-spacing", rule, {
                     type: "ThrowStatement",
                     line: 1,
                     column: 27,
-                    endColumn: 29
+                    endColumn: 30
                 }
             ]
         },
@@ -297,7 +297,7 @@ ruleTester.run("semi-spacing", rule, {
                 type: "ForStatement",
                 messageId: "unexpectedWhitespaceBefore",
                 endLine: 1,
-                endColumn: 6
+                endColumn: 7
             },
             {
                 line: 1,
@@ -319,7 +319,7 @@ ruleTester.run("semi-spacing", rule, {
                 type: "ForStatement",
                 messageId: "unexpectedWhitespaceBefore",
                 endLine: 1,
-                endColumn: 6
+                endColumn: 7
             }
             ]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Updated the location when is there unexpected space (both for before and after)

Currently 
```js
var a = 'b'   ;
          //  ^ it will report here instead of the spaces
```

with this change
```js
var a = 'b'   ;
        // ^^^  it will report here
```
#### Is there anything you'd like reviewers to focus on?
For missing space it currently reports 

```js
var a = 'a';var b = 'b';
       //  ^ it reports here i.e over the `;`
```

I think it should report the next token after `;` right ? i.e `v` in this case. 

I didn't make this change for the missing space, let me know if this is fine to change !

[repl](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgc2VtaS1zcGFjaW5nOiBcImVycm9yXCIqL1xuXG52YXIgZm9vICA7XG52YXIgZm9vO3ZhciBiYXI7Iiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo1LCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7fSwiZW52Ijp7fX19)