### PR TITLE
Update: support `:has()` selector (fixes #14076)

### DIFF
--- a/docs/developer-guide/selectors.md
+++ b/docs/developer-guide/selectors.md
@@ -43,6 +43,7 @@ The following selectors are supported:
 * following sibling: `VariableDeclaration ~ VariableDeclaration`
 * adjacent sibling: `ArrayExpression > Literal + SpreadElement`
 * negation: `:not(ForStatement)`
+* has: `:has(ForStatement)`
 * matches-any: `:matches([attr] > :first-child, :last-child)`
 * class of AST node: `:statement`, `:expression`, `:declaration`, `:function`, or `:pattern`
 

--- a/docs/developer-guide/selectors.md
+++ b/docs/developer-guide/selectors.md
@@ -89,6 +89,8 @@ If two or more selectors match the same node, their listeners will be called in 
 
 If multiple selectors have equal specificity, their listeners will be called in alphabetical order for that node.
 
+Using `:has()` traverses subtrees, so a rule written in a way that uses ESLint's traversal instead of `:has()` may have a much better performance.
+
 ### Restricting syntax with selectors
 
 With the [no-restricted-syntax](/docs/rules/no-restricted-syntax.md) rule, you can restrict the usage of particular syntax in your code. For example, you can use the following configuration to disallow using `if` statements that do not have block statements as their body:

--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -121,6 +121,7 @@ function countClassAttributes(parsedSelector) {
 
         case "compound":
         case "not":
+        case "has":
         case "matches":
             return parsedSelector.selectors.reduce((sum, childSelector) => sum + countClassAttributes(childSelector), 0);
 
@@ -150,6 +151,7 @@ function countIdentifiers(parsedSelector) {
 
         case "compound":
         case "not":
+        case "has":
         case "matches":
             return parsedSelector.selectors.reduce((sum, childSelector) => sum + countIdentifiers(childSelector), 0);
 

--- a/tests/lib/linter/node-event-generator.js
+++ b/tests/lib/linter/node-event-generator.js
@@ -188,6 +188,24 @@ describe("NodeEventGenerator", () => {
         );
 
         assertEmissions(
+            "foo",
+            ["*:has(ExpressionStatement)"],
+            ast => [
+                ["*:has(ExpressionStatement)", ast], // Program
+                ["*:has(ExpressionStatement)", ast.body[0]] // ExpressionStatement
+            ]
+        );
+
+        assertEmissions(
+            "foo++",
+            ["*:not(*:has(ExpressionStatement))"],
+            ast => [
+                ["*:not(*:has(ExpressionStatement))", ast.body[0].expression], // UpdateExpression
+                ["*:not(*:has(ExpressionStatement))", ast.body[0].expression.argument] // Identifier
+            ]
+        );
+
+        assertEmissions(
             "foo()",
             ["CallExpression[callee.name='foo']"],
             ast => [["CallExpression[callee.name='foo']", ast.body[0].expression]] // foo()

--- a/tests/lib/rules/no-restricted-syntax.js
+++ b/tests/lib/rules/no-restricted-syntax.js
@@ -29,6 +29,7 @@ ruleTester.run("no-restricted-syntax", rule, {
         { code: "({ foo: 1, bar: 2 })", options: ["Property > Literal.key"] },
         { code: "A: for (;;) break;", options: ["BreakStatement[label]"] },
         { code: "function foo(bar, baz) {}", options: ["FunctionDeclaration[params.length>2]"] },
+        { code: "var foo = 42;", options: [":has(AssignmentExpression)"] },
 
         //  object format
         { code: "var foo = 42;", options: [{ selector: "ConditionalExpression" }] },
@@ -114,6 +115,15 @@ ruleTester.run("no-restricted-syntax", rule, {
             code: "function foo(bar, baz, qux) {}",
             options: [{ selector: "FunctionDeclaration[params.length>2]", message: "custom error message." }],
             errors: [{ messageId: "restrictedSyntax", data: { message: "custom error message." }, type: "FunctionDeclaration" }]
+        },
+        {
+            code: "foo += 100;",
+            options: [{ selector: ":has(AssignmentExpression)" }],
+            errors: [
+                { messageId: "restrictedSyntax", data: { message: "Using ':has(AssignmentExpression)' is not allowed." }, type: "Program" },
+                { messageId: "restrictedSyntax", data: { message: "Using ':has(AssignmentExpression)' is not allowed." }, type: "ExpressionStatement" },
+                { messageId: "restrictedSyntax", data: { message: "Using ':has(AssignmentExpression)' is not allowed." }, type: "AssignmentExpression" }
+            ]
         },
 
         // with object format, the custom message may contain the string '{{selector}}'


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[X] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixes https://github.com/eslint/eslint/issues/14076
Add support for `:has()` selector.

#### Is there anything you'd like reviewers to focus on?
No