### PR TITLE
allow false result of ternary expression

### DIFF
--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -146,9 +146,16 @@ module.exports = {
             //    expr in [ false ]
 
             const nodeSrc = astUtils.getParenthesisedText(sourceCode, node);
-            
-            const nodeEval = eval(nodeSrc);
-            
+
+            let nodeEval = true;
+            try {
+              nodeEval = eval(nodeSrc);
+            } catch (e) {
+              // eval fails on variable expression
+              // variable expression is not false
+              return false;
+            }
+
             switch (falseStrictness) {
               case 1:
                 // negation or abstract equal: 16 expressions

--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -41,7 +41,15 @@ module.exports = {
                     defaultAssignment: {
                         type: "boolean",
                         default: true
-                    }
+                    },
+                    allowFalseResult: {
+                        type: "boolean",
+                        default: true
+                    },
+                    falseStrictness: {
+                        type: "integer",
+                        default: 4
+                    },
                 },
                 additionalProperties: false
             }
@@ -51,13 +59,16 @@ module.exports = {
 
         messages: {
             unnecessaryConditionalExpression: "Unnecessary use of boolean literals in conditional expression.",
-            unnecessaryConditionalAssignment: "Unnecessary use of conditional expression for default assignment."
+            unnecessaryConditionalAssignment: "Unnecessary use of conditional expression for default assignment.",
+            alternativeConditionIsFalse: "Alternative condition is false (according to config.falseStrictness).",
         }
     },
 
     create(context) {
         const options = context.options[0] || {};
         const defaultAssignment = options.defaultAssignment !== false;
+        const allowFalseResult = options.allowFalseResult !== false;
+        const falseStrictness = ([1,2,3,4].indexOf(options.falseStrictness) !== -1) ? options.falseStrictness : 4;
         const sourceCode = context.getSourceCode();
 
         /**
@@ -116,6 +127,45 @@ module.exports = {
                    node.test.name === node.consequent.name;
         }
 
+        /**
+         * Tests if a given node always evaluates to false
+         * according to option.falseStrictness
+         * @param {ASTNode} node An expression node
+         * @returns {boolean} True if it is determined that the node will always evaluate to false
+         */
+        function isFalseExpression(node) {
+            // three types of false:
+            // 1. if (!(expr)) { expr_is_negate_false }
+            //    t ? c : {} -> t && c
+            //    expr in [ false, "", 0, -0, +0, NaN, void 0, undefined, null, {}, {{}} ]
+            // 2. if (expr == false) { expr_is_abstract_false }
+            //    t ? c : [] -> t && c
+            //    expr in [ false, "", 0, -0, +0, [0], [], [[]], {[]}, {[[]]} ]
+            // 4. if (expr === false) { expr_is_strict_false }
+            //    t ? c : false -> t && c
+            //    expr in [ false ]
+
+            const nodeSrc = astUtils.getParenthesisedText(sourceCode, node);
+            
+            const nodeEval = eval(nodeSrc);
+            
+            switch (falseStrictness) {
+              case 1:
+                // negation or abstract equal: 16 expressions
+                return (!nodeEval) || (nodeEval == false);
+              case 2:
+                // negation: 10 expressions
+                return !nodeEval;
+              case 3:
+                // abstract equal: 10 expressions
+                return nodeEval == false;
+              case 4:
+              default:
+                // strict equal: 1 expression
+                return nodeEval === false;
+            }
+        }
+
         return {
 
             ConditionalExpression(node) {
@@ -159,7 +209,27 @@ module.exports = {
                             return fixer.replaceText(node, `${testText} || ${alternateText}`);
                         }
                     });
+                } else if (allowFalseResult && isFalseExpression(node.alternate)) {
+                    context.report({
+                        node,
+                        messageId: "alternativeConditionIsFalse",
+                        fix: fixer => {
+                            const shouldParenthesizeConsequent =
+                                (
+                                    astUtils.getPrecedence(node.consequent) < OR_PRECEDENCE ||
+                                    astUtils.isCoalesceExpression(node.consequent)
+                                ) &&
+                                !astUtils.isParenthesised(sourceCode, node.consequent);
+                            const consequentText = shouldParenthesizeConsequent
+                                ? `(${sourceCode.getText(node.consequent)})`
+                                : astUtils.getParenthesisedText(sourceCode, node.consequent);
+                            const testText = astUtils.getParenthesisedText(sourceCode, node.test);
+
+                            return fixer.replaceText(node, `${testText} && ${consequentText}`);
+                        }
+                    });
                 }
