### PR TITLE
Update: Add disallowTemplateShorthand option in no-implicit-coercion

### DIFF
--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -36,7 +36,7 @@ This rule has three main options and one override option to allow some coercions
 -   `"boolean"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `boolean` type.
 -   `"number"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `number` type.
 -   `"string"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `string` type.
--   `"disallowTemplateShorthand"` (`false` by default) - When this is `true`, this rule warns shorter type conversions using template strings.
+-   `"disallowTemplateShorthand"` (`false` by default) - When this is `true`, this rule warns `string` type conversions using `${expression}` form.
 -   `"allow"` (`empty` by default) - Each entry in this array can be one of `~`, `!!`, `+` or `*` that are to be allowed.
 
 Note that operator `+` in `allow` list would allow `+foo` (number coercion) as well as `"" + foo` (string coercion).

--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -131,6 +131,8 @@ var s = `a${foo}`;
 var s = `${foo}b`;
 
 var s = `${foo}${bar}`;
+
+var s = tag`${foo}`;
 ```
 
 Examples of **correct** code for the default `{ "disallowTemplateShorthand": false }` option:

--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -33,10 +33,11 @@ This rule is aimed to flag shorter notations for the type conversion, then sugge
 
 This rule has three main options and one override option to allow some coercions as required.
 
-* `"boolean"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `boolean` type.
-* `"number"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `number` type.
-* `"string"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `string` type.
-* `"allow"` (`empty` by default) - Each entry in this array can be one of `~`, `!!`, `+` or `*` that are to be allowed.
+-   `"boolean"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `boolean` type.
+-   `"number"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `number` type.
+-   `"string"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `string` type.
+-   `"templateString"` (`false` by default) - When this is `true`, this rule warns shorter type conversions using template strings.
+-   `"allow"` (`empty` by default) - Each entry in this array can be one of `~`, `!!`, `+` or `*` that are to be allowed.
 
 Note that operator `+` in `allow` list would allow `+foo` (number coercion) as well as `"" + foo` (string coercion).
 
@@ -104,6 +105,24 @@ Examples of **correct** code for the default `{ "string": true }` option:
 
 var s = String(foo);
 foo = String(foo);
+```
+
+### templateString
+
+Examples of **incorrect** code for the default `{ "templateString": true }` option:
+
+```js
+/*eslint no-implicit-coercion: "error"*/
+
+`${foo}`;
+```
+
+Examples of **correct** code for the default `{ "templateString": false }` option:
+
+```js
+/*eslint no-implicit-coercion: "error"*/
+
+`${foo}`;
 ```
 
 ### allow

--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -36,7 +36,7 @@ This rule has three main options and one override option to allow some coercions
 -   `"boolean"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `boolean` type.
 -   `"number"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `number` type.
 -   `"string"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `string` type.
--   `"disallowTemplateString"` (`false` by default) - When this is `true`, this rule warns shorter type conversions using template strings.
+-   `"disallowTemplateShorthand"` (`false` by default) - When this is `true`, this rule warns shorter type conversions using template strings.
 -   `"allow"` (`empty` by default) - Each entry in this array can be one of `~`, `!!`, `+` or `*` that are to be allowed.
 
 Note that operator `+` in `allow` list would allow `+foo` (number coercion) as well as `"" + foo` (string coercion).
@@ -107,22 +107,22 @@ var s = String(foo);
 foo = String(foo);
 ```
 
-### disallowTemplateString
+### disallowTemplateShorthand
 
 This option is **not** affected by the `string` option.
 
-Examples of **incorrect** code for the `{ "disallowTemplateString": true }` option:
+Examples of **incorrect** code for the `{ "disallowTemplateShorthand": true }` option:
 
 ```js
-/*eslint no-implicit-coercion: ["error", { "disallowTemplateString": true }]*/
+/*eslint no-implicit-coercion: ["error", { "disallowTemplateShorthand": true }]*/
 
 var s = `${foo}`;
 ```
 
-Examples of **correct** code for the `{ "disallowTemplateString": true }` option:
+Examples of **correct** code for the `{ "disallowTemplateShorthand": true }` option:
 
 ```js
