### PR TITLE
Update: allowFunctionParams option in no-underscore-dangle (fixes 12579)

### DIFF
--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -33,6 +33,9 @@ var _ = require('underscore');
 var obj = _.contains(items, item);
 obj.__proto__ = {};
 var file = __filename;
+function foo(_bar) {};
+const foo = { onClick(_bar) {} };
+const foo = (_bar) => {};
 ```
 
 ## Options
@@ -44,7 +47,7 @@ This rule has an object option:
 -   `"allowAfterSuper": false` (default) disallows dangling underscores in members of the `super` object
 -   `"allowAfterThisConstructor": false` (default) disallows dangling underscores in members of the `this.constructor` object
 -   `"enforceInMethodNames": false` (default) allows dangling underscores in method names
--   `"allowFunctionParams": false` (default) disallows dangling underscores in first letter of function parameter name
+-   `"allowFunctionParams": false` (default) disallows dangling underscores in function parameter names
 
 ### allow
 
@@ -116,10 +119,10 @@ const o = {
 
 ### allowFunctionParams
 
-Examples of **correct** code for this rule with the `{ "allowFunctionParams": true }` option:
+Examples of **incorrect** code for this rule with the `{ "allowFunctionParams": false }` option:
 
 ```js
-/*eslint no-underscore-dangle: ["error", { "allowFunctionParams": true }]*/
+/*eslint no-underscore-dangle: ["error", { "allowFunctionParams": false }]*/
 
 function foo (_bar) {}
 

