### PR TITLE
Update: improve report location in arrow-body-style (refs #12334)

### DIFF
--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -136,7 +136,7 @@ module.exports = {
 
                     context.report({
                         node,
-                        loc: arrowBody.loc.start,
+                        loc: arrowBody.loc,
                         messageId,
                         fix(fixer) {
                             const fixes = [];
@@ -201,7 +201,7 @@ module.exports = {
                 if (always || (asNeeded && requireReturnForObjectLiteral && arrowBody.type === "ObjectExpression")) {
                     context.report({
                         node,
-                        loc: arrowBody.loc.start,
+                        loc: arrowBody.loc,
                         messageId: "expectedBlock",
                         fix(fixer) {
                             const fixes = [];

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -53,6 +53,8 @@ ruleTester.run("arrow-body-style", rule, {
                 {
                     line: 1,
                     column: 17,
+                    endLine: 1,
+                    endColumn: 18,
                     type: "ArrowFunctionExpression",
                     messageId: "expectedBlock"
                 }
@@ -440,6 +442,8 @@ ruleTester.run("arrow-body-style", rule, {
                 {
                     line: 1,
                     column: 17,
+                    endLine: 3,
+                    endColumn: 2,
                     type: "ArrowFunctionExpression",
                     messageId: "unexpectedSingleBlock"
                 }
@@ -452,6 +456,8 @@ ruleTester.run("arrow-body-style", rule, {
                 {
                     line: 1,
                     column: 17,
+                    endLine: 2,
+                    endColumn: 13,
                     type: "ArrowFunctionExpression",
                     messageId: "unexpectedSingleBlock"
                 }
@@ -464,6 +470,8 @@ ruleTester.run("arrow-body-style", rule, {
                 {
                     line: 1,
                     column: 17,
+                    endLine: 2,
+                    endColumn: 2,
                     type: "ArrowFunctionExpression",
                     messageId: "unexpectedSingleBlock"
                 }
@@ -508,6 +516,8 @@ ruleTester.run("arrow-body-style", rule, {
                 {
                     line: 2,
                     column: 31,
+                    endLine: 7,
+                    endColumn: 16,
                     type: "ArrowFunctionExpression",
                     messageId: "unexpectedObjectBlock"
                 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: #12334 

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Change reporting location `loc.start` to `loc`.

### Before
* "always" option

<img width="330" alt="스크린샷 2020-06-19 오전 12 03 36" src="https://user-images.githubusercontent.com/41323220/85039009-3b9ae480-b1c2-11ea-9a7d-f664ceaf9a01.png">

 * "never" option

<img width="327" alt="스크린샷 2020-06-19 오전 12 03 13" src="https://user-images.githubusercontent.com/41323220/85039089-53726880-b1c2-11ea-8a96-b70e6a62b890.png">

### After

* "always" option

![스크린샷 2020-06-19 오전 12 06 29](https://user-images.githubusercontent.com/41323220/85039144-6422de80-b1c2-11ea-81e0-da70479d8080.png)

* "never" option

![스크린샷 2020-06-19 오전 12 05 41](https://user-images.githubusercontent.com/41323220/85039183-6e44dd00-b1c2-11ea-8d66-0ac963228665.png)

#### Is there anything you'd like reviewers to focus on?
