### PR TITLE
New: Configurable List Size For Per-Rule Performance Metrics

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -720,6 +720,8 @@ Rule   | Time (ms) | Relative
 quotes |    18.066 |   100.0%
 ```
 
+To see a longer list of results (more than 10), set the environment variable to another value such as `TIMING=50` or `TIMING=all`.
+
 ## Rule Naming Conventions
 
 The rule naming conventions for ESLint are fairly simple:

--- a/lib/linter/timing.js
+++ b/lib/linter/timing.js
@@ -44,6 +44,26 @@ const enabled = !!process.env.TIMING;
 const HEADERS = ["Rule", "Time (ms)", "Relative"];
 const ALIGN = [alignLeft, alignRight, alignRight];
 
+/**
+ * Decide how many rules to show in the output list.
+ * @returns {number} the number of rules to show
+ */
+function getListSize() {
+    const MINIMUM_SIZE = 10;
+
+    if (typeof process.env.TIMING !== "string") {
+        return MINIMUM_SIZE;
+    }
+
+    if (process.env.TIMING.toLowerCase() === "all") {
+        return Number.POSITIVE_INFINITY;
+    }
+
+    const TIMING_ENV_VAR_AS_INTEGER = Number.parseInt(process.env.TIMING, 10);
+
+    return TIMING_ENV_VAR_AS_INTEGER > 10 ? TIMING_ENV_VAR_AS_INTEGER : MINIMUM_SIZE;
+}
+
 /* istanbul ignore next */
 /**
  * display the data
@@ -61,7 +81,7 @@ function display(data) {
             return [key, time];
         })
         .sort((a, b) => b[1] - a[1])
-        .slice(0, 10);
+        .slice(0, getListSize());
 
     rows.forEach(row => {
         row.push(`${(row[1] * 100 / total).toFixed(1)}%`);
@@ -133,7 +153,8 @@ module.exports = (function() {
 
     return {
         time,
-        enabled
+        enabled,
+        getListSize
     };
 
 }());

--- a/tests/lib/linter/timing.js
+++ b/tests/lib/linter/timing.js
@@ -1,0 +1,51 @@
+"use strict";
+
+const { getListSize } = require("../../../lib/linter/timing");
+const assert = require("chai").assert;
+
+describe("timing", () => {
+    describe("getListSize()", () => {
+        after(() => {
+            delete process.env.TIMING;
+        });
+
+        it("returns minimum list size with small environment variable value", () => {
+            delete process.env.TIMING; // With no value.
+            assert.strictEqual(getListSize(), 10);
+
+            process.env.TIMING = "true";
+            assert.strictEqual(getListSize(), 10);
+
+            process.env.TIMING = "foo";
+            assert.strictEqual(getListSize(), 10);
+
+            process.env.TIMING = "0";
+            assert.strictEqual(getListSize(), 10);
+
+            process.env.TIMING = "1";
+            assert.strictEqual(getListSize(), 10);
+
+            process.env.TIMING = "5";
+            assert.strictEqual(getListSize(), 10);
+
+            process.env.TIMING = "10";
+            assert.strictEqual(getListSize(), 10);
+        });
+
+        it("returns longer list size with larger environment variable value", () => {
+            process.env.TIMING = "11";
+            assert.strictEqual(getListSize(), 11);
+
+            process.env.TIMING = "100";
+            assert.strictEqual(getListSize(), 100);
+        });
+
+        it("returns maximum list size with environment variable value of 'all'", () => {
+            process.env.TIMING = "all";
+            assert.strictEqual(getListSize(), Number.POSITIVE_INFINITY);
+
+            process.env.TIMING = "ALL";
+            assert.strictEqual(getListSize(), Number.POSITIVE_INFINITY);
+        });
+    });
+});


### PR DESCRIPTION

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[X] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Implements RFC: https://github.com/eslint/rfcs/tree/master/designs/2020-timing-list-size

Enables the `TIMING` environment variable to be set to a larger number or `all` in order to show a longer list of per-rule performance metrics when running eslint from the command line.

#### Is there anything you'd like reviewers to focus on?

Interested to hear ideas for improving the test coverage.