### PR TITLE
sort-keys, add allowLineSeparatedGroups option

### DIFF
--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -38,6 +38,20 @@ function getPropertyName(node) {
 }
 
 /**
+ * Check the Line Separated Groups
+ *
+ * - Compare the start line of the current node with the last line of the previous node.
+ *   If the difference between the two values is greater than 0, Not the same group.
+ * @param {number} thisStartLine is start line of the current node.
+ * @param {number} prevEndLine is end line of the previous node.
+ * @returns {number} number of lines between nodes.
+ * @private
+ */
+function checkLineSeparatedGroups(thisStartLine, prevEndLine) {
+    return Math.max(thisStartLine - prevEndLine - 1, 0);
+}
+
+/**
  * Functions which check that the given 2 names are in specific order.
  *
  * Postfix `I` is meant insensitive.
@@ -105,6 +119,10 @@ module.exports = {
                         type: "integer",
                         minimum: 2,
                         default: 2
+                    },
+                    allowLineSeparatedGroups: {
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -112,6 +130,7 @@ module.exports = {
         ],
 
         messages: {
+            allowLineSeparatedGroups: "'{{thisName}}' should be before '{{prevName}}'. To separate groups by line break, apply the allowLineSeparatedGroups option.",
             sortKeys: "Expected object keys to be in {{natural}}{{insensitive}}{{order}}ending order. '{{thisName}}' should be before '{{prevName}}'."
         }
     },
@@ -124,6 +143,7 @@ module.exports = {
         const insensitive = options && options.caseSensitive === false;
         const natural = options && options.natural;
         const minKeys = options && options.minKeys;
+        const allowLineSeparatedGroups = options && options.allowLineSeparatedGroups || false;
         const isValidOrder = isValidOrders[
             order + (insensitive ? "I" : "") + (natural ? "N" : "")
         ];
@@ -136,6 +156,7 @@ module.exports = {
                 stack = {
                     upper: stack,
                     prevName: null,
+                    prevEndLine: null,
                     numKeys: node.properties.length
                 };
             },
@@ -156,11 +177,22 @@ module.exports = {
                 }
 
                 const prevName = stack.prevName;
+                const prevEndLine = stack.prevEndLine;
                 const numKeys = stack.numKeys;
                 const thisName = getPropertyName(node);
+                const thisStartLine = node.loc.start.line;
+                const isLineSeparatedGroups = prevEndLine && checkLineSeparatedGroups(thisStartLine, prevEndLine);
+
+                if (thisStartLine !== null) {
+                    stack.prevEndLine = thisStartLine;
+                }
 
                 if (thisName !== null) {
                     stack.prevName = thisName;
+                }
+
+                if (allowLineSeparatedGroups && isLineSeparatedGroups) {
+                    return;
                 }
 
                 if (prevName === null || thisName === null || numKeys < minKeys) {
@@ -171,7 +203,7 @@ module.exports = {
                     context.report({
                         node,
                         loc: node.key.loc,
-                        messageId: "sortKeys",
+                        messageId: isLineSeparatedGroups ? "allowLineSeparatedGroups" : "sortKeys",
                         data: {
                             thisName,
                             prevName,

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -163,7 +163,53 @@ ruleTester.run("sort-keys", rule, {
         { code: "var obj = {è:4, À:3, 'Z':2, '#':1}", options: ["desc", { natural: true, caseSensitive: false }] },
 
         // desc, natural, insensitive, minKeys should ignore unsorted keys when number of keys is less than minKeys
-        { code: "var obj = {a:1, _:2, b:3}", options: ["desc", { natural: true, caseSensitive: false, minKeys: 4 }] }
+        { code: "var obj = {a:1, _:2, b:3}", options: ["desc", { natural: true, caseSensitive: false, minKeys: 4 }] },
+
+        // allowLineSeparatedGroups, default false
+        {
+            code: `
+                var obj = {
+                    f: 1,
+                    g: 2,
+
+
+                    a: 3,
+                    b: 4,
+                    c: 5,
+
+                    d: 6,
+                    e: 7
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }]
+        },
+        {
+            code: `
+                var obj = {
+                    b: 1,
+                    c: 2,
+
+                    a: 3
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }]
+        },
+        {
+            code: `
+                var obj = {
+                    c: 1,
+                    d: 2,
+
+                    a: 3,
+                    b() {
+
+                    },
+                    e: 4
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }],
+            parserOptions: { ecmaVersion: 6 }
+        }
     ],
     invalid: [
 
@@ -1758,6 +1804,28 @@ ruleTester.run("sort-keys", rule, {
                         order: "desc",
                         thisName: "b",
                         prevName: "_"
+                    }
+                }
+            ]
+        },
+
+        // If allowLineSeparatedGroups option is false, Groups are not divided by line breaks.
+        {
+            code: `
+                var obj = {
+                    b: 1,
+                    c: 2,
+
+                    a: 3
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: false }],
+            errors: [
+                {
+                    messageId: "allowLineSeparatedGroups",
+                    data: {
+                        thisName: "a",
+                        prevName: "c"
                     }
                 }
             ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [v] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Add `allowLineSeparatedGroups` option to `sort-keys` rule #12759
#### Is there anything you'd like reviewers to focus on?
None.