### PR TITLE
Docs: Fix typo in v7 migration page

### DIFF
--- a/docs/user-guide/migrating-to-7.0.0.md
+++ b/docs/user-guide/migrating-to-7.0.0.md
@@ -171,7 +171,7 @@ Several rules have been enhanced and now report additional errors:
 - [func-names](https://eslint.org/docs/rules/func-names) rule now recognizes function declarations in default exports.
 - [no-extra-parens](https://eslint.org/docs/rules/no-extra-parens) rule now recognizes parentheses in assignment targets.
 - [no-dupe-class-members](https://eslint.org/docs/rules/no-dupe-class-members) rule now recognizes computed keys for static class members.
-- [no-magic-number](https://eslint.org/docs/rules/no-magic-number) rule now recognizes bigint literals.
+- [no-magic-numbers](https://eslint.org/docs/rules/no-magic-numbers) rule now recognizes bigint literals.
 - [radix](https://eslint.org/docs/rules/radix) rule now recognizes invalid numbers for the second parameter of `parseInt()`.
 - [use-isnan](https://eslint.org/docs/rules/use-isnan) rule now recognizes class members by default.
 - [yoda](https://eslint.org/docs/rules/yoda) rule now recognizes bigint literals.


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

I fixed typo `no-magic-number` to `no-magic-numbers` in "Migrating to v7.0.0" page of documentation.

#### Is there anything you'd like reviewers to focus on?
