### PR TITLE
Fix: no-useless-rename invalid autofix with parenthesized identifiers

### DIFF
--- a/tests/lib/rules/no-useless-rename.js
+++ b/tests/lib/rules/no-useless-rename.js
@@ -132,6 +132,26 @@ ruleTester.run("no-useless-rename", rule, {
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
         },
         {
+            code: "({foo: (foo)} = obj);",
+            output: "({foo} = obj);",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "let {\\u0061: a} = obj;",
+            output: "let {a} = obj;",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "a" } }]
+        },
+        {
+            code: "let {a: \\u0061} = obj;",
+            output: "let {\\u0061} = obj;",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "a" } }]
+        },
+        {
+            code: "let {\\u0061: \\u0061} = obj;",
+            output: "let {\\u0061} = obj;",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "a" } }]
+        },
+        {
             code: "let {a, foo: foo} = obj;",
             output: "let {a, foo} = obj;",
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
@@ -224,6 +244,21 @@ ruleTester.run("no-useless-rename", rule, {
             code: "let {foo: {bar: bar = {}} = {}} = obj;",
             output: "let {foo: {bar = {}} = {}} = obj;",
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "bar" } }]
+        },
+        {
+            code: "({foo: (foo) = a} = obj);",
+            output: null, // The rule doesn't autofix this edge case. The correct fix would be without parens: `let {foo = a} = obj;`
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "let {foo: foo = (a)} = obj;",
+            output: "let {foo = (a)} = obj;",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "let {foo: foo = (a, b)} = obj;",
+            output: "let {foo = (a, b)} = obj;",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
         },
         {
             code: "function func({foo: foo}) {}",
@@ -342,6 +377,21 @@ ruleTester.run("no-useless-rename", rule, {
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Import", name: "foo" } }]
         },
         {
+            code: "import {\\u0061 as a} from 'foo';",
+            output: "import {a} from 'foo';",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Import", name: "a" } }]
+        },
+        {
+            code: "import {a as \\u0061} from 'foo';",
+            output: "import {\\u0061} from 'foo';",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Import", name: "a" } }]
+        },
+        {
+            code: "import {\\u0061 as \\u0061} from 'foo';",
+            output: "import {\\u0061} from 'foo';",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Import", name: "a" } }]
+        },
+        {
             code: "import {foo as foo, bar as baz} from 'foo';",
             output: "import {foo, bar as baz} from 'foo';",
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Import", name: "foo" } }]
@@ -365,6 +415,21 @@ ruleTester.run("no-useless-rename", rule, {
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Export", name: "foo" } }]
         },
         {
+            code: "var a = 0; export {a as \\u0061};",
+            output: "var a = 0; export {a};",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Export", name: "a" } }]
+        },
+        {
+            code: "var \\u0061 = 0; export {\\u0061 as a};",
+            output: "var \\u0061 = 0; export {\\u0061};",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Export", name: "a" } }]
+        },
+        {
+            code: "var \\u0061 = 0; export {\\u0061 as \\u0061};",
+            output: "var \\u0061 = 0; export {\\u0061};",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Export", name: "a" } }]
+        },
+        {
             code: "var foo = 0; var bar = 0; export {foo as foo, bar as baz};",
             output: "var foo = 0; var bar = 0; export {foo, bar as baz};",
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Export", name: "foo" } }]
@@ -386,6 +451,21 @@ ruleTester.run("no-useless-rename", rule, {
             code: "export {foo as foo} from 'foo';",
             output: "export {foo} from 'foo';",
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Export", name: "foo" } }]
+        },
+        {
+            code: "export {a as \\u0061} from 'foo';",
+            output: "export {a} from 'foo';",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Export", name: "a" } }]
+        },
+        {
+            code: "export {\\u0061 as a} from 'foo';",
+            output: "export {\\u0061} from 'foo';",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Export", name: "a" } }]
+        },
+        {
+            code: "export {\\u0061 as \\u0061} from 'foo';",
+            output: "export {\\u0061} from 'foo';",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Export", name: "a" } }]
         },
         {
             code: "export {foo as foo, bar as baz} from 'foo';",
@@ -413,6 +493,11 @@ ruleTester.run("no-useless-rename", rule, {
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
         },
         {
+            code: "({/* comment */foo: foo = 1} = {});",
+            output: "({/* comment */foo = 1} = {});",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
             code: "({foo, /* comment */bar: bar} = {});",
             output: "({foo, /* comment */bar} = {});",
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "bar" } }]
@@ -423,7 +508,17 @@ ruleTester.run("no-useless-rename", rule, {
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
         },
         {
+            code: "({foo/**/ : foo = 1} = {});",
+            output: null,
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
             code: "({foo /**/: foo} = {});",
+            output: null,
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "({foo /**/: foo = 1} = {});",
             output: null,
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
         },
@@ -438,6 +533,36 @@ ruleTester.run("no-useless-rename", rule, {
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
         },
         {
+            code: "({foo: (/**/foo)} = {});",
+            output: null,
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "({foo: (foo/**/)} = {});",
+            output: null,
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "({foo: (foo //\n)} = {});",
+            output: null,
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "({foo: /**/foo = 1} = {});",
+            output: null,
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "({foo: (/**/foo) = 1} = {});",
+            output: null,
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "({foo: (foo/**/) = 1} = {});",
+            output: null,
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
             code: "({foo: foo/* comment */} = {});",
             output: "({foo/* comment */} = {});",
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
@@ -445,6 +570,31 @@ ruleTester.run("no-useless-rename", rule, {
         {
             code: "({foo: foo//comment\n,bar} = {});",
             output: "({foo//comment\n,bar} = {});",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "({foo: foo/* comment */ = 1} = {});",
+            output: "({foo/* comment */ = 1} = {});",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "({foo: foo // comment\n = 1} = {});",
+            output: "({foo // comment\n = 1} = {});",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "({foo: foo = /* comment */ 1} = {});",
+            output: "({foo = /* comment */ 1} = {});",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "({foo: foo = // comment\n 1} = {});",
+            output: "({foo = // comment\n 1} = {});",
+            errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
+        },
+        {
+            code: "({foo: foo = (1/* comment */)} = {});",
+            output: "({foo = (1/* comment */)} = {});",
             errors: [{ messageId: "unnecessarilyRenamed", data: { type: "Destructuring assignment", name: "foo" } }]
         },
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v7.18.0
* **Node Version:** v12.18.4
* **npm Version:** v6.14.6

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLXVzZWxlc3MtcmVuYW1lOiBlcnJvciAqL1xuXG4oeyBhOiAoYSkgfSA9IGZvbyApO1xuXG4oeyBhOiAoYSkgPSAxIH0gPSBmb28gKTtcbiIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js
/* eslint no-useless-rename: error */

({ a: (a) } = foo );

({ a: (a) = 1 } = foo );

```

**What did you expect to happen?**

2 errors, but not an invalid autofix.

**What actually happened? Please include the actual, raw output from ESLint.**

2 errors and autofix to:

```js
/* eslint no-useless-rename: error */

({ a) } = foo );

({ (a) = 1 } = foo );

```

```
  3:5  error  Parsing error: Unexpected token )
```

`{ a) }` is obviously a syntax error.

`{ (a) = 1 }` is also a syntax error, those parentheses are not allowed in shorthand properties.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed the `no-useless-rename` rule to correctly fix code such as `{ a: (a) }` and avoid autofixing code such as `{ a: (a) = 1 }`.

#### Is there anything you'd like reviewers to focus on?

This change should be also helpful for future syntax https://github.com/tc39/ecma262/pull/2154, like `export { "a b" as "a b"  } from "foo";`
