### PR TITLE
New: Add prefer-inclusive-language

### DIFF
--- a/docs/rules/prefer-inclusive-language.md
+++ b/docs/rules/prefer-inclusive-language.md
@@ -1,36 +1,106 @@
 # Rule to encourage the use of inclusive language that avoids discrimination against groups of people.   (prefer-inclusive-language)
 
-Please describe the origin of the rule here.
-
+This rule discourages the use of exclusive or oppressive terminology in identifier names.
 
 ## Rule Details
 
-This rule aims to...
+By default, this rule includes two sets of terms that are normalised on the technical level but oppressive on a societal level: "blacklist"/"whitelist", and "master"/"slave". Both sets of terms can be replaced with alternatives that are clear in their intent, and also more inclusive/less offensive. This rule is also configurable, allowing users to choose the terms that best represent the values of their project or team.
 
-Examples of **incorrect** code for this rule:
+### Options
+
+* `deny`: (`string[]`) list of terms to disallow in identifiers (default: `["blacklist", "whitelist", "master", "slave"]`)
+* `allow`: (`string[]`) list of _exact_ terms to ignore (default: `[]`)
+* `ignoreDestructuring`: `false` (default) enforces deny list on destructured identifiers
+* `ignoreDestructuring`: `true` does not check destructured identifiers (but still checks any use of those identifiers later in the code)
+
+### deny: ["blacklist", "whitelist", "master", "slave"]
+
+Examples of **incorrect** code for this rule with the default `{ deny: ["blacklist", "whitelist", "master", "slave"] }` option:
 
 ```js
+var blackList = ['foo', 'bar'];
+let whitelist = ['a', 'b'];
 
-// fill me in
-
+const MasterDetail = new View();
+class Coordinator {
+  attach(slaves) {
+    // ...
+  }
+}
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
+var denyList = ['foo', 'bar'];
+let allowlist = ['a', 'b'];
 
-// fill me in
-
+const ListDetail = new View();
+class Coordinator {
+  attach(workers) {
+    // ...
+  }
+}
 ```
 
-### Options
+### deny: (custom list)
 
-If there are any options, describe them here. Otherwise, delete this section.
+Examples of **incorrect** code for this rule when specifying a custom list:
 
-## When Not To Use It
+```js
+/* eslint prefer-inclusive-language: ["error", {deny: ["foo"]}] */
+const someFoo = ['bar', 'baz'];
+```
 
-Give a short description of when it would be appropriate to turn off this rule.
+Examples of **correct** code for this rule:
 
-## Further Reading
+```js
+/* eslint prefer-inclusive-language: ["error", {deny: ["foo"]}] */
+const someBar = ['foo', 'baz'];
+```
 
-If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.
+### allow: (custom list)
+
+Examples of **incorrect** code for this rule with a custom `allow` option (and a default `deny` option):
+
+```js
+/* eslint prefer-inclusive-language: ["error", {allow: ["masterDetailView"]}] */
+const MasterDetailView = new View();
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/* eslint prefer-inclusive-language: ["error", {allow: ["masterDetailView"]}] */
+const masterDetailView = new View();
+```
+
+### ignoreDestructuring: false
+
+Examples of **incorrect** code for this rule with the default `{ "allowDestructuring": false }` option:
+
+```js
+const { masterList } = someObject;
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const { masterList: list } = someObject;
+```
+
+### ignoreDestructuring: false
+
+Examples of **incorrect** code for this rule with the `{ "allowDestructuring": true }` option:
+
+```js
+/* eslint prefer-inclusive-language: ["error", {allowDestructuring: true}] */
+const masterList = ['one', 'two'];
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/* eslint prefer-inclusive-language: ["error", {allowDestructuring: true}] */
+const { masterList } = someObject;
+```

