### PR TITLE
Update: `--quiet` should not supress `--max-warnings` (fixes #14202)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -301,12 +301,16 @@ const cli = {
             await ESLint.outputFixes(results);
         }
 
+        let resultsToPrint = results;
+
         if (options.quiet) {
             debug("Quiet mode enabled - filtering out warnings");
-            results = ESLint.getErrorResults(results);
+            resultsToPrint = ESLint.getErrorResults(resultsToPrint);
         }
 
-        if (await printResults(engine, results, options.format, options.outputFile)) {
+        if (await printResults(engine, resultsToPrint, options.format, options.outputFile)) {
+
+            // Errors and warnings from the original unfiltered results should determine the exit code
             const { errorCount, warningCount } = countErrors(results);
             const tooManyWarnings =
                 options.maxWarnings >= 0 && warningCount > options.maxWarnings;

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -778,6 +778,16 @@ describe("cli", () => {
             assert.include(log.error.getCall(0).args[0], "ESLint found too many warnings");
         });
 
+        it("should exit with exit code 1 without printing warnings if the quiet option is enabled and warning count exceeds threshold", async () => {
+            const filePath = getFixturePath("max-warnings");
+            const exitCode = await cli.execute(`--no-ignore --quiet --max-warnings 5 ${filePath}`);
+
+            assert.strictEqual(exitCode, 1);
+            assert.ok(log.error.calledOnce);
+            assert.include(log.error.getCall(0).args[0], "ESLint found too many warnings");
+            assert.ok(log.info.notCalled); // didn't print warnings
+        });
+
         it("should not change exit code if warning count equals threshold", async () => {
             const filePath = getFixturePath("max-warnings");
             const exitCode = await cli.execute(`--no-ignore --max-warnings 6 ${filePath}`);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

fixes #14202

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

ESLint will now return exit code 1 and show the "too many warnings" error message when the number of warnings exceeds `--max-warnings` even if the `--quiet` flag was used. ESLint will still not show the actual warnings in that case.


#### Is there anything you'd like reviewers to focus on?

Marked as "Update" since it can produce exit code 1 for runs that used to have exit code 0.