### PR TITLE
Update: semi-spacing should check do-while statements

### DIFF
--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -223,6 +223,7 @@ module.exports = {
             BreakStatement: checkNode,
             ContinueStatement: checkNode,
             DebuggerStatement: checkNode,
+            DoWhileStatement: checkNode,
             ReturnStatement: checkNode,
             ThrowStatement: checkNode,
             ImportDeclaration: checkNode,

--- a/tests/lib/rules/semi-spacing.js
+++ b/tests/lib/rules/semi-spacing.js
@@ -55,7 +55,9 @@ ruleTester.run("semi-spacing", rule, {
         "function foo(){return 2;}",
         "for(var i = 0; i < results.length;) {}",
         { code: "function foo() { return 2; }", options: [{ after: false }] },
-        { code: "for ( var i = 0;i < results.length; ) {}", options: [{ after: false }] }
+        { code: "for ( var i = 0;i < results.length; ) {}", options: [{ after: false }] },
+
+        "do {} while (true); foo"
     ],
     invalid: [
         {
@@ -370,6 +372,51 @@ ruleTester.run("semi-spacing", rule, {
                 endColumn: 7
             }
             ]
+        },
+        {
+            code: "do {} while (true) ;",
+            output: "do {} while (true);",
+            errors: [{
+                messageId: "unexpectedWhitespaceBefore",
+                type: "DoWhileStatement",
+                line: 1,
+                column: 19,
+                endLine: 1,
+                endColumn: 20
+            }]
+        },
+        {
+            code: "do {} while (true);foo",
+            output: "do {} while (true); foo",
+            errors: [{
+                messageId: "missingWhitespaceAfter",
+                type: "DoWhileStatement",
+                line: 1,
+                column: 19,
+                endLine: 1,
+                endColumn: 20
+            }]
+        },
+        {
+            code: "do {} while (true);  foo",
+            output: "do {} while (true) ;foo",
+            options: [{ before: true, after: false }],
+            errors: [{
+                messageId: "missingWhitespaceBefore",
+                type: "DoWhileStatement",
+                line: 1,
+                column: 19,
+                endLine: 1,
+                endColumn: 20
+            },
+            {
+                messageId: "unexpectedWhitespaceAfter",
+                type: "DoWhileStatement",
+                line: 1,
+                column: 20,
+                endLine: 1,
+                endColumn: 22
+            }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

This bug fix can produce **more** warnings.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.1.0
* **Node Version:** v12.14.0
* **npm Version:** v6.13.4

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
      ecmaVersion: 2015
  }
}
```
</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IHNlbWktc3BhY2luZzogXCJlcnJvclwiICovXG5cbmRvIHtcbn0gd2hpbGUoZm9vKSA7XG4iLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjUsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=)

```js
/* eslint semi-spacing: "error" */

do {
} while(foo) ;
```

**What did you expect to happen?**

1 error - unexpected whitespace before semicolon

**What actually happened? Please include the actual, raw output from ESLint.**

No errors.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added `DoWhileStatement` to the list of nodes.

#### Is there anything you'd like reviewers to focus on?

I searched through the history and couldn't find anything about was this intentionally omitted. I don't think there's another rule that could cause possible conflicts (i.e., another rule that controls these spaces).