### PR TITLE
Fix: require-atomic-updates false positive across await (fixes #11954)

### DIFF
--- a/lib/rules/require-atomic-updates.js
+++ b/lib/rules/require-atomic-updates.js
@@ -113,6 +113,9 @@ class SegmentInfo {
 
             if (info) {
                 info.freshReadVariableNames.add(variableName);
+
+                // If a variable is freshly read again, then it's no more out-dated.
+                info.outdatedReadVariableNames.delete(variableName);
             }
         }
     }

--- a/tests/lib/rules/require-atomic-updates.js
+++ b/tests/lib/rules/require-atomic-updates.js
@@ -150,6 +150,18 @@ ruleTester.run("require-atomic-updates", rule, {
                 let bar = await get(foo.id);
                 foo.prop = bar.prop;
             }
+        `,
+
+        // https://github.com/eslint/eslint/issues/11954
+        `
+            let count = 0
+            let queue = []
+            async function A(...args) {
+                count += 1
+                await new Promise(resolve=>resolve())
+                count -= 1
+                return
+            }
         `
     ],
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
make require-atomic-updates work in the case described by issue #11954

#### Is there anything you'd like reviewers to focus on?
I am new to eslint contribution, so sorry if this looks bad.
