### PR TITLE
Fix: prefer-destructuring removes comments (refs #13678)

### DIFF
--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -178,6 +178,11 @@ module.exports = {
             const rightNode = node.init;
             const sourceCode = context.getSourceCode();
 
+            // Don't fix if that would remove any comments. Only comments inside `rightNode.object` can be preserved.
+            if (sourceCode.getCommentsInside(node).length > sourceCode.getCommentsInside(rightNode.object).length) {
+                return null;
+            }
+
             return fixer.replaceText(
                 node,
                 `{${rightNode.property.name}} = ${sourceCode.getText(rightNode.object)}`

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -353,6 +353,224 @@ ruleTester.run("prefer-destructuring", rule, {
                 data: { type: "object" },
                 type: "VariableDeclarator"
             }]
+        },
+
+        // comments
+        {
+            code: "var /* comment */ foo = object.foo;",
+            output: "var /* comment */ {foo} = object;",
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var a, /* comment */foo = object.foo;",
+            output: "var a, /* comment */{foo} = object;",
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo /* comment */ = object.foo;",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var a, foo /* comment */ = object.foo;",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo /* comment */ = object.foo, a;",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo // comment\n = object.foo;",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = /* comment */ object.foo;",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = // comment\n object.foo;",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = (/* comment */ object).foo;",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = (object /* comment */).foo;",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = bar(/* comment */).foo;",
+            output: "var {foo} = bar(/* comment */);",
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = bar/* comment */.baz.foo;",
+            output: "var {foo} = bar/* comment */.baz;",
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = bar[// comment\nbaz].foo;",
+            output: "var {foo} = bar[// comment\nbaz];",
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo // comment\n = bar(/* comment */).foo;",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = bar/* comment */.baz/* comment */.foo;",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = object// comment\n.foo;",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = object./* comment */foo;",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = (/* comment */ object.foo);",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = (object.foo /* comment */);",
+            output: null,
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = object.foo/* comment */;",
+            output: "var {foo} = object/* comment */;",
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = object.foo// comment",
+            output: "var {foo} = object// comment",
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = object.foo/* comment */, a;",
+            output: "var {foo} = object/* comment */, a;",
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = object.foo// comment\n, a;",
+            output: "var {foo} = object// comment\n, a;",
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = object.foo, /* comment */ a;",
+            output: "var {foo} = object, /* comment */ a;",
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

refs #13678, fixes `prefer-destructuring` to not remove comments. It doesn't change the logic of this rule.

**Tell us about your environment**

* **ESLint Version:** v7.8.1
* **Node Version:** v12.14.0
* **npm Version:** v6.13.4

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IHByZWZlci1kZXN0cnVjdHVyaW5nOiBcImVycm9yXCIgKi9cblxudmFyIGZvbyA9IC8qIGNvbW1lbnQgKi8gb2JqLmZvbzsiLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjYsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=)

```js
/* eslint prefer-destructuring: "error" */

var foo = /* comment */ obj.foo;
```

**What did you expect to happen?**

Autofix should not remove comments.

**What actually happened? Please include the actual, raw output from ESLint.**

ESLint auto-fixed the code to:

```js
/* eslint prefer-destructuring: "error" */

var {foo} = obj;
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed `prefer-destructuring` to not auto-fix if that would remove comments. Any comment inside the `VariableDeclarator` will prevent fixing, except for those inside the right side's `object`, which will be preserved.

#### Is there anything you'd like reviewers to focus on?

* It would be possible to auto-fix and preserve other comments, but their surrounding context will change so maybe the comments should be changed as well. It seemed best to just not auto-fix and let the user fix everything if there are comments in the range.
* The added conditional could have been placed in `shouldFix`, but `fixIntoObjectDestructuring` seemed like a more appropriate place, as this check is closely related to the fixing algorithm.
