### PR TITLE
Update: add enforceForJSX option to no-unused-expressions rule

### DIFF
--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -162,3 +162,26 @@ Examples of **correct** code for the `{ "allowTaggedTemplates": true }` option:
 
 tag`some tagged template string`;
 ```
+
+### enforceForJSX
+
+JSX is most-commonly used in the React ecosystem, where it is compiled to `React.createElement` expressions. Though free from side-effects, these calls are not automatically flagged by the `no-unused-expression` rule. If you're using React, or any other side-effect-free JSX pragma, this option can be enabled to flag these expressions.
+
+Examples of **incorrect** code for the `{ "enforceForJSX": true }` option:
+
+```jsx
+/*eslint no-unused-expressions: ["error", { "enforceForJSX": true }]*/
+
+<MyComponent />
+<></>
+```
+
+Examples of **correct** code for the `{ "enforceForJSX": true }` option:
+
+
+```jsx
+/*eslint no-unused-expressions: ["error", { "enforceForJSX": true }]*/
+
+var myComponentPartial = <MyComponent />
+var myFragment = <></>
+```

--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -31,6 +31,7 @@ This rule, in its default state, does not require any arguments. If you would li
 * `allowShortCircuit` set to `true` will allow you to use short circuit evaluations in your expressions (Default: `false`).
 * `allowTernary` set to `true` will enable you to use ternary operators in your expressions similarly to short circuit evaluations (Default: `false`).
 * `allowTaggedTemplates` set to `true` will enable you to use tagged template literals in your expressions (Default: `false`).
+* `enforceForJSX` set to `true` will flag unused JSX element expressions.
 
 These options allow unused expressions *only if all* of the code paths either directly change the state (for example, assignment statement) or could have *side effects* (for example, function call).
 

--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -172,8 +172,9 @@ Examples of **incorrect** code for the `{ "enforceForJSX": true }` option:
 ```jsx
 /*eslint no-unused-expressions: ["error", { "enforceForJSX": true }]*/
 
-<MyComponent />
-<></>
+<MyComponent />;
+
+<></>;
 ```
 
 Examples of **correct** code for the `{ "enforceForJSX": true }` option:
@@ -181,6 +182,7 @@ Examples of **correct** code for the `{ "enforceForJSX": true }` option:
 ```jsx
 /*eslint no-unused-expressions: ["error", { "enforceForJSX": true }]*/
 
-var myComponentPartial = <MyComponent />
-var myFragment = <></>
+var myComponentPartial = <MyComponent />;
+
+var myFragment = <></>;
 ```

--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -31,7 +31,7 @@ This rule, in its default state, does not require any arguments. If you would li
 * `allowShortCircuit` set to `true` will allow you to use short circuit evaluations in your expressions (Default: `false`).
 * `allowTernary` set to `true` will enable you to use ternary operators in your expressions similarly to short circuit evaluations (Default: `false`).
 * `allowTaggedTemplates` set to `true` will enable you to use tagged template literals in your expressions (Default: `false`).
-* `enforceForJSX` set to `true` will flag unused JSX element expressions.
+* `enforceForJSX` set to `true` will flag unused JSX element expressions (Default: `false`).
 
 These options allow unused expressions *only if all* of the code paths either directly change the state (for example, assignment statement) or could have *side effects* (for example, function call).
 

--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -178,7 +178,6 @@ Examples of **incorrect** code for the `{ "enforceForJSX": true }` option:
 
 Examples of **correct** code for the `{ "enforceForJSX": true }` option:
 
-
 ```jsx
 /*eslint no-unused-expressions: ["error", { "enforceForJSX": true }]*/
 

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -51,7 +51,7 @@ module.exports = {
                         type: "boolean",
                         default: false
                     },
