### PR TITLE
Update: Improved error message for no-alert

### DIFF
--- a/lib/rules/no-alert.js
+++ b/lib/rules/no-alert.js
@@ -96,7 +96,7 @@ module.exports = {
         schema: [],
 
         messages: {
-            unexpected: "Unexpected {{name}}."
+            unexpected: "{{name}} is considered to be obtrusive and should be replaced by a more appropriate custom UI implementation."
         }
     },
 

--- a/lib/rules/no-alert.js
+++ b/lib/rules/no-alert.js
@@ -96,7 +96,7 @@ module.exports = {
         schema: [],
 
         messages: {
-            unexpected: "{{name}} is considered to be obtrusive and should be replaced by a more appropriate custom UI implementation."
+            unexpected: "{{name}}() is considered to be obtrusive and should be replaced by a more appropriate custom UI implementation."
         }
     },
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -1603,6 +1603,7 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].messageId, "unexpected");
             assert.include(messages[0].nodeType, "CallExpression");
         });
 
@@ -1759,6 +1760,7 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 2);
             assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].messageId, "unexpected");
             assert.include(messages[0].nodeType, "CallExpression");
             assert.strictEqual(messages[1].ruleId, "no-console");
         });
@@ -1774,6 +1776,7 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].messageId, "unexpected");
             assert.include(messages[0].nodeType, "CallExpression");
         });
     });
@@ -1863,6 +1866,7 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].messageId, "unexpected");
             assert.include(messages[0].nodeType, "CallExpression");
             assert.strictEqual(messages[0].line, 4);
         });
@@ -2195,6 +2199,7 @@ describe("Linter", () => {
 
                 assert.strictEqual(messages.length, 2);
                 assert.strictEqual(messages[1].ruleId, "no-alert");
+                assert.strictEqual(messages[1].messageId, "unexpected");
             });
 
             it("should ignore violations only of specified rule", () => {
@@ -2213,7 +2218,9 @@ describe("Linter", () => {
 
                 assert.strictEqual(messages.length, 2);
                 assert.strictEqual(messages[0].ruleId, "no-alert");
+                assert.strictEqual(messages[0].messageId, "unexpected");
                 assert.strictEqual(messages[1].ruleId, "no-console");
+                assert.strictEqual(messages[1].messageId, "unexpected");
             });
 
             it("should ignore violations of multiple rules when specified", () => {
@@ -2233,6 +2240,7 @@ describe("Linter", () => {
 
                 assert.strictEqual(messages.length, 1);
                 assert.strictEqual(messages[0].ruleId, "no-console");
+                assert.strictEqual(messages[0].messageId, "unexpected");
             });
 
             it("should ignore violations of multiple rules when specified in mixed comments", () => {
@@ -2268,7 +2276,9 @@ describe("Linter", () => {
 
                 assert.strictEqual(messages.length, 2);
                 assert.strictEqual(messages[0].ruleId, "no-alert");
+                assert.strictEqual(messages[0].messageId, "unexpected");
                 assert.strictEqual(messages[1].ruleId, "no-console");
+                assert.strictEqual(messages[1].messageId, "unexpected");
             });
 
             it("should ignore violations of specified rule on next line only", () => {
@@ -2288,7 +2298,9 @@ describe("Linter", () => {
 
                 assert.strictEqual(messages.length, 2);
                 assert.strictEqual(messages[0].ruleId, "no-alert");
+                assert.strictEqual(messages[0].messageId, "unexpected");
                 assert.strictEqual(messages[1].ruleId, "no-console");
+                assert.strictEqual(messages[1].messageId, "unexpected");
             });
 
             it("should ignore all rule violations on next line if none specified", () => {
@@ -2309,6 +2321,7 @@ describe("Linter", () => {
 
                 assert.strictEqual(messages.length, 1);
                 assert.strictEqual(messages[0].ruleId, "no-console");
+                assert.strictEqual(messages[0].messageId, "unexpected");
             });
 
             it("should ignore violations if eslint-disable-next-line is a block comment", () => {
@@ -2328,7 +2341,9 @@ describe("Linter", () => {
 
                 assert.strictEqual(messages.length, 2);
                 assert.strictEqual(messages[0].ruleId, "no-alert");
+                assert.strictEqual(messages[0].messageId, "unexpected");
                 assert.strictEqual(messages[1].ruleId, "no-console");
+                assert.strictEqual(messages[1].messageId, "unexpected");
             });
 
             it("should report a violation", () => {
@@ -2368,7 +2383,9 @@ describe("Linter", () => {
 
                 assert.strictEqual(messages.length, 2);
                 assert.strictEqual(messages[0].ruleId, "no-alert");
+                assert.strictEqual(messages[0].messageId, "unexpected");
                 assert.strictEqual(messages[1].ruleId, "no-console");
+                assert.strictEqual(messages[1].messageId, "unexpected");
             });
         });
     });
@@ -2386,8 +2403,8 @@ describe("Linter", () => {
             const messages = linter.verify(code, config, filename);
 
             assert.strictEqual(messages.length, 1);
-
             assert.strictEqual(messages[0].ruleId, "no-console");
+            assert.strictEqual(messages[0].messageId, "unexpected");
         });
 
         it("should report no violation", () => {
@@ -2449,8 +2466,10 @@ describe("Linter", () => {
             assert.strictEqual(messages.length, 2);
 
             assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].messageId, "unexpected");
             assert.strictEqual(messages[0].line, 5);
             assert.strictEqual(messages[1].ruleId, "no-console");
+            assert.strictEqual(messages[1].messageId, "unexpected");
             assert.strictEqual(messages[1].line, 6);
         });
 
@@ -2470,6 +2489,7 @@ describe("Linter", () => {
             assert.strictEqual(messages.length, 1);
 
             assert.strictEqual(messages[0].ruleId, "no-console");
+            assert.strictEqual(messages[0].messageId, "unexpected");
         });
 
 
@@ -2490,6 +2510,7 @@ describe("Linter", () => {
             assert.strictEqual(messages.length, 1);
 
             assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].messageId, "unexpected");
             assert.strictEqual(messages[0].line, 5);
         });
 
@@ -2520,15 +2541,19 @@ describe("Linter", () => {
             assert.strictEqual(messages.length, 4);
 
             assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].messageId, "unexpected");
             assert.strictEqual(messages[0].line, 6);
 
             assert.strictEqual(messages[1].ruleId, "no-console");
+            assert.strictEqual(messages[1].messageId, "unexpected");
             assert.strictEqual(messages[1].line, 7);
 
             assert.strictEqual(messages[2].ruleId, "no-alert");
+            assert.strictEqual(messages[2].messageId, "unexpected");
             assert.strictEqual(messages[2].line, 9);
 
             assert.strictEqual(messages[3].ruleId, "no-console");
+            assert.strictEqual(messages[3].messageId, "unexpected");
             assert.strictEqual(messages[3].line, 10);
 
         });
@@ -2557,12 +2582,15 @@ describe("Linter", () => {
             assert.strictEqual(messages.length, 3);
 
             assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].messageId, "unexpected");
             assert.strictEqual(messages[0].line, 5);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
+            assert.strictEqual(messages[1].messageId, "unexpected");
             assert.strictEqual(messages[1].line, 8);
 
             assert.strictEqual(messages[2].ruleId, "no-console");
+            assert.strictEqual(messages[2].messageId, "unexpected");
             assert.strictEqual(messages[2].line, 9);
 
         });
@@ -2591,12 +2619,15 @@ describe("Linter", () => {
             assert.strictEqual(messages.length, 3);
 
             assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].messageId, "unexpected");
             assert.strictEqual(messages[0].line, 5);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
+            assert.strictEqual(messages[1].messageId, "unexpected");
             assert.strictEqual(messages[1].line, 8);
 
             assert.strictEqual(messages[2].ruleId, "no-console");
+            assert.strictEqual(messages[2].messageId, "unexpected");
             assert.strictEqual(messages[2].line, 9);
 
         });
@@ -2612,6 +2643,7 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].messageId, "unexpected");
             assert.include(messages[0].nodeType, "CallExpression");
         });
     });
