### PR TITLE
Chore: Upgrade eslint-plugin-jsdoc to v25 and remove --legacy-peer-deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,6 @@ jobs:
         node-version: ${{ matrix.node }}
     - name: Install Packages
       run: npm install
-      if: ${{ !startswith(matrix.node, '15') }}
-    - name: Install Packages
-      run: npm install --legacy-peer-deps
-      if: ${{ startswith(matrix.node, '15') }}
     - name: Test
       run: node Makefile mocha
     - name: Fuzz Test

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -32,6 +32,7 @@ const debug = require("debug")("eslint:cli");
 /** @typedef {import("./eslint/eslint").ESLintOptions} ESLintOptions */
 /** @typedef {import("./eslint/eslint").LintMessage} LintMessage */
 /** @typedef {import("./eslint/eslint").LintResult} LintResult */
+/** @typedef {import("./options").ParsedCLIOptions} ParsedCLIOptions */
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -54,7 +55,7 @@ function quietFixPredicate(message) {
 
 /**
  * Translates the CLI options into the options expected by the CLIEngine.
- * @param {Object} cliOptions The CLI options to translate.
+ * @param {ParsedCLIOptions} cliOptions The CLI options to translate.
  * @returns {ESLintOptions} The options object for the CLIEngine.
  * @private
  */
@@ -221,6 +222,8 @@ const cli = {
         if (Array.isArray(args)) {
             debug("CLI args: %o", args.slice(2));
         }
+
+        /** @type {ParsedCLIOptions} */
         let options;
 
         try {

--- a/lib/options.js
+++ b/lib/options.js
@@ -12,6 +12,52 @@
 const optionator = require("optionator");
 
 //------------------------------------------------------------------------------
+// Typedefs
+//------------------------------------------------------------------------------
+
+/**
+ * The options object parsed by Optionator.
+ * @typedef {Object} CLIOptions
+ * @property {boolean} cache Only check changed files
+ * @property {string} cacheFile Path to the cache file. Deprecated: use --cache-location
+ * @property {string} [cacheLocation] Path to the cache file or directory
+ * @property {"metadata" | "content"} cacheStrategy Strategy to use for detecting changed files in the cache
+ * @property {boolean} [color] Force enabling/disabling of color
+ * @property {string} [config] Use this configuration, overriding .eslintrc.* config options if present
+ * @property {boolean} debug Output debugging information
+ * @property {string[]} [env] Specify environments
+ * @property {boolean} envInfo Output execution environment information
+ * @property {boolean} errorOnUnmatchedPattern Prevent errors when pattern is unmatched
+ * @property {boolean} [eslintrc] Disable use of configuration from .eslintrc.*
+ * @property {string[]} [ext] Specify JavaScript file extensions
+ * @property {boolean} fix Automatically fix problems
+ * @property {boolean} fixDryRun Automatically fix problems without saving the changes to the file system
+ * @property {("problem" | "suggestion" | "layout")[]} fixType Specify the types of fixes to apply (problem, suggestion, layout)
+ * @property {string} format Use a specific output format
+ * @property {string[]} [global] Define global variables
+ * @property {boolean} [help] Show help
+ * @property {boolean} ignore Disable use of ignore files and patterns
+ * @property {string} [ignorePath] Specify path of ignore file
+ * @property {string[]} [ignorePattern] Pattern of files to ignore (in addition to those in .eslintignore)
+ * @property {boolean} init Run config initialization wizard
+ * @property {boolean} [inlineConfig] Prevent comments from changing config or rules
+ * @property {number} maxWarnings Number of warnings to trigger nonzero exit code
+ * @property {string} [outputFile] Specify file to write report to
+ * @property {string} [parser] Specify the parser to be used
+ * @property {Object} [parserOptions] Specify parser options
+ * @property {string[]} [plugin] Specify plugins
+ * @property {string} [printConfig] Print the configuration for the given file
+ * @property {boolean | undefined} reportUnusedDisableDirectives Adds reported errors for unused eslint-disable directives
+ * @property {string} [resolvePluginsRelativeTo] A folder where plugins should be resolved from, CWD by default
+ * @property {Object} [rule] Specify rules
+ * @property {string[]} [rulesdir] Use additional rules from this directory
+ * @property {boolean} stdin Lint code provided on <STDIN>
+ * @property {string} [stdinFilename] Specify filename to process STDIN as
+ * @property {boolean} [quiet] Report errors only
+ * @property {boolean} [version] Output the version number
+ */
+
+//------------------------------------------------------------------------------
 // Initialization and Public Interface
 //------------------------------------------------------------------------------
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -17,7 +17,7 @@ const optionator = require("optionator");
 
 /**
  * The options object parsed by Optionator.
- * @typedef {Object} CLIOptions
+ * @typedef {Object} ParsedCLIOptions
  * @property {boolean} cache Only check changed files
  * @property {string} cacheFile Path to the cache file. Deprecated: use --cache-location
  * @property {string} [cacheLocation] Path to the cache file or directory

--- a/lib/options.js
+++ b/lib/options.js
@@ -32,7 +32,7 @@ const optionator = require("optionator");
  * @property {string[]} [ext] Specify JavaScript file extensions
  * @property {boolean} fix Automatically fix problems
  * @property {boolean} fixDryRun Automatically fix problems without saving the changes to the file system
- * @property {("problem" | "suggestion" | "layout")[]} fixType Specify the types of fixes to apply (problem, suggestion, layout)
+ * @property {("problem" | "suggestion" | "layout")[]} [fixType] Specify the types of fixes to apply (problem, suggestion, layout)
  * @property {string} format Use a specific output format
  * @property {string[]} [global] Define global variables
  * @property {boolean} [help] Show help

--- a/lib/options.js
+++ b/lib/options.js
@@ -55,6 +55,7 @@ const optionator = require("optionator");
  * @property {string} [stdinFilename] Specify filename to process STDIN as
  * @property {boolean} quiet Report errors only
  * @property {boolean} [version] Output the version number
+ * @property {string[]} _ Positional filenames or patterns
  */
 
 //------------------------------------------------------------------------------

--- a/lib/options.js
+++ b/lib/options.js
@@ -28,7 +28,7 @@ const optionator = require("optionator");
  * @property {string[]} [env] Specify environments
  * @property {boolean} envInfo Output execution environment information
  * @property {boolean} errorOnUnmatchedPattern Prevent errors when pattern is unmatched
- * @property {boolean} [eslintrc] Disable use of configuration from .eslintrc.*
+ * @property {boolean} eslintrc Disable use of configuration from .eslintrc.*
  * @property {string[]} [ext] Specify JavaScript file extensions
  * @property {boolean} fix Automatically fix problems
  * @property {boolean} fixDryRun Automatically fix problems without saving the changes to the file system
@@ -40,7 +40,7 @@ const optionator = require("optionator");
  * @property {string} [ignorePath] Specify path of ignore file
  * @property {string[]} [ignorePattern] Pattern of files to ignore (in addition to those in .eslintignore)
  * @property {boolean} init Run config initialization wizard
- * @property {boolean} [inlineConfig] Prevent comments from changing config or rules
+ * @property {boolean} inlineConfig Prevent comments from changing config or rules
  * @property {number} maxWarnings Number of warnings to trigger nonzero exit code
  * @property {string} [outputFile] Specify file to write report to
  * @property {string} [parser] Specify the parser to be used
@@ -53,7 +53,7 @@ const optionator = require("optionator");
  * @property {string[]} [rulesdir] Use additional rules from this directory
  * @property {boolean} stdin Lint code provided on <STDIN>
  * @property {string} [stdinFilename] Specify filename to process STDIN as
- * @property {boolean} [quiet] Report errors only
+ * @property {boolean} quiet Report errors only
  * @property {boolean} [version] Output the version number
  */
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "eslint-config-eslint": "file:packages/eslint-config-eslint",
     "eslint-plugin-eslint-plugin": "^2.2.1",
     "eslint-plugin-internal-rules": "file:tools/internal-rules",
-    "eslint-plugin-jsdoc": "^22.1.0",
+    "eslint-plugin-jsdoc": "^25.4.3",
     "eslint-plugin-node": "^11.1.0",
     "eslint-release": "^2.0.0",
     "eslump": "^2.0.0",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Since #13844 added Node 15 and with it npm v7 to the build matrix, we've had to use `--legacy-peer-deps` when running `npm install` with npm v7. This upgrades the last incompatible dependency so we can just `npm install` in any supported Node/npm version.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Chore: Upgrade eslint-plugin-jsdoc to v25

  This is a Chore instead of an Upgrade because it's in `devDependencies`. v25 is the first release of `eslint-plugin-jsdoc` to bump the `eslint` peer dependency to allow `eslint@7`. Once it's upgraded, we won't have to use `--legacy-peer-deps` to install dependencies with npm v7. The newer version was unsatisfied with the `cliOptions` param to `translateOptions` typed as just `Object`, so I turned our Optionator config into a JSDoc typedef.

- Chore: npm v7 no longer needs --legacy-peer-deps (refs #13844)

  `eslint-plugin-jsdoc` was the last upgrade needed to be compatible with the new peer dependency resolution in npm v7.

#### Is there anything you'd like reviewers to focus on?

Thanks to https://github.com/npm/cli/issues/2896#issuecomment-804234482 for deciphering the error log and pointing out where the incompatibility was.