### PR TITLE
Fix: use regexpp's default ecmaVersion in no-invalid-regexp

### DIFF
--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -9,7 +9,7 @@
 //------------------------------------------------------------------------------
 
 const RegExpValidator = require("regexpp").RegExpValidator;
-const validator = new RegExpValidator({ ecmaVersion: 2018 });
+const validator = new RegExpValidator();
 const validFlags = /[gimuys]/gu;
 const undefined1 = void 0;
 

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -41,7 +41,13 @@ ruleTester.run("no-invalid-regexp", rule, {
         { code: "new RegExp('(?<!a)b')", parserOptions: { ecmaVersion: 2018 } },
         { code: "new RegExp('(?<a>b)\\k<a>')", parserOptions: { ecmaVersion: 2018 } },
         { code: "new RegExp('(?<a>b)\\k<a>', 'u')", parserOptions: { ecmaVersion: 2018 } },
-        { code: "new RegExp('\\\\p{Letter}', 'u')", parserOptions: { ecmaVersion: 2018 } }
+        { code: "new RegExp('\\\\p{Letter}', 'u')", parserOptions: { ecmaVersion: 2018 } },
+
+        // ES2020
+        "new RegExp('(?<\\\\ud835\\\\udc9c>.)', 'g')",
+        "new RegExp('(?<\\\\u{1d49c}>.)', 'g')",
+        "new RegExp('(?<𝒜>.)', 'g');",
+        "new RegExp('\\\\p{Script=Nandinagari}', 'u');"
     ],
     invalid: [
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

**Tell us about your environment**

* **ESLint Version:** v7.16.0
* **Node Version:** v12.18.4
* **npm Version:** v6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2020
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWludmFsaWQtcmVnZXhwOiBlcnJvciAqL1xuXG4vKD88XFx1ZDgzNVxcdWRjOWM+LikvZztcbm5ldyBSZWdFeHAoXCIoPzxcXFxcdWQ4MzVcXFxcdWRjOWM+LilcIiwgXCJnXCIpO1xuXG4vKD88XFx1ezFkNDljfT4uKS9nO1xubmV3IFJlZ0V4cChcIig/PFxcXFx1ezFkNDljfT4uKVwiLCBcImdcIik7XG5cbi8oPzzwnZKcPi4pL2c7XG5uZXcgUmVnRXhwKFwiKD888J2SnD4uKVwiLCBcImdcIik7XG5cbi9cXHB7U2NyaXB0PU5hbmRpbmFnYXJpfS91O1xubmV3IFJlZ0V4cChcIlxcXFxwe1NjcmlwdD1OYW5kaW5hZ2FyaX1cIiwgXCJ1XCIpO1xuIiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjoxMSwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js
/* eslint no-invalid-regexp: error */

/(?<\ud835\udc9c>.)/g;
new RegExp("(?<\\ud835\\udc9c>.)", "g");

/(?<\u{1d49c}>.)/g;
new RegExp("(?<\\u{1d49c}>.)", "g");

/(?<𝒜>.)/g;
new RegExp("(?<𝒜>.)", "g");

/\p{Script=Nandinagari}/u;
new RegExp("\\p{Script=Nandinagari}", "u");

```

**What did you expect to happen?**

No errors. These are valid regular expressions per the ES2020 spec, ref https://github.com/tc39/ecma262/pull/1869#issuecomment-607542663 and https://github.com/tc39/ecma262/pull/1468.

Espree with `ecmaVersion: 2020` doesn't report parsing errors in the equivalent regex literals.

**What actually happened? Please include the actual, raw output from ESLint.**

All four `RegExp` calls are reported:

```
   4:1  error  Invalid regular expression: /(?<\ud835\udc9c>.)/: Invalid capture group name  no-invalid-regexp
   7:1  error  Invalid regular expression: /(?<\u{1d49c}>.)/: Invalid capture group name     no-invalid-regexp
  10:1  error  Invalid regular expression: /(?<𝒜>.)/: Invalid capture group name            no-invalid-regexp
  13:1  error  Invalid regular expression: /\p{Script=Nandinagari}/u: Invalid property name  no-invalid-regexp
```

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In the `no-invalid-regexp` rule I removed the hard-coded `ecmaVersion: 2018` passed into `RegExpValidator` so that the default regexpp's `ecmaVersion` is used, like in other rules that use regexpp. I think it's always the latest official version (not counting the draft?). In https://github.com/eslint/eslint/pull/10062 it was decided to use the latest version in this rule.

This currently bumps `ecmaVersion` from 2018 to 2020 in `no-invalid-regexp`.

#### Is there anything you'd like reviewers to focus on?

* I believe this change can produce only fewer warnings.
* Should we use regexpp's default ecmaVersion, or set it to the max supported by regexpp if they will be different? The actual published `regexpp` doesn't support 2021, so it wouldn't make a difference at the moment.
* The previous `valid` tests are misleading because this rule doesn't use `ecmaVersion` from the configuration. Most of the `allowConstructorFlags` tests are thus useless. I'll submit a PR to modify the tests.
* `"g"` flag in the examples and the tests doesn't have a particular meaning, but I had to add some flags because the logic on when should the rule try to validate the regex both with and without the `"u"` flag is currently wrong. For example, `new RegExp("\\u{0}*");` is a false negative (it's valid with the `"u"` flag, but that flag certainly isn't there in this case). I'll submit a PR to fix that.
