### PR TITLE
fix: func-call-spacing removal of comments (refs #13319)

### DIFF
--- a/lib/rules/func-call-spacing.js
+++ b/lib/rules/func-call-spacing.js
@@ -134,9 +134,10 @@ module.exports = {
                             if (sourceCode.commentsExistBetween(leftToken, rightToken)) {
                                 const comments = sourceCode.getCommentsBefore(rightToken);
 
-                                return [
-                                    fixer.removeRange([leftToken.range[1], comments[0].range[0]]),
-                                    fixer.removeRange([comments[comments.length - 1].range[1], rightToken.range[0]])];
+                                return fixer.replaceTextRange(
+                                    [leftToken.range[1], rightToken.range[0]],
+                                    comments.reduce((prevComment, nextComment) => prevComment + sourceCode.getText(nextComment), "")
+                                );
                             }
 
                             return fixer.removeRange([leftToken.range[1], rightToken.range[0]]);

--- a/lib/rules/func-call-spacing.js
+++ b/lib/rules/func-call-spacing.js
@@ -131,6 +131,14 @@ module.exports = {
                          * https://github.com/eslint/eslint/issues/7787
                          */
                         if (!hasNewline) {
+                            if (sourceCode.commentsExistBetween(leftToken, rightToken)) {
+                                const comments = sourceCode.getCommentsBefore(rightToken);
+
+                                return [
+                                    fixer.removeRange([leftToken.range[1], comments[0].range[0]]),
+                                    fixer.removeRange([comments[comments.length - 1].range[1], rightToken.range[0]])];
+                            }
+
                             return fixer.removeRange([leftToken.range[1], rightToken.range[0]]);
                         }
 

--- a/tests/lib/rules/func-call-spacing.js
+++ b/tests/lib/rules/func-call-spacing.js
@@ -224,6 +224,27 @@ ruleTester.run("func-call-spacing", rule, {
 
         // default ("never")
         {
+            code: "f     /**/ ();",
+            output: "f/**/();",
+            errors: [
+                { messageId: "unexpectedWhitespace", type: "CallExpression" }
+            ]
+        },
+        {
+            code: "f/*comment*/ ();",
+            output: "f/*comment*/();",
+            errors: [
+                { messageId: "unexpectedWhitespace", type: "CallExpression" }
+            ]
+        },
+        {
+            code: "f/*comment*//*comment2*/ ();",
+            output: "f/*comment*//*comment2*/();",
+            errors: [
+                { messageId: "unexpectedWhitespace", type: "CallExpression" }
+            ]
+        },
+        {
             code: "f ();",
             output: "f();",
             errors: [{ messageId: "unexpectedWhitespace", type: "CallExpression" }]

--- a/tests/lib/rules/func-call-spacing.js
+++ b/tests/lib/rules/func-call-spacing.js
@@ -231,6 +231,13 @@ ruleTester.run("func-call-spacing", rule, {
             ]
         },
         {
+            code: "f \n    /**/ ();",
+            output: null,
+            errors: [
+                { messageId: "unexpectedWhitespace", type: "CallExpression" }
+            ]
+        },
+        {
             code: "f/*comment*/ ();",
             output: "f/*comment*/();",
             errors: [
@@ -238,8 +245,29 @@ ruleTester.run("func-call-spacing", rule, {
             ]
         },
         {
+            code: "f/*multiline \ncomment*/ ();",
+            output: null,
+            errors: [
+                { messageId: "unexpectedWhitespace", type: "CallExpression" }
+            ]
+        },
+        {
             code: "f/*comment*//*comment2*/ ();",
             output: "f/*comment*//*comment2*/();",
+            errors: [
+                { messageId: "unexpectedWhitespace", type: "CallExpression" }
+            ]
+        },
+        {
+            code: "f/*comment*/  /*comment2*/ ();",
+            output: "f/*comment*//*comment2*/();",
+            errors: [
+                { messageId: "unexpectedWhitespace", type: "CallExpression" }
+            ]
+        },
+        {
+            code: "f/*comment*/\n  /*comment2*/ ();",
+            output: null,
             errors: [
                 { messageId: "unexpectedWhitespace", type: "CallExpression" }
             ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Fixed removal of inline comments. 
This rule while fixing, removes the comments
like this 

**Before**

```js
// input

fn /*comment*/()

// output

fn()
```
[DEMO](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgZnVuYy1jYWxsLXNwYWNpbmc6IFtcImVycm9yXCIsIFwibmV2ZXJcIl0qL1xuXG5mbiAvKmNvbW1lbnQqLygpOyIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6MTEsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnsiaW5kZW50IjoyfSwiZW52Ijp7fX19)

**After**

```js
// input

fn /*comment*/()

// output

fn/*comment*/()
```

#### Is there anything you'd like reviewers to focus on?
Issue, https://github.com/eslint/eslint/issues/13319
Tracking, https://github.com/eslint/eslint/issues/13319#issuecomment-642882660