### PR TITLE
Fix: Support ENOTDIR error code in the folder existence checking utility

### DIFF
--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -531,7 +531,7 @@ function directoryExists(resolvedPath) {
     try {
         return fs.statSync(resolvedPath).isDirectory();
     } catch (error) {
-        if (error && error.code === "ENOENT") {
+        if (error && (error.code === "ENOENT" || error.code === "ENOTDIR")) {
             return false;
         }
         throw error;

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -3886,6 +3886,26 @@ describe("ESLint", () => {
             assert.deepStrictEqual(actualConfig, expectedConfig);
         });
 
+        it("should return the config for a file that doesn't exist", async () => {
+            const engine = new ESLint();
+            const filePath = getFixturePath("does_not_exist.js");
+            const existingSiblingFilePath = getFixturePath("single-quoted.js");
+            const actualConfig = await engine.calculateConfigForFile(filePath);
+            const expectedConfig = await engine.calculateConfigForFile(existingSiblingFilePath);
+
+            assert.deepStrictEqual(actualConfig, expectedConfig);
+        });
+
+        it("should return the config for a virtual file that is a child of an existing file", async () => {
+            const engine = new ESLint();
+            const parentFileName = "single-quoted.js";
+            const filePath = getFixturePath(parentFileName, "virtual.js"); // single-quoted.js/virtual.js
+            const parentFilePath = getFixturePath(parentFileName);
+            const actualConfig = await engine.calculateConfigForFile(filePath);
+            const expectedConfig = await engine.calculateConfigForFile(parentFilePath);
+
+            assert.deepStrictEqual(actualConfig, expectedConfig);
+        });
 
         it("should return the config when run from within a subdir", async () => {
             const options = {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Add a condition to return `false` in `directoryExists` function if Node API returns `ENOTDIR` error

#### Is there anything you'd like reviewers to focus on?

Reproduced when special custom parsers were used: `jsonc-eslint-parser` together with `eslint-plugin-markdown`. Happened during linting of JSON code fragments in Markdown document when checking virtual file paths, e.g. `directoryExists('C:\Projects\Projects_Compane\project_name\README.md\2_2.json')`

More details can be found in this issue https://github.com/ota-meshi/eslint-plugin-jsonc/issues/28