-                    ignoreJSX: {
+                    disallowJSX: {
                         type: "boolean",
                         default: false
                     }
@@ -70,7 +70,7 @@ module.exports = {
             allowShortCircuit = config.allowShortCircuit || false,
             allowTernary = config.allowTernary || false,
             allowTaggedTemplates = config.allowTaggedTemplates || false,
-            ignoreJSX = config.ignoreJSX || false;
+            disallowJSX = config.disallowJSX || false;
 
         // eslint-disable-next-line jsdoc/require-description
         /**
@@ -146,7 +146,7 @@ module.exports = {
             FunctionExpression: alwaysTrue,
             Identifier: alwaysTrue,
             JSXElement() {
-                return ignoreJSX;
+                return disallowJSX;
             },
             Literal: alwaysTrue,
             LogicalExpression(node) {

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -51,7 +51,7 @@ module.exports = {
                         type: "boolean",
                         default: false
                     },
-                    disallowJSX: {
+                    enforceForJSX: {
                         type: "boolean",
                         default: false
                     }
@@ -70,7 +70,7 @@ module.exports = {
             allowShortCircuit = config.allowShortCircuit || false,
             allowTernary = config.allowTernary || false,
             allowTaggedTemplates = config.allowTaggedTemplates || false,
-            disallowJSX = config.disallowJSX || false;
+            enforceForJSX = config.enforceForJSX || false;
 
         // eslint-disable-next-line jsdoc/require-description
         /**
@@ -146,10 +146,10 @@ module.exports = {
             FunctionExpression: alwaysTrue,
             Identifier: alwaysTrue,
             JSXElement() {
-                return disallowJSX;
+                return enforceForJSX;
             },
             JSXFragment() {
-                return disallowJSX;
+                return enforceForJSX;
             },
             Literal: alwaysTrue,
             LogicalExpression(node) {

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -145,6 +145,9 @@ module.exports = {
             },
             FunctionExpression: alwaysTrue,
             Identifier: alwaysTrue,
+            JSXFragment() {
+                return disallowJSX;
+            },
             JSXElement() {
                 return disallowJSX;
             },

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -145,10 +145,10 @@ module.exports = {
             },
             FunctionExpression: alwaysTrue,
             Identifier: alwaysTrue,
-            JSXFragment() {
+            JSXElement() {
                 return disallowJSX;
             },
-            JSXElement() {
+            JSXFragment() {
                 return disallowJSX;
             },
             Literal: alwaysTrue,

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -39,6 +39,10 @@ module.exports = {
             {
                 type: "object",
                 properties: {
+                    allowJsx: {
+                        type: "boolean",
+                        default: false
+                    },
                     allowShortCircuit: {
                         type: "boolean",
                         default: false
@@ -63,6 +67,7 @@ module.exports = {
 
     create(context) {
         const config = context.options[0] || {},
+            allowJsx = config.allowJsx || false,
             allowShortCircuit = config.allowShortCircuit || false,
             allowTernary = config.allowTernary || false,
             allowTaggedTemplates = config.allowTaggedTemplates || false;
@@ -140,6 +145,9 @@ module.exports = {
             },
             FunctionExpression: alwaysTrue,
             Identifier: alwaysTrue,
+            JSXElement() {
+                return !allowJsx;
+            },
             Literal: alwaysTrue,
             LogicalExpression(node) {
                 if (allowShortCircuit) {

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -39,10 +39,6 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    allowJsx: {
-                        type: "boolean",
-                        default: false
-                    },
                     allowShortCircuit: {
                         type: "boolean",
                         default: false
@@ -52,6 +48,10 @@ module.exports = {
                         default: false
                     },
                     allowTaggedTemplates: {
+                        type: "boolean",
+                        default: false
+                    },
+                    ignoreJSX: {
                         type: "boolean",
                         default: false
                     }
@@ -67,10 +67,10 @@ module.exports = {
 
     create(context) {
         const config = context.options[0] || {},
-            allowJsx = config.allowJsx || false,
             allowShortCircuit = config.allowShortCircuit || false,
             allowTernary = config.allowTernary || false,
-            allowTaggedTemplates = config.allowTaggedTemplates || false;
+            allowTaggedTemplates = config.allowTaggedTemplates || false,
+            ignoreJSX = config.ignoreJSX || false;
 
         // eslint-disable-next-line jsdoc/require-description
         /**
@@ -146,7 +146,7 @@ module.exports = {
             FunctionExpression: alwaysTrue,
             Identifier: alwaysTrue,
             JSXElement() {
-                return !allowJsx;
+                return ignoreJSX;
             },
             Literal: alwaysTrue,
             LogicalExpression(node) {

--- a/tests/lib/rules/no-unused-expressions.js
+++ b/tests/lib/rules/no-unused-expressions.js
@@ -82,6 +82,17 @@ ruleTester.run("no-unused-expressions", rule, {
         {
             code: "obj?.foo(\"bar\")",
             parserOptions: { ecmaVersion: 11 }
+        },
+
+        // JSX
+        {
+            code: "<div />",
+            options: [{ allowJsx: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var partial = <div />",
+            parserOptions: { ecmaFeatures: { jsx: true } }
         }
     ],
     invalid: [
@@ -151,6 +162,13 @@ ruleTester.run("no-unused-expressions", rule, {
         {
             code: "obj?.foo().bar",
             parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }]
+        },
+
+        // JSX
+        {
+            code: "<div />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }]
         }
     ]

--- a/tests/lib/rules/no-unused-expressions.js
+++ b/tests/lib/rules/no-unused-expressions.js
@@ -87,7 +87,6 @@ ruleTester.run("no-unused-expressions", rule, {
         // JSX
         {
             code: "<div />",
-            options: [{ allowJsx: true }],
             parserOptions: { ecmaFeatures: { jsx: true } }
         },
         {
@@ -168,6 +167,7 @@ ruleTester.run("no-unused-expressions", rule, {
         // JSX
         {
             code: "<div />",
+            options: [{ ignoreJSX: true }],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }]
         }

--- a/tests/lib/rules/no-unused-expressions.js
+++ b/tests/lib/rules/no-unused-expressions.js
@@ -90,6 +90,10 @@ ruleTester.run("no-unused-expressions", rule, {
             parserOptions: { ecmaFeatures: { jsx: true } }
         },
         {
+            code: "<></>",
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
             code: "var partial = <div />",
             parserOptions: { ecmaFeatures: { jsx: true } }
         }
@@ -167,6 +171,12 @@ ruleTester.run("no-unused-expressions", rule, {
         // JSX
         {
             code: "<div />",
+            options: [{ disallowJSX: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }]
+        },
+        {
+            code: "<></>",
             options: [{ disallowJSX: true }],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }]

--- a/tests/lib/rules/no-unused-expressions.js
+++ b/tests/lib/rules/no-unused-expressions.js
@@ -96,6 +96,16 @@ ruleTester.run("no-unused-expressions", rule, {
         {
             code: "var partial = <div />",
             parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var partial = <div />",
+            options: [{ enforceForJSX: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "var partial = <></>",
+            options: [{ enforceForJSX: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
         }
     ],
     invalid: [
@@ -171,13 +181,13 @@ ruleTester.run("no-unused-expressions", rule, {
         // JSX
         {
             code: "<div />",
-            options: [{ disallowJSX: true }],
+            options: [{ enforceForJSX: true }],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }]
         },
         {
             code: "<></>",
-            options: [{ disallowJSX: true }],
+            options: [{ enforceForJSX: true }],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }]
         }

--- a/tests/lib/rules/no-unused-expressions.js
+++ b/tests/lib/rules/no-unused-expressions.js
@@ -167,7 +167,7 @@ ruleTester.run("no-unused-expressions", rule, {
         // JSX
         {
             code: "<div />",
-            options: [{ ignoreJSX: true }],
+            options: [{ disallowJSX: true }],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }]
         }


### PR DESCRIPTION
React's createElement call is side-effect free, as are most JSX pragmas.
An unused JSX element indicates a logic error in the same way any unused, side-effect free expression is.
This extension the no-unused-expression rule flags unused JSX elements unless the (new) allowJsx configuration option is set

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

**What rule do you want to change?**
`no-unused-expression`

**Does this change cause the rule to produce more or fewer warnings?**
More warnings; Unused JSX expressions are newly flagged

**How will the change be implemented? (New option, new default behavior, etc.)?**
~New default behavior; new option to opt-out~

No new default behavior; new option to opt-in

**Please provide some example code that this change will affect:**

```tsx
// Flagged (with opt-in)
<div />

// Unflagged
const partial = <div />
```

**What does the rule currently do for this code?**
JSX expressions are currently ignored by `no-unused-expression`

**What will the rule do after it's changed?**
Unused JSX expressions will be flagged

#### What changes did you make? (Give an overview)
Added recognition for JSXElement in the no-unused-expression rule Checker, following the code patterns already in-place in the rule.
Added tests demonstrating flagged and unflagged code, and how the `allowJsx` option interacts with such code.

#### Is there anything you'd like reviewers to focus on?
This originally came out of [this `eslint-plugin-react` PR](https://github.com/yannickcr/eslint-plugin-react/pull/2903).
The scope of this PR is somewhat smaller and had a couple of key differences.
* It includes an escape hatch (`allowJsx` option) since some JSX pragmas may not be side-effect-free
* It does not recognize literal `React.createElement()` calls; the original PR, focused on React, flagged these unused expressions