### PR TITLE
Update: padded-blocks loc position changes (refs #12334)

### DIFF
--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -203,10 +203,14 @@ module.exports = {
             }
 
             if (requirePaddingFor(node)) {
+
                 if (!blockHasTopPadding) {
                     context.report({
                         node,
-                        loc: { line: tokenBeforeFirst.loc.start.line, column: tokenBeforeFirst.loc.start.column },
+                        loc: {
+                            start: tokenBeforeFirst.loc.start,
+                            end: firstBlockToken.loc.start
+                        },
                         fix(fixer) {
                             return fixer.insertTextAfter(tokenBeforeFirst, "\n");
                         },
@@ -216,7 +220,10 @@ module.exports = {
                 if (!blockHasBottomPadding) {
                     context.report({
                         node,
-                        loc: { line: tokenAfterLast.loc.end.line, column: tokenAfterLast.loc.end.column - 1 },
+                        loc: {
+                            end: tokenAfterLast.loc.start,
+                            start: lastBlockToken.loc.end
+                        },
                         fix(fixer) {
                             return fixer.insertTextBefore(tokenAfterLast, "\n");
                         },
@@ -228,7 +235,10 @@ module.exports = {
 
                     context.report({
                         node,
-                        loc: { line: tokenBeforeFirst.loc.start.line, column: tokenBeforeFirst.loc.start.column },
+                        loc: {
+                            start: tokenBeforeFirst.loc.start,
+                            end: firstBlockToken.loc.start
+                        },
                         fix(fixer) {
                             return fixer.replaceTextRange([tokenBeforeFirst.range[1], firstBlockToken.range[0] - firstBlockToken.loc.start.column], "\n");
                         },
@@ -240,7 +250,10 @@ module.exports = {
 
                     context.report({
                         node,
-                        loc: { line: tokenAfterLast.loc.end.line, column: tokenAfterLast.loc.end.column - 1 },
+                        loc: {
+                            end: tokenAfterLast.loc.start,
+                            start: lastBlockToken.loc.end
+                        },
                         messageId: "neverPadBlock",
                         fix(fixer) {
                             return fixer.replaceTextRange([lastBlockToken.range[1], tokenAfterLast.range[0] - tokenAfterLast.loc.start.column], "\n");

--- a/tests/lib/rules/padded-blocks.js
+++ b/tests/lib/rules/padded-blocks.js
@@ -36,6 +36,7 @@ ruleTester.run("padded-blocks", rule, {
         { code: "{\n\na();\n\n/* comment */ }", options: ["always"] },
         { code: "{\n\na();\n\n/* comment */ }", options: [{ blocks: "always" }] },
 
+
         { code: "switch (a) {}", options: [{ switches: "always" }] },
         { code: "switch (a) {\n\ncase 0: foo();\ncase 1: bar();\n\n}", options: ["always"] },
         { code: "switch (a) {\n\ncase 0: foo();\ncase 1: bar();\n\n}", options: [{ switches: "always" }] },
@@ -95,7 +96,9 @@ ruleTester.run("padded-blocks", rule, {
                 {
                     messageId: "alwaysPadBlock",
                     line: 1,
-                    column: 1
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 1
                 }
             ]
         },
@@ -106,7 +109,9 @@ ruleTester.run("padded-blocks", rule, {
                 {
                     messageId: "alwaysPadBlock",
                     line: 1,
-                    column: 3
+                    column: 3,
+                    endLine: 2,
+                    endColumn: 1
                 }
             ]
         },
@@ -116,8 +121,10 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "alwaysPadBlock",
-                    line: 5,
-                    column: 1
+                    line: 4,
+                    column: 10,
+                    endLine: 5,
+                    endColumn: 1
                 }
             ]
         },
@@ -127,8 +134,10 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "alwaysPadBlock",
-                    line: 5,
-                    column: 1
+                    line: 4,
+                    column: 10,
+                    endLine: 5,
+                    endColumn: 1
                 }
             ]
         },
@@ -138,7 +147,10 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "alwaysPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 1
                 }
             ]
         },
@@ -148,7 +160,10 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "alwaysPadBlock",
-                    line: 4
+                    line: 3,
+                    column: 5,
+                    endLine: 4,
+                    endColumn: 1
                 }
             ]
         },
@@ -158,11 +173,17 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "alwaysPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 1
                 },
                 {
                     messageId: "alwaysPadBlock",
-                    line: 3
+                    line: 2,
+                    column: 5,
+                    endLine: 3,
+                    endColumn: 1
                 }
             ]
         },
@@ -172,11 +193,17 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "alwaysPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 1
                 },
                 {
                     messageId: "alwaysPadBlock",
-                    line: 3
+                    line: 2,
+                    column: 5,
+                    endLine: 3,
+                    endColumn: 1
                 }
             ]
         },
