### PR TITLE
Fix: Throw error when rule is missing `meta.docs.suggestion` property

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -396,7 +396,8 @@ module.exports = {
             unnecessaryEscape: "Unnecessary escape character: \\{{character}}.",
             removeEscape: "Remove the `\\`. This maintains the current functionality.",
             escapeBackslash: "Replace the `\\` with `\\\\` to include the actual backslash character."
-        }
+        },
+        docs: { suggestion: true }
     },
     create: function(context) {
         // ...
@@ -437,7 +438,8 @@ module.exports = {
         messages: {
             unnecessaryEscape: "Unnecessary escape character: \\{{character}}.",
             removeEscape: "Remove `\\` before {{character}}.",
-        }
+        },
+        docs: { suggestion: true }
     },
     create: function(context) {
         // ...

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -922,6 +922,9 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
                         if (problem.fix && rule.meta && !rule.meta.fixable) {
                             throw new Error("Fixable rules should export a `meta.fixable` property.");
                         }
+                        if (problem.suggestions && !(rule.meta && rule.meta.docs && rule.meta.docs.suggestion === true)) {
+                            throw new Error("Rules with suggestions should set the `meta.docs.suggestion` property to `true`.");
+                        }
                         lintingProblems.push(problem);
                     }
                 }

--- a/tests/fixtures/testers/rule-tester/suggestions.js
+++ b/tests/fixtures/testers/rule-tester/suggestions.js
@@ -1,6 +1,7 @@
 "use strict";
 
 module.exports.basic = {
+    meta: { docs: { suggestion: true } },
     create(context) {
         return {
             Identifier(node) {
@@ -25,7 +26,8 @@ module.exports.withMessageIds = {
             avoidFoo: "Avoid using identifiers named '{{ name }}'.",
             unused: "An unused key",
             renameFoo: "Rename identifier 'foo' to '{{ newName }}'"
-        }
+        },
+        docs: { suggestion: true }
     },
     create(context) {
         return {
@@ -57,4 +59,16 @@ module.exports.withMessageIds = {
     }
 };
 
-
+module.exports.withoutSuggestionProperty = {
+    create(context) {
+        return {
+            Identifier(node) {
+                context.report({
+                    node,
+                    message: "some message",
+                    suggest: [{ desc: "some suggestion", fix: fixer => fixer.replaceText(node, 'bar') }]
+                });
+            }
+        };
+    }
+};

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1813,6 +1813,17 @@ describe("RuleTester", () => {
                 });
             }, /Invalid suggestion property name 'outpt'/u);
         });
+
+        it("should throw an error if a rule that doesn't have `meta.docs.suggestion` enabled produces suggestions", () => {
+            assert.throws(() => {
+                ruleTester.run("suggestions-missing-suggestion-property", require("../../fixtures/testers/rule-tester/suggestions").withoutSuggestionProperty, {
+                    valid: [],
+                    invalid: [
+                        { code: "var foo = bar;", output: "5", errors: 1 }
+                    ]
+                });
+            }, "Rules with suggestions should set the `meta.docs.suggestion` property to `true`.");
+        });
     });
 
     describe("naming test cases", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**Tell us about your environment**

* **ESLint Version:** 7.23
* **Node Version:** 14
* **npm Version:** 7.6

**What did you do? Please include the actual source code causing the issue.**

There is a `meta.docs.suggestion` property mentioned in the [documentation](https://eslint.org/docs/developer-guide/working-with-rules#rule-basics) and used in eslint's handleful of rules with suggestions.

> suggestion (boolean) specifies whether rules can return suggestions (defaults to false if omitted)

Unfortunately, the usage of this property is not enforced / validated, i.e. a rule providing a suggestion can easily forget to specify the `meta.docs.suggestion` property. As a result, there is no consequence for forgetting to enable the `meta.docs.suggestion` property, and this leads to inconsistency as well as this property being rather useless / unreliable.

**What did you expect to happen?**

eslint should throw an error when a rule provides a suggestion without enabling the `meta.docs.suggestion` property. This would match the behavior of the `meta.fixable` which must be specified when a rule provides autofixes. 

Having static properties like `meta.docs.suggestion` or `meta.fixable` make it easy for humans and tooling to tell whether rules provides autofixes or suggestions. For example, these properties can make it convenient to write tests that rules with autofixes/suggestions mention that they have autofixes/suggestions in their documentation.

**What actually happened? Please include the actual, raw output from ESLint.**

eslint did not throw an error.

#### What changes did you make? (Give an overview)

Updates eslint to throw an error when a rule provides a suggestion without enabling the `meta.docs.suggestion` property.

This is a breaking bug fix / change in that rules (and tests of rules) that provided suggestions without enabling the `meta.docs.suggestion` property will now fail.

#### Is there anything you'd like reviewers to focus on?

No.