### PR TITLE
Chore: enable consistent-meta-messages internal rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -95,12 +95,8 @@ module.exports = {
             files: ["lib/rules/*", "tools/internal-rules/*"],
             excludedFiles: ["index.js"],
             rules: {
-                "internal-rules/no-invalid-meta": "error"
-
-                /*
-                 * TODO: enable it when all the rules using meta.messages
-                 * "internal-rules/consistent-meta-messages": "error"
-                 */
+                "internal-rules/no-invalid-meta": "error",
+                "internal-rules/consistent-meta-messages": "error"
             }
         },
         {

--- a/tests/tools/internal-rules/consistent-docs-url.js
+++ b/tests/tools/internal-rules/consistent-docs-url.js
@@ -55,7 +55,7 @@ ruleTester.run("consistent-docs-url", rule, {
                 "};"
             ].join("\n"),
             errors: [{
-                message: "Rule is missing a meta.docs property",
+                messageId: "missingMetaDocs",
                 line: 2,
                 column: 5
             }]
@@ -73,7 +73,7 @@ ruleTester.run("consistent-docs-url", rule, {
                 "};"
             ].join("\n"),
             errors: [{
-                message: "Rule is missing a meta.docs.url property",
+                messageId: "missingMetaDocsUrl",
                 line: 3,
                 column: 9
             }]
@@ -92,7 +92,11 @@ ruleTester.run("consistent-docs-url", rule, {
                 "};"
             ].join("\n"),
             errors: [{
-                message: "Incorrect url. Expected \"https://eslint.org/docs/rules/<input>\" but got \"http://example.com/wrong-url\"",
+                messageId: "incorrectUrl",
+                data: {
+                    expected: "https://eslint.org/docs/rules/<input>",
+                    url: "http://example.com/wrong-url"
+                },
                 line: 4,
                 column: 18
             }]

--- a/tools/internal-rules/consistent-docs-url.js
+++ b/tools/internal-rules/consistent-docs-url.js
@@ -55,7 +55,7 @@ function checkMetaDocsUrl(context, exportsNode) {
     if (!metaDocs) {
         context.report({
             node: metaProperty,
-            message: "Rule is missing a meta.docs property"
+            messageId: "missingMetaDocs"
         });
         return;
     }
@@ -63,7 +63,7 @@ function checkMetaDocsUrl(context, exportsNode) {
     if (!metaDocsUrl) {
         context.report({
             node: metaDocs,
-            message: "Rule is missing a meta.docs.url property"
+            messageId: "missingMetaDocsUrl"
         });
         return;
     }
@@ -75,7 +75,8 @@ function checkMetaDocsUrl(context, exportsNode) {
     if (url !== expected) {
         context.report({
             node: metaDocsUrl.value,
-            message: `Incorrect url. Expected "${expected}" but got "${url}"`
+            messageId: "incorrectUrl",
+            data: { expected, url }
         });
     }
 
@@ -93,7 +94,12 @@ module.exports = {
             recommended: false
         },
         type: "suggestion",
-        schema: []
+        schema: [],
+        messages: {
+            missingMetaDocs: "Rule is missing a meta.docs property.",
+            missingMetaDocsUrl: "Rule is missing a meta.docs.url property.",
+            incorrectUrl: 'Incorrect url. Expected "{{ expected }}" but got "{{ url }}".'
+        }
     },
 
     create(context) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

This PR enables `internal-rules/consistent-meta-messages`, which enforces existence of `meta.messages` in rules.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Enabled the rule in eslint codebase. 

Also updated `internal-rules/consistent-docs-url` to use `meta.messages`, as it was the only rule (out of all core and internal rules) that hasn't been updated yet.

#### Is there anything you'd like reviewers to focus on?
