### PR TITLE
feat: add allowLineSeparatedGroups option to sort-keys  (fixes #12759)

### DIFF
--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -198,7 +198,7 @@ let obj = {
 Examples of **correct** code for the `{minKeys: 4}` option:
 
 ```js
-/*eslint sort-keys: ["error", "asc", {minKeys: 4}]*//
+/*eslint sort-keys: ["error", "asc", {minKeys: 4}]*/
 /*eslint-env es6*/
 
 // 3 keys
@@ -220,7 +220,7 @@ let obj = {
 Examples of **incorrect** code for the `{allowLineSeparatedGroups: true}` option:
 
 ```js
-/*eslint sort-keys: ["error", "asc", {allowLineSeparatedGroups: true}]*//
+/*eslint sort-keys: ["error", "asc", {allowLineSeparatedGroups: true}]*/
 /*eslint-env es6*/
 
 // Each group follows the sort-keys rule.

--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -61,7 +61,7 @@ let obj = {b: 1, ...c, a: 2};
 
 ```json
 {
-    "sort-keys": ["error", "asc", {"caseSensitive": true, "natural": false, "minKeys": 2}]
+    "sort-keys": ["error", "asc", {"caseSensitive": true, "natural": false, "minKeys": 2, "allowLineSeparatedGroups": false}]
 }
 ```
 
@@ -75,6 +75,7 @@ The 2nd option is an object which has 3 properties.
 * `caseSensitive` - if `true`, enforce properties to be in case-sensitive order. Default is `true`.
 * `minKeys` - Specifies the minimum number of keys that an object should have in order for the object's unsorted keys to produce an error. Default is `2`, which means by default all objects with unsorted keys will result in lint errors.
 * `natural` - if `true`, enforce properties to be in natural order. Default is `false`. Natural Order compares strings containing combination of letters and numbers in the way a human being would sort. It basically sorts numerically, instead of sorting alphabetically. So the number 10 comes after the number 3 in Natural Sorting.
+* `allowLineSeparatedGroups` - if `true`, Group object keys through line break. Default is `false`.
 
 Example for a list:
 
@@ -211,6 +212,38 @@ let obj = {
 let obj = {
     2: 'b',
     1: 'a',
+};
+```
+
+### allowLineSeparatedGroups
+
+Examples of **incorrect** code for the `{allowLineSeparatedGroups: true}` option:
+
+```js
+/*eslint sort-keys: ["error", "asc", {allowLineSeparatedGroups: true}]*//
+/*eslint-env es6*/
+
+// Each group follows the sort-keys rule.
+let obj = {
+    c: 2,
+    b: 3, // 'b' should be before 'c'.
+
+    a: 3
+};
+```
+
+Examples of **correct** code for the `{allowLineSeparatedGroups: true}` option:
+
+```js
+/*eslint sort-keys: ["error", "asc", {allowLineSeparatedGroups: true}]*//
+/*eslint-env es6*/
+
+// Divide groups through line breaks.
+let obj = {
+    b: 2,
+    c: 3,
+
+    a: 3
 };
 ```
 

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -180,7 +180,7 @@ module.exports = {
                 const numKeys = stack.numKeys;
                 const thisName = getPropertyName(node);
                 const thisStartLine = node.loc.start.line;
-                const isLineSeparatedGroups = prevEndLine && checkLineSeparatedGroups(thisStartLine, prevEndLine);
+                const isLineSeparatedGroups = prevEndLine && checkLineSeparatedGroups(thisStartLine, prevEndLine) || false;
 
                 stack.prevEndLine = node.loc.end.line;
 
@@ -189,6 +189,7 @@ module.exports = {
                 }
 
                 if (allowLineSeparatedGroups && isLineSeparatedGroups) {
+                    stack.prevName = null;
                     return;
                 }
 

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -55,7 +55,7 @@ function checkLineSeparatedGroups(thisStartLine, prevEndLine, commentOffset) {
 /**
  * Get Comment Offset between prevEndLine and thisStartLine
  * @param {number} prevEndLine is end line of the previous node.
- * @param {Array<Object>} beforeTokens is token list before thisStartLine.
+ * @param {Array<Token>} beforeTokens is token list before thisStartLine.
  * @returns {number} commentOffset
  */
 function getCommentOffset(prevEndLine, beforeTokens) {
@@ -207,7 +207,7 @@ module.exports = {
                 const numKeys = stack.numKeys;
                 const thisName = getPropertyName(node);
                 const thisStartLine = node.loc.start.line;
-                const beforeTokens = Object.values(sourceCode.getTokensBefore(node, { includeComments: true }));
+                const beforeTokens = sourceCode.getTokensBefore(node, { includeComments: true });
                 const commentOffset = getCommentOffset(prevEndLine, beforeTokens);
                 const isLineSeparatedGroups = prevEndLine && checkLineSeparatedGroups(thisStartLine, prevEndLine, commentOffset);
 

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -44,11 +44,29 @@ function getPropertyName(node) {
  *   If the difference between the two values is greater than 0, Not the same group.
  * @param {number} thisStartLine is start line of the current node.
  * @param {number} prevEndLine is end line of the previous node.
+ * @param {Array<string>} sourceCodeLines use to check comment between groups.
  * @returns {boolean} check group
  * @private
  */
-function checkLineSeparatedGroups(thisStartLine, prevEndLine) {
-    return !!Math.max(thisStartLine - prevEndLine - 1, 0);
+function checkLineSeparatedGroups(thisStartLine, prevEndLine, sourceCodeLines) {
+    let blockCommentFlag = false;
+    let commentOffset = 0;
+
+    sourceCodeLines.slice(prevEndLine, thisStartLine).forEach(value => {
+        if (value.includes("//")) {
+            commentOffset++;
+        } else if (value.includes("/*")) {
+            commentOffset++;
+            blockCommentFlag = true;
+        } else if (value.includes("*/")) {
+            commentOffset++;
+            blockCommentFlag = false;
+        } else if (blockCommentFlag) {
+            commentOffset++;
+        }
+    });
+
+    return !!Math.max(thisStartLine - prevEndLine - commentOffset - 1, 0);
 }
 
 /**
@@ -150,6 +168,9 @@ module.exports = {
         // The stack to save the previous property's name for each object literals.
         let stack = null;
 
+        // The sourceCode use to check comment between groups
+        const sourceCode = context.getSourceCode();
+
         return {
             ObjectExpression(node) {
                 stack = {
@@ -180,7 +201,7 @@ module.exports = {
                 const numKeys = stack.numKeys;
                 const thisName = getPropertyName(node);
                 const thisStartLine = node.loc.start.line;
-                const isLineSeparatedGroups = prevEndLine && checkLineSeparatedGroups(thisStartLine, prevEndLine) || false;
+                const isLineSeparatedGroups = prevEndLine && checkLineSeparatedGroups(thisStartLine, prevEndLine, sourceCode.lines);
 
                 stack.prevEndLine = node.loc.end.line;
 

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -38,6 +38,20 @@ function getPropertyName(node) {
 }
 
 /**
+ * Check the Line Separated Groups
+ *
+ * - Compare the start line of the current node with the last line of the previous node.
+ *   If the difference between the two values is greater than 0, Not the same group.
+ * @param {number} thisStartLine is start line of the current node.
+ * @param {number} prevEndLine is end line of the previous node.
+ * @returns {number} number of lines between nodes.
+ * @private
+ */
+function checkLineSeparatedGroups(thisStartLine, prevEndLine) {
+    return Math.max(thisStartLine - prevEndLine - 1, 0);
+}
+
+/**
  * Functions which check that the given 2 names are in specific order.
  *
  * Postfix `I` is meant insensitive.
@@ -105,6 +119,10 @@ module.exports = {
                         type: "integer",
                         minimum: 2,
                         default: 2
+                    },
+                    allowLineSeparatedGroups: {
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -112,6 +130,7 @@ module.exports = {
         ],
 
         messages: {
+            allowLineSeparatedGroups: "'{{thisName}}' should be before '{{prevName}}'. To separate groups by line break, apply the allowLineSeparatedGroups option.",
             sortKeys: "Expected object keys to be in {{natural}}{{insensitive}}{{order}}ending order. '{{thisName}}' should be before '{{prevName}}'."
         }
     },
@@ -124,6 +143,7 @@ module.exports = {
         const insensitive = options && options.caseSensitive === false;
         const natural = options && options.natural;
         const minKeys = options && options.minKeys;
+        const allowLineSeparatedGroups = options && options.allowLineSeparatedGroups || false;
         const isValidOrder = isValidOrders[
             order + (insensitive ? "I" : "") + (natural ? "N" : "")
         ];
@@ -136,6 +156,7 @@ module.exports = {
                 stack = {
                     upper: stack,
                     prevName: null,
+                    prevEndLine: null,
                     numKeys: node.properties.length
                 };
             },
@@ -156,11 +177,22 @@ module.exports = {
                 }
 
                 const prevName = stack.prevName;
+                const prevEndLine = stack.prevEndLine;
                 const numKeys = stack.numKeys;
                 const thisName = getPropertyName(node);
+                const thisStartLine = node.loc.start.line;
+                const isLineSeparatedGroups = prevEndLine && checkLineSeparatedGroups(thisStartLine, prevEndLine);
+
+                if (thisStartLine !== null) {
+                    stack.prevEndLine = thisStartLine;
+                }
 
                 if (thisName !== null) {
                     stack.prevName = thisName;
+                }
+
+                if (allowLineSeparatedGroups && isLineSeparatedGroups) {
+                    return;
                 }
 
                 if (prevName === null || thisName === null || numKeys < minKeys) {
@@ -171,7 +203,7 @@ module.exports = {
                     context.report({
                         node,
                         loc: node.key.loc,
-                        messageId: "sortKeys",
+                        messageId: isLineSeparatedGroups ? "allowLineSeparatedGroups" : "sortKeys",
                         data: {
                             thisName,
                             prevName,

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -44,29 +44,35 @@ function getPropertyName(node) {
  *   If the difference between the two values is greater than 0, Not the same group.
  * @param {number} thisStartLine is start line of the current node.
  * @param {number} prevEndLine is end line of the previous node.
- * @param {Array<string>} sourceCodeLines use to check comment between groups.
+ * @param {number} commentOffset is total comment line between two values.
  * @returns {boolean} check group
  * @private
  */
-function checkLineSeparatedGroups(thisStartLine, prevEndLine, sourceCodeLines) {
-    let blockCommentFlag = false;
+function checkLineSeparatedGroups(thisStartLine, prevEndLine, commentOffset) {
+    return !!Math.max(thisStartLine - prevEndLine - commentOffset - 1, 0);
+}
+
+/**
+ * Get Comment Offset between prevEndLine and thisStartLine
+ * @param {number} prevEndLine is end line of the previous node.
+ * @param {Array<Object>} beforeTokens is token list before thisStartLine.
+ * @returns {number} commentOffset
+ */
+function getCommentOffset(prevEndLine, beforeTokens) {
     let commentOffset = 0;
 
-    sourceCodeLines.slice(prevEndLine, thisStartLine).forEach(value => {
-        if (value.includes("//")) {
-            commentOffset++;
-        } else if (value.includes("/*")) {
-            commentOffset++;
-            blockCommentFlag = true;
-        } else if (value.includes("*/")) {
-            commentOffset++;
-            blockCommentFlag = false;
-        } else if (blockCommentFlag) {
-            commentOffset++;
-        }
-    });
+    for (let i = 0; i < beforeTokens.length; i++) {
+        const token = beforeTokens[i];
 
-    return !!Math.max(thisStartLine - prevEndLine - commentOffset - 1, 0);
+        if (prevEndLine < token.loc.end.line) {
+            if (token.type === "Line") {
+                commentOffset++;
+            } else if (token.type === "Block") {
+                commentOffset = commentOffset + token.loc.end.line - token.loc.start.line + 1;
+            }
+        }
+    }
+    return commentOffset;
 }
 
 /**
@@ -201,7 +207,9 @@ module.exports = {
                 const numKeys = stack.numKeys;
                 const thisName = getPropertyName(node);
                 const thisStartLine = node.loc.start.line;
-                const isLineSeparatedGroups = prevEndLine && checkLineSeparatedGroups(thisStartLine, prevEndLine, sourceCode.lines);
+                const beforeTokens = Object.values(sourceCode.getTokensBefore(node, { includeComments: true }));
+                const commentOffset = getCommentOffset(prevEndLine, beforeTokens);
+                const isLineSeparatedGroups = prevEndLine && checkLineSeparatedGroups(thisStartLine, prevEndLine, commentOffset);
 
                 stack.prevEndLine = node.loc.end.line;
 
@@ -209,7 +217,7 @@ module.exports = {
                     stack.prevName = thisName;
                 }
 
-                if (allowLineSeparatedGroups && isLineSeparatedGroups) {
+                if (allowLineSeparatedGroups && (isLineSeparatedGroups || thisName === null)) {
                     stack.prevName = null;
                     return;
                 }

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -184,7 +184,7 @@ module.exports = {
                 const isLineSeparatedGroups = prevEndLine && checkLineSeparatedGroups(thisStartLine, prevEndLine);
 
                 if (thisStartLine !== null) {
-                    stack.prevEndLine = thisStartLine;
+                    stack.prevEndLine = node.loc.end.line;
                 }
 
                 if (thisName !== null) {

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -44,11 +44,11 @@ function getPropertyName(node) {
  *   If the difference between the two values is greater than 0, Not the same group.
  * @param {number} thisStartLine is start line of the current node.
  * @param {number} prevEndLine is end line of the previous node.
- * @returns {number} number of lines between nodes.
+ * @returns {boolean} check group
  * @private
  */
 function checkLineSeparatedGroups(thisStartLine, prevEndLine) {
-    return Math.max(thisStartLine - prevEndLine - 1, 0);
+    return !!Math.max(thisStartLine - prevEndLine - 1, 0);
 }
 
 /**
@@ -130,7 +130,6 @@ module.exports = {
         ],
 
         messages: {
-            allowLineSeparatedGroups: "'{{thisName}}' should be before '{{prevName}}'. To separate groups by line break, apply the allowLineSeparatedGroups option.",
             sortKeys: "Expected object keys to be in {{natural}}{{insensitive}}{{order}}ending order. '{{thisName}}' should be before '{{prevName}}'."
         }
     },
@@ -183,9 +182,7 @@ module.exports = {
                 const thisStartLine = node.loc.start.line;
                 const isLineSeparatedGroups = prevEndLine && checkLineSeparatedGroups(thisStartLine, prevEndLine);
 
-                if (thisStartLine !== null) {
-                    stack.prevEndLine = node.loc.end.line;
-                }
+                stack.prevEndLine = node.loc.end.line;
 
                 if (thisName !== null) {
                     stack.prevName = thisName;
@@ -203,7 +200,7 @@ module.exports = {
                     context.report({
                         node,
                         loc: node.key.loc,
-                        messageId: isLineSeparatedGroups ? "allowLineSeparatedGroups" : "sortKeys",
+                        messageId: "sortKeys",
                         data: {
                             thisName,
                             prevName,

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -67,6 +67,7 @@ function getCommentOffset(comments) {
 
         commentOffset = commentOffset + (comment.loc.end.line - comment.loc.start.line) + containLine;
     });
+
     return commentOffset;
 }
 
@@ -176,6 +177,7 @@ module.exports = {
             ObjectExpression(node) {
                 stack = {
                     upper: stack,
+                    prevNode: null,
                     prevName: null,
                     prevEndLine: null,
                     numKeys: node.properties.length
@@ -204,14 +206,17 @@ module.exports = {
                 const thisStartLine = node.loc.start.line;
 
                 // Value for Group Check
-                const beforeToken = sourceCode.getTokenBefore(node);
-                const comments = sourceCode.getCommentsBefore(node);
-                const containComment = sourceCode.commentsExistBetween(beforeToken, node);
+                const beforeNode = stack.prevNode;
+                const comments = beforeNode && sourceCode
+                    .getFirstTokensBetween(beforeNode, node, { skip: 0, includeComments: true, filter: null })
+                    .filter(c => c.type === "block" || c.type === "Line");
+                const containComment = beforeNode && sourceCode.commentsExistBetween(beforeNode, node);
 
                 // Group Check
                 const commentOffset = containComment ? getCommentOffset(comments) : 0;
                 const isLineSeparatedGroups = prevEndLine && checkLineSeparatedGroups(thisStartLine, prevEndLine, commentOffset);
 
+                stack.prevNode = node;
                 stack.prevEndLine = node.loc.end.line;
 
                 if (thisName !== null) {
@@ -219,6 +224,7 @@ module.exports = {
                 }
 
                 if (allowLineSeparatedGroups && (isLineSeparatedGroups || thisName === null)) {
+                    stack.prevNode = null;
                     stack.prevName = null;
                     return;
                 }

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -54,24 +54,19 @@ function checkLineSeparatedGroups(thisStartLine, prevEndLine, commentOffset) {
 
 /**
  * Get Comment Offset between prevEndLine and thisStartLine
- * @param {number} prevEndLine is end line of the previous node.
- * @param {Array<Token>} beforeTokens is token list before thisStartLine.
+ * @param {Array<Comment>} comments is comment info list.
  * @returns {number} commentOffset
  */
-function getCommentOffset(prevEndLine, beforeTokens) {
+function getCommentOffset(comments) {
     let commentOffset = 0;
 
-    for (let i = 0; i < beforeTokens.length; i++) {
-        const token = beforeTokens[i];
+    comments.forEach((comment, index) => {
+        const first = index === 0;
+        const beforeEndLine = first ? 0 : comments[index - 1].loc.end.line;
+        const containLine = comment.loc.start.line - beforeEndLine === 0 ? 0 : 1;
 
-        if (prevEndLine < token.loc.end.line) {
-            if (token.type === "Line") {
-                commentOffset++;
-            } else if (token.type === "Block") {
-                commentOffset = commentOffset + token.loc.end.line - token.loc.start.line + 1;
-            }
-        }
-    }
+        commentOffset = commentOffset + (comment.loc.end.line - comment.loc.start.line) + containLine;
+    });
     return commentOffset;
 }
 
@@ -207,8 +202,14 @@ module.exports = {
                 const numKeys = stack.numKeys;
                 const thisName = getPropertyName(node);
                 const thisStartLine = node.loc.start.line;
-                const beforeTokens = sourceCode.getTokensBefore(node, { includeComments: true });
-                const commentOffset = getCommentOffset(prevEndLine, beforeTokens);
+
+                // Value for Group Check
+                const beforeToken = sourceCode.getTokenBefore(node);
+                const comments = sourceCode.getCommentsBefore(node);
+                const containComment = sourceCode.commentsExistBetween(beforeToken, node);
+
+                // Group Check
+                const commentOffset = containComment ? getCommentOffset(comments) : 0;
                 const isLineSeparatedGroups = prevEndLine && checkLineSeparatedGroups(thisStartLine, prevEndLine, commentOffset);
 
                 stack.prevEndLine = node.loc.end.line;

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -214,13 +214,33 @@ ruleTester.run("sort-keys", rule, {
             code: `
                 var obj = {
                   b,
-
-                  [foo + bar]: 1,
+                  ...z,
+                  a // sort-keys: 'a' should be before 'b'
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }],
+            parserOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: `
+                var obj = {
+                  b,
+                  [a+b]: 1,
                   a // sort-keys: 'a' should be before 'b'
                 }
             `,
             options: ["asc", { allowLineSeparatedGroups: true }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: `
+                var obj = {
+                    c: "/*",
+
+                    a: "*/", // Error. Expected object keys to be in ascending order. 'a' should be before 'c'.
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }]
         },
         {
             code: `
@@ -245,6 +265,43 @@ ruleTester.run("sort-keys", rule, {
             `,
             options: ["asc", { allowLineSeparatedGroups: true }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: `
+                var obj = {
+                    c: 1,
+                    d: 2,
+
+                    a() {
+
+                    },
+                    // abce
+                    f: 3,
+
+                    /*
+
+
+                    */
+
+                    e: 4,
+                    [a+b]: 1,
+                    cc: 1
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "sortKeys",
+                    data: {
+                        natural: "",
+                        insensitive: "",
+                        order: "asc",
+                        thisName: "cc",
+                        prevName: "e"
+                    }
+                }
+            ]
         }
     ],
     invalid: [

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -163,7 +163,53 @@ ruleTester.run("sort-keys", rule, {
         { code: "var obj = {è:4, À:3, 'Z':2, '#':1}", options: ["desc", { natural: true, caseSensitive: false }] },
 
         // desc, natural, insensitive, minKeys should ignore unsorted keys when number of keys is less than minKeys
-        { code: "var obj = {a:1, _:2, b:3}", options: ["desc", { natural: true, caseSensitive: false, minKeys: 4 }] }
+        { code: "var obj = {a:1, _:2, b:3}", options: ["desc", { natural: true, caseSensitive: false, minKeys: 4 }] },
+
+        // allowLineSeparatedGroups, default false
+        {
+            code: `
+                var obj = {
+                    f: 1,
+                    g: 2,
+
+
+                    a: 3,
+                    b: 4,
+                    c: 5,
+
+                    d: 6,
+                    e: 7
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }]
+        },
+        {
+            code: `
+                var obj = {
+                    b: 1,
+                    c: 2,
+
+                    a: 3
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }]
+        },
+        {
+            code: `
+                var obj = {
+                    c: 1,
+                    d: 2,
+
+                    a: 3,
+                    b() {
+
+                    },
+                    e: 4
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }],
+            parserOptions: { ecmaVersion: 6 }
+        }
     ],
     invalid: [
 
@@ -1758,6 +1804,28 @@ ruleTester.run("sort-keys", rule, {
                         order: "desc",
                         thisName: "b",
                         prevName: "_"
+                    }
+                }
+            ]
+        },
+
+        // If allowLineSeparatedGroups option is false, Groups are not divided by line breaks.
+        {
+            code: `
+                var obj = {
+                    b: 1,
+                    c: 2,
+
+                    a: 3
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: false }],
+            errors: [
+                {
+                    messageId: "allowLineSeparatedGroups",
+                    data: {
+                        thisName: "a",
+                        prevName: "c"
                     }
                 }
             ]

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -209,6 +209,42 @@ ruleTester.run("sort-keys", rule, {
             `,
             options: ["asc", { allowLineSeparatedGroups: true }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: `
+                var obj = {
+                  b,
+
+                  [foo + bar]: 1,
+                  a // sort-keys: 'a' should be before 'b'
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: `
+                var obj = {
+                    c: 1,
+                    d: 2,
+
+                    a() {
+
+                    },
+                    // abce
+                    f: 3,
+
+                    /*
+
+
+                    */
+                    [a+b]: 1,
+                    cc: 1,
+                    e: 2
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }],
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
     invalid: [
@@ -1854,6 +1890,68 @@ ruleTester.run("sort-keys", rule, {
                         order: "asc",
                         thisName: "a",
                         prevName: "c"
+                    }
+                }
+            ]
+        },
+        {
+            code: `
+                 var obj = {
+                    b: 1,
+                    c () {
+
+                    },
+                    // comment
+                    a: 3
+                  }
+             `,
+            options: ["asc", { allowLineSeparatedGroups: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "sortKeys",
+                    data: {
+                        natural: "",
+                        insensitive: "",
+                        order: "asc",
+                        thisName: "a",
+                        prevName: "c"
+                    }
+                }
+            ]
+        },
+        {
+            code: `
+                var obj = {
+                    c: 1,
+                    d: 2,
+
+                    a() {
+
+                    },
+                    // abce
+                    f: 3,
+
+                    /*
+
+
+                    */
+                    [a+b]: 1,
+                    e: 4,
+                    cc: 1
+                }
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "sortKeys",
+                    data: {
+                        natural: "",
+                        insensitive: "",
+                        order: "asc",
+                        thisName: "cc",
+                        prevName: "e"
                     }
                 }
             ]

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -2013,6 +2013,29 @@ ruleTester.run("sort-keys", rule, {
                     }
                 }
             ]
+        },
+        {
+            code: `
+                var  obj  =  {
+                    b : 1
+                  // comment
+                  ,  a : 2
+                } ;
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "sortKeys",
+                    data: {
+                        natural: "",
+                        insensitive: "",
+                        order: "asc",
+                        thisName: "a",
+                        prevName: "b"
+                    }
+                }
+            ]
         }
     ]
 });

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -1822,8 +1822,36 @@ ruleTester.run("sort-keys", rule, {
             options: ["asc", { allowLineSeparatedGroups: false }],
             errors: [
                 {
-                    messageId: "allowLineSeparatedGroups",
+                    messageId: "sortKeys",
                     data: {
+                        natural: "",
+                        insensitive: "",
+                        order: "asc",
+                        thisName: "a",
+                        prevName: "c"
+                    }
+                }
+            ]
+        },
+        {
+            code: `
+                 var obj = {
+                    b: 1,
+                    c () {
+
+                    },
+                    a: 3
+                  }
+             `,
+            options: ["asc", { allowLineSeparatedGroups: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "sortKeys",
+                    data: {
+                        natural: "",
+                        insensitive: "",
+                        order: "asc",
                         thisName: "a",
                         prevName: "c"
                     }

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -289,19 +289,20 @@ ruleTester.run("sort-keys", rule, {
                 }
             `,
             options: ["asc", { allowLineSeparatedGroups: true }],
-            parserOptions: { ecmaVersion: 6 },
-            errors: [
-                {
-                    messageId: "sortKeys",
-                    data: {
-                        natural: "",
-                        insensitive: "",
-                        order: "asc",
-                        thisName: "cc",
-                        prevName: "e"
-                    }
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: `
+                var obj = {
+                    b,
+                    /*
+                    */ //
+
+                    a
                 }
-            ]
+            `,
+            options: ["asc", { allowLineSeparatedGroups: true }],
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
     invalid: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Add `allowLineSeparatedGroups` option to `sort-keys` rule #12759

#### Is there anything you'd like reviewers to focus on?
None
