### PR TITLE
Update: require `meta` for fixable rules in RuleTester (refs #13349)

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -861,6 +861,16 @@ class RuleTester {
                 );
             }
 
+            // new-format (object format) rules must have `meta.fixable` property if they make fixes.
+            if (result.output !== item.code && typeof rule !== "function") {
+                assert.ok(
+                    hasOwnProperty(rule, "meta"),
+                    "Fixable rules should export a `meta.fixable` property."
+                );
+
+                // Linter throws if rule has `meta` but doesn't have `meta.fixable`.
+            }
+
             assertASTDidntChange(result.beforeAST, result.afterAST);
         }
 

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -861,14 +861,14 @@ class RuleTester {
                 );
             }
 
-            // new-format (object format) rules must have `meta.fixable` property if they make fixes.
-            if (result.output !== item.code && typeof rule !== "function") {
+            // Rules that produce fixes must have `meta.fixable` property.
+            if (result.output !== item.code) {
                 assert.ok(
                     hasOwnProperty(rule, "meta"),
                     "Fixable rules should export a `meta.fixable` property."
                 );
 
-                // Linter throws if rule has `meta` but doesn't have `meta.fixable`.
+                // Linter throws if a rule that produced a fix has `meta` but doesn't have `meta.fixable`.
             }
 
             assertASTDidntChange(result.beforeAST, result.afterAST);

--- a/tests/fixtures/testers/rule-tester/no-var.js
+++ b/tests/fixtures/testers/rule-tester/no-var.js
@@ -7,27 +7,31 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function(context) {
+"use strict";
 
-    "use strict";
+module.exports = {
 
+    meta: {
+        fixable: "code"
+    },
 
-    var sourceCode = context.getSourceCode();
+    create(context) {
 
-    return {
+        var sourceCode = context.getSourceCode();
 
-        "VariableDeclaration": function(node) {
-            if (node.kind === "var") {
-                context.report({
-                    node: node,
-                    loc: sourceCode.getFirstToken(node).loc,
-                    message: "Bad var.",
-                    fix: function(fixer) {
-                        return fixer.remove(sourceCode.getFirstToken(node));
-                    }
-                })
+        return {
+            "VariableDeclaration": function(node) {
+                if (node.kind === "var") {
+                    context.report({
+                        node: node,
+                        loc: sourceCode.getFirstToken(node).loc,
+                        message: "Bad var.",
+                        fix: function(fixer) {
+                            return fixer.remove(sourceCode.getFirstToken(node));
+                        }
+                    })
+                }
             }
-        }
-    };
-
+        };
+    }
 };

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1247,7 +1247,7 @@ describe("RuleTester", () => {
         /**
          * Legacy-format rule (a function instead of an object with `create` method).
          * @param {RuleContext} context The ESLint rule context object.
-         * @returns {void} No return value
+         * @returns {Object} Listeners.
          */
         function replaceProgramWith5Rule(context) {
             return {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1242,29 +1242,7 @@ describe("RuleTester", () => {
     });
 
     // fixable rules with or without `meta` property
-    it("should not throw an error if a legacy-format rule makes fixes", () => {
-
-        /**
-         * Legacy-format rule (a function instead of an object with `create` method).
-         * @param {RuleContext} context The ESLint rule context object.
-         * @returns {Object} Listeners.
-         */
-        function replaceProgramWith5Rule(context) {
-            return {
-                Program(node) {
-                    context.report({ node, message: "bad", fix: fixer => fixer.replaceText(node, "5") });
-                }
-            };
-        }
-
-        ruleTester.run("replaceProgramWith5", replaceProgramWith5Rule, {
-            valid: [],
-            invalid: [
-                { code: "var foo = bar;", output: "5", errors: 1 }
-            ]
-        });
-    });
-    it("should not throw an error if a new-format rule that has `meta.fixable` makes fixes", () => {
+    it("should not throw an error if a rule that has `meta.fixable` produces fixes", () => {
         const replaceProgramWith5Rule = {
             meta: {
                 fixable: "code"
@@ -1285,7 +1263,7 @@ describe("RuleTester", () => {
             ]
         });
     });
-    it("should throw an error if a new-format rule that doesn't have `meta` makes fixes", () => {
+    it("should throw an error if a new-format rule that doesn't have `meta` produces fixes", () => {
         const replaceProgramWith5Rule = {
             create(context) {
                 return {
@@ -1295,6 +1273,30 @@ describe("RuleTester", () => {
                 };
             }
         };
+
+        assert.throws(() => {
+            ruleTester.run("replaceProgramWith5", replaceProgramWith5Rule, {
+                valid: [],
+                invalid: [
+                    { code: "var foo = bar;", output: "5", errors: 1 }
+                ]
+            });
+        }, "Fixable rules should export a `meta.fixable` property.");
+    });
+    it("should throw an error if a legacy-format rule produces fixes", () => {
+
+        /**
+         * Legacy-format rule (a function instead of an object with `create` method).
+         * @param {RuleContext} context The ESLint rule context object.
+         * @returns {Object} Listeners.
+         */
+        function replaceProgramWith5Rule(context) {
+            return {
+                Program(node) {
+                    context.report({ node, message: "bad", fix: fixer => fixer.replaceText(node, "5") });
+                }
+            };
+        }
 
         assert.throws(() => {
             ruleTester.run("replaceProgramWith5", replaceProgramWith5Rule, {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -304,6 +304,10 @@ describe("RuleTester", () => {
 
     it("should use strict equality to compare output", () => {
         const replaceProgramWith5Rule = {
+            meta: {
+                fixable: "code"
+            },
+
             create: context => ({
                 Program(node) {
                     context.report({ node, message: "bad", fix: fixer => fixer.replaceText(node, "5") });
@@ -1235,6 +1239,71 @@ describe("RuleTester", () => {
                 invalid: [{ code: "foo", errors: [{ data: "something" }] }]
             });
         }, "Error must specify 'messageId' if 'data' is used.");
+    });
+
+    // fixable rules with or without `meta` property
+    it("should not throw an error if a legacy-format rule makes fixes", () => {
+
+        /**
+         * Legacy-format rule (a function instead of an object with `create` method).
+         * @param {RuleContext} context The ESLint rule context object.
+         * @returns {void} No return value
+         */
+        function replaceProgramWith5Rule(context) {
+            return {
+                Program(node) {
+                    context.report({ node, message: "bad", fix: fixer => fixer.replaceText(node, "5") });
+                }
+            };
+        }
+
+        ruleTester.run("replaceProgramWith5", replaceProgramWith5Rule, {
+            valid: [],
+            invalid: [
+                { code: "var foo = bar;", output: "5", errors: 1 }
+            ]
+        });
+    });
+    it("should not throw an error if a new-format rule that has `meta.fixable` makes fixes", () => {
+        const replaceProgramWith5Rule = {
+            meta: {
+                fixable: "code"
+            },
+            create(context) {
+                return {
+                    Program(node) {
+                        context.report({ node, message: "bad", fix: fixer => fixer.replaceText(node, "5") });
+                    }
+                };
+            }
+        };
+
+        ruleTester.run("replaceProgramWith5", replaceProgramWith5Rule, {
+            valid: [],
+            invalid: [
+                { code: "var foo = bar;", output: "5", errors: 1 }
+            ]
+        });
+    });
+    it("should throw an error if a new-format rule that doesn't have `meta` makes fixes", () => {
+        const replaceProgramWith5Rule = {
+            create(context) {
+                return {
+                    Program(node) {
+                        context.report({ node, message: "bad", fix: fixer => fixer.replaceText(node, "5") });
+                    }
+                };
+            }
+        };
+
+        assert.throws(() => {
+            ruleTester.run("replaceProgramWith5", replaceProgramWith5Rule, {
+                valid: [],
+                invalid: [
+                    { code: "var foo = bar;", output: "5", errors: 1 }
+                ]
+            });
+        }, "Fixable rules should export a `meta.fixable` property.");
     });
 
     describe("suggestions", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Add something to the core

refs #13349, fixes step 2 from [this comment](https://github.com/eslint/eslint/issues/13349#issuecomment-646729029).

This PR updates RuleTester to require `meta` property in fixable rules.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

An `invalid` test case, where the rule being tested has fixed the given code, will now fail if the rule doesn't have `meta` property.

#### Is there anything you'd like reviewers to focus on?

* `RuleTester` still doesn't check for `meta.fixable`, because linter already throws an error if the rule that provided a fix does have `meta` but doesn't have `meta.fixable`.
* ~This change doesn't affect legacy-format rules (functions). They will be still allowed to make fixes. I guess that was decided?~
* This change also affects legacy-format rules (functions). RuleTester will no longer allow fixable legacy-format rules.
* This change can break plugins' builds.
