### PR TITLE
Update: add es2021 environment (refs #13602)

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -138,6 +138,7 @@ An environment defines global variables that are predefined. The available envir
 * `es6` - enable all ECMAScript 6 features except for modules (this automatically sets the `ecmaVersion` parser option to 6).
 * `es2017` - adds all ECMAScript 2017 globals and automatically sets the `ecmaVersion` parser option to 8.
 * `es2020` - adds all ECMAScript 2020 globals and automatically sets the `ecmaVersion` parser option to 11.
+* `es2021` - adds all ECMAScript 2021 globals and automatically sets the `ecmaVersion` parser option to 12.
 * `worker` - web workers global variables.
 * `amd` - defines `require()` and `define()` as global variables as per the [amd](https://github.com/amdjs/amdjs-api/wiki/AMD) spec.
 * `mocha` - adds all of the Mocha testing global variables.

--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -265,7 +265,7 @@ function processAnswers(answers) {
     };
 
     config.parserOptions.ecmaVersion = espree.latestEcmaVersion;
-    config.env.es2020 = true;
+    config.env.es2021 = true;
 
     // set the module type
     if (answers.moduleType === "esm") {

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -179,8 +179,8 @@ describe("bin/eslint.js", () => {
 
     describe("running on files", () => {
         it("has exit code 0 if no linting errors occur", () => assertExitCode(runESLint(["bin/eslint.js"]), 0));
-        it("has exit code 0 if a linting warning is reported", () => assertExitCode(runESLint(["bin/eslint.js", "--env", "es2020", "--no-eslintrc", "--rule", "semi: [1, never]"]), 0));
-        it("has exit code 1 if a linting error is reported", () => assertExitCode(runESLint(["bin/eslint.js", "--env", "es2020", "--no-eslintrc", "--rule", "semi: [2, never]"]), 1));
+        it("has exit code 0 if a linting warning is reported", () => assertExitCode(runESLint(["bin/eslint.js", "--env", "es2021", "--no-eslintrc", "--rule", "semi: [1, never]"]), 0));
+        it("has exit code 1 if a linting error is reported", () => assertExitCode(runESLint(["bin/eslint.js", "--env", "es2021", "--no-eslintrc", "--rule", "semi: [2, never]"]), 1));
         it("has exit code 1 if a syntax error is thrown", () => assertExitCode(runESLint(["README.md"]), 1));
     });
 

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -821,7 +821,7 @@ describe("CLIEngine", () => {
             engine = new CLIEngine({
                 parser: "espree",
                 parserOptions: {
-                    ecmaVersion: 2020
+                    ecmaVersion: 2021
                 },
                 useEslintrc: false
             });

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -899,7 +899,7 @@ describe("ESLint", () => {
                 overrideConfig: {
                     parser: "espree",
                     parserOptions: {
-                        ecmaVersion: 2020
+                        ecmaVersion: 2021
                     }
                 },
                 useEslintrc: false

--- a/tests/lib/init/config-initializer.js
+++ b/tests/lib/init/config-initializer.js
@@ -136,7 +136,7 @@ describe("configInitializer", () => {
                 assert.deepStrictEqual(config.rules.quotes, ["error", "single"]);
                 assert.deepStrictEqual(config.rules["linebreak-style"], ["error", "unix"]);
                 assert.deepStrictEqual(config.rules.semi, ["error", "always"]);
-                assert.strictEqual(config.env.es2020, true);
+                assert.strictEqual(config.env.es2021, true);
                 assert.strictEqual(config.parserOptions.ecmaVersion, espree.latestEcmaVersion);
                 assert.strictEqual(config.parserOptions.sourceType, "module");
                 assert.strictEqual(config.env.browser, true);

--- a/tests/lib/rules/no-extend-native.js
+++ b/tests/lib/rules/no-extend-native.js
@@ -48,6 +48,12 @@ ruleTester.run("no-extend-native", rule, {
         {
             code: "{ let Object = function() {}; Object.prototype.p = 0 }",
             parserOptions: { ecmaVersion: 6 }
+        },
+
+        // TODO(mdjermanovic): This test should become `invalid` in the next major version, when we upgrade the `globals` package.
+        {
+            code: "WeakRef.prototype.p = 0",
+            env: { es2021: true }
         }
     ],
     invalid: [{

--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -59,6 +59,7 @@ ruleTester.run("no-undef", rule, {
         { code: "requestIdleCallback;", env: { browser: true } },
         { code: "customElements;", env: { browser: true } },
         { code: "PromiseRejectionEvent;", env: { browser: true } },
+        { code: "(foo, bar) => { foo ||= WeakRef; bar ??= FinalizationRegistry; }", env: { es2021: true } },
 
         // Notifications of readonly are removed: https://github.com/eslint/eslint/issues/4504
         "/*global b:false*/ function f() { b = 1; }",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Add something to the core

refs #13602

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* ~Added new `es2021` environment with `FinalizationRegistry` and `WeakRef` globals.~ edit: this is in `@eslint/eslintrc` now.
* Updated `--init` to enable the new environment in created configs.
* Updated `configuring.md` with the new environment.
* ~Also updated `configuring.md` and `types.js` with `ecmaVersion: 2021`.~ edit: done in #13609
* Also updated some tests where it seemed the intention was to use the latest es environment and/or the latest ecmaVersion. If that wasn't the case, I can revert those changes.

#### Is there anything you'd like reviewers to focus on?

* ~`package.json` has github `espree` reference.~
* Noticed while rebasing at the end that this PR changes some files @nzakas just marked as "do not modify".
