### PR TITLE
Fix: `--init` autoconfig shouldn't add deprecated rules (fixes #14017)

### DIFF
--- a/lib/init/autoconfig.js
+++ b/lib/init/autoconfig.js
@@ -85,7 +85,7 @@ class Registry {
      * @returns {void}
      */
     populateFromCoreRules() {
-        const rulesConfig = configRule.createCoreRuleConfigs();
+        const rulesConfig = configRule.createCoreRuleConfigs(/* noDeprecated = */ true);
 
         this.rules = makeRegistryItems(rulesConfig);
     }

--- a/tests/lib/init/autoconfig.js
+++ b/tests/lib/init/autoconfig.js
@@ -132,6 +132,20 @@ describe("autoconfig", () => {
                 assert.include(Object.keys(registry.rules), "eqeqeq");
             });
 
+            it("should not add deprecated rules", () => {
+                const registry = new autoconfig.Registry();
+
+                registry.populateFromCoreRules();
+
+                const { rules } = registry;
+
+                assert.notProperty(rules, "id-blacklist");
+                assert.notProperty(rules, "no-negated-in-lhs");
+                assert.notProperty(rules, "no-process-exit");
+                assert.notProperty(rules, "no-spaced-func");
+                assert.notProperty(rules, "prefer-reflect");
+            });
+
             it("should not add duplicate rules", () => {
                 const registry = new autoconfig.Registry(rulesConfig);
 

--- a/tests/lib/init/config-initializer.js
+++ b/tests/lib/init/config-initializer.js
@@ -409,6 +409,14 @@ describe("configInitializer", () => {
                 assert.notProperty(config.rules, "no-debugger");
             });
 
+            it("should not include deprecated rules", () => {
+                assert.notProperty(config.rules, "id-blacklist");
+                assert.notProperty(config.rules, "no-negated-in-lhs");
+                assert.notProperty(config.rules, "no-process-exit");
+                assert.notProperty(config.rules, "no-spaced-func");
+                assert.notProperty(config.rules, "prefer-reflect");
+            });
+
             it("should support new ES features if using later ES version", () => {
                 const filename = getFixturePath("new-es-features");
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

fixes #14017

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `--init` autoconfig (`How would you like to define a style for your project? >  Inspect your JavaScript file(s)`) to avoid creating configs that contain deprecated core rules. 

#### Is there anything you'd like reviewers to focus on?
