### PR TITLE
Docs: add exponentiation operators to operator-assignment documentation

### DIFF
--- a/docs/rules/operator-assignment.md
+++ b/docs/rules/operator-assignment.md
@@ -10,6 +10,7 @@ JavaScript provides shorthand operators that combine variable assignment and som
  x *= y    | x = x * y
  x /= y    | x = x / y
  x %= y    | x = x % y
+ x **= y   | x = x ** y
  x <<= y   | x = x << y
  x >>= y   | x = x >> y
  x >>>= y  | x = x >>> y


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added `**` and `**=` to the list of operators in `operator-assignment` rule docs, since the document explicitly lists all operators that are checked by this rule, except for these two.

#### Is there anything you'd like reviewers to focus on?
