### PR TITLE
New: Add airbnb-typescript to init

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -25,6 +25,7 @@ const util = require("util"),
     autoconfig = require("./autoconfig.js"),
     ConfigFile = require("./config-file"),
     npmUtils = require("./npm-utils"),
+    tsUtils = require("./ts-utils"),
     { getSourceCodeOfFiles } = require("./source-code-utils");
 
 const debug = require("debug")("eslint:config-initializer");
@@ -33,16 +34,12 @@ const debug = require("debug")("eslint:config-initializer");
 // Private
 //------------------------------------------------------------------------------
 
-/* istanbul ignore next: hard to test fs function */
 /**
  * Create .eslintrc file in the current working directory
- * @param {Object} config object that contains user's answers
  * @param {string} format The file format to write to.
- * @returns {void}
+ * @returns {string} extname based on format
  */
-function writeFile(config, format) {
-
-    // default is .js
+function getExtName(format) {
     let extname = ".js";
 
     if (format === "YAML") {
@@ -60,6 +57,19 @@ function writeFile(config, format) {
             }
         }
     }
+
+    return extname;
+}
+
+/* istanbul ignore next: hard to test fs function */
+/**
+ * Create .eslintrc file in the current working directory
+ * @param {Object} config object that contains user's answers
+ * @param {string} format The file format to write to.
+ * @returns {void}
+ */
+function writeFile(config, format) {
+    const extname = getExtName(format);
 
     const installedESLint = config.installedESLint;
 
@@ -120,7 +130,9 @@ function getModulesList(config, installESLint) {
             if (extend.startsWith("eslint:") || extend.startsWith("plugin:")) {
                 continue;
             }
-            const moduleName = naming.normalizePackageName(extend, "eslint-config");
+
+            const normalizedExtend = extend.includes("/") ? extend.split("/")[0] : extend;
+            const moduleName = naming.normalizePackageName(normalizedExtend, "eslint-config");
 
             modules[moduleName] = "latest";
             Object.assign(
@@ -314,6 +326,12 @@ function processAnswers(answers) {
         } else {
             config.plugins = ["@typescript-eslint"];
         }
+
+        config.parserOptions.project = tsUtils.findTsConfig();
+
+        const eslintFileName = `.eslintrc${getExtName(answers.format)}`;
+
+        config.ignorePatterns = Array.isArray(config.ignorePatterns) ? [...config.ignorePatterns, eslintFileName] : [eslintFileName];
     }
 
     // setup rules based on problems/style enforcement preferences
@@ -367,6 +385,9 @@ function getLocalESLintVersion() {
  * @returns {string} The shareable config name.
  */
 function getStyleGuideName(answers) {
+    if (answers.styleguide === "airbnb" && answers.typescript) {
+        return "airbnb-typescript";
+    }
     if (answers.styleguide === "airbnb" && answers.framework !== "react") {
         return "airbnb-base";
     }
@@ -612,10 +633,20 @@ function promptUser() {
                 log.info("A package.json is necessary to install plugins such as style guides. Run `npm init` to create a package.json file and try again.");
                 return void 0;
             }
+            if (!tsUtils.checkTsConfig()) {
+                log.info("A tsconfig.json is necessary in order to use eslint along with typescript. Run `tsc --init` to create a tsconfig.json file and try again.");
+                return void 0;
+            }
             if (earlyAnswers.installESLint === false && !semver.satisfies(earlyAnswers.localESLintVersion, earlyAnswers.requiredESLintVersionRange)) {
                 log.info(`Note: it might not work since ESLint's version is mismatched with the ${earlyAnswers.styleguide} config.`);
             }
-            if (earlyAnswers.styleguide === "airbnb" && earlyAnswers.framework !== "react") {
+            if (earlyAnswers.styleguide === "airbnb" && earlyAnswers.typescript) {
+                if (earlyAnswers.framework !== "react") {
+                    earlyAnswers.styleguide = "airbnb-typescript/base";
+                } else {
+                    earlyAnswers.styleguide = "airbnb-typescript";
+                }
+            } else if (earlyAnswers.styleguide === "airbnb" && earlyAnswers.framework !== "react") {
                 earlyAnswers.styleguide = "airbnb-base";
             }
 

--- a/lib/init/ts-utils.js
+++ b/lib/init/ts-utils.js
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Utility for tsconfig.
+ * @author Pouya MozaffarMagham
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const fs = require("fs"),
+    path = require("path");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Find the closest tsconfig.json file, starting at process.cwd (by default),
+ * and working up to root.
+ * @param   {string} [startDir=process.cwd()] Starting directory
+ * @returns {string}                          Relative path to closest tsconfig.json file
+ */
+function findTsConfig(startDir) {
+    let dir = path.resolve(startDir || process.cwd());
+    let levels = 0;
+
+    do {
+        const tsConfigFile = path.join(dir, "tsconfig.json");
+
+        if (!fs.existsSync(tsConfigFile) || !fs.statSync(tsConfigFile).isFile()) {
+            dir = path.join(dir, "..");
+            levels++;
+            continue;
+        }
+        return `${"../".repeat(levels)}tsconfig.json`;
+    } while (dir !== path.resolve(dir, ".."));
+    return null;
+}
+
+//------------------------------------------------------------------------------
+// Private
+//------------------------------------------------------------------------------
+
+/**
+ * Check whether tsconfig.json is found in current path.
+ * @param   {string} [startDir] Starting directory
+ * @returns {boolean} Whether a tsconfig.json is found in current path.
+ */
+function checkTsConfig(startDir) {
+    return !!findTsConfig(startDir);
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+module.exports = {
+    findTsConfig,
+    checkTsConfig
+};

--- a/tests/lib/init/ts-utils.js
+++ b/tests/lib/init/ts-utils.js
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Tests ts utils.
+ * @author Pouya MozaffarMagham
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const
+    assert = require("chai").assert,
+    sinon = require("sinon"),
+    { defineInMemoryFs } = require("../../_utils");
+
+const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Import `ts-utils` with the in-memory file system.
+ * @param {Object} files The file definitions.
+ * @returns {Object} `ts-utils`.
+ */
+function requireTsUtilsWithInMemoryFileSystem(files) {
+    const fs = defineInMemoryFs({ files });
+
+    return proxyquire("../../../lib/init/ts-utils", { fs });
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("tsUtils", () => {
+    afterEach(() => {
+        sinon.verifyAndRestore();
+    });
+    describe("checkTsConfig()", () => {
+        it("should return true if tsconfig.json exists", () => {
+            const stubbedTsUtils = requireTsUtilsWithInMemoryFileSystem({
+                "tsconfig.json": "{ \"file\": \"contents\" }"
+            });
+
+            assert.strictEqual(stubbedTsUtils.checkTsConfig(), true);
+        });
+
+        it("should return false if tsconfig.json does not exist", () => {
+            const stubbedTsUtils = requireTsUtilsWithInMemoryFileSystem({});
+
+            assert.strictEqual(stubbedTsUtils.checkTsConfig(), false);
+        });
+    });
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[X] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Previously, if your project was using Typescript and you used `eslint --init` and answered "yes" to Typescript question, your config would extend from `airbnb` or `airbnb-base` based on the framework you chose; However, `airbnb` config itself has many problems with TS which makes user override them and so on. So I changed the logic so that the config file will extend `airbnb-typescript` if the project is using Typescript. It also checked for framework, if you use React, it will set the style guide to `airbnb-typescript`; whereas, it will be set to `airbnb-typescript/base` otherwise.

#### Is there anything you'd like reviewers to focus on?
Tests. I don't know the exact convention for testing in this project.