### PR TITLE
Docs: Add valid example that shows vars in a block scope

### DIFF
--- a/docs/rules/block-scoped-var.md
+++ b/docs/rules/block-scoped-var.md
@@ -71,6 +71,13 @@ function doTryCatch() {
         f = build;
     }
 }
+
+function doFor() {
+    for (var x = 1; x < 10; x++) {
+        var y = f(x);
+        console.log(y);
+    }
+}
 ```
 
 ## Further Reading

--- a/docs/rules/block-scoped-var.md
+++ b/docs/rules/block-scoped-var.md
@@ -34,6 +34,13 @@ function doTryCatch() {
         var f = build;
     }
 }
+
+function doFor() {
+    for (var x = 1; x < 10; x++) {
+        var y = f(x);
+    }
+    console.log(y);
+}
 ```
 
 Examples of **correct** code for this rule:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
All the current valid examples show hoisting the var to the function scope. This example makes is clear that this rule allows you to declare vars inside a block scope, just not use them out of that scope.


#### Is there anything you'd like reviewers to focus on?
