### PR TITLE
Docs: fix no-invalid-regexp docs regarding ecmaVersion

### DIFF
--- a/docs/rules/no-invalid-regexp.md
+++ b/docs/rules/no-invalid-regexp.md
@@ -30,16 +30,9 @@ new RegExp
 this.RegExp('[')
 ```
 
-## Environments
+Please note that this rule validates regular expressions per the latest ECMAScript specification, regardless of your parser settings.
 
-ECMAScript 6 adds the following flag arguments to the `RegExp` constructor:
-
-* `"u"` ([unicode](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.unicode))
-* `"y"` ([sticky](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky))
-
-You can enable these to be recognized as valid by setting the ECMAScript version to 6 in your [ESLint configuration](../user-guide/configuring).
-
-If you want to allow additional constructor flags for any reason, you can specify them using an `allowConstructorFlags` option in `.eslintrc`. These flags will then be ignored by the rule regardless of the `ecmaVersion` setting.
+If you want to allow additional constructor flags for any reason, you can specify them using the `allowConstructorFlags` option. These flags will then be ignored by the rule.
 
 ## Options
 
@@ -49,14 +42,14 @@ This rule has an object option for exceptions:
 
 ### allowConstructorFlags
 
-Examples of **correct** code for this rule with the `{ "allowConstructorFlags": ["u", "y"] }` option:
+Examples of **correct** code for this rule with the `{ "allowConstructorFlags": ["a", "z"] }` option:
 
 ```js
-/*eslint no-invalid-regexp: ["error", { "allowConstructorFlags": ["u", "y"] }]*/
+/*eslint no-invalid-regexp: ["error", { "allowConstructorFlags": ["a", "z"] }]*/
 
-new RegExp('.', 'y')
+new RegExp('.', 'a')
 
