### PR TITLE
Docs: Fix JS syntax and doc URL in working-with-custom-formatters.md

### DIFF
--- a/docs/developer-guide/working-with-custom-formatters.md
+++ b/docs/developer-guide/working-with-custom-formatters.md
@@ -226,7 +226,7 @@ module.exports = function(results, data) {
                     "\n" +
                     msg.type +
                     " " +
-                    msg.ruleId + (msg.ruleUrl ? " (" + msg.ruleUrl + ")" : ""
+                    msg.ruleId + (msg.ruleUrl ? " (" + msg.ruleUrl + ")" : "") +
                     "\n  " +
                     msg.filePath +
                     ":" +

--- a/docs/developer-guide/working-with-custom-formatters.md
+++ b/docs/developer-guide/working-with-custom-formatters.md
@@ -195,7 +195,7 @@ module.exports = function(results, data) {
                 var logMessage = {
                     filePath: current.filePath,
                     ruleId: msg.ruleId,
-                    ruleUrl: data.rulesMeta[msg.ruleId].url,
+                    ruleUrl: data.rulesMeta[msg.ruleId].docs.url,
                     message: msg.message,
                     line: msg.line,
                     column: msg.column


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)
Fix a minor JS typo in the custom formatter documentation sample for detailed formatter which causes a syntax error https://eslint.org/docs/developer-guide/working-with-custom-formatters#detailed-formatter

#### Is there anything you'd like reviewers to focus on?
