### PR TITLE
Wrongly report BigInt as not defined

### DIFF
--- a/conf/environments.js
+++ b/conf/environments.js
@@ -53,7 +53,7 @@ module.exports = new Map(Object.entries({
 
     // Language
     builtin: {
-        globals: globals.es5
+        globals: globals.builtin
     },
     es6: {
         globals: newGlobals2015,

--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -59,6 +59,7 @@ ruleTester.run("no-undef", rule, {
         { code: "requestIdleCallback;", env: { browser: true } },
         { code: "customElements;", env: { browser: true } },
         { code: "PromiseRejectionEvent;", env: { browser: true } },
+        { code: "BigInt;", env: { browser: true } },
 
         // Notifications of readonly are removed: https://github.com/eslint/eslint/issues/4504
         "/*global b:false*/ function f() { b = 1; }",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Add the test for `BigInt` global in `"no-undef"` with the `"browser"` environment. The test wrongly fail and report `BigInt` as `undefined`.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I noticed a wrongful report of `BigInt` in my code and decide to test directly on the eslint source-code. After adding the test for `BigInt` in `"not-undef"`, the error `"'BigInt' is not defined."` is wrongfully raised.


#### Is there anything you'd like reviewers to focus on?

I can see that `BigInt` are defined under the environment `"es2020"`. But why does the eslint builtins list is `"es5"` ?