### PR TITLE
Breaking: Reduce carbon footprint by calling ESLint only on first CI job

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -138,6 +138,15 @@ ${message}`);
         return;
     }
 
+    if (require("ci-job-number")() > 1) {
+        console.warn(
+            "To speed up CI ESLint runs only in first job.\n" +
+            "Set CI_JOB_NUMBER=1 environment variable if you need " +
+            "to call ESLint for all job."
+        );
+        return;
+    }
+
     // Otherwise, call the CLI.
     process.exitCode = await require("../lib/cli").execute(
         process.argv,

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -142,7 +142,7 @@ ${message}`);
         console.warn(
             "To speed up CI ESLint runs only in first job.\n" +
             "Set CI_JOB_NUMBER=1 environment variable if you need " +
-            "to call ESLint for all job."
+            "to execute ESLint for all jobs."
         );
         return;
     }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@babel/code-frame": "^7.0.0",
     "ajv": "^6.10.0",
     "chalk": "^4.0.0",
+    "ci-job-number": "^1.2.2",
     "cross-spawn": "^7.0.2",
     "debug": "^4.0.1",
     "doctrine": "^3.0.0",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [x] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Cal ESLint only on first CI job to reduce unnecessary servers work (e.g., reduce carbon footprint by unnecessary work).

I added [`ci-job-number`](https://github.com/ai/ci-job-number/). It returns the job numbers and supports many different CI services. For the second and rest jobs, I print warning (with a note of how to disable this behavior) and exit.

#### The context behind these changes

@pwithnall in [his recent talk](https://events.gnome.org/event/1/contributions/79/attachments/12/30/presentation.pdf) suggested thinking more about how our open source projects affect the environment. I found an interesting problem with ESLint and how people are using ESLint on CI.

![20200801193832](https://user-images.githubusercontent.com/19343/89114201-99ac2000-d42e-11ea-94e8-f20da2fc1c0a.png)

```yaml
node_js:
  - node
  - "12"
  - "10"
  - "8"
  - "6"
```

Here is a [Travis CI of my PostCSS](https://travis-ci.org/github/postcss/postcss/builds/691150914). Like many other projects, we many jobs to run tests on all actual Node.js versions. In every job we call `npm test`:

```js
    "test": "eslint . && jest"
```

As a result, we call ESLint for every Node.js version. But since ESLint provides static analysis, ESLint output will be the same for all Node.js versions. As a result, we have 2-4 unnecessary ESLint calls for all commits for all open source projects with multiple Node.js versions in `.travis.yml`.

#### Is there anything you'd like reviewers to focus on?

##### Is it a real problem?

* For `postcss/postcss` every ESLint takes *9 seconds* of CPU time.
* For `postcss/postcss` we have around *250 commits* per year.
* Let’s count that we have *4 Node.js* versions on Travis CI (we had five versions before and now only 3).
* 1 hour of CPU work gives around 1.7 grams of CO2.
* **9000 seconds** of unnecessary CPU time = **42.5 grams of CO2 per year** just for one open-source project.
* ESLint is used in >3 000 000 projects. Let’s assume that 75% of them are dead (of course, it is not fair to use PostCSS’s CPU/jobs/time statistics, so I took a bigger number for dead projects and didn’t count non-GitHub projects).
* We can expect that adding this commit could prevent **31 875 Kg of CO2 per year**. *But please double-check my math or even find a better statistics.*

##### Does somebody already do like this?

* There is [`eslint-ci`](https://github.com/JLHwung/eslint-ci) by @JLHwung, which already adds `ci-job-number` to ESLint. I use `eslint-ci` in all my open-source projects (including PostCSS, Autoprefoxer, and Browserslist). There are also [>200 projects](https://github.com/search?l=JSON&q=%22eslint-ci%22&type=Code), which use `eslint-ci` too.
* I use `ci-job-number` in my [`size-limit`](https://github.com/ai/size-limit/) and [`check-dts`](https://github.com/ai/check-dts).
* [`spech`](https://www.npmjs.com/package/spech), spelling check tool, also uses `ci-job-number`.

##### Why do we need this commit if we have `eslint-ci`?

People think about Travis CI as a free resource (which is not true). It is hard to convince people to avoid spending free resources if they think resources are free for them personally.

##### GitHub Actions can be tricky, and jobs can be used not only for Node.js version.

Yeap, [found](https://github.com/ai/size-limit/issues/165) that GitHub Actions workflows can be very tricky, and jobs can be used not only to test different Node.js versions.

This is why we removed GitHub Actions support from `ci-job-number`. On GitHub Actions, ESLint will run on every job.

We are collecting feedback and evolving `ci-job-number` to have predicted results of every CI service.