### PR TITLE
Chore: use espree.latestEcmaVersion in fuzzer

### DIFF
--- a/tools/code-sample-minimizer.js
+++ b/tools/code-sample-minimizer.js
@@ -52,7 +52,7 @@ function reduceBadExampleSize({
                 comment: true,
                 eslintVisitorKeys: true,
                 eslintScopeManager: true,
-                ecmaVersion: 2018,
+                ecmaVersion: espree.latestEcmaVersion,
                 sourceType: "script"
             })
     },

--- a/tools/eslint-fuzzer.js
+++ b/tools/eslint-fuzzer.js
@@ -129,7 +129,10 @@ function fuzz(options) {
         const text = codeGenerator({ sourceType });
         const config = {
             rules: lodash.mapValues(ruleConfigs, lodash.sample),
-            parserOptions: { sourceType, ecmaVersion: 2020 }
+            parserOptions: {
+                sourceType,
+                ecmaVersion: espree.latestEcmaVersion
+            }
         };
 
         let autofixResult;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

Chore, replaces hard-coded ecmaVersion with `espree.latestEcmaVersion` in fuzzer.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated fuzzer and code sample minimizer.


#### Is there anything you'd like reviewers to focus on?