+
             }
         };
     }


### PR DESCRIPTION
convert ternary expression `test ? conditional : false_expr`
to binary expression `test && conditional`
if alternative is always false

in the binary expression
when test is false, the expression returns false

there are four levels of expression falseness
configured by option.falseStrictness

here is a script to compare expression falseness:
```js
[ "false", "0", "-0", "+0", "''", "'0'", "new String('0')",
  "[]", "[[]]", "[0]", "NaN", "void 0",
  "undefined", "null", "{}", "{{}}",  
  "-1", "1", "+1", "[1]"].map(
  s => [s, eval(s)]).map(([s, x]) => [
  s, !x, x==false, x===false, Object.is(x, false) ]).map(
  ([s, ...x]) => [x.map(x => x|0), s])
```
the result is this table
```
[
  [ [ 1, 1, 1, 1 ], 'false' ],
  [ [ 1, 1, 0, 0 ], '0' ],
  [ [ 1, 1, 0, 0 ], '-0' ],
  [ [ 1, 1, 0, 0 ], '+0' ],
  [ [ 1, 1, 0, 0 ], "''" ],
  [ [ 0, 1, 0, 0 ], "'0'" ],
  [ [ 0, 1, 0, 0 ], "new String('0')" ],
  [ [ 0, 1, 0, 0 ], '[]' ],
  [ [ 0, 1, 0, 0 ], '[[]]' ],
  [ [ 0, 1, 0, 0 ], '[0]' ],
  [ [ 1, 0, 0, 0 ], 'NaN' ],
  [ [ 1, 0, 0, 0 ], 'void 0' ],
  [ [ 1, 0, 0, 0 ], 'undefined' ],
  [ [ 1, 0, 0, 0 ], 'null' ],
  [ [ 1, 0, 0, 0 ], '{}' ],
  [ [ 1, 0, 0, 0 ], '{{}}' ],
  [ [ 0, 0, 0, 0 ], '-1' ],
  [ [ 0, 0, 0, 0 ], '1' ],
  [ [ 0, 0, 0, 0 ], '+1' ],
  [ [ 0, 0, 0, 0 ], '[1]' ]
]
```
background:
the coffeescript compiler translates binary expressions like `if test then expr`
to ternary expressions like `test ? expr : undefined`
which is unnecessary in many situations

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have superficially read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**
no-unneeded-ternary

**Does this change cause the rule to produce more or fewer warnings?**
more

**How will the change be implemented? (New option, new default behavior, etc.)?**
both

**Please provide some example code that this change will affect:**

```js
let test = true;

// f_{falseStrictness}

let f_1234 = () => test ? 2 : false;
let f_12__ = () => test ? 2 : void 0;
let f_123_ = () => test ? 2 : 0;
let f_1_3_ = () => test ? 2 : [];

f_1234();f_12__();f_123_();f_1_3_();

// sample output for falseStrictness = 2
let f_1234 = () => test && 2;
let f_12__ = () => test && 2;
let f_123_ = () => test && 2;
let f_1_3_ = () => test ? 2 : [];
```

**What does the rule currently do for this code?**
unnecessary ternaries are optimized less aggressive

**What will the rule do after it's changed?**
in default setting (falseStrictness = 4)
only `let f_1234 = () => test ? 2 : false;` is transformed
to `let f_1234 = () => test && 2;`
this is the most strict variant, where only `false` is accepted as a `false_expr`
with decreasing falseStrictness, more `false_expr`essions are accepted


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
add function for lossless and lossy reduce of ternary to binary expressions

#### Is there anything you'd like reviewers to focus on?
lets argue which falseStrictness is 2 and which is 3 .... : P

no, i hope i can add a test script and docs in the next days

edit: looking at some test errors
probably i should wrap the `eval(nodeSrc)` call
inside a `try { .... } catch (e) { .... }` block