### PR TITLE
Update: skip keyword check for fns in space-before-blocks (fixes #13553)

### DIFF
--- a/tests/fixtures/parsers/space-before-blocks/return-type-keyword-1.js
+++ b/tests/fixtures/parsers/space-before-blocks/return-type-keyword-1.js
@@ -1,0 +1,206 @@
+"use strict";
+
+/**
+ * Parser: @typescript-eslint/parser@4.2.0
+ * Source code:
+ * class A { foo(bar: string): void{} }
+ */
+
+exports.parse = () => ({
+    type: "Program",
+    body: [
+      {
+        type: "ClassDeclaration",
+        id: {
+          type: "Identifier",
+          name: "A",
+          range: [6, 7],
+          loc: { start: { line: 1, column: 6 }, end: { line: 1, column: 7 } },
+        },
+        body: {
+          type: "ClassBody",
+          body: [
+            {
+              type: "MethodDefinition",
+              key: {
+                type: "Identifier",
+                name: "foo",
+                range: [10, 13],
+                loc: {
+                  start: { line: 1, column: 10 },
+                  end: { line: 1, column: 13 },
+                },
+              },
+              value: {
+                type: "FunctionExpression",
+                id: null,
+                generator: false,
+                expression: false,
+                async: false,
+                body: {
+                  type: "BlockStatement",
+                  body: [],
+                  range: [32, 34],
+                  loc: {
+                    start: { line: 1, column: 32 },
+                    end: { line: 1, column: 34 },
+                  },
+                },
+                range: [13, 34],
+                params: [
+                  {
+                    type: "Identifier",
+                    name: "bar",
+                    range: [14, 25],
+                    loc: {
+                      start: { line: 1, column: 14 },
+                      end: { line: 1, column: 25 },
+                    },
+                    typeAnnotation: {
+                      type: "TSTypeAnnotation",
+                      loc: {
+                        start: { line: 1, column: 17 },
+                        end: { line: 1, column: 25 },
+                      },
+                      range: [17, 25],
+                      typeAnnotation: {
+                        type: "TSStringKeyword",
+                        range: [19, 25],
+                        loc: {
+                          start: { line: 1, column: 19 },
+                          end: { line: 1, column: 25 },
+                        },
+                      },
+                    },
+                  },
+                ],
+                loc: {
+                  start: { line: 1, column: 13 },
+                  end: { line: 1, column: 34 },
+                },
+                returnType: {
+                  type: "TSTypeAnnotation",
+                  loc: {
+                    start: { line: 1, column: 26 },
+                    end: { line: 1, column: 32 },
+                  },
+                  range: [26, 32],
+                  typeAnnotation: {
+                    type: "TSVoidKeyword",
+                    range: [28, 32],
+                    loc: {
+                      start: { line: 1, column: 28 },
+                      end: { line: 1, column: 32 },
+                    },
+                  },
+                },
+              },
+              computed: false,
+              static: false,
+              kind: "method",
+              range: [10, 34],
+              loc: {
+                start: { line: 1, column: 10 },
+                end: { line: 1, column: 34 },
+              },
+            },
+          ],
+          range: [8, 36],
+          loc: { start: { line: 1, column: 8 }, end: { line: 1, column: 36 } },
+        },
+        superClass: null,
+        range: [0, 36],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 36 } },
+      },
+    ],
+    sourceType: "script",
+    range: [0, 36],
+    loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 36 } },
+    tokens: [
+      {
+        type: "Keyword",
+        value: "class",
+        range: [0, 5],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } },
+      },
+      {
+        type: "Identifier",
+        value: "A",
+        range: [6, 7],
+        loc: { start: { line: 1, column: 6 }, end: { line: 1, column: 7 } },
+      },
+      {
+        type: "Punctuator",
+        value: "{",
+        range: [8, 9],
+        loc: { start: { line: 1, column: 8 }, end: { line: 1, column: 9 } },
+      },
+      {
+        type: "Identifier",
+        value: "foo",
+        range: [10, 13],
+        loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 13 } },
+      },
+      {
+        type: "Punctuator",
+        value: "(",
+        range: [13, 14],
+        loc: { start: { line: 1, column: 13 }, end: { line: 1, column: 14 } },
+      },
+      {
+        type: "Identifier",
+        value: "bar",
+        range: [14, 17],
+        loc: { start: { line: 1, column: 14 }, end: { line: 1, column: 17 } },
+      },
+      {
+        type: "Punctuator",
+        value: ":",
+        range: [17, 18],
+        loc: { start: { line: 1, column: 17 }, end: { line: 1, column: 18 } },
+      },
+      {
+        type: "Identifier",
+        value: "string",
+        range: [19, 25],
+        loc: { start: { line: 1, column: 19 }, end: { line: 1, column: 25 } },
+      },
+      {
+        type: "Punctuator",
+        value: ")",
+        range: [25, 26],
+        loc: { start: { line: 1, column: 25 }, end: { line: 1, column: 26 } },
+      },
+      {
+        type: "Punctuator",
+        value: ":",
+        range: [26, 27],
+        loc: { start: { line: 1, column: 26 }, end: { line: 1, column: 27 } },
+      },
+      {
+        type: "Keyword",
+        value: "void",
+        range: [28, 32],
+        loc: { start: { line: 1, column: 28 }, end: { line: 1, column: 32 } },
+      },
+      {
+        type: "Punctuator",
+        value: "{",
+        range: [32, 33],
+        loc: { start: { line: 1, column: 32 }, end: { line: 1, column: 33 } },
+      },
+      {
+        type: "Punctuator",
+        value: "}",
+        range: [33, 34],
+        loc: { start: { line: 1, column: 33 }, end: { line: 1, column: 34 } },
+      },
+      {
+        type: "Punctuator",
+        value: "}",
+        range: [35, 36],
+        loc: { start: { line: 1, column: 35 }, end: { line: 1, column: 36 } },
+      },
+    ],
+    comments: [],
+  });

