### PR TITLE
Update: Improve location for no-mixed-spaces-and-tabs (refs #12334)

### DIFF
--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -67,7 +67,7 @@ module.exports = {
                  * or the reverse before non-tab/-space
                  * characters begin.
                  */
-                let regex = /^(?=[\t ]*(\t | \t))/u;
+                let regex = /^(?=( +|\t+))\1(?:\t| )/u;
 
                 if (smartTabs) {
 
@@ -75,19 +75,27 @@ module.exports = {
                      * At least one space followed by a tab
                      * before non-tab/-space characters begin.
                      */
-                    regex = /^(?=[\t ]* \t)/u;
+                    regex = /^(?=(\t*))\1(?=( +))\2\t/u;
                 }
 
                 lines.forEach((line, i) => {
                     const match = regex.exec(line);
 
                     if (match) {
-                        const lineNumber = i + 1,
-                            column = match.index + 1,
-                            loc = { line: lineNumber, column };
+                        const lineNumber = i + 1;
+                        const loc = {
+                            start: {
+                                line: lineNumber,
+                                column: match[0].length - 2
+                            },
+                            end: {
+                                line: lineNumber,
+                                column: match[0].length
+                            }
+                        };
 
                         if (!ignoredCommentLines.has(lineNumber)) {
-                            const containingNode = sourceCode.getNodeByRangeIndex(sourceCode.getIndexFromLoc(loc));
+                            const containingNode = sourceCode.getNodeByRangeIndex(sourceCode.getIndexFromLoc(loc.start));
 
                             if (!(containingNode && ["Literal", "TemplateElement"].includes(containingNode.type))) {
                                 context.report({

--- a/tests/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/tests/lib/rules/no-mixed-spaces-and-tabs.js
@@ -20,8 +20,15 @@ const ruleTester = new RuleTester();
 ruleTester.run("no-mixed-spaces-and-tabs", rule, {
 
     valid: [
+        "foo",
+        "foo \t",
+        "foo\t ",
         "\tvar x = 5;",
+        "\t\tvar x = 5;",
+        " var x = 5;",
         "    var x = 5;",
+        " foo\t",
+        "\tfoo ",
         "\t/*\n\t * Hello\n\t */",
         "// foo\n\t/**\n\t * Hello\n\t */",
         "/*\n\n \t \n*/",
@@ -80,6 +87,50 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
         {
             code: "\tvar x = 5,\n\t    y = 2;",
             options: ["smart-tabs"]
+        },
+        {
+            code: "\t\t\t   foo",
+            options: ["smart-tabs"]
+        },
+        {
+            code: "foo",
+            options: ["smart-tabs"]
+        },
+        {
+            code: "foo \t",
+            options: ["smart-tabs"]
+        },
+        {
+            code: "foo\t ",
+            options: ["smart-tabs"]
+        },
+        {
+            code: "\tfoo \t",
+            options: ["smart-tabs"]
+        },
+        {
+            code: "\tvar x = 5;",
+            options: ["smart-tabs"]
+        },
+        {
+            code: "\t\tvar x = 5;",
+            options: ["smart-tabs"]
+        },
+        {
+            code: " var x = 5;",
+            options: ["smart-tabs"]
+        },
+        {
+            code: "    var x = 5;",
+            options: ["smart-tabs"]
+        },
+        {
+            code: " foo\t",
+            options: ["smart-tabs"]
+        },
+        {
+            code: "\tfoo ",
+            options: ["smart-tabs"]
         }
     ],
 
@@ -90,7 +141,10 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                 {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
-                    line: 2
+                    line: 2,
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 3
                 }
             ]
         },
@@ -100,7 +154,10 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                 {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 3
                 }
             ]
         },
@@ -110,7 +167,10 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                 {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 3
                 }
             ]
         },
@@ -120,7 +180,10 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                 {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 3
                 }
             ]
         },
@@ -130,7 +193,10 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                 {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 3
                 }
             ]
         },
@@ -140,7 +206,10 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                 {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 3
                 }
             ]
         },
@@ -150,7 +219,10 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                 {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
-                    line: 2
+                    line: 2,
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 3
                 }
             ]
         },
@@ -160,12 +232,18 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                 {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
-                    line: 1
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 3
                 },
                 {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
-                    line: 3
+                    line: 3,
+                    column: 1,
+                    endLine: 3,
+                    endColumn: 3
                 }
             ]
         },
@@ -176,7 +254,10 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                 {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
-                    line: 2
+                    line: 2,
+                    column: 2,
+                    endLine: 2,
+                    endColumn: 4
                 }
             ]
         },
@@ -187,7 +268,10 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                 {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
-                    line: 2
+                    line: 2,
+                    column: 2,
+                    endLine: 2,
+                    endColumn: 4
                 }
             ]
         },
@@ -200,7 +284,9 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 2,
-                    column: 2
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 3
                 }
             ]
         },
@@ -212,7 +298,9 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
                     line: 2,
-                    column: 2
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 3
                 }
             ]
         },
@@ -222,7 +310,10 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                 {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
-                    line: 1
+                    line: 1,
+                    column: 2,
+                    endLine: 1,
+                    endColumn: 4
                 }
             ]
         },
@@ -232,7 +323,64 @@ ruleTester.run("no-mixed-spaces-and-tabs", rule, {
                 {
                     messageId: "mixedSpacesAndTabs",
                     type: "Program",
-                    line: 2
+                    line: 2,
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 3
+                }
+            ]
+        },
+        {
+            code: "   \tfoo",
+            errors: [
+                {
+                    messageId: "mixedSpacesAndTabs",
+                    type: "Program",
+                    line: 1,
+                    column: 3,
+                    endLine: 1,
+                    endColumn: 5
+                }
+            ]
+        },
+        {
+            code: "\t\t\t foo",
+            errors: [
+                {
+                    messageId: "mixedSpacesAndTabs",
+                    type: "Program",
+                    line: 1,
+                    column: 3,
+                    endLine: 1,
+                    endColumn: 5
+                }
+            ]
+        },
+        {
+            code: "\t \tfoo",
+            options: ["smart-tabs"],
+            errors: [
+                {
+                    messageId: "mixedSpacesAndTabs",
+                    type: "Program",
+                    line: 1,
+                    column: 2,
+                    endLine: 1,
+                    endColumn: 4
+                }
+            ]
+        },
+        {
+            code: "\t\t\t   \tfoo",
+            options: ["smart-tabs"],
+            errors: [
+                {
+                    messageId: "mixedSpacesAndTabs",
+                    type: "Program",
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 8
                 }
             ]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

This PR changes reported location in the `no-mixed-spaces-and-tabs` rule.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The rule used to always report the same column: 1 (0-based), which looks like a bug. Also, it didn't report `end` loc.

Now, it will report the range of the first space-tab or tab-space pair, so it will underline both the space and the tab.

Before this change:

![image](https://user-images.githubusercontent.com/44349756/82950642-eb0adf80-9fa5-11ea-9b8a-ece02eedacbd.png)

After this change:

![image](https://user-images.githubusercontent.com/44349756/82950736-20173200-9fa6-11ea-84b8-5bb255d05be5.png)

#### Is there anything you'd like reviewers to focus on?
