### PR TITLE
New: no-unsafe-optional-chaining rule (fixes #13431)

### DIFF
--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -1,0 +1,63 @@
+# disallow optional chaining that possibly errors (no-unsafe-optional-chaining)
+
+The optional chaining(`?.`) expression can short-circuit with `undefined`. Therefore, treating an evaluated optional chaining expression as a function, object, number, etc., can cause TypeError or unexpected results.
+
+## Rule Details
+
+This rule disallows some cases that might be an TypeError.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-unsafe-optional-chaining: "error"*/
+
+(obj?.foo)();
+
+(obj?.foo).bar;
+
+(obj?.foo)`template`;
+
+new (obj?.foo)();
+
+[...obj?.foo];
+
+bar(...obj?.foo);
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-unsafe-optional-chaining: "error"*/
+
+(obj?.foo)?.();
+
+obj?.foo?.bar;
+
+(obj?.foo ?? bar)`template`;
+
+new (obj?.foo ?? bar)();
+
+var baz = {...obj.?foo};
+```
+
+## Options
+
+This rule has an object option:
+
+- `disallowArithmeticOperators`: Disallow arithmetic operation on optional chaining expression (Default `false`). If this is `true`, this rule warns arithmetic operations on optional chaining expression which possibly result in `NaN`.
+
+### disallowArithmeticOperators
+
+Examples of additional **incorrect** code for this rule with the `{ "disallowArithmeticOperators": true }` option:
+
+```js
+/*eslint no-unsafe-optional-chaining: ["error", { "disallowArithmeticOperators": true }]*/
+
+obj?.foo + bar;
+
+obj?.foo * bar;
+
++obj?.foo;
+
+baz += obj?.foo;
+```

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -1,6 +1,6 @@
 # disallow use of optional chaining in contexts where the `undefined` value is not allowed (no-unsafe-optional-chaining)
 
-The optional chaining(`?.`) expression can short-circuit with `undefined`. Therefore, treating an evaluated optional chaining expression as a function, object, number, etc., can cause TypeError or unexpected results. For example:
+The optional chaining (`?.`) expression can short-circuit with a return value of `undefined`. Therefore, treating an evaluated optional chaining expression as a function, object, number, etc., can cause TypeError or unexpected results. For example:
 
 ```js
 var obj = undefined;
@@ -12,7 +12,7 @@ bar instanceof obj?.foo;  // TypeError
 const { bar } = obj?.foo;  // TypeError
 ```
 
-Also, the parentheses around optional chaining in where the `undefined` not allowed can cause TypeError because it stops short-circuiting. For example:
+Also, parentheses limit the scope of short-circuiting in chains. For example:
 
 ```js
 var obj = undefined;
@@ -22,7 +22,7 @@ var obj = undefined;
 
 ## Rule Details
 
-This rule aims to detect some cases where the use of optional chaining doesn't prevent runtime errors. In particular, it flags optional chains in positions where short-circuiting to `undefined` causes throwing a TypeError afterward.
+This rule aims to detect some cases where the use of optional chaining doesn't prevent runtime errors. In particular, it flags optional chaining expressions in positions where short-circuiting to `undefined` causes throwing a TypeError afterward.
 
 Examples of **incorrect** code for this rule:
 
@@ -59,9 +59,9 @@ const { bar } = obj?.foo;
 
 with (obj?.foo);
 
-class A extends obj?.foo {};
+class A extends obj?.foo {}
 
-var a = class A extends obj?.foo {}
+var a = class A extends obj?.foo {};
 ```
 
 Examples of **correct** code for this rule:
@@ -70,10 +70,11 @@ Examples of **correct** code for this rule:
 /*eslint no-unsafe-optional-chaining: "error"*/
 
 (obj?.foo)?.();
+obj?.foo();
 
 (obj?.foo ?? bar)();
 
-obj?.foo?.bar;
+obj?.foo.bar;
 
 (obj?.foo ?? bar)`template`;
 
@@ -88,7 +89,7 @@ const { bar } = obj?.foo || baz;
 
 This rule has an object option:
 
-- `disallowArithmeticOperators`: Disallow arithmetic operation on optional chaining expression (Default `false`). If this is `true`, this rule warns arithmetic operations on optional chaining expression, which possibly result in `NaN`.
+- `disallowArithmeticOperators`: Disallow arithmetic operations on optional chaining expressions (Default `false`). If this is `true`, this rule warns arithmetic operations on optional chaining expressions, which possibly result in `NaN`.
 
 ### disallowArithmeticOperators
 

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -18,6 +18,8 @@ Examples of **incorrect** code for this rule:
 
 (obj?.foo)();
 
+(obj?.foo ?? obj?.bar)();
+
 (obj?.foo).bar;
 
 (obj?.foo)`template`;
@@ -45,6 +47,8 @@ Examples of **correct** code for this rule:
 /*eslint no-unsafe-optional-chaining: "error"*/
 
 (obj?.foo)?.();
+
+(obj?.foo ?? bar).();
 
 obj?.foo?.bar;
 

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -29,6 +29,14 @@ new (obj?.foo)();
 bar(...obj?.foo);
 
 1 in obj?.foo;
+
+bar instanceof obj?.foo;
+
+for (bar of obj?.foo);
+
+[{ bar } = obj?.foo] = [];
+
+with (obj?.foo);
 ```
 
 Examples of **correct** code for this rule:

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -1,4 +1,4 @@
-# disallow optional chaining that possibly errors (no-unsafe-optional-chaining)
+# disallow use of optional chaining in contexts where the `undefined` value is not allowed (no-unsafe-optional-chaining)
 
 The optional chaining(`?.`) expression can short-circuit with `undefined`. Therefore, treating an evaluated optional chaining expression as a function, object, number, etc., can cause TypeError or unexpected results. For example:
 

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -1,6 +1,11 @@
 # disallow optional chaining that possibly errors (no-unsafe-optional-chaining)
 
-The optional chaining(`?.`) expression can short-circuit with `undefined`. Therefore, treating an evaluated optional chaining expression as a function, object, number, etc., can cause TypeError or unexpected results.
+The optional chaining(`?.`) expression can short-circuit with `undefined`. Therefore, treating an evaluated optional chaining expression as a function, object, number, etc., can cause TypeError or unexpected result. For example:
+
+```js
+var obj = {};
+(obj?.foo)(); // TypeError: obj?.foo is not a function
+```
 
 ## Rule Details
 

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -73,9 +73,9 @@ class A extends obj?.foo {}
 var a = class A extends obj?.foo {};
 
 async function foo () {
+    const { bar } = await obj?.foo;
    (await obj?.foo)();
    (await obj?.foo).bar;
-    const { bar } = await obj?.foo;
 }
 ```
 
@@ -104,7 +104,8 @@ const { bar } = obj?.foo || baz;
 
 async function foo () {
   const { bar } = await obj?.foo || baz;
-   await (obj?.foo)?.();
+   (await obj?.foo)?.();
+   (await obj?.foo)?.bar;
 }
 ```
 
@@ -160,6 +161,6 @@ async function foo () {
   baz /= await obj?.foo;
   baz *= await obj?.foo;
   baz %= await obj?.foo;
-  baz **=await obj?.foo;
+  baz **= await obj?.foo;
 }
 ```

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -22,6 +22,8 @@ new (obj?.foo)();
 [...obj?.foo];
 
 bar(...obj?.foo);
+
+1 in obj?.foo;
 ```
 
 Examples of **correct** code for this rule:

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -37,6 +37,8 @@ Examples of **incorrect** code for this rule:
 
 (obj?.foo).bar;
 
+(foo?.()).bar;
+
 (foo, obj?.bar).baz;
 
 (obj?.foo)`template`;
@@ -76,6 +78,8 @@ obj?.foo();
 (obj?.foo ?? bar)();
 
 obj?.foo.bar;
+
+foo?.()?.bar;
 
 (obj?.foo ?? bar)`template`;
 

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -70,6 +70,7 @@ Examples of **correct** code for this rule:
 /*eslint no-unsafe-optional-chaining: "error"*/
 
 (obj?.foo)?.();
+
 obj?.foo();
 
 (obj?.foo ?? bar)();

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -17,7 +17,8 @@ Also, parentheses limit the scope of short-circuiting in chains. For example:
 ```js
 var obj = undefined;
 
-(obj?.foo)(); // TypeError: obj?.foo is not a function
+(obj?.foo)(); // TypeError
+(obj?.foo).bar; // TypeError
 ```
 
 ## Rule Details
@@ -31,13 +32,19 @@ Examples of **incorrect** code for this rule:
 
 (obj?.foo)();
 
-(obj?.foo ?? obj?.bar)();
-
-(foo ? obj?.foo : bar)();
-
 (obj?.foo).bar;
 
 (foo?.()).bar;
+
+(foo?.()).bar();
+
+(obj?.foo ?? obj?.bar)();
+
+(foo || obj?.foo)();
+
+(obj?.foo && foo)();
+
+(foo ? obj?.foo : bar)();
 
 (foo, obj?.bar).baz;
 

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -12,7 +12,7 @@ bar instanceof obj?.foo;  // TypeError
 const { bar } = obj?.foo;  // TypeError
 ```
 
-Also, the parentheses around optional chaining can cause unexpected TypeError because it stop short-circuiting. For example:
+Also, the parentheses around optional chaining in where the `undefined` not allowed can cause TypeError because it stops short-circuiting. For example:
 
 ```js
 var obj = undefined;

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -71,6 +71,12 @@ with (obj?.foo);
 class A extends obj?.foo {}
 
 var a = class A extends obj?.foo {};
+
+async function foo () {
+   (await obj?.foo)();
+   (await obj?.foo).bar;
+    const { bar } = await obj?.foo;
+}
 ```
 
 Examples of **correct** code for this rule:
@@ -95,6 +101,11 @@ new (obj?.foo ?? bar)();
 var baz = {...obj?.foo};
 
 const { bar } = obj?.foo || baz;
+
+async function foo () {
+  const { bar } = await obj?.foo || baz;
+   await (obj?.foo)?.();
+}
 ```
 
 ## Options
@@ -132,4 +143,23 @@ baz /= obj?.foo;
 baz *= obj?.foo;
 baz %= obj?.foo;
 baz **= obj?.foo;
+
+async function foo () {
+  +await obj?.foo;
+  -await obj?.foo;
+
+  await obj?.foo + bar;
+  await obj?.foo - bar;
+  await obj?.foo / bar;
+  await obj?.foo * bar;
+  await obj?.foo % bar;
+  await obj?.foo ** bar;
+
+  baz += await obj?.foo;
+  baz -= await obj?.foo;
+  baz /= await obj?.foo;
+  baz *= await obj?.foo;
+  baz %= await obj?.foo;
+  baz **=await obj?.foo;
+}
 ```

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -147,20 +147,7 @@ baz **= obj?.foo;
 
 async function foo () {
   +await obj?.foo;
-  -await obj?.foo;
-
   await obj?.foo + bar;
-  await obj?.foo - bar;
-  await obj?.foo / bar;
-  await obj?.foo * bar;
-  await obj?.foo % bar;
-  await obj?.foo ** bar;
-
   baz += await obj?.foo;
-  baz -= await obj?.foo;
-  baz /= await obj?.foo;
-  baz *= await obj?.foo;
-  baz %= await obj?.foo;
-  baz **= await obj?.foo;
 }
 ```

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -217,6 +217,7 @@ module.exports = new LazyLoadingRuleMap(Object.entries({
     "no-unreachable-loop": () => require("./no-unreachable-loop"),
     "no-unsafe-finally": () => require("./no-unsafe-finally"),
     "no-unsafe-negation": () => require("./no-unsafe-negation"),
+    "no-unsafe-optional-chaining": () => require("./no-unsafe-optional-chaining"),
     "no-unused-expressions": () => require("./no-unused-expressions"),
     "no-unused-labels": () => require("./no-unused-labels"),
     "no-unused-vars": () => require("./no-unused-vars"),

--- a/lib/rules/no-unsafe-optional-chaining.js
+++ b/lib/rules/no-unsafe-optional-chaining.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const ARITHMETIC_OPERATORS = ["+", "-", "/", "*", "%", "**", "+=", "-=", "/=", "*=", "%=", "**="];
+const UNSAFE_RELATIONAL_OPERATORS = ["in", "instanceof"];
 
 /**
  * Checks whether a node is an arithmetic expression or not
@@ -50,11 +51,16 @@ function isPossiblyError(chainExp) {
         case "VariableDeclarator":
             return isDestructuringPattern(parent.id) && parent.init === chainExp;
         case "AssignmentExpression":
+        case "AssignmentPattern":
             return isDestructuringPattern(parent.left) && parent.right === chainExp;
         case "SpreadElement":
             return parent.parent.type !== "ObjectExpression";
         case "BinaryExpression":
-            return parent.operator === "in" && parent.right === chainExp;
+            return UNSAFE_RELATIONAL_OPERATORS.includes(parent.operator) && parent.right === chainExp;
+        case "ForOfStatement":
+            return parent.right === chainExp;
+        case "WithStatement":
+            return true;
         default:
             return false;
     }
@@ -91,30 +97,6 @@ module.exports = {
         const options = context.options[0] || {};
         const disallowArithmeticOperators = (options.disallowArithmeticOperators) || false;
 
-        /**
-         * Reports an error for unsafe optional chaining usage.
-         * @param {ASTNode} node node to report
-         * @returns {void}
-         */
-        function reportUnsafeOptionalChain(node) {
-            context.report({
-                messageId: "unsafeOptionalChain",
-                node
-            });
-        }
-
-        /**
-         * Reports an error for unsafe arithmetic operations on optional chaining.
-         * @param {ASTNode} node node to report
-         * @returns {void}
-         */
-        function reportUnsafeArithmetic(node) {
-            context.report({
-                messageId: "unsafeArithmetic",
-                node
-            });
-        }
-
         return {
             ChainExpression(node) {
                 if (
@@ -122,10 +104,16 @@ module.exports = {
                     node.parent &&
                     isArithmeticExpression(node.parent)
                 ) {
-                    reportUnsafeArithmetic(node);
+                    context.report({
+                        messageId: "unsafeArithmetic",
+                        node
+                    });
                 }
                 if (isPossiblyError(node)) {
-                    reportUnsafeOptionalChain(node);
+                    context.report({
+                        messageId: "unsafeOptionalChain",
+                        node
+                    });
                 }
             }
         };

--- a/lib/rules/no-unsafe-optional-chaining.js
+++ b/lib/rules/no-unsafe-optional-chaining.js
@@ -79,16 +79,16 @@ module.exports = {
          * @param {Function} reportFunc report function
          * @returns {void}
          */
-        function checkUndefinedShourtCircuit(node, reportFunc) {
+        function checkUndefinedShortCircuit(node, reportFunc) {
             if (!node) {
                 return;
             }
             if (node.type === "LogicalExpression") {
                 if (node.operator === "||" || node.operator === "??") {
-                    checkUndefinedShourtCircuit(node.right, reportFunc);
+                    checkUndefinedShortCircuit(node.right, reportFunc);
                 } else if (node.operator === "&&") {
-                    checkUndefinedShourtCircuit(node.left, reportFunc);
-                    checkUndefinedShourtCircuit(node.right, reportFunc);
+                    checkUndefinedShortCircuit(node.left, reportFunc);
+                    checkUndefinedShortCircuit(node.right, reportFunc);
                 }
             } else if (node.type === "ChainExpression") {
                 reportFunc(node);
@@ -101,7 +101,7 @@ module.exports = {
          * @returns {void}
          */
         function checkUnsafeUsage(node) {
-            checkUndefinedShourtCircuit(node, reportUnsafeUsage);
+            checkUndefinedShortCircuit(node, reportUnsafeUsage);
         }
 
         /**
@@ -110,9 +110,7 @@ module.exports = {
          * @returns {void}
          */
         function checkUnsafeArithmetic(node) {
-            if (disallowArithmeticOperators) {
-                checkUndefinedShourtCircuit(node, reportUnsafeArithmetic);
-            }
+            checkUndefinedShortCircuit(node, reportUnsafeArithmetic);
         }
 
         return {
@@ -154,7 +152,10 @@ module.exports = {
                 if (UNSAFE_RELATIONAL_OPERATORS.includes(node.operator)) {
                     checkUnsafeUsage(node.right);
                 }
-                if (UNSAFE_ARITHMETIC_OPERATORS.includes(node.operator)) {
+                if (
+                    disallowArithmeticOperators &&
+                    UNSAFE_ARITHMETIC_OPERATORS.includes(node.operator)
+                ) {
                     checkUnsafeArithmetic(node.right);
                     checkUnsafeArithmetic(node.left);
                 }
@@ -163,12 +164,18 @@ module.exports = {
                 checkUnsafeUsage(node.object);
             },
             UnaryExpression(node) {
-                if (UNSAFE_ARITHMETIC_OPERATORS.includes(node.operator)) {
+                if (
+                    disallowArithmeticOperators &&
+                    UNSAFE_ARITHMETIC_OPERATORS.includes(node.operator)
+                ) {
                     checkUnsafeArithmetic(node.argument);
                 }
             },
             AssignmentExpression(node) {
-                if (UNSAFE_ASSIGNMENT_OPERATORS.includes(node.operator)) {
+                if (
+                    disallowArithmeticOperators &&
+                    UNSAFE_ASSIGNMENT_OPERATORS.includes(node.operator)
+                ) {
                     checkUnsafeArithmetic(node.right);
                 }
             }

--- a/lib/rules/no-unsafe-optional-chaining.js
+++ b/lib/rules/no-unsafe-optional-chaining.js
@@ -15,7 +15,7 @@ const UNSAFE_RELATIONAL_OPERATORS = ["in", "instanceof"];
  * @returns {boolean} `true` if a node is a destructuring pattern, otherwise `false`
  */
 function isDestructuringPattern(node) {
-    return node && node.type === "ObjectPattern" || node.type === "ArrayPattern";
+    return node && (node.type === "ObjectPattern" || node.type === "ArrayPattern");
 }
 
 module.exports = {

--- a/lib/rules/no-unsafe-optional-chaining.js
+++ b/lib/rules/no-unsafe-optional-chaining.js
@@ -62,7 +62,7 @@ function isPossiblyError(chainExp) {
 
 module.exports = {
     meta: {
-        type: "suggestion",
+        type: "problem",
 
         docs: {
             description: "disallow using unsafe-optional-chaining.",

--- a/lib/rules/no-unsafe-optional-chaining.js
+++ b/lib/rules/no-unsafe-optional-chaining.js
@@ -114,15 +114,21 @@ module.exports = {
         }
 
         return {
-            "CallExpression, NewExpression"(node) {
-                if (node.parent.type !== "ChainExpression") {
-                    checkUnsafeUsage(node.callee);
-                }
-            },
             "AssignmentExpression, AssignmentPattern"(node) {
                 if (isDestructuringPattern(node.left)) {
                     checkUnsafeUsage(node.right);
                 }
+            },
+            "ClassDeclaration, ClassExpression"(node) {
+                checkUnsafeUsage(node.superClass);
+            },
+            CallExpression(node) {
+                if (!node.optional) {
+                    checkUnsafeUsage(node.callee);
+                }
+            },
+            NewExpression(node) {
+                checkUnsafeUsage(node.callee);
             },
             VariableDeclarator(node) {
                 if (isDestructuringPattern(node.id)) {
@@ -130,15 +136,12 @@ module.exports = {
                 }
             },
             MemberExpression(node) {
-                if (node.parent && node.parent.type !== "ChainExpression") {
+                if (!node.optional) {
                     checkUnsafeUsage(node.object);
                 }
             },
             TaggedTemplateExpression(node) {
                 checkUnsafeUsage(node.tag);
-            },
-            ClassDeclaration(node) {
-                checkUnsafeUsage(node.superClass);
             },
             ForOfStatement(node) {
                 checkUnsafeUsage(node.right);

--- a/lib/rules/no-unsafe-optional-chaining.js
+++ b/lib/rules/no-unsafe-optional-chaining.js
@@ -120,7 +120,7 @@ module.exports = {
         }
 
         /**
-         * Checks unsafe arithmetic operaions on optional chaining
+         * Checks unsafe arithmetic operations on optional chaining
          * @param {ASTNode} node node to check
          * @returns {void}
          */

--- a/lib/rules/no-unsafe-optional-chaining.js
+++ b/lib/rules/no-unsafe-optional-chaining.js
@@ -23,7 +23,7 @@ module.exports = {
         type: "problem",
 
         docs: {
-            description: "disallow using unsafe-optional-chaining.",
+            description: "disallow using unsafe optional chaining.",
             category: "Possible Errors",
             recommended: false,
             url: "https://eslint.org/docs/rules/no-unsafe-optional-chaining"

--- a/lib/rules/no-unsafe-optional-chaining.js
+++ b/lib/rules/no-unsafe-optional-chaining.js
@@ -102,6 +102,9 @@ module.exports = {
                     checkUndefinedShortCircuit(node.consequent, reportFunc);
                     checkUndefinedShortCircuit(node.alternate, reportFunc);
                     break;
+                case "AwaitExpression":
+                    checkUndefinedShortCircuit(node.argument, reportFunc);
+                    break;
                 case "ChainExpression":
                     reportFunc(node);
                     break;

--- a/lib/rules/no-unsafe-optional-chaining.js
+++ b/lib/rules/no-unsafe-optional-chaining.js
@@ -34,7 +34,7 @@ function isDestructuringPattern(node) {
  * @param {ASTNode} chainExp a ChainExpression node.
  * @returns {boolean} `true` if it can be a runtime error, otherwise `false`
  */
-function isPossiblyMakeRuntimeError(chainExp) {
+function isPossiblyError(chainExp) {
     const parent = chainExp.parent;
 
     switch (parent.type) {
@@ -53,6 +53,8 @@ function isPossiblyMakeRuntimeError(chainExp) {
             return isDestructuringPattern(parent.left) && parent.right === chainExp;
         case "SpreadElement":
             return parent.parent.type !== "ObjectExpression";
+        case "BinaryExpression":
+            return parent.operator === "in" && parent.right === chainExp;
         default:
             return false;
     }
@@ -80,8 +82,8 @@ module.exports = {
         }],
         fixable: null,
         messages: {
-            unsafeOptionalChain: "Unsafe usage of {{node}}.",
-            unsafeArithmetic: "Unsafe arithmetic operation on {{node}}. It can result in NaN."
+            unsafeOptionalChain: "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+            unsafeArithmetic: "Unsafe arithmetic operation on optional chaining. It can result in NaN."
         }
     },
 
@@ -122,7 +124,7 @@ module.exports = {
                 ) {
                     reportUnsafeArithmetic(node);
                 }
-                if (isPossiblyMakeRuntimeError(node)) {
+                if (isPossiblyError(node)) {
                     reportUnsafeOptionalChain(node);
                 }
             }

--- a/lib/rules/no-unsafe-optional-chaining.js
+++ b/lib/rules/no-unsafe-optional-chaining.js
@@ -1,0 +1,131 @@
+/**
+ * @fileoverview Rule to disallow unsafe optional chaining
+ * @author Yeon JuAn
+ */
+
+"use strict";
+
+const ARITHMETIC_OPERATORS = ["+", "-", "/", "*", "%", "**", "+=", "-=", "/=", "*=", "%=", "**="];
+
+/**
+ * Checks whether a node is an arithmetic expression or not
+ * @param {ASTNode} node node to check
+ * @returns {boolean} `true` if a node is an arithmetic expression, otherwise `false`
+ */
+function isArithmeticExpression(node) {
+    return (
+        node.type === "BinaryExpression" ||
+        node.type === "UnaryExpression" ||
+        node.type === "AssignmentExpression"
+    ) && ARITHMETIC_OPERATORS.includes(node.operator);
+}
+
+/**
+ * Checks whether a node is a destructuring pattern or not
+ * @param {ASTNode} node node to check
+ * @returns {boolean} `true` if a node is a destructuring pattern, otherwise `false`
+ */
+function isDestructuringPattern(node) {
+    return node.type === "ObjectPattern" || node.type === "ArrayPattern";
+}
+
+/**
+ * Checks whether a ChainExpression make an runtime error or not
+ * @param {ASTNode} chainExp a ChainExpression node.
+ * @returns {boolean} `true` if it can be a runtime error, otherwise `false`
+ */
+function isPossiblyMakeRuntimeError(chainExp) {
+    const parent = chainExp.parent;
+
+    switch (parent.type) {
+        case "CallExpression":
+        case "NewExpression":
+            return parent.callee === chainExp && parent.parent.type !== "ChainExpression";
+        case "MemberExpression":
+            return parent.object === chainExp && parent.parent.type !== "ChainExpression";
+        case "TaggedTemplateExpression":
+            return parent.tag === chainExp;
+        case "ClassDeclaration":
+            return parent.superClass === chainExp;
+        case "VariableDeclarator":
+            return isDestructuringPattern(parent.id) && parent.init === chainExp;
+        case "AssignmentExpression":
+            return isDestructuringPattern(parent.left) && parent.right === chainExp;
+        case "SpreadElement":
+            return parent.parent.type !== "ObjectExpression";
+        default:
+            return false;
+    }
+}
+
+module.exports = {
+    meta: {
+        type: "suggestion",
+
+        docs: {
+            description: "disallow using unsafe-optional-chaining.",
+            category: "Possible Errors",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/no-unsafe-optional-chaining"
+        },
+        schema: [{
+            type: "object",
+            properties: {
+                disallowArithmeticOperators: {
+                    type: "boolean",
+                    default: false
+                }
+            },
+            additionalProperties: false
+        }],
+        fixable: null,
+        messages: {
+            unsafeOptionalChain: "Unsafe usage of {{node}}.",
+            unsafeArithmetic: "Unsafe arithmetic operation on {{node}}. It can result in NaN."
+        }
+    },
+
+    create(context) {
+        const options = context.options[0] || {};
+        const disallowArithmeticOperators = (options.disallowArithmeticOperators) || false;
+
+        /**
+         * Reports an error for unsafe optional chaining usage.
+         * @param {ASTNode} node node to report
+         * @returns {void}
+         */
+        function reportUnsafeOptionalChain(node) {
+            context.report({
+                messageId: "unsafeOptionalChain",
+                node
+            });
+        }
+
+        /**
+         * Reports an error for unsafe arithmetic operations on optional chaining.
+         * @param {ASTNode} node node to report
+         * @returns {void}
+         */
+        function reportUnsafeArithmetic(node) {
+            context.report({
+                messageId: "unsafeArithmetic",
+                node
+            });
+        }
+
+        return {
+            ChainExpression(node) {
+                if (
+                    disallowArithmeticOperators &&
+                    node.parent &&
+                    isArithmeticExpression(node.parent)
+                ) {
+                    reportUnsafeArithmetic(node);
+                }
+                if (isPossiblyMakeRuntimeError(node)) {
+                    reportUnsafeOptionalChain(node);
+                }
+            }
+        };
+    }
+};

--- a/lib/rules/no-unsafe-optional-chaining.js
+++ b/lib/rules/no-unsafe-optional-chaining.js
@@ -5,21 +5,9 @@
 
 "use strict";
 
-const ARITHMETIC_OPERATORS = ["+", "-", "/", "*", "%", "**", "+=", "-=", "/=", "*=", "%=", "**="];
+const UNSAFE_ARITHMETIC_OPERATORS = ["+", "-", "/", "*", "%", "**"];
+const UNSAFE_ASSIGNMENT_OPERATORS = ["+=", "-=", "/=", "*=", "%=", "**="];
 const UNSAFE_RELATIONAL_OPERATORS = ["in", "instanceof"];
-
-/**
- * Checks whether a node is an arithmetic expression or not
- * @param {ASTNode} node node to check
- * @returns {boolean} `true` if a node is an arithmetic expression, otherwise `false`
- */
-function isArithmeticExpression(node) {
-    return (
-        node.type === "BinaryExpression" ||
-        node.type === "UnaryExpression" ||
-        node.type === "AssignmentExpression"
-    ) && ARITHMETIC_OPERATORS.includes(node.operator);
-}
 
 /**
  * Checks whether a node is a destructuring pattern or not
@@ -27,43 +15,7 @@ function isArithmeticExpression(node) {
  * @returns {boolean} `true` if a node is a destructuring pattern, otherwise `false`
  */
 function isDestructuringPattern(node) {
-    return node.type === "ObjectPattern" || node.type === "ArrayPattern";
-}
-
-/**
- * Checks whether a ChainExpression make an runtime error or not
- * @param {ASTNode} chainExp a ChainExpression node.
- * @returns {boolean} `true` if it can be a runtime error, otherwise `false`
- */
-function isPossiblyError(chainExp) {
-    const parent = chainExp.parent;
-
-    switch (parent.type) {
-        case "CallExpression":
-        case "NewExpression":
-            return parent.callee === chainExp && parent.parent.type !== "ChainExpression";
-        case "MemberExpression":
-            return parent.object === chainExp && parent.parent.type !== "ChainExpression";
-        case "TaggedTemplateExpression":
-            return parent.tag === chainExp;
-        case "ClassDeclaration":
-            return parent.superClass === chainExp;
-        case "VariableDeclarator":
-            return isDestructuringPattern(parent.id) && parent.init === chainExp;
-        case "AssignmentExpression":
-        case "AssignmentPattern":
-            return isDestructuringPattern(parent.left) && parent.right === chainExp;
-        case "SpreadElement":
-            return parent.parent.type !== "ObjectExpression";
-        case "BinaryExpression":
-            return UNSAFE_RELATIONAL_OPERATORS.includes(parent.operator) && parent.right === chainExp;
-        case "ForOfStatement":
-            return parent.right === chainExp;
-        case "WithStatement":
-            return true;
-        default:
-            return false;
-    }
+    return node && node.type === "ObjectPattern" || node.type === "ArrayPattern";
 }
 
 module.exports = {
@@ -97,23 +49,127 @@ module.exports = {
         const options = context.options[0] || {};
         const disallowArithmeticOperators = (options.disallowArithmeticOperators) || false;
 
-        return {
-            ChainExpression(node) {
-                if (
-                    disallowArithmeticOperators &&
-                    node.parent &&
-                    isArithmeticExpression(node.parent)
-                ) {
-                    context.report({
-                        messageId: "unsafeArithmetic",
-                        node
-                    });
+        /**
+         * Reports unsafe usafe of optional chaining
+         * @param {ASTNode} node node to report
+         * @returns {void}
+         */
+        function reportUnsafeUsage(node) {
+            context.report({
+                messageId: "unsafeOptionalChain",
+                node
+            });
+        }
+
+        /**
+         * Reports unsage arithmetic operation on optional chaining
+         * @param {ASTNode} node node to report
+         * @returns {void}
+         */
+        function reportUnsafeArithmetic(node) {
+            context.report({
+                messageId: "unsafeArithmetic",
+                node
+            });
+        }
+
+        /**
+         * Checks and reports if a node can short-circuit with `undefined` by optional chaining.
+         * @param {ASTNode} node node to check
+         * @param {Function} reportFunc report function
+         * @returns {void}
+         */
+        function checkUndefinedShourtCircuit(node, reportFunc) {
+            if (!node) {
+                return;
+            }
+            if (node.type === "LogicalExpression") {
+                if (node.operator === "||" || node.operator === "??") {
+                    checkUndefinedShourtCircuit(node.right, reportFunc);
+                } else if (node.operator === "&&") {
+                    checkUndefinedShourtCircuit(node.left, reportFunc);
+                    checkUndefinedShourtCircuit(node.right, reportFunc);
                 }
-                if (isPossiblyError(node)) {
-                    context.report({
-                        messageId: "unsafeOptionalChain",
-                        node
-                    });
+            } else if (node.type === "ChainExpression") {
+                reportFunc(node);
+            }
+        }
+
+        /**
+         * Checks unsafe usage of optional chaining
+         * @param {ASTNode} node node to check
+         * @returns {void}
+         */
+        function checkUnsafeUsage(node) {
+            checkUndefinedShourtCircuit(node, reportUnsafeUsage);
+        }
+
+        /**
+         * Checks unsafe arithmetic operaions on optional chaining
+         * @param {ASTNode} node node to check
+         * @returns {void}
+         */
+        function checkUnsafeArithmetic(node) {
+            if (disallowArithmeticOperators) {
+                checkUndefinedShourtCircuit(node, reportUnsafeArithmetic);
+            }
+        }
+
+        return {
+            "CallExpression, NewExpression"(node) {
+                if (node.parent.type !== "ChainExpression") {
+                    checkUnsafeUsage(node.callee);
+                }
+            },
+            "AssignmentExpression, AssignmentPattern"(node) {
+                if (isDestructuringPattern(node.left)) {
+                    checkUnsafeUsage(node.right);
+                }
+            },
+            VariableDeclarator(node) {
+                if (isDestructuringPattern(node.id)) {
+                    checkUnsafeUsage(node.init);
+                }
+            },
+            MemberExpression(node) {
+                if (node.parent && node.parent.type !== "ChainExpression") {
+                    checkUnsafeUsage(node.object);
+                }
+            },
+            TaggedTemplateExpression(node) {
+                checkUnsafeUsage(node.tag);
+            },
+            ClassDeclaration(node) {
+                checkUnsafeUsage(node.superClass);
+            },
+            ForOfStatement(node) {
+                checkUnsafeUsage(node.right);
+            },
+            SpreadElement(node) {
+                if (node.parent && node.parent.type !== "ObjectExpression") {
+                    checkUnsafeUsage(node.argument);
+                }
+            },
+            BinaryExpression(node) {
+                if (UNSAFE_RELATIONAL_OPERATORS.includes(node.operator)) {
+                    checkUnsafeUsage(node.right);
+                }
+                if (UNSAFE_ARITHMETIC_OPERATORS.includes(node.operator)) {
+                    checkUnsafeArithmetic(node.right);
+                    checkUnsafeArithmetic(node.left);
+                }
+            },
+            WithStatement(node) {
+                checkUnsafeUsage(node.object);
+            },
+            UnaryExpression(node) {
+                if (UNSAFE_ARITHMETIC_OPERATORS.includes(node.operator)) {
+                    checkUnsafeArithmetic(node.argument);
+                }
+            },
+            AssignmentExpression(node) {
+                if (UNSAFE_ASSIGNMENT_OPERATORS.includes(node.operator)) {
+                    checkUnsafeArithmetic(node.right);
                 }
             }
         };

--- a/lib/rules/no-unsafe-optional-chaining.js
+++ b/lib/rules/no-unsafe-optional-chaining.js
@@ -5,9 +5,9 @@
 
 "use strict";
 
-const UNSAFE_ARITHMETIC_OPERATORS = ["+", "-", "/", "*", "%", "**"];
-const UNSAFE_ASSIGNMENT_OPERATORS = ["+=", "-=", "/=", "*=", "%=", "**="];
-const UNSAFE_RELATIONAL_OPERATORS = ["in", "instanceof"];
+const UNSAFE_ARITHMETIC_OPERATORS = new Set(["+", "-", "/", "*", "%", "**"]);
+const UNSAFE_ASSIGNMENT_OPERATORS = new Set(["+=", "-=", "/=", "*=", "%=", "**="]);
+const UNSAFE_RELATIONAL_OPERATORS = new Set(["in", "instanceof"]);
 
 /**
  * Checks whether a node is a destructuring pattern or not
@@ -15,7 +15,7 @@ const UNSAFE_RELATIONAL_OPERATORS = ["in", "instanceof"];
  * @returns {boolean} `true` if a node is a destructuring pattern, otherwise `false`
  */
 function isDestructuringPattern(node) {
-    return node && (node.type === "ObjectPattern" || node.type === "ArrayPattern");
+    return node.type === "ObjectPattern" || node.type === "ArrayPattern";
 }
 
 module.exports = {
@@ -23,7 +23,7 @@ module.exports = {
         type: "problem",
 
         docs: {
-            description: "disallow using unsafe optional chaining.",
+            description: "disallow use of optional chaining in contexts where the `undefined` value is not allowed",
             category: "Possible Errors",
             recommended: false,
             url: "https://eslint.org/docs/rules/no-unsafe-optional-chaining"
@@ -50,7 +50,7 @@ module.exports = {
         const disallowArithmeticOperators = (options.disallowArithmeticOperators) || false;
 
         /**
-         * Reports unsafe usafe of optional chaining
+         * Reports unsafe usage of optional chaining
          * @param {ASTNode} node node to report
          * @returns {void}
          */
@@ -62,7 +62,7 @@ module.exports = {
         }
 
         /**
-         * Reports unsage arithmetic operation on optional chaining
+         * Reports unsafe arithmetic operation on optional chaining
          * @param {ASTNode} node node to report
          * @returns {void}
          */
@@ -75,7 +75,7 @@ module.exports = {
 
         /**
          * Checks and reports if a node can short-circuit with `undefined` by optional chaining.
-         * @param {ASTNode} node node to check
+         * @param {ASTNode} [node] node to check
          * @param {Function} reportFunc report function
          * @returns {void}
          */
@@ -83,15 +83,30 @@ module.exports = {
             if (!node) {
                 return;
             }
-            if (node.type === "LogicalExpression") {
-                if (node.operator === "||" || node.operator === "??") {
-                    checkUndefinedShortCircuit(node.right, reportFunc);
-                } else if (node.operator === "&&") {
-                    checkUndefinedShortCircuit(node.left, reportFunc);
-                    checkUndefinedShortCircuit(node.right, reportFunc);
-                }
-            } else if (node.type === "ChainExpression") {
-                reportFunc(node);
+            switch (node.type) {
+                case "LogicalExpression":
+                    if (node.operator === "||" || node.operator === "??") {
+                        checkUndefinedShortCircuit(node.right, reportFunc);
+                    } else if (node.operator === "&&") {
+                        checkUndefinedShortCircuit(node.left, reportFunc);
+                        checkUndefinedShortCircuit(node.right, reportFunc);
+                    }
+                    break;
+                case "SequenceExpression":
+                    checkUndefinedShortCircuit(
+                        node.expressions[node.expressions.length - 1],
+                        reportFunc
+                    );
+                    break;
+                case "ConditionalExpression":
+                    checkUndefinedShortCircuit(node.consequent, reportFunc);
+                    checkUndefinedShortCircuit(node.alternate, reportFunc);
+                    break;
+                case "ChainExpression":
+                    reportFunc(node);
+                    break;
+                default:
+                    break;
             }
         }
 
@@ -152,12 +167,12 @@ module.exports = {
                 }
             },
             BinaryExpression(node) {
-                if (UNSAFE_RELATIONAL_OPERATORS.includes(node.operator)) {
+                if (UNSAFE_RELATIONAL_OPERATORS.has(node.operator)) {
                     checkUnsafeUsage(node.right);
                 }
                 if (
                     disallowArithmeticOperators &&
-                    UNSAFE_ARITHMETIC_OPERATORS.includes(node.operator)
+                    UNSAFE_ARITHMETIC_OPERATORS.has(node.operator)
                 ) {
                     checkUnsafeArithmetic(node.right);
                     checkUnsafeArithmetic(node.left);
@@ -169,7 +184,7 @@ module.exports = {
             UnaryExpression(node) {
                 if (
                     disallowArithmeticOperators &&
-                    UNSAFE_ARITHMETIC_OPERATORS.includes(node.operator)
+                    UNSAFE_ARITHMETIC_OPERATORS.has(node.operator)
                 ) {
                     checkUnsafeArithmetic(node.argument);
                 }
@@ -177,7 +192,7 @@ module.exports = {
             AssignmentExpression(node) {
                 if (
                     disallowArithmeticOperators &&
-                    UNSAFE_ASSIGNMENT_OPERATORS.includes(node.operator)
+                    UNSAFE_ASSIGNMENT_OPERATORS.has(node.operator)
                 ) {
                     checkUnsafeArithmetic(node.right);
                 }

--- a/tests/lib/rules/no-unsafe-optional-chaining.js
+++ b/tests/lib/rules/no-unsafe-optional-chaining.js
@@ -18,10 +18,15 @@ const ruleTester = new RuleTester({ parserOptions });
 
 ruleTester.run("no-unsafe-optional-chaining", rule, {
     valid: [
+        "var foo;",
+        "class Foo {}",
+        "!!obj?.foo",
+
         "obj?.foo();",
         "obj?.foo?.();",
         "(obj?.foo ?? bar)();",
         "(obj?.foo)?.()",
+        "(obj?.foo ?? bar?.baz)?.()",
         "(obj.foo)?.();",
         "obj?.foo.bar;",
         "obj?.foo?.bar;",
@@ -35,6 +40,12 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
         "var bar = {...foo?.bar};",
         "foo?.bar in {};",
         "[foo = obj?.bar] = [];",
+
+        // logical operations
+        "(obj?.foo ?? bar?.baz ?? qux)();",
+        "((obj?.foo ?? bar?.baz) || qux)();",
+        "((obj?.foo || bar?.baz) || qux)();",
+        "((obj?.foo && bar?.baz) || qux)();",
 
         // The default value option disallowArithmeticOperators is false
         "obj?.foo - bar;",
@@ -77,6 +88,50 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
             ]
         },
         {
+            code: "(obj?.foo ?? bar?.baz)();",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 14
+                }
+            ]
+        },
+        {
+            code: "(obj?.foo || bar?.baz)();",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 14
+                }
+            ]
+        },
+        {
+            code: "(obj?.foo && bar)();",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 2
+                }
+            ]
+        },
+        {
+            code: "(bar && obj?.foo)();",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 9
+                }
+            ]
+        },
+        {
             code: "(obj?.foo?.())();",
             errors: [
                 {
@@ -95,6 +150,23 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
                     type: "ChainExpression",
                     line: 1,
                     column: 2
+                }
+            ]
+        },
+        {
+            code: "(obj?.foo && obj?.baz).bar",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 2
+                },
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 14
                 }
             ]
         },
@@ -143,6 +215,17 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
             ]
         },
         {
+            code: "new (obj?.foo?.() || obj?.bar)()",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 22
+                }
+            ]
+        },
+        {
             code: "[...obj?.foo];",
             errors: [
                 {
@@ -150,6 +233,23 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
                     type: "ChainExpression",
                     line: 1,
                     column: 5
+                }
+            ]
+        },
+        {
+            code: "[...(obj?.foo && obj?.bar)];",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 6
+                },
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 18
                 }
             ]
         },
@@ -205,6 +305,17 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
                     type: "ChainExpression",
                     line: 1,
                     column: 15
+                }
+            ]
+        },
+        {
+            code: "const [foo] = obj?.bar || obj?.foo;",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 27
                 }
             ]
         },
@@ -340,6 +451,34 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
                     type: "ChainExpression",
                     line: 1,
                     column: 1
+                }
+            ]
+        },
+        {
+            code: "(foo || obj?.foo) + bar;",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 9
+                }
+            ]
+        },
+        {
+            code: "bar + (foo || obj?.foo);",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 15
                 }
             ]
         },

--- a/tests/lib/rules/no-unsafe-optional-chaining.js
+++ b/tests/lib/rules/no-unsafe-optional-chaining.js
@@ -58,6 +58,8 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
         async function func() {
           await obj?.foo();
           await obj?.foo?.();
+          (await obj?.foo)?.();
+          (await obj?.foo)?.bar;
           await bar?.baz;
           await (foo ?? obj?.foo.baz);
           (await bar?.baz ?? bar).baz;

--- a/tests/lib/rules/no-unsafe-optional-chaining.js
+++ b/tests/lib/rules/no-unsafe-optional-chaining.js
@@ -42,6 +42,8 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
         "var bar = {...foo?.bar};",
         "foo?.bar in {};",
         "[foo = obj?.bar] = [];",
+        "(foo?.bar, bar)();",
+        "(foo?.bar ? baz : qux)();",
 
         // logical operations
         "(obj?.foo ?? bar?.baz ?? qux)();",
@@ -56,6 +58,14 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
         "obj?.foo / bar;",
         "obj?.foo % bar;",
         "obj?.foo ** bar;",
+        "+obj?.foo;",
+        "-obj?.foo;",
+        "bar += obj?.foo;",
+        "bar -= obj?.foo;",
+        "bar %= obj?.foo;",
+        "bar **= obj?.foo;",
+        "bar *= obj?.boo",
+        "bar /= obj?.boo",
 
         {
             code: "(obj?.foo || baz) + bar;",
@@ -80,8 +90,8 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
     invalid: [
         ...[
             "(obj?.foo)();",
-            "(obj?.foo ?? bar?.baz)();",
-            "(obj?.foo || bar?.baz)();",
+            "(obj.foo ?? bar?.baz)();",
+            "(obj.foo || bar?.baz)();",
             "(obj?.foo && bar)();",
             "(bar && obj?.foo)();",
             "(obj?.foo?.())();",
@@ -119,7 +129,17 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
             "1 in foo?.bar;",
 
             // for...of
-            "for (foo of obj?.bar);"
+            "for (foo of obj?.bar);",
+
+            // sequence expression
+            "(foo, obj?.foo)();",
+            "(foo, obj?.foo)[1];",
+
+            // conditional expression
+            "(a ? obj?.foo : b)();",
+            "(a ? b : obj?.foo)();",
+            "(a ? obj?.foo : b)[1];",
+            "(a ? b : obj?.foo).bar;"
         ].map(code => ({
             code,
             errors: [{ messageId: "unsafeOptionalChain", type: "ChainExpression" }]
@@ -155,10 +175,30 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
                 }
             ]
         },
+        {
+            code: "(foo ? obj?.foo : obj?.bar).bar",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 8
+                },
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 19
+                }
+            ]
+        },
         ...[
             "obj?.foo + bar;",
             "(foo || obj?.foo) + bar;",
             "bar + (foo || obj?.foo);",
+            "(a ? obj?.foo : b) + bar",
+            "(a ? b : obj?.foo) + bar",
+            "(foo, bar, baz?.qux) + bar",
             "obj?.foo - bar;",
             "obj?.foo * bar;",
             "obj?.foo / bar;",
@@ -166,10 +206,22 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
             "obj?.foo ** bar;",
             "+obj?.foo;",
             "-obj?.foo;",
+            "+(foo ?? obj?.foo);",
+            "+(foo || obj?.bar);",
+            "+(obj?.bar && foo);",
+            "+(foo ? obj?.foo : bar);",
+            "+(foo ? bar : obj?.foo);",
             "bar += obj?.foo;",
             "bar -= obj?.foo;",
             "bar %= obj?.foo;",
-            "bar **= obj?.foo;"
+            "bar **= obj?.foo;",
+            "bar *= obj?.boo",
+            "bar /= obj?.boo",
+            "bar += (foo ?? obj?.foo);",
+            "bar += (foo || obj?.foo);",
+            "bar += (foo && obj?.foo);",
+            "bar += (foo ? obj?.foo : bar);",
+            "bar += (foo ? bar : obj?.foo);"
         ].map(code => ({
             code,
             options: [{ disallowArithmeticOperators: true }],

--- a/tests/lib/rules/no-unsafe-optional-chaining.js
+++ b/tests/lib/rules/no-unsafe-optional-chaining.js
@@ -200,10 +200,13 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
               (await obj?.foo)();
             }`,
             `async function foo() {
-              (await obj.foo ?? bar?.baz)();
+              (await obj?.foo).bar;
             }`,
             `async function foo() {
-              (await obj?.foo || bar?.baz)();
+              (bar?.baz ?? await obj?.foo)();
+            }`,
+            `async function foo() {
+              (bar && await obj?.foo)();
             }`,
             `async function foo() {
               (await (bar && obj?.foo))();

--- a/tests/lib/rules/no-unsafe-optional-chaining.js
+++ b/tests/lib/rules/no-unsafe-optional-chaining.js
@@ -1,0 +1,390 @@
+/**
+ * @fileoverview Tests for no-unsafe-optional-chaining rule.
+ * @author Yeon JuAn
+ */
+
+"use strict";
+
+const rule = require("../../../lib/rules/no-unsafe-optional-chaining");
+
+const { RuleTester } = require("../../../lib/rule-tester");
+
+const parserOptions = {
+    ecmaVersion: 2021,
+    sourceType: "module"
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+
+ruleTester.run("no-unsafe-optional-chaining", rule, {
+    valid: [
+        "obj?.foo();",
+        "obj?.foo?.();",
+        "(obj?.foo ?? bar)();",
+        "(obj?.foo)?.()",
+        "(obj.foo)?.();",
+        "obj?.foo.bar;",
+        "obj?.foo?.bar;",
+        "(obj?.foo)?.bar;",
+        "(obj?.foo ?? bar).baz;",
+        "(obj?.foo ?? val)`template`",
+        "new (obj?.foo ?? val)()",
+        "obj?.foo?.()();",
+        "const {foo} = obj?.baz || {};",
+        "bar(...obj?.foo ?? []);",
+
+        "var bar = {...foo?.bar};",
+
+        // The default value option disallowArithmeticOperators is false
+        "obj?.foo - bar;",
+        "obj?.foo + bar;",
+        "obj?.foo * bar;",
+        "obj?.foo / bar;",
+        "obj?.foo % bar;",
+        "obj?.foo ** bar;",
+
+        {
+            code: "(obj?.foo || baz) + bar;",
+            options: [{
+                disallowArithmeticOperators: true
+            }]
+        },
+        {
+            code: "(obj?.foo ?? baz) + bar;",
+            options: [{
+                disallowArithmeticOperators: true
+            }]
+        },
+        {
+            code: "bar += obj?.foo ?? val",
+            options: [{
+                disallowArithmeticOperators: true
+            }]
+        }
+    ],
+
+    invalid: [
+        {
+            code: "(obj?.foo)();",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 2
+                }
+            ]
+        },
+        {
+            code: "(obj?.foo?.())();",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 2
+                }
+            ]
+        },
+        {
+            code: "(obj?.foo).bar",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 2
+                }
+            ]
+        },
+        {
+            code: "(obj?.foo)`template`",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 2
+                }
+            ]
+        },
+        {
+            code: "new (obj?.foo)();",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 6
+                }
+            ]
+        },
+        {
+            code: "new (obj?.foo?.())()",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 6
+                }
+            ]
+        },
+        {
+            code: "[...obj?.foo];",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 5
+                }
+            ]
+        },
+        {
+            code: "bar(...obj?.foo);",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 8
+                }
+            ]
+        },
+        {
+            code: "new Bar(...obj?.foo);",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 12
+                }
+            ]
+        },
+        {
+            code: "const {foo} = obj?.bar;",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 15
+                }
+            ]
+        },
+        {
+            code: "const {foo} = obj?.bar();",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 15
+                }
+            ]
+        },
+        {
+            code: "const [foo] = obj?.bar;",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 15
+                }
+            ]
+        },
+        {
+            code: "const [foo] = obj?.bar?.();",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 15
+                }
+            ]
+        },
+        {
+            code: "class A extends obj?.foo {}",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 17
+                }
+            ]
+        },
+        {
+            code: "obj?.foo + bar;",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "obj?.foo - bar;",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "obj?.foo * bar;",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "obj?.foo / bar;",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "obj?.foo % bar;",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "obj?.foo ** bar;",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "+obj?.foo;",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 2
+                }
+            ]
+        },
+        {
+            code: "-obj?.foo;",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 2
+                }
+            ]
+        },
+        {
+            code: "bar += obj?.foo;",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 8
+                }
+            ]
+        },
+        {
+            code: "bar -= obj?.foo;",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 8
+                }
+            ]
+        },
+        {
+            code: "bar %= obj?.foo;",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 8
+                }
+            ]
+        },
+        {
+            code: "bar **= obj?.foo;",
+            options: [{
+                disallowArithmeticOperators: true
+            }],
+            errors: [
+                {
+                    messageId: "unsafeArithmetic",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 9
+                }
+            ]
+        }
+    ]
+});

