### PR TITLE
Update: object-property-newline end location (refs #12334)

### DIFF
--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -77,7 +77,7 @@ module.exports = {
                     if (lastTokenOfPreviousProperty.loc.end.line === firstTokenOfCurrentProperty.loc.start.line) {
                         context.report({
                             node,
-                            loc: firstTokenOfCurrentProperty.loc.start,
+                            loc: firstTokenOfCurrentProperty.loc,
                             messageId,
                             fix(fixer) {
                                 const comma = sourceCode.getTokenBefore(firstTokenOfCurrentProperty);

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -598,7 +598,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 3,
-                    column: 13
+                    column: 13,
+                    endLine: 3,
+                    endColumn: 15
                 }
             ]
         },

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -78,13 +78,31 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 25
+                    column: 25,
+                    endLine: 1,
+                    endColumn: 27
                 },
                 {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 37
+                    column: 37,
+                    endLine: 1,
+                    endColumn: 39
+                }
+            ]
+        },
+        {
+            code: "var obj = { k1: 'val1', k2: \n'val2', \nk3: 'val3' };",
+            output: "var obj = { k1: 'val1',\nk2: \n'val2', \nk3: 'val3' };",
+            errors: [
+                {
+                    messageId: "propertiesOnNewline",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 25,
+                    endLine: 1,
+                    endColumn: 27
                 }
             ]
         },
@@ -96,7 +114,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 13
+                    column: 13,
+                    endLine: 2,
+                    endColumn: 15
                 }
             ]
         },
@@ -108,13 +128,17 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 13
+                    column: 13,
+                    endLine: 2,
+                    endColumn: 15
                 },
                 {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 3,
-                    column: 13
+                    column: 13,
+                    endLine: 3,
+                    endColumn: 15
                 }
             ]
         },
@@ -126,7 +150,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 32
+                    column: 32,
+                    endLine: 1,
+                    endColumn: 34
                 }
             ]
         },
@@ -138,7 +164,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 3,
-                    column: 4
+                    column: 4,
+                    endLine: 3,
+                    endColumn: 6
                 }
             ]
         },
@@ -150,19 +178,25 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 13
+                    column: 13,
+                    endLine: 2,
+                    endColumn: 15
                 },
                 {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 29
+                    column: 29,
+                    endLine: 2,
+                    endColumn: 31
                 },
                 {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 41
+                    column: 41,
+                    endLine: 2,
+                    endColumn: 43
                 }
             ]
         },
@@ -174,7 +208,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 3,
-                    column: 17
+                    column: 17,
+                    endLine: 3,
+                    endColumn: 19
                 }
             ]
         },
@@ -186,7 +222,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 4,
-                    column: 4
+                    column: 4,
+                    endLine: 4,
+                    endColumn: 6
                 }
             ]
         },
@@ -199,7 +237,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 25
+                    column: 25,
+                    endLine: 1,
+                    endColumn: 26
                 }
             ]
         },
@@ -212,7 +252,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 25
+                    column: 25,
+                    endLine: 1,
+                    endColumn: 28
                 }
             ]
         },
@@ -225,7 +267,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 13
+                    column: 13,
+                    endLine: 2,
+                    endColumn: 16
                 }
             ]
         },
@@ -237,7 +281,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 19
+                    column: 19,
+                    endLine: 1,
+                    endColumn: 21
                 }
             ]
         },
@@ -249,7 +295,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 13
+                    column: 13,
+                    endLine: 2,
+                    endColumn: 15
                 }
             ]
         },
@@ -262,7 +310,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 10
+                    column: 10,
+                    endLine: 1,
+                    endColumn: 11
                 }
             ]
         },
@@ -275,7 +325,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 4
+                    column: 4,
+                    endLine: 2,
+                    endColumn: 5
                 }
             ]
         },
@@ -288,7 +340,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 11
+                    column: 11,
+                    endLine: 2,
+                    endColumn: 14
                 }
             ]
         },
