### PR TITLE
Added explanation regarding maxEOF when the eol-last rule is used (fixes Issue #12742)

### DIFF
--- a/docs/rules/no-multiple-empty-lines.md
+++ b/docs/rules/no-multiple-empty-lines.md
@@ -10,9 +10,9 @@ This rule aims to reduce the scrolling required when reading through your code. 
 
 This rule has an object option:
 
-* `"max"` (default: `2`) enforces a maximum number of consecutive empty lines.
-* `"maxEOF"` enforces a maximum number of consecutive empty lines at the end of files.
-* `"maxBOF"` enforces a maximum number of consecutive empty lines at the beginning of files.
+-   `"max"` (default: `2`) enforces a maximum number of consecutive empty lines.
+-   `"maxEOF"` enforces a maximum number of consecutive empty lines at the end of files.
+-   `"maxBOF"` enforces a maximum number of consecutive empty lines at the beginning of files.
 
 ### max
 
@@ -23,8 +23,6 @@ Examples of **incorrect** code for this rule with the default `{ "max": 2 }` opt
 
 var foo = 5;
 
-
-
 var bar = 3;
 ```
 
@@ -34,7 +32,6 @@ Examples of **correct** code for this rule with the default `{ "max": 2 }` optio
 /*eslint no-multiple-empty-lines: "error"*/
 
 var foo = 5;
-
 
 var bar = 3;
 ```
@@ -48,10 +45,7 @@ Examples of **incorrect** code for this rule with the `{ max: 2, maxEOF: 1 }` op
 
 var foo = 5;
 
-
 var bar = 3;
-
-
 ```
 
 Examples of **correct** code for this rule with the `{ max: 2, maxEOF: 1 }` options:
@@ -61,9 +55,7 @@ Examples of **correct** code for this rule with the `{ max: 2, maxEOF: 1 }` opti
 
 var foo = 5;
 
-
 var bar = 3;
-
 ```
 
 ### maxBOF
@@ -73,9 +65,7 @@ Examples of **incorrect** code for this rule with the `{ max: 2, maxBOF: 1 }` op
 ```js
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxBOF": 1 }]*/
 
-
 var foo = 5;
-
 
 var bar = 3;
 ```
@@ -87,10 +77,13 @@ Examples of **correct** code for this rule with the `{ max: 2, maxBOF: 1 }` opti
 
 var foo = 5;
 
-
 var bar = 3;
 ```
 
 ## When Not To Use It
 
 If you do not care about extra blank lines, turn this off.
+
+## Regarding the Airbnb JavaScript Style Guide `eol-last` rule
+
+If you wish to use the Airbnb style guide rule regarding ending files with a single newline character (`eol-last`), `maxEOF` should be set to 0, as an empty line is actually represented by two newline characters (`\n\n`). There is no empty line at the end of a file after the last `\n`, although editors may show an additional line.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
I added an explanation regarding how and why `"maxEOF": 0` should be used for the rule `no-multiple-empty-lines` when it is used with the `eol-last` rule from the Airbnb style guide based on the comments on the discussion on this issue..

#### Is there anything you'd like reviewers to focus on?
