### PR TITLE
New: add `getPhysicalFilename()` method to rule context (fixes #11989)

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -139,6 +139,7 @@ Additionally, the `context` object has the following methods:
     * If the node is an `ImportSpecifier`, `ImportDefaultSpecifier`, or `ImportNamespaceSpecifier`, the declared variable is returned.
     * Otherwise, if the node does not declare any variables, an empty array is returned.
 * `getFilename()` - returns the filename associated with the source.
+* `getPhysicalFilename()` - returns the full path of the file on disk without any code block information.
 * `getScope()` - returns the [scope](./scope-manager-interface.md#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
 * `getSourceCode()` - returns a [`SourceCode`](#contextgetsourcecode) object that you can use to work with the source that was passed to ESLint.
 * `markVariableAsUsed(name)` - marks a variable with the given name in the current scope as used. This affects the [no-unused-vars](../rules/no-unused-vars.md) rule. Returns `true` if a variable with the given name was found and marked as used, otherwise `false`.

--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -139,7 +139,7 @@ Additionally, the `context` object has the following methods:
     * If the node is an `ImportSpecifier`, `ImportDefaultSpecifier`, or `ImportNamespaceSpecifier`, the declared variable is returned.
     * Otherwise, if the node does not declare any variables, an empty array is returned.
 * `getFilename()` - returns the filename associated with the source.
-* `getPhysicalFilename()` - returns the full path of the file on disk without any code block information.
+* `getPhysicalFilename()` - when linting a file, it returns the full path of the file on disk without any code block information. When linting text, it returns the value passed to `—stdin-filename` or `<text>` if not specified.
 * `getScope()` - returns the [scope](./scope-manager-interface.md#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
 * `getSourceCode()` - returns a [`SourceCode`](#contextgetsourcecode) object that you can use to work with the source that was passed to ESLint.
 * `markVariableAsUsed(name)` - marks a variable with the given name in the current scope as used. This affects the [no-unused-vars](../rules/no-unused-vars.md) rule. Returns `true` if a variable with the given name was found and marked as used, otherwise `false`.

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -828,9 +828,10 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
  * @param {string} filename The reported filename of the code
  * @param {boolean} disableFixes If true, it doesn't make `fix` properties.
  * @param {string | undefined} cwd cwd of the cli
+ * @param {string} physicalFilename The full path of the file on disk without any code block information
  * @returns {Problem[]} An array of reported problems
  */
-function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parserName, settings, filename, disableFixes, cwd) {
+function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parserName, settings, filename, disableFixes, cwd, physicalFilename) {
     const emitter = createEmitter();
     const nodeQueue = [];
     let currentNode = sourceCode.ast;
@@ -859,6 +860,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
                 getDeclaredVariables: sourceCode.scopeManager.getDeclaredVariables.bind(sourceCode.scopeManager),
                 getCwd: () => cwd,
                 getFilename: () => filename,
+                getPhysicalFilename: () => physicalFilename,
                 getScope: () => getScope(sourceCode.scopeManager, currentNode),
                 getSourceCode: () => sourceCode,
                 markVariableAsUsed: name => markVariableAsUsed(sourceCode.scopeManager, currentNode, parserOptions, name),
@@ -1181,7 +1183,8 @@ class Linter {
                 settings,
                 options.filename,
                 options.disableFixes,
-                slots.cwd
+                slots.cwd,
+                options.physicalFilename
             );
         } catch (err) {
             err.message += `\nOccurred while linting ${options.filename}`;
@@ -1283,6 +1286,7 @@ class Linter {
      */
     _verifyWithProcessor(textOrSourceCode, config, options, configForRecursive) {
         const filename = options.filename || "<input>";
+        const physicalFilename = filename;
         const filenameToExpose = normalizeFilename(filename);
         const text = ensureText(textOrSourceCode);
         const preprocess = options.preprocess || (rawText => [rawText]);
@@ -1324,7 +1328,7 @@ class Linter {
             return this._verifyWithoutProcessors(
                 blockText,
                 config,
-                { ...options, filename: blockName }
+                { ...options, filename: blockName, physicalFilename }
             );
         });
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -510,7 +510,6 @@ function normalizeVerifyOptions(providedOptions, config) {
 
     return {
         filename: normalizeFilename(providedOptions.filename || "<input>"),
-        physicalFilename: normalizeFilename(providedOptions.physicalFilename || "<input>"),
         allowInlineConfig: !ignoreInlineConfig,
         warnInlineConfig: disableInlineConfig && !ignoreInlineConfig
             ? `your config${configNameOfNoInlineConfig}`
@@ -861,7 +860,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
                 getDeclaredVariables: sourceCode.scopeManager.getDeclaredVariables.bind(sourceCode.scopeManager),
                 getCwd: () => cwd,
                 getFilename: () => filename,
-                getPhysicalFilename: () => physicalFilename,
+                getPhysicalFilename: () => physicalFilename || filename,
                 getScope: () => getScope(sourceCode.scopeManager, currentNode),
                 getSourceCode: () => sourceCode,
                 markVariableAsUsed: name => markVariableAsUsed(sourceCode.scopeManager, currentNode, parserOptions, name),
@@ -1185,7 +1184,7 @@ class Linter {
                 options.filename,
                 options.disableFixes,
                 slots.cwd,
-                options.physicalFilename
+                providedOptions.physicalFilename
             );
         } catch (err) {
             err.message += `\nOccurred while linting ${options.filename}`;

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -860,7 +860,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
                 getDeclaredVariables: sourceCode.scopeManager.getDeclaredVariables.bind(sourceCode.scopeManager),
                 getCwd: () => cwd,
                 getFilename: () => filename,
-                getPhysicalFilename: () => physicalFilename,
+                getPhysicalFilename: () => physicalFilename || filename,
                 getScope: () => getScope(sourceCode.scopeManager, currentNode),
                 getSourceCode: () => sourceCode,
                 markVariableAsUsed: name => markVariableAsUsed(sourceCode.scopeManager, currentNode, parserOptions, name),

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1286,8 +1286,8 @@ class Linter {
      */
     _verifyWithProcessor(textOrSourceCode, config, options, configForRecursive) {
         const filename = options.filename || "<input>";
-        const physicalFilename = filename;
         const filenameToExpose = normalizeFilename(filename);
+        const physicalFilename = options.physicalFilename || filenameToExpose;
         const text = ensureText(textOrSourceCode);
         const preprocess = options.preprocess || (rawText => [rawText]);
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -510,6 +510,7 @@ function normalizeVerifyOptions(providedOptions, config) {
 
     return {
         filename: normalizeFilename(providedOptions.filename || "<input>"),
+        physicalFilename: normalizeFilename(providedOptions.physicalFilename || "<input>"),
         allowInlineConfig: !ignoreInlineConfig,
         warnInlineConfig: disableInlineConfig && !ignoreInlineConfig
             ? `your config${configNameOfNoInlineConfig}`
@@ -860,7 +861,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
                 getDeclaredVariables: sourceCode.scopeManager.getDeclaredVariables.bind(sourceCode.scopeManager),
                 getCwd: () => cwd,
                 getFilename: () => filename,
-                getPhysicalFilename: () => physicalFilename || filename,
+                getPhysicalFilename: () => physicalFilename,
                 getScope: () => getScope(sourceCode.scopeManager, currentNode),
                 getSourceCode: () => sourceCode,
                 markVariableAsUsed: name => markVariableAsUsed(sourceCode.scopeManager, currentNode, parserOptions, name),
@@ -1320,7 +1321,7 @@ class Linter {
                 return this._verifyWithConfigArray(
                     blockText,
                     configForRecursive,
-                    { ...options, filename: blockName }
+                    { ...options, filename: blockName, physicalFilename }
                 );
             }
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -52,7 +52,6 @@ const ESLINT_ENV = "eslint-env";
 
 describe("Linter", () => {
     const filename = "filename.js";
-    const physicalFilename = "physical-filename.js";
 
     /** @type {InstanceType<import("../../../lib/linter/linter.js")["Linter"]>} */
     let linter;
@@ -1571,9 +1570,9 @@ describe("Linter", () => {
 
             config.rules[code] = 1;
 
-            const messages = linter.verify("0", config, { physicalFilename });
+            const messages = linter.verify("0", config, filename);
 
-            assert.strictEqual(messages[0].message, physicalFilename);
+            assert.strictEqual(messages[0].message, filename);
         });
 
         it("defaults filename to '<input>'", () => {
@@ -3433,18 +3432,7 @@ var a = "test2";
                 });
 
                 linter.defineRule("checker", physicalFilenameChecker);
-                linter.verify("foo;", { rules: { checker: "error" } }, { physicalFilename: "foo.js" });
-                assert(physicalFilenameChecker.calledOnce);
-            });
-
-            it("should allow physicalFilename to be passed as third argument", () => {
-                const physicalFilenameChecker = sinon.spy(context => {
-                    assert.strictEqual(context.getPhysicalFilename(), "foo.js");
-                    return {};
-                });
-
-                linter.defineRule("checker", physicalFilenameChecker);
-                linter.verify("foo;", { rules: { checker: "error" } }, { physicalFilename: "foo.js" });
+                linter.verify("foo;", { rules: { checker: "error" } }, { filename: "foo.js" });
                 assert(physicalFilenameChecker.calledOnce);
             });
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -3425,7 +3425,7 @@ var a = "test2";
         });
 
         describe("physicalFilenames", () => {
-            it("should be same as `filename` passed on options object, if no processors are usedt", () => {
+            it("should be same as `filename` passed on options object, if no processors are used", () => {
                 const physicalFilenameChecker = sinon.spy(context => {
                     assert.strictEqual(context.getPhysicalFilename(), "foo.js");
                     return {};

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -1571,7 +1571,7 @@ describe("Linter", () => {
 
             config.rules[code] = 1;
 
-            const messages = linter.verify("0", config, physicalFilename);
+            const messages = linter.verify("0", config, { physicalFilename });
 
             assert.strictEqual(messages[0].message, physicalFilename);
         });
@@ -3433,18 +3433,18 @@ var a = "test2";
                 });
 
                 linter.defineRule("checker", physicalFilenameChecker);
-                linter.verify("foo;", { rules: { checker: "error" } }, { filename: "foo.js" });
+                linter.verify("foo;", { rules: { checker: "error" } }, { physicalFilename: "foo.js" });
                 assert(physicalFilenameChecker.calledOnce);
             });
 
-            it("should allow filename to be passed as third argument", () => {
+            it("should allow physicalFilename to be passed as third argument", () => {
                 const physicalFilenameChecker = sinon.spy(context => {
                     assert.strictEqual(context.getPhysicalFilename(), "foo.js");
                     return {};
                 });
 
                 linter.defineRule("checker", physicalFilenameChecker);
-                linter.verify("foo;", { rules: { checker: "error" } }, { filename: "foo.js" });
+                linter.verify("foo;", { rules: { checker: "error" } }, { physicalFilename: "foo.js" });
                 assert(physicalFilenameChecker.calledOnce);
             });
 
@@ -3459,7 +3459,7 @@ var a = "test2";
                 assert(physicalFilenameChecker.calledOnce);
             });
 
-            it("should default filename to <input> when only two arguments are passed", () => {
+            it("should default physicalFilename to <input> when only two arguments are passed", () => {
                 const physicalFilenameChecker = sinon.spy(context => {
                     assert.strictEqual(context.getPhysicalFilename(), "<input>");
                     return {};

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -3425,7 +3425,7 @@ var a = "test2";
         });
 
         describe("physicalFilenames", () => {
-            it("should allow physicalFilename to be passed on options object", () => {
+            it("should be same as `filename` passed on options object, if no processors are usedt", () => {
                 const physicalFilenameChecker = sinon.spy(context => {
                     assert.strictEqual(context.getPhysicalFilename(), "foo.js");
                     return {};
@@ -4834,14 +4834,17 @@ var a = "test2";
 
     describe("processors", () => {
         let receivedFilenames = [];
+        let receivedPhysicalFilenames = [];
 
         beforeEach(() => {
             receivedFilenames = [];
+            receivedPhysicalFilenames = [];
 
             // A rule that always reports the AST with a message equal to the source text
             linter.defineRule("report-original-text", context => ({
                 Program(ast) {
                     receivedFilenames.push(context.getFilename());
+                    receivedPhysicalFilenames.push(context.getPhysicalFilename());
                     context.report({ node: ast, message: context.getSourceCode().text });
                 }
             }));
@@ -4896,10 +4899,16 @@ var a = "test2";
 
                 assert.strictEqual(problems.length, 3);
                 assert.deepStrictEqual(problems.map(problem => problem.message), ["foo", "bar", "baz"]);
+
+                // filename
                 assert.strictEqual(receivedFilenames.length, 3);
                 assert(/^filename\.js[/\\]0_block\.js/u.test(receivedFilenames[0]));
                 assert(/^filename\.js[/\\]1_block\.js/u.test(receivedFilenames[1]));
                 assert(/^filename\.js[/\\]2_block\.js/u.test(receivedFilenames[2]));
+
+                // physical filename
+                assert.strictEqual(receivedPhysicalFilenames.length, 3);
+                assert.strictEqual(receivedPhysicalFilenames.every(name => name === filename), true);
             });
 
             it("should receive text even if a SourceCode object was given.", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fix #11989 

add a new `getPhysicalFilename()` method to the rule context object. This method will return the full path of the file on disk without any code block information.

#### Is there anything you'd like reviewers to focus on?
No