### PR TITLE
Docs: clarify "case" specifier in padding-line-between-statements

### DIFF
--- a/docs/rules/padding-line-between-statements.md
+++ b/docs/rules/padding-line-between-statements.md
@@ -48,14 +48,14 @@ You can supply any number of configurations. If a statement pair matches multipl
     - `"block"` is lonely blocks.
     - `"block-like"` is block like statements. This matches statements that the last token is the closing brace of blocks; e.g. `{ }`, `if (a) { }`, and `while (a) { }`. Also matches immediately invoked function expression statements.
     - `"break"` is `break` statements.
-    - `"case"` is `case` labels.
+    - `"case"` is `case` clauses in `switch` statements.
     - `"cjs-export"` is `export` statements of CommonJS; e.g. `module.exports = 0`, `module.exports.foo = 1`, and `exports.foo = 2`. This is a special case of assignment.
     - `"cjs-import"` is `import` statements of CommonJS; e.g. `const foo = require("foo")`. This is a special case of variable declarations.
     - `"class"` is `class` declarations.
     - `"const"` is `const` variable declarations, both single-line and multiline.
     - `"continue"` is `continue` statements.
     - `"debugger"` is `debugger` statements.
-    - `"default"` is `default` labels.
+    - `"default"` is `default` clauses in `switch` statements.
     - `"directive"` is directive prologues. This matches directives; e.g. `"use strict"`.
     - `"do"` is `do-while` statements. This matches all statements that the first token is `do` keyword.
     - `"empty"` is empty statements.
@@ -210,6 +210,55 @@ Examples of **correct** code for the `[{ blankLine: "always", prev: "directive",
 "use asm";
 
 foo();
+```
+
+----
+
+This configuration would require blank lines between clauses in `switch` statements.
+
+Examples of **incorrect** code for the `[{ blankLine: "always", prev: ["case", "default"], next: "*" }]` configuration:
+
+```js
+/*eslint padding-line-between-statements: [
+    "error",
+    { blankLine: "always", prev: ["case", "default"], next: "*" }
+]*/
+
+switch (foo) {
+    case 1:
+        bar();
+        break;
+    case 2:
+    case 3:
+        baz();
+        break;
+    default:
+        quux();
+}
+```
+
+Examples of **correct** code for the `[{ blankLine: "always", prev: ["case", "default"], next: "*" }]` configuration:
+
+```js
+/*eslint padding-line-between-statements: [
+    "error",
+    { blankLine: "always", prev: ["case", "default"], next: "*" }
+]*/
+
+switch (foo) {
+    case 1:
+        bar();
+        break;
+
+    case 2:
+
+    case 3:
+        baz();
+        break;
+
+    default:
+        quux();
+}
 ```
 
 ## Compatibility


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update

refs #13561

Documentation for `"case"` and `"default"` specifiers in `padding-line-between-statements` may be misleading. It sounds like the rule will require/disallow blank lines before and after `case:` and `default:` lines, while these specifiers actually apply to whole clauses.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed the text for `"case"` and `"default"` specifiers, and added an example.

#### Is there anything you'd like reviewers to focus on?
