### PR TITLE
Fix: one-var shouldn't split declaration if it isn't in a statement list

### DIFF
--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -493,8 +493,48 @@ ruleTester.run("one-var", rule, {
     ],
     invalid: [
         {
+            code: "var bar = true, baz = false;",
+            output: "var bar = true; var baz = false;",
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
             code: "function foo() { var bar = true, baz = false; }",
             output: "function foo() { var bar = true; var baz = false; }",
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "if (foo) { var bar = true, baz = false; }",
+            output: "if (foo) { var bar = true; var baz = false; }",
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "switch (foo) { case bar: var baz = true, quux = false; }",
+            output: "switch (foo) { case bar: var baz = true; var quux = false; }",
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "switch (foo) { default: var baz = true, quux = false; }",
+            output: "switch (foo) { default: var baz = true; var quux = false; }",
             options: ["never"],
             errors: [{
                 messageId: "split",
@@ -1940,6 +1980,138 @@ ruleTester.run("one-var", rule, {
             errors: [{
                 messageId: "split",
                 data: { type: "const" },
+                type: "VariableDeclaration"
+            }]
+        },
+
+        // "never" should not autofix declarations in a block position
+        {
+            code: "if (foo) var x, y;",
+            output: null,
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "if (foo) var x, y;",
+            output: null,
+            options: [{ var: "never" }],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "if (foo) var x, y;",
+            output: null,
+            options: [{ uninitialized: "never" }],
+            errors: [{
+                messageId: "splitUninitialized",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "if (foo) var x = 1, y = 1;",
+            output: null,
+            options: [{ initialized: "never" }],
+            errors: [{
+                messageId: "splitInitialized",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "if (foo) {} else var x, y;",
+            output: null,
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "while (foo) var x, y;",
+            output: null,
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "do var x, y; while (foo);",
+            output: null,
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "do var x = f(), y = b(); while (x < y);",
+            output: null,
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "for (;;) var x, y;",
+            output: null,
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "for (foo in bar) var x, y;",
+            output: null,
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "for (foo of bar) var x, y;",
+            output: null,
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "with (foo) var x, y;",
+            output: null,
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "label: var x, y;",
+            output: null,
+            options: ["never"],
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
                 type: "VariableDeclaration"
             }]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.16.0
* **Node Version:** v12.18.4
* **npm Version:** v6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG9uZS12YXI6IFtcImVycm9yXCIsIFwibmV2ZXJcIl0gKi9cblxuZG8gXG4gICAgdmFyIHggPSBmKCksIHkgPSBiKCk7XG53aGlsZSAoeCA8IHkpOyIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js
/* eslint one-var: ["error", "never"] */

do 
    var x = f(), y = b();
while (x < y);
```

**What did you expect to happen?**

Given that this rule already reports errors that require non-trivial manual fixes, I'd expect an error without the autofix. This code can be fixed by adding a block (or in some other way), but that seems out of scope for this rule.

**What actually happened? Please include the actual, raw output from ESLint.**

Error with autofix that produces a syntax error:

```js
/* eslint one-var: ["error", "never"] */

do 
    var x = f(); var y = b();
while (x < y);
```

```
  4:18  error  Parsing error: Unexpected token var
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed `splitDeclarations()` to produce a fix only if the given `VariableDeclaration` is in a statement list, i.e. if it is a child of `Program`, `BlockStatement`, or `SwitchCase` node.

Autofix will not be provided if the reported declaration is a direct child of `if`, `while`, `do-while`, `for`, `for-in`, `for-of` or `with`, or if it is labeled.

#### Is there anything you'd like reviewers to focus on?

There's also a false negative in `SwitchCase` nodes when the option is `"consecutive"` (I'll fix that in another PR), and inconsistent behavior with `export`-ed declarations (I'll open an issue for that).
