### PR TITLE
Fix: support typescript generics in arrow-parens (fixes #12570)

### DIFF
--- a/tests/fixtures/parsers/arrow-parens/generics-extends-complex.js
+++ b/tests/fixtures/parsers/arrow-parens/generics-extends-complex.js
@@ -1,0 +1,249 @@
+"use strict";
+
+/**
+ * Parser: @typescript-eslint/parser@3.5.0
+ * Source code:
+ * <T extends (A | B) & C>(a) => b
+ */
+
+exports.parse = () => ({
+    type: "Program",
+    body: [
+      {
+        type: "ExpressionStatement",
+        expression: {
+          type: "ArrowFunctionExpression",
+          generator: false,
+          id: null,
+          params: [
+            {
+              type: "Identifier",
+              name: "a",
+              range: [24, 25],
+              loc: {
+                start: { line: 1, column: 24 },
+                end: { line: 1, column: 25 },
+              },
+            },
+          ],
+          body: {
+            type: "Identifier",
+            name: "b",
+            range: [30, 31],
+            loc: { start: { line: 1, column: 30 }, end: { line: 1, column: 31 } },
+          },
+          async: false,
+          expression: true,
+          range: [0, 31],
+          loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 31 } },
+          typeParameters: {
+            type: "TSTypeParameterDeclaration",
+            range: [0, 23],
+            loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 23 } },
+            params: [
+              {
+                type: "TSTypeParameter",
+                name: {
+                  type: "Identifier",
+                  name: "T",
+                  range: [1, 2],
+                  loc: {
+                    start: { line: 1, column: 1 },
+                    end: { line: 1, column: 2 },
+                  },
+                },
+                constraint: {
+                  type: "TSIntersectionType",
+                  types: [
+                    {
+                      type: "TSParenthesizedType",
+                      typeAnnotation: {
+                        type: "TSUnionType",
+                        types: [
+                          {
+                            type: "TSTypeReference",
+                            typeName: {
+                              type: "Identifier",
+                              name: "A",
+                              range: [12, 13],
+                              loc: {
+                                start: { line: 1, column: 12 },
+                                end: { line: 1, column: 13 },
+                              },
+                            },
+                            range: [12, 13],
+                            loc: {
+                              start: { line: 1, column: 12 },
+                              end: { line: 1, column: 13 },
+                            },
+                          },
+                          {
+                            type: "TSTypeReference",
+                            typeName: {
+                              type: "Identifier",
+                              name: "B",
+                              range: [16, 17],
+                              loc: {
+                                start: { line: 1, column: 16 },
+                                end: { line: 1, column: 17 },
+                              },
+                            },
+                            range: [16, 17],
+                            loc: {
+                              start: { line: 1, column: 16 },
+                              end: { line: 1, column: 17 },
+                            },
+                          },
+                        ],
+                        range: [12, 17],
+                        loc: {
+                          start: { line: 1, column: 12 },
+                          end: { line: 1, column: 17 },
+                        },
+                      },
+                      range: [11, 18],
+                      loc: {
+                        start: { line: 1, column: 11 },
+                        end: { line: 1, column: 18 },
+                      },
+                    },
+                    {
+                      type: "TSTypeReference",
+                      typeName: {
+                        type: "Identifier",
+                        name: "C",
+                        range: [21, 22],
+                        loc: {
+                          start: { line: 1, column: 21 },
+                          end: { line: 1, column: 22 },
+                        },
+                      },
+                      range: [21, 22],
+                      loc: {
+                        start: { line: 1, column: 21 },
+                        end: { line: 1, column: 22 },
+                      },
+                    },
+                  ],
+                  range: [11, 22],
+                  loc: {
+                    start: { line: 1, column: 11 },
+                    end: { line: 1, column: 22 },
+                  },
+                },
+                range: [1, 22],
+                loc: {
+                  start: { line: 1, column: 1 },
+                  end: { line: 1, column: 22 },
+                },
+              },
+            ],
+          },
+        },
+        range: [0, 31],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 31 } },
+      },
+    ],
+    sourceType: "script",
+    range: [0, 31],
+    loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 31 } },
+    tokens: [
+      {
+        type: "Punctuator",
+        value: "<",
+        range: [0, 1],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 1 } },
+      },
+      {
+        type: "Identifier",
+        value: "T",
+        range: [1, 2],
+        loc: { start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
+      },
+      {
+        type: "Keyword",
+        value: "extends",
+        range: [3, 10],
+        loc: { start: { line: 1, column: 3 }, end: { line: 1, column: 10 } },
+      },
+      {
+        type: "Punctuator",
+        value: "(",
+        range: [11, 12],
+        loc: { start: { line: 1, column: 11 }, end: { line: 1, column: 12 } },
+      },
+      {
+        type: "Identifier",
+        value: "A",
+        range: [12, 13],
+        loc: { start: { line: 1, column: 12 }, end: { line: 1, column: 13 } },
+      },
+      {
+        type: "Punctuator",
+        value: "|",
+        range: [14, 15],
+        loc: { start: { line: 1, column: 14 }, end: { line: 1, column: 15 } },
+      },
+      {
+        type: "Identifier",
+        value: "B",
+        range: [16, 17],
+        loc: { start: { line: 1, column: 16 }, end: { line: 1, column: 17 } },
+      },
+      {
+        type: "Punctuator",
+        value: ")",
+        range: [17, 18],
+        loc: { start: { line: 1, column: 17 }, end: { line: 1, column: 18 } },
+      },
+      {
+        type: "Punctuator",
+        value: "&",
+        range: [19, 20],
+        loc: { start: { line: 1, column: 19 }, end: { line: 1, column: 20 } },
+      },
+      {
+        type: "Identifier",
+        value: "C",
+        range: [21, 22],
+        loc: { start: { line: 1, column: 21 }, end: { line: 1, column: 22 } },
+      },
+      {
+        type: "Punctuator",
+        value: ">",
+        range: [22, 23],
+        loc: { start: { line: 1, column: 22 }, end: { line: 1, column: 23 } },
+      },
+      {
+        type: "Punctuator",
+        value: "(",
+        range: [23, 24],
+        loc: { start: { line: 1, column: 23 }, end: { line: 1, column: 24 } },
+      },
+      {
+        type: "Identifier",
+        value: "a",
+        range: [24, 25],
+        loc: { start: { line: 1, column: 24 }, end: { line: 1, column: 25 } },
+      },
+      {
+        type: "Punctuator",
+        value: ")",
+        range: [25, 26],
+        loc: { start: { line: 1, column: 25 }, end: { line: 1, column: 26 } },
+      },
+      {
+        type: "Punctuator",
+        value: "=>",
+        range: [27, 29],
+        loc: { start: { line: 1, column: 27 }, end: { line: 1, column: 29 } },
+      },
+      {
+        type: "Identifier",
+        value: "b",
+        range: [30, 31],
+        loc: { start: { line: 1, column: 30 }, end: { line: 1, column: 31 } },
+      },
+    ],
+    comments: [],
+  });

