### PR TITLE
Breaking: Ajv to v8.5.0, added ajv-draft-04 (fixes #13888)

### DIFF
--- a/conf/config-schema.js
+++ b/conf/config-schema.js
@@ -24,8 +24,7 @@ const baseConfigProperties = {
     globals: { type: "object" },
     overrides: {
         type: "array",
-        items: { $ref: "#/definitions/overrideConfig" },
-        additionalItems: false
+        items: { $ref: "#/definitions/overrideConfig" }
     },
     parser: { type: ["string", "null"] },
     parserOptions: { type: "object" },
@@ -46,8 +45,7 @@ const configSchema = {
                 { type: "string" },
                 {
                     type: "array",
-                    items: { type: "string" },
-                    additionalItems: false
+                    items: { type: "string" }
                 }
             ]
         },
@@ -57,7 +55,6 @@ const configSchema = {
                 {
                     type: "array",
                     items: { type: "string" },
-                    additionalItems: false,
                     minItems: 1
                 }
             ]

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -50,7 +50,7 @@ const
     { getRuleOptionsSchema, validate } = require("../shared/config-validator"),
     { Linter, SourceCodeFixer, interpolate } = require("../linter");
 
-const ajv = require("../shared/ajv")({ strictDefaults: true });
+const ajv = require("../shared/ajv")();
 
 const espreePath = require.resolve("espree");
 

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -533,7 +533,7 @@ class RuleTester {
 
                 if (ajv.errors) {
                     const errors = ajv.errors.map(error => {
-                        const field = error.dataPath[0] === "." ? error.dataPath.slice(1) : error.dataPath;
+                        const field = error.instancePath[0] === "." ? error.instancePath.slice(1) : error.instancePath;
 
                         return `\t${field}: ${error.message}`;
                     }).join("\n");

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -50,7 +50,7 @@ const
     { getRuleOptionsSchema, validate } = require("../shared/config-validator"),
     { Linter, SourceCodeFixer, interpolate } = require("../linter");
 
-const ajv = require("../shared/ajv")();
+const ajv = require("../shared/ajv")({ strictSchema: true });
 
 const espreePath = require.resolve("espree");
 

--- a/lib/rules/array-element-newline.js
+++ b/lib/rules/array-element-newline.js
@@ -47,6 +47,7 @@ module.exports = {
                     ]
                 }
             },
+            type: "array",
             items: [
                 {
                     oneOf: [

--- a/lib/rules/func-names.js
+++ b/lib/rules/func-names.js
@@ -45,6 +45,7 @@ module.exports = {
                     ]
                 }
             },
+            type: "array",
             items: [
                 {
                     $ref: "#/definitions/value"

--- a/lib/rules/no-restricted-modules.js
+++ b/lib/rules/no-restricted-modules.js
@@ -65,8 +65,7 @@ module.exports = {
                             patterns: arrayOfStrings
                         },
                         additionalProperties: false
-                    },
-                    additionalItems: false
+                    }
                 }
             ]
         },

