### PR TITLE
Fix: no-mixed-operators false positives with `? :` (fixes #14223)

### DIFF
--- a/docs/rules/no-mixed-operators.md
+++ b/docs/rules/no-mixed-operators.md
@@ -122,6 +122,10 @@ var foo = a & b | c;
 /*eslint no-mixed-operators: ["error", {"groups": [["&&", "||", "?:"]]}]*/
 
 var foo = a || b ? c : d;
+
+var bar = a ? b || c : d;
+
+var baz = a ? b : c || d;
 ```
 
 Examples of **correct** code for this rule with `{"groups": [["&", "|", "^", "~", "<<", ">>", ">>>"], ["&&", "||"]]}` option:
@@ -145,6 +149,11 @@ var foo = (a + b) * c;
 
 var foo = (a || b) ? c : d;
 var foo = a || (b ? c : d);
+
+var bar = a ? (b || c) : d;
+
+var baz = a ? b : (c || d);
+var baz = (a ? b : c) || d;
 ```
 
 ### allowSamePrecedence

--- a/lib/rules/no-mixed-operators.js
+++ b/lib/rules/no-mixed-operators.js
@@ -162,17 +162,6 @@ module.exports = {
         }
 
         /**
-         * Checks whether the operator of a given node is mixed with a
-         * conditional expression.
-         * @param {ASTNode} node A node to check. This is a conditional
-         *      expression node
-         * @returns {boolean} `true` if the node was mixed.
-         */
-        function isMixedWithConditionalParent(node) {
-            return !astUtils.isParenthesised(sourceCode, node) && !astUtils.isParenthesised(sourceCode, node.test);
-        }
-
-        /**
          * Gets the operator token of a given node.
          * @param {ASTNode} node A node to check. This is a BinaryExpression
          *      node or a LogicalExpression node.
@@ -220,19 +209,13 @@ module.exports = {
          * @returns {void}
          */
         function check(node) {
-            if (TARGET_NODE_TYPE.test(node.parent.type)) {
-                if (node.parent.type === "ConditionalExpression" && !shouldIgnore(node) && isMixedWithConditionalParent(node.parent)) {
-                    reportBothOperators(node);
-                } else {
-                    if (TARGET_NODE_TYPE.test(node.parent.type) &&
-                        isMixedWithParent(node) &&
-                        !shouldIgnore(node)
-                    ) {
-                        reportBothOperators(node);
-                    }
-                }
+            if (
+                TARGET_NODE_TYPE.test(node.parent.type) &&
+                isMixedWithParent(node) &&
+                !shouldIgnore(node)
+            ) {
+                reportBothOperators(node);
             }
-
         }
 
         return {

--- a/tests/lib/rules/no-mixed-operators.js
+++ b/tests/lib/rules/no-mixed-operators.js
@@ -53,12 +53,28 @@ ruleTester.run("no-mixed-operators", rule, {
             options: [{ groups: [["&&", "||", "?:"]] }]
         },
         {
+            code: "a ? (b || c) : d",
+            options: [{ groups: [["&&", "||", "?:"]] }]
+        },
+        {
+            code: "a ? b : (c || d)",
+            options: [{ groups: [["&&", "||", "?:"]] }]
+        },
+        {
             code: "a || (b ? c : d)",
+            options: [{ groups: [["&&", "||", "?:"]] }]
+        },
+        {
+            code: "(a ? b : c) || d",
             options: [{ groups: [["&&", "||", "?:"]] }]
         },
         "a || (b ? c : d)",
         "(a || b) ? c : d",
-        "a || b ? c : d"
+        "a || b ? c : d",
+        "a ? (b || c) : d",
+        "a ? b || c : d",
+        "a ? b : (c || d)",
+        "a ? b : c || d"
     ],
     invalid: [
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

fixes #14223

Fixes false positives such as:

```js
/* eslint no-mixed-operators: ["error", { groups: [["&&", "||", "?:"]] }] */

a ? (b || c) : d; // false positive

(a) ? (b || c) : d; // ok

(a ? (b || c) : d); // also ok

//--------------------------------

a ? b : (c || d); // false positive

(a) ? b : (c || d); // ok

(a ? b : (c || d)); // also ok

```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed invalid `isMixedWithConditionalParent()` check. 

The other check, `isMixedWithParent()`, already covers binary/logical expression nodes in conditional expressions, so `!astUtils.isParenthesised(sourceCode, node.test)` condition in `isMixedWithConditionalParent()` was redundant for child binary/logical expressions in `test`, and wrong for child binary/logical expressions in `consequent`/`alternate`.

`!astUtils.isParenthesised(sourceCode, node)` condition in `isMixedWithConditionalParent()` was also wrong. It gets a `ConditionalExpression` node when its child binary/logical expression node is being checked, so checking parens around the `ConditionalExpression` in that case doesn't make sense.

#### Is there anything you'd like reviewers to focus on?
