### PR TITLE
Update: disallow if(cond); (fixes #13785)

### DIFF
--- a/docs/rules/no-extra-semi.md
+++ b/docs/rules/no-extra-semi.md
@@ -17,6 +17,8 @@ function foo() {
     // code
 };
 
+if (x === 5);
+
 ```
 
 Examples of **correct** code for this rule:
@@ -30,11 +32,14 @@ var foo = function() {
     // code
 };
 
+if (x === 5) {}
 ```
 
 ## When Not To Use It
 
 If you intentionally use extra semicolons then you can disable this rule.
+
+If you intentionally use an `if` without a body, please let us know.
 
 ## Related Rules
 

--- a/docs/rules/no-extra-semi.md
+++ b/docs/rules/no-extra-semi.md
@@ -18,6 +18,7 @@ function foo() {
 };
 
 if (x === 5);
+// code
 
 ```
 
@@ -32,7 +33,9 @@ var foo = function() {
     // code
 };
 
-if (x === 5) {}
+if (x === 5) {
+    // code
+}
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-extra-semi.md
+++ b/docs/rules/no-extra-semi.md
@@ -18,7 +18,7 @@ function foo() {
 };
 
 if (x === 5);
-// code
+// code without else
 
 ```
 
@@ -36,13 +36,16 @@ var foo = function() {
 if (x === 5) {
     // code
 }
+
+if (x === 5);
+else {
+  // code
+}
 ```
 
 ## When Not To Use It
 
 If you intentionally use extra semicolons then you can disable this rule.
-
-If you intentionally use an `if` without a body, please let us know.
 
 ## Related Rules
 

--- a/lib/rules/no-extra-semi.js
+++ b/lib/rules/no-extra-semi.js
@@ -123,11 +123,13 @@ module.exports = {
                         "ForOfStatement",
                         "WhileStatement",
                         "DoWhileStatement",
+                        "IfStatement",
                         "LabeledStatement",
                         "WithStatement"
                     ];
 
-                if (parent.type === "IfStatement") {
+                if (parent.type === "IfStatement" &&
+                    (!parent.alternate || node === parent.alternate)) {
                     reportSuggestion(node, "Remove the `;` to let the `if` branch the code.");
                 } else if (allowedParentTypes.indexOf(parent.type) === -1) {
                     report(node);

--- a/lib/rules/no-extra-semi.js
+++ b/lib/rules/no-extra-semi.js
@@ -31,7 +31,8 @@ module.exports = {
         schema: [],
 
         messages: {
-            unexpected: "Unnecessary semicolon."
+            unexpected: "Unnecessary semicolon.",
+            wrong: "Unexpected semicolon."
         }
     },
 
@@ -58,6 +59,35 @@ module.exports = {
                         .retainSurroundingTokens(nodeOrToken)
                         .remove(nodeOrToken);
                 }
+            });
+        }
+
+        /**
+         * Reports an unexpected semicolon error, likely a bug.
+         * @param {Node|Token} nodeOrToken A node or a token to be reported.
+         * @param {string} desc A description for the suggestion.
+         * @returns {void}
+         */
+        function reportSuggestion(nodeOrToken, desc) {
+            context.report({
+                node: nodeOrToken,
+                messageId: "wrong",
+                suggest: [
+                    {
+                        desc,
+                        fix(fixer) {
+
+                            /*
+                             * Expand the replacement range to include the surrounding
+                             * tokens to avoid conflicting with semi.
+                             * https://github.com/eslint/eslint/issues/7928
+                             */
+                            return new FixTracker(fixer, context.getSourceCode())
+                                .retainSurroundingTokens(nodeOrToken)
+                                .remove(nodeOrToken);
+                        }
+                    }
+                ]
             });
         }
 
@@ -93,12 +123,13 @@ module.exports = {
                         "ForOfStatement",
                         "WhileStatement",
                         "DoWhileStatement",
-                        "IfStatement",
                         "LabeledStatement",
                         "WithStatement"
                     ];
 
-                if (allowedParentTypes.indexOf(parent.type) === -1) {
+                if (parent.type === "IfStatement") {
+                    reportSuggestion(node, "Remove the `;` to let the `if` branch the code.");
+                } else if (allowedParentTypes.indexOf(parent.type) === -1) {
                     report(node);
                 }
             },

--- a/tests/lib/rules/no-extra-semi.js
+++ b/tests/lib/rules/no-extra-semi.js
@@ -25,6 +25,7 @@ ruleTester.run("no-extra-semi", rule, {
         "for(;;);",
         "while(0);",
         "do;while(0);",
+        "if(true);else{}",
         "for(a in b);",
         { code: "for(a of b);", parserOptions: { ecmaVersion: 6 } },
         "foo: ;",

--- a/tests/lib/rules/no-extra-semi.js
+++ b/tests/lib/rules/no-extra-semi.js
@@ -27,8 +27,6 @@ ruleTester.run("no-extra-semi", rule, {
         "do;while(0);",
         "for(a in b);",
         { code: "for(a of b);", parserOptions: { ecmaVersion: 6 } },
-        "if(true);",
-        "if(true); else;",
         "foo: ;",
         "with(foo);",
 
@@ -81,14 +79,14 @@ ruleTester.run("no-extra-semi", rule, {
             errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         },
         {
-            code: "if(true);;",
-            output: "if(true);",
-            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
+            code: "if(true);",
+            output: null,
+            errors: [{ messageId: "wrong", type: "EmptyStatement" }]
         },
         {
-            code: "if(true){} else;;",
-            output: "if(true){} else;",
-            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
+            code: "if(true){} else;",
+            output: null,
+            errors: [{ messageId: "wrong", type: "EmptyStatement" }]
         },
         {
             code: "if(true){;} else {;}",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #13785

#### What changes did you make? (Give an overview)

- made no-extra-semi report a suggestion to remove a semicolon right after if
- Fixed tests to expect the code to newly report errors.
- added an example of this in the documentation.

#### Is there anything you'd like reviewers to focus on?

- is the documentation enough? It doesn't mention the case of `if (cond) {} else ;` that should fail too, but then it doesn't mention that the rule intentionally allows `while (cond);`.
- do tests normally check the exact content of suggestions? Mine don't because I had no template for that.