--- a/lib/rules/no-sequences.js
+++ b/lib/rules/no-sequences.js
@@ -35,6 +35,7 @@ module.exports = {
         },
 
         schema: [{
+            type: "object",
             properties: {
                 allowInParentheses: {
                     type: "boolean",

--- a/lib/rules/nonblock-statement-body-position.js
+++ b/lib/rules/nonblock-statement-body-position.js
@@ -26,8 +26,10 @@ module.exports = {
         schema: [
             POSITION_SCHEMA,
             {
+                type: "object",
                 properties: {
                     overrides: {
+                        type: "object",
                         properties: {
                             if: POSITION_SCHEMA,
                             else: POSITION_SCHEMA,

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -450,8 +450,7 @@ module.exports = {
                             type: "array",
                             items: { enum: Object.keys(StatementTypes) },
                             minItems: 1,
-                            uniqueItems: true,
-                            additionalItems: false
+                            uniqueItems: true
                         }
                     ]
                 }
@@ -466,8 +465,7 @@ module.exports = {
                 },
                 additionalProperties: false,
                 required: ["blankLine", "prev", "next"]
-            },
-            additionalItems: false
+            }
         },
 
         messages: {

--- a/lib/shared/ajv.js
+++ b/lib/shared/ajv.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const Ajv = require("ajv").default;
+const Ajv = require("ajv-draft-04");
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -19,7 +19,9 @@ module.exports = (additionalOptions = {}) => {
         useDefaults: true,
         validateSchema: false,
         verbose: true,
+        strict: "log",
         strictTuples: false,
+        strictSchema: true,
         ...additionalOptions
     });
 

--- a/lib/shared/ajv.js
+++ b/lib/shared/ajv.js
@@ -8,8 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const Ajv = require("ajv"),
-    metaSchema = require("ajv/lib/refs/json-schema-draft-04.json");
+const Ajv = require("ajv").default;
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -17,18 +16,13 @@ const Ajv = require("ajv"),
 
 module.exports = (additionalOptions = {}) => {
     const ajv = new Ajv({
-        meta: false,
         useDefaults: true,
         validateSchema: false,
-        missingRefs: "ignore",
         verbose: true,
-        schemaId: "auto",
+        strictTuples: false,
+        strictTypes: false,
         ...additionalOptions
     });
-
-    ajv.addMetaSchema(metaSchema);
-    // eslint-disable-next-line no-underscore-dangle
-    ajv._opts.defaultMeta = metaSchema.id;
 
     return ajv;
 };

--- a/lib/shared/ajv.js
+++ b/lib/shared/ajv.js
@@ -21,7 +21,6 @@ module.exports = (additionalOptions = {}) => {
         verbose: true,
         strict: "log",
         strictTuples: false,
-        strictSchema: true,
         ...additionalOptions
     });
 

--- a/lib/shared/ajv.js
+++ b/lib/shared/ajv.js
@@ -20,7 +20,6 @@ module.exports = (additionalOptions = {}) => {
         validateSchema: false,
         verbose: true,
         strictTuples: false,
-        strictTypes: false,
         ...additionalOptions
     });
 

--- a/lib/shared/config-validator.js
+++ b/lib/shared/config-validator.js
@@ -242,19 +242,19 @@ function validateProcessor(processorName, source, getProcessor) {
 function formatErrors(errors) {
     return errors.map(error => {
         if (error.keyword === "additionalProperties") {
-            const formattedPropertyPath = error.dataPath.length ? `${error.dataPath.slice(1)}.${error.params.additionalProperty}` : error.params.additionalProperty;
+            const formattedPropertyPath = error.instancePath.length ? `${error.instancePath.slice(1)}.${error.params.additionalProperty}` : error.params.additionalProperty;
 
             return `Unexpected top-level property "${formattedPropertyPath}"`;
         }
         if (error.keyword === "type") {
-            const formattedField = error.dataPath.slice(1);
+            const formattedField = error.instancePath.slice(1);
             const formattedExpectedType = Array.isArray(error.schema) ? error.schema.join("/") : error.schema;
             const formattedValue = JSON.stringify(error.data);
 
             return `Property "${formattedField}" is the wrong type (expected ${formattedExpectedType} but got \`${formattedValue}\`)`;
         }
 
-        const field = error.dataPath[0] === "." ? error.dataPath.slice(1) : error.dataPath;
+        const field = error.instancePath[0] === "." ? error.instancePath.slice(1) : error.instancePath;
 
         return `"${field}" ${error.message}. Value: ${JSON.stringify(error.data)}`;
     }).map(message => `\t- ${message}.\n`).join("");

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@babel/code-frame": "7.12.11",
     "@eslint/eslintrc": "^0.4.1",
-    "ajv": "^6.10.0",
+    "ajv": "^8.0.0",
     "chalk": "^4.0.0",
     "cross-spawn": "^7.0.2",
     "debug": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@babel/code-frame": "7.12.11",
     "@eslint/eslintrc": "^0.4.1",
     "ajv": "^8.5.0",
-    "ajv-draft-04": "^0.1.0",
+    "ajv-draft-04": "^1.0.0",
     "chalk": "^4.0.0",
     "cross-spawn": "^7.0.2",
     "debug": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "dependencies": {
     "@babel/code-frame": "7.12.11",
     "@eslint/eslintrc": "^0.4.1",
-    "ajv": "^8.0.0",
+    "ajv": "^8.5.0",
+    "ajv-draft-04": "^0.1.0",
     "chalk": "^4.0.0",
     "cross-spawn": "^7.0.2",
     "debug": "^4.0.1",

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -5860,7 +5860,7 @@ describe("CLIEngine", () => {
                     const engine = new CLIEngine({ cwd: getPath() });
 
                     engine.executeOnFiles("*.js");
-                }, "Unexpected top-level property \"overrides[0].ignorePatterns\"");
+                }, /Unexpected top-level property/u);
             });
         });
 

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -5693,7 +5693,7 @@ describe("ESLint", () => {
                     const engine = new ESLint({ cwd: getPath() });
 
                     await engine.lintFiles("*.js");
-                }, /Unexpected top-level property "overrides\[0\]\.ignorePatterns"/u);
+                }, /Unexpected top-level property/u);
             });
         });
     });

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -824,8 +824,7 @@ describe("RuleTester", () => {
                     { code: "var answer = 6 * 7;", options: ["bar"], errors: [{ message: "Expected nothing." }] }
                 ]
             });
