### PR TITLE
Chore: "yorkie" -> "simple-git-hooks"

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "webpack": "node Makefile.js webpack",
     "perf": "node Makefile.js perf"
   },
-  "gitHooks": {
-    "pre-commit": "lint-staged"
+  "simple-git-hooks": {
+    "pre-commit": "npx lint-staged"
   },
   "lint-staged": {
     "*.js": [
@@ -128,11 +128,11 @@
     "recast": "^0.19.0",
     "regenerator-runtime": "^0.13.2",
     "shelljs": "^0.8.2",
+    "simple-git-hooks": "^2.0.3",
     "sinon": "^9.0.1",
     "temp": "^0.9.0",
     "webpack": "^5.23.0",
-    "webpack-cli": "^4.5.0",
-    "yorkie": "^2.0.0"
+    "webpack-cli": "^4.5.0"
   },
   "keywords": [
     "ast",


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

Other, please explain: Infrastructure change.

#### What changes did you make? (Give an overview)

Migrated the Git hooks manager from [yorkie](https://github.com/yyx990803/yorkie) to [simple-git-hooks](https://github.com/toplenboren/simple-git-hooks).

`simple-git-hooks` is now used in some famous projects like PostCSS, Autoprefixer and so on. ([See this](https://github.com/toplenboren/simple-git-hooks#who-uses-simple-git-hooks))

Andrey Sitnik has stated about `simple-git-hooks` at his pull requests. ([source](https://github.com/sapegin/mrm/pull/149)) Note that `yorkie` is forked from `husky` v4, so we can treat `yorkie` as `husky` v4.

#### Is there anything you'd like reviewers to focus on?

I'm not sure.
