### PR TITLE
Fix: ecmaVersion defaults to 5 and allows "latest" in RuleTester

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -48,7 +48,8 @@ const
     equal = require("fast-deep-equal"),
     Traverser = require("../../lib/shared/traverser"),
     { getRuleOptionsSchema, validate } = require("../shared/config-validator"),
-    { Linter, SourceCodeFixer, interpolate } = require("../linter");
+    { Linter, SourceCodeFixer, interpolate } = require("../linter"),
+    espree = require("espree");
 
 const ajv = require("../shared/ajv")({ strictDefaults: true });
 
@@ -527,6 +528,46 @@ class RuleTester {
             }
 
             linter.defineParser(config.parser, wrapParser(require(config.parser)));
+
+            /*
+             * RuleTester always wraps parser, so Linter can't know whether or not it's espree.
+             * Therefore, RuleTester has to duplicate Linter's espree-specific normalizations.
+             */
+            if (
+                config.parser === espreePath &&
+                (
+                    typeof config.parserOptions === "undefined" ||
+                    typeof config.parserOptions === "object" && config.parserOptions !== null
+                )
+            ) {
+                const ecmaVersion = config.parserOptions && config.parserOptions.ecmaVersion;
+
+                if (
+                    typeof ecmaVersion === "undefined" &&
+                    !(
+
+                        // skip if an environment sets ecmaVersion, because parserOptions.ecmaVersion has precedence
+                        typeof config.env === "object" && config.env !== null &&
+                        Object.keys(config.env).some(
+                            envName => config.env[envName] && /^es\d+/u.test(envName)
+                        )
+                    )
+                ) {
+                    config = merge(config, {
+                        parserOptions: {
+                            ecmaVersion: 5
+                        }
+                    });
+                }
+
+                if (ecmaVersion === "latest") {
+                    config = merge(config, {
+                        parserOptions: {
+                            ecmaVersion: espree.latestEcmaVersion
+                        }
+                    });
+                }
+            }
 
             if (schema) {
                 ajv.validateSchema(schema);

--- a/tests/fixtures/parsers/empty-program-parser.js
+++ b/tests/fixtures/parsers/empty-program-parser.js
@@ -1,0 +1,25 @@
+exports.parse = function(text, parserOptions) {
+    return {
+        "type": "Program",
+        "start": 0,
+        "end": 0,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 0
+          }
+        },
+        "range": [
+          0,
+          0
+        ],
+        "body": [],
+        "sourceType": "script",
+        "comments": [],
+        "tokens": []
+      };
+};

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -11,7 +11,8 @@ const sinon = require("sinon"),
     EventEmitter = require("events"),
     { RuleTester } = require("../../../lib/rule-tester"),
     assert = require("chai").assert,
