### PR TITLE
Docs: add a correct example to no-unsafe-optional-chaining (#14029)

### DIFF
--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -92,6 +92,8 @@ obj?.foo();
 
 obj?.foo.bar;
 
+obj.foo?.bar;
+
 foo?.()?.bar;
 
 (obj?.foo ?? bar)`template`;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [x] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
I added `obj.foo?.bar` as a correct example for this rule, 
since it's probably the most common usage of optional chaining.

#### Is there anything you'd like reviewers to focus on?
No.