### PR TITLE
Breaking: require `meta` for fixable rules (fixes #13349)

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -920,7 +920,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
                         const problem = reportTranslator(...args);
 
                         if (problem.fix && !(rule.meta && rule.meta.fixable)) {
-                            throw new Error("Fixable rules should export a `meta.fixable` property.");
+                            throw new Error("Fixable rules must set the `meta.fixable` property to \"code\" or \"whitespace\".");
                         }
                         lintingProblems.push(problem);
                     }

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -919,7 +919,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
                         }
                         const problem = reportTranslator(...args);
 
-                        if (problem.fix && rule.meta && !rule.meta.fixable) {
+                        if (problem.fix && !(rule.meta && rule.meta.fixable)) {
                             throw new Error("Fixable rules should export a `meta.fixable` property.");
                         }
                         lintingProblems.push(problem);

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -865,16 +865,6 @@ class RuleTester {
                 );
             }
 
-            // Rules that produce fixes must have `meta.fixable` property.
-            if (result.output !== item.code) {
-                assert.ok(
-                    hasOwnProperty(rule, "meta"),
-                    "Fixable rules should export a `meta.fixable` property."
-                );
-
-                // Linter throws if a rule that produced a fix has `meta` but doesn't have `meta.fixable`.
-            }
-
             assertASTDidntChange(result.beforeAST, result.afterAST);
         }
 

--- a/tests/fixtures/rules/make-syntax-error-rule.js
+++ b/tests/fixtures/rules/make-syntax-error-rule.js
@@ -1,14 +1,19 @@
-module.exports = function(context) {
-    return {
-        Program: function(node) {
-            context.report({
-                node: node,
-                message: "ERROR",
-                fix: function(fixer) {
-                    return fixer.insertTextAfter(node, "this is a syntax error.");
-                }
-            });
-        }
-    };
+module.exports = {
+    meta: {
+        schema: [],
+        fixable: "code"
+    },
+    create(context) {
+        return {
+            Program: function(node) {
+                context.report({
+                    node: node,
+                    message: "ERROR",
+                    fix: function(fixer) {
+                        return fixer.insertTextAfter(node, "this is a syntax error.");
+                    }
+                });
+            }
+        };
+    }
 };
-module.exports.schema = [];

--- a/tests/fixtures/testers/rule-tester/fixes-one-problem.js
+++ b/tests/fixtures/testers/rule-tester/fixes-one-problem.js
@@ -5,19 +5,24 @@
 
 "use strict";
 
-module.exports = context => {
-    return {
-        Program(node) {
-            context.report({
-                node,
-                message: "No programs allowed."
-            });
+module.exports = {
+    meta: {
+        fixable: "code"
+    },
+    create(context) {
+        return {
+            Program(node) {
+                context.report({
+                    node,
+                    message: "No programs allowed."
+                });
 
-            context.report({
-                node,
-                message: "Seriously, no programs allowed.",
-                fix: fixer => fixer.remove(node)
-            });
+                context.report({
+                    node,
+                    message: "Seriously, no programs allowed.",
+                    fix: fixer => fixer.remove(node)
+                });
+            }
         }
     }
 };

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -4934,17 +4934,24 @@ var a = "test2";
             it("should use postprocessed problem ranges when applying autofixes", () => {
                 const code = "foo bar baz";
 
-                linter.defineRule("capitalize-identifiers", context => ({
-                    Identifier(node) {
-                        if (node.name !== node.name.toUpperCase()) {
-                            context.report({
-                                node,
-                                message: "Capitalize this identifier",
-                                fix: fixer => fixer.replaceText(node, node.name.toUpperCase())
-                            });
-                        }
+                linter.defineRule("capitalize-identifiers", {
+                    meta: {
+                        fixable: "code"
+                    },
+                    create(context) {
+                        return {
+                            Identifier(node) {
+                                if (node.name !== node.name.toUpperCase()) {
+                                    context.report({
+                                        node,
+                                        message: "Capitalize this identifier",
+                                        fix: fixer => fixer.replaceText(node, node.name.toUpperCase())
+                                    });
+                                }
+                            }
+                        };
                     }
-                }));
+                });
 
                 const fixResult = linter.verifyAndFix(
                     code,
@@ -5033,15 +5040,23 @@ var a = "test2";
         });
 
         it("stops fixing after 10 passes", () => {
-            linter.defineRule("add-spaces", context => ({
-                Program(node) {
-                    context.report({
-                        node,
-                        message: "Add a space before this node.",
-                        fix: fixer => fixer.insertTextBefore(node, " ")
-                    });
+
+            linter.defineRule("add-spaces", {
+                meta: {
+                    fixable: "whitespace"
+                },
+                create(context) {
+                    return {
+                        Program(node) {
+                            context.report({
+                                node,
+                                message: "Add a space before this node.",
+                                fix: fixer => fixer.insertTextBefore(node, " ")
+                            });
+                        }
+                    };
                 }
-            }));
+            });
 
             const fixResult = linter.verifyAndFix("a", { rules: { "add-spaces": "error" } });
 
@@ -5068,7 +5083,7 @@ var a = "test2";
             }, /Fixable rules should export a `meta\.fixable` property.\nOccurred while linting <input>:1$/u);
         });
 
-        it("should not throw an error if fix is passed and there is no metadata", () => {
+        it("should throw an error if fix is passed and there is no metadata", () => {
             linter.defineRule("test-rule", {
                 create: context => ({
                     Program(node) {
@@ -5077,7 +5092,21 @@ var a = "test2";
                 })
             });
 
-            linter.verify("0", { rules: { "test-rule": "error" } });
+            assert.throws(() => {
+                linter.verify("0", { rules: { "test-rule": "error" } });
+            }, /Fixable rules should export a `meta\.fixable` property./u);
+        });
+
+        it("should throw an error if fix is passed from a legacy-format rule", () => {
+            linter.defineRule("test-rule", context => ({
+                Program(node) {
+                    context.report(node, "hello world", {}, () => ({ range: [1, 1], text: "" }));
+                }
+            }));
+
+            assert.throws(() => {
+                linter.verify("0", { rules: { "test-rule": "error" } });
+            }, /Fixable rules should export a `meta\.fixable` property./u);
         });
     });
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -5080,7 +5080,7 @@ var a = "test2";
 
             assert.throws(() => {
                 linter.verify("0", { rules: { "test-rule": "error" } });
-            }, /Fixable rules should export a `meta\.fixable` property.\nOccurred while linting <input>:1$/u);
+            }, /Fixable rules must set the `meta\.fixable` property to "code" or "whitespace".\nOccurred while linting <input>:1$/u);
         });
 
         it("should throw an error if fix is passed and there is no metadata", () => {
@@ -5094,7 +5094,7 @@ var a = "test2";
 
             assert.throws(() => {
                 linter.verify("0", { rules: { "test-rule": "error" } });
-            }, /Fixable rules should export a `meta\.fixable` property./u);
+            }, /Fixable rules must set the `meta\.fixable` property/u);
         });
 
         it("should throw an error if fix is passed from a legacy-format rule", () => {
@@ -5106,7 +5106,7 @@ var a = "test2";
 
             assert.throws(() => {
                 linter.verify("0", { rules: { "test-rule": "error" } });
-            }, /Fixable rules should export a `meta\.fixable` property./u);
+            }, /Fixable rules must set the `meta\.fixable` property/u);
         });
     });
 

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1289,7 +1289,7 @@ describe("RuleTester", () => {
                     { code: "var foo = bar;", output: "5", errors: 1 }
                 ]
             });
