### PR TITLE
Fix: no-useless-escape wrong loc and fix with CRLF in template elements

### DIFF
--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -172,7 +172,7 @@ module.exports = {
             }
 
             if (isUnnecessaryEscape && !isQuoteEscape) {
-                report(node, match.index + 1, match[0].slice(1));
+                report(node, match.index, match[0].slice(1));
             }
         }
 
@@ -206,7 +206,7 @@ module.exports = {
                     return;
                 }
 
-                const value = isTemplateElement ? node.value.raw : node.raw.slice(1, -1);
+                const value = isTemplateElement ? sourceCode.getText(node) : node.raw;
                 const pattern = /\\[^\d]/gu;
                 let match;
 

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -956,6 +956,96 @@ ruleTester.run("no-useless-escape", rule, {
             }]
         },
         {
+            code: "`multiline template\r\nliteral with useless \\escape`",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                line: 2,
+                column: 22,
+                endColumn: 23,
+                message: "Unnecessary escape character: \\e.",
+                type: "TemplateElement",
+                suggestions: [{
+                    messageId: "removeEscape",
+                    output: "`multiline template\r\nliteral with useless escape`"
+                }, {
+                    messageId: "escapeBackslash",
+                    output: "`multiline template\r\nliteral with useless \\\\escape`"
+                }]
+            }]
+        },
+        {
+            code: "`template literal with line continuation \\\nand useless \\escape`",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                line: 2,
+                column: 13,
+                endColumn: 14,
+                message: "Unnecessary escape character: \\e.",
+                type: "TemplateElement",
+                suggestions: [{
+                    messageId: "removeEscape",
+                    output: "`template literal with line continuation \\\nand useless escape`"
+                }, {
+                    messageId: "escapeBackslash",
+                    output: "`template literal with line continuation \\\nand useless \\\\escape`"
+                }]
+            }]
+        },
+        {
+            code: "`template literal with line continuation \\\r\nand useless \\escape`",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                line: 2,
+                column: 13,
+                endColumn: 14,
+                message: "Unnecessary escape character: \\e.",
+                type: "TemplateElement",
+                suggestions: [{
+                    messageId: "removeEscape",
+                    output: "`template literal with line continuation \\\r\nand useless escape`"
+                }, {
+                    messageId: "escapeBackslash",
+                    output: "`template literal with line continuation \\\r\nand useless \\\\escape`"
+                }]
+            }]
+        },
+        {
+            code: "`template literal with mixed linebreaks \r\r\n\n\\and useless escape`",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                line: 4,
+                column: 1,
+                endColumn: 2,
+                message: "Unnecessary escape character: \\a.",
+                type: "TemplateElement",
+                suggestions: [{
+                    messageId: "removeEscape",
+                    output: "`template literal with mixed linebreaks \r\r\n\nand useless escape`"
+                }, {
+                    messageId: "escapeBackslash",
+                    output: "`template literal with mixed linebreaks \r\r\n\n\\\\and useless escape`"
+                }]
+            }]
+        },
+        {
+            code: "`template literal with mixed linebreaks in line continuations \\\n\\\r\\\r\n\\and useless escape`",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                line: 4,
+                column: 1,
+                endColumn: 2,
+                message: "Unnecessary escape character: \\a.",
+                type: "TemplateElement",
+                suggestions: [{
+                    messageId: "removeEscape",
+                    output: "`template literal with mixed linebreaks in line continuations \\\n\\\r\\\r\nand useless escape`"
+                }, {
+                    messageId: "escapeBackslash",
+                    output: "`template literal with mixed linebreaks in line continuations \\\n\\\r\\\r\n\\\\and useless escape`"
+                }]
+            }]
+        },
+        {
             code: "`\\a```",
             parserOptions: { ecmaVersion: 6 },
             errors: [{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**Tell us about your environment**

* **ESLint Version:** v7.16.0
* **Node Version:** v12.18.4
* **npm Version:** v6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

With CRLF linebreaks:

```js
/* eslint no-useless-escape: error */

`multiline template
literal with useless \escape`

```

**What did you expect to happen?**

1 error with the location of `\`.

Suggestions should remove `\`, or replace it with `\\`.

**What actually happened? Please include the actual, raw output from ESLint.**

```
  4:21  error  Unnecessary escape character: \e  no-useless-escape
```

Location is wrong, editor underlines space before `\`.

Suggestion fixes are also wrong. The "remove" suggestion fixes the code to:

```js
/* eslint no-useless-escape: error */

`multiline template
literal with useless\escape`
```

The "replace" suggestion fixes the code to:

```js
/* eslint no-useless-escape: error */

`multiline template
literal with useless\ \escape`

```

#### What changes did you make? (Give an overview)

Replaced `node.value.raw` with `sourceCode.getText(node)` for TemplateElement nodes.

The rule assumed that `TemplateElement#value.raw` represents source code of the TemplateElement, similar to `Literal#raw`, but it's actually the Template Raw Value ([TRV in the spec](https://tc39.es/ecma262/#sec-static-semantics-tv-and-trv)), the value that tag functions are getting as "raw".

It's usually the same as the source code, but there's at least one difference: CR and CRLF are normalized to LF.

> The TRV of LineTerminatorSequence :: \<CR> is the String value consisting of the code unit 0x000A (LINE FEED).
> The TRV of LineTerminatorSequence :: \<CR> \<LF> is the String value consisting of the code unit 0x000A (LINE FEED).

#### Is there anything you'd like reviewers to focus on?

The regex will now run on the full source code of strings and template elements, incl. quotes, backticks, `${` and `}`. I think that slicing the inner content is unnecessary and probably less efficient.