### PR TITLE
Update: remove suggestion if it didn't provide a fix (fixes #13723)

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -382,6 +382,8 @@ Best practices for suggestions:
 1. Don't try to do too much and suggest large refactors that could introduce a lot of breaking changes.
 1. As noted above, don't try to conform to user-defined styles.
 
+Suggestions are intended to provide fixes. ESLint will automatically remove the whole suggestion from the linting output if the suggestion's `fix` function returned `null` or an empty array/sequence.
+
 #### Suggestion `messageId`s
 
 Instead of using a `desc` key for suggestions a `messageId` can be used instead. This works the same way as `messageId`s for the overall error (see [messageIds](#messageIds)). Here is an example of how to use it in a rule:

--- a/lib/linter/report-translator.js
+++ b/lib/linter/report-translator.js
@@ -196,15 +196,19 @@ function mapSuggestions(descriptor, sourceCode, messages) {
         return [];
     }
 
-    return descriptor.suggest.map(suggestInfo => {
-        const computedDesc = suggestInfo.desc || messages[suggestInfo.messageId];
+    return descriptor.suggest
+        .map(suggestInfo => {
+            const computedDesc = suggestInfo.desc || messages[suggestInfo.messageId];
 
-        return {
-            ...suggestInfo,
-            desc: interpolate(computedDesc, suggestInfo.data),
-            fix: normalizeFixes(suggestInfo, sourceCode)
-        };
-    });
+            return {
+                ...suggestInfo,
+                desc: interpolate(computedDesc, suggestInfo.data),
+                fix: normalizeFixes(suggestInfo, sourceCode)
+            };
+        })
+
+        // Remove suggestions that didn't provide a fix
+        .filter(({ fix }) => fix);
 }
 
 /**


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

fixes #13723

Marked this change as an "Update", because it can cause some existing tests in plugins to fail.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Modified `ReportTranslator` to automatically remove the whole suggestion instance from the linting output if the suggestion's `fix` function returned `null` or an empty array/sequence.

Context:

This change prevents invalid lint messages.

ESLint API defines `Suggestion#fix` as a mandatory field in a [LintMessage](https://eslint.org/docs/developer-guide/nodejs-api#-lintmessage-type). This means that all suggestions produced by the linting must include fixes. Integrations, following the spec, expect that this property exists and has a valid `EditInfo` value. For example, VSCode crashes if it is `null`.

`ReportTranslator` already throws if the `fix` property in a suggestion object provided by the rule isn't a `function`, but it wasn't checking the value returned from that function. 

It's still allowed to `return null` or `return []` from `fix()`, or yield nothing from `*fix()`, as an indicator that suggestion's fix cannot be applied. This is a commonly used pattern in auto-fix `fix` functions (e.g., when it finds out that some comments in the code are interfering with the fix).

After this change, instead of creating an invalid suggestion object with `fix: null`, the whole suggestion will be removed from the final output. If there are multiple suggestions for the same error, only those that didn't provide a fix will be removed.

#### Is there anything you'd like reviewers to focus on?
