### PR TITLE
Docs: fix sibling selector descriptions

### DIFF
--- a/docs/developer-guide/selectors.md
+++ b/docs/developer-guide/selectors.md
@@ -40,8 +40,8 @@ The following selectors are supported:
 * nth-last-child (no ax+b support): `:nth-last-child(1)`
 * descendant: `FunctionExpression ReturnStatement`
 * child: `UnaryExpression > Literal`
-* following sibling: `ArrayExpression > Literal + SpreadElement`
-* adjacent sibling: `VariableDeclaration ~ VariableDeclaration`
+* following sibling: `VariableDeclaration ~ VariableDeclaration`
+* adjacent sibling: `ArrayExpression > Literal + SpreadElement`
 * negation: `:not(ForStatement)`
 * matches-any: `:matches([attr] > :first-child, :last-child)`
 * class of AST node: `:statement`, `:expression`, `:declaration`, `:function`, or `:pattern`


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Per the [esquery documentation](https://github.com/estools/esquery), `~` is following (but not necessarily adjacent) sibling, `+` is adjacent sibling:

> * following sibling: node ~ sibling
> * adjacent sibling: node + adjacent

Our [selectors documentation](https://eslint.org/docs/developer-guide/selectors) has it the other way around:

> * following sibling: ArrayExpression > Literal + SpreadElement
> * adjacent sibling: VariableDeclaration ~ VariableDeclaration

[This demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLXJlc3RyaWN0ZWQtc3ludGF4OiBbXG4gICAgXCJlcnJvclwiLFxuICAgIFwiQXJyYXlFeHByZXNzaW9uID4gTGl0ZXJhbCArIFNwcmVhZEVsZW1lbnRcIixcbiAgICBcIlZhcmlhYmxlRGVjbGFyYXRpb24gfiBWYXJpYWJsZURlY2xhcmF0aW9uXCJcbl0gKi9cblxuWzEsIC4uLmFdOyAvLyBlcnJvciwgYXMgaXQgaXMgYWRqYWNlbnRcblxuWzEsIG5vdF9saXRlcmFsLCAuLi5iXTsgLy8gbm8gZXJyb3IsIGFzIGl0IGlzbid0IGFkamFjZW50XG5cbi8vLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS1cblxudmFyIGZvbztcblxuYmFyKCk7XG5cbnZhciBiYXo7IC8vIGVycm9yLCBhbHRob3VnaCBpdCBpc24ndCBhZGphY2VudFxuIiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo2LCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7fSwiZW52Ijp7fX19) shows that `+` is adjacent, while `~` doesn't have to be adjacent.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed `selectors.md`

#### Is there anything you'd like reviewers to focus on?
