### PR TITLE
Update: add suggestion for no-mixed-operators

### DIFF
--- a/lib/rules/no-mixed-operators.js
+++ b/lib/rules/no-mixed-operators.js
@@ -117,7 +117,8 @@ module.exports = {
         ],
 
         messages: {
-            unexpectedMixedOperator: "Unexpected mix of '{{leftOperator}}' and '{{rightOperator}}'."
+            unexpectedMixedOperator: "Unexpected mix of '{{leftOperator}}' and '{{rightOperator}}'.",
+            addParens: "Add parentheses around the higher precendence operator '{{higherPrecedenceOperator}}' to clarify existing behavior."
         }
     },
 
@@ -183,6 +184,36 @@ module.exports = {
         }
 
         /**
+         * Gets the string display for the operator a given node.
+         * @param {ASTNode} node A node to get suggestions for.
+         * @returns {string} The string display for the operator a given node.
+         */
+        function getOperatorDisplay(node) {
+            return node.operator || "?:";
+        }
+
+        /**
+         * Gets the suggestions for a given node.
+         * @param {ASTNode} node A node to get suggestions for.
+         * @param {ASTNode} higherPrecedenceNode The node that has the higher precedence.
+         * @returns {SuggestionResult[]} The suggestions for the node.
+         */
+        function getSuggestionsForNode(node, higherPrecedenceNode) {
+            if (node === higherPrecedenceNode) {
+                return [
+                    {
+                        messageId: "addParens",
+                        data: { higherPrecedenceOperator: getOperatorDisplay(higherPrecedenceNode) },
+                        fix(fixer) {
+                            return fixer.replaceText(node, `(${sourceCode.getText(node)})`);
+                        }
+                    }
+                ];
+            }
+            return [];
+        }
+
+        /**
          * Reports both the operator of a given node and the operator of the
          * parent node.
          * @param {ASTNode} node A node to check. This is a BinaryExpression
@@ -195,21 +226,34 @@ module.exports = {
             const left = (getChildNode(parent) === node) ? node : parent;
             const right = (getChildNode(parent) !== node) ? node : parent;
             const data = {
-                leftOperator: left.operator || "?:",
-                rightOperator: right.operator || "?:"
+                leftOperator: getOperatorDisplay(left),
+                rightOperator: getOperatorDisplay(right)
             };
+
+            let higherPrecendenceNode = null;
+            const canComparePrecedence = includesBothInAGroup(options.groups, data.leftOperator, data.rightOperator);
+
+            if (canComparePrecedence) {
+                if (astUtils.getPrecedence(left) > astUtils.getPrecedence(right)) {
+                    higherPrecendenceNode = left;
+                } else if (astUtils.getPrecedence(right) > astUtils.getPrecedence(left)) {
+                    higherPrecendenceNode = right;
+                }
+            }
 
             context.report({
                 node: left,
                 loc: getOperatorToken(left).loc,
                 messageId: "unexpectedMixedOperator",
-                data
+                data,
+                suggest: getSuggestionsForNode(higherPrecendenceNode, left)
             });
             context.report({
                 node: right,
                 loc: getOperatorToken(right).loc,
                 messageId: "unexpectedMixedOperator",
-                data
+                data,
+                suggest: getSuggestionsForNode(higherPrecendenceNode, right)
             });
         }
 

--- a/tests/lib/rules/no-mixed-operators.js
+++ b/tests/lib/rules/no-mixed-operators.js
@@ -71,7 +71,14 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: "||"
-                    }
+                    },
+                    suggestions: [{
+                        messageId: "addParens",
+                        data: {
+                            higherPrecedenceOperator: "&&"
+                        },
+                        output: "(a && b) || c"
+                    }]
                 },
                 {
                     column: 8,
@@ -80,7 +87,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: "||"
-                    }
+                    },
+                    suggestions: []
                 }
             ]
         },
@@ -94,7 +102,14 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: "||"
-                    }
+                    },
+                    suggestions: [{
+                        messageId: "addParens",
+                        data: {
+                            higherPrecedenceOperator: "&&"
+                        },
+                        output: "(a && b > 0) || c"
+                    }]
                 },
                 {
                     column: 3,
@@ -102,7 +117,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: ">"
-                    }
+                    },
+                    suggestions: []
                 },
                 {
                     column: 8,
@@ -110,7 +126,14 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: ">"
-                    }
+                    },
+                    suggestions: [{
+                        messageId: "addParens",
+                        data: {
+                            higherPrecedenceOperator: ">"
+                        },
+                        output: "a && (b > 0) || c"
+                    }]
                 },
                 {
                     column: 12,
@@ -118,7 +141,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: "||"
-                    }
+                    },
+                    suggestions: []
                 }
             ]
         },
@@ -132,7 +156,14 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: "||"
-                    }
+                    },
+                    suggestions: [{
+                        messageId: "addParens",
+                        data: {
+                            higherPrecedenceOperator: "&&"
+                        },
+                        output: "(a && b > 0) || c"
+                    }]
                 },
                 {
                     column: 12,
@@ -140,7 +171,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: "||"
-                    }
+                    },
+                    suggestions: []
                 }
             ]
         },
@@ -154,7 +186,14 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: "||"
-                    }
+                    },
+                    suggestions: [{
+                        messageId: "addParens",
+                        data: {
+                            higherPrecedenceOperator: "&&"
+                        },
+                        output: "(a && b + c - d / e) || f"
+                    }]
                 },
                 {
                     column: 12,
@@ -162,7 +201,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "-",
                         rightOperator: "/"
-                    }
+                    },
+                    suggestions: []
                 },
                 {
                     column: 16,
@@ -170,7 +210,14 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "-",
                         rightOperator: "/"
-                    }
+                    },
+                    suggestions: [{
+                        messageId: "addParens",
+                        data: {
+                            higherPrecedenceOperator: "/"
+                        },
+                        output: "a && b + c - (d / e) || f"
+                    }]
                 },
                 {
                     column: 20,
@@ -178,7 +225,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: "||"
-                    }
+                    },
+                    suggestions: []
                 }
             ]
         },
@@ -192,7 +240,14 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: "||"
-                    }
+                    },
+                    suggestions: [{
+                        messageId: "addParens",
+                        data: {
+                            higherPrecedenceOperator: "&&"
+                        },
+                        output: "(a && b + c - d / e) || f"
+                    }]
                 },
                 {
                     column: 12,
@@ -200,7 +255,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "-",
                         rightOperator: "/"
-                    }
+                    },
+                    suggestions: []
                 },
                 {
                     column: 16,
@@ -208,7 +264,14 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "-",
                         rightOperator: "/"
-                    }
+                    },
+                    suggestions: [{
+                        messageId: "addParens",
+                        data: {
+                            higherPrecedenceOperator: "/"
+                        },
+                        output: "a && b + c - (d / e) || f"
+                    }]
                 },
                 {
                     column: 20,
@@ -216,7 +279,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: "||"
-                    }
+                    },
+                    suggestions: []
                 }
             ]
         },
@@ -231,7 +295,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "+",
                         rightOperator: "-"
-                    }
+                    },
+                    suggestions: []
                 },
                 {
                     column: 7,
@@ -240,7 +305,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "+",
                         rightOperator: "-"
-                    }
+                    },
+                    suggestions: []
                 }
             ]
         },
@@ -255,7 +321,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "*",
                         rightOperator: "/"
-                    }
+                    },
+                    suggestions: []
                 },
                 {
                     column: 7,
@@ -264,7 +331,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "*",
                         rightOperator: "/"
-                    }
+                    },
+                    suggestions: []
                 }
             ]
         },
@@ -279,7 +347,14 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "||",
                         rightOperator: "?:"
-                    }
+                    },
+                    suggestions: [{
+                        messageId: "addParens",
+                        data: {
+                            higherPrecedenceOperator: "||"
+                        },
+                        output: "(a || b) ? c : d"
+                    }]
                 },
                 {
                     column: 8,
@@ -288,7 +363,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "||",
                         rightOperator: "?:"
-                    }
+                    },
+                    suggestions: []
                 }
             ]
         },
@@ -303,7 +379,14 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: "?:"
-                    }
+                    },
+                    suggestions: [{
+                        messageId: "addParens",
+                        data: {
+                            higherPrecedenceOperator: "&&"
+                        },
+                        output: "(a && b) ? 1 : 2"
+                    }]
                 },
                 {
                     column: 8,
@@ -312,7 +395,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "&&",
                         rightOperator: "?:"
-                    }
+                    },
+                    suggestions: []
                 }
             ]
         },
@@ -327,7 +411,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "?:",
                         rightOperator: "&&"
-                    }
+                    },
+                    suggestions: []
                 },
                 {
                     column: 7,
@@ -336,7 +421,14 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "?:",
                         rightOperator: "&&"
-                    }
+                    },
+                    suggestions: [{
+                        messageId: "addParens",
+                        data: {
+                            higherPrecedenceOperator: "&&"
+                        },
+                        output: "x ? (a && b) : 0"
+                    }]
                 }
             ]
         },
@@ -351,7 +443,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "?:",
                         rightOperator: "&&"
-                    }
+                    },
+                    suggestions: []
                 },
                 {
                     column: 11,
@@ -360,7 +453,14 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "?:",
                         rightOperator: "&&"
-                    }
+                    },
+                    suggestions: [{
+                        messageId: "addParens",
+                        data: {
+                            higherPrecedenceOperator: "&&"
+                        },
+                        output: "x ? 0 : (a && b)"
+                    }]
                 }
             ]
         },
@@ -376,7 +476,14 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "+",
                         rightOperator: "??"
-                    }
+                    },
+                    suggestions: [{
+                        messageId: "addParens",
+                        data: {
+                            higherPrecedenceOperator: "+"
+                        },
+                        output: "(a + b) ?? c"
+                    }]
                 },
                 {
                     column: 7,
@@ -385,7 +492,8 @@ ruleTester.run("no-mixed-operators", rule, {
                     data: {
                         leftOperator: "+",
                         rightOperator: "??"
-                    }
+                    },
+                    suggestions: []
                 }
             ]
         }


### PR DESCRIPTION
Suggest wrapping the higher precendence operator in parentheses

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[X] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added a suggestion for the no-mixed-operators rule.
The suggestion is to wrap the higher order operator in parenthesis. This preserves existing functionality and provides clarity about the order of operators (fixing the rule violation).

*Example*:
Rule Violation: `a && b || c` 
Suggested Fix:  `(a && b) || c` 

#### Is there anything you'd like reviewers to focus on?
I thought this was safer as a suggestion than a fix, because it may be a bug and should actually be `a && (b || c)`