-        }, "Fixable rules should export a `meta.fixable` property.");
+        }, /Fixable rules must set the `meta\.fixable` property/u);
     });
     it("should throw an error if a legacy-format rule produces fixes", () => {
 
@@ -1313,7 +1313,7 @@ describe("RuleTester", () => {
                     { code: "var foo = bar;", output: "5", errors: 1 }
                 ]
             });
-        }, "Fixable rules should export a `meta.fixable` property.");
+        }, /Fixable rules must set the `meta\.fixable` property/u);
     });
 
     describe("suggestions", () => {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1923,17 +1923,24 @@ describe("RuleTester", () => {
         assert.throw(() => {
             ruleTester.run(
                 "foo",
-                context => ({
-                    Identifier(node) {
-                        context.report({
-                            node,
-                            message: "make a syntax error",
-                            fix(fixer) {
-                                return fixer.replaceText(node, "one two");
+                {
+                    meta: {
+                        fixable: "code"
+                    },
+                    create(context) {
+                        return {
+                            Identifier(node) {
+                                context.report({
+                                    node,
+                                    message: "make a syntax error",
+                                    fix(fixer) {
+                                        return fixer.replaceText(node, "one two");
+                                    }
+                                });
                             }
-                        });
+                        };
                     }
-                }),
+                },
                 {
                     valid: ["one()"],
                     invalid: []


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

fixes #13349 (implements the final step 3)

ESLint v7 requires that a rule that produces fixes must provide `meta.fixable` property, but only if the rule provides `meta`. In other words, rules that don't provide `meta` were allowed to produce fixes.

After this change (ESLint v8.0.0), ESLint will require that a rule that produces fixes must provide `meta` and `meta.fixable`. Otherwise, an error will be thrown in runtime.

This applies to [legacy-format](https://eslint.org/docs/developer-guide/working-with-rules-deprecated) rules, too. Basically, all fixable rules must be converted to the new format.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Changed the check in `Linter`.
* Removed the check from `RuleTester` (added in https://github.com/eslint/eslint/pull/13489 as step 2) because it's no longer necessary.
* Updated the related test case, and added one with a legacy-format rule.
* Updated some unrelated test rules that didn't provide `meta`.


#### Is there anything you'd like reviewers to focus on?

Is there anything that should be updated in the documentation? I think that wording from https://github.com/eslint/eslint/pull/13493 already covers this.
