### PR TITLE
Chore: update no-unused-vars caughtErrors in eslint-config-eslint

### DIFF
--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -403,7 +403,7 @@ function getCacheFile(cacheFile, cwd) {
 
     try {
         fileStats = fs.lstatSync(resolvedCacheFile);
-    } catch (ex) {
+    } catch {
         fileStats = null;
     }
 
@@ -991,7 +991,7 @@ class CLIEngine {
                     const npmFormat = naming.normalizePackageName(normalizedFormatName, "eslint-formatter");
 
                     formatterPath = ModuleResolver.resolve(npmFormat, path.join(cwd, "__placeholder__.js"));
-                } catch (e) {
+                } catch {
                     formatterPath = path.resolve(__dirname, "formatters", normalizedFormatName);
                 }
             }

--- a/lib/cli-engine/config-array-factory.js
+++ b/lib/cli-engine/config-array-factory.js
@@ -517,7 +517,7 @@ class ConfigArrayFactory {
                     try {
                         loadPackageJSONConfigFile(filePath);
                         return filePath;
-                    } catch (error) { /* ignore */ }
+                    } catch { /* ignore */ }
                 } else {
                     return filePath;
                 }

--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -350,7 +350,7 @@ function getLocalESLintVersion() {
         const eslint = require(eslintPath);
 
         return eslint.linter.version || null;
-    } catch (_err) {
+    } catch {
         return null;
     }
 }

--- a/lib/linter/config-comment-parser.js
+++ b/lib/linter/config-comment-parser.js
@@ -78,7 +78,7 @@ module.exports = class ConfigCommentParser {
                     config: items
                 };
             }
