### PR TITLE
Update: support logical assignments in code path analysis (refs #13569)

### DIFF
--- a/lib/linter/code-path-analysis/code-path-state.js
+++ b/lib/linter/code-path-analysis/code-path-state.js
@@ -317,7 +317,7 @@ class CodePathState {
     //--------------------------------------------------------------------------
 
     /**
-     * Creates a context for ConditionalExpression, LogicalExpression,
+     * Creates a context for ConditionalExpression, LogicalExpression, AssignmentExpression (logical assignments only),
      * IfStatement, WhileStatement, DoWhileStatement, or ForStatement.
      *
      * LogicalExpressions have cases that it goes different paths between the
@@ -339,7 +339,7 @@ class CodePathState {
      *     a -> b -> foo();
      *     a -> b -> bar();
      * @param {string} kind A kind string.
-     *   If the new context is LogicalExpression's, this is `"&&"` or `"||"`.
+     *   If the new context is LogicalExpression's or AssignmentExpression's, this is `"&&"` or `"||"` or `"??"`.
      *   If it's IfStatement's or ConditionalExpression's, this is `"test"`.
      *   Otherwise, this is `"loop"`.
      * @param {boolean} isForkingAsResult A flag that shows that goes different

--- a/tests/fixtures/code-path-analysis/assignment--do-while-and.js
+++ b/tests/fixtures/code-path-analysis/assignment--do-while-and.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_2->s1_4;
+s1_3->s1_4->final;
+*/
+do {
+    foo();
+} while (a &&= b);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nDoWhileStatement:enter"];
+    s1_2[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_3[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_4[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_2->s1_4;
+    s1_3->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--do-while-or.js
+++ b/tests/fixtures/code-path-analysis/assignment--do-while-or.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_2->s1_2;
+s1_3->s1_4->final;
+*/
+do {
+    foo();
+} while (a ||= b);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nDoWhileStatement:enter"];
+    s1_2[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_3[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_4[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_2->s1_2;
+    s1_3->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--do-while-qq.js
+++ b/tests/fixtures/code-path-analysis/assignment--do-while-qq.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_2->s1_2;
+s1_3->s1_4;
+s1_2->s1_4->final;
+*/
+do {
+    foo();
+} while (a ??= b);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nDoWhileStatement:enter"];
+    s1_2[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_3[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_4[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_2->s1_2;
+    s1_3->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--for-and-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--for-and-1.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_6;
+s1_3->s1_6->final;
+*/
+for (init; a &&= b; update) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nForStatement:enter\nIdentifier (init)"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (a)"];
+    s1_3[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_5[label="Identifier (update)"];
+    s1_6[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_6;
+    s1_3->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--for-and-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--for-and-2.js
@@ -1,0 +1,22 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_5;
+s1_3->s1_5->final;
+*/
+for (init; a &&= b;) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nForStatement:enter\nIdentifier (init)"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (a)"];
+    s1_3[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_5[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_5;
+    s1_3->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--for-or-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--for-or-1.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_4;
+s1_3->s1_6->final;
+*/
+for (init; a ||= b; update) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nForStatement:enter\nIdentifier (init)"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (a)"];
+    s1_3[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_5[label="Identifier (update)"];
+    s1_6[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_4;
+    s1_3->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--for-or-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--for-or-2.js
@@ -1,0 +1,22 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+s1_3->s1_5->final;
+*/
+for (init; a ||= b;) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nForStatement:enter\nIdentifier (init)"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (a)"];
+    s1_3[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_5[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+    s1_3->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--for-qq-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--for-qq-1.js
@@ -1,0 +1,25 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_4;
+s1_3->s1_6;
+s1_2->s1_6->final;
+*/
+for (init; a ??= b; update) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nForStatement:enter\nIdentifier (init)"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (a)"];
+    s1_3[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_5[label="Identifier (update)"];
+    s1_6[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_4;
+    s1_3->s1_6;
+    s1_2->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--for-qq-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--for-qq-2.js
@@ -1,0 +1,24 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+s1_3->s1_5;
+s1_2->s1_5->final;
+*/
+for (init; a ??= b;) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nForStatement:enter\nIdentifier (init)"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (a)"];
+    s1_3[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_5[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+    s1_3->s1_5;
+    s1_2->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--if-and-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--if-and-1.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+if (a &&= b) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nIfStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_4[label="IfStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--if-and-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--if-and-2.js
@@ -1,0 +1,28 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5;
+s1_1->s1_4->s1_5;
+s1_2->s1_4;
+s1_5->final;
+*/
+if (a &&= b) {
+    foo();
+} else {
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nIfStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_5[label="IfStatement:exit\nProgram:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (bar)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_5;
+    s1_1->s1_4->s1_5;
+    s1_2->s1_4;
+    s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--if-and-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--if-and-3.js
@@ -1,0 +1,37 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_7->s1_9;
+s1_1->s1_8->s1_9;
+s1_2->s1_8;
+s1_3->s1_8;
+s1_4->s1_6->s1_7;
+s1_9->final;
+*/
+if ((a &&= b) && c) {
+    d ? foo() : bar();
+} else {
+    baz();
+}
+
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nIfStatement:enter\nLogicalExpression:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="Identifier (c)\nLogicalExpression:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nConditionalExpression:enter\nIdentifier (d)"];
+    s1_5[label="CallExpression:enter\nIdentifier (foo)\nCallExpression:exit"];
+    s1_7[label="ConditionalExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_9[label="IfStatement:exit\nProgram:exit"];
+    s1_8[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (baz)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_6[label="CallExpression:enter\nIdentifier (bar)\nCallExpression:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_7->s1_9;
+    s1_1->s1_8->s1_9;
+    s1_2->s1_8;
+    s1_3->s1_8;
+    s1_4->s1_6->s1_7;
+    s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--if-and-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--if-and-3.js
@@ -12,7 +12,6 @@ if ((a &&= b) && c) {
     baz();
 }
 
-
 /*DOT
 digraph {
     node[shape=box,style="rounded,filled",fillcolor=white];

--- a/tests/fixtures/code-path-analysis/assignment--if-or-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--if-or-1.js
@@ -7,7 +7,6 @@ if (a ||= b) {
     foo();
 }
 
-
 /*DOT
 digraph {
     node[shape=box,style="rounded,filled",fillcolor=white];

--- a/tests/fixtures/code-path-analysis/assignment--if-or-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--if-or-1.js
@@ -1,0 +1,24 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_3;
+s1_2->s1_4->final;
+*/
+if (a ||= b) {
+    foo();
+}
+
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nIfStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_4[label="IfStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_3;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--if-or-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--if-or-2.js
@@ -1,0 +1,26 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5;
+s1_1->s1_3;
+s1_2->s1_4->s1_5->final;
+*/
+if (a ||= b) {
+    foo();
+} else {
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nIfStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_5[label="IfStatement:exit\nProgram:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (bar)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_5;
+    s1_1->s1_3;
+    s1_2->s1_4->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--if-or-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--if-or-3.js
@@ -1,0 +1,36 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_7->s1_9;
+s1_1->s1_4;
+s1_2->s1_4;
+s1_3->s1_8->s1_9;
+s1_4->s1_6->s1_7;
+s1_9->final;
+*/
+if ((a ||= b) || c) {
+    d ? foo() : bar();
+} else {
+    baz();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nIfStatement:enter\nLogicalExpression:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="Identifier (c)\nLogicalExpression:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nConditionalExpression:enter\nIdentifier (d)"];
+    s1_5[label="CallExpression:enter\nIdentifier (foo)\nCallExpression:exit"];
+    s1_7[label="ConditionalExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_9[label="IfStatement:exit\nProgram:exit"];
+    s1_8[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (baz)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_6[label="CallExpression:enter\nIdentifier (bar)\nCallExpression:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_7->s1_9;
+    s1_1->s1_4;
+    s1_2->s1_4;
+    s1_3->s1_8->s1_9;
+    s1_4->s1_6->s1_7;
+    s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--if-qq-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--if-qq-1.js
@@ -1,0 +1,25 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_3;
+s1_2->s1_4;
+s1_1->s1_4->final;
+*/
+if (a ??= b) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nIfStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_4[label="IfStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_3;
+    s1_2->s1_4;
+    s1_1->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--if-qq-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--if-qq-2.js
@@ -1,0 +1,30 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5;
+s1_1->s1_3;
+s1_2->s1_4->s1_5;
+s1_1->s1_4;
+s1_5->final;
+*/
+if (a ??= b) {
+    foo();
+} else {
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nIfStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_5[label="IfStatement:exit\nProgram:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (bar)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_5;
+    s1_1->s1_3;
+    s1_2->s1_4->s1_5;
+    s1_1->s1_4;
+    s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--logical-and-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--logical-and-1.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a &&= b && c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="LogicalExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nLogicalExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--logical-and-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--logical-and-2.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a &&= b || c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="LogicalExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nLogicalExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--logical-and-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--logical-and-3.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a &&= b ?? c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="LogicalExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nLogicalExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--logical-or-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--logical-or-1.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a ||= b && c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="LogicalExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nLogicalExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--logical-or-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--logical-or-2.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a ||= b || c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="LogicalExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nLogicalExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--logical-or-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--logical-or-3.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a ||= b ?? c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="LogicalExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nLogicalExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--logical-qq-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--logical-qq-1.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a ??= b && c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="LogicalExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nLogicalExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--logical-qq-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--logical-qq-2.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a ??= b || c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="LogicalExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nLogicalExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--logical-qq-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--logical-qq-3.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a ??= b ?? c;
+
+/*DOT
+digraph {
+node[shape=box,style="rounded,filled",fillcolor=white];
+initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+s1_2[label="LogicalExpression:enter\nIdentifier (b)"];
+s1_3[label="Identifier (c)\nLogicalExpression:exit"];
+s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--logical-qq-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--logical-qq-3.js
@@ -7,15 +7,15 @@ a ??= b ?? c;
 
 /*DOT
 digraph {
-node[shape=box,style="rounded,filled",fillcolor=white];
-initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
-final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
-s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
-s1_2[label="LogicalExpression:enter\nIdentifier (b)"];
-s1_3[label="Identifier (c)\nLogicalExpression:exit"];
-s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
-initial->s1_1->s1_2->s1_3->s1_4;
-s1_1->s1_4;
-s1_2->s1_4->final;
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="LogicalExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nLogicalExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
 }
 */

--- a/tests/fixtures/code-path-analysis/assignment--multi-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--multi-1.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a &&= b &&= c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nAssignmentExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--multi-10.js
+++ b/tests/fixtures/code-path-analysis/assignment--multi-10.js
@@ -1,0 +1,28 @@
+/*expected
+initial->s1_1->s1_2->s1_4->s1_5->s1_6->s1_8->s1_9;
+s1_1->s1_3->s1_4->s1_9;
+s1_5->s1_7->s1_8;
+s1_9->final;
+*/
+a[b ? c : d] ||= e[f ? g : h] = i;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nMemberExpression:enter\nIdentifier (a)\nConditionalExpression:enter\nIdentifier (b)"];
+    s1_2[label="Identifier (c)"];
+    s1_4[label="ConditionalExpression:exit\nMemberExpression:exit"];
+    s1_5[label="AssignmentExpression:enter\nMemberExpression:enter\nIdentifier (e)\nConditionalExpression:enter\nIdentifier (f)"];
+    s1_6[label="Identifier (g)"];
+    s1_8[label="ConditionalExpression:exit\nMemberExpression:exit\nIdentifier (i)\nAssignmentExpression:exit"];
+    s1_9[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    s1_3[label="Identifier (d)"];
+    s1_7[label="Identifier (h)"];
+    initial->s1_1->s1_2->s1_4->s1_5->s1_6->s1_8->s1_9;
+    s1_1->s1_3->s1_4->s1_9;
+    s1_5->s1_7->s1_8;
+    s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--multi-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--multi-2.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a &&= b ||= c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nAssignmentExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--multi-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--multi-3.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a ||= b ||= c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nAssignmentExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--multi-4.js
+++ b/tests/fixtures/code-path-analysis/assignment--multi-4.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a ||= b ??= c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nAssignmentExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--multi-5.js
+++ b/tests/fixtures/code-path-analysis/assignment--multi-5.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a ??= b ??= c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nAssignmentExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--multi-6.js
+++ b/tests/fixtures/code-path-analysis/assignment--multi-6.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+a ??= b &&= c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)\nAssignmentExpression:exit"];
+    s1_4[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--multi-7.js
+++ b/tests/fixtures/code-path-analysis/assignment--multi-7.js
@@ -1,0 +1,24 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5;
+s1_1->s1_5;
+s1_2->s1_5;
+s1_3->s1_5->final;
+*/
+a ??= b ||= c &&= d;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (b)"];
+    s1_3[label="AssignmentExpression:enter\nIdentifier (c)"];
+    s1_4[label="Identifier (d)\nAssignmentExpression:exit\nAssignmentExpression:exit"];
+    s1_5[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5;
+    s1_1->s1_5;
+    s1_2->s1_5;
+    s1_3->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--multi-8.js
+++ b/tests/fixtures/code-path-analysis/assignment--multi-8.js
@@ -1,0 +1,14 @@
+/*expected
+initial->s1_1->final;
+*/
+a = b = c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)\nAssignmentExpression:enter\nIdentifier (b)\nIdentifier (c)\nAssignmentExpression:exit\nAssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--multi-9.js
+++ b/tests/fixtures/code-path-analysis/assignment--multi-9.js
@@ -1,0 +1,24 @@
+/*expected
+initial->s1_1->s1_2->s1_4->s1_5->s1_7->s1_8->s1_9;
+s1_1->s1_3->s1_4->s1_6->s1_7->s1_9->final;
+*/
+a[b ? c : d] = e[f ? g : h] ||= i;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nMemberExpression:enter\nIdentifier (a)\nConditionalExpression:enter\nIdentifier (b)"];
+    s1_2[label="Identifier (c)"];
+    s1_4[label="ConditionalExpression:exit\nMemberExpression:exit\nAssignmentExpression:enter\nMemberExpression:enter\nIdentifier (e)\nConditionalExpression:enter\nIdentifier (f)"];
+    s1_5[label="Identifier (g)"];
+    s1_7[label="ConditionalExpression:exit\nMemberExpression:exit"];
+    s1_8[label="Identifier (i)"];
+    s1_9[label="AssignmentExpression:exit\nAssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    s1_3[label="Identifier (d)"];
+    s1_6[label="Identifier (h)"];
+    initial->s1_1->s1_2->s1_4->s1_5->s1_7->s1_8->s1_9;
+    s1_1->s1_3->s1_4->s1_6->s1_7->s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--nested-and-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--nested-and-1.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+(a &&= b) && c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nLogicalExpression:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="LogicalExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--nested-and-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--nested-and-2.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_3;
+s1_2->s1_4->final;
+*/
+(a &&= b) || c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nLogicalExpression:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="LogicalExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_3;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--nested-and-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--nested-and-3.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+(a &&= b) ?? c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nLogicalExpression:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="LogicalExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--nested-or-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--nested-or-1.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_3;
+s1_2->s1_4->final;
+*/
+(a ||= b) && c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nLogicalExpression:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="LogicalExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_3;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--nested-or-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--nested-or-2.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+(a ||= b) || c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nLogicalExpression:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="LogicalExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--nested-or-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--nested-or-3.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+(a ||= b) ?? c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nLogicalExpression:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="LogicalExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--nested-qq-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--nested-qq-1.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_3;
+s1_2->s1_4;
+s1_1->s1_4->final;
+*/
+(a ??= b) && c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nLogicalExpression:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="LogicalExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_3;
+    s1_2->s1_4;
+    s1_1->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--nested-qq-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--nested-qq-2.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_3;
+s1_2->s1_4;
+s1_1->s1_4->final;
+*/
+(a ??= b) || c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nLogicalExpression:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="LogicalExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_3;
+    s1_2->s1_4;
+    s1_1->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--nested-qq-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--nested-qq-3.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+(a ??= b) ?? c;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nLogicalExpression:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="LogicalExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--simple-and-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--simple-and-1.js
@@ -1,0 +1,18 @@
+/*expected
+initial->s1_1->s1_2->s1_3;
+s1_1->s1_3->final;
+*/
+a &&= b;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3;
+    s1_1->s1_3->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--simple-and-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--simple-and-2.js
@@ -1,0 +1,25 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5->s1_6;
+s1_1->s1_6;
+s1_2->s1_4->s1_5;
+s1_6->final;
+*/
+a &&= b ? c : d;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="ConditionalExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)"];
+    s1_5[label="ConditionalExpression:exit"];
+    s1_6[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    s1_4[label="Identifier (d)"];
+    initial->s1_1->s1_2->s1_3->s1_5->s1_6;
+    s1_1->s1_6;
+    s1_2->s1_4->s1_5;
+    s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--simple-and-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--simple-and-3.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_4->s1_5->s1_6;
+s1_1->s1_3->s1_4->s1_6->final;
+*/
+a[b ? c : d] &&= e;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nMemberExpression:enter\nIdentifier (a)\nConditionalExpression:enter\nIdentifier (b)"];
+    s1_2[label="Identifier (c)"];
+    s1_4[label="ConditionalExpression:exit\nMemberExpression:exit"];
+    s1_5[label="Identifier (e)"];
+    s1_6[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    s1_3[label="Identifier (d)"];
+    initial->s1_1->s1_2->s1_4->s1_5->s1_6;
+    s1_1->s1_3->s1_4->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--simple-bitand.js
+++ b/tests/fixtures/code-path-analysis/assignment--simple-bitand.js
@@ -1,0 +1,14 @@
+/*expected
+initial->s1_1->final;
+*/
+a &= b;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)\nIdentifier (b)\nAssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--simple-eq.js
+++ b/tests/fixtures/code-path-analysis/assignment--simple-eq.js
@@ -1,0 +1,14 @@
+/*expected
+initial->s1_1->final;
+*/
+a = b;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)\nIdentifier (b)\nAssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--simple-or-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--simple-or-1.js
@@ -1,0 +1,18 @@
+/*expected
+initial->s1_1->s1_2->s1_3;
+s1_1->s1_3->final;
+*/
+a ||= b;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3;
+    s1_1->s1_3->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--simple-or-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--simple-or-2.js
@@ -1,0 +1,25 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5->s1_6;
+s1_1->s1_6;
+s1_2->s1_4->s1_5;
+s1_6->final;
+*/
+a ||= b ? c : d;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="ConditionalExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)"];
+    s1_5[label="ConditionalExpression:exit"];
+    s1_6[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    s1_4[label="Identifier (d)"];
+    initial->s1_1->s1_2->s1_3->s1_5->s1_6;
+    s1_1->s1_6;
+    s1_2->s1_4->s1_5;
+    s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--simple-or-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--simple-or-3.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_4->s1_5->s1_6;
+s1_1->s1_3->s1_4->s1_6->final;
+*/
+a[b ? c : d] ||= e;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nMemberExpression:enter\nIdentifier (a)\nConditionalExpression:enter\nIdentifier (b)"];
+    s1_2[label="Identifier (c)"];
+    s1_4[label="ConditionalExpression:exit\nMemberExpression:exit"];
+    s1_5[label="Identifier (e)"];
+    s1_6[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    s1_3[label="Identifier (d)"];
+    initial->s1_1->s1_2->s1_4->s1_5->s1_6;
+    s1_1->s1_3->s1_4->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--simple-plus.js
+++ b/tests/fixtures/code-path-analysis/assignment--simple-plus.js
@@ -1,0 +1,14 @@
+/*expected
+initial->s1_1->final;
+*/
+a += b;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)\nIdentifier (b)\nAssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--simple-qq-1.js
+++ b/tests/fixtures/code-path-analysis/assignment--simple-qq-1.js
@@ -1,0 +1,18 @@
+/*expected
+initial->s1_1->s1_2->s1_3;
+s1_1->s1_3->final;
+*/
+a ??= b;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3;
+    s1_1->s1_3->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--simple-qq-2.js
+++ b/tests/fixtures/code-path-analysis/assignment--simple-qq-2.js
@@ -1,0 +1,25 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5->s1_6;
+s1_1->s1_6;
+s1_2->s1_4->s1_5;
+s1_6->final;
+*/
+a ??= b ? c : d;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (a)"];
+    s1_2[label="ConditionalExpression:enter\nIdentifier (b)"];
+    s1_3[label="Identifier (c)"];
+    s1_5[label="ConditionalExpression:exit"];
+    s1_6[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    s1_4[label="Identifier (d)"];
+    initial->s1_1->s1_2->s1_3->s1_5->s1_6;
+    s1_1->s1_6;
+    s1_2->s1_4->s1_5;
+    s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--simple-qq-3.js
+++ b/tests/fixtures/code-path-analysis/assignment--simple-qq-3.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_4->s1_5->s1_6;
+s1_1->s1_3->s1_4->s1_6->final;
+*/
+a[b ? c : d] ??= e;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nMemberExpression:enter\nIdentifier (a)\nConditionalExpression:enter\nIdentifier (b)"];
+    s1_2[label="Identifier (c)"];
+    s1_4[label="ConditionalExpression:exit\nMemberExpression:exit"];
+    s1_5[label="Identifier (e)"];
+    s1_6[label="AssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    s1_3[label="Identifier (d)"];
+    initial->s1_1->s1_2->s1_4->s1_5->s1_6;
+    s1_1->s1_3->s1_4->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--while-and.js
+++ b/tests/fixtures/code-path-analysis/assignment--while-and.js
@@ -1,0 +1,22 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_5;
+s1_3->s1_5->final;
+*/
+while (a &&= b) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nWhileStatement:enter"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (a)"];
+    s1_3[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_5[label="WhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_5;
+    s1_3->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--while-or.js
+++ b/tests/fixtures/code-path-analysis/assignment--while-or.js
@@ -1,0 +1,22 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+s1_3->s1_5->final;
+*/
+while (a ||= b) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nWhileStatement:enter"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (a)"];
+    s1_3[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_5[label="WhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+    s1_3->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/assignment--while-qq.js
+++ b/tests/fixtures/code-path-analysis/assignment--while-qq.js
@@ -1,0 +1,24 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+s1_3->s1_5;
+s1_2->s1_5->final;
+*/
+while (a ??= b) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nWhileStatement:enter"];
+    s1_2[label="AssignmentExpression:enter\nIdentifier (a)"];
+    s1_3[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_4[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_5[label="WhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+    s1_3->s1_5;
+    s1_2->s1_5->final;
+}
+*/

--- a/tests/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -557,7 +557,7 @@ describe("CodePathAnalyzer", () => {
                     }
                 }));
                 const messages = linter.verify(source, {
-                    parserOptions: { ecmaVersion: 2020 },
+                    parserOptions: { ecmaVersion: 2021 },
                     rules: { test: 2 }
                 });
 

--- a/tests/lib/rules/no-this-before-super.js
+++ b/tests/lib/rules/no-this-before-super.js
@@ -39,6 +39,10 @@ ruleTester.run("no-this-before-super", rule, {
         "class A extends B { constructor() { super(); this.c(); } }",
         "class A extends B { constructor() { super(); super.c(); } }",
         "class A extends B { constructor() { if (true) { super(); } else { super(); } this.c(); } }",
+        "class A extends B { constructor() { foo = super(); this.c(); } }",
+        "class A extends B { constructor() { foo += super().a; this.c(); } }",
+        "class A extends B { constructor() { foo |= super().a; this.c(); } }",
+        "class A extends B { constructor() { foo &= super().a; this.c(); } }",
 
         // allows `this`/`super` in nested executable scopes, even if before `super()`.
         "class A extends B { constructor() { class B extends C { constructor() { super(); this.d = 0; } } super(); } }",
@@ -160,6 +164,21 @@ ruleTester.run("no-this-before-super", rule, {
         },
         {
             code: "class A extends B { constructor() { try { super(); } catch (err) { } this.a; } }",
+            errors: [{ messageId: "noBeforeSuper", data: { kind: "this" }, type: "ThisExpression" }]
+        },
+        {
+            code: "class A extends B { constructor() { foo &&= super().a; this.c(); } }",
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{ messageId: "noBeforeSuper", data: { kind: "this" }, type: "ThisExpression" }]
+        },
+        {
+            code: "class A extends B { constructor() { foo ||= super().a; this.c(); } }",
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{ messageId: "noBeforeSuper", data: { kind: "this" }, type: "ThisExpression" }]
+        },
+        {
+            code: "class A extends B { constructor() { foo ??= super().a; this.c(); } }",
+            parserOptions: { ecmaVersion: 2021 },
             errors: [{ messageId: "noBeforeSuper", data: { kind: "this" }, type: "ThisExpression" }]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Add something to the core

refs #13569

Adds support for logical assignments in code path analysis.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated code path analysis to account for short-circuiting semantics of logical assignments.

#### Is there anything you'd like reviewers to focus on?

`(a &&= b) ?? c` works in line with how `(a && b) ?? c` already works, but I think `(a && b) ?? c` isn't entirely correct (#13614).