-new RegExp('.', 'yu')
+new RegExp('.', 'az')
 ```
 
 ## Further Reading

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -24,30 +24,68 @@ ruleTester.run("no-invalid-regexp", rule, {
         "new RegExp('.', 'im')",
         "global.RegExp('\\\\')",
         "new RegExp('.', y)",
-        { code: "new RegExp('.', 'y')", options: [{ allowConstructorFlags: ["y"] }] },
-        { code: "new RegExp('.', 'u')", options: [{ allowConstructorFlags: ["U"] }] },
-        { code: "new RegExp('.', 'yu')", options: [{ allowConstructorFlags: ["y", "u"] }] },
-        { code: "new RegExp('/', 'yu')", options: [{ allowConstructorFlags: ["y", "u"] }] },
-        { code: "new RegExp('\\/', 'yu')", options: [{ allowConstructorFlags: ["y", "u"] }] },
-        { code: "new RegExp('.', 'y')", parserOptions: { ecmaVersion: 6 } },
-        { code: "new RegExp('.', 'u')", parserOptions: { ecmaVersion: 6 } },
-        { code: "new RegExp('.', 'yu')", parserOptions: { ecmaVersion: 6 } },
-        { code: "new RegExp('/', 'yu')", parserOptions: { ecmaVersion: 6 } },
-        { code: "new RegExp('\\/', 'yu')", parserOptions: { ecmaVersion: 6 } },
-        { code: "new RegExp('\\\\u{65}', 'u')", parserOptions: { ecmaVersion: 2015 } },
-        { code: "new RegExp('[\\\\u{0}-\\\\u{1F}]', 'u')", parserOptions: { ecmaVersion: 2015 } },
-        { code: "new RegExp('.', 's')", parserOptions: { ecmaVersion: 2018 } },
-        { code: "new RegExp('(?<=a)b')", parserOptions: { ecmaVersion: 2018 } },
-        { code: "new RegExp('(?<!a)b')", parserOptions: { ecmaVersion: 2018 } },
-        { code: "new RegExp('(?<a>b)\\k<a>')", parserOptions: { ecmaVersion: 2018 } },
-        { code: "new RegExp('(?<a>b)\\k<a>', 'u')", parserOptions: { ecmaVersion: 2018 } },
-        { code: "new RegExp('\\\\p{Letter}', 'u')", parserOptions: { ecmaVersion: 2018 } },
+        "new RegExp('.', 'y')",
+        "new RegExp('.', 'u')",
+        "new RegExp('.', 'yu')",
+        "new RegExp('/', 'yu')",
+        "new RegExp('\\/', 'yu')",
+        "new RegExp('\\\\u{65}', 'u')",
+        "new RegExp('\\\\u{65}*', 'u')",
+        "new RegExp('[\\\\u{0}-\\\\u{1F}]', 'u')",
+        "new RegExp('.', 's')",
+        "new RegExp('(?<=a)b')",
+        "new RegExp('(?<!a)b')",
+        "new RegExp('(?<a>b)\\k<a>')",
+        "new RegExp('(?<a>b)\\k<a>', 'u')",
+        "new RegExp('\\\\p{Letter}', 'u')",
 
         // ES2020
         "new RegExp('(?<\\\\ud835\\\\udc9c>.)', 'g')",
         "new RegExp('(?<\\\\u{1d49c}>.)', 'g')",
         "new RegExp('(?<𝒜>.)', 'g');",
-        "new RegExp('\\\\p{Script=Nandinagari}', 'u');"
+        "new RegExp('\\\\p{Script=Nandinagari}', 'u');",
+
+        // allowConstructorFlags
+        {
+            code: "new RegExp('.', 'g')",
+            options: [{ allowConstructorFlags: [] }]
+        },
+        {
+            code: "new RegExp('.', 'g')",
+            options: [{ allowConstructorFlags: ["a"] }]
+        },
+        {
+            code: "new RegExp('.', 'a')",
+            options: [{ allowConstructorFlags: ["a"] }]
+        },
+        {
+            code: "new RegExp('.', 'ag')",
+            options: [{ allowConstructorFlags: ["a"] }]
+        },
+        {
+            code: "new RegExp('.', 'ga')",
+            options: [{ allowConstructorFlags: ["a"] }]
+        },
+        {
+            code: "new RegExp('.', 'a')",
+            options: [{ allowConstructorFlags: ["a", "z"] }]
+        },
+        {
+            code: "new RegExp('.', 'z')",
+            options: [{ allowConstructorFlags: ["a", "z"] }]
+        },
+        {
+            code: "new RegExp('.', 'az')",
+            options: [{ allowConstructorFlags: ["a", "z"] }]
+        },
+        {
+            code: "new RegExp('.', 'za')",
+            options: [{ allowConstructorFlags: ["a", "z"] }]
+        },
+        {
+            code: "new RegExp('.', 'agz')",
+            options: [{ allowConstructorFlags: ["a", "z"] }]
+        }
     ],
     invalid: [
         {
@@ -67,10 +105,63 @@ ruleTester.run("no-invalid-regexp", rule, {
             }]
         },
         {
+            code: "RegExp('.', 'a');",
+            options: [{}],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'a'" },
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "new RegExp('.', 'a');",
+            options: [{ allowConstructorFlags: [] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'a'" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "new RegExp('.', 'z');",
+            options: [{ allowConstructorFlags: ["a"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'z'" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "new RegExp('.', 'az');",
+            options: [{ allowConstructorFlags: ["z"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'a'" },
+                type: "NewExpression"
+            }]
+        },
+        {
             code: "new RegExp(')');",
             errors: [{
                 messageId: "regexMessage",
                 data: { message: "Invalid regular expression: /)/: Unmatched ')'" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: String.raw`new RegExp('\\a', 'u');`,
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid regular expression: /\\a/u: Invalid escape" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: String.raw`new RegExp('\\a', 'u');`,
+            options: [{ allowConstructorFlags: ["u"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid regular expression: /\\a/u: Invalid escape" },
                 type: "NewExpression"
             }]
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Documentation for the `no-invalid-regexp` rule is misleading since the change made in https://github.com/eslint/eslint/pull/10062. In particular, the rule doesn't use configured `ecmaVersion`.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Fixed the docs to note that this rule validates regular expressions per the latest ECMAScript Specification.
* Updated the examples for `allowConstructorFlags` option to use some unknown flags.
* Removed `ecmaVersion` from tests.
* Added new tests for `allowConstructorFlags`.
* Added a couple of tests about the `u` flag.

#### Is there anything you'd like reviewers to focus on?
