### PR TITLE
Fix: correct no-shadow false positives (fixes #12687)

### DIFF
--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -139,6 +139,98 @@ module.exports = {
         }
 
         /**
+         * Traverse `node`s heirarchy up to level and check if the range is the same
+         * @param {Object} surroundingNode The node around `node`
+         * @param {Object} node The node suspected of shadowing
+         * @param {number} level At what level in the parent hierarchy to check
+         * @returns {boolean} Whether or not they have the same range
+         */
+        function hasSameRange(surroundingNode, node, level) {
+            let parent = node;
+
+            for (let i = 0; i < level; i++) {
+                parent = parent.parent;
+                if (!parent) {
+                    return false;
+                }
+            }
+
+            if (
+                surroundingNode.range[0] === parent.range[0] &&
+                surroundingNode.range[1] === parent.range[1]
+            ) {
+                return true;
+            }
+
+            return false;
+        }
+
+        /**
+         * Checks whether the shadowing variable practically shadows
+         * @param {Object} shadowedVar The node being shadowed
+         * @param {Object} shadowingVar The node shadowing `shadowedVar`
+         * @returns {boolean} Whether or not the `shadowingVar` is practically inaccessible in the scope of shadowedVar
+         */
+        function isInaccessible(shadowedVar, shadowingVar) {
+            if (!(shadowedVar.defs[0] && shadowingVar.defs[0])) {
+                return false;
+            }
+
+            const shadowedNode = shadowedVar.defs[0].node;
+            const shadowNode = shadowingVar.defs[0].node;
+
+            // Skip variable declaration
+            if (shadowedNode.type === "VariableDeclarator") {
+                if (shadowNode.type === "ArrowFunctionExpression" || shadowNode.type === "FunctionDeclaration") {
+                    if (
+
+                        // a = (a) => ...
+                        (shadowNode.parent.type !== "BlockStatement" &&
+                            hasSameRange(shadowedNode, shadowNode, 2)) ||
+
+                        // a = [].map(a => ...)
+                        hasSameRange(shadowedNode, shadowNode, 4) ||
+                        hasSameRange(shadowedNode, shadowNode, 5)
+                    ) {
+                        return true;
+                    }
+                } else if (shadowNode.type === "VariableDeclarator" && shadowNode.parent.kind !== "var") {
+
+                    // Inaccesible declaration eg. const { a } = (() => { const a = ...; return a })()
+                    if (hasSameRange(shadowedNode, shadowNode, 5)) {
+                        return true;
+                    }
+                }
+            }
+
+            // Skip function param declaration eg. function func(a = [].find(a => true)) {}
+            if (
+                shadowedNode.type === "FunctionDeclaration" &&
+                (shadowNode.type === "ArrowFunctionExpression" || shadowNode.type === "FunctionDeclaration")
+            ) {
+                if (hasSameRange(shadowedNode, shadowNode, 3)) {
+                    return true;
+                }
+            }
+
+
+            // Skip for loop context eg. for (const a of [].find(a => true)) {}
+            if (
+                shadowedNode.parent && shadowedNode.parent.parent &&
+                (shadowedNode.parent.parent.type === "ForOfStatement" || shadowedNode.parent.parent.type === "ForInStatement") &&
+
+                shadowNode.parent && shadowNode.parent.parent &&
+                (shadowNode.parent.parent.type === "ForOfStatement" || shadowNode.parent.parent.type === "ForInStatement")
+            ) {
+                if (hasSameRange(shadowedNode.parent.parent, shadowNode, 2)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /**
          * Checks the current context for shadowed variables.
          * @param {Scope} scope Fixme
          * @returns {void}
@@ -165,6 +257,10 @@ module.exports = {
                     !isOnInitializer(variable, shadowed) &&
                     !(options.hoist !== "all" && isInTdz(variable, shadowed))
                 ) {
+                    if (isInaccessible(shadowed, variable)) {
+                        continue;
+                    }
+
                     context.report({
                         node: variable.identifiers[0],
                         messageId: "noShadow",

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -57,7 +57,16 @@ ruleTester.run("no-shadow", rule, {
         { code: "function foo() { var top = 0; }", env: { browser: true } },
         { code: "var Object = 0;", options: [{ builtinGlobals: true }] },
         { code: "var top = 0;", options: [{ builtinGlobals: true }], env: { browser: true } },
-        { code: "function foo(cb) { (function (cb) { cb(42); })(cb); }", options: [{ allow: ["cb"] }] }
+        { code: "function foo(cb) { (function (cb) { cb(42); })(cb); }", options: [{ allow: ["cb"] }] },
+        { code: "const a = [].find(a=>a)", parserOptions: { ecmaVersion: 6 } },
+        { code: "const [a = [].find(a => true)] = dummy", parserOptions: { ecmaVersion: 6 } },
+        { code: "const { a = [].find(a => true) } = dummy", parserOptions: { ecmaVersion: 6 } },
+        { code: "function func(a = [].find(a => true)) {}", parserOptions: { ecmaVersion: 6 } },
+        { code: "for (const a in [].find(a => true)) {}", parserOptions: { ecmaVersion: 6 } },
+        { code: "for (const a of [].find(a => true)) {}", parserOptions: { ecmaVersion: 6 } },
+        { code: "const a = [].map(a => true).filter(a => a === 'b')", parserOptions: { ecmaVersion: 6 } },
+        { code: "const { a } = (({ a }) => ({ a }))();", parserOptions: { ecmaVersion: 6 } },
+        { code: "const { a } = function() { const a = 1; return { a } }();", parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         {
@@ -526,6 +535,15 @@ ruleTester.run("no-shadow", rule, {
                 type: "Identifier",
                 line: 1,
                 column: 31
+            }]
+        },
+        {
+            code: "[].filter(a => a.find(a => a > 10));",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "noShadow",
+                data: { name: "a" },
+                type: "Identifier"
             }]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**
no-shadow

**Does this change cause the rule to produce more or fewer warnings?**
fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**
check explicitly for cases where its known that the bound variable is inaccessible

**Please provide some example code that this change will affect:**
```js
const person = people.find(person => person.name === "John");
```

**What does the rule currently do for this code?**
produces a warning that the `person` binding in the arrow function shadows the `person` const binding, which is incorrect.

**What will the rule do after it's changed?**
no longer show warnings for inaccessible variable bindings

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added checks for the different situations defined in #12687

#### Is there anything you'd like reviewers to focus on?
No