### PR TITLE
Fix: Pass internal config paths in FileEnumerator default (fixes #13789)

### DIFF
--- a/lib/cli-engine/file-enumerator.js
+++ b/lib/cli-engine/file-enumerator.js
@@ -213,7 +213,11 @@ class FileEnumerator {
      */
     constructor({
         cwd = process.cwd(),
-        configArrayFactory = new CascadingConfigArrayFactory({ cwd }),
+        configArrayFactory = new CascadingConfigArrayFactory({
+            cwd,
+            eslintRecommendedPath: path.resolve(__dirname, "../../conf/eslint-recommended.js"),
+            eslintAllPath: path.resolve(__dirname, "../../conf/eslint-all.js")
+        }),
         extensions = null,
         globInputPaths = true,
         errorOnUnmatchedPattern = true,

--- a/tests/lib/cli-engine/file-enumerator.js
+++ b/tests/lib/cli-engine/file-enumerator.js
@@ -488,4 +488,31 @@ describe("FileEnumerator", () => {
             });
         });
     });
+
+    // https://github.com/eslint/eslint/issues/13789
+    describe("constructor default values when config extends eslint:recommended", () => {
+        const root = path.join(os.tmpdir(), "eslint/file-enumerator");
+        const files = {
+            "file.js": "",
+            ".eslintrc.json": JSON.stringify({
+                extends: ["eslint:recommended"]
+            })
+        };
+        const { prepare, cleanup, getPath } = createCustomTeardown({ cwd: root, files });
+
+
+        /** @type {FileEnumerator} */
+        let enumerator;
+
+        beforeEach(async () => {
+            await prepare();
+            enumerator = new FileEnumerator({ cwd: getPath() });
+        });
+
+        afterEach(cleanup);
+
+        it("should not throw an exception iterating files", () => {
+            Array.from(enumerator.iterateFiles(["."]));
+        });
+    });
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

When `CLIEngine` instantiates `FileEnumerator`, it explicitly passes its own `CascadingConfigArrayFactory` instance, which now includes values for `builtInRules`, `loadRules`, `eslintRecommendedPath`, and `eslintAllPath`. This is the only place that ESLint core instantiates `FileEnumerator`, so core does not rely on the constructor's default value for `configArrayFactory`.

After `CascadingConfigArrayFactory` was extracted into `@eslint/eslintrc`, it no longer assumed values for `eslintRecommendedPath` and `eslintAllPath`, which `CLIEngine` now provides. If those values are not passed, as is the case with the default `CascadingConfigArrayFactory` for `configArrayFactory`, file enumeration will encounter the exception that was reported in #13789.

From the perspective of ESLint core, the default value for `configArrayFactory` is dead code. However, even though `FileEnumerator` is an undocumented API, it's called by `eslint-plugin-import`'s `no-unused-modules` rule, which hits the exception reproduced by this test.

#### Is there anything you'd like reviewers to focus on?

`FileEnumerator` is an undocumented API, so we probably shouldn't be encouraging people to use it, but `eslint-plugin-import/no-unused-modules` already does. We don't have a supported API to achieve the same purpose, but the pre-lint step contemplated in RFC42 would probably serve that purpose.