### PR TITLE
Fix: nested indenting for offsetTernaryExpressions: true (fixes #13971)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1178,6 +1178,7 @@ module.exports = {
                     offsets.setDesiredOffset(colonToken, firstToken, 1);
 
                     offsets.setDesiredOffset(firstConsequentToken, firstToken,
+                        firstConsequentToken.type === "Punctuator" &&
                         options.offsetTernaryExpressions ? 2 : 1);
 
                     /*

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2216,6 +2216,16 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+              condition1
+                ? Promise.resolve(1)
+                : condition2
+                  ? Promise.resolve(2)
+                  : Promise.resolve(3)
+            `,
+            options: [2, { offsetTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
               condition
               \t? () => {
               \t\t\treturn true

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2206,6 +2206,16 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+              condition1
+                ? condition2
+                  ? Promise.resolve(1)
+                  : Promise.resolve(2)
+                : Promise.resolve(3)
+            `,
+            options: [2, { offsetTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
               condition
               \t? () => {
               \t\t\treturn true


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

resolves #13971

This update applies one more condition for the consequent to avoid extra indenting in a nested ternary expression like this:

```js
condition1
  ? condition2
    ? Promise.resolve(1)
    : Promise.resolve(2)
  : Promise.resolve(3)
```

Note that the condition was mostly copied from the condition that @sheerun had included for the alternate in PR #12556 (bb6cf5082623ffb67bb1495fee52c0610ee5f421).

#### Is there anything you'd like reviewers to focus on?

I hope there is enough information in issue #13971 to explain the issue and in this PR to understand the solution. I would be happy to add some more test cases and documentation updates if needed.

This PR can help unblock the following issues and updates in some other projects:

- https://github.com/standard/standard/issues/1624
- https://github.com/brodybits/prettierx/issues/41
- https://github.com/sheerun/prettier-standard/issues/76
- https://github.com/brodybits/react-native-module-init/pull/85