### PR TITLE
feat: function-paren-newline accepts includeComments as option (fixes #12251)

### DIFF
--- a/lib/rules/function-paren-newline.js
+++ b/lib/rules/function-paren-newline.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const { isCommentToken } = require("./utils/ast-utils");
+
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
@@ -44,6 +46,15 @@ module.exports = {
                         additionalProperties: false
                     }
                 ]
+            },
+            {
+                type: "object",
+                properties: {
+                    includeComments: {
+                        type: "boolean"
+                    }
+                },
+                additionalProperties: false
             }
         ],
 
@@ -58,10 +69,12 @@ module.exports = {
 
     create(context) {
         const sourceCode = context.getSourceCode();
-        const rawOption = context.options[0] || "multiline";
+        const options = context.options;
+        const rawOption = options[0] || "multiline";
         const multilineOption = rawOption === "multiline";
         const multilineArgumentsOption = rawOption === "multiline-arguments";
         const consistentOption = rawOption === "consistent";
+        const includeComments = options[1] && !!options[1].includeComments;
         let minItems;
 
         if (typeof rawOption === "object") {
@@ -106,18 +119,25 @@ module.exports = {
         function validateParens(parens, elements) {
             const leftParen = parens.leftParen;
             const rightParen = parens.rightParen;
-            const tokenAfterLeftParen = sourceCode.getTokenAfter(leftParen);
-            const tokenBeforeRightParen = sourceCode.getTokenBefore(rightParen);
+            const tokenAfterLeftParen = sourceCode.getTokenAfter(leftParen, { includeComments });
+            const tokenBeforeRightParen = sourceCode.getTokenBefore(rightParen, { includeComments });
             const hasLeftNewline = !astUtils.isTokenOnSameLine(leftParen, tokenAfterLeftParen);
+
+            // --------------------------------
+
             const hasRightNewline = !astUtils.isTokenOnSameLine(tokenBeforeRightParen, rightParen);
+
             const needsNewlines = shouldHaveNewlines(elements, hasLeftNewline);
 
             if (hasLeftNewline && !needsNewlines) {
+                const hasCommentAfterLeftParen = includeComments ? isCommentToken(tokenAfterLeftParen)
+                    : sourceCode.getText().slice(leftParen.range[1], tokenAfterLeftParen.range[0]).trim();
+
                 context.report({
                     node: leftParen,
                     messageId: "unexpectedAfter",
                     fix(fixer) {
-                        return sourceCode.getText().slice(leftParen.range[1], tokenAfterLeftParen.range[0]).trim()
+                        return hasCommentAfterLeftParen
 
                             // If there is a comment between the ( and the first element, don't do a fix.
                             ? null
@@ -133,11 +153,15 @@ module.exports = {
             }
 
             if (hasRightNewline && !needsNewlines) {
+
+                const hasCommentBeforeRightParen = includeComments ? isCommentToken(tokenBeforeRightParen)
+                    : sourceCode.getText().slice(tokenBeforeRightParen.range[1], rightParen.range[0]).trim();
+
                 context.report({
                     node: rightParen,
                     messageId: "unexpectedBefore",
                     fix(fixer) {
-                        return sourceCode.getText().slice(tokenBeforeRightParen.range[1], rightParen.range[0]).trim()
+                        return hasCommentBeforeRightParen
 
                             // If there is a comment between the last element and the ), don't do a fix.
                             ? null

--- a/tests/lib/rules/function-paren-newline.js
+++ b/tests/lib/rules/function-paren-newline.js
@@ -583,6 +583,19 @@ ruleTester.run("function-paren-newline", rule, {
             code: "import(\n  source\n)",
             options: ["consistent"],
             parserOptions: { ecmaVersion: 2020 }
+        },
+        {
+            code: `
+              function foo({
+            bar,
+            baz
+        } /*: {
+            bar: string,
+            baz: string,
+        } */) {
+            return bar + baz;
+        }`,
+            options: ["never", { includeComments: true }]
         }
     ],
 
@@ -1437,6 +1450,30 @@ ruleTester.run("function-paren-newline", rule, {
             options: ["consistent"],
             parserOptions: { ecmaVersion: 2020 },
             errors: [RIGHT_MISSING_ERROR]
+        },
+        {
+            code: `function foo(
+              {
+                bar,
+                baz
+              } /*: {
+                bar: string,
+                baz: string,
+              } */) {
+                return bar + baz;
+              }`,
+            output: `function foo({
+                bar,
+                baz
+              } /*: {
+                bar: string,
+                baz: string,
+              } */) {
+                return bar + baz;
+              }`,
+            options: ["never", { includeComments: true }],
+            errors: [LEFT_UNEXPECTED_ERROR]
+
         }
     ]
 });


### PR DESCRIPTION


<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I added `includeComments` to the rule options. This option can be used with previous options like `['never', {includeComments: true}]` and fixes #12251.

I will update docs and add more tests if you agree with this option.

#### Is there anything you'd like reviewers to focus on?

No.
