### PR TITLE
Update: add comment to message in no-warning-comments (fixes #12327)

### DIFF
--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -49,7 +49,6 @@ module.exports = {
     },
 
     create(context) {
-
         const sourceCode = context.getSourceCode(),
             configuration = context.options[0] || {},
             warningTerms = configuration.terms || ["todo", "fixme", "xxx"],
@@ -109,7 +108,15 @@ module.exports = {
              * \bTERM\b|\bTERM\b, this checks the entire comment
              * for the term.
              */
-            return new RegExp(prefix + escaped + suffix + eitherOrWordBoundary + term + wordBoundary, "iu");
+            return new RegExp(
+                prefix +
+                    escaped +
+                    suffix +
+                    eitherOrWordBoundary +
+                    term +
+                    wordBoundary,
+                "iu"
+            );
         }
 
         const warningRegExps = warningTerms.map(convertToRegExp);
@@ -137,22 +144,28 @@ module.exports = {
          * @returns {void} undefined.
          */
         function checkComment(node) {
-            if (astUtils.isDirectiveComment(node) && selfConfigRegEx.test(node.value)) {
+            if (
+                astUtils.isDirectiveComment(node) &&
+                selfConfigRegEx.test(node.value)
+            ) {
                 return;
             }
 
             const matches = commentContainsWarningTerm(node.value);
 
             matches.forEach(({ type, comment }) => {
-                let commentsToDisplay = "";
+                let commentToDisplay = "";
                 let truncated = false;
 
                 for (const c of comment.trim().split(/\s+/u)) {
-                    commentsToDisplay = commentsToDisplay.trim();
-                    if (c.length + commentsToDisplay.length <= CHAR_LIMIT) {
-                        commentsToDisplay = `${commentsToDisplay} ${c}`;
+                    commentToDisplay = commentToDisplay.trim();
+                    const tmp = `${commentToDisplay} ${c}`;
+
+                    if (tmp.length <= CHAR_LIMIT) {
+                        commentToDisplay = tmp;
                     } else {
                         truncated = true;
+                        break;
                     }
                 }
 
@@ -161,7 +174,9 @@ module.exports = {
                     messageId: "unexpectedComment",
                     data: {
                         type,
-                        comment: `${commentsToDisplay.trim()}${truncated ? "..." : ""}`
+                        comment: `${commentToDisplay.trim()}${
+                            truncated ? "..." : ""
+                        }`
                     }
                 });
             });
@@ -171,7 +186,9 @@ module.exports = {
             Program() {
                 const comments = sourceCode.getAllComments();
 
-                comments.filter(token => token.type !== "Shebang").forEach(checkComment);
+                comments
+                    .filter(token => token.type !== "Shebang")
+                    .forEach(checkComment);
             }
         };
     }

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -8,7 +8,7 @@
 const { escapeRegExp } = require("lodash");
 const astUtils = require("./utils/ast-utils");
 
-const CHAR_LIMIT = 30;
+const CHAR_LIMIT = 40;
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -44,7 +44,7 @@ module.exports = {
         ],
 
         messages: {
-            unexpectedComment: "Unexpected '{{type}}' comment: {{comment}}."
+            unexpectedComment: "Unexpected '{{type}}' comment: '{{comment}}'."
         }
     },
 
@@ -145,26 +145,27 @@ module.exports = {
 
             matches.forEach(({ type, comment }) => {
                 let len = 0;
-                const comments = [];
+                const commentsToDisplay = [];
                 let truncated = false;
 
-                comment
-                    .split(/\s/u).forEach(c => {
-                        if (c.length + len <= CHAR_LIMIT) {
-                            comments.push(c);
-                        } else {
-                            truncated = true;
-                        }
+                for (const c of comment.split(/\s+/u)) {
+                    if (c.length + len <= CHAR_LIMIT) {
+                        commentsToDisplay.push(c);
+                    } else {
+                        truncated = true;
+                        break;
+                    }
 
-                        len += c.length;
-                    });
+                    len += c.length;
+                }
+
 
                 context.report({
                     node,
                     messageId: "unexpectedComment",
                     data: {
                         type,
-                        comment: `'${comments.join(" ").trim()}${truncated ? "..." : ""}'`
+                        comment: `${commentsToDisplay.join(" ").trim()}${truncated ? "..." : ""}`
                     }
                 });
             });

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -42,7 +42,7 @@ module.exports = {
         ],
 
         messages: {
-            unexpectedComment: "Unexpected '{{matchedTerm}}' comment."
+            unexpectedComment: "Unexpected '{{type}}' comment: {{comment}}."
         }
     },
 
@@ -122,7 +122,7 @@ module.exports = {
 
             warningRegExps.forEach((regex, index) => {
                 if (regex.test(comment)) {
-                    matches.push(warningTerms[index]);
+                    matches.push({ type: warningTerms[index], comment });
                 }
             });
 
@@ -141,12 +141,18 @@ module.exports = {
 
             const matches = commentContainsWarningTerm(node.value);
 
-            matches.forEach(matchedTerm => {
+            matches.forEach(({ type, comment }) => {
+                let commentToDisplay = comment.trim();
+
+                if (commentToDisplay.length >= 30) {
+                    commentToDisplay = `${commentToDisplay.slice(0, 30)}..`;
+                }
                 context.report({
                     node,
                     messageId: "unexpectedComment",
                     data: {
-                        matchedTerm
+                        type,
+                        comment: `${commentToDisplay}`
                     }
                 });
             });

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -8,6 +8,8 @@
 const { escapeRegExp } = require("lodash");
 const astUtils = require("./utils/ast-utils");
 
+const CHAR_LIMIT = 30;
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -142,17 +144,27 @@ module.exports = {
             const matches = commentContainsWarningTerm(node.value);
 
             matches.forEach(({ type, comment }) => {
-                let commentToDisplay = comment.trim();
+                let len = 0;
+                const comments = [];
+                let truncated = false;
 
-                if (commentToDisplay.length >= 30) {
-                    commentToDisplay = `${commentToDisplay.slice(0, 30)}..`;
-                }
+                comment
+                    .split(/\s/u).forEach(c => {
+                        if (c.length + len <= CHAR_LIMIT) {
+                            comments.push(c);
+                        } else {
+                            truncated = true;
+                        }
+
+                        len += c.length;
+                    });
+
                 context.report({
                     node,
                     messageId: "unexpectedComment",
                     data: {
                         type,
-                        comment: `${commentToDisplay}`
+                        comment: `'${comments.join(" ").trim()}${truncated ? "..." : ""}'`
                     }
                 });
             });

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -44,7 +44,7 @@ module.exports = {
         ],
 
         messages: {
-            unexpectedComment: "Unexpected '{{type}}' comment: '{{comment}}'."
+            unexpectedComment: "Unexpected '{{matchedTerm}}' comment: '{{comment}}'."
         }
     },
 
@@ -131,7 +131,7 @@ module.exports = {
 
             warningRegExps.forEach((regex, index) => {
                 if (regex.test(comment)) {
-                    matches.push({ type: warningTerms[index], comment });
+                    matches.push(warningTerms[index]);
                 }
             });
 
@@ -153,13 +153,13 @@ module.exports = {
 
             const matches = commentContainsWarningTerm(node.value);
 
-            matches.forEach(({ type, comment }) => {
-                let commentToDisplay = "";
+            matches.forEach(matchedTerm => {
+                const comment = node.value;
+                let commentToDisplay;
                 let truncated = false;
 
                 for (const c of comment.trim().split(/\s+/u)) {
-                    commentToDisplay = commentToDisplay.trim();
-                    const tmp = `${commentToDisplay} ${c}`;
+                    const tmp = commentToDisplay ? `${commentToDisplay} ${c}` : c;
 
                     if (tmp.length <= CHAR_LIMIT) {
                         commentToDisplay = tmp;
@@ -173,8 +173,8 @@ module.exports = {
                     node,
                     messageId: "unexpectedComment",
                     data: {
-                        type,
-                        comment: `${commentToDisplay.trim()}${
+                        matchedTerm,
+                        comment: `${commentToDisplay}${
                             truncated ? "..." : ""
                         }`
                     }

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -144,28 +144,24 @@ module.exports = {
             const matches = commentContainsWarningTerm(node.value);
 
             matches.forEach(({ type, comment }) => {
-                let len = 0;
-                const commentsToDisplay = [];
+                let commentsToDisplay = "";
                 let truncated = false;
 
-                for (const c of comment.split(/\s+/u)) {
-                    if (c.length + len <= CHAR_LIMIT) {
-                        commentsToDisplay.push(c);
+                for (const c of comment.trim().split(/\s+/u)) {
+                    commentsToDisplay = commentsToDisplay.trim();
+                    if (c.length + commentsToDisplay.length <= CHAR_LIMIT) {
+                        commentsToDisplay = `${commentsToDisplay} ${c}`;
                     } else {
                         truncated = true;
-                        break;
                     }
-
-                    len += c.length;
                 }
-
 
                 context.report({
                     node,
                     messageId: "unexpectedComment",
                     data: {
                         type,
-                        comment: `${commentsToDisplay.join(" ").trim()}${truncated ? "..." : ""}`
+                        comment: `${commentsToDisplay.trim()}${truncated ? "..." : ""}`
                     }
                 });
             });

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -144,18 +144,19 @@ module.exports = {
          * @returns {void} undefined.
          */
         function checkComment(node) {
+            const comment = node.value;
+
             if (
                 astUtils.isDirectiveComment(node) &&
-                selfConfigRegEx.test(node.value)
+                selfConfigRegEx.test(comment)
             ) {
                 return;
             }
 
-            const matches = commentContainsWarningTerm(node.value);
+            const matches = commentContainsWarningTerm(comment);
 
             matches.forEach(matchedTerm => {
-                const comment = node.value;
-                let commentToDisplay;
+                let commentToDisplay = "";
                 let truncated = false;
 
                 for (const c of comment.trim().split(/\s+/u)) {

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -43,165 +43,179 @@ ruleTester.run("no-warning-comments", rule, {
         {
             code: "// fixme",
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme" } }
             ]
         },
         {
             code: "// any fixme",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme" } }
             ]
         },
         {
             code: "// any fixme",
             options: [{ terms: ["fixme"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme" } }
             ]
         },
         {
             code: "// any FIXME",
             options: [{ terms: ["fixme"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any FIXME" } }
             ]
         },
         {
             code: "// any fIxMe",
             options: [{ terms: ["fixme"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fIxMe" } }
             ]
         },
         {
             code: "/* any fixme */",
             options: [{ terms: ["FIXME"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "FIXME" } }
+                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "any fixme" } }
             ]
         },
         {
             code: "/* any FIXME */",
             options: [{ terms: ["FIXME"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "FIXME" } }
+                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "any FIXME" } }
             ]
         },
         {
             code: "/* any fIxMe */",
             options: [{ terms: ["FIXME"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "FIXME" } }
+                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "any fIxMe" } }
             ]
         },
         {
             code: "// any fixme or todo",
             options: [{ terms: ["fixme", "todo"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } },
-                { messageId: "unexpectedComment", data: { matchedTerm: "todo" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme or todo" } },
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any fixme or todo" } }
             ]
         },
         {
             code: "/* any fixme or todo */",
             options: [{ terms: ["fixme", "todo"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } },
-                { messageId: "unexpectedComment", data: { matchedTerm: "todo" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme or todo" } },
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any fixme or todo" } }
             ]
         },
         {
             code: "/* any fixme or todo */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "todo" } },
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any fixme or todo" } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme or todo" } }
             ]
         },
         {
             code: "/* fixme and todo */",
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme and todo" } }
             ]
         },
         {
             code: "/* fixme and todo */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "todo" } },
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "fixme and todo" } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme and todo" } }
             ]
         },
         {
             code: "/* any fixme */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme" } }
             ]
         },
         {
             code: "/* fixme! */",
             options: [{ terms: ["fixme"] }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme!" } }
             ]
         },
         {
             code: "// regex [litera|$]",
             options: [{ terms: ["[litera|$]"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "[litera|$]" } }
+                { messageId: "unexpectedComment", data: { type: "[litera|$]", comment: "regex [litera|$]" } }
             ]
         },
         {
             code: "/* eslint one-var: 2 */",
             options: [{ terms: ["eslint"] }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "eslint" } }
+                { messageId: "unexpectedComment", data: { type: "eslint", comment: "eslint one-var: 2" } }
             ]
         },
         {
             code: "/* eslint one-var: 2 */",
             options: [{ terms: ["one"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "one" } }
+                { messageId: "unexpectedComment", data: { type: "one", comment: "eslint one-var: 2" } }
             ]
         },
         {
             code: "/* any block comment with TODO, FIXME or XXX */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "todo" } },
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } },
-                { messageId: "unexpectedComment", data: { matchedTerm: "xxx" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any block comment with TODO, F.." } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any block comment with TODO, F.." } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any block comment with TODO, F.." } }
             ]
         },
         {
             code: "/* any block comment with (TODO, FIXME's or XXX!) */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "todo" } },
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } },
-                { messageId: "unexpectedComment", data: { matchedTerm: "xxx" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any block comment with (TODO, .." } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any block comment with (TODO, .." } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any block comment with (TODO, .." } }
             ]
         },
         {
             code: "/** \n *any block comment \n*with (TODO, FIXME's or XXX!) **/",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "todo" } },
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } },
-                { messageId: "unexpectedComment", data: { matchedTerm: "xxx" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "* \n *any block comment \n*with .." } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "* \n *any block comment \n*with .." } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "* \n *any block comment \n*with .." } }
             ]
         },
         {
             code: "// any comment with TODO, FIXME or XXX",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { matchedTerm: "todo" } },
-                { messageId: "unexpectedComment", data: { matchedTerm: "fixme" } },
-                { messageId: "unexpectedComment", data: { matchedTerm: "xxx" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any comment with TODO, FIXME o.." } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any comment with TODO, FIXME o.." } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any comment with TODO, FIXME o.." } }
+            ]
+        },
+        {
+            code: "// TODO: something small",
+            options: [{ location: "anywhere" }],
+            errors: [
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "TODO: something small" } }
+            ]
+        },
+        {
+            code: "// TODO: something really longer than 30 characters",
+            options: [{ location: "anywhere" }],
+            errors: [
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "TODO: something really longer .." } }
             ]
         }
     ]

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -181,18 +181,18 @@ ruleTester.run("no-warning-comments", rule, {
             code: "/* any block comment with (TODO, FIXME's or XXX!) */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any block comment with (TODO, FIXME's or XXX!)" } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any block comment with (TODO, FIXME's or XXX!)" } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any block comment with (TODO, FIXME's or XXX!)" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any block comment with (TODO, FIXME's or..." } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any block comment with (TODO, FIXME's or..." } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any block comment with (TODO, FIXME's or..." } }
             ]
         },
         {
             code: "/** \n *any block comment \n*with (TODO, FIXME's or XXX!) **/",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "* *any block comment *with (TODO, FIXME's or..." } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "* *any block comment *with (TODO, FIXME's or..." } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "* *any block comment *with (TODO, FIXME's or..." } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "* *any block comment *with (TODO, FIXME's..." } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "* *any block comment *with (TODO, FIXME's..." } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "* *any block comment *with (TODO, FIXME's..." } }
             ]
         },
         {
@@ -227,7 +227,7 @@ ruleTester.run("no-warning-comments", rule, {
                     messageId: "unexpectedComment",
                     data: {
                         type: "todo",
-                        comment: "TODO: something really longer than 40..."
+                        comment: "TODO: something really longer than 40 and..."
                     }
                 }
             ]

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -244,6 +244,19 @@ ruleTester.run("no-warning-comments", rule, {
                     }
                 }
             ]
+        },
+        {
+            code: "// TODO: https://github.com/eslint/eslint/pull/13522#discussion_r470293411",
+            options: [{ location: "anywhere" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "todo",
+                        comment: "TODO:..."
+                    }
+                }
+            ]
         }
     ]
 });

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -43,179 +43,206 @@ ruleTester.run("no-warning-comments", rule, {
         {
             code: "// fixme",
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'fixme'" } }
             ]
         },
         {
             code: "// any fixme",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fixme'" } }
             ]
         },
         {
             code: "// any fixme",
             options: [{ terms: ["fixme"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fixme'" } }
             ]
         },
         {
             code: "// any FIXME",
             options: [{ terms: ["fixme"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any FIXME" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any FIXME'" } }
             ]
         },
         {
             code: "// any fIxMe",
             options: [{ terms: ["fixme"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fIxMe" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fIxMe'" } }
             ]
         },
         {
             code: "/* any fixme */",
             options: [{ terms: ["FIXME"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "any fixme" } }
+                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "'any fixme'" } }
             ]
         },
         {
             code: "/* any FIXME */",
             options: [{ terms: ["FIXME"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "any FIXME" } }
+                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "'any FIXME'" } }
             ]
         },
         {
             code: "/* any fIxMe */",
             options: [{ terms: ["FIXME"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "any fIxMe" } }
+                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "'any fIxMe'" } }
             ]
         },
         {
             code: "// any fixme or todo",
             options: [{ terms: ["fixme", "todo"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme or todo" } },
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any fixme or todo" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fixme or todo'" } },
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "'any fixme or todo'" } }
             ]
         },
         {
             code: "/* any fixme or todo */",
             options: [{ terms: ["fixme", "todo"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme or todo" } },
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any fixme or todo" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fixme or todo'" } },
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "'any fixme or todo'" } }
             ]
         },
         {
             code: "/* any fixme or todo */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any fixme or todo" } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme or todo" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "'any fixme or todo'" } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fixme or todo'" } }
             ]
         },
         {
             code: "/* fixme and todo */",
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme and todo" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'fixme and todo'" } }
             ]
         },
         {
             code: "/* fixme and todo */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "fixme and todo" } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme and todo" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "'fixme and todo'" } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'fixme and todo'" } }
             ]
         },
         {
             code: "/* any fixme */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fixme'" } }
             ]
         },
         {
             code: "/* fixme! */",
             options: [{ terms: ["fixme"] }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme!" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'fixme!'" } }
             ]
         },
         {
             code: "// regex [litera|$]",
             options: [{ terms: ["[litera|$]"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "[litera|$]", comment: "regex [litera|$]" } }
+                { messageId: "unexpectedComment", data: { type: "[litera|$]", comment: "'regex [litera|$]'" } }
             ]
         },
         {
             code: "/* eslint one-var: 2 */",
             options: [{ terms: ["eslint"] }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "eslint", comment: "eslint one-var: 2" } }
+                { messageId: "unexpectedComment", data: { type: "eslint", comment: "'eslint one-var: 2'" } }
             ]
         },
         {
             code: "/* eslint one-var: 2 */",
             options: [{ terms: ["one"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "one", comment: "eslint one-var: 2" } }
+                { messageId: "unexpectedComment", data: { type: "one", comment: "'eslint one-var: 2'" } }
             ]
         },
         {
             code: "/* any block comment with TODO, FIXME or XXX */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any block comment with TODO, F.." } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any block comment with TODO, F.." } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any block comment with TODO, F.." } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "'any block comment with TODO, FIXME...'" } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any block comment with TODO, FIXME...'" } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "'any block comment with TODO, FIXME...'" } }
             ]
         },
         {
             code: "/* any block comment with (TODO, FIXME's or XXX!) */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any block comment with (TODO, .." } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any block comment with (TODO, .." } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any block comment with (TODO, .." } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "'any block comment with (TODO,...'" } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any block comment with (TODO,...'" } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "'any block comment with (TODO,...'" } }
             ]
         },
         {
             code: "/** \n *any block comment \n*with (TODO, FIXME's or XXX!) **/",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "* \n *any block comment \n*with .." } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "* \n *any block comment \n*with .." } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "* \n *any block comment \n*with .." } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "'*   *any block comment  *with (TODO,...'" } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'*   *any block comment  *with (TODO,...'" } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "'*   *any block comment  *with (TODO,...'" } }
             ]
         },
         {
             code: "// any comment with TODO, FIXME or XXX",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any comment with TODO, FIXME o.." } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any comment with TODO, FIXME o.." } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any comment with TODO, FIXME o.." } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "'any comment with TODO, FIXME or XXX'" } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any comment with TODO, FIXME or XXX'" } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "'any comment with TODO, FIXME or XXX'" } }
             ]
         },
         {
             code: "// TODO: something small",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "TODO: something small" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "'TODO: something small'" } }
             ]
         },
         {
             code: "// TODO: something really longer than 30 characters",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "TODO: something really longer .." } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "'TODO: something really longer than...'" } }
+            ]
+        },
+        {
+            code:
+                "/* TODO: something \n really longer than 30 characters \n and also a new line */",
+            options: [{ location: "anywhere" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        type: "todo",
+                        comment: "'TODO: something   really longer than...'"
+                    }
+                }
+            ]
+        },
+        {
+            code: "// TODO: small",
+            options: [{ location: "anywhere" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        type: "todo",
+                        comment: "'TODO: small'"
+                    }
+                }
             ]
         }
     ]

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -43,179 +43,179 @@ ruleTester.run("no-warning-comments", rule, {
         {
             code: "// fixme",
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "fixme" } }
             ]
         },
         {
             code: "// any fixme",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "any fixme" } }
             ]
         },
         {
             code: "// any fixme",
             options: [{ terms: ["fixme"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "any fixme" } }
             ]
         },
         {
             code: "// any FIXME",
             options: [{ terms: ["fixme"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any FIXME" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "any FIXME" } }
             ]
         },
         {
             code: "// any fIxMe",
             options: [{ terms: ["fixme"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fIxMe" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "any fIxMe" } }
             ]
         },
         {
             code: "/* any fixme */",
             options: [{ terms: ["FIXME"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "any fixme" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "FIXME", comment: "any fixme" } }
             ]
         },
         {
             code: "/* any FIXME */",
             options: [{ terms: ["FIXME"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "any FIXME" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "FIXME", comment: "any FIXME" } }
             ]
         },
         {
             code: "/* any fIxMe */",
             options: [{ terms: ["FIXME"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "any fIxMe" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "FIXME", comment: "any fIxMe" } }
             ]
         },
         {
             code: "// any fixme or todo",
             options: [{ terms: ["fixme", "todo"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme or todo" } },
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any fixme or todo" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "any fixme or todo" } },
+                { messageId: "unexpectedComment", data: { matchedTerm: "todo", comment: "any fixme or todo" } }
             ]
         },
         {
             code: "/* any fixme or todo */",
             options: [{ terms: ["fixme", "todo"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme or todo" } },
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any fixme or todo" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "any fixme or todo" } },
+                { messageId: "unexpectedComment", data: { matchedTerm: "todo", comment: "any fixme or todo" } }
             ]
         },
         {
             code: "/* any fixme or todo */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any fixme or todo" } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme or todo" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "todo", comment: "any fixme or todo" } },
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "any fixme or todo" } }
             ]
         },
         {
             code: "/* fixme and todo */",
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme and todo" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "fixme and todo" } }
             ]
         },
         {
             code: "/* fixme and todo */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "fixme and todo" } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme and todo" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "todo", comment: "fixme and todo" } },
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "fixme and todo" } }
             ]
         },
         {
             code: "/* any fixme */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "any fixme" } }
             ]
         },
         {
             code: "/* fixme! */",
             options: [{ terms: ["fixme"] }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme!" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "fixme!" } }
             ]
         },
         {
             code: "// regex [litera|$]",
             options: [{ terms: ["[litera|$]"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "[litera|$]", comment: "regex [litera|$]" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "[litera|$]", comment: "regex [litera|$]" } }
             ]
         },
         {
             code: "/* eslint one-var: 2 */",
             options: [{ terms: ["eslint"] }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "eslint", comment: "eslint one-var: 2" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "eslint", comment: "eslint one-var: 2" } }
             ]
         },
         {
             code: "/* eslint one-var: 2 */",
             options: [{ terms: ["one"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "one", comment: "eslint one-var: 2" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "one", comment: "eslint one-var: 2" } }
             ]
         },
         {
             code: "/* any block comment with TODO, FIXME or XXX */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any block comment with TODO, FIXME or..." } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any block comment with TODO, FIXME or..." } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any block comment with TODO, FIXME or..." } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "todo", comment: "any block comment with TODO, FIXME or..." } },
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "any block comment with TODO, FIXME or..." } },
+                { messageId: "unexpectedComment", data: { matchedTerm: "xxx", comment: "any block comment with TODO, FIXME or..." } }
             ]
         },
         {
             code: "/* any block comment with (TODO, FIXME's or XXX!) */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any block comment with (TODO, FIXME's or..." } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any block comment with (TODO, FIXME's or..." } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any block comment with (TODO, FIXME's or..." } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "todo", comment: "any block comment with (TODO, FIXME's or..." } },
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "any block comment with (TODO, FIXME's or..." } },
+                { messageId: "unexpectedComment", data: { matchedTerm: "xxx", comment: "any block comment with (TODO, FIXME's or..." } }
             ]
         },
         {
             code: "/** \n *any block comment \n*with (TODO, FIXME's or XXX!) **/",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "* *any block comment *with (TODO,..." } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "* *any block comment *with (TODO,..." } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "* *any block comment *with (TODO,..." } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "todo", comment: "* *any block comment *with (TODO,..." } },
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "* *any block comment *with (TODO,..." } },
+                { messageId: "unexpectedComment", data: { matchedTerm: "xxx", comment: "* *any block comment *with (TODO,..." } }
             ]
         },
         {
             code: "// any comment with TODO, FIXME or XXX",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any comment with TODO, FIXME or XXX" } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any comment with TODO, FIXME or XXX" } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any comment with TODO, FIXME or XXX" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "todo", comment: "any comment with TODO, FIXME or XXX" } },
+                { messageId: "unexpectedComment", data: { matchedTerm: "fixme", comment: "any comment with TODO, FIXME or XXX" } },
+                { messageId: "unexpectedComment", data: { matchedTerm: "xxx", comment: "any comment with TODO, FIXME or XXX" } }
             ]
         },
         {
             code: "// TODO: something small",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "TODO: something small" } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "todo", comment: "TODO: something small" } }
             ]
         },
         {
             code: "// TODO: something really longer than 40 characters",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "TODO: something really longer than 40..." } }
+                { messageId: "unexpectedComment", data: { matchedTerm: "todo", comment: "TODO: something really longer than 40..." } }
             ]
         },
         {
@@ -226,7 +226,7 @@ ruleTester.run("no-warning-comments", rule, {
                 {
                     messageId: "unexpectedComment",
                     data: {
-                        type: "todo",
+                        matchedTerm: "todo",
                         comment: "TODO: something really longer than 40..."
                     }
                 }
@@ -239,7 +239,7 @@ ruleTester.run("no-warning-comments", rule, {
                 {
                     messageId: "unexpectedComment",
                     data: {
-                        type: "todo",
+                        matchedTerm: "todo",
                         comment: "TODO: small"
                     }
                 }

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -172,9 +172,9 @@ ruleTester.run("no-warning-comments", rule, {
             code: "/* any block comment with TODO, FIXME or XXX */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "any block comment with TODO, FIXME or XXX" } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any block comment with TODO, FIXME or XXX" } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any block comment with TODO, FIXME or XXX" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any block comment with TODO, FIXME or..." } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any block comment with TODO, FIXME or..." } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any block comment with TODO, FIXME or..." } }
             ]
         },
         {
@@ -190,9 +190,9 @@ ruleTester.run("no-warning-comments", rule, {
             code: "/** \n *any block comment \n*with (TODO, FIXME's or XXX!) **/",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "* *any block comment *with (TODO, FIXME's..." } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "* *any block comment *with (TODO, FIXME's..." } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "* *any block comment *with (TODO, FIXME's..." } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "* *any block comment *with (TODO,..." } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "* *any block comment *with (TODO,..." } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "* *any block comment *with (TODO,..." } }
             ]
         },
         {
@@ -227,7 +227,7 @@ ruleTester.run("no-warning-comments", rule, {
                     messageId: "unexpectedComment",
                     data: {
                         type: "todo",
-                        comment: "TODO: something really longer than 40 and..."
+                        comment: "TODO: something really longer than 40..."
                     }
                 }
             ]

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -43,191 +43,191 @@ ruleTester.run("no-warning-comments", rule, {
         {
             code: "// fixme",
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'fixme'" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme" } }
             ]
         },
         {
             code: "// any fixme",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fixme'" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme" } }
             ]
         },
         {
             code: "// any fixme",
             options: [{ terms: ["fixme"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fixme'" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme" } }
             ]
         },
         {
             code: "// any FIXME",
             options: [{ terms: ["fixme"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any FIXME'" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any FIXME" } }
             ]
         },
         {
             code: "// any fIxMe",
             options: [{ terms: ["fixme"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fIxMe'" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fIxMe" } }
             ]
         },
         {
             code: "/* any fixme */",
             options: [{ terms: ["FIXME"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "'any fixme'" } }
+                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "any fixme" } }
             ]
         },
         {
             code: "/* any FIXME */",
             options: [{ terms: ["FIXME"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "'any FIXME'" } }
+                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "any FIXME" } }
             ]
         },
         {
             code: "/* any fIxMe */",
             options: [{ terms: ["FIXME"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "'any fIxMe'" } }
+                { messageId: "unexpectedComment", data: { type: "FIXME", comment: "any fIxMe" } }
             ]
         },
         {
             code: "// any fixme or todo",
             options: [{ terms: ["fixme", "todo"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fixme or todo'" } },
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "'any fixme or todo'" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme or todo" } },
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any fixme or todo" } }
             ]
         },
         {
             code: "/* any fixme or todo */",
             options: [{ terms: ["fixme", "todo"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fixme or todo'" } },
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "'any fixme or todo'" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme or todo" } },
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any fixme or todo" } }
             ]
         },
         {
             code: "/* any fixme or todo */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "'any fixme or todo'" } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fixme or todo'" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any fixme or todo" } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme or todo" } }
             ]
         },
         {
             code: "/* fixme and todo */",
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'fixme and todo'" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme and todo" } }
             ]
         },
         {
             code: "/* fixme and todo */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "'fixme and todo'" } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'fixme and todo'" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "fixme and todo" } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme and todo" } }
             ]
         },
         {
             code: "/* any fixme */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any fixme'" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any fixme" } }
             ]
         },
         {
             code: "/* fixme! */",
             options: [{ terms: ["fixme"] }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'fixme!'" } }
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "fixme!" } }
             ]
         },
         {
             code: "// regex [litera|$]",
             options: [{ terms: ["[litera|$]"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "[litera|$]", comment: "'regex [litera|$]'" } }
+                { messageId: "unexpectedComment", data: { type: "[litera|$]", comment: "regex [litera|$]" } }
             ]
         },
         {
             code: "/* eslint one-var: 2 */",
             options: [{ terms: ["eslint"] }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "eslint", comment: "'eslint one-var: 2'" } }
+                { messageId: "unexpectedComment", data: { type: "eslint", comment: "eslint one-var: 2" } }
             ]
         },
         {
             code: "/* eslint one-var: 2 */",
             options: [{ terms: ["one"], location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "one", comment: "'eslint one-var: 2'" } }
+                { messageId: "unexpectedComment", data: { type: "one", comment: "eslint one-var: 2" } }
             ]
         },
         {
             code: "/* any block comment with TODO, FIXME or XXX */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "'any block comment with TODO, FIXME...'" } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any block comment with TODO, FIXME...'" } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "'any block comment with TODO, FIXME...'" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any block comment with TODO, FIXME or XXX" } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any block comment with TODO, FIXME or XXX" } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any block comment with TODO, FIXME or XXX" } }
             ]
         },
         {
             code: "/* any block comment with (TODO, FIXME's or XXX!) */",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "'any block comment with (TODO,...'" } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any block comment with (TODO,...'" } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "'any block comment with (TODO,...'" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any block comment with (TODO, FIXME's or XXX!)" } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any block comment with (TODO, FIXME's or XXX!)" } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any block comment with (TODO, FIXME's or XXX!)" } }
             ]
         },
         {
             code: "/** \n *any block comment \n*with (TODO, FIXME's or XXX!) **/",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "'*   *any block comment  *with (TODO,...'" } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'*   *any block comment  *with (TODO,...'" } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "'*   *any block comment  *with (TODO,...'" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "* *any block comment *with (TODO, FIXME's or..." } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "* *any block comment *with (TODO, FIXME's or..." } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "* *any block comment *with (TODO, FIXME's or..." } }
             ]
         },
         {
             code: "// any comment with TODO, FIXME or XXX",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "'any comment with TODO, FIXME or XXX'" } },
-                { messageId: "unexpectedComment", data: { type: "fixme", comment: "'any comment with TODO, FIXME or XXX'" } },
-                { messageId: "unexpectedComment", data: { type: "xxx", comment: "'any comment with TODO, FIXME or XXX'" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "any comment with TODO, FIXME or XXX" } },
+                { messageId: "unexpectedComment", data: { type: "fixme", comment: "any comment with TODO, FIXME or XXX" } },
+                { messageId: "unexpectedComment", data: { type: "xxx", comment: "any comment with TODO, FIXME or XXX" } }
             ]
         },
         {
             code: "// TODO: something small",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "'TODO: something small'" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "TODO: something small" } }
             ]
         },
         {
-            code: "// TODO: something really longer than 30 characters",
+            code: "// TODO: something really longer than 40 characters",
             options: [{ location: "anywhere" }],
             errors: [
-                { messageId: "unexpectedComment", data: { type: "todo", comment: "'TODO: something really longer than...'" } }
+                { messageId: "unexpectedComment", data: { type: "todo", comment: "TODO: something really longer than 40..." } }
             ]
         },
         {
             code:
-                "/* TODO: something \n really longer than 30 characters \n and also a new line */",
+                "/* TODO: something \n really longer than 40 characters \n and also a new line */",
             options: [{ location: "anywhere" }],
             errors: [
                 {
                     messageId: "unexpectedComment",
                     data: {
                         type: "todo",
-                        comment: "'TODO: something   really longer than...'"
+                        comment: "TODO: something really longer than 40..."
                     }
                 }
             ]
@@ -240,7 +240,7 @@ ruleTester.run("no-warning-comments", rule, {
                     messageId: "unexpectedComment",
                     data: {
                         type: "todo",
-                        comment: "'TODO: small'"
+                        comment: "TODO: small"
                     }
                 }
             ]

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -246,14 +246,14 @@ ruleTester.run("no-warning-comments", rule, {
             ]
         },
         {
-            code: "// TODO: https://github.com/eslint/eslint/pull/13522#discussion_r470293411",
+            code: "// https://github.com/eslint/eslint/pull/13522#discussion_r470293411 TODO",
             options: [{ location: "anywhere" }],
             errors: [
                 {
                     messageId: "unexpectedComment",
                     data: {
                         matchedTerm: "todo",
-                        comment: "TODO:..."
+                        comment: "..."
                     }
                 }
             ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added data in the error message which will show the comment itself. 
It will only show till 30 characters

![image](https://user-images.githubusercontent.com/26347874/88196634-0cfba800-cc5f-11ea-8021-b2b4f40c3cb9.png)


#### Is there anything you'd like reviewers to focus on?
Is `30` is fine ? after `30` char it will be truncated. 