### PR TITLE
Fix: yoda rule autofix produces syntax errors with adjacent tokens

### DIFF
--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -265,36 +265,37 @@ module.exports = {
          * @returns {string} A string representation of the node with the sides and operator flipped
          */
         function getFlippedString(node) {
-            const tokenBefore = sourceCode.getTokenBefore(node);
             const operatorToken = sourceCode.getFirstTokenBetween(
                 node.left,
                 node.right,
                 token => token.value === node.operator
             );
-            const textBeforeOperator = sourceCode
-                .getText()
-                .slice(
-                    sourceCode.getTokenBefore(operatorToken).range[1],
-                    operatorToken.range[0]
-                );
-            const textAfterOperator = sourceCode
-                .getText()
-                .slice(
-                    operatorToken.range[1],
-                    sourceCode.getTokenAfter(operatorToken).range[0]
-                );
-            const leftText = sourceCode
-                .getText()
-                .slice(
-                    node.range[0],
-                    sourceCode.getTokenBefore(operatorToken).range[1]
-                );
+            const lastLeftToken = sourceCode.getTokenBefore(operatorToken);
             const firstRightToken = sourceCode.getTokenAfter(operatorToken);
-            const rightText = sourceCode
-                .getText()
-                .slice(firstRightToken.range[0], node.range[1]);
 
+            const source = sourceCode.getText();
+
+            const leftText = source.slice(
+                node.range[0],
+                lastLeftToken.range[1]
+            );
+            const textBeforeOperator = source.slice(
+                lastLeftToken.range[1],
+                operatorToken.range[0]
+            );
+            const textAfterOperator = source.slice(
+                operatorToken.range[1],
+                firstRightToken.range[0]
+            );
+            const rightText = source.slice(
+                firstRightToken.range[0],
+                node.range[1]
+            );
+
+            const tokenBefore = sourceCode.getTokenBefore(node);
+            const tokenAfter = sourceCode.getTokenAfter(node);
             let prefix = "";
+            let suffix = "";
 
             if (
                 tokenBefore &&
@@ -304,13 +305,22 @@ module.exports = {
                 prefix = " ";
             }
 
+            if (
+                tokenAfter &&
+                node.range[1] === tokenAfter.range[0] &&
+                !astUtils.canTokensBeAdjacent(lastLeftToken, tokenAfter)
+            ) {
+                suffix = " ";
+            }
+
             return (
                 prefix +
                 rightText +
                 textBeforeOperator +
                 OPERATOR_FLIP_MAP[operatorToken.value] +
                 textAfterOperator +
-                leftText
+                leftText +
+                suffix
             );
         }
 

--- a/tests/lib/rules/yoda.js
+++ b/tests/lib/rules/yoda.js
@@ -1165,6 +1165,150 @@ ruleTester.run("yoda", rule, {
             ]
         },
         {
+            code: "0 < f()in obj",
+            output: "f() > 0 in obj",
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: "<" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "1 > x++instanceof foo",
+            output: "x++ < 1 instanceof foo",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: ">" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "x < ('foo')in bar",
+            output: "('foo') > x in bar",
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "left", operator: "<" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "false <= ((x))in foo",
+            output: "((x)) >= false in foo",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: "<=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "x >= (1)instanceof foo",
+            output: "(1) <= x instanceof foo",
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "left", operator: ">=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "false <= ((x)) in foo",
+            output: "((x)) >= false in foo",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: "<=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "x >= 1 instanceof foo",
+            output: "1 <= x instanceof foo",
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "left", operator: ">=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "x >= 1/**/instanceof foo",
+            output: "1 <= x/**/instanceof foo",
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "left", operator: ">=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "(x >= 1)instanceof foo",
+            output: "(1 <= x)instanceof foo",
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "left", operator: ">=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "(x) >= (1)instanceof foo",
+            output: "(1) <= (x)instanceof foo",
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "left", operator: ">=" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "1 > x===foo",
+            output: "x < 1===foo",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: ">" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "1 > x",
+            output: "x < 1",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "expected",
+                    data: { expectedSide: "right", operator: ">" },
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+
+        {
             code: "if (`green` < x.y && x.y < `blue`) {}",
             output: "if (`green` < x.y && `blue` > x.y) {}",
             options: ["always", { exceptRange: true }],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.11.0
* **Node Version:** v12.18.4
* **npm Version:** v6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IHlvZGE6IFwiZXJyb3JcIiAqL1xuXG4wIDwgZigpaW4gb2JqXG4iLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjUsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=)

```js
/* eslint yoda: "error" */

0 < f()in obj
```

**What did you expect to happen?**

1 error and correctly fixed code.

**What actually happened? Please include the actual, raw output from ESLint.**

1 error, autofixed to:

```js
/* eslint yoda: "error" */

f() > 0in obj
```

```
  3:8  error  Parsing error: Identifier directly after number
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the autofix to add a space if tokens on the right side cannot be adjacent.

#### Is there anything you'd like reviewers to focus on?
