### PR TITLE
fix: check that the range param is not undefined

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -383,6 +383,10 @@ class OffsetStorage {
          * search tree indexed by key.
          */
 
+        if (!range) {
+            return;
+        }
+
         const descriptorToInsert = { offset, from: fromToken, force };
 
         const descriptorAfterRange = this._tree.findLe(range[1]).value;


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)
### This PR resolved the next issue:

When I add this option `"parser": "babel-eslint"` in my `.eslintrc` file but I also have this rules `"indent": ["error", 2]` or some other implementation of this rule and I want to run `eslint .` or `eslint . --fix`.

The terminal gave us this error:

![image](https://user-images.githubusercontent.com/28031187/88981638-0509bc80-d28c-11ea-8855-b8c990a712f7.png)


This error only happens when I have these options in my `.eslintrc` file.

When adding this validation in this `setDesiredOffsets` function and I run some of these options `eslint .` or `eslint . --fix`, the eslint output is completed without any problem

### Note:
if any of you have some feedback or a better solution, please let me know.

#### Is there anything you'd like reviewers to focus on?

**Tell us about your environment**

* **ESLint Version:** v7.5.0
* **Node Version:** v14.0.0
* **npm Version:** v6.14.4

**What parser (default, Babel-ESLint, etc.) are you using?**

I'm using this parser `babel-eslint` with the version `v10.1.0`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
{
  "parser": "babel-eslint",
  "parserOptions": {
    "ecmaVersion": 2019,
    "sourceType": "module",
    "allowImportExportEverywhere": true,
    "ecmaFeatures": {
      "impliedStrict": true
    }
  },
  "extends": ["eslint:recommended"],
  "rules": {
    "no-unexpected-multiline": "off",
    "no-else-return": ["error", { "allowElseIf": true }],
    "no-async-promise-executor": "off",
    "no-trailing-spaces": "error",
    "space-infix-ops": "error",
    "computed-property-spacing": "error",
    "space-before-function-paren": "error",
    "arrow-spacing": "error",
    "no-multi-spaces": "error",
    "eol-last": ["error", "always"],
    "comma-dangle": ["error", "never"],
    "space-before-blocks": ["error", "always"],
    "space-in-parens": ["error", "never"],
    "comma-spacing": ["error", { "before": false, "after": true }],
    "key-spacing": ["error", { "beforeColon": false }],
    "semi": ["error", "always"],
    "quotes": ["error", "single"],
    "object-curly-spacing": ["error", "always"],
    "array-bracket-spacing": ["error", "never"],
    "prefer-const": "error",
    "no-path-concat": "error",
    "no-unused-vars": ["error", { "args": "none" }],
    "camelcase": "error",
    "no-var": "error",
    "one-var": ["error", "never"],
    "spaced-comment": ["error", "always"],
    "padding-line-between-statements": [
      "error",
      {
        "blankLine": "always",
        "prev":  ["const", "let", "var"],
        "next": "function"
      }
    ],
    "no-tabs": "error",
    "indent": ["error", 2],
    "max-len": [
      "error",
      {
        "code": 80,
        "ignoreRegExpLiterals": true,
        "ignoreUrls": true,
        "tabWidth": 2
      }
    ]
  },
  "env": {
    "node": true,
    "browser": true,
    "es2017": true
  }
}

```

</details>

**What did you do? Please include the actual source code causing the issue.**

This error happens when I have this configuration and run `eslint .` or `eslint . --fix`.


<details>
<summary>Code</summary>

<!-- Paste your configuration below: -->
```js
import camelCase from './camelCase'

class Router {
  constructor ({ routes, common }) {
    this.routes = routes
    this.common = common
  }

  fire (chunk) {
    if (typeof chunk === 'undefined') {
      console.error(
        "Failed to execute 'fire': " +
        'The 1 parameter is required, but it was not present.'
      )
      return
    }

    if (typeof chunk !== 'string') {
      console.error(
        "Failed to execute 'fire': " +
        'The 1 parameter must be string.'
      )
      return
    }

    const chunkFile = this.routes[chunk]

    if (chunkFile) {
      if (Array.isArray(this.common)) {
        this.common.map((module) => {
          import(/* webpackChunkName: "common" */ `../routes/${module}`)
            .then(module => module.default())
            .catch(e => console.warn(e))
        })
      }
      if (typeof this.common === 'string') {
        import(/* webpackChunkName: "common" */ `../routes/${this.common}`)
          .then(module => module.default())
          .catch(e => console.warn(e))
      }
      import(/* webpackChunkName: "chunk" */ `../routes/${chunkFile}`)
        .then(module => module.default())
        .catch(e => console.warn(e))
    }
  }

  loadEvents () {
    document.body.className
      .toLowerCase()
      .replace(/-/g, '_')
      .split(/\s+/)
      .map(camelCase)
      .forEach(className => this.fire(className))
  }
}

export default Router


```

</details>


**What did you expect to happen?**

I expected the eslint output was completed with my code indented

**What actually happened? Please include the actual, raw output from ESLint.**

![image](https://user-images.githubusercontent.com/28031187/88981638-0509bc80-d28c-11ea-8855-b8c990a712f7.png)

