### PR TITLE
Update: enable es2020 environment in --init

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -265,11 +265,7 @@ function processAnswers(answers) {
     };
 
     config.parserOptions.ecmaVersion = espree.latestEcmaVersion;
-    config.env.es6 = true;
-    config.globals = {
-        Atomics: "readonly",
-        SharedArrayBuffer: "readonly"
-    };
+    config.env.es2020 = true;
 
     // set the module type
     if (answers.moduleType === "esm") {

--- a/tests/lib/init/config-initializer.js
+++ b/tests/lib/init/config-initializer.js
@@ -136,9 +136,7 @@ describe("configInitializer", () => {
                 assert.deepStrictEqual(config.rules.quotes, ["error", "single"]);
                 assert.deepStrictEqual(config.rules["linebreak-style"], ["error", "unix"]);
                 assert.deepStrictEqual(config.rules.semi, ["error", "always"]);
-                assert.strictEqual(config.env.es6, true);
-                assert.strictEqual(config.globals.Atomics, "readonly");
-                assert.strictEqual(config.globals.SharedArrayBuffer, "readonly");
+                assert.strictEqual(config.env.es2020, true);
                 assert.strictEqual(config.parserOptions.ecmaVersion, espree.latestEcmaVersion);
                 assert.strictEqual(config.parserOptions.sourceType, "module");
                 assert.strictEqual(config.env.browser, true);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

Updates `--init` behavior.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`--init` will now enable the latest `es2020` env, instead of `es6` env + `es2017` globals.

#### Is there anything you'd like reviewers to focus on?

Does it make sense to enable the latest es environment in new projects? `--init` is already setting the latest `ecmaVersion`.