### PR TITLE
Fix: Crash with esquery when using JSX (fixes #13639)

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -942,7 +942,9 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
     });
 
     // only run code path analyzer if the top level node is "Program", skip otherwise
-    const eventGenerator = nodeQueue[0].node.type === "Program" ? new CodePathAnalyzer(new NodeEventGenerator(emitter)) : new NodeEventGenerator(emitter);
+    const eventGenerator = nodeQueue[0].node.type === "Program"
+        ? new CodePathAnalyzer(new NodeEventGenerator(emitter, { visitorKeys: sourceCode.visitorKeys, fallback: Traverser.getKeys }))
+        : new NodeEventGenerator(emitter, { visitorKeys: sourceCode.visitorKeys, fallback: Traverser.getKeys });
 
     nodeQueue.forEach(traversalInfo => {
         currentNode = traversalInfo.node;

--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -208,10 +208,12 @@ class NodeEventGenerator {
      * An SafeEmitter which is the destination of events. This emitter must already
      * have registered listeners for all of the events that it needs to listen for.
      * (See lib/linter/safe-emitter.js for more details on `SafeEmitter`.)
+     * @param {ESQueryOptions} esqueryOptions `esquery` options for traversing custom nodes.
      * @returns {NodeEventGenerator} new instance
      */
-    constructor(emitter) {
+    constructor(emitter, esqueryOptions) {
         this.emitter = emitter;
+        this.esqueryOptions = esqueryOptions;
         this.currentAncestry = [];
         this.enterSelectorsByNodeType = new Map();
         this.exitSelectorsByNodeType = new Map();
@@ -250,7 +252,7 @@ class NodeEventGenerator {
      * @returns {void}
      */
     applySelector(node, selector) {
-        if (esquery.matches(node, selector.parsedSelector, this.currentAncestry)) {
+        if (esquery.matches(node, selector.parsedSelector, this.currentAncestry, this.esqueryOptions)) {
             this.emitter.emit(selector.rawSelector, node);
         }
     }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-utils": "^2.1.0",
     "eslint-visitor-keys": "^2.0.0",
     "espree": "^7.3.1",
-    "esquery": "^1.2.0",
+    "esquery": "^1.4.0",
     "esutils": "^2.0.2",
     "file-entry-cache": "^6.0.0",
     "functional-red-black-tree": "^1.0.1",

--- a/tests/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -12,6 +12,7 @@
 const assert = require("assert"),
     fs = require("fs"),
     path = require("path"),
+    vk = require("eslint-visitor-keys"),
     { Linter } = require("../../../../lib/linter"),
     EventGeneratorTester = require("../../../../tools/internal-testers/event-generator-tester"),
     createEmitter = require("../../../../lib/linter/safe-emitter"),
@@ -19,11 +20,14 @@ const assert = require("assert"),
     CodePath = require("../../../../lib/linter/code-path-analysis/code-path"),
     CodePathAnalyzer = require("../../../../lib/linter/code-path-analysis/code-path-analyzer"),
     CodePathSegment = require("../../../../lib/linter/code-path-analysis/code-path-segment"),
-    NodeEventGenerator = require("../../../../lib/linter/node-event-generator");
+    NodeEventGenerator = require("../../../../lib/linter/node-event-generator"),
+    Traverser = require("../../../lib/shared/traverser");
 
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
+
+const STANDARD_ESQUERY_OPTION = { visitorKeys: vk.KEYS, fallback: Traverser.getKeys };
 
 const expectedPattern = /\/\*expected\s+((?:.|[\r\n])+?)\s*\*\//gu;
 const lineEndingPattern = /\r?\n/gu;
@@ -54,7 +58,7 @@ function getExpectedDotArrows(source) {
 
 describe("CodePathAnalyzer", () => {
     EventGeneratorTester.testEventGeneratorInterface(
-        new CodePathAnalyzer(new NodeEventGenerator(createEmitter()))
+        new CodePathAnalyzer(new NodeEventGenerator(createEmitter(), STANDARD_ESQUERY_OPTION))
     );
 
     describe("interface of code paths", () => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -5293,9 +5293,11 @@ var a = "test2";
             let types = [];
             let sourceCode;
             let scopeManager;
+            let firstChildNodes = [];
 
             beforeEach(() => {
                 types = [];
+                firstChildNodes = [];
                 linter.defineRule("collect-node-types", () => ({
                     "*"(node) {
                         types.push(node.type);
@@ -5306,12 +5308,18 @@ var a = "test2";
 
                     return {};
                 });
+                linter.defineRule("esquery-option", () => ({
+                    ":first-child"(node) {
+                        firstChildNodes.push(node);
+                    }
+                }));
                 linter.defineParser("enhanced-parser2", testParsers.enhancedParser2);
                 linter.verify("@foo class A {}", {
                     parser: "enhanced-parser2",
                     rules: {
                         "collect-node-types": "error",
-                        "save-scope-manager": "error"
+                        "save-scope-manager": "error",
+                        "esquery-option": "error"
                     }
                 });
 
@@ -5349,6 +5357,13 @@ var a = "test2";
                 assert.deepStrictEqual(
                     types2,
                     ["Program", "ClassDeclaration", "Decorator", "Identifier", "Identifier", "ClassBody"]
+                );
+            });
+
+            it("esquery should use the visitorKeys (so 'visitorKeys.ClassDeclaration' includes 'experimentalDecorators')", () => {
+                assert.deepStrictEqual(
+                    firstChildNodes,
+                    [sourceCode.ast.body[0], sourceCode.ast.body[0].experimentalDecorators[0]]
                 );
             });
         });

--- a/tests/lib/rules/no-restricted-syntax.js
+++ b/tests/lib/rules/no-restricted-syntax.js
@@ -145,18 +145,26 @@ ruleTester.run("no-restricted-syntax", rule, {
                 { messageId: "restrictedSyntax", data: { message: "Using '[optional=true]' is not allowed." }, type: "CallExpression" },
                 { messageId: "restrictedSyntax", data: { message: "Using '[optional=true]' is not allowed." }, type: "MemberExpression" }
             ]
-        }
+        },
 
-        /*
-         * TODO(mysticatea): fix https://github.com/estools/esquery/issues/110
-         * {
-         *     code: "a?.b",
-         *     options: [":nth-child(1)"],
-         *     parserOptions: { ecmaVersion: 2020 },
-         *     errors: [
-         *         { messageId: "restrictedSyntax", data: { message: "Using ':nth-child(1)' is not allowed." }, type: "ExpressionStatement" }
-         *     ]
-         * }
-         */
+        // fix https://github.com/estools/esquery/issues/110
+        {
+            code: "a?.b",
+            options: [":nth-child(1)"],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [
+                { messageId: "restrictedSyntax", data: { message: "Using ':nth-child(1)' is not allowed." }, type: "ExpressionStatement" }
+            ]
+        },
+
+        // https://github.com/eslint/eslint/issues/13639#issuecomment-683976062
+        {
+            code: "const foo = [<div/>, <div/>]",
+            options: ["* ~ *"],
+            parserOptions: { ecmaVersion: 2020, ecmaFeatures: { jsx: true } },
+            errors: [
+                { messageId: "restrictedSyntax", data: { message: "Using '* ~ *' is not allowed." }, type: "JSXElement" }
+            ]
+        }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

fixes #13639

#### What changes did you make? (Give an overview)

This PR uses a new option in esquery to solve the crash problem with non-standard ASTs such as JSX and some queries.

#### Is there anything you'd like reviewers to focus on?