@@ -2668,6 +2700,7 @@ describe("Linter", () => {
             assert.strictEqual(messages[0].column, 1);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
+            assert.strictEqual(messages[1].messageId, "unexpected");
             assert.include(messages[1].nodeType, "CallExpression");
         });
 
@@ -2692,6 +2725,7 @@ describe("Linter", () => {
             assert.strictEqual(messages[0].column, 1);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
+            assert.strictEqual(messages[1].messageId, "unexpected");
             assert.include(messages[1].nodeType, "CallExpression");
         });
 
@@ -2716,6 +2750,7 @@ describe("Linter", () => {
             assert.strictEqual(messages[0].column, 1);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
+            assert.strictEqual(messages[1].messageId, "unexpected");
             assert.include(messages[1].nodeType, "CallExpression");
         });
     });
@@ -3072,6 +3107,7 @@ var a = "test2";
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].messageId, "unexpected");
         });
 
         it("should report a violation for global variable declarations", () => {
@@ -3127,6 +3163,7 @@ var a = "test2";
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].messageId, "unexpected");
         });
 
         it("should not report a violation for rule changes", () => {
@@ -3165,6 +3202,7 @@ var a = "test2";
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].messageId, "unexpected");
         });
 
         it("should report a violation for env changes", () => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -1603,7 +1603,6 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
-            assert.include(messages[0].message, "alert");
             assert.include(messages[0].nodeType, "CallExpression");
         });
 
@@ -1760,7 +1759,6 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 2);
             assert.strictEqual(messages[0].ruleId, "no-alert");
-            assert.include(messages[0].message, "alert");
             assert.include(messages[0].nodeType, "CallExpression");
             assert.strictEqual(messages[1].ruleId, "no-console");
         });
@@ -1776,7 +1774,6 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
-            assert.include(messages[0].message, "alert");
             assert.include(messages[0].nodeType, "CallExpression");
         });
     });
@@ -1866,7 +1863,6 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
-            assert.include(messages[0].message, "alert");
             assert.include(messages[0].nodeType, "CallExpression");
             assert.strictEqual(messages[0].line, 4);
         });
