### PR TITLE
Docs: fix no-multiple-empty-lines examples (fixes #13432)

### DIFF
--- a/docs/rules/no-multiple-empty-lines.md
+++ b/docs/rules/no-multiple-empty-lines.md
@@ -23,6 +23,8 @@ Examples of **incorrect** code for this rule with the default `{ "max": 2 }` opt
 
 var foo = 5;
 
+
+
 var bar = 3;
 ```
 
@@ -32,6 +34,7 @@ Examples of **correct** code for this rule with the default `{ "max": 2 }` optio
 /*eslint no-multiple-empty-lines: "error"*/
 
 var foo = 5;
+
 
 var bar = 3;
 ```
@@ -45,7 +48,10 @@ Examples of **incorrect** code for this rule with the `{ max: 2, maxEOF: 0 }` op
 
 var foo = 5;
 
+
 var bar = 3;
+
+
 ```
 
 Examples of **correct** code for this rule with the `{ max: 2, maxEOF: 0 }` options:
@@ -54,6 +60,7 @@ Examples of **correct** code for this rule with the `{ max: 2, maxEOF: 0 }` opti
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/
 
 var foo = 5;
+
 
 var bar = 3;
 ```
@@ -92,7 +99,9 @@ Examples of **incorrect** code for this rule with the `{ max: 2, maxBOF: 1 }` op
 ```js
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxBOF": 1 }]*/
 
+
 var foo = 5;
+
 
 var bar = 3;
 ```
@@ -103,6 +112,7 @@ Examples of **correct** code for this rule with the `{ max: 2, maxBOF: 1 }` opti
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxBOF": 1}]*/
 
 var foo = 5;
+
 
 var bar = 3;
 ```


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

fixes #13432

#### What changes did you make? (Give an overview)

Reverted some changes from #13374. It seems that the last commit in that PR had some accidental auto-formatting changes that broke the examples in `no-multiple-empty-lines` documentation.

#### Is there anything you'd like reviewers to focus on?
