### PR TITLE
Fix: Do not traverse directories that conflict with eslintignore rules.

### DIFF
--- a/lib/cli-engine/file-enumerator.js
+++ b/lib/cli-engine/file-enumerator.js
@@ -273,7 +273,7 @@ class FileEnumerator {
      * @returns {IterableIterator<FileAndConfig>} The found files.
      */
     *iterateFiles(patternOrPatterns) {
-        const { globInputPaths, errorOnUnmatchedPattern } = internalSlotsMap.get(this);
+        const { cwd, configArrayFactory, globInputPaths, errorOnUnmatchedPattern } = internalSlotsMap.get(this);
         const patterns = Array.isArray(patternOrPatterns)
             ? patternOrPatterns
             : [patternOrPatterns];
@@ -284,11 +284,13 @@ class FileEnumerator {
         const set = new Set();
 
         for (const pattern of patterns) {
+            const absolutePath = path.resolve(cwd, pattern);
+            const patternConfig = configArrayFactory.getConfigArrayForFile(pattern, { ignoreNotFoundError: true });
             let foundRegardlessOfIgnored = false;
             let found = false;
 
             // Skip empty string.
-            if (!pattern) {
+            if (!pattern || (patternConfig && this._isIgnoredFile(absolutePath, patternConfig))) {
                 continue;
             }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

https://github.com/eslint/eslint/issues/12854

**Tell us about your environment**

* **ESLint Version:** 7.21.0
* **Node Version:** 12.18.3
* **npm Version:** 6.14.9
* **Operating System:** MacOS

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**
`@typescript-eslint/parser`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports =  {
  parser:  '@typescript-eslint/parser',  // Specifies the ESLint parser
  ignorePatterns: [
    'node_modules/**',
    '/node_modules/',
    'node_modules',
    '**/node_modules/**',
    'node_modules/microevent.ts/**',
    'dist',
    'types-local',
    'graphql.ts',
    'packages/@universe/aether/cjs/**',
    'packages/@universe/aether/esm/**',
  ],
  extends:  [
    'preact',
    'eslint:recommended',
    'plugin:@typescript-eslint/recommended',
  ],
  parserOptions:  {
    ecmaVersion:  2018,  // Allows for the parsing of modern ECMAScript features
    sourceType:  'module',  // Allows for the use of imports
    ecmaFeatures:  {
      jsx:  true,  // Allows for the parsing of JSX
    },
  },
  settings: {
    react: {
      version: 'detect',
    },
  },
  plugins: ['simple-import-sort'],
  rules:  {
    'simple-import-sort/imports': 'error',
    'simple-import-sort/exports': 'error',
    'sort-imports': 'off',
    'import/order': 'off',
    semi: [ 'error', 'always' ],
    'jsx-quotes': [ 'error', 'prefer-double' ],
    'react/jsx-curly-brace-presence': [ 'error', { props: "never", children: "never" }],
    'max-len': [ 'error', { code: 180, tabWidth: 2 }],
    'no-multiple-empty-lines': [ 'error', { max: 1 }],
    'no-var': ['error'],
    'space-before-function-paren': [ 'error', 'never' ],
    'no-return-assign': 'off',
    'no-unused-expressions': 'off',
    'brace-style': [ 'error', 'stroustrup', { allowSingleLine: true }],
    'comma-dangle': [ 'error', 'always-multiline' ],
    "array-bracket-spacing": [ "error", "always", {
      singleValue: false,
      objectsInArrays: false,
      arraysInArrays: false,
    }],
    'object-curly-spacing': [ 'error', 'always' ],
    'no-unused-vars': 'off',
    '@typescript-eslint/no-unused-vars': [ 'error', { varsIgnorePattern: '^_', argsIgnorePattern: '^_' }],

    // TODO: Fully enable these rules.
    '@typescript-eslint/interface-name-prefix': 'off',
    '@typescript-eslint/explicit-function-return-type': 'off',
    '@typescript-eslint/explicit-module-boundary-types': 'off',
    "react-hooks/rules-of-hooks": "warn",
    "react-hooks/exhaustive-deps": "warn",
    "react/no-deprecated": "warn",
    "react/no-did-mount-set-state": "warn",
  },
};
```

</details>

**What did you do? Please include the actual source code causing the issue, as well as the command that you used to run ESLint.**

There is a package names `microevent.ts`. It is depended on by `react-dev-utils` and `@storybook/react`, which is how it got into my repo.

**What did you expect to happen?**
The lint command to work!

**What actually happened? Please copy-paste the actual, raw output from ESLint.**

When installed, and when using a glob pattern to match typescript files `**.*.ts`, the eslint command will always fail with 

```
Oops! Something went wrong! :(

ESLint: 7.20.0

No files matching the pattern "node_modules/microevent.ts" were found.
Please check for typing mistakes in the pattern.

<!-- Paste the source code below: -->
```bash
npm install microevent.ts
eslint **/*.ts **/*.tsx
```

**Steps to reproduce this issue:**
See above.
<!-- Please tell us exactly how to see the issue you're describing -->

1. Install microevent.ts
1. Use the glob `**/*.ts`
1. Panic.