--- a/tests/fixtures/parsers/arrow-parens/generics-extends.js
+++ b/tests/fixtures/parsers/arrow-parens/generics-extends.js
@@ -1,0 +1,151 @@
+"use strict";
+
+/**
+ * Parser: @typescript-eslint/parser@3.5.0
+ * Source code:
+ * <T extends A>(a) => b
+ */
+
+exports.parse = () => ({
+    type: "Program",
+    body: [
+      {
+        type: "ExpressionStatement",
+        expression: {
+          type: "ArrowFunctionExpression",
+          generator: false,
+          id: null,
+          params: [
+            {
+              type: "Identifier",
+              name: "a",
+              range: [14, 15],
+              loc: {
+                start: { line: 1, column: 14 },
+                end: { line: 1, column: 15 },
+              },
+            },
+          ],
+          body: {
+            type: "Identifier",
+            name: "b",
+            range: [20, 21],
+            loc: { start: { line: 1, column: 20 }, end: { line: 1, column: 21 } },
+          },
+          async: false,
+          expression: true,
+          range: [0, 21],
+          loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 21 } },
+          typeParameters: {
+            type: "TSTypeParameterDeclaration",
+            range: [0, 13],
+            loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 13 } },
+            params: [
+              {
+                type: "TSTypeParameter",
+                name: {
+                  type: "Identifier",
+                  name: "T",
+                  range: [1, 2],
+                  loc: {
+                    start: { line: 1, column: 1 },
+                    end: { line: 1, column: 2 },
+                  },
+                },
+                constraint: {
+                  type: "TSTypeReference",
+                  typeName: {
+                    type: "Identifier",
+                    name: "A",
+                    range: [11, 12],
+                    loc: {
+                      start: { line: 1, column: 11 },
+                      end: { line: 1, column: 12 },
+                    },
+                  },
+                  range: [11, 12],
+                  loc: {
+                    start: { line: 1, column: 11 },
+                    end: { line: 1, column: 12 },
+                  },
+                },
+                range: [1, 12],
+                loc: {
+                  start: { line: 1, column: 1 },
+                  end: { line: 1, column: 12 },
+                },
+              },
+            ],
+          },
+        },
+        range: [0, 21],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 21 } },
+      },
+    ],
+    sourceType: "script",
+    range: [0, 21],
+    loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 21 } },
+    tokens: [
+      {
+        type: "Punctuator",
+        value: "<",
+        range: [0, 1],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 1 } },
+      },
+      {
+        type: "Identifier",
+        value: "T",
+        range: [1, 2],
+        loc: { start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
+      },
+      {
+        type: "Keyword",
+        value: "extends",
+        range: [3, 10],
+        loc: { start: { line: 1, column: 3 }, end: { line: 1, column: 10 } },
+      },
+      {
+        type: "Identifier",
+        value: "A",
+        range: [11, 12],
+        loc: { start: { line: 1, column: 11 }, end: { line: 1, column: 12 } },
+      },
+      {
+        type: "Punctuator",
+        value: ">",
+        range: [12, 13],
+        loc: { start: { line: 1, column: 12 }, end: { line: 1, column: 13 } },
+      },
+      {
+        type: "Punctuator",
+        value: "(",
+        range: [13, 14],
+        loc: { start: { line: 1, column: 13 }, end: { line: 1, column: 14 } },
+      },
+      {
+        type: "Identifier",
+        value: "a",
+        range: [14, 15],
+        loc: { start: { line: 1, column: 14 }, end: { line: 1, column: 15 } },
+      },
+      {
+        type: "Punctuator",
+        value: ")",
+        range: [15, 16],
+        loc: { start: { line: 1, column: 15 }, end: { line: 1, column: 16 } },
+      },
+      {
+        type: "Punctuator",
+        value: "=>",
+        range: [17, 19],
+        loc: { start: { line: 1, column: 17 }, end: { line: 1, column: 19 } },
+      },
+      {
+        type: "Identifier",
+        value: "b",
+        range: [20, 21],
+        loc: { start: { line: 1, column: 20 }, end: { line: 1, column: 21 } },
+      },
+    ],
+    comments: [],
+  });