--- a/tests/lib/rules/no-unsafe-optional-chaining.js
+++ b/tests/lib/rules/no-unsafe-optional-chaining.js
@@ -34,6 +34,7 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
         "bar(...obj?.foo ?? []);",
         "var bar = {...foo?.bar};",
         "foo?.bar in {};",
+        "[foo = obj?.bar] = [];",
 
         // The default value option disallowArithmeticOperators is false
         "obj?.foo - bar;",
@@ -175,17 +176,6 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
             ]
         },
         {
-            code: "1 in foo?.bar;",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 6
-                }
-            ]
-        },
-        {
             code: "const {foo} = obj?.bar;",
             errors: [
                 {
@@ -241,6 +231,39 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
             ]
         },
         {
+            code: "[{ foo } = obj?.bar] = [];",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 12
+                }
+            ]
+        },
+        {
+            code: "({bar: [ foo ] = obj?.prop} = {});",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 18
+                }
+            ]
+        },
+        {
+            code: "[[ foo ] = obj?.bar] = [];",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 12
+                }
+            ]
+        },
+        {
             code: "class A extends obj?.foo {}",
             errors: [
                 {
@@ -251,6 +274,61 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
                 }
             ]
         },
+
+        // unsafe relational operations
+        {
+            code: "foo instanceof obj?.prop",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 16
+                }
+            ]
+        },
+        {
+            code: "1 in foo?.bar;",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 6
+                }
+            ]
+        },
+
+        // unsafe `for...of`
+        {
+            code: "for (foo of obj?.bar);",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 13
+                }
+            ]
+        },
+
+        // unsafe `with`
+        {
+            code: "with (obj?.foo) {};",
+            parserOptions: {
+                sourceType: "script"
+            },
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 7
+                }
+            ]
+        },
+
+        // unsafe arithmetic operations
         {
             code: "obj?.foo + bar;",
             options: [{

--- a/tests/lib/rules/no-unsafe-optional-chaining.js
+++ b/tests/lib/rules/no-unsafe-optional-chaining.js
@@ -32,8 +32,8 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
         "obj?.foo?.()();",
         "const {foo} = obj?.baz || {};",
         "bar(...obj?.foo ?? []);",
-
         "var bar = {...foo?.bar};",
+        "foo?.bar in {};",
 
         // The default value option disallowArithmeticOperators is false
         "obj?.foo - bar;",
@@ -88,6 +88,17 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
         },
         {
             code: "(obj?.foo).bar",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 2
+                }
+            ]
+        },
+        {
+            code: "(obj?.foo)[1];",
             errors: [
                 {
                     messageId: "unsafeOptionalChain",
@@ -164,6 +175,17 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
             ]
         },
         {
+            code: "1 in foo?.bar;",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 6
+                }
+            ]
+        },
+        {
             code: "const {foo} = obj?.bar;",
             errors: [
                 {
@@ -193,6 +215,17 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
                     type: "ChainExpression",
                     line: 1,
                     column: 15
+                }
+            ]
+        },
+        {
+            code: "([foo] = obj?.bar);",
+            errors: [
+                {
+                    messageId: "unsafeOptionalChain",
+                    type: "ChainExpression",
+                    line: 1,
+                    column: 10
                 }
             ]
         },

