### PR TITLE
Fix: track variables, not names in require-atomic-updates (fixes #14208)

### DIFF
--- a/lib/rules/require-atomic-updates.js
+++ b/lib/rules/require-atomic-updates.js
@@ -13,6 +13,10 @@
  */
 function createReferenceMap(scope, outReferenceMap = new Map()) {
     for (const reference of scope.references) {
+        if (reference.resolved === null) {
+            continue;
+        }
+
         outReferenceMap.set(reference.identifier, reference);
     }
     for (const childScope of scope.childScopes) {

--- a/lib/rules/require-atomic-updates.js
+++ b/lib/rules/require-atomic-updates.js
@@ -86,42 +86,42 @@ class SegmentInfo {
      * @returns {void}
      */
     initialize(segment) {
-        const outdatedReadVariableNames = new Set();
-        const freshReadVariableNames = new Set();
+        const outdatedReadVariables = new Set();
+        const freshReadVariables = new Set();
 
         for (const prevSegment of segment.prevSegments) {
             const info = this.info.get(prevSegment);
 
             if (info) {
-                info.outdatedReadVariableNames.forEach(Set.prototype.add, outdatedReadVariableNames);
-                info.freshReadVariableNames.forEach(Set.prototype.add, freshReadVariableNames);
+                info.outdatedReadVariables.forEach(Set.prototype.add, outdatedReadVariables);
+                info.freshReadVariables.forEach(Set.prototype.add, freshReadVariables);
             }
         }
 
-        this.info.set(segment, { outdatedReadVariableNames, freshReadVariableNames });
+        this.info.set(segment, { outdatedReadVariables, freshReadVariables });
     }
 
     /**
      * Mark a given variable as read on given segments.
      * @param {PathSegment[]} segments The segments that it read the variable on.
-     * @param {string} variableName The variable name to be read.
+     * @param {Variable} variable The variable to be read.
      * @returns {void}
      */
-    markAsRead(segments, variableName) {
+    markAsRead(segments, variable) {
         for (const segment of segments) {
             const info = this.info.get(segment);
 
             if (info) {
-                info.freshReadVariableNames.add(variableName);
+                info.freshReadVariables.add(variable);
 
                 // If a variable is freshly read again, then it's no more out-dated.
-                info.outdatedReadVariableNames.delete(variableName);
+                info.outdatedReadVariables.delete(variable);
             }
         }
     }
 
     /**
-     * Move `freshReadVariableNames` to `outdatedReadVariableNames`.
+     * Move `freshReadVariables` to `outdatedReadVariables`.
      * @param {PathSegment[]} segments The segments to process.
      * @returns {void}
      */
@@ -130,8 +130,8 @@ class SegmentInfo {
             const info = this.info.get(segment);
 
             if (info) {
-                info.freshReadVariableNames.forEach(Set.prototype.add, info.outdatedReadVariableNames);
-                info.freshReadVariableNames.clear();
+                info.freshReadVariables.forEach(Set.prototype.add, info.outdatedReadVariables);
+                info.freshReadVariables.clear();
             }
         }
     }
@@ -139,14 +139,14 @@ class SegmentInfo {
     /**
      * Check if a given variable is outdated on the current segments.
      * @param {PathSegment[]} segments The current segments.
-     * @param {string} variableName The variable name to check.
+     * @param {Variable} variable The variable to check.
      * @returns {boolean} `true` if the variable is outdated on the segments.
      */
-    isOutdated(segments, variableName) {
+    isOutdated(segments, variable) {
         for (const segment of segments) {
             const info = this.info.get(segment);
 
-            if (info && info.outdatedReadVariableNames.has(variableName)) {
+            if (info && info.outdatedReadVariables.has(variable)) {
                 return true;
             }
         }
@@ -214,26 +214,22 @@ module.exports = {
                 if (!reference) {
                     return;
                 }
-                const name = reference.identifier.name;
                 const variable = reference.resolved;
                 const writeExpr = getWriteExpr(reference);
                 const isMemberAccess = reference.identifier.parent.type === "MemberExpression";
 
                 // Add a fresh read variable.
                 if (reference.isRead() && !(writeExpr && writeExpr.parent.operator === "=")) {
-                    segmentInfo.markAsRead(codePath.currentSegments, name);
+                    segmentInfo.markAsRead(codePath.currentSegments, variable);
                 }
-
-                const isVariableDeclaration = isLocalVariableWithoutEscape(variable, isMemberAccess) ||
-                    node.parent.type === "VariableDeclarator";
 
                 /*
                  * Register the variable to verify after ESLint traversed the `writeExpr` node
                  * if this reference is an assignment to a variable which is referred from other closure.
                  */
                 if (writeExpr &&
-                    writeExpr.parent.right === writeExpr &&
-                    !isVariableDeclaration
+                    writeExpr.parent.right === writeExpr && // ← exclude variable declarations.
+                    !isLocalVariableWithoutEscape(variable, isMemberAccess)
                 ) {
                     let refs = assignmentReferences.get(writeExpr);
 
@@ -248,7 +244,7 @@ module.exports = {
 
             /*
              * Verify assignments.
-             * If the reference exists in `outdatedReadVariableNames` list, report it.
+             * If the reference exists in `outdatedReadVariables` list, report it.
              */
             ":expression:exit"(node) {
                 const { codePath, referenceMap } = stack;
@@ -270,9 +266,9 @@ module.exports = {
                     assignmentReferences.delete(node);
 
                     for (const reference of references) {
-                        const name = reference.identifier.name;
+                        const variable = reference.resolved;
 
-                        if (segmentInfo.isOutdated(codePath.currentSegments, name)) {
+                        if (segmentInfo.isOutdated(codePath.currentSegments, variable)) {
                             context.report({
                                 node: node.parent,
                                 messageId: "nonAtomicUpdate",

--- a/lib/rules/require-atomic-updates.js
+++ b/lib/rules/require-atomic-updates.js
@@ -224,13 +224,16 @@ module.exports = {
                     segmentInfo.markAsRead(codePath.currentSegments, name);
                 }
 
+                const isVariableDeclaration = isLocalVariableWithoutEscape(variable, isMemberAccess) ||
+                    node.parent.type === "VariableDeclarator";
+
                 /*
                  * Register the variable to verify after ESLint traversed the `writeExpr` node
                  * if this reference is an assignment to a variable which is referred from other closure.
                  */
                 if (writeExpr &&
-                    writeExpr.parent.right === writeExpr && // ← exclude variable declarations.
-                    !isLocalVariableWithoutEscape(variable, isMemberAccess)
+                    writeExpr.parent.right === writeExpr &&
+                    !isVariableDeclaration
                 ) {
                     let refs = assignmentReferences.get(writeExpr);
 

--- a/tests/lib/rules/require-atomic-updates.js
+++ b/tests/lib/rules/require-atomic-updates.js
@@ -186,6 +186,21 @@ ruleTester.run("require-atomic-updates", rule, {
                 const prop = props.find(a => a.id === entry2.id) || null;
               }
             }
+        `,
+
+        `
+            async function run() {
+              {
+                let entry;
+                await entry;
+              }
+              {
+                let entry;
+                () => entry;
+
+                entry = 1;
+              }
+            }
         `
     ],
 

--- a/tests/lib/rules/require-atomic-updates.js
+++ b/tests/lib/rules/require-atomic-updates.js
@@ -162,6 +162,30 @@ ruleTester.run("require-atomic-updates", rule, {
                 count -= 1
                 return
             }
+        `,
+
+        // https://github.com/eslint/eslint/issues/14208
+        `
+            async function foo(e) {
+            }
+
+            async function run() {
+              const input = [];
+              const props = [];
+
+              for(const entry of input) {
+                const prop = props.find(a => a.id === entry.id) || null;
+                await foo(entry);
+              }
+
+              for(const entry of input) {
+                const prop = props.find(a => a.id === entry.id) || null;
+              }
+
+              for(const entry2 of input) {
+                const prop = props.find(a => a.id === entry2.id) || null;
+              }
+            }
         `
     ],
 

--- a/tests/lib/rules/require-atomic-updates.js
+++ b/tests/lib/rules/require-atomic-updates.js
@@ -53,6 +53,7 @@ ruleTester.run("require-atomic-updates", rule, {
         "let foo; async function x() { foo = condition ? foo : await bar; }",
         "async function x() { let foo; bar(() => { let foo; blah(foo); }); foo += await result; }",
         "let foo; async function x() { foo = foo + 1; await bar; }",
+        "async function x() { foo += await bar; }",
 
 
         /*
@@ -201,6 +202,13 @@ ruleTester.run("require-atomic-updates", rule, {
                 entry = 1;
               }
             }
+        `,
+
+        `
+            async function run() {
+                await a;
+                b = 1;
+            }
         `
     ],
 
@@ -290,7 +298,7 @@ ruleTester.run("require-atomic-updates", rule, {
             errors: [COMPUTED_PROPERTY_ERROR, STATIC_PROPERTY_ERROR]
         },
         {
-            code: "async function x() { foo += await bar; }",
+            code: "let foo = ''; async function x() { foo += await bar; }",
             errors: [VARIABLE_ERROR]
         },
         {


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

fixes #14208

Fixes false positives like:
```js
async function foo(e) {
}

async function run() {
  const input = [];
  const props = [];

  for(const entry of input) {
    const prop = props.find(a => a.id === entry.id) || null;
    await foo(entry);
  }

  // false positive:
  // Possible race condition: `const entry` might be reassigned based on an outdated value of `const entry`
  for(const entry of input) {
    const prop = props.find(a => a.id === entry.id) || null;
  }

  for(const entry2 of input) {
    const prop = props.find(a => a.id === entry2.id) || null;
  }
}
```

#### What changes did you make? (Give an overview)

I adapted the `if` condition surrounding the code block that is pushing/setting a reference to the `assignmentReferences` map. This map is subsequently used to get `references` and check for outdated identifier names.

I moved the `isLocalVariableWithoutEscape` in said `if` condition out to a separate variable and extended it with: 
```js
const isVariableDeclaration = isLocalVariableWithoutEscape(variable, isMemberAccess) ||
    node.parent.type === "VariableDeclarator";
```

Since the condition had a comment with  "exclude variable declarations", I removed it and expressed it with the `isVariableDeclaration` variable name.

#### Is there anything you'd like reviewers to focus on?

This is the first time contributing to ESLint (or open-source that is). Please focus on edge-cases or other implications since I do not have the complete context. I'm happy to hear about your concerns and improvement points.