-        }, "Schema for rule no-invalid-schema is invalid:,\t/items: should be object,boolean\n\t/items/0/enum: should NOT have fewer than 1 items\n\t/items: should match some schema in anyOf");
-
+        }, "Schema for rule no-invalid-schema is invalid:,\t/items: must be object\n\t/items/0/enum: must NOT have fewer than 1 items\n\t/items: must match a schema in anyOf");
     });
 
     it("should prevent schema violations in options", () => {
@@ -839,7 +838,7 @@ describe("RuleTester", () => {
                     { code: "var answer = 6 * 7;", options: ["bar"], errors: [{ message: "Expected foo." }] }
                 ]
             });
-        }, /Value "bar" should be equal to one of the allowed values./u);
+        }, /Value "bar" must be equal to one of the allowed values./u);
 
     });
 

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -824,7 +824,7 @@ describe("RuleTester", () => {
                     { code: "var answer = 6 * 7;", options: ["bar"], errors: [{ message: "Expected nothing." }] }
                 ]
             });
-        }, "Schema for rule no-invalid-schema is invalid:,\titems: should be object\n\titems[0].enum: should NOT have fewer than 1 items\n\titems: should match some schema in anyOf");
+        }, "Schema for rule no-invalid-schema is invalid:,\t/items: should be object,boolean\n\t/items/0/enum: should NOT have fewer than 1 items\n\t/items: should match some schema in anyOf");
 
     });
 
@@ -877,7 +877,7 @@ describe("RuleTester", () => {
                 ],
                 invalid: []
             });
