### PR TITLE
Fix: max-lines-per-function flagging arrow IIFEs (fixes #13332)

### DIFF
--- a/docs/rules/max-lines-per-function.md
+++ b/docs/rules/max-lines-per-function.md
@@ -165,6 +165,10 @@ Examples of **incorrect** code for this rule with the `{ "IIFEs": true }` option
 (function(){
     var x = 0;
 }());
+
+(() => {
+    var x = 0;
+})();
 ```
 
 Examples of **correct** code for this rule with the `{ "IIFEs": true }` option:
@@ -174,6 +178,10 @@ Examples of **correct** code for this rule with the `{ "IIFEs": true }` option:
 (function(){
     var x = 0;
 }());
+
+(() => {
+    var x = 0;
+})();
 ```
 
 ## When Not To Use It

--- a/lib/rules/max-lines-per-function.js
+++ b/lib/rules/max-lines-per-function.js
@@ -134,7 +134,7 @@ module.exports = {
          * @returns {boolean} True if it's an IIFE
          */
         function isIIFE(node) {
-            return node.type === "FunctionExpression" && node.parent && node.parent.type === "CallExpression" && node.parent.callee === node;
+            return (node.type === "FunctionExpression" || node.type === "ArrowFunctionExpression") && node.parent && node.parent.type === "CallExpression" && node.parent.callee === node;
         }
 
         /**

--- a/tests/lib/rules/max-lines-per-function.js
+++ b/tests/lib/rules/max-lines-per-function.js
@@ -164,6 +164,30 @@ if ( x === y ) {
     return bar;
 }());`,
             options: [{ max: 2, skipComments: true, skipBlankLines: false, IIFEs: false }]
+        },
+
+        // Arrow IIFEs should be recognised if IIFEs: true
+        {
+            code: `(() => {
+    let x = 0;
+    let y = 0;
+    let z = x + y;
+    let foo = {};
+    return bar;
+})();`,
+            options: [{ max: 7, skipComments: true, skipBlankLines: false, IIFEs: true }]
+        },
+
+        // Arrow IIFEs should not be recognised if IIFEs: false
+        {
+            code: `(() => {
+    let x = 0;
+    let y = 0;
+    let z = x + y;
+    let foo = {};
+    return bar;
+})();`,
+            options: [{ max: 2, skipComments: true, skipBlankLines: false, IIFEs: false }]
         }
     ],
 
@@ -434,6 +458,21 @@ if ( x === y ) {
             options: [{ max: 2, skipComments: true, skipBlankLines: false, IIFEs: true }],
             errors: [
                 { messageId: "exceed", data: { name: "Function", lineCount: 7, maxLines: 2 } }
+            ]
+        },
+
+        // Test the IIFEs option includes arrow IIFEs
+        {
+            code: `(() => {
+    let x = 0;
+    let y = 0;
+    let z = x + y;
+    let foo = {};
+    return bar;
+})();`,
+            options: [{ max: 2, skipComments: true, skipBlankLines: false, IIFEs: true }],
+            errors: [
+                { messageId: "exceed", data: { name: "Arrow function", lineCount: 7, maxLines: 2 } }
             ]
         }
     ]


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #13332.

#### What changes did you make? (Give an overview)
Include a check if the node is an `ArrowFunctionExpression` in `isIIFE` in max-lines-per-function.

#### Is there anything you'd like reviewers to focus on?
No.