--- a/tests/fixtures/parsers/arrow-parens/generics-simple-async.js
+++ b/tests/fixtures/parsers/arrow-parens/generics-simple-async.js
@@ -1,0 +1,128 @@
+"use strict";
+
+/**
+ * Parser: @typescript-eslint/parser@3.5.0
+ * Source code:
+ * async <T>(a) => b
+ */
+
+exports.parse = () => ({
+    type: "Program",
+    body: [
+      {
+        type: "ExpressionStatement",
+        expression: {
+          type: "ArrowFunctionExpression",
+          generator: false,
+          id: null,
+          params: [
+            {
+              type: "Identifier",
+              name: "a",
+              range: [10, 11],
+              loc: {
+                start: { line: 1, column: 10 },
+                end: { line: 1, column: 11 },
+              },
+            },
+          ],
+          body: {
+            type: "Identifier",
+            name: "b",
+            range: [16, 17],
+            loc: { start: { line: 1, column: 16 }, end: { line: 1, column: 17 } },
+          },
+          async: true,
+          expression: true,
+          range: [0, 17],
+          loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 17 } },
+          typeParameters: {
+            type: "TSTypeParameterDeclaration",
+            range: [6, 9],
+            loc: { start: { line: 1, column: 6 }, end: { line: 1, column: 9 } },
+            params: [
+              {
+                type: "TSTypeParameter",
+                name: {
+                  type: "Identifier",
+                  name: "T",
+                  range: [7, 8],
+                  loc: {
+                    start: { line: 1, column: 7 },
+                    end: { line: 1, column: 8 },
+                  },
+                },
+                range: [7, 8],
+                loc: {
+                  start: { line: 1, column: 7 },
+                  end: { line: 1, column: 8 },
+                },
+              },
+            ],
+          },
+        },
+        range: [0, 17],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 17 } },
+      },
+    ],
+    sourceType: "script",
+    range: [0, 17],
+    loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 17 } },
+    tokens: [
+      {
+        type: "Identifier",
+        value: "async",
+        range: [0, 5],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } },
+      },
+      {
+        type: "Punctuator",
+        value: "<",
+        range: [6, 7],
+        loc: { start: { line: 1, column: 6 }, end: { line: 1, column: 7 } },
+      },
+      {
+        type: "Identifier",
+        value: "T",
+        range: [7, 8],
+        loc: { start: { line: 1, column: 7 }, end: { line: 1, column: 8 } },
+      },
+      {
+        type: "Punctuator",
+        value: ">",
+        range: [8, 9],
+        loc: { start: { line: 1, column: 8 }, end: { line: 1, column: 9 } },
+      },
+      {
+        type: "Punctuator",
+        value: "(",
+        range: [9, 10],
+        loc: { start: { line: 1, column: 9 }, end: { line: 1, column: 10 } },
+      },
+      {
+        type: "Identifier",
+        value: "a",
+        range: [10, 11],
+        loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 11 } },
+      },
+      {
+        type: "Punctuator",
+        value: ")",
+        range: [11, 12],
+        loc: { start: { line: 1, column: 11 }, end: { line: 1, column: 12 } },
+      },
+      {
+        type: "Punctuator",
+        value: "=>",
+        range: [13, 15],
+        loc: { start: { line: 1, column: 13 }, end: { line: 1, column: 15 } },
+      },
+      {
+        type: "Identifier",
+        value: "b",
+        range: [16, 17],
+        loc: { start: { line: 1, column: 16 }, end: { line: 1, column: 17 } },
+      },
+    ],
+    comments: [],
+  });