-        }, /Schema for rule invalid-defaults is invalid: default is ignored for: data1\.foo/u);
+        }, /Schema for rule invalid-defaults is invalid: strict mode: default is ignored for: data0\.foo/u);
     });
 
     it("throw an error when an unknown config option is included", () => {

--- a/tests/lib/shared/config-validator.js
+++ b/tests/lib/shared/config-validator.js
@@ -257,7 +257,7 @@ describe("Validator", () => {
             it("should throw with an object", () => {
                 const fn = validator.validate.bind(null, { extends: {} }, null, ruleMapper);
 
-                assert.throws(fn, "ESLint configuration in null is invalid:\n\t- Property \"extends\" is the wrong type (expected string but got `{}`).\n\t- Property \"extends\" is the wrong type (expected array but got `{}`).\n\t- \"/extends\" should match exactly one schema in oneOf. Value: {}.");
+                assert.throws(fn, "ESLint configuration in null is invalid:\n\t- Property \"extends\" is the wrong type (expected string but got `{}`).\n\t- Property \"extends\" is the wrong type (expected array but got `{}`).\n\t- \"/extends\" must match exactly one schema in oneOf. Value: {}.");
             });
         });
 
@@ -332,7 +332,7 @@ describe("Validator", () => {
 
                 const fn = validator.validate.bind(null, { rules: { "mock-no-options-rule": [2, "extra"] } }, "tests", ruleMapper);
 
-                assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-no-options-rule\" is invalid:\n\tValue [\"extra\"] should NOT have more than 0 items.\n");
+                assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-no-options-rule\" is invalid:\n\tValue [\"extra\"] must NOT have more than 0 items.\n");
             });
         });
 
@@ -357,13 +357,13 @@ describe("Validator", () => {
             it("should throw if override does not specify files", () => {
                 const fn = validator.validate.bind(null, { overrides: [{ rules: {} }] }, "tests", ruleMapper);
 
-                assert.throws(fn, "ESLint configuration in tests is invalid:\n\t- \"/overrides/0\" should have required property 'files'. Value: {\"rules\":{}}.\n");
+                assert.throws(fn, "ESLint configuration in tests is invalid:\n\t- \"/overrides/0\" must have required property 'files'. Value: {\"rules\":{}}.\n");
             });
 
             it("should throw if override has an empty files array", () => {
                 const fn = validator.validate.bind(null, { overrides: [{ files: [] }] }, "tests", ruleMapper);
 
-                assert.throws(fn, "ESLint configuration in tests is invalid:\n\t- Property \"overrides/0/files\" is the wrong type (expected string but got `[]`).\n\t- \"/overrides/0/files\" should NOT have fewer than 1 items. Value: [].\n\t- \"/overrides/0/files\" should match exactly one schema in oneOf. Value: [].\n");
+                assert.throws(fn, "ESLint configuration in tests is invalid:\n\t- Property \"overrides/0/files\" is the wrong type (expected string but got `[]`).\n\t- \"/overrides/0/files\" must NOT have fewer than 1 items. Value: [].\n\t- \"/overrides/0/files\" must match exactly one schema in oneOf. Value: [].\n");
             });
 
             it("should not throw if override has nested overrides", () => {
@@ -409,7 +409,7 @@ describe("Validator", () => {
 
                     const fn = validator.validate.bind(null, { overrides: [{ files: "*", rules: { "mock-no-options-rule": [2, "extra"] } }] }, "tests", ruleMapper);
 
-                    assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-no-options-rule\" is invalid:\n\tValue [\"extra\"] should NOT have more than 0 items.\n");
+                    assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-no-options-rule\" is invalid:\n\tValue [\"extra\"] must NOT have more than 0 items.\n");
                 });
             });
 
@@ -467,13 +467,13 @@ describe("Validator", () => {
         it("should throw for incorrect configuration values", () => {
             const fn = validator.validateRuleOptions.bind(null, ruleMapper("mock-rule"), "mock-rule", [2, "frist"], "tests");
 
-            assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tValue \"frist\" should be equal to one of the allowed values.\n");
+            assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tValue \"frist\" must be equal to one of the allowed values.\n");
         });
 
         it("should throw for too many configuration values", () => {
             const fn = validator.validateRuleOptions.bind(null, ruleMapper("mock-rule"), "mock-rule", [2, "first", "second"], "tests");
 
-            assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tValue [\"first\",\"second\"] should NOT have more than 1 items.\n");
+            assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tValue [\"first\",\"second\"] must NOT have more than 1 items.\n");
         });
 
     });

