### PR TITLE
Update: Allow no-restricted-globals to replace the default message

### DIFF
--- a/lib/rules/no-restricted-globals.js
+++ b/lib/rules/no-restricted-globals.js
@@ -31,7 +31,7 @@ module.exports = {
                         properties: {
                             name: { type: "string" },
                             message: { type: "string" },
-                            isFullMessage: { type: "boolean" }
+                            replaceDefaultMessage: { type: "boolean" }
                         },
                         required: ["name"],
                         additionalProperties: false
@@ -81,7 +81,7 @@ module.exports = {
             /* eslint-disable */
             const messageId =
                 !option.message ? "defaultMessage" :
-                !option.isFullMessage ? "customMessage" :
+                !option.replaceDefaultMessage ? "customMessage" :
                 "fullCustomMessage";
             /* eslint-enable */
 

--- a/lib/rules/no-restricted-globals.js
+++ b/lib/rules/no-restricted-globals.js
@@ -30,7 +30,8 @@ module.exports = {
                         type: "object",
                         properties: {
                             name: { type: "string" },
-                            message: { type: "string" }
+                            message: { type: "string" },
+                            isFullMessage: { type: "boolean" }
                         },
                         required: ["name"],
                         additionalProperties: false
@@ -44,7 +45,9 @@ module.exports = {
         messages: {
             defaultMessage: "Unexpected use of '{{name}}'.",
             // eslint-disable-next-line eslint-plugin/report-message-format
-            customMessage: "{{customMessage}}"
+            customMessage: "Unexpected use of '{{name}}'. {{customMessage}}",
+            // eslint-disable-next-line eslint-plugin/report-message-format
+            fullCustomMessage: "{{customMessage}}"
         }
     },
 
@@ -55,11 +58,11 @@ module.exports = {
             return {};
         }
 
-        const restrictedGlobalMessages = context.options.reduce((memo, option) => {
+        const restrictedGlobalOptions = context.options.reduce((memo, option) => {
             if (typeof option === "string") {
-                memo[option] = null;
+                memo[option] = { name: option };
             } else {
-                memo[option.name] = option.message;
+                memo[option.name] = option;
             }
 
             return memo;
@@ -72,18 +75,22 @@ module.exports = {
          * @private
          */
         function reportReference(reference) {
-            const name = reference.identifier.name,
-                customMessage = restrictedGlobalMessages[name],
-                messageId = customMessage
-                    ? "customMessage"
-                    : "defaultMessage";
+            const name = reference.identifier.name;
+            const option = restrictedGlobalOptions[name];
+
+            /* eslint-disable */
+            const messageId =
+                !option.message ? "defaultMessage" :
+                !option.isFullMessage ? "customMessage" :
+                "fullCustomMessage";
+            /* eslint-enable */
 
             context.report({
                 node: reference.identifier,
                 messageId,
                 data: {
                     name,
-                    customMessage
+                    customMessage: option.message
                 }
             });
         }
@@ -95,7 +102,7 @@ module.exports = {
          * @private
          */
         function isRestricted(name) {
-            return Object.prototype.hasOwnProperty.call(restrictedGlobalMessages, name);
+            return Object.prototype.hasOwnProperty.call(restrictedGlobalOptions, name);
         }
 
         return {

--- a/lib/rules/no-restricted-globals.js
+++ b/lib/rules/no-restricted-globals.js
@@ -44,7 +44,7 @@ module.exports = {
         messages: {
             defaultMessage: "Unexpected use of '{{name}}'.",
             // eslint-disable-next-line eslint-plugin/report-message-format
-            customMessage: "Unexpected use of '{{name}}'. {{customMessage}}"
+            customMessage: "{{customMessage}}"
         }
     },
 


### PR DESCRIPTION
### Summary

Modifying the error message generated by no-restricted-globals so that it is less verbose. By allowing rule configurations to remove the default error message.

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

no-restricted-globals

**Does this change cause the rule to produce more or fewer warnings?**

no

**How will the change be implemented? (New option, new default behavior, etc.)?**

new option, `isFullMessage = true` disables the default message.

**Please provide some example code that this change will affect:**

```js
isNaN('123.52')
```

**What does the rule currently do for this code?**

When using airbnb-base it shows the error message: **"Unexpected use of 'isNaN'. Use Number.isNaN instead https://github.com/airbnb/javascript#standard-library--isnan"**

**What will the rule do after it's changed?**

When using airbnb-base it shows the error message: **"Use Number.isNaN instead https://github.com/airbnb/javascript#standard-library--isnan"**

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Implemented a new option `isFullMessage`, that can be set to true to disable the default message text. And allow the custom message to completely replace the error text.

#### Is there anything you'd like reviewers to focus on?

Updated pull request to make this an opt-in rather than a change to the default behavior.