@@ -186,11 +213,17 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "alwaysPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 1
                 },
                 {
                     messageId: "alwaysPadBlock",
-                    line: 2
+                    line: 2,
+                    column: 5,
+                    endLine: 2,
+                    endColumn: 5
                 }
             ]
         },
@@ -200,11 +233,17 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "alwaysPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 2
                 },
                 {
                     messageId: "alwaysPadBlock",
-                    line: 2
+                    line: 1,
+                    column: 6,
+                    endLine: 2,
+                    endColumn: 1
                 }
             ]
         },
@@ -215,11 +254,17 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "alwaysPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 2
                 },
                 {
                     messageId: "alwaysPadBlock",
-                    line: 2
+                    line: 1,
+                    column: 6,
+                    endLine: 2,
+                    endColumn: 1
                 }
             ]
         },
@@ -231,12 +276,16 @@ ruleTester.run("padded-blocks", rule, {
                 {
                     messageId: "alwaysPadBlock",
                     line: 1,
-                    column: 12
+                    column: 12,
+                    endLine: 2,
+                    endColumn: 1
                 },
                 {
                     messageId: "alwaysPadBlock",
-                    line: 4,
-                    column: 1
+                    line: 3,
+                    column: 15,
+                    endLine: 4,
+                    endColumn: 1
                 }
             ]
         },
@@ -248,12 +297,16 @@ ruleTester.run("padded-blocks", rule, {
                 {
                     messageId: "alwaysPadBlock",
                     line: 1,
-                    column: 12
+                    column: 12,
+                    endLine: 2,
+                    endColumn: 1
                 },
                 {
                     messageId: "alwaysPadBlock",
-                    line: 4,
-                    column: 1
+                    line: 3,
+                    column: 15,
+                    endLine: 4,
+                    endColumn: 1
                 }
             ]
         },
@@ -265,12 +318,16 @@ ruleTester.run("padded-blocks", rule, {
                 {
                     messageId: "alwaysPadBlock",
                     line: 1,
-                    column: 12
+                    column: 12,
+                    endLine: 2,
+                    endColumn: 1
                 },
                 {
                     messageId: "alwaysPadBlock",
-                    line: 4,
-                    column: 1
+                    line: 3,
+                    column: 24,
+                    endLine: 4,
+                    endColumn: 1
                 }
             ]
         },
@@ -283,12 +340,16 @@ ruleTester.run("padded-blocks", rule, {
                 {
                     messageId: "alwaysPadBlock",
                     line: 1,
-                    column: 9
+                    column: 9,
+                    endLine: 2,
+                    endColumn: 1
                 },
                 {
                     messageId: "alwaysPadBlock",
-                    line: 3,
-                    column: 1
+                    line: 2,
+                    column: 16,
+                    endLine: 3,
+                    endColumn: 1
                 }
             ]
         },
@@ -301,12 +362,16 @@ ruleTester.run("padded-blocks", rule, {
                 {
                     messageId: "alwaysPadBlock",
                     line: 1,
-                    column: 9
+                    column: 9,
+                    endLine: 2,
+                    endColumn: 1
                 },
                 {
                     messageId: "alwaysPadBlock",
-                    line: 3,
-                    column: 1
+                    line: 2,
+                    column: 16,
+                    endLine: 3,
+                    endColumn: 1
                 }
             ]
         },
@@ -316,11 +381,17 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "alwaysPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 2
                 },
                 {
                     messageId: "alwaysPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 6
                 }
             ]
         },
@@ -331,7 +402,10 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "neverPadBlock",
-                    line: 5
+                    line: 3,
+                    column: 10,
+                    endLine: 5,
+                    endColumn: 1
                 }
             ]
         },
@@ -342,11 +416,17 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "neverPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 3,
+                    endColumn: 1
                 },
                 {
                     messageId: "neverPadBlock",
-                    line: 5
+                    line: 3,
+                    column: 5,
+                    endLine: 5,
+                    endColumn: 1
                 }
             ]
         },
@@ -357,11 +437,17 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "neverPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 3,
+                    endColumn: 1
                 },
                 {
                     messageId: "neverPadBlock",
-                    line: 5
+                    line: 3,
+                    column: 5,
+                    endLine: 5,
+                    endColumn: 1
                 }
             ]
         },
@@ -372,11 +458,17 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "neverPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 4,
+                    endColumn: 3
                 },
                 {
                     messageId: "neverPadBlock",
-                    line: 7
+                    line: 4,
+                    column: 7,
+                    endLine: 7,
+                    endColumn: 1
                 }
             ]
         },
@@ -387,7 +479,10 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "neverPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 3,
+                    endColumn: 1
                 }
             ]
         },
@@ -398,7 +493,10 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "neverPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 3,
+                    endColumn: 2
                 }
             ]
         },