@@ -301,7 +355,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 15
+                    column: 15,
+                    endLine: 2,
+                    endColumn: 18
                 }
             ]
         },
@@ -314,7 +370,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 19
+                    column: 19,
+                    endLine: 1,
+                    endColumn: 20
                 }
             ]
         },
@@ -327,7 +385,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 19
+                    column: 19,
+                    endLine: 1,
+                    endColumn: 22
                 }
             ]
         },
@@ -340,7 +400,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 13
+                    column: 13,
+                    endLine: 2,
+                    endColumn: 16
                 }
             ]
         },
@@ -352,7 +414,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 5,
-                    column: 4
+                    column: 4,
+                    endLine: 5,
+                    endColumn: 5
                 }
             ]
         },
@@ -364,7 +428,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 26
+                    column: 26,
+                    endLine: 1,
+                    endColumn: 29
                 }
             ]
         },
@@ -376,7 +442,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewline",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 26
+                    column: 26,
+                    endLine: 1,
+                    endColumn: 29
                 }
             ]
         },
@@ -391,7 +459,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 3,
-                    column: 13
+                    column: 13,
+                    endLine: 3,
+                    endColumn: 15
                 }
             ]
         },
@@ -404,13 +474,17 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 3,
-                    column: 9
+                    column: 9,
+                    endLine: 3,
+                    endColumn: 11
                 },
                 {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 3,
-                    column: 21
+                    column: 21,
+                    endLine: 3,
+                    endColumn: 23
                 }
             ]
         },
@@ -423,7 +497,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 4,
-                    column: 4
+                    column: 4,
+                    endLine: 4,
+                    endColumn: 6
                 }
             ]
         },
@@ -436,7 +512,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 3,
-                    column: 4
+                    column: 4,
+                    endLine: 3,
+                    endColumn: 6
                 }
             ]
         },
@@ -449,13 +527,17 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 13
+                    column: 13,
+                    endLine: 2,
+                    endColumn: 15
                 },
                 {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 4,
-                    column: 4
+                    column: 4,
+                    endLine: 4,
+                    endColumn: 6
                 }
             ]
         },
@@ -468,7 +550,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 4,
-                    column: 4
+                    column: 4,
+                    endLine: 4,
+                    endColumn: 6
                 }
             ]
         },
@@ -482,7 +566,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 14
+                    column: 14,
+                    endLine: 2,
+                    endColumn: 16
                 }
             ]
         },
@@ -496,7 +582,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 3,
-                    column: 13
+                    column: 13,
+                    endLine: 3,
+                    endColumn: 16
                 }
             ]
         },
@@ -524,7 +612,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 2,
-                    column: 14
+                    column: 14,
+                    endLine: 2,
+                    endColumn: 16
                 }
             ]
         },
@@ -538,7 +628,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 3,
-                    column: 13
+                    column: 13,
+                    endLine: 3,
+                    endColumn: 16
                 }
             ]
         },
@@ -552,7 +644,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 3,
-                    column: 13
+                    column: 13,
+                    endLine: 3,
+                    endColumn: 15
                 }
             ]
         },
@@ -567,7 +661,9 @@ ruleTester.run("object-property-newline", rule, {
                     messageId: "propertiesOnNewlineAll",
                     type: "ObjectExpression",
                     line: 3,
-                    column: 13
+                    column: 13,
+                    endLine: 3,
+                    endColumn: 15
                 }
             ]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

removed the `.start` of the reporting location to include both `start` and `end` as well.

#### Is there anything you'd like reviewers to focus on?

Currently, the location of the key is being reported (both in master and in this PR)
Will it make sense to report the leading whitespace?

like this

![image](https://user-images.githubusercontent.com/26347874/83948344-57090580-a83a-11ea-898b-9e3b67a90034.png)

by replacing the `loc`

```js

loc: {
   start: comma.loc.end,
  end: firstTokenOfCurrentProperty.loc.start
}
```
