### PR TITLE
Chore: remove extra array-bracket-spacing test cases

### DIFF
--- a/tests/lib/rules/array-bracket-spacing.js
+++ b/tests/lib/rules/array-bracket-spacing.js
@@ -91,14 +91,6 @@ ruleTester.run("array-bracket-spacing", rule, {
         { code: "[ x, { y, z }] = arr;", options: ["always", { objectsInArrays: false }], parserOptions: { ecmaVersion: 6 } },
 
         // never
-        { code: "obj[foo]", options: ["never"] },
-        { code: "obj['foo']", options: ["never"] },
-        { code: "obj['foo' + 'bar']", options: ["never"] },
-        { code: "obj['foo'+'bar']", options: ["never"] },
-        { code: "obj[obj2[foo]]", options: ["never"] },
-        { code: "obj.map(function(item) { return [\n1,\n2,\n3,\n4\n]; })", options: ["never"] },
-        { code: "obj['map'](function(item) { return [\n1,\n2,\n3,\n4\n]; })", options: ["never"] },
-        { code: "obj['for' + 'Each'](function(item) { return [\n1,\n2,\n3,\n4\n]; })", options: ["never"] },
         { code: "var arr = [1, 2, 3, 4];", options: ["never"] },
         { code: "var arr = [[1, 2], 2, 3, 4];", options: ["never"] },
         { code: "var arr = [\n1, 2, 3, 4\n];", options: ["never"] },

--- a/tests/lib/rules/array-bracket-spacing.js
+++ b/tests/lib/rules/array-bracket-spacing.js
@@ -67,15 +67,6 @@ ruleTester.run("array-bracket-spacing", rule, {
         { code: "var arr = [[ 1, 2 ], [2], 3, { 'foo': 'bar' }];", options: ["always", { arraysInArrays: false, objectsInArrays: false, singleValue: false }] },
 
         // always
-        { code: "obj[ foo ]", options: ["always"] },
-        { code: "obj[\nfoo\n]", options: ["always"] },
-        { code: "obj[ 'foo' ]", options: ["always"] },
-        { code: "obj[ 'foo' + 'bar' ]", options: ["always"] },
-        { code: "obj[ obj2[ foo ] ]", options: ["always"] },
-        { code: "obj.map(function(item) { return [\n1,\n2,\n3,\n4\n]; })", options: ["always"] },
-        { code: "obj[ 'map' ](function(item) { return [\n1,\n2,\n3,\n4\n]; })", options: ["always"] },
-        { code: "obj[ 'for' + 'Each' ](function(item) { return [\n1,\n2,\n3,\n4\n]; })", options: ["always"] },
-
         { code: "var arr = [ 1, 2, 3, 4 ];", options: ["always"] },
         { code: "var arr = [ [ 1, 2 ], 2, 3, 4 ];", options: ["always"] },
         { code: "var arr = [\n1, 2, 3, 4\n];", options: ["always"] },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

This removes cases for `array-bracket-spacing` that I think should only be there for `computed-property-spacing`.

Discovered while working on PR #13989

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

see above

#### Is there anything you'd like reviewers to focus on?

N/A