@@ -2616,7 +2612,6 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
-            assert.include(messages[0].message, "alert");
             assert.include(messages[0].nodeType, "CallExpression");
         });
     });

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -1603,7 +1603,7 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
-            assert.strictEqual(messages[0].message, "Unexpected alert.");
+            assert.include(messages[0].message, "alert");
             assert.include(messages[0].nodeType, "CallExpression");
         });
 
@@ -1760,7 +1760,7 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 2);
             assert.strictEqual(messages[0].ruleId, "no-alert");
-            assert.strictEqual(messages[0].message, "Unexpected alert.");
+            assert.include(messages[0].message, "alert");
             assert.include(messages[0].nodeType, "CallExpression");
             assert.strictEqual(messages[1].ruleId, "no-console");
         });
@@ -1776,7 +1776,7 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
-            assert.strictEqual(messages[0].message, "Unexpected alert.");
+            assert.include(messages[0].message, "alert");
             assert.include(messages[0].nodeType, "CallExpression");
         });
     });
@@ -1866,7 +1866,7 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
-            assert.strictEqual(messages[0].message, "Unexpected alert.");
+            assert.include(messages[0].message, "alert");
             assert.include(messages[0].nodeType, "CallExpression");
             assert.strictEqual(messages[0].line, 4);
         });
@@ -2030,7 +2030,7 @@ describe("Linter", () => {
                         column: 1,
                         endLine: 1,
                         endColumn: 14,
-                        message: "Unexpected alert.",
+                        message: "alert is considered to be obtrusive and should be replaced by a more appropriate custom UI implementation.",
                         messageId: "unexpected",
                         nodeType: "CallExpression"
                     },
@@ -2616,7 +2616,7 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "no-alert");
-            assert.strictEqual(messages[0].message, "Unexpected alert.");
+            assert.include(messages[0].message, "alert");
             assert.include(messages[0].nodeType, "CallExpression");
         });
     });
@@ -2673,7 +2673,7 @@ describe("Linter", () => {
             assert.strictEqual(messages[0].column, 1);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
-            assert.strictEqual(messages[1].message, "Unexpected alert.");
+            assert.include(messages[1].message, "alert");
             assert.include(messages[1].nodeType, "CallExpression");
         });
 
@@ -2698,7 +2698,7 @@ describe("Linter", () => {
             assert.strictEqual(messages[0].column, 1);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
-            assert.strictEqual(messages[1].message, "Unexpected alert.");
+            assert.include(messages[1].message, "alert");
             assert.include(messages[1].nodeType, "CallExpression");
         });
 
@@ -2723,7 +2723,7 @@ describe("Linter", () => {
             assert.strictEqual(messages[0].column, 1);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
-            assert.strictEqual(messages[1].message, "Unexpected alert.");
+            assert.include(messages[1].message, "alert");
             assert.include(messages[1].nodeType, "CallExpression");
         });
     });

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -2668,7 +2668,6 @@ describe("Linter", () => {
             assert.strictEqual(messages[0].column, 1);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
-            assert.include(messages[1].message, "alert");
             assert.include(messages[1].nodeType, "CallExpression");
         });
 
@@ -2693,7 +2692,6 @@ describe("Linter", () => {
             assert.strictEqual(messages[0].column, 1);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
-            assert.include(messages[1].message, "alert");
             assert.include(messages[1].nodeType, "CallExpression");
         });
 
@@ -2718,7 +2716,6 @@ describe("Linter", () => {
             assert.strictEqual(messages[0].column, 1);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
-            assert.include(messages[1].message, "alert");
             assert.include(messages[1].nodeType, "CallExpression");
         });
     });

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -2030,7 +2030,7 @@ describe("Linter", () => {
                         column: 1,
                         endLine: 1,
                         endColumn: 14,
-                        message: "alert is considered to be obtrusive and should be replaced by a more appropriate custom UI implementation.",
+                        message: "alert() is considered to be obtrusive and should be replaced by a more appropriate custom UI implementation.",
                         messageId: "unexpected",
                         nodeType: "CallExpression"
                     },


### PR DESCRIPTION
### Summary

The error message displayed for using the alert, confirm, and prompt is not very helpful. Especially to junior developers.

It current appears as follows:

`"Unexpected alert."`

This PR will incorporate the wording from the docs and make it more useful:

`"alert() is considered to be obtrusive and should be replaced by a more appropriate custom UI implementation."`

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

no-alert

**Does this change cause the rule to produce more or fewer warnings?**

no

**How will the change be implemented? (New option, new default behavior, etc.)?**

Updates the error message to be more informative.

**Please provide some example code that this change will affect:**

```js
alert('test');
```

**What does the rule currently do for this code?**

It displays the error message: `"Unexpected alert."`

**What will the rule do after it's changed?**

It will display the error message: `"alert() is considered to be obtrusive and should be replaced by a more appropriate custom UI implementation."`

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the default error message as described above.

#### Is there anything you'd like reviewers to focus on?

Is the updated message too long? Are there ways to improve the message further?