-/*eslint no-implicit-coercion: ["error", { "disallowTemplateString": true }]*/
+/*eslint no-implicit-coercion: ["error", { "disallowTemplateShorthand": true }]*/
 
 var s = String(foo);
 
@@ -133,10 +133,10 @@ var s = `${foo}b`;
 var s = `${foo}${bar}`;
 ```
 
-Examples of **correct** code for the default `{ "disallowTemplateString": false }` option:
+Examples of **correct** code for the default `{ "disallowTemplateShorthand": false }` option:
 
 ```js
-/*eslint no-implicit-coercion: ["error", { "disallowTemplateString": false }]*/
+/*eslint no-implicit-coercion: ["error", { "disallowTemplateShorthand": false }]*/
 
 var s = `${foo}`;
 ```

--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -109,20 +109,34 @@ foo = String(foo);
 
 ### templateString
 
-Examples of **incorrect** code for the default `{ "templateString": true }` option:
+Examples of **incorrect** code for the `{ "templateString": true }` option:
 
 ```js
-/*eslint no-implicit-coercion: "error"*/
+/*eslint no-implicit-coercion: ["error", { "templateString": true }]*/
 
-`${foo}`;
+var s = `${foo}`;
+```
+
+Examples of **correct** code for the `{ "templateString": true }` option:
+
+```js
+/*eslint no-implicit-coercion: ["error", { "templateString": true }]*/
+
+var s = String(foo);
+
+var s = `a${foo}`;
+
+var s = `${foo}b`;
+
+var s = `${foo}${bar}`;
 ```
 
 Examples of **correct** code for the default `{ "templateString": false }` option:
 
 ```js
-/*eslint no-implicit-coercion: "error"*/
+/*eslint no-implicit-coercion: ["error", { "templateString": false }]*/
 
-`${foo}`;
+var s = `${foo}`;
 ```
 
 ### allow

--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -109,6 +109,8 @@ foo = String(foo);
 
 ### templateString
 
+This option is **not** affected by the `string` option.
+
 Examples of **incorrect** code for the `{ "templateString": true }` option:
 
 ```js

--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -36,7 +36,7 @@ This rule has three main options and one override option to allow some coercions
 -   `"boolean"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `boolean` type.
 -   `"number"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `number` type.
 -   `"string"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `string` type.
--   `"templateString"` (`false` by default) - When this is `true`, this rule warns shorter type conversions using template strings.
+-   `"disallowTemplateString"` (`false` by default) - When this is `true`, this rule warns shorter type conversions using template strings.
 -   `"allow"` (`empty` by default) - Each entry in this array can be one of `~`, `!!`, `+` or `*` that are to be allowed.
 
 Note that operator `+` in `allow` list would allow `+foo` (number coercion) as well as `"" + foo` (string coercion).
@@ -107,22 +107,22 @@ var s = String(foo);
 foo = String(foo);
 ```
 
-### templateString
+### disallowTemplateString
 
 This option is **not** affected by the `string` option.
 
-Examples of **incorrect** code for the `{ "templateString": true }` option:
+Examples of **incorrect** code for the `{ "disallowTemplateString": true }` option:
 
 ```js
-/*eslint no-implicit-coercion: ["error", { "templateString": true }]*/
+/*eslint no-implicit-coercion: ["error", { "disallowTemplateString": true }]*/
 
 var s = `${foo}`;
 ```
 
-Examples of **correct** code for the `{ "templateString": true }` option:
+Examples of **correct** code for the `{ "disallowTemplateString": true }` option:
 
 ```js
-/*eslint no-implicit-coercion: ["error", { "templateString": true }]*/
+/*eslint no-implicit-coercion: ["error", { "disallowTemplateString": true }]*/
 
 var s = String(foo);
 
@@ -133,10 +133,10 @@ var s = `${foo}b`;
 var s = `${foo}${bar}`;
 ```
 