@@ -409,7 +507,10 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "neverPadBlock",
-                    line: 4
+                    line: 2,
+                    column: 5,
+                    endLine: 4,
+                    endColumn: 1
                 }
             ]
         },
@@ -420,7 +521,10 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "neverPadBlock",
-                    line: 4
+                    line: 2,
+                    column: 9,
+                    endLine: 4,
+                    endColumn: 3
                 }
             ]
         },
@@ -432,7 +536,9 @@ ruleTester.run("padded-blocks", rule, {
                 {
                     messageId: "alwaysPadBlock",
                     line: 1,
-                    column: 1
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 1
                 }
             ]
         },
@@ -444,7 +550,9 @@ ruleTester.run("padded-blocks", rule, {
                 {
                     messageId: "neverPadBlock",
                     line: 1,
-                    column: 1
+                    column: 1,
+                    endLine: 3,
+                    endColumn: 1
                 }
             ]
         },
@@ -456,7 +564,9 @@ ruleTester.run("padded-blocks", rule, {
                 {
                     messageId: "neverPadBlock",
                     line: 1,
-                    column: 1
+                    column: 1,
+                    endLine: 3,
+                    endColumn: 1
                 }
             ]
         },
@@ -468,12 +578,16 @@ ruleTester.run("padded-blocks", rule, {
                 {
                     messageId: "neverPadBlock",
                     line: 1,
-                    column: 12
+                    column: 12,
+                    endLine: 3,
+                    endColumn: 1
                 },
                 {
                     messageId: "neverPadBlock",
-                    line: 5,
-                    column: 1
+                    line: 3,
+                    column: 15,
+                    endLine: 5,
+                    endColumn: 1
                 }
             ]
         },
@@ -485,7 +599,9 @@ ruleTester.run("padded-blocks", rule, {
                 {
                     messageId: "neverPadBlock",
                     line: 1,
-                    column: 12
+                    column: 12,
+                    endLine: 3,
+                    endColumn: 1
                 }
             ]
         },
@@ -496,8 +612,10 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "neverPadBlock",
-                    line: 4,
-                    column: 3
+                    line: 2,
+                    column: 15,
+                    endLine: 4,
+                    endColumn: 3
                 }
             ]
         },
@@ -509,19 +627,31 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "neverPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 9,
+                    endLine: 3,
+                    endColumn: 1
                 },
                 {
                     messageId: "neverPadBlock",
-                    line: 3
+                    line: 3,
+                    column: 14,
+                    endLine: 5,
+                    endColumn: 1
                 },
                 {
                     messageId: "neverPadBlock",
-                    line: 7
+                    line: 5,
+                    column: 7,
+                    endLine: 7,
+                    endColumn: 1
                 },
                 {
                     messageId: "neverPadBlock",
-                    line: 9
+                    line: 7,
+                    column: 2,
+                    endLine: 9,
+                    endColumn: 1
                 }
             ]
         },
@@ -533,11 +663,17 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "neverPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 9,
+                    endLine: 3,
+                    endColumn: 1
                 },
                 {
                     messageId: "neverPadBlock",
-                    line: 9
+                    line: 7,
+                    column: 2,
+                    endLine: 9,
+                    endColumn: 1
                 }
             ]
         },
@@ -549,19 +685,31 @@ ruleTester.run("padded-blocks", rule, {
             errors: [
                 {
                     messageId: "neverPadBlock",
-                    line: 1
+                    line: 1,
+                    column: 9,
+                    endLine: 3,
+                    endColumn: 1
                 },
                 {
                     messageId: "neverPadBlock",
-                    line: 3
+                    line: 3,
+                    column: 14,
+                    endLine: 5,
+                    endColumn: 1
                 },
                 {
                     messageId: "neverPadBlock",
-                    line: 7
+                    line: 5,
+                    column: 7,
+                    endLine: 7,
+                    endColumn: 1
                 },
                 {
                     messageId: "neverPadBlock",
-                    line: 9
+                    line: 7,
+                    column: 2,
+                    endLine: 9,
+                    endColumn: 1
                 }
             ]
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

**BEFORE**
- `always`

![image](https://user-images.githubusercontent.com/26347874/82351080-bb922b00-9a19-11ea-8ec2-55e22ead522e.png)

- `never`

![image](https://user-images.githubusercontent.com/26347874/82351127-cc42a100-9a19-11ea-87ed-da2eae2de9ba.png)

**AFTER**

- `always`

![image](https://user-images.githubusercontent.com/26347874/82351271-014ef380-9a1a-11ea-8c30-9dddb2d13dbe.png)

- `never`

![image](https://user-images.githubusercontent.com/26347874/82351366-1deb2b80-9a1a-11ea-9b6e-7c1001c5415b.png)

#### Is there anything you'd like reviewers to focus on?
refs #12334