--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -125,10 +125,16 @@ Examples of **incorrect** code for this rule with the `{ "allowFunctionParams": 
 /*eslint no-underscore-dangle: ["error", { "allowFunctionParams": false }]*/
 
 function foo (_bar) {}
+function foo (_bar = 0) {}
+function foo (..._bar) {}
 
 const foo = function onClick (_bar) {}
+const foo = function onClick (_bar = 0) {}
+const foo = function onClick (..._bar) {}
 
 const foo = (_bar) => {};
+const foo = (_bar = 0) => {};
+const foo = (...bar) => {};
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -125,7 +125,7 @@ function foo (_bar) {}
 
 const foo = function onClick (_bar) {}
 
-const foo = (_bar) {};
+const foo = (_bar) => {};
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -42,12 +42,12 @@ const foo = (_bar) => {};
 
 This rule has an object option:
 
--   `"allow"` allows specified identifiers to have dangling underscores
--   `"allowAfterThis": false` (default) disallows dangling underscores in members of the `this` object
--   `"allowAfterSuper": false` (default) disallows dangling underscores in members of the `super` object
--   `"allowAfterThisConstructor": false` (default) disallows dangling underscores in members of the `this.constructor` object
--   `"enforceInMethodNames": false` (default) allows dangling underscores in method names
--   `"allowFunctionParams": true` (default) disallows dangling underscores in function parameter names parameter name
+-  `"allow"` allows specified identifiers to have dangling underscores
+-  `"allowAfterThis": false` (default) disallows dangling underscores in members of the `this` object
+-  `"allowAfterSuper": false` (default) disallows dangling underscores in members of the `super` object
+-  `"allowAfterThisConstructor": false` (default) disallows dangling underscores in members of the `this.constructor` object
+-  `"enforceInMethodNames": false` (default) allows dangling underscores in method names
+-  `"allowFunctionParams": true` (default) allows dangling underscores in function parameter names
 
 ### allow
 

--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -134,7 +134,7 @@ const foo = function onClick (..._bar) {}
 
 const foo = (_bar) => {};
 const foo = (_bar = 0) => {};
-const foo = (...bar) => {};
+const foo = (..._bar) => {};
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -29,7 +29,7 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-underscore-dangle: "error"*/
 
-var _ = require("underscore");
+var _ = require('underscore');
 var obj = _.contains(items, item);
 obj.__proto__ = {};
 var file = __filename;

--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -29,7 +29,7 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-underscore-dangle: "error"*/
 
-var _ = require('underscore');
+var _ = require("underscore");
 var obj = _.contains(items, item);
 obj.__proto__ = {};
 var file = __filename;
@@ -39,11 +39,12 @@ var file = __filename;
 
 This rule has an object option:
 
-* `"allow"` allows specified identifiers to have dangling underscores
-* `"allowAfterThis": false` (default) disallows dangling underscores in members of the `this` object
-* `"allowAfterSuper": false` (default) disallows dangling underscores in members of the `super` object
-* `"allowAfterThisConstructor": false` (default) disallows dangling underscores in members of the `this.constructor` object
-* `"enforceInMethodNames": false` (default) allows dangling underscores in method names
+-   `"allow"` allows specified identifiers to have dangling underscores
+-   `"allowAfterThis": false` (default) disallows dangling underscores in members of the `this` object
+-   `"allowAfterSuper": false` (default) disallows dangling underscores in members of the `super` object
+-   `"allowAfterThisConstructor": false` (default) disallows dangling underscores in members of the `this.constructor` object
+-   `"enforceInMethodNames": false` (default) allows dangling underscores in method names
+-   `"allowFunctionParams": false` (default) disallows dangling underscores in first letter of function parameter name
 
 ### allow
 
@@ -111,6 +112,20 @@ const o = {
 const o = {
   bar_() = {}
 };
+```
+
+### allowFunctionParams
+
+Examples of **correct** code for this rule with the `{ "allowFunctionParams": true }` option:
+
+```js
+/*eslint no-underscore-dangle: ["error", { "allowFunctionParams": true }]*/
+
+function foo (_bar) {}
+
+const foo = function onClick (_bar) {}
+
+const foo = (_bar) {};
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -132,18 +132,18 @@ module.exports = {
 
         /**
          * Check if function parameter has a dangling underscore.
-         * @param {ASTNode} node node to evaluate
-         * @returns {boolean} true if function parameter name has a dangling underscore.
+         * @param {ASTNode} node function node to evaluate
+         * @returns {void}
          * @private
          */
-        function checkForDanglingUnderscoreInFunctionParameter(node) {
+        function checkForDanglingUnderscoreInFunctionParameters(node) {
             if (!allowFunctionParams) {
                 node.params.forEach(param => {
                     const identifier = param.name;
 
                     if (typeof identifier !== "undefined" && hasDanglingUnderscore(identifier) && !isAllowed(identifier)) {
                         context.report({
-                            node,
+                            node: param,
                             messageId: "unexpectedUnderscore",
                             data: {
                                 identifier
@@ -161,7 +161,7 @@ module.exports = {
          * @private
          */
         function checkForDanglingUnderscoreInFunction(node) {
-            if (node.id) {
+            if (node.type === "FunctionDeclaration" && node.id) {
                 const identifier = node.id.name;
 
                 if (typeof identifier !== "undefined" && hasDanglingUnderscore(identifier) && !isAllowed(identifier)) {
@@ -174,7 +174,7 @@ module.exports = {
                     });
                 }
             }
-            checkForDanglingUnderscoreInFunctionParameter(node);
+            checkForDanglingUnderscoreInFunctionParameters(node);
         }
 
         /**

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -137,18 +137,20 @@ module.exports = {
          * @private
          */
         function checkForFollowingUnderscoreInFunctionParameter(node) {
-            if (!allowFunctionParams && node.params) {
-                const identifier = node.params.name;
+            if (!allowFunctionParams) {
+                node.params.forEach(param => {
+                    const identifier = param.name;
 
-                if (typeof identifier !== "undefined" && identifier.indexOf("_") === 0) {
-                    context.report({
-                        node,
-                        messageId: "unexpectedUnderscore",
-                        data: {
-                            identifier
-                        }
-                    });
-                }
+                    if (typeof identifier !== "undefined" && hasTrailingUnderscore(identifier)) {
+                        context.report({
+                            node,
+                            messageId: "unexpectedUnderscore",
+                            data: {
+                                identifier
+                            }
+                        });
+                    }
+                });
             }
         }
 

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -139,16 +139,31 @@ module.exports = {
         function checkForDanglingUnderscoreInFunctionParameters(node) {
             if (!allowFunctionParams) {
                 node.params.forEach(param => {
-                    const identifier = param.name;
+                    let identifier = "";
+                    const { type } = param;
 
-                    if (typeof identifier !== "undefined" && hasDanglingUnderscore(identifier) && !isAllowed(identifier)) {
-                        context.report({
-                            node: param,
-                            messageId: "unexpectedUnderscore",
-                            data: {
-                                identifier
-                            }
-                        });
+                    if (type === "RestElement" && param.argument !== "undefined") {
+                        if (param.argument.name !== "undefined") {
+                            identifier = param.argument.name;
+                        }
+                    } else if (type === "AssignmentPattern" && param.left !== "undefined") {
+                        if (param.left.name !== "undefined") {
+                            identifier = param.left.name;
+                        }
+                    } else if (type === "Identifier" && param.name !== "undefined") {
+                        identifier = param.name;
+                    }
+
+                    if (identifier !== "") {
+                        if (typeof identifier !== "undefined" && hasDanglingUnderscore(identifier) && !isAllowed(identifier)) {
+                            context.report({
+                                node: param,
+                                messageId: "unexpectedUnderscore",
+                                data: {
+                                    identifier
+                                }
+                            });
+                        }
                     }
                 });
             }

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -131,12 +131,12 @@ module.exports = {
         }
 
         /**
-         * Check if a node is a function parameter
+         * Check if function parameter has a underscore at the beginning.
          * @param {ASTNode} node node to evaluate
-         * @returns {boolean} true if it is a function parameter
+         * @returns {boolean} true if function parameter name has a underscore at the beginning.
          * @private
          */
-        function checkParameter(node) {
+        function checkForFollowingUnderscoreInFunctionParameter(node) {
             if (!allowFunctionParams && node.params) {
                 const identifier = node.params.name;
 
@@ -172,7 +172,7 @@ module.exports = {
                     });
                 }
             }
-            checkParameter(node);
+            checkForFollowingUnderscoreInFunctionParameter(node);
         }
 
         /**
@@ -254,8 +254,8 @@ module.exports = {
             MemberExpression: checkForTrailingUnderscoreInMemberExpression,
             MethodDefinition: checkForTrailingUnderscoreInMethod,
             Property: checkForTrailingUnderscoreInMethod,
-            FunctionExpression: checkParameter,
-            ArrowFunctionExpression: checkParameter
+            FunctionExpression: checkForFollowingUnderscoreInFunctionParameter,
+            ArrowFunctionExpression: checkForFollowingUnderscoreInFunctionParameter
         };
 
     }

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -141,7 +141,7 @@ module.exports = {
                 node.params.forEach(param => {
                     const identifier = param.name;
 
-                    if (typeof identifier !== "undefined" && hasDanglingUnderscore(identifier)) {
+                    if (typeof identifier !== "undefined" && hasDanglingUnderscore(identifier) && !isAllowed(identifier)) {
                         context.report({
                             node,
                             messageId: "unexpectedUnderscore",

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -45,6 +45,10 @@ module.exports = {
                     enforceInMethodNames: {
                         type: "boolean",
                         default: false
+                    },
+                    allowFunctionParams: {
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -64,6 +68,7 @@ module.exports = {
         const allowAfterSuper = typeof options.allowAfterSuper !== "undefined" ? options.allowAfterSuper : false;
         const allowAfterThisConstructor = typeof options.allowAfterThisConstructor !== "undefined" ? options.allowAfterThisConstructor : false;
         const enforceInMethodNames = typeof options.enforceInMethodNames !== "undefined" ? options.enforceInMethodNames : false;
+        const allowFunctionParams = typeof options.allowFunctionParams !== "undefined" ? options.allowFunctionParams : false;
 
         //-------------------------------------------------------------------------
         // Helpers
@@ -126,6 +131,28 @@ module.exports = {
         }
 
         /**
+         * Check if a node is a function parameter
+         * @param {ASTNode} node node to evaluate
+         * @returns {boolean} true if it is a function parameter
+         * @private
+         */
+        function checkParameter(node) {
+            if (!allowFunctionParams && node.params) {
+                const identifier = node.params.name;
+
+                if (typeof identifier !== "undefined" && identifier.indexOf("_") === 0) {
+                    context.report({
+                        node,
+                        messageId: "unexpectedUnderscore",
+                        data: {
+                            identifier
+                        }
+                    });
+                }
+            }
+        }
+
+        /**
          * Check if function has a underscore at the end
          * @param {ASTNode} node node to evaluate
          * @returns {void}
@@ -145,6 +172,7 @@ module.exports = {
                     });
                 }
             }
+            checkParameter(node);
         }
 
         /**
@@ -225,7 +253,9 @@ module.exports = {
             VariableDeclarator: checkForTrailingUnderscoreInVariableExpression,
             MemberExpression: checkForTrailingUnderscoreInMemberExpression,
             MethodDefinition: checkForTrailingUnderscoreInMethod,
-            Property: checkForTrailingUnderscoreInMethod
+            Property: checkForTrailingUnderscoreInMethod,
+            FunctionExpression: checkParameter,
+            ArrowFunctionExpression: checkParameter
         };
 
     }

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -139,23 +139,21 @@ module.exports = {
         function checkForDanglingUnderscoreInFunctionParameters(node) {
             if (!allowFunctionParams) {
                 node.params.forEach(param => {
-                    let identifier = "";
                     const { type } = param;
+                    let nodeToCheck;
 
-                    if (type === "RestElement" && param.argument !== "undefined") {
-                        if (param.argument.name !== "undefined") {
-                            identifier = param.argument.name;
-                        }
-                    } else if (type === "AssignmentPattern" && param.left !== "undefined") {
-                        if (param.left.name !== "undefined") {
-                            identifier = param.left.name;
-                        }
-                    } else if (type === "Identifier" && param.name !== "undefined") {
-                        identifier = param.name;
+                    if (type === "RestElement") {
+                        nodeToCheck = param.argument;
+                    } else if (type === "AssignmentPattern") {
+                        nodeToCheck = param.left;
+                    } else {
+                        nodeToCheck = param;
                     }
 
-                    if (identifier !== "") {
-                        if (typeof identifier !== "undefined" && hasDanglingUnderscore(identifier) && !isAllowed(identifier)) {
+                    if (nodeToCheck.type === "Identifier") {
+                        const identifier = nodeToCheck.name;
+
+                        if (hasDanglingUnderscore(identifier) && !isAllowed(identifier)) {
                             context.report({
                                 node: param,
                                 messageId: "unexpectedUnderscore",

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rule to flag trailing underscores in variable declarations.
+ * @fileoverview Rule to flag dangling underscores in variable declarations.
  * @author Matt DuVall <http://www.mattduvall.com>
  */
 
@@ -85,12 +85,12 @@ module.exports = {
         }
 
         /**
-         * Check if identifier has a underscore at the end
+         * Check if identifier has a dangling underscore
          * @param {string} identifier name of the node
          * @returns {boolean} true if its is present
          * @private
          */
-        function hasTrailingUnderscore(identifier) {
+        function hasDanglingUnderscore(identifier) {
             const len = identifier.length;
 
             return identifier !== "_" && (identifier[0] === "_" || identifier[len - 1] === "_");
@@ -131,17 +131,17 @@ module.exports = {
         }
 
         /**
-         * Check if function parameter has a underscore at the beginning.
+         * Check if function parameter has a dangling underscore.
          * @param {ASTNode} node node to evaluate
-         * @returns {boolean} true if function parameter name has a underscore at the beginning.
+         * @returns {boolean} true if function parameter name has a dangling underscore.
          * @private
          */
-        function checkForFollowingUnderscoreInFunctionParameter(node) {
+        function checkForDanglingUnderscoreInFunctionParameter(node) {
             if (!allowFunctionParams) {
                 node.params.forEach(param => {
                     const identifier = param.name;
 
-                    if (typeof identifier !== "undefined" && hasTrailingUnderscore(identifier)) {
+                    if (typeof identifier !== "undefined" && hasDanglingUnderscore(identifier)) {
                         context.report({
                             node,
                             messageId: "unexpectedUnderscore",
@@ -155,16 +155,16 @@ module.exports = {
         }
 
         /**
-         * Check if function has a underscore at the end
+         * Check if function has a dangling underscore
          * @param {ASTNode} node node to evaluate
          * @returns {void}
          * @private
          */
-        function checkForTrailingUnderscoreInFunctionDeclaration(node) {
+        function checkForDanglingUnderscoreInFunction(node) {
             if (node.id) {
                 const identifier = node.id.name;
 
-                if (typeof identifier !== "undefined" && hasTrailingUnderscore(identifier) && !isAllowed(identifier)) {
+                if (typeof identifier !== "undefined" && hasDanglingUnderscore(identifier) && !isAllowed(identifier)) {
                     context.report({
                         node,
                         messageId: "unexpectedUnderscore",
@@ -174,19 +174,19 @@ module.exports = {
                     });
                 }
             }
-            checkForFollowingUnderscoreInFunctionParameter(node);
+            checkForDanglingUnderscoreInFunctionParameter(node);
         }
 
         /**
-         * Check if variable expression has a underscore at the end
+         * Check if variable expression has a dangling underscore
          * @param {ASTNode} node node to evaluate
          * @returns {void}
          * @private
          */
-        function checkForTrailingUnderscoreInVariableExpression(node) {
+        function checkForDanglingUnderscoreInVariableExpression(node) {
             const identifier = node.id.name;
 
-            if (typeof identifier !== "undefined" && hasTrailingUnderscore(identifier) &&
+            if (typeof identifier !== "undefined" && hasDanglingUnderscore(identifier) &&
                 !isSpecialCaseIdentifierInVariableExpression(identifier) && !isAllowed(identifier)) {
                 context.report({
                     node,
@@ -199,18 +199,18 @@ module.exports = {
         }
 
         /**
-         * Check if member expression has a underscore at the end
+         * Check if member expression has a dangling underscore
          * @param {ASTNode} node node to evaluate
          * @returns {void}
          * @private
          */
-        function checkForTrailingUnderscoreInMemberExpression(node) {
+        function checkForDanglingUnderscoreInMemberExpression(node) {
             const identifier = node.property.name,
                 isMemberOfThis = node.object.type === "ThisExpression",
                 isMemberOfSuper = node.object.type === "Super",
                 isMemberOfThisConstructor = isThisConstructorReference(node);
 
-            if (typeof identifier !== "undefined" && hasTrailingUnderscore(identifier) &&
+            if (typeof identifier !== "undefined" && hasDanglingUnderscore(identifier) &&
                 !(isMemberOfThis && allowAfterThis) &&
                 !(isMemberOfSuper && allowAfterSuper) &&
                 !(isMemberOfThisConstructor && allowAfterThisConstructor) &&
@@ -226,16 +226,16 @@ module.exports = {
         }
 
         /**
-         * Check if method declaration or method property has a underscore at the end
+         * Check if method declaration or method property has a dangling underscore
          * @param {ASTNode} node node to evaluate
          * @returns {void}
          * @private
          */
-        function checkForTrailingUnderscoreInMethod(node) {
+        function checkForDanglingUnderscoreInMethod(node) {
             const identifier = node.key.name;
             const isMethod = node.type === "MethodDefinition" || node.type === "Property" && node.method;
 
-            if (typeof identifier !== "undefined" && enforceInMethodNames && isMethod && hasTrailingUnderscore(identifier) && !isAllowed(identifier)) {
+            if (typeof identifier !== "undefined" && enforceInMethodNames && isMethod && hasDanglingUnderscore(identifier) && !isAllowed(identifier)) {
                 context.report({
                     node,
                     messageId: "unexpectedUnderscore",
@@ -251,13 +251,13 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            FunctionDeclaration: checkForTrailingUnderscoreInFunctionDeclaration,
-            VariableDeclarator: checkForTrailingUnderscoreInVariableExpression,
-            MemberExpression: checkForTrailingUnderscoreInMemberExpression,
-            MethodDefinition: checkForTrailingUnderscoreInMethod,
-            Property: checkForTrailingUnderscoreInMethod,
-            FunctionExpression: checkForFollowingUnderscoreInFunctionParameter,
-            ArrowFunctionExpression: checkForFollowingUnderscoreInFunctionParameter
+            FunctionDeclaration: checkForDanglingUnderscoreInFunction,
+            VariableDeclarator: checkForDanglingUnderscoreInVariableExpression,
+            MemberExpression: checkForDanglingUnderscoreInMemberExpression,
+            MethodDefinition: checkForDanglingUnderscoreInMethod,
+            Property: checkForDanglingUnderscoreInMethod,
+            FunctionExpression: checkForDanglingUnderscoreInFunction,
+            ArrowFunctionExpression: checkForDanglingUnderscoreInFunction
         };
 
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "7.5.0",
+  "version": "7.6.0",
   "author": "Nicholas C. Zakas <nicholas+npm@nczconsulting.com>",
   "description": "An AST-based pattern checker for JavaScript.",
   "bin": {

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -32,6 +32,9 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "const foo = { onClick(_bar = 0) { } }", parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = (_bar) => {}", parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = (_bar = 0) => {}", parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo( ..._bar) {}", parserOptions: { ecmaVersion: 6 } },
+        { code: "const foo = (..._bar) => {}", parserOptions: { ecmaVersion: 6 } },
+        { code: "const foo = { onClick(..._bar) { } }", parserOptions: { ecmaVersion: 6 } },
         { code: "export default function() {}", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "var _foo = 1", options: [{ allow: ["_foo"] }] },
         { code: "var __proto__ = 1;", options: [{ allow: ["__proto__"] }] },
@@ -77,13 +80,13 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "this.constructor._bar", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "MemberExpression" }] },
         { code: "function foo(_bar) {}", options: [{ allowFunctionParams: false }], errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] },
         { code: "const foo = { onClick(_bar) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] },
-        { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] }
-
-        /*
-         * { code: "function foo(_bar = 0) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] },
-         * { code: "const foo = { onClick(_bar = 0) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] },
-         * { code: "const foo = (_bar = 0) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] }
-         */
+        { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] },
+        { code: "function foo(_bar = 0) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "AssignmentPattern" }] },
+        { code: "const foo = { onClick(_bar = 0) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "AssignmentPattern" }] },
+        { code: "const foo = (_bar = 0) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "AssignmentPattern" }] },
+        { code: "function foo(..._bar) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "RestElement" }] },
+        { code: "const foo = { onClick(..._bar) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "RestElement" }] },
+        { code: "const foo = (..._bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "RestElement" }] }
 
     ]
 });

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -65,12 +65,8 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "class foo { onClick_() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "onClick_" }, type: "MethodDefinition" }] },
         { code: "const o = { _onClick() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_onClick" }, type: "Property" }] },
         { code: "const o = { onClick_() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "onClick_" }, type: "Property" }] },
-        { code: "this.constructor._bar", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "MemberExpression" }] }
-
-        /*
-         * { code: "function foo(_bar) {}", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionDeclaration" }] },
-         *  { code: "function foo(_bar) {}", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionDeclaration" }] },
-         *  { code: "function foo(_bar) {}", options: [{ allowFunctionParams: false }], errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionDeclaration" }] }
-         */
+        { code: "this.constructor._bar", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "MemberExpression" }] },
+        { code: "function foo(_bar) {}", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionDeclaration" }] },
+        { code: "function foo(_bar) {}", options: [{ allowFunctionParams: false }], errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionDeclaration" }] }
     ]
 });

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -26,6 +26,7 @@ ruleTester.run("no-underscore-dangle", rule, {
         "console.log(__filename); console.log(__dirname);",
         "var _ = require('underscore');",
         "var a = b._;",
+        "function foo(bar) {}",
         { code: "export default function() {}", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "var _foo = 1", options: [{ allow: ["_foo"] }] },
         { code: "var __proto__ = 1;", options: [{ allow: ["__proto__"] }] },
@@ -40,7 +41,12 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "const o = { _onClick() { } }", options: [{ allow: ["_onClick"], enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "const o = { _foo: 'bar' }", parserOptions: { ecmaVersion: 6 } },
         { code: "const o = { foo_: 'bar' }", parserOptions: { ecmaVersion: 6 } },
-        { code: "this.constructor._bar", options: [{ allowAfterThisConstructor: true }] }
+        { code: "this.constructor._bar", options: [{ allowAfterThisConstructor: true }] },
+        { code: "const foo = { onClick(bar) { } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "const foo = (bar) => {}", parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo(_bar) {}", options: [{ allowFunctionParams: true }] },
+        { code: "const foo = { onClick(_bar) { } }", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         { code: "var _foo = 1", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_foo" }, type: "VariableDeclarator" }] },
@@ -56,7 +62,12 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "class foo { onClick_() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "onClick_" }, type: "MethodDefinition" }] },
         { code: "const o = { _onClick() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_onClick" }, type: "Property" }] },
         { code: "const o = { onClick_() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "onClick_" }, type: "Property" }] },
-        { code: "this.constructor._bar", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "MemberExpression" }] },
-        { code: "foo.constructor._bar", options: [{ allowAfterThisConstructor: true }], errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "MemberExpression" }] }
+        { code: "this.constructor._bar", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "MemberExpression" }] }
+
+        /*
+         * { code: "function foo(_bar) {}", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionDeclaration" }] },
+         *  { code: "function foo(_bar) {}", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionDeclaration" }] },
+         *  { code: "function foo(_bar) {}", options: [{ allowFunctionParams: false }], errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionDeclaration" }] }
+         */
     ]
 });

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -27,8 +27,11 @@ ruleTester.run("no-underscore-dangle", rule, {
         "var _ = require('underscore');",
         "var a = b._;",
         "function foo(_bar) {}",
+        { code: "function foo( _bar = 0) {}", parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = { onClick(_bar) { } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "const foo = { onClick(_bar = 0) { } }", parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = (_bar) => {}", parserOptions: { ecmaVersion: 6 } },
+        { code: "const foo = (_bar = 0) => {}", parserOptions: { ecmaVersion: 6 } },
         { code: "export default function() {}", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "var _foo = 1", options: [{ allow: ["_foo"] }] },
         { code: "var __proto__ = 1;", options: [{ allow: ["__proto__"] }] },
@@ -47,13 +50,12 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "const foo = { onClick(bar) { } }", parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = (bar) => {}", parserOptions: { ecmaVersion: 6 } },
         { code: "function foo(_bar) {}", options: [{ allowFunctionParams: true }] },
+        { code: "function foo( _bar = 0) {}", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = { onClick(_bar) { } }", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "function foo(bar) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = { onClick(bar) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = (bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
-        { code: "function foo({ _bar }) {}", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } },
-        { code: "function foo([ _bar ]) {}", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "function foo(_bar) {}", options: [{ allowFunctionParams: false, allow: ["_bar"] }] },
         { code: "const foo = { onClick(_bar) { } }", options: [{ allowFunctionParams: false, allow: ["_bar"] }], parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: false, allow: ["_bar"] }], parserOptions: { ecmaVersion: 6 } }
@@ -73,8 +75,15 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "const o = { _onClick() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_onClick" }, type: "Property" }] },
         { code: "const o = { onClick_() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "onClick_" }, type: "Property" }] },
         { code: "this.constructor._bar", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "MemberExpression" }] },
-        { code: "function foo(_bar) {}", options: [{ allowFunctionParams: false }], errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionDeclaration" }] },
-        { code: "const foo = { onClick(_bar) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionExpression" }] },
-        { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "ArrowFunctionExpression" }] }
+        { code: "function foo(_bar) {}", options: [{ allowFunctionParams: false }], errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] },
+        { code: "const foo = { onClick(_bar) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] },
+        { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] }
+
+        /*
+         * { code: "function foo(_bar = 0) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] },
+         * { code: "const foo = { onClick(_bar = 0) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] },
+         * { code: "const foo = (_bar = 0) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] }
+         */
+
     ]
 });

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -69,6 +69,10 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "const o = { onClick_() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "onClick_" }, type: "Property" }] },
         { code: "this.constructor._bar", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "MemberExpression" }] },
         { code: "function foo(_bar) {}", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionDeclaration" }] },
-        { code: "function foo(_bar) {}", options: [{ allowFunctionParams: false }], errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionDeclaration" }] }
+        { code: "function foo(_bar) {}", options: [{ allowFunctionParams: false }], errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionDeclaration" }] },
+        { code: "const foo = { onClick(_bar) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionExpression" }] },
+        { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "ArrowFunctionExpression" }] },
+        { code: "const foo = { onClick(_bar) { } }", parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "FunctionExpression" }] },
+        { code: "const foo = (_bar) => {}", parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "ArrowFunctionExpression" }] }
     ]
 });

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -53,7 +53,10 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "const foo = { onClick(bar) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = (bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
         { code: "function foo({ _bar }) {}", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } },
-        { code: "function foo([ _bar ]) {}", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } }
+        { code: "function foo([ _bar ]) {}", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo(_bar) {}", options: [{ allowFunctionParams: false, allow: ["_bar"] }] },
+        { code: "const foo = { onClick(_bar) { } }", options: [{ allowFunctionParams: false, allow: ["_bar"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: false, allow: ["_bar"] }], parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         { code: "var _foo = 1", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_foo" }, type: "VariableDeclarator" }] },

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -46,7 +46,10 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "const foo = (bar) => {}", parserOptions: { ecmaVersion: 6 } },
         { code: "function foo(_bar) {}", options: [{ allowFunctionParams: true }] },
         { code: "const foo = { onClick(_bar) { } }", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } },
-        { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } }
+        { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo(bar) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "const foo = { onClick(bar) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "const foo = (bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         { code: "var _foo = 1", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_foo" }, type: "VariableDeclarator" }] },

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -49,7 +49,9 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "function foo(bar) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = { onClick(bar) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
-        { code: "const foo = (bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } }
+        { code: "const foo = (bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo({ _bar }) {}", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo([ _bar ]) {}", options: [{ allowFunctionParams: true }], parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         { code: "var _foo = 1", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_foo" }, type: "VariableDeclarator" }] },

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -27,6 +27,9 @@ ruleTester.run("no-underscore-dangle", rule, {
         "var _ = require('underscore');",
         "var a = b._;",
         "function foo(_bar) {}",
+        "function foo(bar_) {}",
+        "(function _foo() {})",
+        { code: "function foo(_bar) {}", options: [{}] },
         { code: "function foo( _bar = 0) {}", parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = { onClick(_bar) { } }", parserOptions: { ecmaVersion: 6 } },
         { code: "const foo = { onClick(_bar = 0) { } }", parserOptions: { ecmaVersion: 6 } },
@@ -61,7 +64,12 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "const foo = (bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
         { code: "function foo(_bar) {}", options: [{ allowFunctionParams: false, allow: ["_bar"] }] },
         { code: "const foo = { onClick(_bar) { } }", options: [{ allowFunctionParams: false, allow: ["_bar"] }], parserOptions: { ecmaVersion: 6 } },
-        { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: false, allow: ["_bar"] }], parserOptions: { ecmaVersion: 6 } }
+        { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: false, allow: ["_bar"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo([_bar]) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo([_bar] = []) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo( { _bar }) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo( { _bar = 0 } = {}) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo(...[_bar]) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 2016 } }
     ],
     invalid: [
         { code: "var _foo = 1", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_foo" }, type: "VariableDeclarator" }] },
@@ -79,6 +87,8 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "const o = { onClick_() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "onClick_" }, type: "Property" }] },
         { code: "this.constructor._bar", errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "MemberExpression" }] },
         { code: "function foo(_bar) {}", options: [{ allowFunctionParams: false }], errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] },
+        { code: "(function foo(_bar) {})", options: [{ allowFunctionParams: false }], errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] },
+        { code: "function foo(bar, _foo) {}", options: [{ allowFunctionParams: false }], errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_foo" }, type: "Identifier" }] },
         { code: "const foo = { onClick(_bar) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] },
         { code: "const foo = (_bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "Identifier" }] },
         { code: "function foo(_bar = 0) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "AssignmentPattern" }] },
@@ -87,6 +97,7 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "function foo(..._bar) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "RestElement" }] },
         { code: "const foo = { onClick(..._bar) { } }", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "RestElement" }] },
         { code: "const foo = (..._bar) => {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" }, type: "RestElement" }] }
+
 
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
(fixes #12579 )
If there is an underscore at the beginning of the function parameter name, it will give a warning.

#### Is there anything you'd like reviewers to focus on?
None