### PR TITLE
Fix: Do not output `undefined` as line and column when it's unavailable in checkstyle format

### DIFF
--- a/lib/cli-engine/formatters/checkstyle.js
+++ b/lib/cli-engine/formatters/checkstyle.js
@@ -42,8 +42,8 @@ module.exports = function(results) {
 
         messages.forEach(message => {
             output += [
-                `<error line="${xmlEscape(message.line)}"`,
-                `column="${xmlEscape(message.column)}"`,
+                `<error line="${xmlEscape(message.line || 0)}"`,
+                `column="${xmlEscape(message.column || 0)}"`,
                 `severity="${xmlEscape(getMessageType(message))}"`,
                 `message="${xmlEscape(message.message)}${message.ruleId ? ` (${message.ruleId})` : ""}"`,
                 `source="${message.ruleId ? xmlEscape(`eslint.rules.${message.ruleId}`) : ""}" />`

--- a/tests/lib/cli-engine/formatters/checkstyle.js
+++ b/tests/lib/cli-engine/formatters/checkstyle.js
@@ -151,4 +151,21 @@ describe("formatter:checkstyle", () => {
             assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo.\" source=\"\" /></file></checkstyle>");
         });
     });
+
+    describe("when passing single message without line and column", () => {
+        const code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                severity: 2,
+                ruleId: "foo"
+            }]
+        }];
+
+        it("should return line and column as 0 instead of undefined", () => {
+            const result = formatter(code);
+
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"0\" column=\"0\" severity=\"error\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /></file></checkstyle>");
+        });
+    });
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What did you do? Please include the actual source code causing the issue.**
Run eslint with checkstyle format and .eslintignore.
```
$ eslint ./testdata/*.js -f=checkstyle
```

**What did you expect to happen?**
eslintignore warning should output line and column as 0 or do not output line and column fields.

**What actually happened? Please include the actual, raw output from ESLint.**
eslintignore warning output `undefined` as line and column fields of checkstyle XML.

```
<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="/home/haya14busa/src/github.com/reviewdog/action-eslint/testdata/test.js"><error line="undefined" column="undefined" severity="warning" message="File ignored because of a matching ignore pattern. Use &quot;--no-ignore&quot; to override." source="" /></file></checkstyle>
```


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Use 0 if line and column are undefined. It's consistent with other formatters.

#### Is there anything you'd like reviewers to focus on?
N/A