### PR TITLE
Update: Improve report location for linebreak-style (refs #12334)

### DIFF
--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -86,8 +86,14 @@ module.exports = {
                     context.report({
                         node,
                         loc: {
-                            line: i,
-                            column: sourceCode.lines[i - 1].length
+                            start: {
+                                line: i,
+                                column: sourceCode.lines[i - 1].length
+                            },
+                            end: {
+                                line: i + 1,
+                                column: 0
+                            }
                         },
                         messageId: expectedLF ? "expectedLF" : "expectedCRLF",
                         fix: createFix(range, expectedLFChars)

--- a/tests/lib/rules/linebreak-style.js
+++ b/tests/lib/rules/linebreak-style.js
@@ -46,6 +46,8 @@ ruleTester.run("linebreak-style", rule, {
             errors: [{
                 line: 1,
                 column: 13,
+                endLine: 2,
+                endColumn: 1,
                 messageId: "expectedLF"
             }]
         },
@@ -56,6 +58,8 @@ ruleTester.run("linebreak-style", rule, {
             errors: [{
                 line: 1,
                 column: 13,
+                endLine: 2,
+                endColumn: 1,
                 messageId: "expectedLF"
             }]
         },
@@ -66,6 +70,8 @@ ruleTester.run("linebreak-style", rule, {
             errors: [{
                 line: 1,
                 column: 13,
+                endLine: 2,
+                endColumn: 1,
                 messageId: "expectedCRLF"
             }]
         },
@@ -75,11 +81,15 @@ ruleTester.run("linebreak-style", rule, {
             errors: [{
                 line: 4,
                 column: 24,
+                endLine: 5,
+                endColumn: 1,
                 messageId: "expectedLF"
             },
             {
                 line: 6,
                 column: 3,
+                endLine: 7,
+                endColumn: 1,
                 messageId: "expectedLF"
             }]
         },
@@ -90,16 +100,46 @@ ruleTester.run("linebreak-style", rule, {
             errors: [{
                 line: 3,
                 column: 1,
+                endLine: 4,
+                endColumn: 1,
                 messageId: "expectedCRLF"
             },
             {
                 line: 5,
                 column: 1,
+                endLine: 6,
+                endColumn: 1,
                 messageId: "expectedCRLF"
             },
             {
                 line: 6,
                 column: 17,
+                endLine: 7,
+                endColumn: 1,
+                messageId: "expectedCRLF"
+            }]
+        },
+        {
+            code: "\r\n",
+            output: "\n",
+            options: ["unix"],
+            errors: [{
+                line: 1,
+                column: 1,
+                endLine: 2,
+                endColumn: 1,
+                messageId: "expectedLF"
+            }]
+        },
+        {
+            code: "\n",
+            output: "\r\n",
+            options: ["windows"],
+            errors: [{
+                line: 1,
+                column: 1,
+                endLine: 2,
+                endColumn: 1,
                 messageId: "expectedCRLF"
             }]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #12334

Change reported location in the `linebreak-style` rule.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added start of the next line as the `end` location.

Before this change:

![image](https://user-images.githubusercontent.com/44349756/82201830-39164800-9901-11ea-823e-b98815764902.png)

After this change:

![image](https://user-images.githubusercontent.com/44349756/82201922-619e4200-9901-11ea-9300-b191933ec3f8.png)

#### Is there anything you'd like reviewers to focus on?
