### PR TITLE
Fix: Stop path analyzer on unknown nodes

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -938,7 +938,8 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
         });
     });
 
-    const eventGenerator = new CodePathAnalyzer(new NodeEventGenerator(emitter));
+    // only run code path analyzer if the top level node is "Program", skip otherwise
+    const eventGenerator = nodeQueue[0].node.type === "Program" ? new CodePathAnalyzer(new NodeEventGenerator(emitter)) : new NodeEventGenerator(emitter);
 
     nodeQueue.forEach(traversalInfo => {
         currentNode = traversalInfo.node;

--- a/tests/fixtures/parsers/linter-test-parsers.js
+++ b/tests/fixtures/parsers/linter-test-parsers.js
@@ -10,5 +10,6 @@ module.exports = {
     noLineError: require("./no-line-error"),
     enhancedParser2: require("./enhanced-parser2"),
     enhancedParser3: require("./enhanced-parser3"),
-    throwsWithOptions: require("./throws-with-options")
+    throwsWithOptions: require("./throws-with-options"),
+    nonJSParser: require('./non-js-parser')
 };

--- a/tests/fixtures/parsers/non-js-parser.js
+++ b/tests/fixtures/parsers/non-js-parser.js
@@ -1,0 +1,238 @@
+/**
+ * Source code:
+ * function foo(a: number=0): Foo { }
+ */
+
+exports.parseForESLint = () => ({
+    ast: {
+        "kind": "Document",
+        "definitions": [
+            {
+                "kind": "ObjectTypeExtension",
+                "name": {
+                    "kind": "Name",
+                    "value": "Query",
+                    "loc": {
+                        "start": 12,
+                        "end": 17
+                    },
+                    "type": "Name"
+                },
+                "interfaces": [],
+                "directives": [],
+                "fields": [
+                    {
+                        "kind": "FieldDefinition",
+                        "name": {
+                            "kind": "Name",
+                            "value": "login",
+                            "loc": {
+                                "start": 24,
+                                "end": 29
+                            },
+                            "type": "Name"
+                        },
+                        "arguments": [
+                            {
+                                "kind": "InputValueDefinition",
+                                "name": {
+                                    "kind": "Name",
+                                    "value": "input",
+                                    "loc": {
+                                        "start": 30,
+                                        "end": 35
+                                    },
+                                    "type": "Name"
+                                },
+                                "type": "InputValueDefinition",
+                                "directives": [],
+                                "loc": {
+                                    "start": 30,
+                                    "end": 49
+                                },
+                                "fieldType": {
+                                    "kind": "NonNullType",
+                                    "type": "NonNullType",
+                                    "loc": {
+                                        "start": 37,
+                                        "end": 49
+                                    },
+                                    "fieldType": {
+                                        "kind": "NamedType",
+                                        "name": {
+                                            "kind": "Name",
+                                            "value": "Credentials",
+                                            "loc": {
+                                                "start": 37,
+                                                "end": 48
+                                            },
+                                            "type": "Name"
+                                        },
+                                        "loc": {
+                                            "start": 37,
+                                            "end": 48
+                                        },
+                                        "type": "NamedType"
+                                    }
+                                }
+                            }
+                        ],
+                        "type": "FieldDefinition",
+                        "directives": [],
+                        "loc": {
+                            "start": 24,
+                            "end": 63
+                        },
+                        "fieldType": {
+                            "kind": "NamedType",
+                            "name": {
+                                "kind": "Name",
+                                "value": "UserProfile",
+                                "loc": {
+                                    "start": 52,
+                                    "end": 63
+                                },
+                                "type": "Name"
+                            },
+                            "loc": {
+                                "start": 52,
+                                "end": 63
+                            },
+                            "type": "NamedType"
+                        }
+                    }
+                ],
+                "loc": {
+                    "start": 0,
+                    "end": 65
+                },
+                "type": "ObjectTypeExtension"
+            },
+            {
+                "kind": "InputObjectTypeDefinition",
+                "name": {
+                    "kind": "Name",
+                    "value": "Credentials",
+                    "loc": {
+                        "start": 73,
+                        "end": 84
+                    },
+                    "type": "Name"
+                },
+                "directives": [],
+                "fields": [
+                    {
+                        "kind": "InputValueDefinition",
+                        "name": {
+                            "kind": "Name",
+                            "value": "login",
+                            "loc": {
+                                "start": 91,
+                                "end": 96
+                            },
+                            "type": "Name"
+                        },
+                        "type": "InputValueDefinition",
+                        "directives": [],
+                        "loc": {
+                            "start": 91,
+                            "end": 105
+                        },
+                        "fieldType": {
+                            "kind": "NonNullType",
+                            "type": "NonNullType",
+                            "loc": {
+                                "start": 98,
+                                "end": 105
+                            },
+                            "fieldType": {
+                                "kind": "NamedType",
+                                "name": {
+                                    "kind": "Name",
+                                    "value": "String",
+                                    "loc": {
+                                        "start": 98,
+                                        "end": 104
+                                    },
+                                    "type": "Name"
+                                },
+                                "loc": {
+                                    "start": 98,
+                                    "end": 104
+                                },
+                                "type": "NamedType"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "InputValueDefinition",
+                        "name": {
+                            "kind": "Name",
+                            "value": "password",
+                            "loc": {
+                                "start": 110,
+                                "end": 118
+                            },
+                            "type": "Name"
+                        },
+                        "type": "InputValueDefinition",
+                        "directives": [],
+                        "loc": {
+                            "start": 110,
+                            "end": 127
+                        },
+                        "fieldType": {
+                            "kind": "NonNullType",
+                            "type": "NonNullType",
+                            "loc": {
+                                "start": 120,
+                                "end": 127
+                            },
+                            "fieldType": {
+                                "kind": "NamedType",
+                                "name": {
+                                    "kind": "Name",
+                                    "value": "String",
+                                    "loc": {
+                                        "start": 120,
+                                        "end": 126
+                                    },
+                                    "type": "Name"
+                                },
+                                "loc": {
+                                    "start": 120,
+                                    "end": 126
+                                },
+                                "type": "NamedType"
+                            }
+                        }
+                    }
+                ],
+                "loc": {
+                    "start": 67,
+                    "end": 129
+                },
+                "type": "InputObjectTypeDefinition"
+            }
+        ],
+        "loc": {
+            "start": 0,
+            "end": 130
+        },
+        "type": "Document",
+        "tokens": [],
+        "comments": [],
+        "range": {}
+    },
+    services: {},
+    scopeManager: { variables: [], scopes: [{ set: new Map(), variables: [], through: [] }], getDeclaredVariables: () => {} },
+    visitorKeys: {
+        Document: ['definitions'],
+        ObjectTypeDefinition: ['interfaces', 'directives', 'fields'],
+        ObjectTypeExtension: ['interfaces', 'directives', 'fields'],
+        InputObjectTypeDefinition: ['directives', 'fields'],
+        InputValueDefinition: ['directives', 'fieldType'],
+        FieldDefinition: ['directives', 'fieldType', 'arguments'],
+        EnumTypeDefinition: ['directives', 'values']
+    }
+});

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -5247,6 +5247,30 @@ var a = "test2";
             assert.strictEqual(messages.length, 0);
         });
 
+        it("should not throw or return errors when the custom parser returns unknown AST nodes", () => {
+            const code = "foo && bar %% baz";
+
+            const nodes = [];
+
+            linter.defineRule("collect-node-types", () => ({
+                "*"(node) {
+                    nodes.push(node.type);
+                }
+            }));
+
+            linter.defineParser("non-js-parser", testParsers.nonJSParser);
+
+            const messages = linter.verify(code, {
+                parser: "non-js-parser",
+                rules: {
+                    "collect-node-types": "error"
+                }
+            }, filename, true);
+
+            assert.strictEqual(messages.length, 0);
+            assert.isTrue(nodes.length > 0);
+        });
+
         it("should strip leading line: prefix from parser error", () => {
             linter.defineParser("line-error", testParsers.lineError);
             const messages = linter.verify(";", { parser: "line-error" }, "filename");


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Updated code path analyzer to bail if no known ESTree nodes are found in AST. I'm trying to get ESLint to work with syntaxes other then ESTree and this is one place where it throws an error, since all the AST nodes are hardcoded in code-path-analyzer and can't be supplied by the parser. Unfortunately, it would be very tricky to create a unit test for this, and since this is a one-line change that shouldn't affect happy path, I figured it would be OK without unit test. 

#### Is there anything you'd like reviewers to focus on?
Nope