### PR TITLE
Update: check ternary `:` even if `?` was reported in space-infix-ops

### DIFF
--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -132,7 +132,9 @@ module.exports = {
 
             if (nonSpacedConsequentNode) {
                 report(node, nonSpacedConsequentNode);
-            } else if (nonSpacedAlternateNode) {
+            }
+
+            if (nonSpacedAlternateNode) {
                 report(node, nonSpacedAlternateNode);
             }
         }

--- a/tests/lib/rules/space-infix-ops.js
+++ b/tests/lib/rules/space-infix-ops.js
@@ -161,15 +161,69 @@ ruleTester.run("space-infix-ops", rule, {
         },
         {
             code: "a?b:c",
-            output: "a ? b:c",
-            errors: [{
-                messageId: "missingSpace",
-                data: { operator: "?" },
-                type: "ConditionalExpression",
-                line: 1,
-                column: 2,
-                endColumn: 3
-            }]
+            output: "a ? b : c",
+            errors: [
+                {
+                    messageId: "missingSpace",
+                    data: { operator: "?" },
+                    type: "ConditionalExpression",
+                    line: 1,
+                    column: 2,
+                    endColumn: 3
+                },
+                {
+                    messageId: "missingSpace",
+                    data: { operator: ":" },
+                    type: "ConditionalExpression",
+                    line: 1,
+                    column: 4,
+                    endColumn: 5
+                }
+            ]
+        },
+        {
+            code: "a? b :c",
+            output: "a ? b : c",
+            errors: [
+                {
+                    messageId: "missingSpace",
+                    data: { operator: "?" },
+                    type: "ConditionalExpression",
+                    line: 1,
+                    column: 2,
+                    endColumn: 3
+                },
+                {
+                    messageId: "missingSpace",
+                    data: { operator: ":" },
+                    type: "ConditionalExpression",
+                    line: 1,
+                    column: 6,
+                    endColumn: 7
+                }
+            ]
+        },
+        {
+            code: "a ?b: c",
+            output: "a ? b : c",
+            errors: [
+                {
+                    messageId: "missingSpace",
+                    data: { operator: "?" },
+                    type: "ConditionalExpression",
+                    line: 1,
+                    column: 3,
+                    endColumn: 4
+                },
+                {
+                    messageId: "missingSpace",
+                    data: { operator: ":" },
+                    type: "ConditionalExpression",
+                    line: 1,
+                    column: 5,
+                    endColumn: 6
+                }
+            ]
         },
         {
             code: "a?b : c",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.16.0
* **Node Version:** v12.18.4
* **npm Version:** v6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IHNwYWNlLWluZml4LW9wczogXCJlcnJvclwiICovXG5cbmEgP2IgOmNcbiIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6MTEsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=)

```js
/* eslint space-infix-ops: "error" */

a ?b :c

```

**What did you expect to happen?**

Since this rule reports and underlines operator tokens, I'd expect two errors: one for `?`, the other for `:`.

**What actually happened? Please include the actual, raw output from ESLint.**

Only 1 error, and it underlines only `?`

```
  3:3  error  Operator '?' must be spaced  space-infix-ops
```

Nonetheless, the multi-pass `--fix` correctly fixes the code to `a ? b : c`, because fixing the error for `?` causes the error for `:` to appear.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed the `space-infix-ops` rule to report `:` if it isn't spaced, even when `?` from the same ternary expression was already reported.

#### Is there anything you'd like reviewers to focus on?

* Am I missing something?
* One report used to hide another, so this change shouldn't normally cause new reports in a lint-free code. However, I marked this as an `Update` since it can produce more reports (which might matter with `--max-warnings`), and it could even make a lint-free code to fail in some edge cases, like this:

```js
/* eslint space-infix-ops: "error" */

a
    ?b // eslint-disable-line space-infix-ops
    :c

```
