### PR TITLE
Fix: add end location to reports in object-curly-newline (refs #12334)

### DIFF
--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -224,7 +224,7 @@ module.exports = {
                     context.report({
                         messageId: "expectedLinebreakAfterOpeningBrace",
                         node,
-                        loc: openBrace.loc.start,
+                        loc: openBrace.loc,
                         fix(fixer) {
                             if (hasCommentsFirstToken) {
                                 return null;
@@ -238,7 +238,7 @@ module.exports = {
                     context.report({
                         messageId: "expectedLinebreakBeforeClosingBrace",
                         node,
-                        loc: closeBrace.loc.start,
+                        loc: closeBrace.loc,
                         fix(fixer) {
                             if (hasCommentsLastToken) {
                                 return null;
@@ -260,7 +260,7 @@ module.exports = {
                     context.report({
                         messageId: "unexpectedLinebreakAfterOpeningBrace",
                         node,
-                        loc: openBrace.loc.start,
+                        loc: openBrace.loc,
                         fix(fixer) {
                             if (hasCommentsFirstToken) {
                                 return null;
@@ -280,7 +280,7 @@ module.exports = {
                     context.report({
                         messageId: "unexpectedLinebreakBeforeClosingBrace",
                         node,
-                        loc: closeBrace.loc.start,
+                        loc: closeBrace.loc,
                         fix(fixer) {
                             if (hasCommentsLastToken) {
                                 return null;

--- a/tests/lib/rules/object-curly-newline.js
+++ b/tests/lib/rules/object-curly-newline.js
@@ -607,8 +607,20 @@ ruleTester.run("object-curly-newline", rule, {
             ].join("\n"),
             options: ["always"],
             errors: [
-                { line: 1, column: 9, messageId: "expectedLinebreakAfterOpeningBrace" },
-                { line: 1, column: 14, messageId: "expectedLinebreakBeforeClosingBrace" }
+                {
+                    line: 1,
+                    column: 9,
+                    endLine: 1,
+                    endColumn: 10,
+                    messageId: "expectedLinebreakAfterOpeningBrace"
+                },
+                {
+                    line: 1,
+                    column: 14,
+                    endLine: 1,
+                    endColumn: 15,
+                    messageId: "expectedLinebreakBeforeClosingBrace"
+                }
             ]
         },
         {
@@ -717,8 +729,20 @@ ruleTester.run("object-curly-newline", rule, {
             ].join("\n"),
             options: ["never"],
             errors: [
-                { line: 1, column: 9, messageId: "unexpectedLinebreakAfterOpeningBrace" },
-                { line: 3, column: 1, messageId: "unexpectedLinebreakBeforeClosingBrace" }
+                {
+                    line: 1,
+                    column: 9,
+                    endLine: 1,
+                    endColumn: 10,
+                    messageId: "unexpectedLinebreakAfterOpeningBrace"
+                },
+                {
+                    line: 3,
+                    column: 1,
+                    endLine: 3,
+                    endColumn: 2,
+                    messageId: "unexpectedLinebreakBeforeClosingBrace"
+                }
             ]
         },
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

refs #12334

This PR adds `loc.end` to reports in the `object-curly-newline` rule.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

changed `*.loc.start` to just `*.loc`.

#### Is there anything you'd like reviewers to focus on?

This is consistent with similar rules: `array-bracket-newline` and `function-paren-newline`.
