### PR TITLE
Docs: Provide install commands for Yarn

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -24,12 +24,20 @@ You should then set up a configuration file:
 
 ```
 $ npx eslint --init
+
+# or
+
+$ yarn run eslint --init
 ```
 
 After that, you can run ESLint on any file or directory like this:
 
 ```
 $ npx eslint yourfile.js
+
+# or
+
+$ yarn run eslint yourfile.js
 ```
 
 It is also possible to install ESLint globally rather than locally (using `npm install eslint --global`). However, this is not recommended, and any plugins or shareable configs that you use must be installed locally in either case.


### PR DESCRIPTION
npx doesn't work properly with plugins installed with Yarn.

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [x] Documentation update

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The installation guide might be slightly confusing for new users - e.g.: I use TypeScript in my project, I install `eslint` with yarn as the guide says, and then run it with `npx eslint --init`. It then fails with an error because the TypeScript plugin has been installed with yarn and `npx` doesn't see it:
```
Error: Failed to load plugin '@typescript-eslint' declared in '.eslintrc.js': Cannot find module 'eslint'
```
This can be fixed by using `yarn run <cmd>` instead of `npx <cmd>`. This PR changes documentation to reflect this.