### PR TITLE
Include XO style guide in `eslint --init`

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -531,7 +531,8 @@ function promptUser() {
             choices: [
                 { message: "Airbnb: https://github.com/airbnb/javascript", name: "airbnb" },
                 { message: "Standard: https://github.com/standard/standard", name: "standard" },
-                { message: "Google: https://github.com/google/eslint-config-google", name: "google" }
+                { message: "Google: https://github.com/google/eslint-config-google", name: "google" },
+                { message: "XO: https://github.com/xojs/eslint-config-xo", name: "xo" }
             ],
             skip() {
                 this.state.answers.packageJsonExists = npmUtils.checkPackageJson();

--- a/tests/lib/init/config-initializer.js
+++ b/tests/lib/init/config-initializer.js
@@ -240,6 +240,14 @@ describe("configInitializer", () => {
                 assert.include(modules, "eslint-config-standard@latest");
             });
 
+            it("should support the xo style guide", () => {
+                const config = { extends: "xo" };
+                const modules = init.getModulesList(config);
+
+                assert.deepStrictEqual(config, { extends: "xo", installedESLint: true });
+                assert.include(modules, "eslint-config-xo@latest");
+            });
+
             it("should install required sharable config", () => {
                 const config = { extends: "google" };
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[x] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

XO is a pretty strict and popular ESLint config by Sindre Sorhus, I was surprised not to find it among the ones listed in `eslint --init`. It’s usually used through XO’s own CLI tool but this config works everywhere.