--- a/tests/lib/rules/no-unsafe-optional-chaining.js
+++ b/tests/lib/rules/no-unsafe-optional-chaining.js
@@ -38,10 +38,20 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
         "new bar();",
         "obj?.foo?.()();",
         "const {foo} = obj?.baz || {};",
+        "const foo = obj?.bar",
+        "foo = obj?.bar",
+        "foo.bar = obj?.bar",
         "bar(...obj?.foo ?? []);",
         "var bar = {...foo?.bar};",
         "foo?.bar in {};",
+        "foo?.bar < foo?.baz;",
+        "foo?.bar <= foo?.baz;",
+        "foo?.bar > foo?.baz;",
+        "foo?.bar >= foo?.baz;",
         "[foo = obj?.bar] = [];",
+        "[foo.bar = obj?.bar] = [];",
+        "({foo = obj?.bar} = obj);",
+        "({foo: obj.bar = obj?.baz} = obj);",
         "(foo?.bar, bar)();",
         "(foo?.bar ? baz : qux)();",
 
@@ -66,23 +76,53 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
         "bar **= obj?.foo;",
         "bar *= obj?.boo",
         "bar /= obj?.boo",
-
-        {
-            code: "(obj?.foo || baz) + bar;",
+        ...[
+            "obj?.foo | bar",
+            "obj?.foo & bar",
+            "obj?.foo >> obj?.bar;",
+            "obj?.foo << obj?.bar;",
+            "obj?.foo >>> obj?.bar;",
+            "(obj?.foo || baz) + bar;",
+            "(obj?.foo ?? baz) + bar;",
+            "(obj?.foo ?? baz) - bar;",
+            "(obj?.foo ?? baz) * bar;",
+            "(obj?.foo ?? baz) / bar;",
+            "(obj?.foo ?? baz) % bar;",
+            "(obj?.foo ?? baz) ** bar;",
+            "void obj?.foo;",
+            "typeof obj?.foo;",
+            "!obj?.foo",
+            "~obj?.foo",
+            "+(obj?.foo ?? bar)",
+            "-(obj?.foo ?? bar)",
+            "bar |= obj?.foo;",
+            "bar &= obj?.foo;",
+            "bar ^= obj?.foo;",
+            "bar <<= obj?.foo;",
+            "bar >>= obj?.foo;",
+            "bar >>>= obj?.foo;",
+            "bar ||= obj?.foo",
+            "bar &&= obj?.foo",
+            "bar += (obj?.foo ?? baz);",
+            "bar -= (obj?.foo ?? baz)",
+            "bar *= (obj?.foo ?? baz)",
+            "bar /= (obj?.foo ?? baz)",
+            "bar %= (obj?.foo ?? baz);",
+            "bar **= (obj?.foo ?? baz)"
+        ].map(code => ({
+            code,
             options: [{
                 disallowArithmeticOperators: true
             }]
+        })),
+        {
+            code: "obj?.foo - bar;",
+            options: [{}]
         },
         {
-            code: "(obj?.foo ?? baz) + bar;",
+            code: "obj?.foo - bar;",
             options: [{
-                disallowArithmeticOperators: true
-            }]
-        },
-        {
-            code: "bar += obj?.foo ?? val",
-            options: [{
-                disallowArithmeticOperators: true
+                disallowArithmeticOperators: false
             }]
         }
     ],