--- a/tests/fixtures/parsers/arrow-parens/generics-simple-no-params.js
+++ b/tests/fixtures/parsers/arrow-parens/generics-simple-no-params.js
@@ -1,0 +1,106 @@
+"use strict";
+
+/**
+ * Parser: @typescript-eslint/parser@3.5.0
+ * Source code:
+ * <T>() => b
+ */
+
+exports.parse = () => ({
+    type: "Program",
+    body: [
+      {
+        type: "ExpressionStatement",
+        expression: {
+          type: "ArrowFunctionExpression",
+          generator: false,
+          id: null,
+          params: [],
+          body: {
+            type: "Identifier",
+            name: "b",
+            range: [9, 10],
+            loc: { start: { line: 1, column: 9 }, end: { line: 1, column: 10 } },
+          },
+          async: false,
+          expression: true,
+          range: [0, 10],
+          loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+          typeParameters: {
+            type: "TSTypeParameterDeclaration",
+            range: [0, 3],
+            loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 3 } },
+            params: [
+              {
+                type: "TSTypeParameter",
+                name: {
+                  type: "Identifier",
+                  name: "T",
+                  range: [1, 2],
+                  loc: {
+                    start: { line: 1, column: 1 },
+                    end: { line: 1, column: 2 },
+                  },
+                },
+                range: [1, 2],
+                loc: {
+                  start: { line: 1, column: 1 },
+                  end: { line: 1, column: 2 },
+                },
+              },
+            ],
+          },
+        },
+        range: [0, 10],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+      },
+    ],
+    sourceType: "script",
+    range: [0, 10],
+    loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+    tokens: [
+      {
+        type: "Punctuator",
+        value: "<",
+        range: [0, 1],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 1 } },
+      },
+      {
+        type: "Identifier",
+        value: "T",
+        range: [1, 2],
+        loc: { start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
+      },
+      {
+        type: "Punctuator",
+        value: ">",
+        range: [2, 3],
+        loc: { start: { line: 1, column: 2 }, end: { line: 1, column: 3 } },
+      },
+      {
+        type: "Punctuator",
+        value: "(",
+        range: [3, 4],
+        loc: { start: { line: 1, column: 3 }, end: { line: 1, column: 4 } },
+      },
+      {
+        type: "Punctuator",
+        value: ")",
+        range: [4, 5],
+        loc: { start: { line: 1, column: 4 }, end: { line: 1, column: 5 } },
+      },
+      {
+        type: "Punctuator",
+        value: "=>",
+        range: [6, 8],
+        loc: { start: { line: 1, column: 6 }, end: { line: 1, column: 8 } },
+      },
+      {
+        type: "Identifier",
+        value: "b",
+        range: [9, 10],
+        loc: { start: { line: 1, column: 9 }, end: { line: 1, column: 10 } },
+      },
+    ],
+    comments: [],
+  });

