### PR TITLE
Docs: fix of `first` examples in semi-style

### DIFF
--- a/docs/rules/semi-style.md
+++ b/docs/rules/semi-style.md
@@ -60,9 +60,9 @@ foo();
 [1, 2, 3].forEach(bar)
 
 for (
-    var i = 0
-    ; i < 10
-    ; ++i
+    var i = 0;
+    i < 10;
+    ++i
 ) {
     foo()
 }
@@ -77,9 +77,9 @@ foo()
 ;[1, 2, 3].forEach(bar)
 
 for (
-    var i = 0;
-    i < 10;
-    ++i
+    var i = 0
+    ; i < 10
+    ; ++i
 ) {
     foo()
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [X] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
The semicolon seemed to be in the wrong place in the `first` example, probably from a copy/paste.

#### Is there anything you'd like reviewers to focus on?
