### PR TITLE
Chore: make proper checkboxes in the GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,16 +8,16 @@
 
 - [ ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
 
-#### What is the purpose of this pull request? (put an "X" next to an item)
+#### What is the purpose of this pull request?
 
-[ ] Documentation update
-[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
-[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
-[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
-[ ] Add autofixing to a rule
-[ ] Add a CLI option
-[ ] Add something to the core
-[ ] Other, please explain:
+- [ ] Documentation update
+- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
+- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
+- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
+- [ ] Add autofixing to a rule
+- [ ] Add a CLI option
+- [ ] Add something to the core
+- [ ] Other, please explain:
 
 <!--
     If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [X] Other, please explain: GitHub PR template update

#### What changes did you make? (Give an overview)

I changed the `[ ]` notation to `- [ ]` for the pull request purpose options in the GitHub PR template, which get rendered properly as checkboxes.

#### Is there anything you'd like reviewers to focus on?

Please consider whether or not it makes sense that I also removed the `(put an "X" next to an item)` note.