### PR TITLE
New: add no-dupe-ternary-expression (refs #13744)

### DIFF
--- a/docs/rules/no-dupe-ternary-expressions.md
+++ b/docs/rules/no-dupe-ternary-expressions.md
@@ -1,0 +1,66 @@
+# Disallow duplicate left and right hand ternary expressions (no-dupe-ternary-expressions)
+
+Ternary operators are most often used as a shorthand `if-else` clause to execute code based on the conditional expression of the ternary operator.
+
+```js
+const getFee = (isMember) => isMember ? 2.00 : 3.00;
+```
+
+Identical left and right-hand ternary expressions are almost always a mistake in the code. Unless there are side effects in the expressions, identical left and right hand expressions mean the same code will be executed whether or not the condition being tested evaluates to true or false.
+
+```js
+const getFee = (isMember) => isMember ? 2.00 : 2.00;
+```
+
+In the above example `getFee()` will always return the same fee whether or not `isMember` is true or false.
+
+## Rule Details
+
+This rule disallows identical left and right hand ternary expressions, no matter how far or where they are nested.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-dupe-ternary-expressions: "error"*/
+
+const getFee = (isMember) => isMember ? 2.00 : 2.00;
+
+const formula = complexCondition1 && complexCondition2 ? `(${User.months}*${currentRate})-${User.fee}` : `(${User.months}*${currentRate})-${User.fee}`
+
+thing === otherThing
+  ? User.a && myBoolean
+  : User.a && myBoolean
+
+condition1 ? foo() : condition2 ? bar() : condition3 ? baz() : baz()
+
+5 < 7 ? (5 < 6 ? true : true) : false
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-dupe-ternary-expressions: "error"*/
+
+const getFee = (isMember) => isMember ? 2.00 : 3.00;
+
+const formula = complexCondition1 && complexCondition2 ? `(${User.months}*${currentRate})-${User.fee}` : `(${User.months}*${oldRate})-${User.fee}`
+
+thing === otherThing
+  ? User.a && myBoolean
+  : User.b && myBoolean
+
+condition1 ? foo() : condition2 ? bar() : condition3 ? baz() : qux()
+
+5 < 7 ? (5 < 6 ? true : false) : false
+```
+
+## When Not To Use It
+
+It is difficult to imagine a scenario wherein a developer explicitly needs identical left and right hand ternary expressions. Strictly speaking this would mean the ternary operator is unnecessary since the same result could be achieved by executing that code without any condition being checked. If you find or think of any examples please [file an issue][0] and let us know.
+
+## Related Rules
+
+* [no-dupe-else-if](no-dupe-else-if.md)
+* [no-unneeded-ternary](no-unneeded-ternary.md)
+
+  [0]: https://github.com/eslint/eslint/issues/new/choose

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -114,6 +114,7 @@ module.exports = new LazyLoadingRuleMap(Object.entries({
     "no-dupe-class-members": () => require("./no-dupe-class-members"),
     "no-dupe-else-if": () => require("./no-dupe-else-if"),
     "no-dupe-keys": () => require("./no-dupe-keys"),
+    "no-dupe-ternary-expressions": () => require("./no-dupe-ternary-expressions"),
     "no-duplicate-case": () => require("./no-duplicate-case"),
     "no-duplicate-imports": () => require("./no-duplicate-imports"),
     "no-else-return": () => require("./no-else-return"),

--- a/lib/rules/no-dupe-ternary-expressions.js
+++ b/lib/rules/no-dupe-ternary-expressions.js
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Disallow duplicate left and right hand ternary expressions
+ * @author Che Fisher
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        type: "problem",
+
+        docs: {
+            description: "disallow duplicate left and right hand ternary expressions",
+            category: "Possible Errors",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/no-dupe-ternary-expressions"
+        },
+
+        schema: [],
+
+        messages: {
+            duplicateExpression: "Identical left and right-hand expressions '{{expression}}'."
+        }
+    },
+
+    create(context) {
+        const sourceCode = context.getSourceCode();
+        const text = sourceCode.getText();
+
+        //----------------------------------------------------------------------
+        // Helpers
+        //----------------------------------------------------------------------
+
+        /**
+         * Test if a node has identical alternate and consequent expressions i.e. id ? expression : expression
+         * @param  {ASTNode} node The node to report.
+         * @returns {boolean} True if expressions are identical
+         * @private
+         */
+        function isDuplicateExpression(node) {
+            const left = node.alternate;
+            const right = node.consequent;
+
+            return left && right &&
+                text.slice(...left.range) === text.slice(...right.range);
+        }
+
+        return {
+            ConditionalExpression(node) {
+                if (isDuplicateExpression(node)) {
+                    context.report({
+                        node,
+                        messageId: "duplicateExpression",
+                        data: {
+                            expression: node.alternate
+                        }
+                    });
+                }
+            }
+
+        };
+    }
+};

--- a/tests/lib/rules/no-dupe-ternary-expressions.js
+++ b/tests/lib/rules/no-dupe-ternary-expressions.js
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview Disallow duplicate left and right hand ternary expressions
+ * @author Che Fisher
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-dupe-ternary-expressions"),
+    { RuleTester } = require("../../../lib/rule-tester");
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-dupe-ternary-expressions", rule, {
+
+    valid: [
+        "isMember ? 2.00 : 3.00;",
+        "formula = condition && condition1 ? User.months * currentRate - User.fee : User.months * oldRate - User.fee",
+        "thing === otherThing\n  ? User.a && myBoolean\n  : User.b && myBoolean",
+        "condition1 ? foo() : condition2 ? bar() : condition3 ? baz() : qux()",
+        "5 < 7 ? (5 < 6 ? true : false) : false"
+    ],
+
+    invalid: [
+        {
+            code: "isMember ? 2.00 : 2.00",
+            errors: [{
+                messageId: "duplicateExpression",
+                type: "ConditionalExpression"
+            }]
+        },
+        {
+            code: "formula = condition && condition1 ? User.months * oldRate - User.fee : User.months * oldRate - User.fee",
+            errors: [{
+                messageId: "duplicateExpression",
+                type: "ConditionalExpression"
+            }]
+        },
+        {
+            code: "thing === otherThing\n  ? User.a && myBoolean\n  : User.a && myBoolean",
+            errors: [{
+                messageId: "duplicateExpression",
+                type: "ConditionalExpression"
+            }]
+        },
+        {
+            code: "condition1 ? foo() : condition2 ? bar() : condition3 ? baz(true) : baz(true)",
+            errors: [{
+                messageId: "duplicateExpression",
+                type: "ConditionalExpression"
+            }]
+        },
+        {
+            code: "5 < 7 ? (5 < 6 ? false : false) : true",
+            errors: [{
+                messageId: "duplicateExpression",
+                type: "ConditionalExpression"
+            }]
+        }
+    ]
+});

--- a/tools/rule-types.json
+++ b/tools/rule-types.json
@@ -101,6 +101,7 @@
     "no-dupe-class-members": "problem",
     "no-dupe-else-if": "problem",
     "no-dupe-keys": "problem",
+    "no-dupe-ternary-expressions": "problem",
     "no-duplicate-case": "problem",
     "no-duplicate-imports": "problem",
     "no-else-return": "suggestion",


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))

**Please describe what the rule should do:**
This rule should detect duplicate ternary expressions (i.e. identical ternary alternate and consequent nodes).

**What category of rule is this? (place an "X" next to just one item)**

- [x] Warns about a potential error

**Provide 2-3 code examples that this rule will warn about:**

```js
        "const getFee = isMember => isMember ? 2.00 : 2.00;",
        "formula = condition && condition1 ? User.months * oldRate - User.fee : User.months * oldRate - User.fee",
        "condition1 ? foo() : condition2 ? bar() : condition3 ? baz() : baz()",
        "5 < 7 ? (5 < 6 ? false : false) : true"
```

**Why should this rule be included in ESLint (instead of a plugin)?**

It warns about a very likely problem that is applicable to any/all projects.

#### What changes did you make? (Give an overview)

- added docs explaining rule and limitations
- added tests
- added core rule logic

#### Is there anything you'd like reviewers to focus on?
The rule has been discussed [here](https://github.com/eslint/eslint/issues/13744).

The rule ended up being deceptively simple to write. If reviewers could please focus on the tests and whether they cover all edge cases that would be greatly appreciated.

This rule does **not** detect duplicate ternary conditions.