### PR TITLE
Docs: fix description for `never` in multiline-ternary (fixes #13368)

### DIFF
--- a/docs/rules/multiline-ternary.md
+++ b/docs/rules/multiline-ternary.md
@@ -27,7 +27,7 @@ This rule has a string option:
 
 * `"always"` (default) enforces newlines between the operands of a ternary expression.
 * `"always-multiline"` enforces newlines between the operands of a ternary expression if the expression spans multiple lines.
-* `"never"` disallows newlines between the operands of a ternary expression (enforcing that the entire ternary expression is on one line).
+* `"never"` disallows newlines between the operands of a ternary expression.
 
 ### always
 
@@ -134,6 +134,10 @@ Examples of **correct** code for this rule with the `"never"` option:
 foo > bar ? value1 : value2;
 
 foo > bar ? (baz > qux ? value1 : value2) : value3;
+
+foo > bar ? (
+    baz > qux ? value1 : value2
+) : value3;
 ```
 
 ## When Not To Use It


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update

fixes #13368

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed note that the option `"never"` is "enforcing that the entire ternary expression is on one line", because it doesn't work like that. Also added an example.

#### Is there anything you'd like reviewers to focus on?
