### PR TITLE
Fix: Replace Infinity with Number.MAX_SAFE_INTEGER (fixes #13427)

### DIFF
--- a/lib/cli-engine/config-array-factory.js
+++ b/lib/cli-engine/config-array-factory.js
@@ -722,7 +722,12 @@ class ConfigArrayFactory {
          *
          * Refer https://github.com/eslint/eslint/issues/12592
          */
-        const clonedRulesConfig = rules && JSON.parse(JSON.stringify((rules)));
+        const clonedRulesConfig = rules && JSON.parse(
+            JSON.stringify(
+                rules,
+                (key, value) => (value === Infinity ? Number.MAX_SAFE_INTEGER : value)
+            )
+        );
 
         // Flatten `extends`.
         for (const extendName of extendList.filter(Boolean)) {

--- a/tests/fixtures/config-file/cloned-config/configWithInfinity.js
+++ b/tests/fixtures/config-file/cloned-config/configWithInfinity.js
@@ -1,0 +1,6 @@
+module.exports = {
+
+  rules: {
+      "max-len": [ "error", { code: Infinity }]
+  }
+};

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -1172,9 +1172,7 @@ describe("cli", () => {
 
                 assert.strictEqual(exit, 0);
             });
-        });
 
-        describe("config file and input file", () => {
             it("should exit with 1 as camelcase has wrong property type", async () => {
                 const configPath = getFixturePath("config-file", "cloned-config", "eslintConfigFail.js");
                 const filePath = getFixturePath("config-file", "cloned-config", "index.js");
@@ -1186,6 +1184,16 @@ describe("cli", () => {
                     assert.strictEqual(/Configuration for rule "camelcase" is invalid:/u.test(error), true);
                 }
 
+            });
+
+            it("should not cause an error when a rule configuration has `Infinity`", async () => {
+                const configPath = getFixturePath("config-file", "cloned-config", "configWithInfinity.js");
+                const filePath = getFixturePath("config-file", "cloned-config", "index.js");
+                const args = `--config ${configPath} ${filePath}`;
+
+                const exit = await cli.execute(args);
+
+                assert.strictEqual(exit, 0);
             });
         });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

When cloning a rule's config, if `Infinity` is found, it will be replaced with `Number.MAX_SAFE_INTEGER`. This should result in the same effective config while preserving serialization.

Note: This only fixes the issue introduced in v7.3.0. Configs using `Infinity` will still fail in other areas (like caching and `--print-config`).

We can remove this change once `eslint-config-airbnb` updates their config.


#### Is there anything you'd like reviewers to focus on?