@@ -110,6 +150,7 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
             // destructuring
             "const {foo} = obj?.bar;",
             "const {foo} = obj?.bar();",
+            "const {foo: bar} = obj?.bar();",
             "const [foo] = obj?.bar;",
             "const [foo] = obj?.bar || obj?.foo;",
             "([foo] = obj?.bar);",

--- a/tests/lib/rules/no-unsafe-optional-chaining.js
+++ b/tests/lib/rules/no-unsafe-optional-chaining.js
@@ -21,7 +21,6 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
         "var foo;",
         "class Foo {}",
         "!!obj?.foo",
-
         "obj?.foo();",
         "obj?.foo?.();",
         "(obj?.foo ?? bar)();",
@@ -31,9 +30,12 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
         "obj?.foo.bar;",
         "obj?.foo?.bar;",
         "(obj?.foo)?.bar;",
+        "(obj?.foo)?.bar.baz;",
+        "(obj?.foo)?.().bar",
         "(obj?.foo ?? bar).baz;",
         "(obj?.foo ?? val)`template`",
         "new (obj?.foo ?? val)()",
+        "new bar();",
         "obj?.foo?.()();",
         "const {foo} = obj?.baz || {};",
         "bar(...obj?.foo ?? []);",
@@ -76,83 +78,52 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
     ],
 
     invalid: [
-        {
-            code: "(obj?.foo)();",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 2
-                }
-            ]
-        },
-        {
-            code: "(obj?.foo ?? bar?.baz)();",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 14
-                }
-            ]
-        },
-        {
-            code: "(obj?.foo || bar?.baz)();",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 14
-                }
-            ]
-        },
-        {
-            code: "(obj?.foo && bar)();",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 2
-                }
-            ]
-        },
-        {
-            code: "(bar && obj?.foo)();",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 9
-                }
-            ]
-        },
-        {
-            code: "(obj?.foo?.())();",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 2
-                }
-            ]
-        },
-        {
-            code: "(obj?.foo).bar",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 2
-                }
-            ]
-        },
+        ...[
+            "(obj?.foo)();",
+            "(obj?.foo ?? bar?.baz)();",
+            "(obj?.foo || bar?.baz)();",
+            "(obj?.foo && bar)();",
+            "(bar && obj?.foo)();",
+            "(obj?.foo?.())();",
+            "(obj?.foo).bar",
+            "(obj?.foo)[1];",
+            "(obj?.foo)`template`",
+            "new (obj?.foo)();",
+            "new (obj?.foo?.())()",
+            "new (obj?.foo?.() || obj?.bar)()",
+
+            // spread
+            "[...obj?.foo];",
+            "bar(...obj?.foo);",
+            "new Bar(...obj?.foo);",
+
+            // destructuring
+            "const {foo} = obj?.bar;",
+            "const {foo} = obj?.bar();",
+            "const [foo] = obj?.bar;",
+            "const [foo] = obj?.bar || obj?.foo;",
+            "([foo] = obj?.bar);",
+            "const [foo] = obj?.bar?.();",
+            "[{ foo } = obj?.bar] = [];",
+            "({bar: [ foo ] = obj?.prop} = {});",
+            "[[ foo ] = obj?.bar] = [];",
+
+            // class declaration
+            "class A extends obj?.foo {}",
+
+            // class expression
+            "var a = class A extends obj?.foo {}",
+
+            // relational operations
+            "foo instanceof obj?.prop",
+            "1 in foo?.bar;",
+
+            // for...of
+            "for (foo of obj?.bar);"
+        ].map(code => ({
+            code,
+            errors: [{ messageId: "unsafeOptionalChain", type: "ChainExpression" }]
+        })),
         {
             code: "(obj?.foo && obj?.baz).bar",
             errors: [
@@ -171,260 +142,6 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
             ]
         },
         {
-            code: "(obj?.foo)[1];",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 2
-                }
-            ]
-        },
-        {
-            code: "(obj?.foo)`template`",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 2
-                }
-            ]
-        },
-        {
-            code: "new (obj?.foo)();",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 6
-                }
-            ]
-        },
-        {
-            code: "new (obj?.foo?.())()",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 6
-                }
-            ]
-        },
-        {
-            code: "new (obj?.foo?.() || obj?.bar)()",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 22
-                }
-            ]
-        },
-        {
-            code: "[...obj?.foo];",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 5
-                }
-            ]
-        },
-        {
-            code: "[...(obj?.foo && obj?.bar)];",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 6
-                },
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 18
-                }
-            ]
-        },
-        {
-            code: "bar(...obj?.foo);",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 8
-                }
-            ]
-        },
-        {
-            code: "new Bar(...obj?.foo);",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 12
-                }
-            ]
-        },
-        {
-            code: "const {foo} = obj?.bar;",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 15
-                }
-            ]
-        },
-        {
-            code: "const {foo} = obj?.bar();",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 15
-                }
-            ]
-        },
-        {
-            code: "const [foo] = obj?.bar;",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 15
-                }
-            ]
-        },
-        {
-            code: "const [foo] = obj?.bar || obj?.foo;",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 27
-                }
-            ]
-        },
-        {
-            code: "([foo] = obj?.bar);",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 10
-                }
-            ]
-        },
-        {
-            code: "const [foo] = obj?.bar?.();",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 15
-                }
-            ]
-        },
-        {
-            code: "[{ foo } = obj?.bar] = [];",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 12
-                }
-            ]
-        },
-        {
-            code: "({bar: [ foo ] = obj?.prop} = {});",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 18
-                }
-            ]
-        },
-        {
-            code: "[[ foo ] = obj?.bar] = [];",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 12
-                }
-            ]
-        },
-        {
-            code: "class A extends obj?.foo {}",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 17
-                }
-            ]
-        },
-
-        // unsafe relational operations
-        {
-            code: "foo instanceof obj?.prop",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 16
-                }
-            ]
-        },
-        {
-            code: "1 in foo?.bar;",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 6
-                }
-            ]
-        },
-
-        // unsafe `for...of`
-        {
-            code: "for (foo of obj?.bar);",
-            errors: [
-                {
-                    messageId: "unsafeOptionalChain",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 13
-                }
-            ]
-        },
-
-        // unsafe `with`
-        {
             code: "with (obj?.foo) {};",
             parserOptions: {
                 sourceType: "script"
@@ -438,203 +155,25 @@ ruleTester.run("no-unsafe-optional-chaining", rule, {
                 }
             ]
         },
-
-        // unsafe arithmetic operations
-        {
-            code: "obj?.foo + bar;",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 1
-                }
-            ]
-        },
-        {
-            code: "(foo || obj?.foo) + bar;",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 9
-                }
-            ]
-        },
-        {
-            code: "bar + (foo || obj?.foo);",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 15
-                }
-            ]
-        },
-        {
-            code: "obj?.foo - bar;",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 1
-                }
-            ]
-        },
-        {
-            code: "obj?.foo * bar;",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 1
-                }
-            ]
-        },
-        {
-            code: "obj?.foo / bar;",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 1
-                }
-            ]
-        },
-        {
-            code: "obj?.foo % bar;",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 1
-                }
-            ]
-        },
-        {
-            code: "obj?.foo ** bar;",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 1
-                }
-            ]
-        },
-        {
-            code: "+obj?.foo;",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 2
-                }
-            ]
-        },
-        {
-            code: "-obj?.foo;",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 2
-                }
-            ]
-        },
-        {
-            code: "bar += obj?.foo;",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 8
-                }
-            ]
-        },
-        {
-            code: "bar -= obj?.foo;",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 8
-                }
-            ]
-        },
-        {
-            code: "bar %= obj?.foo;",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 8
-                }
-            ]
-        },
-        {
-            code: "bar **= obj?.foo;",
-            options: [{
-                disallowArithmeticOperators: true
-            }],
-            errors: [
-                {
-                    messageId: "unsafeArithmetic",
-                    type: "ChainExpression",
-                    line: 1,
-                    column: 9
-                }
-            ]
-        }
+        ...[
+            "obj?.foo + bar;",
+            "(foo || obj?.foo) + bar;",
+            "bar + (foo || obj?.foo);",
+            "obj?.foo - bar;",
+            "obj?.foo * bar;",
+            "obj?.foo / bar;",
+            "obj?.foo % bar;",
+            "obj?.foo ** bar;",
+            "+obj?.foo;",
+            "-obj?.foo;",
+            "bar += obj?.foo;",
+            "bar -= obj?.foo;",
+            "bar %= obj?.foo;",
+            "bar **= obj?.foo;"
+        ].map(code => ({
+            code,
+            options: [{ disallowArithmeticOperators: true }],
+            errors: [{ messageId: "unsafeArithmetic", type: "ChainExpression" }]
+        }))
     ]
 });

