### PR TITLE
Fix: prefer-exponentiation-operator invalid autofix with await

### DIFF
--- a/lib/rules/prefer-exponentiation-operator.js
+++ b/lib/rules/prefer-exponentiation-operator.js
@@ -30,6 +30,7 @@ function doesBaseNeedParens(base) {
         astUtils.getPrecedence(base) <= PRECEDENCE_OF_EXPONENTIATION_EXPR ||
 
         // An unary operator cannot be used immediately before an exponentiation expression
+        base.type === "AwaitExpression" ||
         base.type === "UnaryExpression"
     );
 }

--- a/tests/lib/rules/prefer-exponentiation-operator.js
+++ b/tests/lib/rules/prefer-exponentiation-operator.js
@@ -218,6 +218,8 @@ ruleTester.run("prefer-exponentiation-operator", rule, {
         invalid("Math.pow(a, -b)", "a**-b"),
         invalid("Math.pow(-2, 3)", "(-2)**3"),
         invalid("Math.pow(2, -3)", "2**-3"),
+        invalid("async () => Math.pow(await a, b)", "async () => (await a)**b"),
+        invalid("async () => Math.pow(a, await b)", "async () => a**await b"),
 
         // base and exponent with a lower precedence
         invalid("Math.pow(a * b, c)", "(a * b)**c"),


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

This is similar to https://github.com/eslint/eslint/issues/12739

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.15.0
* **Node Version:** v12.18.4
* **npm Version:** v6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2017
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IHByZWZlci1leHBvbmVudGlhdGlvbi1vcGVyYXRvcjogZXJyb3IgKi9cblxuYXN5bmMgKCkgPT4gTWF0aC5wb3coYXdhaXQgYSwgYilcbiIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6OCwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js
/* eslint prefer-exponentiation-operator: error */

async () => Math.pow(await a, b)
```

**What did you expect to happen?**

`await` expression without parens cannot be left-hand side of an exponentiation expression, so the following autofix is expected: 

```js
/* eslint prefer-exponentiation-operator: error */

async () => (await a)**b
```

**What actually happened? Please include the actual, raw output from ESLint.**

autofix:

```js
/* eslint prefer-exponentiation-operator: error */

async () => await a**b
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `prefer-exponentiation-operator` rule to add parens around `await` before `**`.

#### Is there anything you'd like reviewers to focus on?