--- a/docs/rules/prefer-inclusive-language.md
+++ b/docs/rules/prefer-inclusive-language.md
@@ -1,0 +1,36 @@
+# Rule to encourage the use of inclusive language that avoids discrimination against groups of people.   (prefer-inclusive-language)
+
+Please describe the origin of the rule here.
+
+
+## Rule Details
+
+This rule aims to...
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+// fill me in
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+// fill me in
+
+```
+
+### Options
+
+If there are any options, describe them here. Otherwise, delete this section.
+
+## When Not To Use It
+
+Give a short description of when it would be appropriate to turn off this rule.
+
+## Further Reading
+
+If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -250,6 +250,7 @@ module.exports = new LazyLoadingRuleMap(Object.entries({
     "prefer-const": () => require("./prefer-const"),
     "prefer-destructuring": () => require("./prefer-destructuring"),
     "prefer-exponentiation-operator": () => require("./prefer-exponentiation-operator"),
+    "prefer-inclusive-language": () => require("./prefer-inclusive-language"),
     "prefer-named-capture-group": () => require("./prefer-named-capture-group"),
     "prefer-numeric-literals": () => require("./prefer-numeric-literals"),
     "prefer-object-spread": () => require("./prefer-object-spread"),

--- a/lib/rules/prefer-inclusive-language.js
+++ b/lib/rules/prefer-inclusive-language.js
@@ -25,7 +25,14 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    denyList: {
+                    allow: {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        },
+                        default: []
+                    },
+                    deny: {
                         type: "array",
                         items: {
                             type: "string"
@@ -44,7 +51,8 @@ module.exports = {
 
     create(context) {
         const options = context.options[0] || {};
-        const denyList = options.denyList || [
+        const allowList = options.allow || [];
+        const denyList = options.deny || [
             "whitelist",
             "blacklist",
             "master",
@@ -58,13 +66,23 @@ module.exports = {
         //----------------------------------------------------------------------
 
         /**
-         * Checks if a string constains denied language
+         * Checks if a string contains denied language
          * @param {string} name The string to check.
          * @returns {boolean} if the string contains a term on the denyList
          * @private
          */
-        function isDisallowed(name) {
+        function containsExclusiveLanguage(name) {
             return denyList.findIndex(term => name.toLowerCase().includes(term)) > -1;
+        }
+
+        /**
+         * Checks if a string is on the "allow" list
+         * @param {string} name The string to check.
+         * @returns {boolean} if the string is an exact match with a term on the allowList
+         * @private
+         */
+        function isExplicitlyAllowed(name) {
+            return allowList.indexOf(name) > -1;
         }
 
         /**
@@ -87,9 +105,9 @@ module.exports = {
 
         return {
             Identifier(node) {
-                const disallowed = isDisallowed(node.name);
+                const name = node.name;
 
-                if (disallowed) {
+                if (containsExclusiveLanguage(name) && !isExplicitlyAllowed(name)) {
                     report(node);
                 }
             }

--- a/lib/rules/prefer-inclusive-language.js
+++ b/lib/rules/prefer-inclusive-language.js
@@ -43,6 +43,10 @@ module.exports = {
                             "master",
                             "slave"
                         ]
+                    },
+                    ignoreDestructuring: {
+                        type: "boolean",
+                        default: false
                     }
                 }
             }
@@ -58,6 +62,7 @@ module.exports = {
             "master",
             "slave"
         ];
+        const ignoreDestructuring = options.ignoreDestructuring || false;
 
         const reported = [];
 
@@ -106,8 +111,52 @@ module.exports = {
         return {
             Identifier(node) {
                 const name = node.name;
+                const nameContainsEclusiveLanguage = containsExclusiveLanguage(name);
 
-                if (containsExclusiveLanguage(name) && !isExplicitlyAllowed(name)) {
+                // First, we ignore the node if it match the ignore list
+                if (isExplicitlyAllowed(name)) {
+                    return;
+                }
+
+                /*
+                 * Borrows heavily from camelcase:
+                 *
+                 * Properties have their own rules, and
+                 * AssignmentPattern nodes can be treated like Properties:
+                 * e.g.: const { no_camelcased = false } = bar;
+                 */
+                if (node.parent.type === "Property" || node.parent.type === "AssignmentPattern") {
+
+                    if (node.parent.parent && node.parent.parent.type === "ObjectPattern") {
+                        if (node.parent.shorthand && node.parent.value.left && nameContainsEclusiveLanguage) {
+                            report(node);
+                        }
+
+                        const assignmentKeyEqualsValue = node.parent.key.name === node.parent.value.name;
+
+                        if (nameContainsEclusiveLanguage && node.parent.computed) {
+                            report(node);
+                        }
+
+                        // prevent checking righthand side of destructured object
+                        if (node.parent.key === node && node.parent.value !== node) {
+                            return;
+                        }
+
+                        const valueContainsExclusiveLanguage = node.parent.value.name && nameContainsEclusiveLanguage;
+
+                        // ignore destructuring if the option is set, unless a new identifier is created
+                        if (valueContainsExclusiveLanguage && !(assignmentKeyEqualsValue && ignoreDestructuring)) {
+                            report(node);
+                        }
+                    }
+
+                    if (ignoreDestructuring) {
+                        return;
+                    }
+                }
+
+                if (containsExclusiveLanguage(name)) {
                     report(node);
                 }
             }

--- a/lib/rules/prefer-inclusive-language.js
+++ b/lib/rules/prefer-inclusive-language.js
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview Rule to encourage the use of inclusive language that avoids discrimination against groups of people.
+ * @author Drew Wyatt
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "require the use of inclusive language that avoids discrimination against groups of people",
+            category: "Best Practices",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/prefer-inclusive-language"
+        },
+        type: "suggestion",
+        fixable: null,
+        messages: {
+            exclusive: "Identifier '{{name}}' may be considered harmful or exclusive. Use inclusive language that avoids discrimination against groups of people based on race, gender, or socioeconomic status."
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    denyList: {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        },
+                        default: [
+                            "whitelist",
+                            "blacklist",
+                            "master",
+                            "slave"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+
+    create(context) {
+        const options = context.options[0] || {};
+        const denyList = options.denyList || [
+            "whitelist",
+            "blacklist",
+            "master",
+            "slave"
+        ];
+
+        const reported = [];
+
+        //----------------------------------------------------------------------
+        // Helpers
+        //----------------------------------------------------------------------
+
+        /**
+         * Checks if a string constains denied language
+         * @param {string} name The string to check.
+         * @returns {boolean} if the string contains a term on the denyList
+         * @private
+         */
+        function isDisallowed(name) {
+            return denyList.findIndex(term => name.toLowerCase().includes(term)) > -1;
+        }
+
+        /**
+         * Reports an AST node as a rule violation.
+         * @param {ASTNode} node The node to report.
+         * @returns {void}
+         * @private
+         */
+        function report(node) {
+            if (!reported.includes(node)) {
+                reported.push(node);
+                context.report({ node, messageId: "exclusive", data: { name: node.name } });
+            }
+        }
+
+
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+
+        return {
+            Identifier(node) {
+                const disallowed = isDisallowed(node.name);
+
+                if (disallowed) {
+                    report(node);
+                }
+            }
+        };
+    }
+};

--- a/tests/lib/rules/prefer-inclusive-language.js
+++ b/tests/lib/rules/prefer-inclusive-language.js
@@ -26,15 +26,52 @@ ruleTester.run("prefer-inclusive-language", rule, {
         {
             code: "const denyList = ['foo', 'bar'];",
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "const denyList = ['master', 'bar'];",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "const masterDetailView = new View({ with: 'stuff' });",
+            options: [{ allow: ["masterDetailView"] }],
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
     invalid: [
+        {
+            code: "const blacklist = ['foo', 'bar'];",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "exclusive",
+                data: { name: "blacklist" },
+                type: "Identifier"
+            }]
+        },
         {
             code: "const blackList = ['foo', 'bar'];",
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "exclusive",
                 data: { name: "blackList" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "const masterDetailView = new View({ with: 'stuff' });",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "exclusive",
+                data: { name: "masterDetailView" },
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "const MasterDetailView = new View({ with: 'stuff' });",
+            options: [{ allow: ["masterDetailView"] }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "exclusive",
+                data: { name: "MasterDetailView" },
                 type: "Identifier"
             }]
         }

--- a/tests/lib/rules/prefer-inclusive-language.js
+++ b/tests/lib/rules/prefer-inclusive-language.js
@@ -19,10 +19,7 @@ const ruleTester = new RuleTester();
 
 ruleTester.run("prefer-inclusive-language", rule, {
     valid: [
-        {
-            code: "const allowList = ['foo', 'bar'];",
-            parserOptions: { ecmaVersion: 6 }
-        },
+        "var allowList = ['foo', 'bar'];",
         {
             code: "const denyList = ['foo', 'bar'];",
             parserOptions: { ecmaVersion: 6 }
@@ -35,9 +32,21 @@ ruleTester.run("prefer-inclusive-language", rule, {
             code: "const masterDetailView = new View({ with: 'stuff' });",
             options: [{ allow: ["masterDetailView"] }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "const masterDetailView = new View({ with: 'stuff' });",
+            options: [{ deny: ["whitelist", "blacklist", "slave"] }],
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
     invalid: [
+        {
+            code: "var blacklist = ['foo', 'bar'];",
+            errors: [{
+                messageId: "exclusive",
+                data: { name: "blacklist" }
+            }]
+        },
         {
             code: "const blacklist = ['foo', 'bar'];",
             parserOptions: { ecmaVersion: 6 },

--- a/tests/lib/rules/prefer-inclusive-language.js
+++ b/tests/lib/rules/prefer-inclusive-language.js
@@ -104,6 +104,13 @@ ruleTester.run("prefer-inclusive-language", rule, {
                 messageId: "exclusive",
                 data: { name: "masterList" }
             }]
+        },
+        {
+            code: "function attach(slave) { /* ... */ }",
+            errors: [{
+                messageId: "exclusive",
+                data: { name: "slave" }
+            }]
         }
     ]
 });

--- a/tests/lib/rules/prefer-inclusive-language.js
+++ b/tests/lib/rules/prefer-inclusive-language.js
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview Rule to encourage the use of inclusive language that avoids discrimination against groups of people.
+ * @author Drew Wyatt
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/prefer-inclusive-language"),
+    { RuleTester } = require("../../../lib/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-inclusive-language", rule, {
+    valid: [
+        {
+            code: "const allowList = ['foo', 'bar'];",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "const denyList = ['foo', 'bar'];",
+            parserOptions: { ecmaVersion: 6 }
+        }
+    ],
+    invalid: [
+        {
+            code: "const blackList = ['foo', 'bar'];",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "exclusive",
+                data: { name: "blackList" },
+                type: "Identifier"
+            }]
+        }
+    ]
+});

--- a/tests/lib/rules/prefer-inclusive-language.js
+++ b/tests/lib/rules/prefer-inclusive-language.js
@@ -43,8 +43,7 @@ ruleTester.run("prefer-inclusive-language", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "exclusive",
-                data: { name: "blacklist" },
-                type: "Identifier"
+                data: { name: "blacklist" }
             }]
         },
         {
@@ -52,8 +51,7 @@ ruleTester.run("prefer-inclusive-language", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "exclusive",
-                data: { name: "blackList" },
-                type: "Identifier"
+                data: { name: "blackList" }
             }]
         },
         {
@@ -61,8 +59,7 @@ ruleTester.run("prefer-inclusive-language", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "exclusive",
-                data: { name: "masterDetailView" },
-                type: "Identifier"
+                data: { name: "masterDetailView" }
             }]
         },
         {
@@ -71,8 +68,7 @@ ruleTester.run("prefer-inclusive-language", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "exclusive",
-                data: { name: "MasterDetailView" },
-                type: "Identifier"
+                data: { name: "MasterDetailView" }
             }]
         }
     ]

--- a/tests/lib/rules/prefer-inclusive-language.js
+++ b/tests/lib/rules/prefer-inclusive-language.js
@@ -37,6 +37,15 @@ ruleTester.run("prefer-inclusive-language", rule, {
             code: "const masterDetailView = new View({ with: 'stuff' });",
             options: [{ deny: ["whitelist", "blacklist", "slave"] }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "const { masterList } = someObject;",
+            options: [{ ignoreDestructuring: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "const { masterList: list } = someObject;",
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
     invalid: [
@@ -78,6 +87,22 @@ ruleTester.run("prefer-inclusive-language", rule, {
             errors: [{
                 messageId: "exclusive",
                 data: { name: "MasterDetailView" }
+            }]
+        },
+        {
+            code: "const { masterList } = someObject;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "exclusive",
+                data: { name: "masterList" }
+            }]
+        },
+        {
+            code: "const { list: masterList } = someObject;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "exclusive",
+                data: { name: "masterList" }
             }]
         }
     ]

--- a/tests/lib/rules/prefer-inclusive-language.js
+++ b/tests/lib/rules/prefer-inclusive-language.js
@@ -111,6 +111,34 @@ ruleTester.run("prefer-inclusive-language", rule, {
                 messageId: "exclusive",
                 data: { name: "slave" }
             }]
+        },
+        {
+            code: "class Dispatcher { attachSlave(node) {} }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "exclusive",
+                data: { name: "attachSlave" }
+            }]
+        },
+        {
+            code: "class Dispatcher { attach(slave) {} }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "exclusive",
+                data: { name: "slave" }
+            }]
+        },
+        {
+            code: "class Dispatcher { attachSlave(slave) {} }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "exclusive",
+                data: { name: "attachSlave" }
+            },
+            {
+                messageId: "exclusive",
+                data: { name: "slave" }
+            }]
         }
     ]
 });

--- a/tools/rule-types.json
+++ b/tools/rule-types.json
@@ -237,6 +237,7 @@
     "prefer-const": "suggestion",
     "prefer-destructuring": "suggestion",
     "prefer-exponentiation-operator": "suggestion",
+    "prefer-inclusive-language": "suggestion",
     "prefer-named-capture-group": "suggestion",
     "prefer-numeric-literals": "suggestion",
     "prefer-object-spread": "suggestion",


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

**Please describe what the rule should do:**

This rule is heavily inspired by the newly proposed [`inclusive_language` rule in SwiftLint](https://github.com/realm/SwiftLint/pull/3243) and [Github's recent decision to rename default branches to `main`](https://twitter.com/natfriedman/status/1271253144442253312) (also mentioned in the linked PR). 

This PR aims to focus (by default) on two sets of terms [identified by the IETF](https://tools.ietf.org/id/draft-knodel-terminology-00.html#rfc.section.1.1): master/slave and blacklist/whitelist.
Both sets of terms can be replaced with alternatives that are clear in their intent, and also more inclusive/less offensive. This list does not seek to be exhaustive or to meet the needs of all projects/teams that might use this (which is why it is configurable).

**What category of rule is this? (place an "X" next to just one item)**

- [ ] Enforces code style
- [ ] Warns about a potential error
- [x] Suggests an alternate way of doing something
- [ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**

```js
var blackList = ['foo', 'bar'];
let whitelist = ['a', 'b'];

const MasterDetail = new View();
class Coordinator {
  attach(slaves) {
    // ...
  }
}
```

**Why should this rule be included in ESLint (instead of a plugin)?**

This rule aims to help uphold The Standards outlined in the [Open JS Foundation Code of Conduct](https://github.com/openjs-foundation/cross-project-council/blob/master/CODE_OF_CONDUCT.md), which this project adheres to. Specifically:

- Demonstrating empathy and kindness toward other people
- Being respectful of differing opinions, viewpoints, and experiences
- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
- Focusing on what is best not just for us as individuals, but for the overall community