--- a/tools/rule-types.json
+++ b/tools/rule-types.json
@@ -204,6 +204,7 @@
     "no-unreachable-loop": "problem",
     "no-unsafe-finally": "problem",
     "no-unsafe-negation": "problem",
+    "no-unsafe-optional-chaining": "problem",
     "no-unused-expressions": "suggestion",
     "no-unused-labels": "suggestion",
     "no-unused-vars": "problem",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added a new rule `no-unsafe-optional-chaining` which proposed by @mysticatea  #13431

This rule will catch cases that may possibly TypeError when using `optional chaining`.

```js
var obj = {};

// TypeError

(obj?.foo).bar;

(obj?.foo)();

(obj?.foo)`template`;

new (obj?.foo)();

class A extends obj?.foo {};

[...obj?.foo];

bar(...obj?.foo);

new Bar(...obj?.foo);

1 in obj?.foo;

var { a } = obj?.foo;

var [a] = obj?.foo;

// [edited]
foo instanceof obj?.prop

for (foo of obj?.prop);

[{ foo } = obj?.prop] = [];

with (obj?.prop);

// [edited] - handle logical result.

(obj?.foo ?? obj?.bar)();

(foo || obj?.foo)();
```

And by the option `disallowArithmeticOperators: true` it also catches the operation which possibly results in unexpected NaN. - [comment](https://github.com/eslint/eslint/issues/13431#issuecomment-647141087)

```js

obj?.foo * bar;
obj?.foo - bar;
obj?.foo + bar;
obj?.foo % bar;
obj?.foo ** bar;

a *= obj?.foo;
a -= obj?.foo;
a += obj?.foo;
a %= obj?.foo;
a **= obj?.foo;

+obj?.foo;
-obj?.foo;
```

#### Is there anything you'd like reviewers to focus on?

Maybe there are some other cases we should handle?
