### PR TITLE
Update: add allowSeparatedGroups option to sort-imports (fixes #12951)

### DIFF
--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -41,6 +41,7 @@ This rule accepts an object with its properties as
     * `all` = import all members provided by exported bindings.
     * `multiple` = import multiple members.
     * `single` = import single member.
+* `allowSeparatedGroups` (default: `false`)
 
 Default option settings are:
 
@@ -50,7 +51,8 @@ Default option settings are:
         "ignoreCase": false,
         "ignoreDeclarationSort": false,
         "ignoreMemberSort": false,
-        "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
+        "memberSyntaxSortOrder": ["none", "all", "multiple", "single"],
+        "allowSeparatedGroups": false
     }]
 }
 ```
@@ -225,6 +227,53 @@ import {a, b} from 'foo.js';
 ```
 
 Default is `["none", "all", "multiple", "single"]`.
+
+### `allowSeparatedGroups`
+
+When `true` the rule checks the sorting of import declaration statements only for those that appear on consecutive lines.
+
+In other words, a blank line or a comment line or line with any other statement after an import declaration statement will reset the sorting of import declaration statements.
+
+Examples of **incorrect** code for this rule with the `{ "allowSeparatedGroups": true }` option:
+
+```js
+/*eslint sort-imports: ["error", { "allowSeparatedGroups": true }]*/
+
+import b from 'foo.js';
+import c from 'bar.js';
+import a from 'baz.js';
+```
+
+Examples of **correct** code for this rule with the `{ "allowSeparatedGroups": true }` option:
+
+```js
+/*eslint sort-imports: ["error", { "allowSeparatedGroups": true }]*/
+
+import b from 'foo.js';
+import c from 'bar.js';
+
+import a from 'baz.js';
+```
+
+```js
+/*eslint sort-imports: ["error", { "allowSeparatedGroups": true }]*/
+
+import b from 'foo.js';
+import c from 'bar.js';
+// comment
+import a from 'baz.js';
+```
+
+```js
+/*eslint sort-imports: ["error", { "allowSeparatedGroups": true }]*/
+
+import b from 'foo.js';
+import c from 'bar.js';
+quux();
+import a from 'baz.js';
+```
+
+Default is `false`.
 
 ## When Not To Use It
 

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -101,7 +101,45 @@ ruleTester.run("sort-imports", rule, {
         },
 
         // https://github.com/eslint/eslint/issues/5305
-        "import React, {Component} from 'react';"
+        "import React, {Component} from 'react';",
+
+        // allowSeparatedGroups
+        {
+            code: "import b from 'b';\n\nimport a from 'a';",
+            options: [{ allowSeparatedGroups: true }]
+        },
+        {
+            code: "import a from 'a';\n\nimport 'b';",
+            options: [{ allowSeparatedGroups: true }]
+        },
+        {
+            code: "import { b } from 'b';\n\n\nimport { a } from 'a';",
+            options: [{ allowSeparatedGroups: true }]
+        },
+        {
+            code: "import b from 'b';\n// comment\nimport a from 'a';",
+            options: [{ allowSeparatedGroups: true }]
+        },
+        {
+            code: "import b from 'b';\nfoo();\nimport a from 'a';",
+            options: [{ allowSeparatedGroups: true }]
+        },
+        {
+            code: "import { b } from 'b';/*\n comment \n*/import { a } from 'a';",
+            options: [{ allowSeparatedGroups: true }]
+        },
+        {
+            code: "import b from\n'b';\n\nimport\n a from 'a';",
+            options: [{ allowSeparatedGroups: true }]
+        },
+        {
+            code: "import c from 'c';\n\nimport a from 'a';\nimport b from 'b';",
+            options: [{ allowSeparatedGroups: true }]
+        },
+        {
+            code: "import c from 'c';\n\nimport b from 'b';\n\nimport a from 'a';",
+            options: [{ allowSeparatedGroups: true }]
+        }
     ],
     invalid: [
         {
@@ -285,6 +323,125 @@ ruleTester.run("sort-imports", rule, {
             errors: [{
                 messageId: "sortMembersAlphabetically",
                 data: { memberName: "qux" },
+                type: "ImportSpecifier"
+            }]
+        },
+
+        // allowSeparatedGroups
+        {
+            code: "import b from 'b';\nimport a from 'a';",
+            output: null,
+            errors: [{
+                messageId: "sortImportsAlphabetically",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import b from 'b';\nimport a from 'a';",
+            output: null,
+            options: [{}],
+            errors: [{
+                messageId: "sortImportsAlphabetically",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import b from 'b';\nimport a from 'a';",
+            output: null,
+            options: [{ allowSeparatedGroups: false }],
+            errors: [{
+                messageId: "sortImportsAlphabetically",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import b from 'b';import a from 'a';",
+            output: null,
+            options: [{ allowSeparatedGroups: false }],
+            errors: [{
+                messageId: "sortImportsAlphabetically",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import b from 'b'; /* comment */ import a from 'a';",
+            output: null,
+            options: [{ allowSeparatedGroups: false }],
+            errors: [{
+                messageId: "sortImportsAlphabetically",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import b from 'b'; // comment\nimport a from 'a';",
+            output: null,
+            options: [{ allowSeparatedGroups: false }],
+            errors: [{
+                messageId: "sortImportsAlphabetically",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import b from 'b'; // comment 1\n/* comment 2 */import a from 'a';",
+            output: null,
+            options: [{ allowSeparatedGroups: false }],
+            errors: [{
+                messageId: "sortImportsAlphabetically",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import { b } from 'b'; /* comment line 1 \n comment line 2 */ import { a } from 'a';",
+            output: null,
+            options: [{ allowSeparatedGroups: false }],
+            errors: [{
+                messageId: "sortImportsAlphabetically",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import b\nfrom 'b'; import a\nfrom 'a';",
+            output: null,
+            options: [{ allowSeparatedGroups: false }],
+            errors: [{
+                messageId: "sortImportsAlphabetically",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import { b } from \n'b'; /* comment */ import\n { a } from 'a';",
+            output: null,
+            options: [{ allowSeparatedGroups: false }],
+            errors: [{
+                messageId: "sortImportsAlphabetically",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import { b } from \n'b';\nimport\n { a } from 'a';",
+            output: null,
+            options: [{ allowSeparatedGroups: false }],
+            errors: [{
+                messageId: "sortImportsAlphabetically",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import c from 'c';\n\nimport b from 'b';\nimport a from 'a';",
+            output: null,
+            options: [{ allowSeparatedGroups: true }],
+            errors: [{
+                messageId: "sortImportsAlphabetically",
+                type: "ImportDeclaration",
+                line: 4
+            }]
+        },
+        {
+            code: "import b from 'b';\n\nimport { c, a } from 'c';",
+            output: "import b from 'b';\n\nimport { a, c } from 'c';",
+            options: [{ allowSeparatedGroups: true }],
+            errors: [{
+                messageId: "sortMembersAlphabetically",
                 type: "ImportSpecifier"
             }]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Changes an existing rule

fixes #12951

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added `allowSeparatedGroups` option to the `sort-imports` rule.

Examples of **correct** code for this rule with the `{ "allowSeparatedGroups": true }` option:

```js
/*eslint sort-imports: ["error", { "allowSeparatedGroups": true }]*/

import b from 'foo.js';
import c from 'bar.js';

import a from 'baz.js';
```

```js
/*eslint sort-imports: ["error", { "allowSeparatedGroups": true }]*/

import b from 'foo.js';
import c from 'bar.js';
// comment
import a from 'baz.js';
```

```js
/*eslint sort-imports: ["error", { "allowSeparatedGroups": true }]*/

import b from 'foo.js';
import c from 'bar.js';
quux();
import a from 'baz.js';
```

#### Is there anything you'd like reviewers to focus on?
