### PR TITLE
New: Add --max-errors flag to CLI

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -80,6 +80,7 @@ Miscellaneous:
   --init                         Run config initialization wizard - default: false
   --env-info                     Output execution environment information - default: false
   --no-error-on-unmatched-pattern  Prevent errors when pattern is unmatched - default: false
+  --max-errors Int               Number of errors to allow before triggering nonzero exit code - default: 0
   --debug                        Output debugging information
   -h, --help                     Show help
   -v, --version                  Output the version number
@@ -319,6 +320,16 @@ Example:
 
     eslint --max-warnings 10 file.js
 
+#### `--max-errors`
+
+This option allows you to specify an error threshold, which can be used to force ESLint to exit with a success status up to a specific number of error-level rule violations in your project.
+
+Normally, if ESLint runs and finds any errors, it will exit with an error exit status. However, if `--max-errors` is specified and the total error count is less than the specified threshold, ESLint will exit with a success status. Specifying a threshold of `0` or omitting this option will prevent this behavior.
+
+Example:
+
+    eslint --max-errors 10 file.js
+
 ### Output
 
 #### `-o`, `--output-file`
@@ -489,6 +500,6 @@ A more detailed breakdown of supported patterns and directories ESLint ignores b
 
 When linting files, ESLint will exit with one of the following exit codes:
 
-* `0`: Linting was successful and there are no linting errors. If the `--max-warnings` flag is set to `n`, the number of linting warnings is at most `n`.
-* `1`: Linting was successful and there is at least one linting error, or there are more linting warnings than allowed by the `--max-warnings` option.
+* `0`: Linting was successful and there are no linting errors. If the `---max-errors` flag is set to `y`, the number of linting errors is at most `y` If the `--max-warnings` flag is set to `n`, the number of linting warnings is at most `n`.
+* `1`: Linting was successful and there is at least one linting error and more than allowed by the `---max-errors` flag, or there are more linting warnings than allowed by the `--max-warnings` option.
 * `2`: Linting was unsuccessful due to a configuration problem or an internal error.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -306,17 +306,18 @@ const cli = {
 
         if (await printResults(engine, results, options.format, options.outputFile)) {
             const { errorCount, warningCount } = countErrors(results);
+            const tooManyErrors = errorCount > options.maxErrors;
             const tooManyWarnings =
                 options.maxWarnings >= 0 && warningCount > options.maxWarnings;
 
-            if (!errorCount && tooManyWarnings) {
+            if (!tooManyErrors && tooManyWarnings) {
                 log.error(
                     "ESLint found too many warnings (maximum: %s).",
                     options.maxWarnings
                 );
             }
 
-            return (errorCount || tooManyWarnings) ? 1 : 0;
+            return (tooManyErrors || tooManyWarnings) ? 1 : 0;
         }
 
         return 2;

--- a/lib/options.js
+++ b/lib/options.js
@@ -236,6 +236,12 @@ module.exports = optionator({
             description: "Prevent errors when pattern is unmatched"
         },
         {
+            option: "max-errors",
+            type: "Int",
+            default: "0",
+            description: "Number of errors to allow before triggering nonzero exit code"
+        },
+        {
             option: "debug",
             type: "Boolean",
             default: false,

--- a/tests/fixtures/max-errors/.eslintrc
+++ b/tests/fixtures/max-errors/.eslintrc
@@ -1,0 +1,6 @@
+{
+    "rules": {
+        "quotes": [2, "single"]
+    },
+    "root": true
+}

--- a/tests/fixtures/max-errors/six-warnings.js
+++ b/tests/fixtures/max-errors/six-warnings.js
@@ -1,0 +1,6 @@
+var one = "One!";
+var two = "Two!";
+var three = "Three!";
+var four = "Four!";
+var five = "Five!";
+var six = "Six!";

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -785,6 +785,36 @@ describe("cli", () => {
         });
     });
 
+    describe("when given the max-errors flag", () => {
+        it("should not change exit code if errors count under threshold", async () => {
+            const filePath = getFixturePath("max-errors");
+            const exitCode = await cli.execute(`--no-ignore --max-errors 10 ${filePath}`);
+
+            assert.strictEqual(exitCode, 0);
+        });
+
+        it("should exit with exit code 1 if error count exceeds threshold", async () => {
+            const filePath = getFixturePath("max-errors");
+            const exitCode = await cli.execute(`--no-ignore --max-errors 5 ${filePath}`);
+
+            assert.strictEqual(exitCode, 1);
+        });
+
+        it("should not change exit code if error count equals threshold", async () => {
+            const filePath = getFixturePath("max-errors");
+            const exitCode = await cli.execute(`--no-ignore --max-errors 6 ${filePath}`);
+
+            assert.strictEqual(exitCode, 0);
+        });
+
+        it("should not change exit code if flag is not specified and there are errors", async () => {
+            const filePath = getFixturePath("max-errors");
+            const exitCode = await cli.execute(filePath);
+
+            assert.strictEqual(exitCode, 1);
+        });
+    });
+
     describe("when passed --no-inline-config", () => {
         let localCLI;
 

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -311,6 +311,26 @@ describe("options", () => {
         });
     });
 
+    describe("--max-errors", () => {
+        it("should return correct value for .maxErrors when passed", () => {
+            const currentOptions = options.parse("--max-errors 10");
+
+            assert.strictEqual(currentOptions.maxErrors, 10);
+        });
+
+        it("should return 0 for .maxErrors when not passed", () => {
+            const currentOptions = options.parse("");
+
+            assert.strictEqual(currentOptions.maxErrors, 0);
+        });
+
+        it("should throw an error when supplied with a non-integer", () => {
+            assert.throws(() => {
+                options.parse("--max-errors 10.2");
+            }, /Invalid value for option 'max-errors' - expected type Int/u);
+        });
+    });
+
     describe("--init", () => {
         it("should return true for --init when passed", () => {
             const currentOptions = options.parse("--init");


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[X] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)
Changed the CLI options to allow a `---max-errors` option. Similar to PR #3580 in relation to max-warnings. This change would be  useful for using eslint in legacy code bases where we want to continuously start reducing the number of errors however still want the build system to only break builds on new errors and not existing.

#### Is there anything you'd like reviewers to focus on?
N/A