### PR TITLE
Fix: indent for async arrow functions (fixes #13497)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1094,6 +1094,17 @@ module.exports = {
                     parameterParens.add(closingParen);
                     addElementListIndent(node.params, openingParen, closingParen, options.FunctionExpression.parameters);
                 }
+
+                if (firstToken.type === "Identifier" && firstToken.value === "async") {
+                    const openingParen = sourceCode.getTokenAfter(firstToken);
+                    const closingParen = sourceCode.getTokenBefore(node.body, astUtils.isClosingParenToken);
+
+                    parameterParens.add(openingParen);
+                    parameterParens.add(closingParen);
+
+                    addElementListIndent(node.params, openingParen, closingParen, options.FunctionExpression.parameters);
+                }
+
                 addBlocklessNodeIndent(node.body);
             },
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1084,27 +1084,15 @@ module.exports = {
             },
 
             ArrowFunctionExpression(node) {
-                const firstToken = sourceCode.getFirstToken(node);
+                const maybeOpeningParen = sourceCode.getFirstToken(node, node.async ? 1 : 0);
 
-                if (astUtils.isOpeningParenToken(firstToken)) {
-                    const openingParen = firstToken;
+                if (astUtils.isOpeningParenToken(maybeOpeningParen)) {
+                    const openingParen = maybeOpeningParen;
                     const closingParen = sourceCode.getTokenBefore(node.body, astUtils.isClosingParenToken);
 
                     parameterParens.add(openingParen);
                     parameterParens.add(closingParen);
                     addElementListIndent(node.params, openingParen, closingParen, options.FunctionExpression.parameters);
-                }
-
-                if (firstToken.type === "Identifier" && firstToken.value === "async") {
-                    const nextToken = sourceCode.getTokenAfter(firstToken);
-
-                    if (astUtils.isOpeningParenToken(nextToken)) {
-                        const closingParen = sourceCode.getTokenBefore(node.body, astUtils.isClosingParenToken);
-
-                        parameterParens.add(nextToken);
-                        parameterParens.add(closingParen);
-                        addElementListIndent(node.params, nextToken, closingParen, options.FunctionExpression.parameters);
-                    }
                 }
 
                 addBlocklessNodeIndent(node.body);

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1097,12 +1097,14 @@ module.exports = {
 
                 if (firstToken.type === "Identifier" && firstToken.value === "async") {
                     const openingParen = sourceCode.getTokenAfter(firstToken);
-                    const closingParen = sourceCode.getTokenBefore(node.body, astUtils.isClosingParenToken);
 
-                    parameterParens.add(openingParen);
-                    parameterParens.add(closingParen);
+                    if (astUtils.isOpeningParenToken(openingParen)) {
+                        const closingParen = sourceCode.getTokenBefore(node.body, astUtils.isClosingParenToken);
 
-                    addElementListIndent(node.params, openingParen, closingParen, options.FunctionExpression.parameters);
+                        parameterParens.add(openingParen);
+                        parameterParens.add(closingParen);
+                        addElementListIndent(node.params, openingParen, closingParen, options.FunctionExpression.parameters);
+                    }
                 }
 
                 addBlocklessNodeIndent(node.body);

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1084,7 +1084,7 @@ module.exports = {
             },
 
             ArrowFunctionExpression(node) {
-                const maybeOpeningParen = sourceCode.getFirstToken(node, node.async ? 1 : 0);
+                const maybeOpeningParen = sourceCode.getFirstToken(node, { skip: node.async ? 1 : 0 });
 
                 if (astUtils.isOpeningParenToken(maybeOpeningParen)) {
                     const openingParen = maybeOpeningParen;

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1096,14 +1096,14 @@ module.exports = {
                 }
 
                 if (firstToken.type === "Identifier" && firstToken.value === "async") {
-                    const openingParen = sourceCode.getTokenAfter(firstToken);
+                    const nextToken = sourceCode.getTokenAfter(firstToken);
 
-                    if (astUtils.isOpeningParenToken(openingParen)) {
+                    if (astUtils.isOpeningParenToken(nextToken)) {
                         const closingParen = sourceCode.getTokenBefore(node.body, astUtils.isClosingParenToken);
 
-                        parameterParens.add(openingParen);
+                        parameterParens.add(nextToken);
                         parameterParens.add(closingParen);
-                        addElementListIndent(node.params, openingParen, closingParen, options.FunctionExpression.parameters);
+                        addElementListIndent(node.params, nextToken, closingParen, options.FunctionExpression.parameters);
                     }
                 }
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -11600,8 +11600,8 @@ ruleTester.run("indent", rule, {
                  b => {}
             `,
             output: unIndent`
-            const a = async
-            b => {}
+                const a = async
+                b => {}
             `,
             options: [2],
             errors: expectedErrors([

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -5732,7 +5732,7 @@ ruleTester.run("indent", rule, {
                 {
                   return arg1 + arg2;
                 }
-    `,
+            `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         },
         {
@@ -5742,14 +5742,14 @@ ruleTester.run("indent", rule, {
                 {
                   return arg1 + arg2;
                 }
-    `,
+            `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         },
         {
             code: unIndent`
                 const a = async
                 b => {}
-                `,
+            `,
             options: [2]
         },
         {
@@ -5760,7 +5760,7 @@ ruleTester.run("indent", rule, {
                 {
                   return arg1 + arg2;
                 }
-                    `,
+            `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         },
         {
@@ -5770,7 +5770,7 @@ ruleTester.run("indent", rule, {
                 {
                   return arg1 + arg2;
                 }
-                    `,
+            `,
             options: [2]
         },
         {
@@ -5780,7 +5780,7 @@ ruleTester.run("indent", rule, {
                 {
                   return arg1 + arg2;
                 }
-                    `,
+            `,
             options: [2]
         },
         {
@@ -5790,7 +5790,7 @@ ruleTester.run("indent", rule, {
                 {
                   return arg1 + arg2;
                 }
-                    `,
+            `,
             options: [2, { FunctionDeclaration: { parameters: 4 }, FunctionExpression: { parameters: 4 } }]
         },
         {
@@ -5800,28 +5800,28 @@ ruleTester.run("indent", rule, {
                 {
                   return arg1 + arg2;
                 }
-                    `,
+            `,
             options: [2, { FunctionDeclaration: { parameters: 4 }, FunctionExpression: { parameters: 4 } }]
         },
         {
             code: unIndent`
                 async function fn(ar1,
                                   ar2){}
-                    `,
+            `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         },
         {
             code: unIndent`
                 async function /* some comments */ fn(ar1,
                                                       ar2){}
-                    `,
+            `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         },
         {
             code: unIndent`
                 async  /* some comments */  function fn(ar1,
                                                         ar2){}
-                    `,
+            `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         }
     ],
@@ -11575,18 +11575,18 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
-const foo = async (arg1,
-                    arg2) =>
-{
-  return arg1 + arg2;
-}
+                const foo = async (arg1,
+                                    arg2) =>
+                {
+                  return arg1 + arg2;
+                }
             `,
             output: unIndent`
-const foo = async (arg1,
-                   arg2) =>
-{
-  return arg1 + arg2;
-}
+                const foo = async (arg1,
+                                   arg2) =>
+                {
+                  return arg1 + arg2;
+                }
             `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }],
             parserOptions: { ecmaVersion: 2020 },
@@ -11596,13 +11596,13 @@ const foo = async (arg1,
         },
         {
             code: unIndent`
-const a = async
- b => {}
-`,
+                const a = async
+                 b => {}
+            `,
             output: unIndent`
-const a = async
-b => {}
-`,
+            const a = async
+            b => {}
+            `,
             options: [2],
             errors: expectedErrors([
                 [2, 0, 1, "Identifier"]

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -5822,6 +5822,13 @@ async function /* some comments */ fn(ar1,
                                       ar2){}
     `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
+        },
+        {
+            code: unIndent`
+async  /* some comments */  function fn(ar1,
+                                        ar2){}
+    `,
+            options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         }
     ],
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -5724,6 +5724,64 @@ ruleTester.run("indent", rule, {
             `,
             options: [4, { MemberExpression: 2 }],
             parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: unIndent`
+const foo = async (arg1,
+                   arg2) =>
+{
+  return arg1 + arg2;
+}
+    `,
+            options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
+        },
+        {
+            code: unIndent`
+const foo = (arg1,
+             arg2) => async (arr1,
+                             arr2) =>
+{
+  return arg1 + arg2;
+}
+    `,
+            options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
+        },
+        {
+            code: unIndent`
+const foo = async (arg1,
+  arg2) =>
+{
+  return arg1 + arg2;
+}
+    `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+const foo = async (arg1,
+        arg2) =>
+{
+  return arg1 + arg2;
+}
+    `,
+            options: [2, { FunctionDeclaration: { parameters: 4 }, FunctionExpression: { parameters: 4 } }]
+        },
+        {
+            code: unIndent`
+const foo = (arg1,
+        arg2) =>
+{
+  return arg1 + arg2;
+}
+    `,
+            options: [2, { FunctionDeclaration: { parameters: 4 }, FunctionExpression: { parameters: 4 } }]
+        },
+        {
+            code: unIndent`
+async function fn(ar1,
+                  ar2){}
+    `,
+            options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         }
     ],
 
@@ -11472,6 +11530,27 @@ ruleTester.run("indent", rule, {
             errors: expectedErrors([
                 [6, 4, 0, "Punctuator"],
                 [7, 4, 0, "Punctuator"]
+            ])
+        },
+        {
+            code: unIndent`
+const foo = async (arg1,
+                    arg2) =>
+{
+  return arg1 + arg2;
+}
+            `,
+            output: unIndent`
+const foo = async (arg1,
+                   arg2) =>
+{
+  return arg1 + arg2;
+}
+            `,
+            options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: expectedErrors([
+                [2, 19, 20, "Identifier"]
             ])
         }
     ]

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -5737,7 +5737,17 @@ const foo = async (arg1,
         },
         {
             code: unIndent`
-const a = async b => {}
+const foo = async /* some comments */(arg1,
+                                      arg2) =>
+{
+  return arg1 + arg2;
+}
+    `,
+            options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
+        },
+        {
+            code: unIndent`
+const a = async /*comments */b => {}
     `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         },
@@ -5771,6 +5781,16 @@ const foo = async (arg1,
         },
         {
             code: unIndent`
+const foo = async /*comments*/(arg1,
+  arg2) =>
+{
+  return arg1 + arg2;
+}
+    `,
+            options: [2]
+        },
+        {
+            code: unIndent`
 const foo = async (arg1,
         arg2) =>
 {
@@ -5793,6 +5813,13 @@ const foo = (arg1,
             code: unIndent`
 async function fn(ar1,
                   ar2){}
+    `,
+            options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
+        },
+        {
+            code: unIndent`
+async function /* some comments */ fn(ar1,
+                                      ar2){}
     `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         }

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -5737,6 +5737,19 @@ const foo = async (arg1,
         },
         {
             code: unIndent`
+const a = async b => {}
+    `,
+            options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
+        },
+        {
+            code: unIndent`
+const a = async
+b => {}
+`,
+            options: [2]
+        },
+        {
+            code: unIndent`
 const foo = (arg1,
              arg2) => async (arr1,
                              arr2) =>
@@ -11551,6 +11564,20 @@ const foo = async (arg1,
             parserOptions: { ecmaVersion: 2020 },
             errors: expectedErrors([
                 [2, 19, 20, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+const a = async
+ b => {}
+`,
+            output: unIndent`
+const a = async
+b => {}
+`,
+            options: [2],
+            errors: expectedErrors([
+                [2, 0, 1, "Identifier"]
             ])
         }
     ]

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -5727,107 +5727,101 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
-const foo = async (arg1,
-                   arg2) =>
-{
-  return arg1 + arg2;
-}
+                const foo = async (arg1,
+                                   arg2) =>
+                {
+                  return arg1 + arg2;
+                }
     `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         },
         {
             code: unIndent`
-const foo = async /* some comments */(arg1,
-                                      arg2) =>
-{
-  return arg1 + arg2;
-}
+                const foo = async /* some comments */(arg1,
+                                                      arg2) =>
+                {
+                  return arg1 + arg2;
+                }
     `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         },
         {
             code: unIndent`
-const a = async /*comments */b => {}
-    `,
-            options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
-        },
-        {
-            code: unIndent`
-const a = async
-b => {}
-`,
+                const a = async
+                b => {}
+                `,
             options: [2]
         },
         {
             code: unIndent`
-const foo = (arg1,
-             arg2) => async (arr1,
-                             arr2) =>
-{
-  return arg1 + arg2;
-}
-    `,
+                const foo = (arg1,
+                             arg2) => async (arr1,
+                                             arr2) =>
+                {
+                  return arg1 + arg2;
+                }
+                    `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         },
         {
             code: unIndent`
-const foo = async (arg1,
-  arg2) =>
-{
-  return arg1 + arg2;
-}
-    `,
+                const foo = async (arg1,
+                  arg2) =>
+                {
+                  return arg1 + arg2;
+                }
+                    `,
             options: [2]
         },
         {
             code: unIndent`
-const foo = async /*comments*/(arg1,
-  arg2) =>
-{
-  return arg1 + arg2;
-}
-    `,
+                const foo = async /*comments*/(arg1,
+                  arg2) =>
+                {
+                  return arg1 + arg2;
+                }
+                    `,
             options: [2]
         },
         {
             code: unIndent`
-const foo = async (arg1,
-        arg2) =>
-{
-  return arg1 + arg2;
-}
-    `,
+                const foo = async (arg1,
+                        arg2) =>
+                {
+                  return arg1 + arg2;
+                }
+                    `,
             options: [2, { FunctionDeclaration: { parameters: 4 }, FunctionExpression: { parameters: 4 } }]
         },
         {
             code: unIndent`
-const foo = (arg1,
-        arg2) =>
-{
-  return arg1 + arg2;
-}
-    `,
+                const foo = (arg1,
+                        arg2) =>
+                {
+                  return arg1 + arg2;
+                }
+                    `,
             options: [2, { FunctionDeclaration: { parameters: 4 }, FunctionExpression: { parameters: 4 } }]
         },
         {
             code: unIndent`
-async function fn(ar1,
-                  ar2){}
-    `,
+                async function fn(ar1,
+                                  ar2){}
+                    `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         },
         {
             code: unIndent`
-async function /* some comments */ fn(ar1,
-                                      ar2){}
-    `,
+                async function /* some comments */ fn(ar1,
+                                                      ar2){}
+                    `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         },
         {
             code: unIndent`
-async  /* some comments */  function fn(ar1,
-                                        ar2){}
-    `,
+                async  /* some comments */  function fn(ar1,
+                                                        ar2){}
+                    `,
             options: [2, { FunctionDeclaration: { parameters: "first" }, FunctionExpression: { parameters: "first" } }]
         }
     ],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
fixes #13497 

Indent for async arrow function was not working as the first token in the async arrow function node is the `async` not the opening paren. So the condition [here](https://github.com/eslint/eslint/blob/master/lib/rules/indent.js#L1089) would not be truthy. 
So I added one more check for simply checking the type as `Identifier` and value as `async`

#### Is there anything you'd like reviewers to focus on?
None