### PR TITLE
Docs: space-in-parens examples with no arguments etc.

### DIFF
--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -36,9 +36,13 @@ Examples of **incorrect** code for this rule with the default `"never"` option:
 ```js
 /*eslint space-in-parens: ["error", "never"]*/
 
+foo( );
+
 foo( 'bar');
 foo('bar' );
 foo( 'bar' );
+
+foo( /* bar */ );
 
 var foo = ( 1 + 2 ) * 3;
 ( function () { return 'bar'; }() );
@@ -52,6 +56,8 @@ Examples of **correct** code for this rule with the default `"never"` option:
 foo();
 
 foo('bar');
+
+foo(/* bar */);
 
 var foo = (1 + 2) * 3;
 (function () { return 'bar'; }());
@@ -68,6 +74,8 @@ foo( 'bar');
 foo('bar' );
 foo('bar');
 
+foo(/* bar */);
+
 var foo = (1 + 2) * 3;
 (function () { return 'bar'; }());
 ```
@@ -78,8 +86,11 @@ Examples of **correct** code for this rule with the `"always"` option:
 /*eslint space-in-parens: ["error", "always"]*/
 
 foo();
+foo( );
 
 foo( 'bar' );
+
+foo( /* bar */ );
 
 var foo = ( 1 + 2 ) * 3;
 ( function () { return 'bar'; }() );


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

add examples such as `foo( )` & `foo(/* bar */)`

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Add incorrect & correct examples for `space-in-parens`:

- `foo( )`
- `foo(/* bar */)`
- `foo( /* bar */ )`

related to: PR #13986 - test `foo( )` with space-in-parens: ["error", "always"]

#### Is there anything you'd like reviewers to focus on?

see above