### PR TITLE
Upgrade: pin @babel/code-frame@7.12.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
-    "@babel/code-frame": "^7.0.0",
+    "@babel/code-frame": "^7.12.13",
     "@eslint/eslintrc": "^0.3.0",
     "ajv": "^6.10.0",
     "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
-    "@babel/code-frame": "^7.12.13",
+    "@babel/code-frame": "7.12.11",
     "@eslint/eslintrc": "^0.3.0",
     "ajv": "^6.10.0",
     "chalk": "^4.0.0",

--- a/tests/lib/cli-engine/formatters/codeframe.js
+++ b/tests/lib/cli-engine/formatters/codeframe.js
@@ -86,7 +86,7 @@ describe("formatter:codeframe", () => {
                 "> 1 | var foo = 1;",
                 "    |     ^",
                 "  2 |  var bar = 2;",
-                "  3 |",
+                "  3 | ",
                 "\n",
                 "1 warning found."
             ].join("\n"));
@@ -115,7 +115,7 @@ describe("formatter:codeframe", () => {
                     "> 1 | var foo = 1;",
                     "    |     ^",
                     "  2 |  var bar = 2;",
-                    "  3 |",
+                    "  3 | ",
                     "\n",
                     "1 warning found.",
                     "1 warning potentially fixable with the `--fix` option."
@@ -147,7 +147,7 @@ describe("formatter:codeframe", () => {
                 "> 1 | var foo = 1;",
                 "    |     ^",
                 "  2 |  var bar = 2;",
-                "  3 |",
+                "  3 | ",
                 "\n",
                 "1 error found."
             ].join("\n"));
@@ -212,12 +212,12 @@ describe("formatter:codeframe", () => {
                 "error: Missing semicolon (semi) at foo.js:1:14:",
                 "> 1 | const foo = 1",
                 "    |              ^",
-                "  2 |",
+                "  2 | ",
                 "\n",
                 "error: 'foo' is assigned a value but never used (no-unused-vars) at foo.js:1:7:",
                 "> 1 | const foo = 1",
                 "    |       ^",
-                "  2 |",
+                "  2 | ",
                 "\n",
                 "2 errors found."
             ].join("\n"));
@@ -258,13 +258,13 @@ describe("formatter:codeframe", () => {
 
             assert.strictEqual(stripAnsi(result), [
                 "error: 'foo' is assigned a value but never used (no-unused-vars) at foo.js:4:11:",
-                "  2 |",
+                "  2 | ",
                 "  3 |     // a comment",
                 "> 4 |     const foo = 1;",
                 "    |           ^",
                 "  5 | }",
-                "  6 |",
-                "  7 |",
+                "  6 | ",
+                "  7 | ",
                 "\n",
                 "1 error found."
             ].join("\n"));
@@ -305,12 +305,12 @@ describe("formatter:codeframe", () => {
                 "error: Missing semicolon (semi) at foo.js:1:14:",
                 "> 1 | const foo = 1",
                 "    |              ^",
-                "  2 |",
+                "  2 | ",
                 "\n",
                 "error: Missing semicolon (semi) at bar.js:1:14:",
                 "> 1 | const bar = 2",
                 "    |              ^",
-                "  2 |",
+                "  2 | ",
                 "\n",
                 "2 errors found."
             ].join("\n"));
@@ -341,7 +341,7 @@ describe("formatter:codeframe", () => {
                 "error: Parsing error: Unexpected token { at foo.js:1:2:",
                 "> 1 | e{}",
                 "    |  ^",
-                "  2 |",
+                "  2 | ",
                 "\n",
                 "1 error found."
             ].join("\n"));

--- a/tests/lib/cli-engine/formatters/codeframe.js
+++ b/tests/lib/cli-engine/formatters/codeframe.js
@@ -86,7 +86,7 @@ describe("formatter:codeframe", () => {
                 "> 1 | var foo = 1;",
                 "    |     ^",
                 "  2 |  var bar = 2;",
-                "  3 | ",
+                "  3 |",
                 "\n",
                 "1 warning found."
             ].join("\n"));
@@ -115,7 +115,7 @@ describe("formatter:codeframe", () => {
                     "> 1 | var foo = 1;",
                     "    |     ^",
                     "  2 |  var bar = 2;",
-                    "  3 | ",
+                    "  3 |",
                     "\n",
                     "1 warning found.",
                     "1 warning potentially fixable with the `--fix` option."
@@ -147,7 +147,7 @@ describe("formatter:codeframe", () => {
                 "> 1 | var foo = 1;",
                 "    |     ^",
                 "  2 |  var bar = 2;",
-                "  3 | ",
+                "  3 |",
                 "\n",
                 "1 error found."
             ].join("\n"));
@@ -212,12 +212,12 @@ describe("formatter:codeframe", () => {
                 "error: Missing semicolon (semi) at foo.js:1:14:",
                 "> 1 | const foo = 1",
                 "    |              ^",
-                "  2 | ",
+                "  2 |",
                 "\n",
                 "error: 'foo' is assigned a value but never used (no-unused-vars) at foo.js:1:7:",
                 "> 1 | const foo = 1",
                 "    |       ^",
-                "  2 | ",
+                "  2 |",
                 "\n",
                 "2 errors found."
             ].join("\n"));
@@ -258,13 +258,13 @@ describe("formatter:codeframe", () => {
 
             assert.strictEqual(stripAnsi(result), [
                 "error: 'foo' is assigned a value but never used (no-unused-vars) at foo.js:4:11:",
-                "  2 | ",
+                "  2 |",
                 "  3 |     // a comment",
                 "> 4 |     const foo = 1;",
                 "    |           ^",
                 "  5 | }",
-                "  6 | ",
-                "  7 | ",
+                "  6 |",
+                "  7 |",
                 "\n",
                 "1 error found."
             ].join("\n"));
@@ -305,12 +305,12 @@ describe("formatter:codeframe", () => {
                 "error: Missing semicolon (semi) at foo.js:1:14:",
                 "> 1 | const foo = 1",
                 "    |              ^",
-                "  2 | ",
+                "  2 |",
                 "\n",
                 "error: Missing semicolon (semi) at bar.js:1:14:",
                 "> 1 | const bar = 2",
                 "    |              ^",
-                "  2 | ",
+                "  2 |",
                 "\n",
                 "2 errors found."
             ].join("\n"));
@@ -341,7 +341,7 @@ describe("formatter:codeframe", () => {
                 "error: Parsing error: Unexpected token { at foo.js:1:2:",
                 "> 1 | e{}",
                 "    |  ^",
-                "  2 | ",
+                "  2 |",
                 "\n",
                 "1 error found."
             ].join("\n"));


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

We're using `@babel/code-frame` for the `codeframe` formatter.

The latest `@babel/code-frame` version `7.12.13`, which was released yesterday, is causing failures on our CI:

https://github.com/eslint/eslint/pull/14012/checks?check_run_id=1826678459

Tests are failing because `7.12.13` produces different output for empty lines: https://github.com/babel/babel/pull/12567. That change is intentional. In particular, it removes a trailing space after `|` if the line is empty.


`7.12.13` is in the specified range:

https://github.com/eslint/eslint/blob/4cab165bf4e6e5e9f42a59a37a8ff2548c0af87d/package.json#L49

#### What changes did you make? (Give an overview)

* ~Fixed the failing tests to match the behavior of `v7.12.13`.~

* ~Updated `"@babel/code-frame": "^7.12.13"` in `package.json`.~

Pinned `@babel/code-frame` to `7.12.11` (that's the previous version, there is no `7.12.12`).

#### Is there anything you'd like reviewers to focus on?

~The change in `@babel/code-frame` changes the output of our `codeframe` formatter. An alternative is to pin `@babel/code-frame` to a previous version and upgrade in the next ESLint major. Another alternative is to update the code in the formatter to restore the previous output, if possible.~

* As we probably don't want to stay on `7.12.11` forever, the next ESLint major version should have `^7.12.13` (or higher). That will be a breaking change in the `codeframe` formatter.
* An alternative is that we modify the output to match the previous behavior.