### PR TITLE
Update: fix `let` logic in for-in and for-of loops in no-extra-parens

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -844,44 +844,48 @@ module.exports = {
             ExportDefaultDeclaration: node => checkExpressionOrExportStatement(node.declaration),
             ExpressionStatement: node => checkExpressionOrExportStatement(node.expression),
 
-            "ForInStatement, ForOfStatement"(node) {
-                if (node.left.type !== "VariableDeclarator") {
+            ForInStatement(node) {
+                if (node.left.type !== "VariableDeclaration") {
                     const firstLeftToken = sourceCode.getFirstToken(node.left, astUtils.isNotOpeningParenToken);
 
                     if (
-                        firstLeftToken.value === "let" && (
-
-                            /*
-                             * If `let` is the only thing on the left side of the loop, it's the loop variable: `for ((let) of foo);`
-                             * Removing it will cause a syntax error, because it will be parsed as the start of a VariableDeclarator.
-                             */
-                            (firstLeftToken.range[1] === node.left.range[1] || /*
-                             * If `let` is followed by a `[` token, it's a property access on the `let` value: `for ((let[foo]) of bar);`
-                             * Removing it will cause the property access to be parsed as a destructuring declaration of `foo` instead.
-                             */
-                            astUtils.isOpeningBracketToken(
-                                sourceCode.getTokenAfter(firstLeftToken, astUtils.isNotClosingParenToken)
-                            ))
+                        firstLeftToken.value === "let" &&
+                        astUtils.isOpeningBracketToken(
+                            sourceCode.getTokenAfter(firstLeftToken, astUtils.isNotClosingParenToken)
                         )
                     ) {
+
+                        // ForInStatement#left expression cannot start with `let[`.
                         tokensToIgnore.add(firstLeftToken);
                     }
                 }
 
-                if (node.type === "ForOfStatement") {
-                    const hasExtraParens = node.right.type === "SequenceExpression"
-                        ? hasDoubleExcessParens(node.right)
-                        : hasExcessParens(node.right);
+                if (hasExcessParens(node.left)) {
+                    report(node.left);
+                }
 
-                    if (hasExtraParens) {
-                        report(node.right);
-                    }
-                } else if (hasExcessParens(node.right)) {
+                if (hasExcessParens(node.right)) {
                     report(node.right);
+                }
+            },
+
+            ForOfStatement(node) {
+                if (node.left.type !== "VariableDeclaration") {
+                    const firstLeftToken = sourceCode.getFirstToken(node.left, astUtils.isNotOpeningParenToken);
+
+                    if (firstLeftToken.value === "let") {
+
+                        // ForOfStatement#left expression cannot start with `let`.
+                        tokensToIgnore.add(firstLeftToken);
+                    }
                 }
 
                 if (hasExcessParens(node.left)) {
                     report(node.left);
+                }
+
+                if (hasExcessParensWithPrecedence(node.right, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
+                    report(node.right);
                 }
             },
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.18.0
* **Node Version:** v12.18.4
* **npm Version:** 6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWV4dHJhLXBhcmVuczogZXJyb3IgKi9cblxuZm9yICgobGV0KSBpbiBmb28pO1xuXG5mb3IgKChsZXQuYSkgb2YgZm9vKTtcbiIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js
/* eslint no-extra-parens: error */

for ((let) in foo);

for ((let.a) of foo);

```

**What did you expect to happen?**

Per the [ForInOfStatement specification](https://tc39.es/ecma262/#prod-ForInOfStatement), `ForInStatement#left` expression cannot start with **let[**, and `ForOfStatement#left` expression cannot start with **let**:

> for ( [lookahead ≠ **let [**] LeftHandSideExpression[?Yield, ?Await] in Expression[+In, ?Yield, ?Await] ) Statement[?Yield, ?Await, ?Return]

> for ( [lookahead ≠ **let**] LeftHandSideExpression[?Yield, ?Await] of AssignmentExpression[+In, ?Yield, ?Await] ) Statement[?Yield, ?Await, ?Return]

So, I would expect:

* 1 error for `for ((let) in foo);`
* no errors for `for ((let.a) of foo);`

**What actually happened? Please include the actual, raw output from ESLint.**


* no errors for `for ((let) in foo);`
* 1 error for `for ((let.a) of foo);`

```
  5:6  error  Unnecessary parentheses around expression  no-extra-parens

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```

After the autofix:

```js
/* eslint no-extra-parens: error */

for ((let) in foo);

for (let.a of foo);
```

`for (let.a of foo);` is indeed a syntax error in engines:

> Uncaught SyntaxError: The left-hand side of a for-of loop may not start with 'let'.

Espree currently allows that, but it shouldn't. Reported https://github.com/acornjs/acorn/issues/1009

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Split `"ForInStatement, ForOfStatement"(node)` into two functions, as they're already different enough, and fixed the logic about expressions starting with `let` identifier.

#### Is there anything you'd like reviewers to focus on?

This fix produces more warnings for `for-in` loops and fewer warnings for `for-of` loops.

This is similar to the previous fix for `for` loops https://github.com/eslint/eslint/pull/13981
