### PR TITLE
Docs: fix examples for no-multi-str

### DIFF
--- a/docs/rules/no-multi-str.md
+++ b/docs/rules/no-multi-str.md
@@ -17,8 +17,9 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-multi-str: "error"*/
-var x = "Line 1 \
-         Line 2";
+
+var x = "some very \
+long line";
 ```
 
 Examples of **correct** code for this rule:
@@ -26,6 +27,8 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-multi-str: "error"*/
 
-var x = "Line 1\n" +
-        "Line 2";
+var x = "some very long line";
+
+var x = "some very " +
+        "long line";
 ```

--- a/docs/rules/no-multi-str.md
+++ b/docs/rules/no-multi-str.md
@@ -19,7 +19,7 @@ Examples of **incorrect** code for this rule:
 /*eslint no-multi-str: "error"*/
 
 var x = "some very \
-long line";
+long text";
 ```
 
 Examples of **correct** code for this rule:
@@ -27,8 +27,8 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-multi-str: "error"*/
 
-var x = "some very long line";
+var x = "some very long text";
 
 var x = "some very " +
-        "long line";
+        "long text";
 ```


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Changes examples for the `no-multi-str` rule.

#### What changes did you make? (Give an overview)

The examples were technically okay for this rule, but perhaps misleading. It looked like that line continuation in a string literal contributes to the string as a linebreak, while it actually has no value.

I changed the examples so that all "correct" and "incorrect" examples represent the same string.


#### Is there anything you'd like reviewers to focus on?
