### PR TITLE
Fix: --init crash on question to upgrade/downgrade ESLint (fixes #13978)

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -565,7 +565,8 @@ function promptUser() {
         {
             type: "toggle",
             name: "installESLint",
-            message(answers) {
+            message() {
+                const { answers } = this.state;
                 const verb = semver.ltr(answers.localESLintVersion, answers.requiredESLintVersionRange)
                     ? "upgrade"
                     : "downgrade";


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

fixes #13978

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `--init` "upgrade/downgrade ESLint" prompt to get the expected `answers` object.

It used to crash because the argument passed into `message()` was `state`, not `answers`. Thus, `localESLintVersion` and `requiredESLintVersionRange` properties were undefined, and then `semver.ltr(undefined, undefined)` throws.

#### Is there anything you'd like reviewers to focus on?

* We don't have tests for enquirer prompts and the flow. I tried this fix with ESLint v7.10.0 and `eslint-config-standard` (which requires eslint `^7.12.1`, so an upgrade is needed) and it seems to be working fine.
* `message()` apparently gets `state` as the argument (not `answers`). The fix could have been to get `answers` property from the argument. However, I couldn't find this documented, so decided to use `this.state.answers`, like in the rest of the code.
