### PR TITLE
Fix: add end location to reports in keyword-spacing (refs #12334)

### DIFF
--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -126,7 +126,7 @@ module.exports = {
                 !sourceCode.isSpaceBetweenTokens(prevToken, token)
             ) {
                 context.report({
-                    loc: token.loc.start,
+                    loc: token.loc,
                     messageId: "expectedBefore",
                     data: token,
                     fix(fixer) {
@@ -178,7 +178,7 @@ module.exports = {
                 !sourceCode.isSpaceBetweenTokens(token, nextToken)
             ) {
                 context.report({
-                    loc: token.loc.start,
+                    loc: token.loc,
                     messageId: "expectedAfter",
                     data: token,
                     fix(fixer) {

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -1364,14 +1364,14 @@ ruleTester.run("keyword-spacing", rule, {
             code: "import *as a from \"foo\"",
             output: "import * as a from \"foo\"",
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
-            errors: expectedBefore("as")
-        },
-        {
-            code: "import* as a from\"foo\"",
-            output: "import*as a from\"foo\"",
-            options: [NEITHER],
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
-            errors: unexpectedBefore("as")
+            errors: [{
+                messageId: "expectedBefore",
+                data: { value: "as" },
+                line: 1,
+                column: 9,
+                endLine: 1,
+                endColumn: 11
+            }]
         },
         {
             code: "import* as a from\"foo\"",
@@ -1380,27 +1380,26 @@ ruleTester.run("keyword-spacing", rule, {
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: [{
                 messageId: "unexpectedBefore",
+                data: { value: "as" },
                 line: 1,
                 column: 8,
                 endLine: 1,
                 endColumn: 9
-            }
-            ]
+            }]
         },
         {
-            code: "import *as a from\"foo\"",
+            code: "import*   as a from\"foo\"",
             output: "import*as a from\"foo\"",
             options: [NEITHER],
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
-            errors: [
-                {
-                    messageId: "unexpectedAfter",
-                    line: 1,
-                    column: 7,
-                    endLine: 1,
-                    endColumn: 8
-                }
-            ]
+            errors: [{
+                messageId: "unexpectedBefore",
+                data: { value: "as" },
+                line: 1,
+                column: 8,
+                endLine: 1,
+                endColumn: 11
+            }]
         },
         {
             code: "import*as a from\"foo\"",
@@ -2510,6 +2509,47 @@ ruleTester.run("keyword-spacing", rule, {
         // import
         //----------------------------------------------------------------------
 
+        {
+            code: "import* as a from \"foo\"",
+            output: "import * as a from \"foo\"",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "expectedAfter",
+                data: { value: "import" },
+                line: 1,
+                column: 1,
+                endLine: 1,
+                endColumn: 7
+            }]
+        },
+        {
+            code: "import *as a from\"foo\"",
+            output: "import*as a from\"foo\"",
+            options: [NEITHER],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "unexpectedAfter",
+                data: { value: "import" },
+                line: 1,
+                column: 7,
+                endLine: 1,
+                endColumn: 8
+            }]
+        },
+        {
+            code: "import   *as a from\"foo\"",
+            output: "import*as a from\"foo\"",
+            options: [NEITHER],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{
+                messageId: "unexpectedAfter",
+                data: { value: "import" },
+                line: 1,
+                column: 7,
+                endLine: 1,
+                endColumn: 10
+            }]
+        },
         {
             code: "{}import{a} from \"foo\"",
             output: "{} import {a} from \"foo\"",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

refs #12334

This PR adds `loc.end` to reports in the `keyword-spacing` rule.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

changed `*.loc.start` to just `*.loc`.

#### Is there anything you'd like reviewers to focus on?