### PR TITLE
Docs: fix examples in object-curly-newline

### DIFF
--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -341,22 +341,24 @@ let f = {
     foo: function() {
     dosomething();}};
 
-let {
-    g} = obj;
-let {h, i
+let {g
 } = obj;
 let {
-    j, k} = obj;
-let {l, m
+    h} = obj;
+let {i, j
+} = obj;
+let {k, l
 } = obj;
 let {
-    n, o
-} = obj;
-let {p = function() {
+    m, n} = obj;
+let {
+    o, p} = obj;
+let {q = function() {
     dosomething();
-}} = obj;
+    }
+} = obj;
 let {
-    q = function() {
+    r = function() {
         dosomething();
     }} = obj;
 ```
@@ -393,19 +395,22 @@ let {} = obj;
 let {
 } = obj;
 let {g} = obj;
-let {h, i} = obj;
 let {
-    j, k
+    h
 } = obj;
-let {l,
-    m} = obj;
+let {i, j} = obj;
 let {
-    n,
-    o
+    k, l
 } = obj;
-let {p = function() {dosomething();}} = obj;
+let {m,
+    n} = obj;
 let {
-    q = function() {
+    o,
+    p
+} = obj;
+let {q = function() {dosomething();}} = obj;
+let {
+    r = function() {
         dosomething();
     }
 } = obj;

--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -342,8 +342,6 @@ let f = {
     dosomething();}};
 
 let {
-} = obj;
-let {
     g} = obj;
 let {h, i
 } = obj;
@@ -392,6 +390,8 @@ let f = {
 };
 
 let {} = obj;
+let {
+} = obj;
 let {g} = obj;
 let {h, i} = obj;
 let {

--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -335,7 +335,7 @@ let d = {
     foo: 1, bar: 2};
 let e = {foo: function() {
     dosomething();
-	}
+    }
 };
 let f = {
     foo: function() {

--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -325,10 +325,6 @@ Examples of **incorrect** code for this rule with the default `{ "consistent": t
 /*eslint object-curly-newline: ["error", { "consistent": true }]*/
 /*eslint-env es6*/
 
-let empty1 = {};
-let empty2 = {
-};
-
 let a = {foo: 1
 };
 let b = {
@@ -372,6 +368,10 @@ Examples of **correct** code for this rule with the default `{ "consistent": tru
 /*eslint object-curly-newline: ["error", { "consistent": true }]*/
 /*eslint-env es6*/
 
+
+let empty1 = {};
+let empty2 = {
+};
 let a = {foo: 1};
 let b = {
     foo: 1

--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -325,29 +325,43 @@ Examples of **incorrect** code for this rule with the default `{ "consistent": t
 /*eslint object-curly-newline: ["error", { "consistent": true }]*/
 /*eslint-env es6*/
 
-let a = {foo: 1
+let a = {
 };
-let b = {
+let b = {foo: 1
+};
+let c = {
     foo: 1};
-let c = {foo: 1, bar: 2
+let d = {foo: 1, bar: 2
 };
-let d = {
+let e = {
     foo: 1, bar: 2};
-let e = {foo: function() {
+let f = {foo: function() {
     dosomething();
 }};
+let g = {
+    foo: function() {
+    dosomething();}};
 
-let {f
+let {
 } = obj;
 let {
-    g} = obj;
-let {h, i
+    h} = obj;
+let {i, j
 } = obj;
 let {
-    j, k} = obj;
-let {l = function() {
+    k, l} = obj;
+let {m, n
+} = obj;
+let {
+    o, p
+} = obj;
+let {q = function() {
     dosomething();
 }} = obj;
+let {
+    r = function() {
+        dosomething();
+    }} = obj;
 ```
 
 Examples of **correct** code for this rule with the default `{ "consistent": true }` option:

--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -325,41 +325,43 @@ Examples of **incorrect** code for this rule with the default `{ "consistent": t
 /*eslint object-curly-newline: ["error", { "consistent": true }]*/
 /*eslint-env es6*/
 
-let a = {
+let empty1 = {};
+let empty2 = {
 };
-let b = {foo: 1
+
+let a = {foo: 1
 };
-let c = {
+let b = {
     foo: 1};
-let d = {foo: 1, bar: 2
+let c = {foo: 1, bar: 2
 };
-let e = {
+let d = {
     foo: 1, bar: 2};
-let f = {foo: function() {
+let e = {foo: function() {
     dosomething();
 }};
-let g = {
+let f = {
     foo: function() {
     dosomething();}};
 
 let {
 } = obj;
 let {
-    h} = obj;
-let {i, j
+    g} = obj;
+let {h, i
 } = obj;
 let {
-    k, l} = obj;
-let {m, n
+    j, k} = obj;
+let {l, m
 } = obj;
 let {
-    o, p
+    n, o
 } = obj;
-let {q = function() {
+let {p = function() {
     dosomething();
 }} = obj;
 let {
-    r = function() {
+    q = function() {
         dosomething();
     }} = obj;
 ```
@@ -370,40 +372,39 @@ Examples of **correct** code for this rule with the default `{ "consistent": tru
 /*eslint object-curly-newline: ["error", { "consistent": true }]*/
 /*eslint-env es6*/
 
-let a = {};
-let b = {foo: 1};
-let c = {
+let a = {foo: 1};
+let b = {
     foo: 1
 };
-let d = {
+let c = {
     foo: 1, bar: 2
 };
-let e = {
+let d = {
     foo: 1,
     bar: 2
 };
-let f = {foo: function() {dosomething();}};
-let g = {
+let e = {foo: function() {dosomething();}};
+let f = {
     foo: function() {
         dosomething();
     }
 };
 
 let {} = obj;
-let {h} = obj;
-let {i, j} = obj;
+let {g} = obj;
+let {h, i} = obj;
 let {
-    k, l
+    j, k
 } = obj;
-let {m,
-    n} = obj;
+let {l,
+    m} = obj;
 let {
-    o,
-    p
+    n,
+    o
 } = obj;
-let {q = function() {dosomething();}} = obj;
+let {p = function() {dosomething();}} = obj;
 let {
-    r = function() {
+    q = function() {
         dosomething();
     }
 } = obj;

--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -335,7 +335,8 @@ let d = {
     foo: 1, bar: 2};
 let e = {foo: function() {
     dosomething();
-}};
+	}
+};
 let f = {
     foo: function() {
     dosomething();}};


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
The example of correct/incorrect really helpful to user.
So if not match between these two, can give confusion.
When I was reading in `object-curly-newline` docs there was not matching example in case of `consistent`.


#### Is there anything you'd like reviewers to focus on?
I'm not sure that I correctly added example in correct case. So I ask to review to focus on pair between correct case and incorrect case.