--- a/tests/lib/shared/config-validator.js
+++ b/tests/lib/shared/config-validator.js
@@ -257,7 +257,7 @@ describe("Validator", () => {
             it("should throw with an object", () => {
                 const fn = validator.validate.bind(null, { extends: {} }, null, ruleMapper);
 
-                assert.throws(fn, "ESLint configuration in null is invalid:\n\t- Property \"extends\" is the wrong type (expected string but got `{}`).\n\t- Property \"extends\" is the wrong type (expected array but got `{}`).\n\t- \"extends\" should match exactly one schema in oneOf. Value: {}.");
+                assert.throws(fn, "ESLint configuration in null is invalid:\n\t- Property \"extends\" is the wrong type (expected string but got `{}`).\n\t- Property \"extends\" is the wrong type (expected array but got `{}`).\n\t- \"/extends\" should match exactly one schema in oneOf. Value: {}.");
             });
         });
 
@@ -357,13 +357,13 @@ describe("Validator", () => {
             it("should throw if override does not specify files", () => {
                 const fn = validator.validate.bind(null, { overrides: [{ rules: {} }] }, "tests", ruleMapper);
 
-                assert.throws(fn, "ESLint configuration in tests is invalid:\n\t- \"overrides[0]\" should have required property 'files'. Value: {\"rules\":{}}.\n");
+                assert.throws(fn, "ESLint configuration in tests is invalid:\n\t- \"/overrides/0\" should have required property 'files'. Value: {\"rules\":{}}.\n");
             });
 
             it("should throw if override has an empty files array", () => {
                 const fn = validator.validate.bind(null, { overrides: [{ files: [] }] }, "tests", ruleMapper);
 
-                assert.throws(fn, "ESLint configuration in tests is invalid:\n\t- Property \"overrides[0].files\" is the wrong type (expected string but got `[]`).\n\t- \"overrides[0].files\" should NOT have fewer than 1 items. Value: [].\n\t- \"overrides[0].files\" should match exactly one schema in oneOf. Value: [].\n");
+                assert.throws(fn, "ESLint configuration in tests is invalid:\n\t- Property \"overrides/0/files\" is the wrong type (expected string but got `[]`).\n\t- \"/overrides/0/files\" should NOT have fewer than 1 items. Value: [].\n\t- \"/overrides/0/files\" should match exactly one schema in oneOf. Value: [].\n");
             });
 
             it("should not throw if override has nested overrides", () => {
@@ -377,7 +377,7 @@ describe("Validator", () => {
             it("should throw if override tries to set root", () => {
                 const fn = validator.validate.bind(null, { overrides: [{ files: "*", root: "true" }] }, "tests", ruleMapper);
 
-                assert.throws(fn, "ESLint configuration in tests is invalid:\n\t- Unexpected top-level property \"overrides[0].root\".\n");
+                assert.throws(fn, "ESLint configuration in tests is invalid:\n\t- Unexpected top-level property \"overrides/0.root\".\n");
             });
 
             describe("env", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Update Ajv version to v7

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Update Ajv to version v7.0.0-rc.0
- Update schemas:
  - remove ignored `additionalItems` keywords (it is possible though that the intention was to have only one item allowed in these schemas, in which case schemas have to be changed from `items: {...}` to `items: [{...}], additionalItems: false`
  - add missing `type` keywords (in the second commit).
- Remove `strictDefaults` option ([strict mode](https://github.com/ajv-validator/ajv/blob/master/docs/strict-mode.md) is on by default now) and other deprecated option
- Use JSON Schema draft-07 (although it was not explicitly specified that schemas are draft-04)
- Fix failing tests (all updates are because of changes in how dataPath is shown)

#### Is there anything you'd like reviewers to focus on?

- Review updated schemas whether they are correct.
- Please note that Ajv v7 no longer supports JSON Schema draft-04, but all schemas I have seen are draft-07 compatible, so no changes were necessary. As I wrote in #13888, it may have effect on plugins maybe? It is probably still worth trying to release as a minor version upgrade (once Ajv v7 becomes the main version in 1-2 weeks) and monitor if there are some issues while resolving them.

cc @nzakas 