### PR TITLE
Fix: don't count line after EOF in max-lines

### DIFF
--- a/docs/rules/max-lines.md
+++ b/docs/rules/max-lines.md
@@ -6,6 +6,7 @@ Some people consider large files a code smell. Large files tend to do a lot of t
 
 This rule enforces a maximum number of lines per file, in order to aid in maintainability and reduce complexity.
 
+Please note that most editors show an additional empty line at the end if the file ends with a line break. This rule does not count that extra line.
 
 ## Options
 

--- a/lib/rules/max-lines.js
+++ b/lib/rules/max-lines.js
@@ -131,6 +131,14 @@ module.exports = {
                     text
                 }));
 
+                /*
+                 * If file ends with a linebreak, `sourceCode.lines` will have one extra empty line at the end.
+                 * That isn't a real line, so we shouldn't count it.
+                 */
+                if (lines.length > 1 && lodash.last(lines).text === "") {
+                    lines.pop();
+                }
+
                 if (skipBlankLines) {
                     lines = lines.filter(l => l.text.trim() !== "");
                 }

--- a/tests/lib/rules/max-lines.js
+++ b/tests/lib/rules/max-lines.js
@@ -21,8 +21,15 @@ ruleTester.run("max-lines", rule, {
     valid: [
         "var x;",
         "var xy;\nvar xy;",
+        { code: "A", options: [1] },
+        { code: "A\n", options: [1] },
+        { code: "A\r", options: [1] },
+        { code: "A\r\n", options: [1] },
         { code: "var xy;\nvar xy;", options: [2] },
+        { code: "var xy;\nvar xy;\n", options: [2] },
         { code: "var xy;\nvar xy;", options: [{ max: 2 }] },
+        { code: "// comment\n", options: [{ max: 0, skipComments: true }] },
+        { code: "foo;\n /* comment */\n", options: [{ max: 1, skipComments: true }] },
         {
             code: [
                 "//a single line comment",
@@ -234,6 +241,50 @@ ruleTester.run("max-lines", rule, {
             ]
         },
         {
+
+            // Questionable. Makes sense to report this, and makes sense to not report this.
+            code: "",
+            options: [{ max: 0 }],
+            errors: [
+                {
+                    messageId: "exceed",
+                    data: { max: 0, actual: 1 },
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 1
+                }
+            ]
+        },
+        {
+            code: " ",
+            options: [{ max: 0 }],
+            errors: [
+                {
+                    messageId: "exceed",
+                    data: { max: 0, actual: 1 },
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 2
+                }
+            ]
+        },
+        {
+            code: "\n",
+            options: [{ max: 0 }],
+            errors: [
+                {
+                    messageId: "exceed",
+                    data: { max: 0, actual: 1 },
+                    line: 1,
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 1
+                }
+            ]
+        },
+        {
             code: "A",
             options: [{ max: 0 }],
             errors: [
@@ -244,6 +295,62 @@ ruleTester.run("max-lines", rule, {
                     column: 1,
                     endLine: 1,
                     endColumn: 2
+                }
+            ]
+        },
+        {
+            code: "A\n",
+            options: [{ max: 0 }],
+            errors: [
+                {
+                    messageId: "exceed",
+                    data: { max: 0, actual: 1 },
+                    line: 1,
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 1
+                }
+            ]
+        },
+        {
+            code: "A\n ",
+            options: [{ max: 0 }],
+            errors: [
+                {
+                    messageId: "exceed",
+                    data: { max: 0, actual: 2 },
+                    line: 1,
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 2
+                }
+            ]
+        },
+        {
+            code: "A\n ",
+            options: [{ max: 1 }],
+            errors: [
+                {
+                    messageId: "exceed",
+                    data: { max: 1, actual: 2 },
+                    line: 2,
+                    column: 1,
+                    endLine: 2,
+                    endColumn: 2
+                }
+            ]
+        },
+        {
+            code: "A\n\n",
+            options: [{ max: 1 }],
+            errors: [
+                {
+                    messageId: "exceed",
+                    data: { max: 1, actual: 2 },
+                    line: 2,
+                    column: 1,
+                    endLine: 3,
+                    endColumn: 1
                 }
             ]
         },
@@ -269,7 +376,7 @@ ruleTester.run("max-lines", rule, {
             errors: [
                 {
                     messageId: "exceed",
-                    data: { max: 2, actual: 4 },
+                    data: { max: 2, actual: 3 },
                     line: 3,
                     column: 1,
                     endLine: 4,
@@ -283,7 +390,7 @@ ruleTester.run("max-lines", rule, {
             errors: [
                 {
                     messageId: "exceed",
-                    data: { max: 2, actual: 4 },
+                    data: { max: 2, actual: 3 },
                     line: 3,
                     column: 1,
                     endLine: 4,
@@ -352,6 +459,26 @@ ruleTester.run("max-lines", rule, {
                 "var x",
                 "var c;",
                 "console.log",
+                "/* block comments */\n"
+            ].join("\n"),
+            options: [{ max: 2, skipComments: true }],
+            errors: [
+                {
+                    messageId: "exceed",
+                    data: { max: 2, actual: 4 },
+                    line: 3,
+                    column: 1,
+                    endLine: 6,
+                    endColumn: 1
+                }
+            ]
+        },
+        {
+            code: [
+                "var a = 'a'; ",
+                "var x",
+                "var c;",
+                "console.log",
                 "/** block \n\n comments */"
             ].join("\n"),
             options: [{ max: 2, skipComments: true }],
@@ -363,6 +490,25 @@ ruleTester.run("max-lines", rule, {
                     column: 1,
                     endLine: 7,
                     endColumn: 13
+                }
+            ]
+        },
+        {
+            code: [
+                "var a = 'a'; ",
+                "",
+                "",
+                "// comment"
+            ].join("\n"),
+            options: [{ max: 2, skipComments: true }],
+            errors: [
+                {
+                    messageId: "exceed",
+                    data: { max: 2, actual: 3 },
+                    line: 3,
+                    column: 1,
+                    endLine: 4,
+                    endColumn: 11
                 }
             ]
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.10.0
* **Node Version:** v12.18.4
* **npm Version:** v6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG1heC1saW5lczogW1wiZXJyb3JcIiwgeyBtYXg6IDMgfV0gKi9cbnNlY29uZF9saW5lXG50aGlyZF9saW5lXG4iLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjYsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=)

```js
/* eslint max-lines: ["error", { max: 3 }] */
second_line
third_line

```

There's a linebreak at the end of `third_line`, and nothing after that linebreak.

**What did you expect to happen?**

No errors. Editors may show 4 lines, but in this case there are only 3 real lines.

**What actually happened? Please include the actual, raw output from ESLint.**

1 error:

```
  4:1  error  File has too many lines (4). Maximum allowed is 3  max-lines
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `max-lines` rule to not count line after EOF.

#### Is there anything you'd like reviewers to focus on?
