### PR TITLE
Docs: Adds deprecated callouts to `working-with-rules-deprecated` page.

### DIFF
--- a/docs/developer-guide/working-with-rules-deprecated.md
+++ b/docs/developer-guide/working-with-rules-deprecated.md
@@ -1,4 +1,6 @@
-# Working with Rules
+# Working with Rules (Deprecated)
+
+**Note:** This page covers the deprecated rule format for ESLint <= 2.13.1. [This is the most recent rule format](./working-with-rules.md).
 
 Each rule in ESLint has two files named with its identifier (for example, `no-extra-semi`).
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Added a couple of callouts (title and note) to the `working-with-rules-deprecated` page to better indicate to readers that the information on the page is deprecated.

I wound up on the [working-with-rules-deprecated](https://github.com/eslint/eslint/blob/master/docs/developer-guide/working-with-rules-deprecated.md) page via a google search or something, but I didn't notice that the page name had `deprecated` in it. As I was reading, I was like, this doesn't seem right... Took me a good 15 minutes to realize I was reading the old version. I figured adding a note to the top, similar to the note at the top of the [working-with-rules](https://github.com/eslint/eslint/blob/master/docs/developer-guide/working-with-rules.md) page might be helpful in case anyone else winds up here like I did.

#### Is there anything you'd like reviewers to focus on?

Not particularly. 😊 