### PR TITLE
Update: add end location to report in `consistent-return` (refs #12334)

### DIFF
--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -104,18 +104,18 @@ module.exports = {
             } else if (node.type === "ArrowFunctionExpression") {
 
                 // `=>` token
-                loc = context.getSourceCode().getTokenBefore(node.body, astUtils.isArrowToken).loc.start;
+                loc = context.getSourceCode().getTokenBefore(node.body, astUtils.isArrowToken).loc;
             } else if (
                 node.parent.type === "MethodDefinition" ||
                 (node.parent.type === "Property" && node.parent.method)
             ) {
 
                 // Method name.
-                loc = node.parent.key.loc.start;
+                loc = node.parent.key.loc;
             } else {
 
                 // Function name or `function` keyword.
-                loc = (node.id || node).loc.start;
+                loc = (node.id || node).loc;
             }
 
             if (!name) {

--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -115,7 +115,7 @@ module.exports = {
             } else {
 
                 // Function name or `function` keyword.
-                loc = (node.id || node).loc;
+                loc = (node.id || context.getSourceCode().getFirstToken(node)).loc;
             }
 
             if (!name) {

--- a/tests/lib/rules/consistent-return.js
+++ b/tests/lib/rules/consistent-return.js
@@ -52,7 +52,11 @@ ruleTester.run("consistent-return", rule, {
                 {
                     messageId: "missingReturnValue",
                     data: { name: "Function 'foo'" },
-                    type: "ReturnStatement"
+                    type: "ReturnStatement",
+                    line: 1,
+                    column: 46,
+                    endLine: 1,
+                    endColumn: 53
                 }
             ]
         },
@@ -63,7 +67,11 @@ ruleTester.run("consistent-return", rule, {
                 {
                     messageId: "missingReturnValue",
                     data: { name: "Arrow function" },
-                    type: "ReturnStatement"
+                    type: "ReturnStatement",
+                    line: 1,
+                    column: 47,
+                    endLine: 1,
+                    endColumn: 54
                 }
             ]
         },
@@ -73,7 +81,11 @@ ruleTester.run("consistent-return", rule, {
                 {
                     messageId: "unexpectedReturnValue",
                     data: { name: "Function 'foo'" },
-                    type: "ReturnStatement"
+                    type: "ReturnStatement",
+                    line: 1,
+                    column: 41,
+                    endLine: 1,
+                    endColumn: 54
                 }
             ]
         },
@@ -83,7 +95,11 @@ ruleTester.run("consistent-return", rule, {
                 {
                     messageId: "missingReturnValue",
                     data: { name: "Function" },
-                    type: "ReturnStatement"
+                    type: "ReturnStatement",
+                    line: 1,
+                    column: 44,
+                    endLine: 1,
+                    endColumn: 51
                 }
             ]
         },
@@ -93,7 +109,11 @@ ruleTester.run("consistent-return", rule, {
                 {
                     messageId: "unexpectedReturnValue",
                     data: { name: "Function" },
-                    type: "ReturnStatement"
+                    type: "ReturnStatement",
+                    line: 1,
+                    column: 39,
+                    endLine: 1,
+                    endColumn: 52
                 }
             ]
         },
@@ -104,7 +124,11 @@ ruleTester.run("consistent-return", rule, {
                 {
                     messageId: "unexpectedReturnValue",
                     data: { name: "Arrow function" },
-                    type: "ReturnStatement"
+                    type: "ReturnStatement",
+                    line: 1,
+                    column: 33,
+                    endLine: 1,
+                    endColumn: 46
                 }
             ]
         },
@@ -116,7 +140,10 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "missingReturnValue",
                     data: { name: "Function 'foo'" },
                     type: "ReturnStatement",
-                    column: 41
+                    line: 1,
+                    column: 41,
+                    endLine: 1,
+                    endColumn: 58
                 }
             ]
         },
@@ -128,7 +155,10 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "missingReturnValue",
                     data: { name: "Function 'foo'" },
                     type: "ReturnStatement",
-                    column: 41
+                    line: 1,
+                    column: 41,
+                    endLine: 1,
+                    endColumn: 55
                 }
             ]
         },
@@ -140,7 +170,10 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "unexpectedReturnValue",
                     data: { name: "Function 'foo'" },
                     type: "ReturnStatement",
