### PR TITLE
Chore: don't check Program.start in SourceCode#getComments (refs #14744)

### DIFF
--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -349,7 +349,7 @@ class SourceCode extends TokenStore {
             let currentToken = this.getTokenBefore(node, { includeComments: true });
 
             while (currentToken && isCommentToken(currentToken)) {
-                if (node.parent && (currentToken.start < node.parent.start)) {
+                if (node.parent && node.parent.type !== "Program" && (currentToken.start < node.parent.start)) {
                     break;
                 }
                 comments.leading.push(currentToken);
@@ -361,7 +361,7 @@ class SourceCode extends TokenStore {
             currentToken = this.getTokenAfter(node, { includeComments: true });
 
             while (currentToken && isCommentToken(currentToken)) {
-                if (node.parent && (currentToken.end > node.parent.end)) {
+                if (node.parent && node.parent.type !== "Program" && (currentToken.end > node.parent.end)) {
                     break;
                 }
                 comments.trailing.push(currentToken);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

refs #14744

Refactors `SourceCode#getComments()` to retain the intended behavior when used with Espree 8 which sets `Program.start` and `Program.end` differently than Espree 7.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Skip comparing comment's start/end with `Program` node's start/end, and thus don't break the loop that should get all comments around a top-level statement.

`Program.start` used to be `0` in Espree 7, so the condition was always `false`. Similar for `Program.end`, which used to be the last index.

I tried this with Espree 8.0.0-beta.1, all tests are passing except those for naming convention rules that will be fixed in https://github.com/eslint/eslint/pull/14591.

#### Is there anything you'd like reviewers to focus on?


