### PR TITLE
Update: fix no-invalid-regexp false negatives with no flags specified

### DIFF
--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -70,6 +70,28 @@ module.exports = {
         }
 
         /**
+         * Gets flags of a regular expression created by the given `RegExp()` or `new RegExp()` call
+         * Examples:
+         *     new RegExp(".")         // => ""
+         *     new RegExp(".", "gu")   // => "gu"
+         *     new RegExp(".", flags)  // => null
+         * @param {ASTNode} node `CallExpression` or `NewExpression` node
+         * @returns {string|null} flags if they can be determined, `null` otherwise
+         * @private
+         */
+        function getFlags(node) {
+            if (node.arguments.length < 2) {
+                return "";
+            }
+
+            if (isString(node.arguments[1])) {
+                return node.arguments[1].value;
+            }
+
+            return null;
+        }
+
+        /**
          * Check syntax error in a given pattern.
          * @param {string} pattern The RegExp pattern to validate.
          * @param {boolean} uFlag The Unicode flag.
@@ -104,18 +126,23 @@ module.exports = {
                     return;
                 }
                 const pattern = node.arguments[0].value;
-                let flags = isString(node.arguments[1]) ? node.arguments[1].value : "";
+                let flags = getFlags(node);
 
-                if (allowedFlags) {
+                if (flags && allowedFlags) {
                     flags = flags.replace(allowedFlags, "");
                 }
 
-                // If flags are unknown, check both are errored or not.
-                const message = validateRegExpFlags(flags) || (
-                    flags
-                        ? validateRegExpPattern(pattern, flags.indexOf("u") !== -1)
-                        : validateRegExpPattern(pattern, true) && validateRegExpPattern(pattern, false)
-                );
+                const message =
+                    (
+                        flags && validateRegExpFlags(flags)
+                    ) ||
+                    (
+
+                        // If flags are unknown, report the regex only if its pattern is invalid both with and without the "u" flag
+                        flags === null
+                            ? validateRegExpPattern(pattern, true) && validateRegExpPattern(pattern, false)
+                            : validateRegExpPattern(pattern, flags.includes("u"))
+                    );
 
                 if (message) {
                     context.report({

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -39,6 +39,20 @@ ruleTester.run("no-invalid-regexp", rule, {
         "new RegExp('(?<a>b)\\k<a>', 'u')",
         "new RegExp('\\\\p{Letter}', 'u')",
 
+        // unknown flags
+        "RegExp('{', flags)", // valid without the "u" flag
+        "new RegExp('{', flags)", // valid without the "u" flag
+        "RegExp('\\\\u{0}*', flags)", // valid with the "u" flag
+        "new RegExp('\\\\u{0}*', flags)", // valid with the "u" flag
+        {
+            code: "RegExp('{', flags)", // valid without the "u" flag
+            options: [{ allowConstructorFlags: ["u"] }]
+        },
+        {
+            code: "RegExp('\\\\u{0}*', flags)", // valid with the "u" flag
+            options: [{ allowConstructorFlags: ["a"] }]
+        },
+
         // ES2020
         "new RegExp('(?<\\\\ud835\\\\udc9c>.)', 'g')",
         "new RegExp('(?<\\\\u{1d49c}>.)', 'g')",
@@ -163,6 +177,48 @@ ruleTester.run("no-invalid-regexp", rule, {
                 messageId: "regexMessage",
                 data: { message: "Invalid regular expression: /\\a/u: Invalid escape" },
                 type: "NewExpression"
+            }]
+        },
+        {
+            code: String.raw`RegExp('\\u{0}*');`,
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid regular expression: /\\u{0}*/: Nothing to repeat" },
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: String.raw`new RegExp('\\u{0}*');`,
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid regular expression: /\\u{0}*/: Nothing to repeat" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: String.raw`new RegExp('\\u{0}*', '');`,
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid regular expression: /\\u{0}*/: Nothing to repeat" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: String.raw`new RegExp('\\u{0}*', 'a');`,
+            options: [{ allowConstructorFlags: ["a"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid regular expression: /\\u{0}*/: Nothing to repeat" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: String.raw`RegExp('\\u{0}*');`,
+            options: [{ allowConstructorFlags: ["a"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid regular expression: /\\u{0}*/: Nothing to repeat" },
+                type: "CallExpression"
             }]
         },
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.18.0
* **Node Version:** v12.18.4
* **npm Version:** 6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWludmFsaWQtcmVnZXhwOiBlcnJvciAqL1xuXG5uZXcgUmVnRXhwKFwiXFxcXHV7MH0qXCIpO1xuXG5uZXcgUmVnRXhwKFwiXFxcXHV7MH0qXCIsIFwiXCIpO1xuIiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo2LCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7fSwiZW52Ijp7fX19)

```js
/* eslint no-invalid-regexp: error */

new RegExp("\\u{0}*");

new RegExp("\\u{0}*", "");

```

**What did you expect to happen?**

2 errors

These regular expressions would be valid with the `u` flag, but it isn't specified.

**What actually happened? Please include the actual, raw output from ESLint.**

no errors

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `no-invalid-regexp` rule to distinguish cases where the flags are not specified, so it is known that the regex does not have the `u` flag, from cases where the flags are unknown so the rule reports an error only if the pattern is invalid both with and without the `u` flag.

#### Is there anything you'd like reviewers to focus on?
