### PR TITLE
New: Adds options to `padding-line-between-statements`

### DIFF
--- a/docs/rules/padding-line-between-statements.md
+++ b/docs/rules/padding-line-between-statements.md
@@ -29,59 +29,41 @@ You can supply any number of configurations. If a statement pair matches multipl
 {
     "padding-line-between-statements": [
         "error",
-        { "blankLine": LINEBREAK_TYPE, "prev": STATEMENT_TYPE, "next": STATEMENT_TYPE },
-        { "blankLine": LINEBREAK_TYPE, "prev": STATEMENT_TYPE, "next": STATEMENT_TYPE },
-        { "blankLine": LINEBREAK_TYPE, "prev": STATEMENT_TYPE, "next": STATEMENT_TYPE },
-        { "blankLine": LINEBREAK_TYPE, "prev": STATEMENT_TYPE, "next": STATEMENT_TYPE },
+        { "blankLine": LINEBREAK_TYPE, "prev": MODIFIER_TYPE STATEMENT_TYPE, "next": STATEMENT_TYPE },
+        { "blankLine": LINEBREAK_TYPE, "prev": MODIFIER_TYPE STATEMENT_TYPE, "next": STATEMENT_TYPE },
+        { "blankLine": LINEBREAK_TYPE, "prev": MODIFIER_TYPE STATEMENT_TYPE, "next": STATEMENT_TYPE },
+        { "blankLine": LINEBREAK_TYPE, "prev": MODIFIER_TYPE STATEMENT_TYPE, "next": STATEMENT_TYPE },
         ...
     ]
 }
 ```
 
-- `LINEBREAK_TYPE` is one of the following.
+- `LINEBREAK_TYPE` is one of the following:
     - `"any"` just ignores the statement pair.
     - `"never"` disallows blank lines.
     - `"always"` requires one or more blank lines. Note it does not count lines that comments exist as blank lines.
 
-- `STATEMENT_TYPE` is one of the following, or an array of the following.
-    - `"*"` is wildcard. This matches any statements.
-    - `"block"` is lonely blocks.
-    - `"block-like"` is block like statements. This matches statements that the last token is the closing brace of blocks; e.g. `{ }`, `if (a) { }`, and `while (a) { }`. Also matches immediately invoked function expression statements.
-    - `"break"` is `break` statements.
-    - `"case"` is `case` clauses in `switch` statements.
-    - `"cjs-export"` is `export` statements of CommonJS; e.g. `module.exports = 0`, `module.exports.foo = 1`, and `exports.foo = 2`. This is a special case of assignment.
-    - `"cjs-import"` is `import` statements of CommonJS; e.g. `const foo = require("foo")`. This is a special case of variable declarations.
-    - `"class"` is `class` declarations.
-    - `"const"` is `const` variable declarations, both single-line and multiline.
-    - `"continue"` is `continue` statements.
-    - `"debugger"` is `debugger` statements.
-    - `"default"` is `default` clauses in `switch` statements.
-    - `"directive"` is directive prologues. This matches directives; e.g. `"use strict"`.
-    - `"do"` is `do-while` statements. This matches all statements that the first token is `do` keyword.
-    - `"empty"` is empty statements.
-    - `"export"` is `export` declarations.
-    - `"expression"` is expression statements.
-    - `"for"` is `for` loop families. This matches all statements that the first token is `for` keyword.
-    - `"function"` is function declarations.
-    - `"if"` is `if` statements.
-    - `"iife"` is immediately invoked function expression statements. This matches calls on a function expression, optionally prefixed with a unary operator.
-    - `"import"` is `import` declarations.
-    - `"let"` is `let` variable declarations, both single-line and multiline.
-    - `"multiline-block-like"` is block like statements. This is the same as `block-like` type, but only if the block is multiline.
-    - `"multiline-const"` is multiline `const` variable declarations.
-    - `"multiline-expression"` is expression statements. This is the same as `expression` type, but only if the statement is multiline.
-    - `"multiline-let"` is multiline `let` variable declarations.
-    - `"multiline-var"` is multiline `var` variable declarations.
-    - `"return"` is `return` statements.
-    - `"singleline-const"` is single-line `const` variable declarations.
-    - `"singleline-let"` is single-line `let` variable declarations.
-    - `"singleline-var"` is single-line `var` variable declarations.
-    - `"switch"` is `switch` statements.
-    - `"throw"` is `throw` statements.
-    - `"try"` is `try` statements.
-    - `"var"` is `var` variable declarations, both single-line and multiline.
-    - `"while"` is `while` loop statements.
-    - `"with"` is `with` statements.
+- `STATEMENT_TYPE` is one (or an array) of the following:
+    - A keyword (e.g. "const", or "class")
+    - A space-delimited list of keywords (e.g. "export const")
+    - One of the following special keywords (cannot partake in space-delimited lists):
+        - `"*"` is wildcard. This matches any statements.
+        - `"block"` is lonely blocks.
+        - `"block-like"` is block like statements. This matches statements that the last token is the closing brace of blocks; e.g. `{ }`, `if (a) { }`, and `while (a) { }`. Also matches immediately invoked function expression statements.
+        - `"cjs-export"` is `export` statements of CommonJS; e.g. `module.exports = 0`, `module.exports.foo = 1`, and `exports.foo = 2`. This is a special case of assignment.
+        - `"cjs-import"` is `import` statements of CommonJS; e.g. `const foo = require("foo")`. This is a special case of variable declarations.
+        - `"directive"` is directive prologues. This matches directives; e.g. `"use strict"`.
+        - `"empty"` is empty statements.
+        - `"iife"` is immediately invoked function expression statements. This matches calls on a function expression, optionally prefixed with a unary operator.
+        - `"function"` is function declarations.
+        - `"expression"` is expression statements.
+        - `"named-export"` is named exports; e.g. `export const foo = {}`, `export function foo() {}`, and `export { foo }`.
+        - `"default-export"` is default exports; e.g. `export default foo() {}`.
+        - `"all-export"` is specific exports; e.g. `export * from "foo"`.
+
+- `MODIFIER_TYPE` is one of the following:
+    - `"singleline-"` only treats single line `STATEMENT_TYPE`s.
+    - `"multiline-"` only treats multi line `STATEMENT_TYPE`s.
 
 ## Examples
 

--- a/docs/rules/padding-line-between-statements.md
+++ b/docs/rules/padding-line-between-statements.md
@@ -46,7 +46,7 @@ You can supply any number of configurations. If a statement pair matches multipl
 - `STATEMENT_TYPE` is one (or an array) of the following:
     - A keyword (e.g. "const", or "class")
     - A space-delimited list of keywords (e.g. "export const")
-    - One of the following special keywords (cannot partake in space-delimited lists):
+    - One of the following (cannot partake in space-delimited lists):
         - `"*"` is wildcard. This matches any statements.
         - `"block"` is lonely blocks.
         - `"block-like"` is block like statements. This matches statements that the last token is the closing brace of blocks; e.g. `{ }`, `if (a) { }`, and `while (a) { }`. Also matches immediately invoked function expression statements.
@@ -59,7 +59,7 @@ You can supply any number of configurations. If a statement pair matches multipl
         - `"expression"` is expression statements.
         - `"named-export"` is named exports; e.g. `export const foo = {}`, `export function foo() {}`, and `export { foo }`.
         - `"default-export"` is default exports; e.g. `export default foo() {}`.
-        - `"all-export"` is specific exports; e.g. `export * from "foo"`.
+        - `"all-export"` is module reexports; e.g. `export * from "foo"`.
 
 - `MODIFIER_TYPE` is one of the following:
     - `"singleline-"` only treats single line `STATEMENT_TYPE`s.

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -30,7 +30,7 @@ const PADDING_LINE_SEQUENCE = new RegExp(
 function newKeywordTester(keyword) {
     return {
         test: (node, sourceCode) => keyword.split(" ").every(
-            (kwd, i) => sourceCode.getFirstToken(node, i)?.value === kwd
+            (kwd, i) => sourceCode.getFirstToken(node, i).value === kwd
         )
     };
 }
@@ -83,8 +83,8 @@ function isCJSImport(node) {
     if (node.type === "VariableDeclaration") {
         const declaration = node.declarations[0];
 
-        if (declaration?.init) {
-            let call = declaration?.init;
+        if (declaration.init) {
+            let call = declaration.init;
 
             while (call.type === "MemberExpression") {
                 call = call.object;

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Rule to require or disallow newlines between statements
- * @author Toru Nagashima
+ * @author Toru Nagashima & jun-sheaf
  */
 
 "use strict";
@@ -20,8 +20,6 @@ const PADDING_LINE_SEQUENCE = new RegExp(
     String.raw`^(\s*?${LT})\s*${LT}(\s*;?)$`,
     "u"
 );
-const CJS_EXPORT = /^(?:module\s*\.\s*)?exports(?:\s*\.|\s*\[|$)/u;
-const CJS_IMPORT = /^require\(/u;
 
 /**
  * Creates tester which check if a node starts with specific keyword.
@@ -31,36 +29,9 @@ const CJS_IMPORT = /^require\(/u;
  */
 function newKeywordTester(keyword) {
     return {
-        test: (node, sourceCode) =>
-            sourceCode.getFirstToken(node).value === keyword
-    };
-}
-
-/**
- * Creates tester which check if a node starts with specific keyword and spans a single line.
- * @param {string} keyword The keyword to test.
- * @returns {Object} the created tester.
- * @private
- */
-function newSinglelineKeywordTester(keyword) {
-    return {
-        test: (node, sourceCode) =>
-            node.loc.start.line === node.loc.end.line &&
-            sourceCode.getFirstToken(node).value === keyword
-    };
-}
-
-/**
- * Creates tester which check if a node starts with specific keyword and spans multiple lines.
- * @param {string} keyword The keyword to test.
- * @returns {Object} the created tester.
- * @private
- */
-function newMultilineKeywordTester(keyword) {
-    return {
-        test: (node, sourceCode) =>
-            node.loc.start.line !== node.loc.end.line &&
-            sourceCode.getFirstToken(node).value === keyword
+        test: (node, sourceCode) => keyword.split(" ").every(
+            (kwd, i) => sourceCode.getFirstToken(node, i)?.value === kwd
+        )
     };
 }
 
@@ -90,7 +61,71 @@ function isIIFEStatement(node) {
         if (call.type === "UnaryExpression") {
             call = astUtils.skipChainExpression(call.argument);
         }
-        return call.type === "CallExpression" && astUtils.isFunction(call.callee);
+
+        if (call.type === "CallExpression") {
+            call = call.callee;
+            while (call.type === "SequenceExpression") {
+                call = call.expressions[call.expressions.length - 1];
+            }
+            return astUtils.isFunction(call);
+        }
+    }
+    return false;
+}
+
+/**
+ * Checks the given node is a CommonJS import statement
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is a CommonJS import statement.
+ * @private
+ */
+function isCJSImport(node) {
+    if (node.type === "VariableDeclaration") {
+        const declaration = node.declarations[0];
+
+        if (declaration?.init) {
+            let call = declaration?.init;
+
+            while (call.type === "MemberExpression") {
+                call = call.object;
+            }
+            if (
+                call.type === "CallExpression" &&
+                call.callee.type === "Identifier"
+            ) {
+                return call.callee.name === "require";
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Checks the given node is a CommonJS export statement
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is a CommonJS export statement.
+ * @private
+ */
+function isCJSExport(node) {
+    if (node.type === "ExpressionStatement") {
+        const expression = node.expression;
+
+        if (expression.type === "AssignmentExpression") {
+            let left = expression.left;
+
+            if (left.type === "MemberExpression") {
+                while (left.object.type === "MemberExpression") {
+                    left = left.object;
+                }
+                return (
+                    left.object.type === "Identifier" &&
+                    (left.object.name === "exports" ||
+                        (left.object.name === "module" &&
+                            left.property.type === "Identifier" &&
+                            left.property.name === "exports"))
+                );
+            }
+        }
     }
     return false;
 }
@@ -98,12 +133,12 @@ function isIIFEStatement(node) {
 /**
  * Checks whether the given node is a block-like statement.
  * This checks the last token of the node is the closing brace of a block.
- * @param {SourceCode} sourceCode The source code to get tokens.
  * @param {ASTNode} node The node to check.
+ * @param {SourceCode} sourceCode The source code to get tokens.
  * @returns {boolean} `true` if the node is a block-like statement.
  * @private
  */
-function isBlockLikeStatement(sourceCode, node) {
+function isBlockLikeStatement(node, sourceCode) {
 
     // do-while with a block is a block-like statement.
     if (node.type === "DoWhileStatement" && node.body.type === "BlockStatement") {
@@ -171,6 +206,19 @@ function isDirectivePrologue(node, sourceCode) {
         return true;
     }
     return false;
+}
+
+/**
+ * Check whether the given node is an expression
+ * @param {ASTNode} node The node to check.
+ * @param {SourceCode} sourceCode The source code object to get tokens.
+ * @returns {boolean} `true` if the node is an expression
+ */
+function isExpression(node, sourceCode) {
+    return (
+        node.type === "ExpressionStatement" &&
+        !isDirectivePrologue(node, sourceCode)
+    );
 }
 
 /**
@@ -349,76 +397,19 @@ const PaddingTypes = {
  */
 const StatementTypes = {
     "*": { test: () => true },
-    "block-like": {
-        test: (node, sourceCode) => isBlockLikeStatement(sourceCode, node)
-    },
-    "cjs-export": {
-        test: (node, sourceCode) =>
-            node.type === "ExpressionStatement" &&
-            node.expression.type === "AssignmentExpression" &&
-            CJS_EXPORT.test(sourceCode.getText(node.expression.left))
-    },
-    "cjs-import": {
-        test: (node, sourceCode) =>
-            node.type === "VariableDeclaration" &&
-            node.declarations.length > 0 &&
-            Boolean(node.declarations[0].init) &&
-            CJS_IMPORT.test(sourceCode.getText(node.declarations[0].init))
-    },
-    directive: {
-        test: isDirectivePrologue
-    },
-    expression: {
-        test: (node, sourceCode) =>
-            node.type === "ExpressionStatement" &&
-            !isDirectivePrologue(node, sourceCode)
-    },
-    iife: {
-        test: isIIFEStatement
-    },
-    "multiline-block-like": {
-        test: (node, sourceCode) =>
-            node.loc.start.line !== node.loc.end.line &&
-            isBlockLikeStatement(sourceCode, node)
-    },
-    "multiline-expression": {
-        test: (node, sourceCode) =>
-            node.loc.start.line !== node.loc.end.line &&
-            node.type === "ExpressionStatement" &&
-            !isDirectivePrologue(node, sourceCode)
-    },
-
-    "multiline-const": newMultilineKeywordTester("const"),
-    "multiline-let": newMultilineKeywordTester("let"),
-    "multiline-var": newMultilineKeywordTester("var"),
-    "singleline-const": newSinglelineKeywordTester("const"),
-    "singleline-let": newSinglelineKeywordTester("let"),
-    "singleline-var": newSinglelineKeywordTester("var"),
+    "block-like": { test: isBlockLikeStatement },
+    "cjs-export": { test: isCJSExport },
+    "cjs-import": { test: isCJSImport },
+    directive: { test: isDirectivePrologue },
+    expression: { test: isExpression },
+    iife: { test: isIIFEStatement },
 
     block: newNodeTypeTester("BlockStatement"),
     empty: newNodeTypeTester("EmptyStatement"),
     function: newNodeTypeTester("FunctionDeclaration"),
-
-    break: newKeywordTester("break"),
-    case: newKeywordTester("case"),
-    class: newKeywordTester("class"),
-    const: newKeywordTester("const"),
-    continue: newKeywordTester("continue"),
-    debugger: newKeywordTester("debugger"),
-    default: newKeywordTester("default"),
-    do: newKeywordTester("do"),
-    export: newKeywordTester("export"),
-    for: newKeywordTester("for"),
-    if: newKeywordTester("if"),
-    import: newKeywordTester("import"),
-    let: newKeywordTester("let"),
-    return: newKeywordTester("return"),
-    switch: newKeywordTester("switch"),
-    throw: newKeywordTester("throw"),
-    try: newKeywordTester("try"),
-    var: newKeywordTester("var"),
-    while: newKeywordTester("while"),
-    with: newKeywordTester("with")
+    "named-export": newNodeTypeTester("ExportNamedDeclaration"),
+    "default-export": newNodeTypeTester("ExportDefaultDeclaration"),
+    "all-export": newNodeTypeTester("ExportAllDeclaration")
 };
 
 //------------------------------------------------------------------------------
@@ -445,10 +436,10 @@ module.exports = {
                 },
                 statementType: {
                     anyOf: [
-                        { enum: Object.keys(StatementTypes) },
+                        { type: "string" },
                         {
                             type: "array",
-                            items: { enum: Object.keys(StatementTypes) },
+                            items: { type: "string" },
                             minItems: 1,
                             uniqueItems: true,
                             additionalItems: false
@@ -516,10 +507,28 @@ module.exports = {
             while (innerStatementNode.type === "LabeledStatement") {
                 innerStatementNode = innerStatementNode.body;
             }
-            if (Array.isArray(type)) {
-                return type.some(match.bind(null, innerStatementNode));
-            }
-            return StatementTypes[type].test(innerStatementNode, sourceCode);
+
+            const types = !Array.isArray(type) ? [type] : type;
+
+            return types.some(t => {
+                let tt = t;
+
+                if (/^singleline-/u.test(tt)) {
+                    if (node.loc.start.line !== node.loc.end.line) {
+                        return false;
+                    }
+                    tt = tt.slice(11);
+                }
+                if (/^multiline-/u.test(tt)) {
+                    if (node.loc.start.line === node.loc.end.line) {
+                        return false;
+                    }
+                    tt = tt.slice(10);
+                }
+                return tt in StatementTypes
+                    ? StatementTypes[tt].test(innerStatementNode, sourceCode)
+                    : newKeywordTester(tt).test(innerStatementNode, sourceCode);
+            });
         }
 
         /**


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

`padding-line-between-statements`

**Does this change cause the rule to produce more or fewer warnings?**

This change does not produce more or less warnings.

**How will the change be implemented? (New option, new default behavior, etc.)?**

Several ways (see below)

**Please provide some example code that this change will affect:**

```js
(1, 2, () => undefined)() // This was originally not treated.
```

**What does the rule currently do for this code?**

It adds padding to different statement types.

**What will the rule do after it's changed?**

The same thing. There are no breaking changes.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The following changes have been made:
  - CommonJS requires and exports are no longer detected using regular expressions. A proper traversal is now done.
  - The case when an IIFE is in a comma-sequenced expression is now fixed.
  - There are three new special STATEMENT_TYPE
      - `named-export`,
      - `default-export`, and
      - `all-export`
  - `multiline-` and `singleline-` can now be applied to any STATEMENT_TYPE.
  - STATEMENT_TYPE validation has been removed. The default behavior is to treat any STATEMENT_TYPE as a keyword.
  - Space-delimited STATEMENT_TYPEs are treated as sequences of keywords.

#### Is there anything you'd like reviewers to focus on?

None
