### PR TITLE
Fix: Update the chatroom link to go directly to help channel

### DIFF
--- a/messages/extend-config-missing.txt
+++ b/messages/extend-config-missing.txt
@@ -2,4 +2,4 @@ ESLint couldn't find the config "<%- configName %>" to extend from. Please check
 
 The config "<%- configName %>" was referenced from the config file in "<%- importerName %>".
 
-If you still have problems, please stop by https://eslint.org/chat to chat with the team.
+If you still have problems, please stop by https://eslint.org/chat/help to chat with the team.

--- a/messages/no-config-found.txt
+++ b/messages/no-config-found.txt
@@ -4,4 +4,4 @@ ESLint couldn't find a configuration file. To set up a configuration file for th
 
 ESLint looked for configuration files in <%= directoryPath %> and its ancestors. If it found none, it then looked in your home directory.
 
-If you think you already have a configuration file or if you need more help, please stop by the ESLint chat room: https://eslint.org/chat
+If you think you already have a configuration file or if you need more help, please stop by the ESLint chat room: https://eslint.org/chat/help

--- a/messages/plugin-conflict.txt
+++ b/messages/plugin-conflict.txt
@@ -4,4 +4,4 @@ ESLint couldn't determine the plugin "<%- pluginId %>" uniquely.
 
 Please remove the "plugins" setting from either config or remove either plugin installation.
 
-If you still can't figure out the problem, please stop by https://eslint.org/chat to chat with the team.
+If you still can't figure out the problem, please stop by https://eslint.org/chat/help to chat with the team.

--- a/messages/plugin-missing.txt
+++ b/messages/plugin-missing.txt
@@ -8,4 +8,4 @@ It's likely that the plugin isn't installed correctly. Try reinstalling by runni
 
 The plugin "<%- pluginName %>" was referenced from the config file in "<%- importerName %>".
 
-If you still can't figure out the problem, please stop by https://eslint.org/chat to chat with the team.
+If you still can't figure out the problem, please stop by https://eslint.org/chat/help to chat with the team.

--- a/messages/whitespace-found.txt
+++ b/messages/whitespace-found.txt
@@ -1,3 +1,3 @@
 ESLint couldn't find the plugin "<%- pluginName %>". because there is whitespace in the name. Please check your configuration and remove all whitespace from the plugin name.
 
-If you still can't figure out the problem, please stop by https://eslint.org/chat to chat with the team.
+If you still can't figure out the problem, please stop by https://eslint.org/chat/help to chat with the team.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the chatroom link output by error messages to point directly to the #help channel.

#### Is there anything you'd like reviewers to focus on?

Did I miss any chatroom link instances?

I marked this as a bug because we were dropping people into the #welcome channel, but that was confusing to people. Feel free to mark as something other than a bug if that doesn't make sense.