### PR TITLE
Update: report es2021 globals in no-extend-native (refs #13602)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "file-entry-cache": "^6.0.1",
     "functional-red-black-tree": "^1.0.1",
     "glob-parent": "^5.0.0",
-    "globals": "^12.1.0",
+    "globals": "^13.6.0",
     "ignore": "^4.0.6",
     "import-fresh": "^3.0.0",
     "imurmurhash": "^0.1.4",

--- a/tests/lib/rules/no-extend-native.js
+++ b/tests/lib/rules/no-extend-native.js
@@ -48,12 +48,6 @@ ruleTester.run("no-extend-native", rule, {
         {
             code: "{ let Object = function() {}; Object.prototype.p = 0 }",
             parserOptions: { ecmaVersion: 6 }
-        },
-
-        // TODO(mdjermanovic): This test should become `invalid` in the next major version, when we upgrade the `globals` package.
-        {
-            code: "WeakRef.prototype.p = 0",
-            env: { es2021: true }
         }
     ],
     invalid: [{
@@ -69,6 +63,30 @@ ruleTester.run("no-extend-native", rule, {
         errors: [{
             messageId: "unexpected",
             data: { builtin: "BigInt" },
+            type: "AssignmentExpression"
+        }]
+    }, {
+        code: "WeakRef.prototype.p = 0",
+        env: { es2021: true },
+        errors: [{
+            messageId: "unexpected",
+            data: { builtin: "WeakRef" },
+            type: "AssignmentExpression"
+        }]
+    }, {
+        code: "FinalizationRegistry.prototype.p = 0",
+        env: { es2021: true },
+        errors: [{
+            messageId: "unexpected",
+            data: { builtin: "FinalizationRegistry" },
+            type: "AssignmentExpression"
+        }]
+    }, {
+        code: "AggregateError.prototype.p = 0",
+        env: { es2021: true },
+        errors: [{
+            messageId: "unexpected",
+            data: { builtin: "AggregateError" },
             type: "AssignmentExpression"
         }]
     }, {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

refs #13602

Updates `no-extended-native` rule to start reporting `es2021` globals. Those are, currently: `WeakRef`, `FinalizationRegistry`, and `AggregateError`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `globals` dependency in `package.json`, from `^12.1.0` to `^13.6.0`, as `12.x` doesn't have any `es2021` globals.

`no-extend-native` uses `globals.builtin` to know which of the global variables are ES builtins, because it's designed to report only them. 

#### Is there anything you'd like reviewers to focus on?

* `no-extend-native` is the only place in `eslint/eslint` where it's directly using the `globals` package, so this shouldn't affect anything else. `@eslint/eslintrc` uses the `globals` package for eslint environments.
* We could probably refactor the code to use the latest eslint `es*` environment instead of `globals.builtin`, but it seems better to do that when we implement the new config system, as there will be some changes in where and how we store environments.
* This was originally planned for a major release as it produces more warnings, but per the updated semver policy we can make this change in a minor release because it's related to a new language feature.
