### PR TITLE
Update: check computed keys in no-prototype-builtins (fixes #13088)

### DIFF
--- a/lib/rules/no-prototype-builtins.js
+++ b/lib/rules/no-prototype-builtins.js
@@ -46,15 +46,15 @@ module.exports = {
          */
         function disallowBuiltIns(node) {
 
-            // TODO: just use `astUtils.getStaticPropertyName(node.callee)`
             const callee = astUtils.skipChainExpression(node.callee);
 
-            if (callee.type !== "MemberExpression" || callee.computed) {
+            if (callee.type !== "MemberExpression") {
                 return;
             }
-            const propName = callee.property.name;
 
-            if (DISALLOWED_PROPS.indexOf(propName) > -1) {
+            const propName = astUtils.getStaticPropertyName(callee);
+
+            if (propName !== null && DISALLOWED_PROPS.indexOf(propName) > -1) {
                 context.report({
                     messageId: "prototypeBuildIn",
                     loc: callee.property.loc,

--- a/tests/lib/rules/no-prototype-builtins.js
+++ b/tests/lib/rules/no-prototype-builtins.js
@@ -17,99 +17,156 @@ const rule = require("../../../lib/rules/no-prototype-builtins"),
 //------------------------------------------------------------------------------
 const ruleTester = new RuleTester();
 
-const valid = [
-    { code: "Object.prototype.hasOwnProperty.call(foo, 'bar')" },
-    { code: "Object.prototype.isPrototypeOf.call(foo, 'bar')" },
-    { code: "Object.prototype.propertyIsEnumerable.call(foo, 'bar')" },
-    { code: "Object.prototype.hasOwnProperty.apply(foo, ['bar'])" },
-    { code: "Object.prototype.isPrototypeOf.apply(foo, ['bar'])" },
-    { code: "Object.prototype.propertyIsEnumerable.apply(foo, ['bar'])" },
-    { code: "hasOwnProperty(foo, 'bar')" },
-    { code: "isPrototypeOf(foo, 'bar')" },
-    { code: "propertyIsEnumerable(foo, 'bar')" },
-    { code: "({}.hasOwnProperty.call(foo, 'bar'))" },
-    { code: "({}.isPrototypeOf.call(foo, 'bar'))" },
-    { code: "({}.propertyIsEnumerable.call(foo, 'bar'))" },
-    { code: "({}.hasOwnProperty.apply(foo, ['bar']))" },
-    { code: "({}.isPrototypeOf.apply(foo, ['bar']))" },
-    { code: "({}.propertyIsEnumerable.apply(foo, ['bar']))" }
-];
-
-const invalid = [
-    {
-        code: "foo.hasOwnProperty('bar')",
-        errors: [{
-            line: 1,
-            column: 5,
-            endLine: 1,
-            endColumn: 19,
-            messageId: "prototypeBuildIn",
-            data: { prop: "hasOwnProperty" },
-            type: "CallExpression"
-        }]
-    },
-    {
-        code: "foo.isPrototypeOf('bar')",
-        errors: [{
-            line: 1,
-            column: 5,
-            endLine: 1,
-            endColumn: 18,
-            messageId: "prototypeBuildIn",
-            data: { prop: "isPrototypeOf" },
-            type: "CallExpression"
-        }]
-    },
-    {
-        code: "foo.propertyIsEnumerable('bar')",
-        errors: [{
-            line: 1,
-            column: 5,
-            endLine: 1,
-            endColumn: 25,
-            messageId: "prototypeBuildIn",
-            data: { prop: "propertyIsEnumerable" }
-        }]
-    },
-    {
-        code: "foo.bar.hasOwnProperty('bar')",
-        errors: [{
-            line: 1,
-            column: 9,
-            endLine: 1,
-            endColumn: 23,
-            messageId: "prototypeBuildIn",
-            data: { prop: "hasOwnProperty" },
-            type: "CallExpression"
-        }]
-    },
-    {
-        code: "foo.bar.baz.isPrototypeOf('bar')",
-        errors: [{
-            line: 1,
-            column: 13,
-            endLine: 1,
-            endColumn: 26,
-            messageId: "prototypeBuildIn",
-            data: { prop: "isPrototypeOf" },
-            type: "CallExpression"
-        }]
-    },
-
-    // Optional chaining
-    {
-        code: "foo?.hasOwnProperty('bar')",
-        parserOptions: { ecmaVersion: 2020 },
-        errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" } }]
-    },
-    {
-        code: "(foo?.hasOwnProperty)('bar')",
-        parserOptions: { ecmaVersion: 2020 },
-        errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" } }]
-    }
-];
-
 ruleTester.run("no-prototype-builtins", rule, {
-    valid,
-    invalid
+    valid: [
+        "Object.prototype.hasOwnProperty.call(foo, 'bar')",
+        "Object.prototype.isPrototypeOf.call(foo, 'bar')",
+        "Object.prototype.propertyIsEnumerable.call(foo, 'bar')",
+        "Object.prototype.hasOwnProperty.apply(foo, ['bar'])",
+        "Object.prototype.isPrototypeOf.apply(foo, ['bar'])",
+        "Object.prototype.propertyIsEnumerable.apply(foo, ['bar'])",
+        "foo.hasOwnProperty",
+        "foo.hasOwnProperty.bar()",
+        "foo(hasOwnProperty)",
+        "hasOwnProperty(foo, 'bar')",
+        "isPrototypeOf(foo, 'bar')",
+        "propertyIsEnumerable(foo, 'bar')",
+        "({}.hasOwnProperty.call(foo, 'bar'))",
+        "({}.isPrototypeOf.call(foo, 'bar'))",
+        "({}.propertyIsEnumerable.call(foo, 'bar'))",
+        "({}.hasOwnProperty.apply(foo, ['bar']))",
+        "({}.isPrototypeOf.apply(foo, ['bar']))",
+        "({}.propertyIsEnumerable.apply(foo, ['bar']))",
+        "foo[hasOwnProperty]('bar')",
+        "foo['HasOwnProperty']('bar')",
+        { code: "foo[`isPrototypeOff`]('bar')", parserOptions: { ecmaVersion: 2015 } },
+        { code: "foo?.['propertyIsEnumerabl']('bar')", parserOptions: { ecmaVersion: 2020 } },
+        "foo[1]('bar')",
+        "foo[null]('bar')",
+
+        // out of scope for this rule
+        "foo['hasOwn' + 'Property']('bar')",
+        { code: "foo[`hasOwnProperty${''}`]('bar')", parserOptions: { ecmaVersion: 2015 } }
+    ],
+
+    invalid: [
+        {
+            code: "foo.hasOwnProperty('bar')",
+            errors: [{
+                line: 1,
+                column: 5,
+                endLine: 1,
+                endColumn: 19,
+                messageId: "prototypeBuildIn",
+                data: { prop: "hasOwnProperty" },
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "foo.isPrototypeOf('bar')",
+            errors: [{
+                line: 1,
+                column: 5,
+                endLine: 1,
+                endColumn: 18,
+                messageId: "prototypeBuildIn",
+                data: { prop: "isPrototypeOf" },
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "foo.propertyIsEnumerable('bar')",
+            errors: [{
+                line: 1,
+                column: 5,
+                endLine: 1,
+                endColumn: 25,
+                messageId: "prototypeBuildIn",
+                data: { prop: "propertyIsEnumerable" }
+            }]
+        },
+        {
+            code: "foo.bar.hasOwnProperty('bar')",
+            errors: [{
+                line: 1,
+                column: 9,
+                endLine: 1,
+                endColumn: 23,
+                messageId: "prototypeBuildIn",
+                data: { prop: "hasOwnProperty" },
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "foo.bar.baz.isPrototypeOf('bar')",
+            errors: [{
+                line: 1,
+                column: 13,
+                endLine: 1,
+                endColumn: 26,
+                messageId: "prototypeBuildIn",
+                data: { prop: "isPrototypeOf" },
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "foo['hasOwnProperty']('bar')",
+            errors: [{
+                line: 1,
+                column: 5,
+                endLine: 1,
+                endColumn: 21,
+                messageId: "prototypeBuildIn",
+                data: { prop: "hasOwnProperty" },
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "foo[`isPrototypeOf`]('bar').baz",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                line: 1,
+                column: 5,
+                endLine: 1,
+                endColumn: 20,
+                messageId: "prototypeBuildIn",
+                data: { prop: "isPrototypeOf" },
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: String.raw`foo.bar["propertyIsEnumerable"]('baz')`,
+            errors: [{
+                line: 1,
+                column: 9,
+                endLine: 1,
+                endColumn: 31,
+                messageId: "prototypeBuildIn",
+                data: { prop: "propertyIsEnumerable" },
+                type: "CallExpression"
+            }]
+        },
+
+        // Optional chaining
+        {
+            code: "foo?.hasOwnProperty('bar')",
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" } }]
+        },
+        {
+            code: "(foo?.hasOwnProperty)('bar')",
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" } }]
+        },
+        {
+            code: "foo?.['hasOwnProperty']('bar')",
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" } }]
+        },
+        {
+            code: "(foo?.[`hasOwnProperty`])('bar')",
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" } }]
+        }
+    ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

fixes #13088

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed `no-prototype-builtins` rule to check computed property access and report simple cases like `foo["hasOwnProperty"]("bar")`.

Also refactored the test file so that the tests can be checked by `eslint-plugin-eslint-plugin` rules.

#### Is there anything you'd like reviewers to focus on?

The removed TODO suggested to just replace all lines with `astUtils.getStaticPropertyName(node.callee)` but I think it's more correct to explicitly check for `MemberExpression`. Also, `astUtils.skipChainExpression` would be anyway needed to get `callee.property.loc`. 
