### PR TITLE
Update: Improve report location for no-unneeded-ternary (refs #12334)

### DIFF
--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -122,7 +122,6 @@ module.exports = {
                 if (isBooleanLiteral(node.alternate) && isBooleanLiteral(node.consequent)) {
                     context.report({
                         node,
-                        loc: node.consequent.loc.start,
                         messageId: "unnecessaryConditionalExpression",
                         fix(fixer) {
                             if (node.consequent.value === node.alternate.value) {
@@ -144,7 +143,6 @@ module.exports = {
                 } else if (!defaultAssignment && matchesDefaultAssignment(node)) {
                     context.report({
                         node,
-                        loc: node.consequent.loc.start,
                         messageId: "unnecessaryConditionalAssignment",
                         fix: fixer => {
                             const shouldParenthesizeAlternate =

--- a/tests/lib/rules/no-unneeded-ternary.js
+++ b/tests/lib/rules/no-unneeded-ternary.js
@@ -54,7 +54,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalExpression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 19
+                column: 9,
+                endLine: 1,
+                endColumn: 31
             }]
         },
         {
@@ -64,7 +66,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalExpression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 18
+                column: 9,
+                endLine: 1,
+                endColumn: 30
             }]
         },
         {
@@ -74,7 +78,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalExpression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 13
+                column: 9,
+                endLine: 1,
+                endColumn: 25
             }]
         },
         {
@@ -84,7 +90,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalExpression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 19
+                column: 9,
+                endLine: 1,
+                endColumn: 31
             }]
         },
         {
@@ -94,7 +102,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalExpression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 18
+                column: 9,
+                endLine: 1,
+                endColumn: 30
             }]
         },
         {
@@ -104,7 +114,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalExpression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 17
+                column: 9,
+                endLine: 1,
+                endColumn: 29
             }]
         },
         {
@@ -114,7 +126,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalExpression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 18
+                column: 9,
+                endLine: 1,
+                endColumn: 30
             }]
         },
         {
@@ -124,7 +138,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalExpression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 21
+                column: 9,
+                endLine: 1,
+                endColumn: 33
             }]
         },
         {
@@ -134,7 +150,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalExpression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 28
+                column: 9,
+                endLine: 1,
+                endColumn: 40
             }]
         },
         {
@@ -144,7 +162,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalExpression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 15
+                column: 9,
+                endLine: 1,
+                endColumn: 28
             }]
         },
         {
@@ -154,7 +174,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalExpression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 17
+                column: 9,
+                endLine: 1,
+                endColumn: 30
             }]
         },
         {
@@ -164,7 +186,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalExpression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 28
+                column: 9,
+                endLine: 1,
+                endColumn: 40
             }]
         },
         {
@@ -174,7 +198,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalExpression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 16
+                column: 9,
+                endLine: 1,
+                endColumn: 28
             }]
         },
         {
@@ -193,7 +219,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 4,
-                column: 38
+                column: 30,
+                endLine: 4,
+                endColumn: 78
             }]
         },
         {
@@ -204,7 +232,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 7
+                column: 1,
+                endLine: 1,
+                endColumn: 30
             }]
         },
         {
@@ -216,7 +246,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 24
+                column: 18,
+                endLine: 1,
+                endColumn: 39
             }]
         },
         {
@@ -227,7 +259,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 15
+                column: 9,
+                endLine: 1,
+                endColumn: 25
             }]
         },
         {
@@ -238,7 +272,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 24
+                column: 9,
+                endLine: 1,
+                endColumn: 66
             }]
         },
         {
@@ -250,7 +286,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 13
+                column: 9,
+                endLine: 1,
+                endColumn: 23
             }]
         },
         {
@@ -262,7 +300,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 13
+                column: 9,
+                endLine: 1,
+                endColumn: 22
             }]
         },
         {
@@ -274,7 +314,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 13
+                column: 9,
+                endLine: 1,
+                endColumn: 25
             }]
         },
         {
@@ -286,7 +328,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 13
+                column: 9,
+                endLine: 1,
+                endColumn: 24
             }]
         },
         {
@@ -298,7 +342,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 13
+                column: 9,
+                endLine: 1,
+                endColumn: 27
             }]
         },
         {
@@ -310,7 +356,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 13
+                column: 9,
+                endLine: 1,
+                endColumn: 18
             }]
         },
         {
@@ -322,7 +370,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 13
+                column: 9,
+                endLine: 1,
+                endColumn: 23
             }]
         },
         {
@@ -333,7 +383,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 7
+                column: 3,
+                endLine: 1,
+                endColumn: 12
             }]
         },
         {
@@ -344,7 +396,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 5
+                column: 1,
+                endLine: 1,
+                endColumn: 10
             }]
         },
         {
@@ -355,7 +409,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 15
+                column: 9,
+                endLine: 1,
+                endColumn: 24
             }]
         },
         {
@@ -367,7 +423,9 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 messageId: "unnecessaryConditionalAssignment",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 15
+                column: 9,
+                endLine: 1,
+                endColumn: 27
             }]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #12334

This PR changes reported location in the `no-unneeded-ternary` rule.

This change can produce more warnings in certain cases with `eslint-disable-*` comments.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Reported location will be now the full location or the conditional expression, instead of the start loc of its consequent.

Before this change:

![image](https://user-images.githubusercontent.com/44349756/86485470-0dd4a480-bd59-11ea-8384-1d83c69d22a8.png)

After this change:

![image](https://user-images.githubusercontent.com/44349756/86485614-7754b300-bd59-11ea-9ad9-2443fa67837d.png)

I believe it's more correct to report conditional expression's loc instead of consequent's loc, for two reasons:

* The whole conditional expression needs to be replaced with another expression (`!!b`).
* In the `b ? true : false` case, this expression isn't considered invalid by this rule only because of its consequent. If the alternate wasn't a boolean literal as well, this expression would be valid by this rule.

#### Is there anything you'd like reviewers to focus on?

This change can produce new warnings, in cases like the following:

```js
/* eslint no-unneeded-ternary: "error" */

var a = b 
  ? true // eslint-disable-line no-unneeded-ternary
  : false
```

user would have to change the line of the disable comment, to e.g.,:

```js
/* eslint no-unneeded-ternary: "error" */

// eslint-disable-next-line no-unneeded-ternary
var a = b 
  ? true 
  : false
```


