### PR TITLE
Docs: correct the function-call-argument-newline 'default' descriptions

### DIFF
--- a/docs/rules/function-call-argument-newline.md
+++ b/docs/rules/function-call-argument-newline.md
@@ -72,7 +72,7 @@ baz(
 
 ### never
 
-Examples of **incorrect** code for this rule with the default `"never"` option:
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint function-call-argument-newline: ["error", "never"]*/
@@ -123,7 +123,7 @@ baz("one", "two", (x) => {
 
 ### consistent
 
-Examples of **incorrect** code for this rule with the default `"consistent"` option:
+Examples of **incorrect** code for this rule with the `"consistent"` option:
 
 ```js
 /*eslint function-call-argument-newline: ["error", "consistent"]*/
@@ -143,7 +143,7 @@ baz("one", "two",
 );
 ```
 
-Examples of **correct** code for this rule with the default `"consistent"` option:
+Examples of **correct** code for this rule with the `"consistent"` option:
 
 ```js
 /*eslint function-call-argument-newline: ["error", "consistent"]*/


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [X] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

The documentation's descriptions of options for the `function-call-argument-newline` rule use "default" for the `"never"` and `"consistent"` options, although these options are not defaults. The only default is `"always"` for this rule. If a user reads these parts of the documentation, they might incorrectly expect their desired option of `"never"` or `"consistent"` to be the default value while the tool actually uses `"always"`.

#### Is there anything you'd like reviewers to focus on?

Please ensure that the word "default" is correctly used throughout this document.