--- a/tests/fixtures/parsers/space-before-blocks/return-type-keyword-2.js
+++ b/tests/fixtures/parsers/space-before-blocks/return-type-keyword-2.js
@@ -1,0 +1,98 @@
+"use strict";
+
+/**
+ * Parser: @typescript-eslint/parser@4.2.0
+ * Source code:
+ * function foo(): null {}
+ */
+
+exports.parse = () => ({
+    type: "Program",
+    body: [
+      {
+        type: "FunctionDeclaration",
+        id: {
+          type: "Identifier",
+          name: "foo",
+          range: [9, 12],
+          loc: { start: { line: 1, column: 9 }, end: { line: 1, column: 12 } },
+        },
+        generator: false,
+        expression: false,
+        async: false,
+        params: [],
+        body: {
+          type: "BlockStatement",
+          body: [],
+          range: [21, 23],
+          loc: { start: { line: 1, column: 21 }, end: { line: 1, column: 23 } },
+        },
+        range: [0, 23],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 23 } },
+        returnType: {
+          type: "TSTypeAnnotation",
+          loc: { start: { line: 1, column: 14 }, end: { line: 1, column: 20 } },
+          range: [14, 20],
+          typeAnnotation: {
+            type: "TSNullKeyword",
+            range: [16, 20],
+            loc: { start: { line: 1, column: 16 }, end: { line: 1, column: 20 } },
+          },
+        },
+      },
+    ],
+    sourceType: "script",
+    range: [0, 23],
+    loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 23 } },
+    tokens: [
+      {
+        type: "Keyword",
+        value: "function",
+        range: [0, 8],
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 8 } },
+      },
+      {
+        type: "Identifier",
+        value: "foo",
+        range: [9, 12],
+        loc: { start: { line: 1, column: 9 }, end: { line: 1, column: 12 } },
+      },
+      {
+        type: "Punctuator",
+        value: "(",
+        range: [12, 13],
+        loc: { start: { line: 1, column: 12 }, end: { line: 1, column: 13 } },
+      },
+      {
+        type: "Punctuator",
+        value: ")",
+        range: [13, 14],
+        loc: { start: { line: 1, column: 13 }, end: { line: 1, column: 14 } },
+      },
+      {
+        type: "Punctuator",
+        value: ":",
+        range: [14, 15],
+        loc: { start: { line: 1, column: 14 }, end: { line: 1, column: 15 } },
+      },
+      {
+        type: "Keyword",
+        value: "null",
+        range: [16, 20],
+        loc: { start: { line: 1, column: 16 }, end: { line: 1, column: 20 } },
+      },
+      {
+        type: "Punctuator",
+        value: "{",
+        range: [21, 22],
+        loc: { start: { line: 1, column: 21 }, end: { line: 1, column: 22 } },
+      },
+      {
+        type: "Punctuator",
+        value: "}",
+        range: [22, 23],
+        loc: { start: { line: 1, column: 22 }, end: { line: 1, column: 23 } },
+      },
+    ],
+    comments: [],
+  });

--- a/tests/lib/rules/space-before-blocks.js
+++ b/tests/lib/rules/space-before-blocks.js
@@ -10,7 +10,8 @@
 //------------------------------------------------------------------------------
 
 const rule = require("../../../lib/rules/space-before-blocks"),
-    { RuleTester } = require("../../../lib/rule-tester");
+    { RuleTester } = require("../../../lib/rule-tester"),
+    fixtureParser = require("../../fixtures/fixture-parser");
 
 //------------------------------------------------------------------------------
 // Tests
@@ -554,6 +555,21 @@ ruleTester.run("space-before-blocks", rule, {
             output: "class test{ constructor() {} }",
             options: classesNeverOthersOffArgs,
             parserOptions: { ecmaVersion: 6 },
+            errors: [expectedNoSpacingError]
+        },
+
+        // https://github.com/eslint/eslint/issues/13553
+        {
+            code: "class A { foo(bar: string): void{} }",
+            output: "class A { foo(bar: string): void {} }",
+            parser: fixtureParser("space-before-blocks", "return-type-keyword-1"),
+            errors: [expectedSpacingError]
+        },
+        {
+            code: "function foo(): null {}",
+            output: "function foo(): null{}",
+            options: neverArgs,
+            parser: fixtureParser("space-before-blocks", "return-type-keyword-2"),
             errors: [expectedNoSpacingError]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

fixes #13553

This change can produce **more** warnings in TypeScript code. It shouldn't make any difference for JS code.

Currently, `space-before-blocks` reports error in the following code:

```js
/* eslint space-before-blocks: ["error", "always"] */

function foo(): string{} // error
```

But, it doesn't report an error if the return type happens to end with a keyword token, like `void`:

```js
/* eslint space-before-blocks: ["error", "always"] */

function foo(): void{} // no errors
```

This PR aims to fix this inconsistency and make the rule work better with TS.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed `space-before-blocks` rule to skip the keyword check before blocks that represent a function body. In other words, to enforce spacing before function body blocks even if the preceding token is a keyword.

This rule generally doesn't enforce spacing between keywords and blocks, to avoid conflicts with the `keyword-spacing` rule. However, `keyword-spacing` enforces spacing only around keywords that appear in certain contexts, which doesn't include type annotations before function body blocks, so there are no conflicts in that range.

#### Is there anything you'd like reviewers to focus on?

I'd also like to refactor the confusing `{ASTNode|Token}` logic in another PR. It mistakenly reports `{` of a `switch` statement as a node, and also produces inconsistent locations.