### PR TITLE
add 'inlineConfigGroup' option

### DIFF
--- a/conf/config-schema.js
+++ b/conf/config-schema.js
@@ -22,6 +22,7 @@ const baseConfigProperties = {
     rules: { type: "object" },
     settings: { type: "object" },
     noInlineConfig: { type: "boolean" },
+    inlineConfigGroup: { type: "string" },
     reportUnusedDisableDirectives: { type: "boolean" },
 
     ecmaFeatures: { type: "object" } // deprecated; logs a warning when used

--- a/conf/default-cli-options.js
+++ b/conf/default-cli-options.js
@@ -26,6 +26,7 @@ module.exports = {
     cacheFile: ".eslintcache",
     fix: false,
     allowInlineConfig: true,
+    inlineConfigGroup: "default",
     reportUnusedDisableDirectives: void 0,
     globInputPaths: true
 };

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -81,6 +81,7 @@ const DEFAULT_ERROR_LOC = { start: { line: 1, column: 0 }, end: { line: 1, colum
  * @property {boolean} [allowInlineConfig] Allow/disallow inline comments' ability
  *      to change config once it is set. Defaults to true if not supplied.
  *      Useful if you want to validate JS without comments overriding rules.
+ * @property {string} [inlineConfigGroup] TODO
  * @property {boolean} [disableFixes] if `true` then the linter doesn't make `fix`
  *      properties into the lint result.
  * @property {string} [filename] the filename of the source code.
@@ -283,11 +284,12 @@ function stripDirectiveComment(value) {
  * @param {string} filename The file being checked.
  * @param {ASTNode} ast The top node of the AST.
  * @param {function(string): {create: Function}} ruleMapper A map from rule IDs to defined rules
- * @param {string|null} warnInlineConfig If a string then it should warn directive comments as disabled. The string value is the config name what the setting came from.
+ * @param {string|null} warnInlineConfig If a string then it should warn directive comments as disabled. The string value is the config name where the setting came from.
+ * @param {string} directiveGroup TODO
  * @returns {{configuredRules: Object, enabledGlobals: {value:string,comment:Token}[], exportedVariables: Object, problems: Problem[], disableDirectives: DisableDirective[]}}
  * A collection of the directive comments that were found, along with any problems that occurred when parsing
  */
-function getDirectiveComments(filename, ast, ruleMapper, warnInlineConfig) {
+function getDirectiveComments(filename, ast, ruleMapper, warnInlineConfig, directiveGroup) {
     const configuredRules = {};
     const enabledGlobals = Object.create(null);
     const exportedVariables = {};
@@ -296,13 +298,20 @@ function getDirectiveComments(filename, ast, ruleMapper, warnInlineConfig) {
 
     ast.comments.filter(token => token.type !== "Shebang").forEach(comment => {
         const trimmedCommentText = stripDirectiveComment(comment.value);
-        const match = /^(eslint(?:-env|-enable|-disable(?:(?:-next)?-line)?)?|exported|globals?)(?:\s|$)/u.exec(trimmedCommentText);
+        const match = /^(eslint(?:\[(\S+)\])?(?:-env|-enable|-disable(?:(?:-next)?-line)?)?|exported|globals?)(?:\s|$)/u.exec(trimmedCommentText);
 
         if (!match) {
             return;
         }
-        const directiveText = match[1];
-        const lineCommentSupported = /^eslint-disable-(next-)?line$/u.test(directiveText);
+
+        const commentDirectiveGroup = match[2] || "default";
+
+        if (commentDirectiveGroup !== directiveGroup) {
+            return;
+        }
+
+        const directiveText = match[1].replace(/^eslint\[\S+\]/u, "eslint");
+        const lineCommentSupported = /^eslint(\[\S+\])?-disable-(next-)?line$/u.test(directiveText);
 
         if (comment.type === "Line" && !lineCommentSupported) {
             return;
@@ -511,6 +520,7 @@ function normalizeVerifyOptions(providedOptions, config) {
         warnInlineConfig: disableInlineConfig && !ignoreInlineConfig
             ? `your config${configNameOfNoInlineConfig}`
             : null,
+        inlineConfigGroup: config.inlineConfigGroup || "default",
         reportUnusedDisableDirectives,
         disableFixes: Boolean(providedOptions.disableFixes)
     };
@@ -1152,7 +1162,7 @@ class Linter {
 
         const sourceCode = slots.lastSourceCode;
         const commentDirectives = options.allowInlineConfig
-            ? getDirectiveComments(options.filename, sourceCode.ast, ruleId => getRule(slots, ruleId), options.warnInlineConfig)
+            ? getDirectiveComments(options.filename, sourceCode.ast, ruleId => getRule(slots, ruleId), options.warnInlineConfig, options.inlineConfigGroup)
             : { configuredRules: {}, enabledGlobals: {}, exportedVariables: {}, problems: [], disableDirectives: [] };
 
         // augment global scope with declared global variables

--- a/lib/shared/types.js
+++ b/lib/shared/types.js
@@ -32,6 +32,7 @@ module.exports = {};
  * @property {Record<string, GlobalConf>} [globals] The global variable settings.
  * @property {string | string[]} [ignorePatterns] The glob patterns that ignore to lint.
  * @property {boolean} [noInlineConfig] The flag that disables directive comments.
+ * @property {string} [inlineConfigGroup] TODO
  * @property {OverrideConfigData[]} [overrides] The override settings per kind of files.
  * @property {string} [parser] The path to a parser or the package name of a parser.
  * @property {ParserOptions} [parserOptions] The parser options.


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [x] Add a CLI option
- [x] Add something to the core
- [ ] Other, please explain:


#### What changes did you make?
Add support for a `inlineConfigGroup` option and directive comments that include a group name.

E.g if `inlineConfigGroup` was `build` then `/* eslint[build]-disable */` would be respected and `/* eslint-disable */` would be ignored.

When a group is omitted it defaults to `default`.

**Note this is not finished yet. I haven't checked it works or added tests, but I wanted to get some feedback before continuing**


#### Why?
We have an eslint config for our source code but we have a separate config that we use to run over build output to make sure it doesn't accidentally contain any features that devices don't support.

The problem is that the built version of our app still includes comments, including eslint directives. For the lint that runs over the build we need to ignore those comments. We would also like to include some directive comments in the src specifically for the build linter to ignore false alarms.

E.g. we have a lint rule that prevents es6 methods and one looks for `<something>.find`. This obviously has false positives and for those cases we'd like to be able to do

```js
// eslint[build]-disable-next-line
CoreUtils.find(...)
```

#### TODO
- [ ] check this makes sense
- [ ] tests
- [ ] docs
