### PR TITLE
Fix: Add required error var (fixes #13352)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -90,7 +90,7 @@ function getErrorMessage(error) {
             const template = lodash.template(templateText);
 
             return template(error.messageData || {});
-        } catch {
+        } catch (e) {
 
             // Ignore template error then fallback to use `error.stack`.
         }


### PR DESCRIPTION
Fixes #13352.

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added useless but strictly-speaking syntactically required error var `e` to a try … catch block in eslint.js

#### Is there anything you'd like reviewers to focus on?

There are a few other try … catch blocks in the codebase that don't have an error var but they are mostly in strings. I wasn't sure if I should touch those or not.