### PR TITLE
Update: Fix && vs || short-circuiting false negatives (fixes #13634)

### DIFF
--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -79,6 +79,17 @@ function isPossibleConstructor(node) {
             return false;
 
         case "LogicalExpression":
+
+            /*
+             * If the && operator shortcuts, the left side was falsy and therefore not a constructor, and if
+             * it doesn't shortcut, it takes the value from the right side, so the right side must always be a
+             * possible constructor. A future improvement could verify that the left side could be truthy by
+             * excluding falsy literals.
+             */
+            if (node.operator === "&&") {
+                return isPossibleConstructor(node.right);
+            }
+
             return (
                 isPossibleConstructor(node.left) ||
                 isPossibleConstructor(node.right)

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -81,8 +81,8 @@ function isPossibleConstructor(node) {
         case "LogicalExpression":
 
             /*
-             * If the && operator shortcuts, the left side was falsy and therefore not a constructor, and if
-             * it doesn't shortcut, it takes the value from the right side, so the right side must always be a
+             * If the && operator short-circuits, the left side was falsy and therefore not a constructor, and if
+             * it doesn't short-circuit, it takes the value from the right side, so the right side must always be a
              * possible constructor. A future improvement could verify that the left side could be truthy by
              * excluding falsy literals.
              */

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1611,6 +1611,17 @@ module.exports = {
             }
 
             case "LogicalExpression":
+
+                /*
+                 * If the && operator shortcuts, the left side was falsy and therefore not an error, and if it
+                 * doesn't shortcut, it takes the value from the right side, so the right side must always be
+                 * a plausible error. A future improvement could verify that the left side could be truthy by
+                 * excluding falsy literals.
+                 */
+                if (node.operator === "&&") {
+                    return module.exports.couldBeError(node.right);
+                }
+
                 return module.exports.couldBeError(node.left) || module.exports.couldBeError(node.right);
 
             case "ConditionalExpression":

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1613,8 +1613,8 @@ module.exports = {
             case "LogicalExpression":
 
                 /*
-                 * If the && operator shortcuts, the left side was falsy and therefore not an error, and if it
-                 * doesn't shortcut, it takes the value from the right side, so the right side must always be
+                 * If the && operator short-circuits, the left side was falsy and therefore not an error, and if it
+                 * doesn't short-circuit, it takes the value from the right side, so the right side must always be
                  * a plausible error. A future improvement could verify that the left side could be truthy by
                  * excluding falsy literals.
                  */

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -43,8 +43,10 @@ ruleTester.run("constructor-super", rule, {
         "class A extends (B ||= 5) { constructor() { super(); } }",
         "class A extends (B ??= 5) { constructor() { super(); } }",
         "class A extends (B || C) { constructor() { super(); } }",
-        "class A extends (B && 5) { constructor() { super(); } }",
         "class A extends (5 && B) { constructor() { super(); } }",
+
+        // A future improvement could detect the left side as statically falsy, making this invalid.
+        "class A extends (false && B) { constructor() { super(); } }",
         "class A extends (B || 5) { constructor() { super(); } }",
         "class A extends (B ?? 5) { constructor() { super(); } }",
 
@@ -124,6 +126,10 @@ ruleTester.run("constructor-super", rule, {
         },
         {
             code: "class A extends (B = 5) { constructor() { super(); } }",
+            errors: [{ messageId: "badSuper", type: "CallExpression" }]
+        },
+        {
+            code: "class A extends (B && 5) { constructor() { super(); } }",
             errors: [{ messageId: "badSuper", type: "CallExpression" }]
         },
         {

--- a/tests/lib/rules/no-throw-literal.js
+++ b/tests/lib/rules/no-throw-literal.js
@@ -152,6 +152,13 @@ ruleTester.run("no-throw-literal", rule, {
                 type: "ThrowStatement"
             }]
         },
+        {
+            code: "throw foo && 'literal'", // evaluates either to a falsy value of `foo` (which, then, cannot be an Error object), or to 'literal'
+            errors: [{
+                messageId: "object",
+                type: "ThrowStatement"
+            }]
+        },
 
         // ConditionalExpression
         {

--- a/tests/lib/rules/prefer-promise-reject-errors.js
+++ b/tests/lib/rules/prefer-promise-reject-errors.js
@@ -117,6 +117,7 @@ ruleTester.run("prefer-promise-reject-errors", rule, {
         "Promise.reject(foo &= new Error())",
 
         // evaluates either to a falsy value of `foo` (which, then, cannot be an Error object), or to `5`
+        "Promise.reject(foo && 5)",
         "Promise.reject(foo &&= 5)"
 
     ].map(invalidCase => {

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -1099,7 +1099,10 @@ describe("ast-utils", () => {
             "(1, 2, foo)": true,
             "1 && 2": false,
             "1 && foo": true,
-            "foo && 2": true,
+            "foo && 2": false,
+
+            // A future improvement could detect the left side as statically falsy, making this false.
+            "false && foo": true,
             "foo &&= 2": false,
             "foo.bar ??= 2": true,
             "foo[bar] ||= 2": true,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    ESLint adheres to the Open JS Foundation Code of Conduct:
    https://eslint.org/conduct

    This template is for bug reports. If you are here for another reason, please see below:

    1. To propose a new rule: https://eslint.org/docs/developer-guide/contributing/new-rules
    2. To request a rule change: https://eslint.org/docs/developer-guide/contributing/rule-changes
    3. To request a change that is not a bug fix, rule change, or new rule: https://eslint.org/docs/developer-guide/contributing/changes
    4. If you have any questions, please stop by our chatroom: https://eslint.org/chat

    Note that leaving sections blank will make it difficult for us to troubleshoot and we may have to close the issue.
-->

---

*Bug report copied from #13634.*

**Tell us about your environment**

<!--
    If you are using ESLint v6.5.0 or later, you can run ESLint with the `--env-info` flag and paste the output here.
-->

* **ESLint Version:** 7.7.0
* **Node Version:** 14.9.0
* **npm Version:** 6.14.7

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: 2020
    }
};
```

</details>

**What did you do? Please include the actual source code causing the issue, as well as the command that you used to run ESLint.**

<!-- Paste the source code below: -->
```js
/* eslint constructor-super: "error",
   no-throw-literal: "error",
   prefer-promise-reject-errors: "error"
 */
let anything;

// If anything is a constructor, it'll be truthy, we'll evaluate the
// right side of the &&, and we'll extend 42.
class Subclass extends (anything && 42) {
    constructor() {
        super();
    }
}

// If anything is an Error instance, it'll be truthy, we'll evaluate
// the right side of the &&, and we'll throw 42.
throw anything && 42;

// If anything is an Error instance, it'll be truthy, we'll evaluate
// the right side of the &&, and we'll reject with 42.
Promise.reject(anything && 5);
```

<!-- Paste the command you used to run ESLint: -->
[Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IGNvbnN0cnVjdG9yLXN1cGVyOiBcImVycm9yXCIsXG4gICBuby10aHJvdy1saXRlcmFsOiBcImVycm9yXCIsXG4gICBwcmVmZXItcHJvbWlzZS1yZWplY3QtZXJyb3JzOiBcImVycm9yXCJcbiAqL1xubGV0IGFueXRoaW5nO1xuXG4vLyBJZiBhbnl0aGluZyBpcyBhIGNvbnN0cnVjdG9yLCBpdCdsbCBiZSB0cnV0aHksIHdlJ2xsIGV2YWx1YXRlIHRoZVxuLy8gcmlnaHQgc2lkZSBvZiB0aGUgJiYsIGFuZCB3ZSdsbCBleHRlbmQgNDIuXG5jbGFzcyBTdWJjbGFzcyBleHRlbmRzIChhbnl0aGluZyAmJiA0Mikge1xuICAgIGNvbnN0cnVjdG9yKCkge1xuICAgICAgICBzdXBlcigpO1xuICAgIH1cbn1cblxuLy8gSWYgYW55dGhpbmcgaXMgYW4gRXJyb3IgaW5zdGFuY2UsIGl0J2xsIGJlIHRydXRoeSwgd2UnbGwgZXZhbHVhdGVcbi8vIHRoZSByaWdodCBzaWRlIG9mIHRoZSAmJiwgYW5kIHdlJ2xsIHRocm93IDQyLlxudGhyb3cgYW55dGhpbmcgJiYgNDI7XG5cbi8vIElmIGFueXRoaW5nIGlzIGFuIEVycm9yIGluc3RhbmNlLCBpdCdsbCBiZSB0cnV0aHksIHdlJ2xsIGV2YWx1YXRlXG4vLyB0aGUgcmlnaHQgc2lkZSBvZiB0aGUgJiYsIGFuZCB3ZSdsbCByZWplY3Qgd2l0aCA0Mi5cblByb21pc2UucmVqZWN0KGFueXRoaW5nICYmIDUpOyIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6MTEsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=)

**What did you expect to happen?**

We should report errors in each of the above cases. All three are looking for a specific type of truthy value from the expression. Because the expression uses `&&`, any possibly-valid value would evaluate to the right side of the expression, which would not be a valid value in these examples.

This was originally discovered in https://github.com/eslint/eslint/pull/13618#discussion_r479584827. Because it relates to existing behavior that existed prior to that pull request, we decided to split it into its own issue that can be fixed after the pull request is merged. This bug is a false negative in the 3 rules above, and fixing it would cause them to report more errors. Does anyone object to fixing this in a semver-minor change as allowed by our semver policy?

The fix would update both [`astUtils.couldBeError()`](https://github.com/eslint/eslint/blob/a32032430a0779a4e3b2d137d4d0682844084b82/lib/rules/utils/ast-utils.js#L1587-L1588) and [`constructor-super`'s `isPossibleConstructor()`](https://github.com/eslint/eslint/blob/a32032430a0779a4e3b2d137d4d0682844084b82/lib/rules/constructor-super.js#L65-L69) to only check the right side of `&&` `LogicalExpression`s.

**What actually happened? Please include the actual, raw output from ESLint.**

No errors are reported.

---

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

When `constructor-super`, `no-throw-literal`, and `prefer-promise-reject-errors` are looking for plausible constructor or error values, they fail to consider the short-circuiting behavior differences between the `&&` and `||` operators. This results in a false negative where these rules allow `foo && 42` when that expression cannot be a constructor or error. If the left side is falsy, the expression short-circuits with the falsy value. If the left side is truthy, the result of the expression is the right side value. All three rules already report the right side value in isolation but currently incorrectly allow it when on the right side of an `&&` expression.

When @mdjermanovic added support for logical assignment operators in #13618, [we decided](https://github.com/eslint/eslint/pull/13618#discussion_r479584827) to ship with the corrected behavior for `&&=` by only checking the right side of the expression, accepting that treatment of `&&=` would be inconsistent with existing treatment of `&&`. This PR then fixes the `&&` treatment in what we believe can be a semver-minor bug fix.

#### Is there anything you'd like reviewers to focus on?

Does everyone else agree with @mdjermanovic and me that this is can be a semver-minor bug fix?

A future improvement could detect statically falsy values on the left side of `&&` expressions and report those as well. Such a change could also update the `||` treatment to ignore plausibly-(constructor|error) values on the right side if the left side is statically truthy but not plausibly a constructor or error, so `42 || foo` should fail.