### PR TITLE
Fix: prefer-destructuring invalid autofix with computed property access

### DIFF
--- a/docs/rules/prefer-destructuring.md
+++ b/docs/rules/prefer-destructuring.md
@@ -21,6 +21,8 @@ The rule has a second object with a single key, `enforceForRenamedProperties`, w
 - Accessing an object property whose key is an integer will fall under the category `array` destructuring.
 - Accessing an array element through a computed index will fall under the category `object` destructuring.
 
+The `--fix` option on the command line fixes only problems reported in variable declarations, and among them only those that fall under the category `object` destructuring. Furthermore, the name of the declared variable has to be the same as the name used for non-computed member access in the initializer. For example, `var foo = object.foo` can be automatically fixed by this rule. Problems that involve computed member access (e.g., `var foo = object[foo]`) or renamed properties (e.g., `var foo = object.bar`) are not automatically fixed.
+
 Examples of **incorrect** code for this rule:
 
 ```javascript

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -163,6 +163,8 @@ module.exports = {
             return node.type === "VariableDeclarator" &&
                 node.id.type === "Identifier" &&
                 node.init.type === "MemberExpression" &&
+                !node.init.computed &&
+                node.init.property.type === "Identifier" &&
                 node.id.name === node.init.property.name;
         }
 

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -238,6 +238,16 @@ ruleTester.run("prefer-destructuring", rule, {
             }]
         },
         {
+            code: "var foo = object[foo];",
+            output: null,
+            options: [{ object: true }, { enforceForRenamedProperties: true }],
+            errors: [{
+                messageId: "preferDestructuring",
+                data: { type: "object" },
+                type: "VariableDeclarator"
+            }]
+        },
+        {
             code: "var foo = object['foo'];",
             output: null,
             errors: [{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.9.0
* **Node Version:** v12.18.4
* **npm Version:** v6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IHByZWZlci1kZXN0cnVjdHVyaW5nOiBbXCJlcnJvclwiLFxuICB7IFwib2JqZWN0XCI6IHRydWUgfSxcbiAgeyBcImVuZm9yY2VGb3JSZW5hbWVkUHJvcGVydGllc1wiOiB0cnVlIH1cbl0gKi9cblxudmFyIGEgPSBiW2FdOyIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js
/* eslint prefer-destructuring: ["error",
  { "object": true },
  { "enforceForRenamedProperties": true }
] */

var a = b[a];
```

**What did you expect to happen?**

1 error, but not with an invalid autofix.

**What actually happened? Please include the actual, raw output from ESLint.**

1 error and autofix to:

```js
/* eslint prefer-destructuring: ["error",
  { "object": true },
  { "enforceForRenamedProperties": true }
] */

var {a} = b;
```

This changes the semantics. A correct autofix would be `var { [a]: a } = b;`

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `prefer-destructuring` rule to not auto-fix in this case, since the rule generally doesn't auto-fix renamed properties. This was just mistakenly treated as if it was `var a = b.a;`.

#### Is there anything you'd like reviewers to focus on?
