### PR TITLE
Update: specify minimum entity length for max-len ignore entities

### DIFF
--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -21,9 +21,9 @@ This rule has a number or object option:
 * `"ignoreComments": true` ignores all trailing comments and comments on their own line
 * `"ignoreTrailingComments": true` ignores only trailing comments
 * `"ignoreUrls": true` ignores lines that contain a URL
-* `"ignoreStrings": true` ignores lines that contain a double-quoted or single-quoted string
-* `"ignoreTemplateLiterals": true` ignores lines that contain a template literal
-* `"ignoreRegExpLiterals": true` ignores lines that contain a RegExp literal
+* `"ignoreStrings": true | {minLength: number}` ignores lines that contain a double-quoted or single-quoted string (minimum string length that makes the line ignored can be optionally specified)
+* `"ignoreTemplateLiterals": true | {minLength: number}` ignores lines that contain a template literal (minimum template literal length that makes the line ignored can be optionally specified)
+* `"ignoreRegExpLiterals": true | {minLength: number}` ignores lines that contain a RegExp literal  (minimum RegExp literl length that makes the line ignored can be optionally specified)
 
 ### code
 

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -31,16 +31,55 @@ const OPTIONS_SCHEMA = {
             type: "boolean"
         },
         ignoreStrings: {
-            type: "boolean"
+            anyOf: [
+                {
+                    type: "boolean"
+                },
+                {
+                    type: "object",
+                    properties: {
+                        minLength: {
+                            type: "integer",
+                            minimum: 1
+                        }
+                    }
+                }
+            ]
         },
         ignoreUrls: {
             type: "boolean"
         },
         ignoreTemplateLiterals: {
-            type: "boolean"
+            anyOf: [
+                {
+                    type: "boolean"
+                },
+                {
+                    type: "object",
+                    properties: {
+                        minLength: {
+                            type: "integer",
+                            minimum: 1
+                        }
+                    }
+                }
+            ]
         },
         ignoreRegExpLiterals: {
-            type: "boolean"
+            anyOf: [
+                {
+                    type: "boolean"
+                },
+                {
+                    type: "object",
+                    properties: {
+                        minLength: {
+                            type: "integer",
+                            minimum: 1
+                        }
+                    }
+                }
+            ]
         },
         ignoreTrailingComments: {
             type: "boolean"
@@ -142,6 +181,11 @@ module.exports = {
             ignoreTrailingComments = !!options.ignoreTrailingComments || !!options.ignoreComments,
             ignoreUrls = !!options.ignoreUrls,
             maxCommentLength = options.comments;
+        const minLongRegExpLiteralLength = (options.ignoreRegExpLiterals &&
+          options.ignoreRegExpLiterals.minLength) || 0;
+        const minLongStringLength = (options.ignoreStrings && options.ignoreStrings.minLength) || 0;
+        const minLongTemplateLiteralLength = (options.ignoreTemplateLiterals &&
+          options.ignoreTemplateLiterals.minLength) || 0;
         let ignorePattern = options.ignorePattern || null;
 
         if (ignorePattern) {
@@ -151,6 +195,15 @@ module.exports = {
         //--------------------------------------------------------------------------
         // Helpers
         //--------------------------------------------------------------------------
+
+        /**
+         * Get number of characters representing the token
+         * @param {ASTNode} token The node
+         * @returns {int} the token length
+         */
+        function getTokenLength(token) {
+            return token.range[1] - token.range[0];
+        }
 
         /**
          * Tells if a given comment is trailing: it starts on the current line and
@@ -227,29 +280,35 @@ module.exports = {
         }
 
         /**
-         * Retrieves an array containing all strings (" or ') in the source code.
+         * Retrieves an array containing all strings longer than configured minimum (" or ') in the source code.
          * @returns {ASTNode[]} An array of string nodes.
          */
-        function getAllStrings() {
-            return sourceCode.ast.tokens.filter(token => (token.type === "String" ||
-                (token.type === "JSXText" && sourceCode.getNodeByRangeIndex(token.range[0] - 1).type === "JSXAttribute")));
+        function getLongStrings() {
+            return sourceCode.ast.tokens.filter(token => (
+                token.type === "String" ||
+                (token.type === "JSXText" && sourceCode.getNodeByRangeIndex(token.range[0] - 1).type === "JSXAttribute")
+            ) && getTokenLength(token) >= minLongStringLength);
         }
 
         /**
-         * Retrieves an array containing all template literals in the source code.
+         * Retrieves an array containing all template literals longer than configured minimum in the source code.
          * @returns {ASTNode[]} An array of template literal nodes.
          */
-        function getAllTemplateLiterals() {
-            return sourceCode.ast.tokens.filter(token => token.type === "Template");
+        function getLongTemplateLiterals() {
+            return sourceCode.ast.tokens.filter(token => (
+                token.type === "Template" &&
+                getTokenLength(token) >= minLongTemplateLiteralLength));
         }
 
 
         /**
-         * Retrieves an array containing all RegExp literals in the source code.
+         * Retrieves an array containing all RegExp literals longer than configured minimum in the source code.
          * @returns {ASTNode[]} An array of RegExp literal nodes.
          */
-        function getAllRegExpLiterals() {
-            return sourceCode.ast.tokens.filter(token => token.type === "RegularExpression");
+        function getLongRegExpLiterals() {
+            return sourceCode.ast.tokens.filter(token => (
+                token.type === "RegularExpression" &&
+                getTokenLength(token) >= minLongRegExpLiteralLength));
         }
 
 
@@ -311,14 +370,14 @@ module.exports = {
             // we iterate over comments in parallel with the lines
             let commentsIndex = 0;
 
-            const strings = getAllStrings();
-            const stringsByLine = strings.reduce(groupByLineNumber, {});
+            const longStrings = getLongStrings();
+            const longStringsByLine = longStrings.reduce(groupByLineNumber, {});
 
-            const templateLiterals = getAllTemplateLiterals();
-            const templateLiteralsByLine = templateLiterals.reduce(groupByLineNumber, {});
+            const longTemplateLiterals = getLongTemplateLiterals();
+            const longTemplateLiteralsByLine = longTemplateLiterals.reduce(groupByLineNumber, {});
 
-            const regExpLiterals = getAllRegExpLiterals();
-            const regExpLiteralsByLine = regExpLiterals.reduce(groupByLineNumber, {});
+            const longRegExpLiterals = getLongRegExpLiterals();
+            const longRegExpLiteralsByLine = longRegExpLiterals.reduce(groupByLineNumber, {});
 
             lines.forEach((line, i) => {
 
@@ -367,9 +426,9 @@ module.exports = {
                 }
                 if (ignorePattern && ignorePattern.test(textToMeasure) ||
                     ignoreUrls && URL_REGEXP.test(textToMeasure) ||
-                    ignoreStrings && stringsByLine[lineNumber] ||
-                    ignoreTemplateLiterals && templateLiteralsByLine[lineNumber] ||
-                    ignoreRegExpLiterals && regExpLiteralsByLine[lineNumber]
+                    ignoreStrings && longStringsByLine[lineNumber] ||
+                    ignoreTemplateLiterals && longTemplateLiteralsByLine[lineNumber] ||
+                    ignoreRegExpLiterals && longRegExpLiteralsByLine[lineNumber]
                 ) {
 
                     // ignore this line

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -121,8 +121,17 @@ ruleTester.run("max-len", rule, {
             parserOptions: { ecmaFeatures: { jsx: true } }
         },
         {
+            code: "var foo = veryLongIdentifier; var str = 'this is a very long string';",
+            options: [29, 4, { ignoreStrings: { minLength: 20 } }]
+        },
+        {
             code: "var foo = veryLongIdentifier;\nvar bar = `this is a very long string`;",
             options: [29, 4, { ignoreTemplateLiterals: true }],
+            parserOptions
+        },
+        {
+            code: "var foo = `this is a very long string`;",
+            options: [29, 4, { ignoreTemplateLiterals: { minLength: 28 } }],
             parserOptions
         },
         {
@@ -138,6 +147,10 @@ ruleTester.run("max-len", rule, {
         {
             code: "var foo = /this is a very long pattern/;",
             options: [29, 4, { ignoreRegExpLiterals: true }]
+        },
+        {
+            code: "var foo = /this is a very long pattern/;",
+            options: [29, 4, { ignoreRegExpLiterals: { minLength: 29 } }]
         },
 
         // check indented comment lines - https://github.com/eslint/eslint/issues/6322
@@ -821,6 +834,52 @@ ruleTester.run("max-len", rule, {
                     column: 1,
                     endLine: 1,
                     endColumn: 59
+                }
+            ]
+        },
+        {
+            code: "var foo = /this is a very long pattern/;",
+            options: [29, 4, { ignoreRegExpLiterals: { minLength: 30 } }],
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 40, maxLength: 29 },
+                    type: "Program",
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 41
+                }
+            ]
+        },
+        {
+            code: "var foo = veryLongIdentifier; var str = 'this is short str';",
+            options: [29, 4, { ignoreStrings: { minLength: 20 } }],
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 60, maxLength: 29 },
+                    type: "Program",
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 61
+                }
+            ]
+        },
+        {
+            code: "var foo = veryLongIdentifier; var str = `this is ${short}!`;",
+            options: [29, 4, { ignoreStrings: { minLength: 20 } }],
+            parserOptions,
+            errors: [
+                {
+                    messageId: "max",
+                    data: { lineLength: 60, maxLength: 29 },
+                    type: "Program",
+                    line: 1,
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 61
                 }
             ]
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
`max-len` rule's options `ignoreStrings`, `ignoreRegExpLiterals` and `ignoreTemplateLiterals` are useless for me since they are affected by any occurrence of such entity - which is quite irrelevant, e.g. single-character string is definitely not an argument to violate configured maximum line length. My change allows configuring minimum character length of these tokens that will make the ignore effective.

Not implemented for other ignore options, because:

- `ignorePattern` does not need that, the pattern itself can be made to not match unwanted short occurrences
- `ignoreComments` and `ignoreTrailingComments` - it would be irrelevant since these options won't ignore long lines except of the comments itself
- `ignoreUrls` because a) short urls are way more rare than short strings/regexps/template literals b) it would be tricky to do due to current `ignoreUrls` implementation (looks only for :// and does not match the whole url, that would have to be added), so it's not worth the effort

The change is fully backwards compatible. Without using new rule option value types it doesn't change behaviour of the rule anyhow.

**What rule do you want to change?**
`max-len`

**Does this change cause the rule to produce more or fewer warnings?**
more - but only in case new option value types are used

**How will the change be implemented? (New option, new default behavior, etc.)?**
optional new value type (object of shape `{minLength: number}`) for existing options

**Please provide some example code that this change will affect:**

```js
const someVeryVeryVeryVeryLongIdentifierThatViolatesMaxLineLength = 'a';
```

**What does the rule currently do for this code?**
with `ignoreStrings: true` it does not emit warning because there is a string literal

**What will the rule do after it's changed?**
with e.g. `ignoreStrings: {minLength: 10}` it does emit warning because the string literal is shorter

#### Is there anything you'd like reviewers to focus on?
no