--- a/tests/fixtures/parsers/arrow-parens/generics-simple.js
+++ b/tests/fixtures/parsers/arrow-parens/generics-simple.js
@@ -1,0 +1,119 @@
+"use strict";
+
+/**
+ * Parser: @typescript-eslint/parser@3.5.0
+ * Source code:
+ * <T>(a) => b
+ */
+
+exports.parse = () => ({
+    type: "Program",
+    body: [
+      {
+        type: "ExpressionStatement",
+        expression: {
+          type: "ArrowFunctionExpression",
+          generator: false,
+          id: null,
+          params: [
+            {
+              type: "Identifier",
+              name: "a",
+              range: [4, 5],
+              loc: { start: { line: 1, column: 4 }, end: { line: 1, column: 5 } },
+            },
+          ],
+          body: {
+            type: "Identifier",
+            name: "b",
+            range: [10, 11],
+            loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 11 } },
+          },
+          async: false,
+          expression: true,
+          range: [0, 11],
+          loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 11 } },
+          typeParameters: {
+            type: "TSTypeParameterDeclaration",
+            range: [0, 3],
+            loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 3 } },
+            params: [
+              {
+                type: "TSTypeParameter",
+                name: {
+                  type: "Identifier",
+                  name: "T",
+                  range: [1, 2],
+                  loc: {
+                    start: { line: 1, column: 1 },
+                    end: { line: 1, column: 2 },
+                  },
+                },
+                range: [1, 2],
+                loc: {
+                  start: { line: 1, column: 1 },
+                  end: { line: 1, column: 2 },
+                },
+              },
+            ],
+          },
+        },
+        range: [0, 11],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 11 } },
+      },
+    ],
+    sourceType: "script",
+    range: [0, 11],
+    loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 11 } },
+    tokens: [
+      {
+        type: "Punctuator",
+        value: "<",
+        range: [0, 1],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 1 } },
+      },
+      {
+        type: "Identifier",
+        value: "T",
+        range: [1, 2],
+        loc: { start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
+      },
+      {
+        type: "Punctuator",
+        value: ">",
+        range: [2, 3],
+        loc: { start: { line: 1, column: 2 }, end: { line: 1, column: 3 } },
+      },
+      {
+        type: "Punctuator",
+        value: "(",
+        range: [3, 4],
+        loc: { start: { line: 1, column: 3 }, end: { line: 1, column: 4 } },
+      },
+      {
+        type: "Identifier",
+        value: "a",
+        range: [4, 5],
+        loc: { start: { line: 1, column: 4 }, end: { line: 1, column: 5 } },
+      },
+      {
+        type: "Punctuator",
+        value: ")",
+        range: [5, 6],
+        loc: { start: { line: 1, column: 5 }, end: { line: 1, column: 6 } },
+      },
+      {
+        type: "Punctuator",
+        value: "=>",
+        range: [7, 9],
+        loc: { start: { line: 1, column: 7 }, end: { line: 1, column: 9 } },
+      },
+      {
+        type: "Identifier",
+        value: "b",
+        range: [10, 11],
+        loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 11 } },
+      },
+    ],
+    comments: [],
+  });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

fixes #12570

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed `arrow-parens` rule:

* Refactored the code.
* Changed the way it finds opening paren of params to, I believe, the most reliable one. This should prevent crashes, invalid autofixes, and some false positives in typescript code.
* Added check for unexpected tokens before opening paren. This should prevent false positives like `<T>(a) => b` with `"as-needed"` option.
* Also fixed an autofix bug with adjacent tokens, unrelated to typescript.

#### Is there anything you'd like reviewers to focus on?