-                    column: 46
+                    line: 1,
+                    column: 46,
+                    endLine: 1,
+                    endColumn: 58
                 }
             ]
         },
@@ -152,7 +185,10 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "unexpectedReturnValue",
                     data: { name: "Function 'foo'" },
                     type: "ReturnStatement",
-                    column: 43
+                    line: 1,
+                    column: 43,
+                    endLine: 1,
+                    endColumn: 55
                 }
             ]
         },
@@ -163,7 +199,11 @@ ruleTester.run("consistent-return", rule, {
                 {
                     messageId: "missingReturnValue",
                     data: { name: "Program" },
-                    type: "ReturnStatement"
+                    type: "ReturnStatement",
+                    line: 1,
+                    column: 25,
+                    endLine: 1,
+                    endColumn: 32
                 }
             ]
         },
@@ -174,7 +214,10 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "missingReturn",
                     data: { name: "function 'foo'" },
                     type: "FunctionDeclaration",
-                    column: 10
+                    line: 1,
+                    column: 10,
+                    endLine: 1,
+                    endColumn: 13
                 }
             ]
         },
@@ -185,7 +228,10 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "missingReturn",
                     data: { name: "function '_foo'" },
                     type: "FunctionDeclaration",
-                    column: 10
+                    line: 1,
+                    column: 10,
+                    endLine: 1,
+                    endColumn: 14
                 }
             ]
         },
@@ -196,7 +242,10 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "missingReturn",
                     data: { name: "function 'foo'" },
                     type: "FunctionExpression",
-                    column: 12
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 15
                 }
             ]
         },
@@ -207,7 +256,10 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "missingReturn",
                     data: { name: "function" },
                     type: "FunctionExpression",
-                    column: 3
+                    line: 1,
+                    column: 3,
+                    endLine: 1,
+                    endColumn: 37
                 }
             ]
         },
@@ -219,7 +271,10 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "missingReturn",
                     data: { name: "arrow function" },
                     type: "ArrowFunctionExpression",
-                    column: 6
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 8
                 }
             ]
         },
@@ -231,7 +286,10 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "missingReturn",
                     data: { name: "method 'foo'" },
                     type: "FunctionExpression",
-                    column: 12
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 15
                 }
             ]
         },
@@ -243,7 +301,10 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "missingReturn",
                     data: { name: "method 'foo'" },
                     type: "FunctionExpression",
-                    column: 10
+                    line: 1,
+                    column: 10,
+                    endLine: 1,
+                    endColumn: 13
                 }
             ]
         },
@@ -255,6 +316,7 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "missingReturn",
                     data: { name: "program" },
                     type: "Program",
+                    line: 1,
                     column: 1
                 }
             ]
@@ -267,7 +329,10 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "missingReturn",
                     data: { name: "method 'CapitalizedFunction'" },
                     type: "FunctionExpression",
-                    column: 11
+                    line: 1,
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 30
                 }
             ]
         },
@@ -279,7 +344,10 @@ ruleTester.run("consistent-return", rule, {
                     messageId: "missingReturn",
                     data: { name: "method 'constructor'" },
                     type: "FunctionExpression",
-                    column: 4
+                    line: 1,
+                    column: 4,
+                    endLine: 1,
+                    endColumn: 15
                 }
             ]
         }

--- a/tests/lib/rules/consistent-return.js
+++ b/tests/lib/rules/consistent-return.js
@@ -259,7 +259,7 @@ ruleTester.run("consistent-return", rule, {
                     line: 1,
                     column: 3,
                     endLine: 1,
-                    endColumn: 37
+                    endColumn: 11
                 }
             ]
         },
@@ -317,7 +317,9 @@ ruleTester.run("consistent-return", rule, {
                     data: { name: "program" },
                     type: "Program",
                     line: 1,
-                    column: 1
+                    column: 1,
+                    endLine: void 0,
+                    endColumn: void 0
                 }
             ]
         },


### PR DESCRIPTION

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->


[X] Other, please explain:

refs #12334

This PR adds `loc.end` to reports in `consistent-return`

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Just a small change from `loc.start` to `loc`

#### Is there anything you'd like reviewers to focus on?
No
