### PR TITLE
Fix: no-extra-parens false positive with `let` identifier in for-loop

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -895,6 +895,22 @@ module.exports = {
                 }
 
                 if (node.init) {
+
+                    if (node.init.type !== "VariableDeclaration") {
+                        const firstToken = sourceCode.getFirstToken(node.init, astUtils.isNotOpeningParenToken);
+
+                        if (
+                            firstToken.value === "let" &&
+                            astUtils.isOpeningBracketToken(
+                                sourceCode.getTokenAfter(firstToken, astUtils.isNotClosingParenToken)
+                            )
+                        ) {
+
+                            // ForStatement#init expression cannot start with `let[`.
+                            tokensToIgnore.add(firstToken);
+                        }
+                    }
+
                     startNewReportsBuffering();
 
                     if (hasExcessParens(node.init)) {

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -599,6 +599,22 @@ ruleTester.run("no-extra-parens", rule, {
             options: ["functions"]
         },
         "(let)[foo]",
+
+        // ForStatement#init expression cannot start with `let[`. It would be parsed as a `let` declaration with array pattern, or a syntax error.
+        "for ((let[a]);;);",
+        "for ((let)[a];;);",
+        "for ((let[a] = 1);;);",
+        "for ((let[a]) = 1;;);",
+        "for ((let)[a] = 1;;);",
+        "for ((let[a, b] = foo);;);",
+        "for ((let[a].b = 1);;);",
+        "for ((let[a].b) = 1;;);",
+        "for ((let[a]).b = 1;;);",
+        "for ((let)[a].b = 1;;);",
+        "for ((let[a])();;);",
+        "for ((let)[a]();;);",
+        "for ((let[a]) + b;;);",
+
         "for ((let) in foo);",
         "for ((let[foo]) in bar);",
         "for ((let)[foo] in bar);",
@@ -1880,6 +1896,165 @@ ruleTester.run("no-extra-parens", rule, {
             "Identifier",
             1
         ),
+
+        // ForStatement#init expression cannot start with `let[`, but it can start with `let` if it isn't followed by `[`
+        invalid(
+            "for ((let);;);",
+            "for (let;;);",
+            "Identifier",
+            1
+        ),
+        invalid(
+            "for ((let = 1);;);",
+            "for (let = 1;;);",
+            "AssignmentExpression",
+            1
+        ),
+        invalid(
+            "for ((let) = 1;;);",
+            "for (let = 1;;);",
+            "Identifier",
+            1
+        ),
+        invalid(
+            "for ((let = []);;);",
+            "for (let = [];;);",
+            "AssignmentExpression",
+            1
+        ),
+        invalid(
+            "for ((let) = [];;);",
+            "for (let = [];;);",
+            "Identifier",
+            1
+        ),
+        invalid(
+            "for ((let());;);",
+            "for (let();;);",
+            "CallExpression",
+            1
+        ),
+        invalid(
+            "for ((let([]));;);",
+            "for (let([]);;);",
+            "CallExpression",
+            1
+        ),
+        invalid(
+            "for ((let())[a];;);",
+            "for (let()[a];;);",
+            "CallExpression",
+            1
+        ),
+        invalid(
+            "for ((let`[]`);;);",
+            "for (let`[]`;;);",
+            "TaggedTemplateExpression",
+            1
+        ),
+        invalid(
+            "for ((let.a);;);",
+            "for (let.a;;);",
+            "MemberExpression",
+            1
+        ),
+        invalid(
+            "for ((let).a;;);",
+            "for (let.a;;);",
+            "Identifier",
+            1
+        ),
+        invalid(
+            "for ((let).a = 1;;);",
+            "for (let.a = 1;;);",
+            "Identifier",
+            1
+        ),
+        invalid(
+            "for ((let).a[b];;);",
+            "for (let.a[b];;);",
+            "Identifier",
+            1
+        ),
+        invalid(
+            "for ((let.a)[b];;);",
+            "for (let.a[b];;);",
+            "MemberExpression",
+            1
+        ),
+        invalid(
+            "for ((let.a[b]);;);",
+            "for (let.a[b];;);",
+            "MemberExpression",
+            1
+        ),
+        invalid(
+            "for ((let);[];);",
+            "for (let;[];);",
+            "Identifier",
+            1
+        ),
+        invalid(
+            "for (((let[a]));;);",
+            "for ((let[a]);;);",
+            "MemberExpression",
+            1
+        ),
+        invalid(
+            "for (((let))[a];;);",
+            "for ((let)[a];;);",
+            "Identifier",
+            1
+        ),
+        invalid(
+            "for (((let[a])).b;;);",
+            "for ((let[a]).b;;);",
+            "MemberExpression",
+            1
+        ),
+        invalid(
+            "for (((let))[a].b;;);",
+            "for ((let)[a].b;;);",
+            "Identifier",
+            1
+        ),
+        invalid(
+            "for (((let)[a]).b;;);",
+            "for ((let)[a].b;;);",
+            "MemberExpression",
+            1
+        ),
+        invalid(
+            "for (((let[a]) = b);;);",
+            "for ((let[a]) = b;;);",
+            "AssignmentExpression",
+            1
+        ),
+        invalid(
+            "for (((let)[a]) = b;;);",
+            "for ((let)[a] = b;;);",
+            "MemberExpression",
+            1
+        ),
+        invalid(
+            "for (((let)[a] = b);;);",
+            "for ((let)[a] = b;;);",
+            "AssignmentExpression",
+            1
+        ),
+        invalid(
+            "for ((Let[a]);;);",
+            "for (Let[a];;);",
+            "MemberExpression",
+            1
+        ),
+        invalid(
+            "for ((lett)[a];;);",
+            "for (lett[a];;);",
+            "Identifier",
+            1
+        ),
+
         invalid(
             "for ((let.foo) in bar);",
             "for (let.foo in bar);",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

**Tell us about your environment**

* **ESLint Version:** v7.17.0
* **Node Version:** v12.18.4
* **npm Version:** v6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWV4dHJhLXBhcmVuczogZXJyb3IgKi9cblxuZm9yICgobGV0KVthXS5iID0gMTs7KTtcbiIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js
/* eslint no-extra-parens: error */

for ((let)[a].b = 1;;);

```

**What did you expect to happen?**

No errors. An _expression_ as `ForStatement#init` cannot start with **let[**

[IterationStatement in the spec](https://tc39.es/ecma262/#prod-IterationStatement):

> for ( [**lookahead ≠ let [**] Expression[~In, ?Yield, ?Await]opt ; Expression[+In, ?Yield, ?Await]opt ; Expression[+In, ?Yield, ?Await]opt ) Statement[?Yield, ?Await, ?Return]

If for-loop initializer starts with `let[`, it can be either a `let` declaration with an array pattern, or a syntax error.

**What actually happened? Please include the actual, raw output from ESLint.**

```
  3:6  error  Unnecessary parentheses around expression  no-extra-parens
```

autofix:

```js
/* eslint no-extra-parens: error */

for (let[a].b = 1;;);

```

```
  3:12  error  Parsing error: Complex binding patterns require an initialization value
```

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `no-extra-parens` rule to not report parens inside a for loop initializer expression if removing those parens would make the expression to start with `let[`.

#### Is there anything you'd like reviewers to focus on?

The similar logic for `for-in` and `for-of` loops is slightly wrong, I'll fix that in another PR.
