### PR TITLE
Chore: Mark SourceCode getComments() method as deprecated (fixes #13293)

### DIFF
--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -305,6 +305,7 @@ class SourceCode extends TokenStore {
      * @returns {Object} An object containing a leading and trailing array
      *      of comments indexed by their position.
      * @public
+     * @deprecated replaced by getCommentsBefore(), getCommentsAfter(), and getCommentsInside().
      */
     getComments(node) {
         if (this._commentCache.has(node)) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Update source-code.js `getComments` method:

Program node [exclude leading and trailing comments from our range](https://github.com/eslint/espree/blob/master/lib/espree.js#L156), and i add special conditions, when given node has parent Program, leading and trailing comments tokens always belong to this node
