### PR TITLE
Update: use regexpp's default ecmaVersion in no-control-regex

### DIFF
--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -8,7 +8,6 @@
 const RegExpValidator = require("regexpp").RegExpValidator;
 const collector = new (class {
     constructor() {
-        this.ecmaVersion = 2018;
         this._source = "";
         this._controlChars = [];
         this._validator = new RegExpValidator(this);

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -41,6 +41,11 @@ ruleTester.run("no-control-regex", rule, {
             code: "var regex = /(?<a>\\x1f)/",
             parserOptions: { ecmaVersion: 2018 },
             errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
+        },
+        {
+            code: String.raw`var regex = /(?<\u{1d49c}>.)\x1f/`,
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.16.0
* **Node Version:** v12.18.4
* **npm Version:** v6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2020
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWNvbnRyb2wtcmVnZXg6IGVycm9yICovXG5cbi8oPzxcXHV7MWQ0OWN9Pi4pXFx4MWYvXG4iLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjExLCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7fSwiZW52Ijp7fX19)

```js
/* eslint no-control-regex: error */

/(?<\u{1d49c}>.)\x1f/
```

**What did you expect to happen?**

1 error, since the regex is valid in ES2020 and there's an escape sequence for a control character.

When we flip the sequence and the group, the rule does report an error, as in [this demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWNvbnRyb2wtcmVnZXg6IGVycm9yICovXG5cbi9cXHgxZig/PFxcdXsxZDQ5Y30+LikvXG4iLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjExLCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7fSwiZW52Ijp7fX19).

**What actually happened? Please include the actual, raw output from ESLint.**

no errors

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->


<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed the `no-control-regex` rule to use regexpp's default ecmaVersion (currently 2020), instead of the hard-coded 2018.

It's similar to https://github.com/eslint/eslint/pull/13968, but for this rule the change means more errors as there are fewer parsing errors (this rule reports control characters until the first parsing failure).

#### Is there anything you'd like reviewers to focus on?

* This rule doesn't pass the `"u"` flag, so it doesn't report `\u{1f}` and there are also false negatives like `/\u{0}*\x1f/u`. I'll open an issue for that.
* It's interesting that both rules that use `regexpp.RegExpValidator` had hard-coded ecmaVersion 2018, but neither of rules that use `regexpp.RegExpParser` did.
