### PR TITLE
Fix: handle parenthesized chaining expression in prefer-destructuring

### DIFF
--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -221,7 +221,11 @@ module.exports = {
          * @returns {void}
          */
         function performCheck(leftNode, rightNode, reportNode) {
-            if (rightNode.type !== "MemberExpression" || rightNode.object.type === "Super") {
+            if (
+                rightNode.type !== "MemberExpression" ||
+                rightNode.object.type === "Super" ||
+                (rightNode.type === "MemberExpression" && rightNode.object.type === "ChainExpression")
+            ) {
                 return;
             }
 

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -157,7 +157,15 @@ ruleTester.run("prefer-destructuring", rule, {
 
         // Optional chaining
         "var foo = array?.[0];", // because the fixed code can throw TypeError.
-        "var foo = object?.foo;"
+        "var foo = object?.foo;",
+        "var bar = (object?.foo).bar;",
+        "var bar = (object?.foo()).bar;",
+        "var bar = (object?.foo?.()).bar;",
+        "var bar = (object?.foo)?.bar;",
+        "bar = (object?.foo).bar;",
+        "bar = (object?.foo)[0];",
+        "bar = (object?.foo()).bar;",
+        "bar = (object?.foo())[0];"
     ],
 
     invalid: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)


The current version, `prefer-destructuring` warns following cases.

- [online demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IHByZWZlci1kZXN0cnVjdHVyaW5nOiBbXCJlcnJvclwiLCB7XG4gICAgICBcImFycmF5XCI6IHRydWUsXG4gICAgICBcIm9iamVjdFwiOiB0cnVlXG4gICAgfSwge1xuICAgICAgXCJlbmZvcmNlRm9yUmVuYW1lZFByb3BlcnRpZXNcIjogZmFsc2VcbiAgICB9XSovXG5cbnZhciBiYXIgPSAob2JqZWN0Py5mb28pLmJhcjtcbnZhciBiYXIgPSAob2JqZWN0Py5mb28oKSkuYmFyO1xudmFyIGJhciA9IChvYmplY3Q/LmZvbz8uKCkpLmJhcjtcbmJhciA9IChvYmplY3Q/LmZvbykuYmFyO1xuYmFyID0gKG9iamVjdD8uZm9vKVswXTtcbmJhciA9IChvYmplY3Q/LmZvbygpKS5iYXI7XG5iYXIgPSAob2JqZWN0Py5mb28oKSlbMF07XG4iLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjExLCJzb3VyY2VUeXBlIjoibW9kdWxlIiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7ImluZGVudCI6Mn0sImVudiI6eyJicm93c2VyIjp0cnVlfX19)
```js
/* eslint prefer-destructuring: ["error", {
      "array": true,
      "object": true
    }, {
      "enforceForRenamedProperties": false
    }]*/

var bar = (object?.foo).bar; // Error
var bar = (object?.foo()).bar; // Error
var bar = (object?.foo?.()).bar; // Error
bar = (object?.foo).bar; // Error
bar = (object?.foo)[0]; // Error
bar = (object?.foo()).bar; // Error
bar = (object?.foo())[0]; // Error
```

But as described in [this comment](https://github.com/eslint/eslint/issues/13431#issuecomment-650575626), it would occur TypeError when auto fixed.
This PR change "prefer-destructuring" to ignore those cases.

#### Is there anything you'd like reviewers to focus on?


