### PR TITLE
Fix: arrow-parens no reporting for comments inside (fixes #12995)

### DIFF
--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -159,6 +159,7 @@ Examples of **incorrect** code for this rule with the `"as-needed"` option:
 a.then((foo) => {});
 a.then((foo) => a);
 a((foo) => { if (true) {} });
+const f = /** @type {number} */(a) => a + a;
 ```
 
 Examples of **correct** code for this rule with the `"as-needed"` option:
@@ -177,6 +178,7 @@ a.then(foo => { if (true) {} });
 (a = 10) => a;
 ([a, b]) => a;
 ({a, b}) => a;
+const f = /** @type {number} */a => a + a;
 ```
 
 ### requireForBlockBody

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -160,8 +160,8 @@ a.then((foo) => {});
 a.then((foo) => a);
 a((foo) => { if (true) {} });
 const f = /** @type {number} */(a) => a + a;
-const g = (/* comment */ a) => a + a;
-const h = (a /* comment */) => a + a;
+const g = /* comment */ (a) => a + a;
+const h = (a) /* comment */ => a + a;
 ```
 
 Examples of **correct** code for this rule with the `"as-needed"` option:
@@ -181,6 +181,8 @@ a.then(foo => { if (true) {} });
 ([a, b]) => a;
 ({a, b}) => a;
 const f = (/** @type {number} */a) => a + a;
+const g = (/* comment */ a) => a + a;
+const h = (a /* comment */) => a + a;
 ```
 
 ### requireForBlockBody

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -160,6 +160,8 @@ a.then((foo) => {});
 a.then((foo) => a);
 a((foo) => { if (true) {} });
 const f = /** @type {number} */(a) => a + a;
+const g = (/* comment */ a) => a + a;
+const h = (a /* comment */) => a + a;
 ```
 
 Examples of **correct** code for this rule with the `"as-needed"` option:

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -178,7 +178,7 @@ a.then(foo => { if (true) {} });
 (a = 10) => a;
 ([a, b]) => a;
 ({a, b}) => a;
-const f = /** @type {number} */a => a + a;
+const f = (/** @type {number} */a) => a + a;
 ```
 
 ### requireForBlockBody

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -110,9 +110,13 @@ module.exports = {
              * @returns {boolean} `true` if there are comments inside of parens, else `false`
              */
             function hasCommentsInParens() {
-                const closingParenToken = sourceCode.getTokenAfter(firstTokenOfParam, astUtils.isClosingParenToken);
+                if (firstTokenOfParam.type === "Punctuator" && firstTokenOfParam.value === "(") {
+                    const closingParenToken = sourceCode.getTokenAfter(node.params[0], astUtils.isClosingParenToken);
 
-                return closingParenToken && sourceCode.commentsExistBetween(firstTokenOfParam, closingParenToken);
+                    return closingParenToken && sourceCode.commentsExistBetween(firstTokenOfParam, closingParenToken);
+                }
+                return false;
+
             }
 
             if (hasCommentsInParens()) {

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -105,6 +105,14 @@ module.exports = {
                 ], `${shouldAddSpaceForAsync ? " " : ""}${paramToken.value}`);
             }
 
+            if (
+                node.params.length === 1 &&
+                (sourceCode.getCommentsBefore(node.params[0]).length > 0 ||
+                sourceCode.getCommentsAfter(node.params[0]).length > 0)
+            ) {
+                return;
+            }
+
             // "as-needed", { "requireForBlockBody": true }: x => x
             if (
                 requireForBlockBody &&

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -110,7 +110,7 @@ module.exports = {
              * @returns {boolean} `true` if there are comments inside of parens, else `false`
              */
             function hasCommentsInParens() {
-                if (firstTokenOfParam.type === "Punctuator" && firstTokenOfParam.value === "(") {
+                if (astUtils.isOpeningParenToken(firstTokenOfParam)) {
                     const closingParenToken = sourceCode.getTokenAfter(node.params[0], astUtils.isClosingParenToken);
 
                     return closingParenToken && sourceCode.commentsExistBetween(firstTokenOfParam, closingParenToken);

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -105,11 +105,43 @@ module.exports = {
                 ], `${shouldAddSpaceForAsync ? " " : ""}${paramToken.value}`);
             }
 
-            if (
-                node.params.length === 1 &&
-                (sourceCode.getCommentsBefore(node.params[0]).length > 0 ||
-                sourceCode.getCommentsAfter(node.params[0]).length > 0)
-            ) {
+            /**
+             * Checks whether there are comments inside the params or not.
+             * @param {ASTNode} paramNode node to check
+             * @returns {boolean} `true` if there are comments inside of braces, else `false`
+             */
+            function isCommentsInParens(paramNode) {
+
+                if (paramNode.params.length !== 1) {
+                    return false;
+                }
+
+                if (!astUtils.isOpeningParenToken(firstTokenOfParam)) {
+                    return false;
+                }
+
+                if (sourceCode.getCommentsBefore(paramNode.params[0]).length > 0) {
+                    return true;
+                }
+
+                if (sourceCode.getCommentsAfter(paramNode.params[0]).length > 0) {
+                    return true;
+                }
+
+                const commaToken = sourceCode.getTokenAfter(paramNode.params[0]);
+
+                if (commaToken.type === "Punctuator" && commaToken.value === ",") {
+                    if (sourceCode.getCommentsAfter(commaToken).length > 0) {
+                        return true;
+                    }
+                }
+
+
+                return false;
+            }
+
+
+            if (isCommentsInParens(node)) {
                 return;
             }
 

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -136,10 +136,8 @@ module.exports = {
                     }
                 }
 
-
                 return false;
             }
-
 
             if (isCommentsInParens(node)) {
                 return;

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -107,46 +107,21 @@ module.exports = {
 
             /**
              * Checks whether there are comments inside the params or not.
-             * @param {ASTNode} paramNode node to check
-             * @returns {boolean} `true` if there are comments inside of braces, else `false`
+             * @returns {boolean} `true` if there are comments inside of parens, else `false`
              */
-            function isCommentsInParens(paramNode) {
+            function hasCommentsInParens() {
+                const closingParenToken = sourceCode.getTokenAfter(firstTokenOfParam, astUtils.isClosingParenToken);
 
-                if (paramNode.params.length !== 1) {
-                    return false;
-                }
-
-                if (!astUtils.isOpeningParenToken(firstTokenOfParam)) {
-                    return false;
-                }
-
-                if (sourceCode.getCommentsBefore(paramNode.params[0]).length > 0) {
-                    return true;
-                }
-
-                if (sourceCode.getCommentsAfter(paramNode.params[0]).length > 0) {
-                    return true;
-                }
-
-                const commaToken = sourceCode.getTokenAfter(paramNode.params[0]);
-
-                if (commaToken.type === "Punctuator" && commaToken.value === ",") {
-                    if (sourceCode.getCommentsAfter(commaToken).length > 0) {
-                        return true;
-                    }
-                }
-
-                return false;
+                return closingParenToken && sourceCode.commentsExistBetween(firstTokenOfParam, closingParenToken);
             }
 
-            if (isCommentsInParens(node)) {
+            if (hasCommentsInParens()) {
                 return;
             }
 
             // "as-needed", { "requireForBlockBody": true }: x => x
             if (
                 requireForBlockBody &&
-                node.params.length === 1 &&
                 node.params[0].type === "Identifier" &&
                 !node.params[0].typeAnnotation &&
                 node.body.type !== "BlockStatement" &&
@@ -182,7 +157,6 @@ module.exports = {
 
             // "as-needed": x => x
             if (asNeeded &&
-                node.params.length === 1 &&
                 node.params[0].type === "Identifier" &&
                 !node.params[0].typeAnnotation &&
                 !node.returnType
@@ -216,7 +190,7 @@ module.exports = {
         }
 
         return {
-            ArrowFunctionExpression: parens
+            "ArrowFunctionExpression[params.length=1]": parens
         };
     }
 };

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -128,6 +128,14 @@ const valid = [
         code: "const i = (a \n /**/,) => a + a;",
         parserOptions: { ecmaVersion: 2017 },
         options: ["as-needed"]
+    },
+    {
+        code: "var bar = ({/*comment here*/a}) => a",
+        options: ["as-needed"]
+    },
+    {
+        code: "var bar = (/*comment here*/{a}) => a",
+        options: ["as-needed"]
     }
 ];
 
@@ -380,6 +388,26 @@ const invalid = [
             messageId: "expectedParens",
             endLine: 1,
             endColumn: 12
+        }]
+    },
+    {
+        code: `const foo = a => {};
+
+// comment between 'a' and an unrelated closing paren
+
+bar();`,
+        output: `const foo = (a) => {};
+
+// comment between 'a' and an unrelated closing paren
+
+bar();`,
+        errors: [{
+            line: 1,
+            column: 13,
+            type: "ArrowFunctionExpression",
+            messageId: "expectedParens",
+            endLine: 1,
+            endColumn: 14
         }]
     }
 

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -105,12 +105,27 @@ const valid = [
         options: ["as-needed"]
     },
     {
+        code: "var foo = (a , /**/) => b;",
+        parserOptions: { ecmaVersion: 2017 },
+        options: ["as-needed"]
+    },
+    {
+        code: "var foo = (a\n,\n/**/) => b;",
+        parserOptions: { ecmaVersion: 2017 },
+        options: ["as-needed"]
+    },
+    {
         code: "var foo = (a,//\n) => b;",
         parserOptions: { ecmaVersion: 2017 },
         options: ["as-needed"]
     },
     {
         code: "const i = (a/**/,) => a + a;",
+        parserOptions: { ecmaVersion: 2017 },
+        options: ["as-needed"]
+    },
+    {
+        code: "const i = (a \n /**/,) => a + a;",
         parserOptions: { ecmaVersion: 2017 },
         options: ["as-needed"]
     }

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -98,6 +98,21 @@ const valid = [
     {
         code: "const f = (/*\n */a//\n) => a + a;",
         options: ["as-needed"]
+    },
+    {
+        code: "var foo = (a,/**/) => b;",
+        parserOptions: { ecmaVersion: 2017 },
+        options: ["as-needed"]
+    },
+    {
+        code: "var foo = (a,//\n) => b;",
+        parserOptions: { ecmaVersion: 2017 },
+        options: ["as-needed"]
+    },
+    {
+        code: "const i = (a/**/,) => a + a;",
+        parserOptions: { ecmaVersion: 2017 },
+        options: ["as-needed"]
     }
 ];
 
@@ -327,7 +342,32 @@ const invalid = [
             endLine: 2,
             endColumn: 3
         }]
+    },
+    {
+        code: "var foo = /**/ a => b;",
+        output: "var foo = /**/ (a) => b;",
+        errors: [{
+            line: 1,
+            column: 16,
+            type: "ArrowFunctionExpression",
+            messageId: "expectedParens",
+            endLine: 1,
+            endColumn: 17
+        }]
+    },
+    {
+        code: "var bar = a /**/ =>  b;",
+        output: "var bar = (a) /**/ =>  b;",
+        errors: [{
+            line: 1,
+            column: 11,
+            type: "ArrowFunctionExpression",
+            messageId: "expectedParens",
+            endLine: 1,
+            endColumn: 12
+        }]
     }
+
 ];
 
 ruleTester.run("arrow-parens", rule, {

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -29,6 +29,12 @@ const valid = [
     "(a) => {\n}",
     "a.then((foo) => {});",
     "a.then((foo) => { if (true) {}; });",
+    "const f = (/* */a) => a + a;",
+    "const f = (a/** */) => a + a;",
+    "const f = (a//\n) => a + a;",
+    "const f = (//\na) => a + a;",
+    "const f = (/*\n */a//\n) => a + a;",
+    "const f = (/** @type {number} */a/**hello*/) => a + a;",
     { code: "a.then(async (foo) => { if (true) {}; });", parserOptions: { ecmaVersion: 8 } },
 
     // "always" (explicit)
@@ -68,7 +74,31 @@ const valid = [
     { code: "async a => ({})", options: ["as-needed", { requireForBlockBody: true }], parserOptions: { ecmaVersion: 8 } },
     { code: "async a => a", options: ["as-needed", { requireForBlockBody: true }], parserOptions: { ecmaVersion: 8 } },
     { code: "(a: T) => a", options: ["as-needed", { requireForBlockBody: true }], parser: parser("identifer-type") },
-    { code: "(a): T => a", options: ["as-needed", { requireForBlockBody: true }], parser: parser("return-type") }
+    { code: "(a): T => a", options: ["as-needed", { requireForBlockBody: true }], parser: parser("return-type") },
+    {
+        code: "const f = (/** @type {number} */a/**hello*/) => a + a;",
+        options: ["as-needed"]
+    },
+    {
+        code: "const f = (/* */a) => a + a;",
+        options: ["as-needed"]
+    },
+    {
+        code: "const f = (a/** */) => a + a;",
+        options: ["as-needed"]
+    },
+    {
+        code: "const f = (a//\n) => a + a;",
+        options: ["as-needed"]
+    },
+    {
+        code: "const f = (//\na) => a + a;",
+        options: ["as-needed"]
+    },
+    {
+        code: "const f = (/*\n */a//\n) => a + a;",
+        options: ["as-needed"]
+    }
 ];
 
 const type = "ArrowFunctionExpression";
@@ -270,6 +300,32 @@ const invalid = [
             endColumn: 8,
             messageId: "unexpectedParensInline",
             type
+        }]
+    },
+    {
+        code: "const f = /** @type {number} */(a)/**hello*/ => a + a;",
+        options: ["as-needed"],
+        output: "const f = /** @type {number} */a/**hello*/ => a + a;",
+        errors: [{
+            line: 1,
+            column: 33,
+            type,
+            messageId: "unexpectedParens",
+            endLine: 1,
+            endColumn: 34
+        }]
+    },
+    {
+        code: "const f = //\n(a) => a + a;",
+        output: "const f = //\na => a + a;",
+        options: ["as-needed"],
+        errors: [{
+            line: 2,
+            column: 2,
+            type,
+            messageId: "unexpectedParens",
+            endLine: 2,
+            endColumn: 3
         }]
     }
 ];


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
**rule: `arrow-parens`**

no reporting when there are comments inside params. 
applicable for `as-needed` option for 

Example of valid code [(these are invalid in master as of now)](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgYXJyb3ctcGFyZW5zOiBbXCJlcnJvclwiLCBcImFzLW5lZWRlZFwiXSovXG5cblxuY29uc3QgZiA9ICgvKiogQHR5cGUge251bWJlcn0gKi9hLyoqaGVsbG8qLykgPT4gYSArIGE7XG5jb25zdCBmZiA9IChhIC8qKi8pID0+IGFcbmNvbnN0IGZmZiA9ICgvL1xuYSkgPT4gYSIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6Im1vZHVsZSIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js
/*eslint arrow-parens: ["error", "as-needed"]*/


const f = (/** @type {number} */a/**hello*/) => a + a;
const ff = (a /**/) => a
const fff = (//
a) => a

```
These are valid by default in `master` as well

#### Is there anything you'd like reviewers to focus on?
None