### PR TITLE
Docs: Update plugin-missing error message

### DIFF
--- a/messages/plugin-missing.txt
+++ b/messages/plugin-missing.txt
@@ -2,7 +2,9 @@ ESLint couldn't find the plugin "<%- pluginName %>".
 
 (The package "<%- pluginName %>" was not found when loaded as a Node module from the directory "<%- resolvePluginsRelativeTo %>".)
 
-It's likely that the plugin isn't installed correctly. Try reinstalling by running the following:
+If you've referenced the plugin in the `extends` array, double check that the format is `plugin:plugin-name/config-name`. There must be a slash (`/`) followed by the config name. Please consult the documentation for the plugin for more information.
+
+If you've referenced the plugin in the `plugins` array, then it's likely the plugin isn't installed correctly. Try reinstalling by running the following:
 
     npm install <%- pluginName %>@latest --save-dev
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the error message displayed when a plugin can't be found. We are getting *a lot* of people stopping by the chat or filing issues for this particular type of error, and it's typically because they're using something like `plugin:foo` in the `extends` array instead of `plugin:foo/bar`. I've updated the error message to mention this case to hopefully save us some customer support time.


#### Is there anything you'd like reviewers to focus on?

Does the error message make sense?