### PR TITLE
Update: support logical assignments in core rules (refs #13569)

### DIFF
--- a/docs/rules/operator-assignment.md
+++ b/docs/rules/operator-assignment.md
@@ -23,7 +23,7 @@ JavaScript provides shorthand operators that combine variable assignment and som
 
 This rule requires or disallows assignment operator shorthand where possible.
 
-The rule applies to the operators listed in the above table.
+The rule applies to the operators listed in the above table. It does not report the logical assignment operators `&&=`, `||=`, and `??=` because their short-circuiting behavior is different from the other assignment operators.
 
 ## Options
 

--- a/docs/rules/operator-assignment.md
+++ b/docs/rules/operator-assignment.md
@@ -23,6 +23,8 @@ JavaScript provides shorthand operators that combine variable assignment and som
 
 This rule requires or disallows assignment operator shorthand where possible.
 
+The rule applies to the operators listed in the above table.
+
 ## Options
 
 This rule has a single string option:

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -5,6 +5,13 @@
 
 "use strict";
 
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("./utils/ast-utils");
+
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -60,7 +67,23 @@ function isPossibleConstructor(node) {
             return node.name !== "undefined";
 
         case "AssignmentExpression":
-            return isPossibleConstructor(node.right);
+            if (node.operator === "=") {
+                return isPossibleConstructor(node.right);
+            }
+
+            if (astUtils.isLogicalAssignmentOperator(node.operator)) {
+                return (
+                    isPossibleConstructor(node.left) ||
+                    isPossibleConstructor(node.right)
+                );
+            }
+
+            /**
+             * All other assignment operators are mathematical assignment operators (arithmetic or bitwise).
+             * An assignment expression with a mathematical operator can either evaluate to a primitive value,
+             * or throw, depending on the operands. Thus, it cannot evaluate to a constructor function.
+             */
+            return false;
 
         case "LogicalExpression":
             return (

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -5,13 +5,6 @@
 
 "use strict";
 
-
-//------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
-const astUtils = require("./utils/ast-utils");
-
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -67,11 +60,11 @@ function isPossibleConstructor(node) {
             return node.name !== "undefined";
 
         case "AssignmentExpression":
-            if (node.operator === "=") {
+            if (["=", "&&="].includes(node.operator)) {
                 return isPossibleConstructor(node.right);
             }
 
-            if (astUtils.isLogicalAssignmentOperator(node.operator)) {
+            if (["||=", "??="].includes(node.operator)) {
                 return (
                     isPossibleConstructor(node.left) ||
                     isPossibleConstructor(node.right)

--- a/lib/rules/operator-assignment.js
+++ b/lib/rules/operator-assignment.js
@@ -151,7 +151,7 @@ module.exports = {
          * @returns {void}
          */
         function prohibit(node) {
-            if (node.operator !== "=") {
+            if (node.operator !== "=" && !astUtils.isLogicalAssignmentOperator(node.operator)) {
                 context.report({
                     node,
                     messageId: "unexpected",

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1578,11 +1578,11 @@ module.exports = {
                 return true; // possibly an error object.
 
             case "AssignmentExpression":
-                if (node.operator === "=") {
+                if (["=", "&&="].includes(node.operator)) {
                     return module.exports.couldBeError(node.right);
                 }
 
-                if (isLogicalAssignmentOperator(node.operator)) {
+                if (["||=", "??="].includes(node.operator)) {
                     return module.exports.couldBeError(node.left) || module.exports.couldBeError(node.right);
                 }
 

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1578,7 +1578,20 @@ module.exports = {
                 return true; // possibly an error object.
 
             case "AssignmentExpression":
-                return module.exports.couldBeError(node.right);
+                if (node.operator === "=") {
+                    return module.exports.couldBeError(node.right);
+                }
+
+                if (isLogicalAssignmentOperator(node.operator)) {
+                    return module.exports.couldBeError(node.left) || module.exports.couldBeError(node.right);
+                }
+
+                /**
+                 * All other assignment operators are mathematical assignment operators (arithmetic or bitwise).
+                 * An assignment expression with a mathematical operator can either evaluate to a primitive value,
+                 * or throw, depending on the operands. Thus, it cannot evaluate to an `Error` object.
+                 */
+                return false;
 
             case "SequenceExpression": {
                 const exprs = node.expressions;

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -40,6 +40,8 @@ const STATEMENT_LIST_PARENTS = new Set(["Program", "BlockStatement", "SwitchCase
 const DECIMAL_INTEGER_PATTERN = /^(0|[1-9]\d*)$/u;
 const OCTAL_ESCAPE_PATTERN = /^(?:[^\\]|\\[^0-7]|\\0(?![0-9]))*\\(?:[1-7]|0[0-9])/u;
 
+const LOGICAL_ASSIGNMENT_OPERATORS = new Set(["&&=", "||=", "??="]);
+
 /**
  * Checks reference if is non initializer and writable.
  * @param {Reference} reference A reference to check.
@@ -720,6 +722,15 @@ function isMixedLogicalAndCoalesceExpressions(left, right) {
         (isLogicalExpression(left) && isCoalesceExpression(right)) ||
             (isCoalesceExpression(left) && isLogicalExpression(right))
     );
+}
+
+/**
+ * Checks if the given operator is a logical assignment operator.
+ * @param {string} operator The operator to check.
+ * @returns {boolean} `true` if the operator is a logical assignment operator.
+ */
+function isLogicalAssignmentOperator(operator) {
+    return LOGICAL_ASSIGNMENT_OPERATORS.has(operator);
 }
 
 //------------------------------------------------------------------------------
@@ -1754,5 +1765,6 @@ module.exports = {
     isSpecificId,
     isSpecificMemberAccess,
     equalLiteralValue,
-    isSameReference
+    isSameReference,
+    isLogicalAssignmentOperator
 };

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -128,7 +128,7 @@ ruleTester.run("constructor-super", rule, {
         },
         {
 
-            // `B &&= 5` evaluates either to a falsy value of `B` (which, then, cannot be an Error object), or to '5'
+            // `B &&= 5` evaluates either to a falsy value of `B` (which, then, cannot be a constructor), or to '5'
             code: "class A extends (B &&= 5) { constructor() { super(); } }",
             errors: [{ messageId: "badSuper", type: "CallExpression" }]
         },

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -40,7 +40,6 @@ ruleTester.run("constructor-super", rule, {
         "class A extends (B &&= C) { constructor() { super(); } }",
         "class A extends (B ||= C) { constructor() { super(); } }",
         "class A extends (B ??= C) { constructor() { super(); } }",
-        "class A extends (B &&= 5) { constructor() { super(); } }",
         "class A extends (B ||= 5) { constructor() { super(); } }",
         "class A extends (B ??= 5) { constructor() { super(); } }",
         "class A extends (B || C) { constructor() { super(); } }",
@@ -125,6 +124,12 @@ ruleTester.run("constructor-super", rule, {
         },
         {
             code: "class A extends (B = 5) { constructor() { super(); } }",
+            errors: [{ messageId: "badSuper", type: "CallExpression" }]
+        },
+        {
+
+            // `B &&= 5` evaluates either to a falsy value of `B` (which, then, cannot be an Error object), or to '5'
+            code: "class A extends (B &&= 5) { constructor() { super(); } }",
             errors: [{ messageId: "badSuper", type: "CallExpression" }]
         },
         {

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -16,7 +16,7 @@ const { RuleTester } = require("../../../lib/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2020 } });
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2021 } });
 
 ruleTester.run("constructor-super", rule, {
     valid: [
@@ -37,7 +37,18 @@ ruleTester.run("constructor-super", rule, {
         "class A extends B { constructor() { if (true) { super(); } else { super(); } } }",
         "class A extends (class B {}) { constructor() { super(); } }",
         "class A extends (B = C) { constructor() { super(); } }",
+        "class A extends (B &&= C) { constructor() { super(); } }",
+        "class A extends (B ||= C) { constructor() { super(); } }",
+        "class A extends (B ??= C) { constructor() { super(); } }",
+        "class A extends (B &&= 5) { constructor() { super(); } }",
+        "class A extends (B ||= 5) { constructor() { super(); } }",
+        "class A extends (B ??= 5) { constructor() { super(); } }",
         "class A extends (B || C) { constructor() { super(); } }",
+        "class A extends (B && 5) { constructor() { super(); } }",
+        "class A extends (5 && B) { constructor() { super(); } }",
+        "class A extends (B || 5) { constructor() { super(); } }",
+        "class A extends (B ?? 5) { constructor() { super(); } }",
+
         "class A extends (a ? B : C) { constructor() { super(); } }",
         "class A extends (B, C) { constructor() { super(); } }",
 
@@ -110,6 +121,30 @@ ruleTester.run("constructor-super", rule, {
         },
         {
             code: "class A extends 'test' { constructor() { super(); } }",
+            errors: [{ messageId: "badSuper", type: "CallExpression" }]
+        },
+        {
+            code: "class A extends (B = 5) { constructor() { super(); } }",
+            errors: [{ messageId: "badSuper", type: "CallExpression" }]
+        },
+        {
+            code: "class A extends (B += C) { constructor() { super(); } }",
+            errors: [{ messageId: "badSuper", type: "CallExpression" }]
+        },
+        {
+            code: "class A extends (B -= C) { constructor() { super(); } }",
+            errors: [{ messageId: "badSuper", type: "CallExpression" }]
+        },
+        {
+            code: "class A extends (B **= C) { constructor() { super(); } }",
+            errors: [{ messageId: "badSuper", type: "CallExpression" }]
+        },
+        {
+            code: "class A extends (B |= C) { constructor() { super(); } }",
+            errors: [{ messageId: "badSuper", type: "CallExpression" }]
+        },
+        {
+            code: "class A extends (B &= C) { constructor() { super(); } }",
             errors: [{ messageId: "badSuper", type: "CallExpression" }]
         },
 

--- a/tests/lib/rules/func-name-matching.js
+++ b/tests/lib/rules/func-name-matching.js
@@ -29,6 +29,9 @@ ruleTester.run("func-name-matching", rule, {
         "foo = function foo() {};",
         { code: "foo = function foo() {};", options: ["always"] },
         { code: "foo = function bar() {};", options: ["never"] },
+        { code: "foo &&= function foo() {};", parserOptions: { ecmaVersion: 2021 } },
+        { code: "obj.foo ||= function foo() {};", parserOptions: { ecmaVersion: 2021 } },
+        { code: "obj['foo'] ??= function foo() {};", parserOptions: { ecmaVersion: 2021 } },
         "obj.foo = function foo() {};",
         { code: "obj.foo = function foo() {};", options: ["always"] },
         { code: "obj.foo = function bar() {};", options: ["never"] },
@@ -282,6 +285,27 @@ ruleTester.run("func-name-matching", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 { messageId: "matchVariable", data: { funcName: "bar", name: "foo" } }
+            ]
+        },
+        {
+            code: "foo &&= function bar() {};",
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [
+                { messageId: "matchVariable", data: { funcName: "bar", name: "foo" } }
+            ]
+        },
+        {
+            code: "obj.foo ||= function bar() {};",
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [
+                { messageId: "matchProperty", data: { funcName: "bar", name: "foo" } }
+            ]
+        },
+        {
+            code: "obj['foo'] ??= function bar() {};",
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [
+                { messageId: "matchProperty", data: { funcName: "bar", name: "foo" } }
             ]
         },
         {

--- a/tests/lib/rules/no-bitwise.js
+++ b/tests/lib/rules/no-bitwise.js
@@ -22,7 +22,12 @@ ruleTester.run("no-bitwise", rule, {
     valid: [
         "a + b",
         "!a",
+        "a && b",
+        "a || b",
         "a += b",
+        { code: "a &&= b", parserOptions: { ecmaVersion: 2021 } },
+        { code: "a ||= b", parserOptions: { ecmaVersion: 2021 } },
+        { code: "a ??= b", parserOptions: { ecmaVersion: 2021 } },
         { code: "~[1, 2, 3].indexOf(1)", options: [{ allow: ["~"] }] },
         { code: "~1<<2 === -8", options: [{ allow: ["~", "<<"] }] },
         { code: "a|0", options: [{ int32Hint: true }] },

--- a/tests/lib/rules/no-extend-native.js
+++ b/tests/lib/rules/no-extend-native.js
@@ -160,6 +160,23 @@ ruleTester.run("no-extend-native", rule, {
         code: "(Object?.defineProperty)(Object.prototype, 'p', { value: 0 })",
         parserOptions: { ecmaVersion: 2020 },
         errors: [{ messageId: "unexpected", data: { builtin: "Object" } }]
+    },
+
+    // Logical assignments
+    {
+        code: "Array.prototype.p &&= 0",
+        parserOptions: { ecmaVersion: 2021 },
+        errors: [{ messageId: "unexpected", data: { builtin: "Array" } }]
+    },
+    {
+        code: "Array.prototype.p ||= 0",
+        parserOptions: { ecmaVersion: 2021 },
+        errors: [{ messageId: "unexpected", data: { builtin: "Array" } }]
+    },
+    {
+        code: "Array.prototype.p ??= 0",
+        parserOptions: { ecmaVersion: 2021 },
+        errors: [{ messageId: "unexpected", data: { builtin: "Array" } }]
     }
 
     ]

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -719,6 +719,24 @@ const patterns = [
         errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "obj.method &&= function () { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 2021 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "obj.method ||= function () { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 2021 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "obj.method ??= function () { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 2021 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
     }
 ];
 

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -368,6 +368,57 @@ ruleTester.run("no-param-reassign", rule, {
                 messageId: "assignmentToFunctionParamProp",
                 data: { name: "a" }
             }]
+        },
+        {
+            code: "function foo(a) { a &&= b; }",
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "a" }
+            }]
+        },
+        {
+            code: "function foo(a) { a ||= b; }",
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "a" }
+            }]
+        },
+        {
+            code: "function foo(a) { a ??= b; }",
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "assignmentToFunctionParam",
+                data: { name: "a" }
+            }]
+        },
+        {
+            code: "function foo(a) { a.b &&= c; }",
+            options: [{ props: true }],
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "a" }
+            }]
+        },
+        {
+            code: "function foo(a) { a.b.c ||= d; }",
+            options: [{ props: true }],
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "a" }
+            }]
+        },
+        {
+            code: "function foo(a) { a[b] ??= c; }",
+            options: [{ props: true }],
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "assignmentToFunctionParamProp",
+                data: { name: "a" }
+            }]
         }
     ]
 });

--- a/tests/lib/rules/no-throw-literal.js
+++ b/tests/lib/rules/no-throw-literal.js
@@ -30,7 +30,10 @@ ruleTester.run("no-throw-literal", rule, {
         "throw new foo();", // NewExpression
         "throw foo.bar;", // MemberExpression
         "throw foo[bar];", // MemberExpression
-        "throw foo = new Error();", // AssignmentExpression
+        "throw foo = new Error();", // AssignmentExpression with the `=` operator
+        { code: "throw foo &&= 'literal'", parserOptions: { ecmaVersion: 2021 } }, // AssignmentExpression with a logical operator
+        { code: "throw foo.bar ||= 'literal'", parserOptions: { ecmaVersion: 2021 } }, // AssignmentExpression with a logical operator
+        { code: "throw foo[bar] ??= 'literal'", parserOptions: { ecmaVersion: 2021 } }, // AssignmentExpression with a logical operator
         "throw 1, 2, new Error();", // SequenceExpression
         "throw 'literal' && new Error();", // LogicalExpression (right)
         "throw new Error() || 'literal';", // LogicalExpression (left)
@@ -104,7 +107,21 @@ ruleTester.run("no-throw-literal", rule, {
 
         // AssignmentExpression
         {
-            code: "throw foo = 'error';",
+            code: "throw foo = 'error';", // RHS is a literal
+            errors: [{
+                messageId: "object",
+                type: "ThrowStatement"
+            }]
+        },
+        {
+            code: "throw foo += new Error();", // evaluates to a primitive value, or throws while evaluating
+            errors: [{
+                messageId: "object",
+                type: "ThrowStatement"
+            }]
+        },
+        {
+            code: "throw foo &= new Error();", // evaluates to a primitive value, or throws while evaluating
             errors: [{
                 messageId: "object",
                 type: "ThrowStatement"

--- a/tests/lib/rules/no-throw-literal.js
+++ b/tests/lib/rules/no-throw-literal.js
@@ -31,7 +31,6 @@ ruleTester.run("no-throw-literal", rule, {
         "throw foo.bar;", // MemberExpression
         "throw foo[bar];", // MemberExpression
         "throw foo = new Error();", // AssignmentExpression with the `=` operator
-        { code: "throw foo &&= 'literal'", parserOptions: { ecmaVersion: 2021 } }, // AssignmentExpression with a logical operator
         { code: "throw foo.bar ||= 'literal'", parserOptions: { ecmaVersion: 2021 } }, // AssignmentExpression with a logical operator
         { code: "throw foo[bar] ??= 'literal'", parserOptions: { ecmaVersion: 2021 } }, // AssignmentExpression with a logical operator
         "throw 1, 2, new Error();", // SequenceExpression
@@ -122,6 +121,14 @@ ruleTester.run("no-throw-literal", rule, {
         },
         {
             code: "throw foo &= new Error();", // evaluates to a primitive value, or throws while evaluating
+            errors: [{
+                messageId: "object",
+                type: "ThrowStatement"
+            }]
+        },
+        {
+            code: "throw foo &&= 'literal'", // evaluates either to a falsy value of `foo` (which, then, cannot be an Error object), or to 'literal'
+            parserOptions: { ecmaVersion: 2021 },
             errors: [{
                 messageId: "object",
                 type: "ThrowStatement"

--- a/tests/lib/rules/operator-assignment.js
+++ b/tests/lib/rules/operator-assignment.js
@@ -16,7 +16,7 @@ const rule = require("../../../lib/rules/operator-assignment"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2020 } });
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2021 } });
 
 const EXPECTED_OPERATOR_ASSIGNMENT = [{ messageId: "replaced", type: "AssignmentExpression" }];
 const UNEXPECTED_OPERATOR_ASSIGNMENT = [{ messageId: "unexpected", type: "AssignmentExpression" }];
@@ -84,6 +84,32 @@ ruleTester.run("operator-assignment", rule, {
         {
             code: "this.x = foo.this.x + y",
             options: ["always"]
+        },
+
+        // does not check logical operators
+        {
+            code: "x = x && y",
+            options: ["always"]
+        },
+        {
+            code: "x = x || y",
+            options: ["always"]
+        },
+        {
+            code: "x = x ?? y",
+            options: ["always"]
+        },
+        {
+            code: "x &&= y",
+            options: ["never"]
+        },
+        {
+            code: "x ||= y",
+            options: ["never"]
+        },
+        {
+            code: "x ??= y",
+            options: ["never"]
         }
     ],
 

--- a/tests/lib/rules/operator-linebreak.js
+++ b/tests/lib/rules/operator-linebreak.js
@@ -57,7 +57,48 @@ ruleTester.run("operator-linebreak", rule, {
         { code: "1 + 1\n", options: ["none"] },
         { code: "answer = everything ? 42 : foo;", options: ["none"] },
         { code: "answer = everything \n?\n 42 : foo;", options: [null, { overrides: { "?": "ignore" } }] },
-        { code: "answer = everything ? 42 \n:\n foo;", options: [null, { overrides: { ":": "ignore" } }] }
+        { code: "answer = everything ? 42 \n:\n foo;", options: [null, { overrides: { ":": "ignore" } }] },
+
+        {
+            code: "a \n &&= b",
+            options: ["after", { overrides: { "&&=": "ignore" } }],
+            parserOptions: { ecmaVersion: 2021 }
+        },
+        {
+            code: "a ??= \n b",
+            options: ["before", { overrides: { "??=": "ignore" } }],
+            parserOptions: { ecmaVersion: 2021 }
+        },
+        {
+            code: "a ||= \n b",
+            options: ["after", { overrides: { "=": "before" } }],
+            parserOptions: { ecmaVersion: 2021 }
+        },
+        {
+            code: "a \n &&= b",
+            options: ["before", { overrides: { "&=": "after" } }],
+            parserOptions: { ecmaVersion: 2021 }
+        },
+        {
+            code: "a \n ||= b",
+            options: ["before", { overrides: { "|=": "after" } }],
+            parserOptions: { ecmaVersion: 2021 }
+        },
+        {
+            code: "a &&= \n b",
+            options: ["after", { overrides: { "&&": "before" } }],
+            parserOptions: { ecmaVersion: 2021 }
+        },
+        {
+            code: "a ||= \n b",
+            options: ["after", { overrides: { "||": "before" } }],
+            parserOptions: { ecmaVersion: 2021 }
+        },
+        {
+            code: "a ??= \n b",
+            options: ["after", { overrides: { "??": "before" } }],
+            parserOptions: { ecmaVersion: 2021 }
+        }
     ],
 
     invalid: [
@@ -637,6 +678,97 @@ ruleTester.run("operator-linebreak", rule, {
             errors: [{
                 messageId: "operatorAtBeginning",
                 data: { operator: "??" }
+            }]
+        },
+
+        {
+            code: "a \n  &&= b",
+            output: "a &&= \n  b",
+            options: ["after"],
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "operatorAtEnd",
+                data: { operator: "&&=" },
+                type: "AssignmentExpression",
+                line: 2,
+                column: 3,
+                endLine: 2,
+                endColumn: 6
+            }]
+        },
+        {
+            code: "a ||=\n b",
+            output: "a\n ||= b",
+            options: ["before"],
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "operatorAtBeginning",
+                data: { operator: "||=" },
+                type: "AssignmentExpression",
+                line: 1,
+                column: 3,
+                endLine: 1,
+                endColumn: 6
+            }]
+        },
+        {
+            code: "a  ??=\n b",
+            output: "a  ??= b",
+            options: ["none"],
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "noLinebreak",
+                data: { operator: "??=" },
+                type: "AssignmentExpression",
+                line: 1,
+                column: 4,
+                endLine: 1,
+                endColumn: 7
+            }]
+        },
+        {
+            code: "a \n  &&= b",
+            output: "a   &&= b",
+            options: ["before", { overrides: { "&&=": "none" } }],
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "noLinebreak",
+                data: { operator: "&&=" },
+                type: "AssignmentExpression",
+                line: 2,
+                column: 3,
+                endLine: 2,
+                endColumn: 6
+            }]
+        },
+        {
+            code: "a ||=\nb",
+            output: "a\n||= b",
+            options: ["after", { overrides: { "||=": "before" } }],
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "operatorAtBeginning",
+                data: { operator: "||=" },
+                type: "AssignmentExpression",
+                line: 1,
+                column: 3,
+                endLine: 1,
+                endColumn: 6
+            }]
+        },
+        {
+            code: "a\n??=b",
+            output: "a??=\nb",
+            options: ["none", { overrides: { "??=": "after" } }],
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "operatorAtEnd",
+                data: { operator: "??=" },
+                type: "AssignmentExpression",
+                line: 2,
+                column: 1,
+                endLine: 2,
+                endColumn: 4
             }]
         }
     ]

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -98,7 +98,19 @@ ruleTester.run("prefer-destructuring", rule, {
         },
         "[foo] = array;",
         "foo += array[0]",
+        {
+            code: "foo &&= array[0]",
+            parserOptions: { ecmaVersion: 2021 }
+        },
         "foo += bar.foo",
+        {
+            code: "foo ||= bar.foo",
+            parserOptions: { ecmaVersion: 2021 }
+        },
+        {
+            code: "foo ??= bar['foo']",
+            parserOptions: { ecmaVersion: 2021 }
+        },
         {
             code: "foo = object.foo;",
             options: [{ AssignmentExpression: { object: false } }, { enforceForRenamedProperties: true }]

--- a/tests/lib/rules/prefer-promise-reject-errors.js
+++ b/tests/lib/rules/prefer-promise-reject-errors.js
@@ -16,7 +16,7 @@ const { RuleTester } = require("../../../lib/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2020 } });
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2021 } });
 
 ruleTester.run("prefer-promise-reject-errors", rule, {
 
@@ -29,6 +29,8 @@ ruleTester.run("prefer-promise-reject-errors", rule, {
         "Promise.reject(new Error())",
         "Promise.reject(new TypeError)",
         "Promise.reject(new Error('foo'))",
+        "Promise.reject(foo || 5)",
+        "Promise.reject(5 && foo)",
         "new Foo((resolve, reject) => reject(5))",
         "new Promise(function(resolve, reject) { return function(reject) { reject(5) } })",
         "new Promise(function(resolve, reject) { if (foo) { const reject = somethingElse; reject(5) } })",
@@ -46,7 +48,13 @@ ruleTester.run("prefer-promise-reject-errors", rule, {
 
         // Optional chaining
         "Promise.reject(obj?.foo)",
-        "Promise.reject(obj?.foo())"
+        "Promise.reject(obj?.foo())",
+
+        // Assignments
+        "Promise.reject(foo = new Error())",
+        "Promise.reject(foo ||= 5)",
+        "Promise.reject(foo.bar ??= 5)",
+        "Promise.reject(foo[bar] &&= 5)"
     ],
 
     invalid: [
@@ -98,7 +106,16 @@ ruleTester.run("prefer-promise-reject-errors", rule, {
         "Promise?.reject(5)",
         "Promise?.reject?.(5)",
         "(Promise?.reject)(5)",
-        "(Promise?.reject)?.(5)"
+        "(Promise?.reject)?.(5)",
+
+        // Assignments with mathematical operators will either evaluate to a primitive value or throw a TypeError
+        "Promise.reject(foo += new Error())",
+        "Promise.reject(foo -= new Error())",
+        "Promise.reject(foo **= new Error())",
+        "Promise.reject(foo <<= new Error())",
+        "Promise.reject(foo |= new Error())",
+        "Promise.reject(foo &= new Error())"
+
     ].map(invalidCase => {
         const errors = { errors: [{ messageId: "rejectAnError", type: "CallExpression" }] };
 

--- a/tests/lib/rules/prefer-promise-reject-errors.js
+++ b/tests/lib/rules/prefer-promise-reject-errors.js
@@ -54,7 +54,7 @@ ruleTester.run("prefer-promise-reject-errors", rule, {
         "Promise.reject(foo = new Error())",
         "Promise.reject(foo ||= 5)",
         "Promise.reject(foo.bar ??= 5)",
-        "Promise.reject(foo[bar] &&= 5)"
+        "Promise.reject(foo[bar] ??= 5)"
     ],
 
     invalid: [
@@ -114,7 +114,10 @@ ruleTester.run("prefer-promise-reject-errors", rule, {
         "Promise.reject(foo **= new Error())",
         "Promise.reject(foo <<= new Error())",
         "Promise.reject(foo |= new Error())",
-        "Promise.reject(foo &= new Error())"
+        "Promise.reject(foo &= new Error())",
+
+        // evaluates either to a falsy value of `foo` (which, then, cannot be an Error object), or to `5`
+        "Promise.reject(foo &&= 5)"
 
     ].map(invalidCase => {
         const errors = { errors: [{ messageId: "rejectAnError", type: "CallExpression" }] };

--- a/tests/lib/rules/space-infix-ops.js
+++ b/tests/lib/rules/space-infix-ops.js
@@ -47,7 +47,11 @@ ruleTester.run("space-infix-ops", rule, {
         { code: "const foo = function(a: number = 0): Bar { };", parser: parser("type-annotations/function-expression-type-annotation"), parserOptions: { ecmaVersion: 6 } },
 
         // TypeScript Type Aliases
-        { code: "type Foo<T> = T;", parser: parser("typescript-parsers/type-alias"), parserOptions: { ecmaVersion: 6 } }
+        { code: "type Foo<T> = T;", parser: parser("typescript-parsers/type-alias"), parserOptions: { ecmaVersion: 6 } },
+
+        { code: "a &&= b", parserOptions: { ecmaVersion: 2021 } },
+        { code: "a ||= b", parserOptions: { ecmaVersion: 2021 } },
+        { code: "a ??= b", parserOptions: { ecmaVersion: 2021 } }
     ],
     invalid: [
         {
@@ -408,7 +412,6 @@ ruleTester.run("space-infix-ops", rule, {
         },
 
         // Type Annotations
-
         {
             code: "var a: Foo= b;",
             output: "var a: Foo = b;",
@@ -432,6 +435,49 @@ ruleTester.run("space-infix-ops", rule, {
                 line: 1,
                 column: 23,
                 type: "AssignmentPattern"
+            }]
+        },
+
+        {
+            code: "a&&=b",
+            output: "a &&= b",
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "missingSpace",
+                data: { operator: "&&=" },
+                line: 1,
+                column: 2,
+                endLine: 1,
+                endColumn: 5,
+                type: "AssignmentExpression"
+            }]
+        },
+        {
+            code: "a ||=b",
+            output: "a ||= b",
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "missingSpace",
+                data: { operator: "||=" },
+                line: 1,
+                column: 3,
+                endLine: 1,
+                endColumn: 6,
+                type: "AssignmentExpression"
+            }]
+        },
+        {
+            code: "a??= b",
+            output: "a ??= b",
+            parserOptions: { ecmaVersion: 2021 },
+            errors: [{
+                messageId: "missingSpace",
+                data: { operator: "??=" },
+                line: 1,
+                column: 2,
+                endLine: 1,
+                endColumn: 5,
+                type: "AssignmentExpression"
             }]
         }
     ]

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -1032,7 +1032,7 @@ describe("ast-utils", () => {
             "1 && 2": false,
             "1 && foo": true,
             "foo && 2": true,
-            "foo &&= 2": true,
+            "foo &&= 2": false,
             "foo.bar ??= 2": true,
             "foo[bar] ||= 2": true,
             "foo ? 1 : 2": false,

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -1014,12 +1014,27 @@ describe("ast-utils", () => {
             "foo.bar": true,
             "(foo = bar)": true,
             "(foo = 1)": false,
+            "(foo += bar)": false,
+            "(foo -= bar)": false,
+            "(foo *= bar)": false,
+            "(foo /= bar)": false,
+            "(foo %= bar)": false,
+            "(foo **= bar)": false,
+            "(foo <<= bar)": false,
+            "(foo >>= bar)": false,
+            "(foo >>>= bar)": false,
+            "(foo &= bar)": false,
+            "(foo |= bar)": false,
+            "(foo ^= bar)": false,
             "(1, 2, 3)": false,
             "(foo, 2, 3)": false,
             "(1, 2, foo)": true,
             "1 && 2": false,
             "1 && foo": true,
             "foo && 2": true,
+            "foo &&= 2": true,
+            "foo.bar ??= 2": true,
+            "foo[bar] ||= 2": true,
             "foo ? 1 : 2": false,
             "foo ? bar : 2": true,
             "foo ? 1 : bar": true,
@@ -1029,7 +1044,7 @@ describe("ast-utils", () => {
 
         Object.keys(EXPECTED_RESULTS).forEach(key => {
             it(`returns ${EXPECTED_RESULTS[key]} for ${key}`, () => {
-                const ast = espree.parse(key, { ecmaVersion: 6 });
+                const ast = espree.parse(key, { ecmaVersion: 2021 });
 
                 assert.strictEqual(astUtils.couldBeError(ast.body[0].expression), EXPECTED_RESULTS[key]);
             });

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -1639,4 +1639,28 @@ describe("ast-utils", () => {
             });
         });
     });
+
+    describe("isLogicalAssignmentOperator", () => {
+        const expectedResults = {
+            "&&=": true,
+            "||=": true,
+            "??=": true,
+            "&&": false,
+            "||": false,
+            "??": false,
+            "=": false,
+            "&=": false,
+            "|=": false,
+            "+=": false,
+            "**=": false,
+            "==": false,
+            "===": false
+        };
+
+        Object.entries(expectedResults).forEach(([key, value]) => {
+            it(`should return ${value} for ${key}`, () => {
+                assert.strictEqual(astUtils.isLogicalAssignmentOperator(key), value);
+            });
+        });
+    });
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Other, please explain:

refs #13569

Changes the following rules and helper functions in order to support logical assignments:

* `operator-assignment` rule to NOT report `&&=`, `||=`, and `??=` for now.
* `astUtils.couldBeError` to return `true` for code such as `foo &&= 5`. Also, to return `false` for code such as `foo += bar` (this change can produce more warnings).
* `constructor-super` to treat classes such as `class A extends (B &&= 5)` as those that extend a constructor. Also, to treat classes such as `class A extends (B += C)` as those that don't extend a constructor (this change can produce more warnings).

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the above, and also added tests for: `operator-linebreak`, `space-infix-ops`, `no-invalid-this`, `no-param-reassign`, `no-bitwise`, `func-names-matching`, `prefer-destrucuring`, and `no-extend-native`.

#### Is there anything you'd like reviewers to focus on?

* `operator-assignment`

 I'm not sure what would be the best course of action for the `operator-assignment` rule.

Without any changes, that rule would (and currently does when used with `@babel/eslint-parser`) report `x &&= y`, `x ||= y`, and `x ??= y` if the option is `"never"`, but not `x = x && y`, `x = x || y`, and `x = x ?? y` if the option is `"always"`.

This is certainly inconsistent and should be fixed, either to report both directions or neither of them.

I fixed the rule to ignore  `x &&= y`, `x ||= y`, and `x ??= y` for now, with an idea to add an option for logical operators in a subsequent release. Logical assignments are a bit different from other assignments due to their short-circuiting semantics, so a separate configuration might make sense anyway.

An alternative is to fix the rule to report `x = x && y`, `x = x || y`, and `x = x ?? y` by default, but only if `ecmaVersion` is set to `2021` or above (which might be missing in a configuration for a third-party parser).

* The `complexity` rule: logical assignments should probably increase complexity. This looks to me like a breaking change for users of `@babel/eslint-parser`, so I think we should make this change in the next major version, rather than now.
* `no-constant-condition`: This rule should probably report conditions such as `if (foo ||= true) {}`. However, the existing code which would be used for this change has some issues that should be fixed first (see https://github.com/eslint/eslint/pull/13245#discussion_r418571282 and other comments below). I guess we could make this change later, either in a minor or major version.
* `no-self-assign`: It might make sense to consider reporting `x &&= x` and other logical assignments to itself.
* `func-names`: `x &&= function () {}`, and other two logical assignment operators, do assign function's `name` automatically. Our documentation for `as-needed` says "requires function expressions to have a name, if the name cannot be assigned automatically in an ES6 environment". Should we reword this?
* Several rules and helper functions assume that `AssigmentExpression` is always the `=` direct assignment. In other words, they don't check the assignment's operator, and thus have some false positives or false negatives with `+=`, `-=` etc. I fixed only `astUtils.couldBeError` and `constructor-super` now, because only these two wouldn't work well with logical assignments. For other rules, this possible oversight turned out to be correct behavior for `&&=`, `||=`, and `??=`, so I didn't fix them now for `+=`, `-=` and other operators (I'll do that in another PR, since it's an existing issue unrelated to logical assignments).