-        } catch (ex) {
+        } catch {
 
             debug("Levn parsing failed; falling back to manual parsing.");
 

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -35,7 +35,7 @@ const collector = new (class {
         try {
             this._source = regexpStr;
             this._validator.validatePattern(regexpStr); // Call onCharacter hook
-        } catch (err) {
+        } catch {
 
             // Ignore syntax errors in RegExp.
         }

--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -93,7 +93,7 @@ module.exports = {
             try {
                 validator.validateFlags(flags);
                 return null;
-            } catch (err) {
+            } catch {
                 return `Invalid flags supplied to RegExp constructor '${flags}'`;
             }
         }

--- a/lib/rules/no-misleading-character-class.js
+++ b/lib/rules/no-misleading-character-class.js
@@ -147,7 +147,7 @@ module.exports = {
                     pattern.length,
                     flags.includes("u")
                 );
-            } catch (e) {
+            } catch {
 
                 // Ignore regular expressions with syntax errors
                 return;

--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -76,7 +76,7 @@ module.exports = {
 
             try {
                 regExpAST = regExpParser.parsePattern(pattern, 0, pattern.length, flags.includes("u"));
-            } catch (e) {
+            } catch {
 
                 // Ignore regular expressions with syntax errors
                 return;

--- a/lib/rules/no-useless-backreference.js
+++ b/lib/rules/no-useless-backreference.js
@@ -95,7 +95,7 @@ module.exports = {
 
             try {
                 regExpAST = parser.parsePattern(pattern, 0, pattern.length, flags.includes("u"));
-            } catch (e) {
+            } catch {
 
                 // Ignore regular expressions with syntax errors
                 return;

--- a/lib/rules/prefer-named-capture-group.js
+++ b/lib/rules/prefer-named-capture-group.js
@@ -59,7 +59,7 @@ module.exports = {
 
             try {
                 ast = parser.parsePattern(pattern, 0, pattern.length, uFlag);
-            } catch (_) {
+            } catch {
 
                 // ignore regex syntax errors
                 return;

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -154,7 +154,7 @@ module.exports = {
 
                 try {
                     tokens = espree.tokenize(key.value);
-                } catch (e) {
+                } catch {
                     return;
                 }
 
@@ -239,7 +239,7 @@ module.exports = {
 
                         try {
                             tokens = espree.tokenize(key.value);
-                        } catch (e) {
+                        } catch {
                             necessaryQuotes = true;
                             return;
                         }

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1415,7 +1415,7 @@ module.exports = {
 
             try {
                 tokens = espree.tokenize(leftValue, espreeOptions);
-            } catch (e) {
+            } catch {
                 return false;
             }
 
@@ -1444,7 +1444,7 @@ module.exports = {
 
             try {
                 tokens = espree.tokenize(rightValue, espreeOptions);
-            } catch (e) {
+            } catch {
                 return false;
             }
 

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -134,7 +134,7 @@ rules:
     no-unmodified-loop-condition: "error"
     no-unneeded-ternary: "error"
     no-unused-expressions: "error"
-    no-unused-vars: ["error", {vars: "all", args: "after-used"}]
+    no-unused-vars: ["error", {vars: "all", args: "after-used", caughtErrors: "all"}]
     no-use-before-define: "error"
     no-useless-call: "error"
     no-useless-computed-key: "error"

--- a/tests/_utils/in-memory-fs.js
+++ b/tests/_utils/in-memory-fs.js
@@ -111,7 +111,7 @@ const context = vm.createContext();
 function isExistingFile(fs, filePath) {
     try {
         return fs.statSync(filePath).isFile();
-    } catch (error) {
+    } catch {
         return false;
     }
 }

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -58,7 +58,7 @@ describe("CLIEngine", () => {
 
         try {
             return fs.realpathSync(filepath);
-        } catch (e) {
+        } catch {
             return filepath;
         }
     }
@@ -2161,7 +2161,7 @@ describe("CLIEngine", () => {
             function doDelete(filePath) {
                 try {
                     fs.unlinkSync(filePath);
-                } catch (ex) {
+                } catch {
 
                     /*
                      * we don't care if the file didn't exist, since our
@@ -2197,7 +2197,7 @@ describe("CLIEngine", () => {
                 function deleteCacheDir() {
                     try {
                         fs.unlinkSync("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory");
-                    } catch (ex) {
+                    } catch {
 
                         /*
                          * we don't care if the file didn't exist, since our

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -55,7 +55,7 @@ describe("ESLint", () => {
 
         try {
             return fs.realpathSync(filepath);
-        } catch (e) {
+        } catch {
             return filepath;
         }
     }
@@ -2102,7 +2102,7 @@ describe("ESLint", () => {
             function doDelete(filePath) {
                 try {
                     fs.unlinkSync(filePath);
-                } catch (ex) {
+                } catch {
 
                     /*
                      * we don't care if the file didn't exist, since our
@@ -2138,7 +2138,7 @@ describe("ESLint", () => {
                 function deleteCacheDir() {
                     try {
                         fs.unlinkSync("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory");
-                    } catch (ex) {
+                    } catch {
 
                         /*
                          * we don't care if the file didn't exist, since our

--- a/tests/lib/init/config-initializer.js
+++ b/tests/lib/init/config-initializer.js
@@ -67,7 +67,7 @@ describe("configInitializer", () => {
 
         try {
             return fs.realpathSync(filepath);
-        } catch (e) {
+        } catch {
             return filepath;
         }
     }

--- a/tests/lib/init/source-code-utils.js
+++ b/tests/lib/init/source-code-utils.js
@@ -41,7 +41,7 @@ describe("SourceCodeUtil", () => {
         try {
             filepath = fs.realpathSync(filepath);
             return filepath;
-        } catch (e) {
+        } catch {
             return filepath;
         }
     }

--- a/tools/code-sample-minimizer.js
+++ b/tools/code-sample-minimizer.js
@@ -76,7 +76,7 @@ function reduceBadExampleSize({
     function reproducesBadCase(updatedSourceText) {
         try {
             parser.parse(updatedSourceText);
-        } catch (err) {
+        } catch {
             return false;
         }
 

--- a/tools/eslint-fuzzer.js
+++ b/tools/eslint-fuzzer.js
@@ -65,7 +65,7 @@ function fuzz(options) {
 
             try {
                 fixResult = linter.verifyAndFix(text, reducedConfig, {});
-            } catch (err) {
+            } catch {
                 return reducedConfig;
             }
 
@@ -91,7 +91,7 @@ function fuzz(options) {
 
             try {
                 messages = linter.verify(currentText, config);
-            } catch (err) {
+            } catch {
                 return currentText;
             }
 
@@ -150,7 +150,7 @@ function fuzz(options) {
                     try {
                         linter.verify(reducedText, smallConfig);
                         return false;
-                    } catch (_) {
+                    } catch {
                         return true;
                     }
                 }
@@ -172,7 +172,7 @@ function fuzz(options) {
                         const smallFixResult = linter.verifyAndFix(reducedText, smallConfig);
 
                         return smallFixResult.fixed && smallFixResult.messages.length === 1 && smallFixResult.messages[0].fatal;
-                    } catch (_) {
+                    } catch {
                         return false;
                     }
                 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

Updates `eslint-config-eslint`

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added `caughtErrors: "all"` to `no-unused-vars` in order to enforce omission of catch binding in cases where the caught error  would not be used.

#### Is there anything you'd like reviewers to focus on?

Does this change make sense? Also, please verify that all supported Node versions support optional catch binding.
