### PR TITLE
Docs: Clarify functions rule in comma-dangle

### DIFF
--- a/docs/rules/comma-dangle.md
+++ b/docs/rules/comma-dangle.md
@@ -67,7 +67,7 @@ The default for each option is `"never"` unless otherwise specified.
 * `imports` is for import declarations of ES Modules. (e.g. `import {a,} from "foo";`)
 * `exports` is for export declarations of ES Modules. (e.g. `export {a,};`)
 * `functions` is for function declarations and function calls. (e.g. `(function(a,){ })(b,);`)
-    * `functions` should only be enabled when linting ECMAScript 2017 or higher.
+    * `functions` will be ignored unless `parserOptions.ecmaVersion` is specified as 8 or higher.
 
 ### never
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [x] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
clarify that the `functions` rule requires `parserOptions.ecmaVersion` to be specified as 8 or higher, not just that the code must be EMCA 2017 or higher.

_relates to issue: https://github.com/typescript-eslint/typescript-eslint/issues/2431_