-Examples of **correct** code for the default `{ "templateString": false }` option:
+Examples of **correct** code for the default `{ "disallowTemplateString": false }` option:
 
 ```js
-/*eslint no-implicit-coercion: ["error", { "templateString": false }]*/
+/*eslint no-implicit-coercion: ["error", { "disallowTemplateString": false }]*/
 
 var s = `${foo}`;
 ```

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -24,7 +24,7 @@ function parseOptions(options) {
         boolean: "boolean" in options ? options.boolean : true,
         number: "number" in options ? options.number : true,
         string: "string" in options ? options.string : true,
-        templateString: "templateString" in options ? options.templateString : false,
+        disallowTemplateShorthand: "disallowTemplateShorthand" in options ? options.disallowTemplateShorthand : false,
         allow: options.allow || []
     };
 }
@@ -181,7 +181,7 @@ module.exports = {
                     type: "boolean",
                     default: true
                 },
-                templateString: {
+                disallowTemplateShorthand: {
                     type: "boolean",
                     default: false
                 },
@@ -307,7 +307,7 @@ module.exports = {
             },
 
             TemplateLiteral(node) {
-                if (!options.templateString) {
+                if (!options.disallowTemplateShorthand) {
                     return;
                 }
 

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -24,6 +24,7 @@ function parseOptions(options) {
         boolean: "boolean" in options ? options.boolean : true,
         number: "number" in options ? options.number : true,
         string: "string" in options ? options.string : true,
+        templateString: "templateString" in options ? options.templateString : false,
         allow: options.allow || []
     };
 }
@@ -180,6 +181,10 @@ module.exports = {
                     type: "boolean",
                     default: true
                 },
+                templateString: {
+                    type: "boolean",
+                    default: false
+                },
                 allow: {
                     type: "array",
                     items: {
@@ -299,6 +304,33 @@ module.exports = {
 
                     report(node, recommendation, true);
                 }
+            },
+
+            TemplateLiteral(node) {
+                if (!options.templateString) {
+                    return;
+                }
+
+                // `` or `${foo}${bar}`
+                if (node.expressions.length !== 1) {
+                    return;
+                }
+
+
+                //  `prefix${foo}`
+                if (node.quasis[0].value.raw !== "") {
+                    return;
+                }
+
+                //  `${foo}postfix`
+                if (node.quasis[1].value.raw !== "") {
+                    return;
+                }
+
+                const code = sourceCode.getText(node.expressions[0]);
+                const recommendation = `String(${code})`;
+
+                report(node, recommendation, true);
             }
         };
     }

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -323,12 +323,12 @@ module.exports = {
 
 
                 //  `prefix${foo}`
-                if (node.quasis[0].value.raw !== "") {
+                if (node.quasis[0].value.cooked !== "") {
                     return;
                 }
 
                 //  `${foo}postfix`
-                if (node.quasis[1].value.raw !== "") {
+                if (node.quasis[1].value.cooked !== "") {
                     return;
                 }
 

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -311,6 +311,11 @@ module.exports = {
                     return;
                 }
 
+                // tag`${foo}`
+                if (node.parent.type === "TaggedTemplateExpression") {
+                    return;
+                }
+
                 // `` or `${foo}${bar}`
                 if (node.expressions.length !== 1) {
                     return;

--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -249,6 +249,17 @@ ruleTester.run("no-implicit-coercion", rule, {
             }]
         },
         {
+            code: "`${foo}`",
+            output: "String(foo)",
+            options: [{ templateString: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(foo)" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
             code: "foo += \"\"",
             output: "foo = String(foo)",
             errors: [{

--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -88,13 +88,13 @@ ruleTester.run("no-implicit-coercion", rule, {
         { code: "`${foo}` + ''", parserOptions: { ecmaVersion: 6 } },
         "foo += 'bar'",
         { code: "foo += `${bar}`", parserOptions: { ecmaVersion: 6 } },
-        { code: "`a${foo}`", options: [{ templateString: true }], parserOptions: { ecmaVersion: 6 } },
-        { code: "`${foo}b`", options: [{ templateString: true }], parserOptions: { ecmaVersion: 6 } },
-        { code: "`${foo}${bar}`", options: [{ templateString: true }], parserOptions: { ecmaVersion: 6 } },
-        { code: "tag`${foo}`", options: [{ templateString: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "`a${foo}`", options: [{ disallowTemplateShorthand: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "`${foo}b`", options: [{ disallowTemplateShorthand: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "`${foo}${bar}`", options: [{ disallowTemplateShorthand: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "tag`${foo}`", options: [{ disallowTemplateShorthand: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "`${foo}`", parserOptions: { ecmaVersion: 6 } },
         { code: "`${foo}`", options: [{ }], parserOptions: { ecmaVersion: 6 } },
-        { code: "`${foo}`", options: [{ templateString: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "`${foo}`", options: [{ disallowTemplateShorthand: false }], parserOptions: { ecmaVersion: 6 } },
         "+42"
     ],
     invalid: [
@@ -258,7 +258,7 @@ ruleTester.run("no-implicit-coercion", rule, {
         {
             code: "`${foo}`",
             output: "String(foo)",
-            options: [{ templateString: true }],
+            options: [{ disallowTemplateShorthand: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "useRecommendation",
@@ -269,7 +269,7 @@ ruleTester.run("no-implicit-coercion", rule, {
         {
             code: "`\\\n${foo}`",
             output: "String(foo)",
-            options: [{ templateString: true }],
+            options: [{ disallowTemplateShorthand: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "useRecommendation",
@@ -280,7 +280,7 @@ ruleTester.run("no-implicit-coercion", rule, {
         {
             code: "`${foo}\\\n`",
             output: "String(foo)",
-            options: [{ templateString: true }],
+            options: [{ disallowTemplateShorthand: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "useRecommendation",

--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -88,6 +88,10 @@ ruleTester.run("no-implicit-coercion", rule, {
         { code: "`${foo}` + ''", parserOptions: { ecmaVersion: 6 } },
         "foo += 'bar'",
         { code: "foo += `${bar}`", parserOptions: { ecmaVersion: 6 } },
+        { code: "`a${foo}`", options: [{ templateString: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "`${foo}b`", options: [{ templateString: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "`${foo}${bar}`", options: [{ templateString: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "tag`${foo}`", options: [{ templateString: true }], parserOptions: { ecmaVersion: 6 } },
         "+42"
     ],
     invalid: [

--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -264,6 +264,28 @@ ruleTester.run("no-implicit-coercion", rule, {
             }]
         },
         {
+            code: "`\\\n${foo}`",
+            output: "String(foo)",
+            options: [{ templateString: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(foo)" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "`${foo}\\\n`",
+            output: "String(foo)",
+            options: [{ templateString: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "String(foo)" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
             code: "foo += \"\"",
             output: "foo = String(foo)",
             errors: [{

--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -92,6 +92,9 @@ ruleTester.run("no-implicit-coercion", rule, {
         { code: "`${foo}b`", options: [{ templateString: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "`${foo}${bar}`", options: [{ templateString: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "tag`${foo}`", options: [{ templateString: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "`${foo}`", parserOptions: { ecmaVersion: 6 } },
+        { code: "`${foo}`", options: [{ }], parserOptions: { ecmaVersion: 6 } },
+        { code: "`${foo}`", options: [{ templateString: false }], parserOptions: { ecmaVersion: 6 } },
         "+42"
     ],
     invalid: [


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)
This adds the `templateString` option to `no-implicit-coercion`. This makes the
rule report the following code:

```js
`${foo}`
```

For backwards compatibility, this was added as a separate option instead of as
default behaviour.

#### Is there anything you'd like reviewers to focus on?

Closes #12866