### PR TITLE
Fix: report end loc in one-var-declaration-per-line (refs #12334)

### DIFF
--- a/lib/rules/one-var-declaration-per-line.js
+++ b/lib/rules/one-var-declaration-per-line.js
@@ -71,7 +71,7 @@ module.exports = {
                         context.report({
                             node,
                             messageId: "expectVarOnNewline",
-                            loc: current.loc.start,
+                            loc: current.loc,
                             fix: fixer => fixer.insertTextBefore(current, "\n")
                         });
                     }

--- a/tests/lib/rules/one-var-declaration-per-line.js
+++ b/tests/lib/rules/one-var-declaration-per-line.js
@@ -68,6 +68,7 @@ ruleTester.run("one-var-declaration-per-line", rule, {
     ],
 
     invalid: [
+        { code: "var foo, bar;", output: "var foo, \nbar;", options: ["always"], errors: [{ line: 1, column: 10, endLine: 1, endColumn: 13 }] },
         { code: "var a, b;", output: "var a, \nb;", options: ["always"], errors: [errorAt(1, 8)] },
         { code: "let a, b;", output: "let a, \nb;", options: ["always"], parserOptions: { ecmaVersion: 6 }, errors: [errorAt(1, 8)] },
         { code: "var a, b = 0;", output: "var a, \nb = 0;", options: ["always"], errors: [errorAt(1, 8)] },
@@ -76,6 +77,7 @@ ruleTester.run("one-var-declaration-per-line", rule, {
         { code: "let a, b = 0;", output: "let a, \nb = 0;", options: ["always"], parserOptions: { ecmaVersion: 6 }, errors: [errorAt(1, 8)] },
         { code: "const a = 0, b = 0;", output: "const a = 0, \nb = 0;", options: ["always"], parserOptions: { ecmaVersion: 6 }, errors: [errorAt(1, 14)] },
 
+        { code: "var foo, bar, baz = 0;", output: "var foo, bar, \nbaz = 0;", options: ["initializations"], errors: [{ line: 1, column: 15, endLine: 1, endColumn: 22 }] },
         { code: "var a, b, c = 0;", output: "var a, b, \nc = 0;", options: ["initializations"], errors: [errorAt(1, 11)] },
         { code: "var a, b,\nc = 0, d;", output: "var a, b,\nc = 0, \nd;", options: ["initializations"], errors: [errorAt(2, 8)] },
         { code: "var a, b,\nc = 0, d = 0;", output: "var a, b,\nc = 0, \nd = 0;", options: ["initializations"], errors: [errorAt(2, 8)] },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [x] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Other, please explain:

ref #12334

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

added loc.end to report in  `one-var-declaration-per-line`.

#### Is there anything you'd like reviewers to focus on?
