### PR TITLE
Fix: account for linebreaks before postfix `++`/`--` in no-extra-parens

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -1109,7 +1109,22 @@ module.exports = {
             },
 
             UnaryExpression: checkArgumentWithPrecedence,
-            UpdateExpression: checkArgumentWithPrecedence,
+            UpdateExpression(node) {
+                if (node.prefix) {
+                    checkArgumentWithPrecedence(node);
+                } else {
+                    const { argument } = node;
+                    const operatorToken = sourceCode.getLastToken(node);
+
+                    if (argument.loc.end.line === operatorToken.loc.start.line) {
+                        checkArgumentWithPrecedence(node);
+                    } else {
+                        if (hasDoubleExcessParens(argument)) {
+                            report(argument);
+                        }
+                    }
+                }
+            },
             AwaitExpression: checkArgumentWithPrecedence,
 
             VariableDeclarator(node) {

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -363,6 +363,15 @@ ruleTester.run("no-extra-parens", rule, {
             "}"
         ].join("\n"),
 
+        // linebreaks before postfix update operators are not allowed
+        "(a\n)++",
+        "(a\n)--",
+        "(a\n\n)++",
+        "(a.b\n)--",
+        "(a\n.b\n)++",
+        "(a[\nb\n]\n)--",
+        "(a[b]\n\n)++",
+
         // async/await
         "async function a() { await (a + b) }",
         "async function a() { await (a + await b) }",
@@ -755,6 +764,18 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("+((bar-foo))", "+(bar-foo)", "BinaryExpression"),
         invalid("++(foo)", "++foo", "Identifier"),
         invalid("--(foo)", "--foo", "Identifier"),
+        invalid("++\n(foo)", "++\nfoo", "Identifier"),
+        invalid("--\n(foo)", "--\nfoo", "Identifier"),
+        invalid("++(\nfoo)", "++\nfoo", "Identifier"),
+        invalid("--(\nfoo)", "--\nfoo", "Identifier"),
+        invalid("(foo)++", "foo++", "Identifier"),
+        invalid("(foo)--", "foo--", "Identifier"),
+        invalid("((foo)\n)++", "(foo\n)++", "Identifier"),
+        invalid("((foo\n))--", "(foo\n)--", "Identifier"),
+        invalid("((foo\n)\n)++", "(foo\n\n)++", "Identifier"),
+        invalid("(a\n.b)--", "a\n.b--", "MemberExpression"),
+        invalid("(a.\nb)++", "a.\nb++", "MemberExpression"),
+        invalid("(a\n[\nb\n])--", "a\n[\nb\n]--", "MemberExpression"),
         invalid("(a || b) ? c : d", "a || b ? c : d", "LogicalExpression"),
         invalid("a ? (b = c) : d", "a ? b = c : d", "AssignmentExpression"),
         invalid("a ? b : (c = d)", "a ? b : c = d", "AssignmentExpression"),


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.10.0
* **Node Version:** v12.18.4
* **npm Version:** v6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWV4dHJhLXBhcmVuczogXCJlcnJvclwiICovXG5cbihhXG4pKytcbiIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6Im1vZHVsZSIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6eyJicm93c2VyIjpmYWxzZX19fQ==)

```js
/* eslint no-extra-parens: "error" */

(a
)++
```

**What did you expect to happen?**

No errors. Per the specification for [`UpdateExpression`](https://www.ecma-international.org/ecma-262/11.0/index.html#sec-update-expressions), linebreaks are not allowed before postfix `++` and `--`. In similar situations (`return`, `throw`, `yield`) `no-extra-parens` doesn't report an error.

**What actually happened? Please include the actual, raw output from ESLint.**

`no-extra-parens` error and auto-fix to:

```js
/* eslint no-extra-parens: "error" */

a
++

```

Message after the auto-fix:

```
  5:1  error  Parsing error: Unexpected token
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `no-extra-parens` rule to not report an error if the parenthesized argument of an `UpdateExpression` is not on the same line as the postfix operator.

#### Is there anything you'd like reviewers to focus on?