-    nodeAssert = require("assert");
+    nodeAssert = require("assert"),
+    espree = require("espree");
 
 const NODE_ASSERT_STRICT_EQUAL_OPERATOR = (() => {
     try {
@@ -780,6 +781,204 @@ describe("RuleTester", () => {
             ]
         });
         assert.strictEqual(spy.args[1][1].parser, require.resolve("esprima"));
+    });
+
+    it("should pass normalized ecmaVersion to the rule", () => {
+        const reportEcmaVersionRule = {
+            meta: {
+                messages: {
+                    ecmaVersionMessage: "context.parserOptions.ecmaVersion is {{type}} {{ecmaVersion}}."
+                }
+            },
+            create: context => ({
+                Program(node) {
+                    const { ecmaVersion } = context.parserOptions;
+
+                    context.report({
+                        node,
+                        messageId: "ecmaVersionMessage",
+                        data: { type: typeof ecmaVersion, ecmaVersion }
+                    });
+                }
+            })
+        };
+
+        const notEspree = require.resolve("../../fixtures/parsers/empty-program-parser");
+
+        ruleTester.run("report-ecma-version", reportEcmaVersionRule, {
+            valid: [],
+            invalid: [
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "5" } }]
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "5" } }],
+                    parserOptions: {}
+                },
+                {
+                    code: "<div/>",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "5" } }],
+                    parserOptions: { ecmaFeatures: { jsx: true } }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "5" } }],
+                    parser: require.resolve("espree")
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "6" } }],
+                    parserOptions: { ecmaVersion: 6 }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "6" } }],
+                    parserOptions: { ecmaVersion: 2015 }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "5" } }],
+                    env: { browser: true }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "5" } }],
+                    env: { es6: false }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "6" } }],
+                    env: { es6: true }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "8" } }],
+                    env: { es6: false, es2017: true }
+                },
+                {
+                    code: "let x",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "6" } }],
+                    env: { es6: "truthy" }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "8" } }],
+                    env: { es2017: true }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "11" } }],
+                    env: { es2020: true }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "12" } }],
+                    env: { es2021: true }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: String(espree.latestEcmaVersion) } }],
+                    parserOptions: { ecmaVersion: "latest" }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: String(espree.latestEcmaVersion) } }],
+                    parser: require.resolve("espree"),
+                    parserOptions: { ecmaVersion: "latest" }
+                },
+                {
+                    code: "<div/>",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: String(espree.latestEcmaVersion) } }],
+                    parserOptions: { ecmaVersion: "latest", ecmaFeatures: { jsx: true } }
+                },
+                {
+                    code: "import 'foo'",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: String(espree.latestEcmaVersion) } }],
+                    parserOptions: { ecmaVersion: "latest", sourceType: "module" }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: String(espree.latestEcmaVersion) } }],
+                    parserOptions: { ecmaVersion: "latest" },
+                    env: { es6: true }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: String(espree.latestEcmaVersion) } }],
+                    parserOptions: { ecmaVersion: "latest" },
+                    env: { es2020: true }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "undefined", ecmaVersion: "undefined" } }],
+                    parser: notEspree
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "undefined", ecmaVersion: "undefined" } }],
+                    parser: notEspree,
+                    parserOptions: {}
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "5" } }],
+                    parser: notEspree,
+                    parserOptions: { ecmaVersion: 5 }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "6" } }],
+                    parser: notEspree,
+                    parserOptions: { ecmaVersion: 6 }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "6" } }],
+                    parser: notEspree,
+                    parserOptions: { ecmaVersion: 2015 }
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "string", ecmaVersion: "latest" } }],
+                    parser: notEspree,
+                    parserOptions: { ecmaVersion: "latest" }
+                }
+            ]
+        });
+
+        [{ parserOptions: { ecmaVersion: 6 } }, { env: { es6: true } }].forEach(options => {
+            new RuleTester(options).run("report-ecma-version", reportEcmaVersionRule, {
+                valid: [],
+                invalid: [
+                    {
+                        code: "",
+                        errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "6" } }]
+                    },
+                    {
+                        code: "",
+                        errors: [{ messageId: "ecmaVersionMessage", data: { type: "number", ecmaVersion: "6" } }],
+                        parserOptions: {}
+                    }
+                ]
+            });
+        });
+
+        new RuleTester({ parser: notEspree }).run("report-ecma-version", reportEcmaVersionRule, {
+            valid: [],
+            invalid: [
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "undefined", ecmaVersion: "undefined" } }]
+                },
+                {
+                    code: "",
+                    errors: [{ messageId: "ecmaVersionMessage", data: { type: "string", ecmaVersion: "latest" } }],
+                    parserOptions: { ecmaVersion: "latest" }
+                }
+            ]
+        });
     });
 
     it("should pass-through services from parseForESLint to the rule", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

I noticed that this test is failing in https://github.com/eslint/eslint/pull/14653:

https://github.com/eslint/eslint/blob/353ddf965078030794419b089994373e27ffc86e/tests/lib/rule-tester/rule-tester.js#L632-L641

The test is unrelated to the PR. It's failing because:

* Test expects a parsing error on ES6 code (template string) when ecmaVersion isn't specified.
* PR uses Espree v8.
* Espree v8 has new default for ecmaVersion (latest, currently 13)
* RuleTester always wraps parsers to add some checks directly on AST.
* Linter gets a parser that isn't Espree (it's wrapped Espree) so it doesn't set `ecmaVersion: 5`
* The ES6 code doesn't produce a parsing error, because it's parsed with the latest ecmaVersion (new Espree's default).

This reveals some problems:

* RuleTester doesn't support `ecmaVersion: "latest"`
* If ecmaVersion isn't specified, rules that use `context.parserOptions` will get `ecmaVersion: 5` in runtime, but `ecmaVersion: undefined` when run through RuleTester.
* With Espree v8, all tests that don't have ecmaVersion specified will be parsed with the latest ecmaVersion.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated RuleTester to perform normalizations from https://github.com/eslint/eslint/pull/14622

#### Is there anything you'd like reviewers to focus on?

* Is this a good solution? An alternative is to add some identification key to the wrapper object and read that key in Linter.
* This doesn't work well with tests that have `/*eslint-env*/` comments in the code because `parserOptions` in configurations have precedence over `parserOptions` in environments. For example, a test with `code: "/*eslint-env es6*/ let x;"` will produce a parsing error after this change.
* Should we consider reverting https://github.com/eslint/eslint/pull/14622? 
