### PR TITLE
Chore: refactor calculating range and loc in no-useless-escape

### DIFF
--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -109,9 +109,9 @@ module.exports = {
          * @returns {void}
          */
         function report(node, startOffset, character) {
-            const start = sourceCode.getLocFromIndex(sourceCode.getIndexFromLoc(node.loc.start) + startOffset);
-            const rangeStart = sourceCode.getIndexFromLoc(node.loc.start) + startOffset;
+            const rangeStart = node.range[0] + startOffset;
             const range = [rangeStart, rangeStart + 1];
+            const start = sourceCode.getLocFromIndex(rangeStart);
 
             context.report({
                 node,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Changes a few lines where `no-useless-escape` calculates range and loc of the reported backslash.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Replaced `sourceCode.getIndexFromLoc(node.loc.start)` with `node.range[0]`.

#### Is there anything you'd like reviewers to focus on?

Am I missing something, it seems unnecessary to get index from the `loc` when we have `range`?
