### PR TITLE
Chore: assertions on reporting loc in `unicode-bom` (refs #12334)

### DIFF
--- a/lib/rules/unicode-bom.js
+++ b/lib/rules/unicode-bom.js
@@ -43,8 +43,13 @@ module.exports = {
             Program: function checkUnicodeBOM(node) {
 
                 const sourceCode = context.getSourceCode(),
-                    location = { column: 0, line: 1 },
+                    firstToken = sourceCode.getFirstToken(node),
+                    location = { start: { column: 0, line: 1 } },
                     requireBOM = context.options[0] || "never";
+
+                if (firstToken) {
+                    location.end = firstToken.loc.end;
+                }
 
                 if (!sourceCode.hasBOM && (requireBOM === "always")) {
                     context.report({

--- a/lib/rules/unicode-bom.js
+++ b/lib/rules/unicode-bom.js
@@ -43,13 +43,8 @@ module.exports = {
             Program: function checkUnicodeBOM(node) {
 
                 const sourceCode = context.getSourceCode(),
-                    firstToken = sourceCode.getFirstToken(node),
-                    location = { start: { column: 0, line: 1 } },
+                    location = { column: 0, line: 1 },
                     requireBOM = context.options[0] || "never";
-
-                if (firstToken) {
-                    location.end = firstToken.loc.end;
-                }
 
                 if (!sourceCode.hasBOM && (requireBOM === "always")) {
                     context.report({

--- a/tests/lib/rules/unicode-bom.js
+++ b/tests/lib/rules/unicode-bom.js
@@ -41,24 +41,52 @@ ruleTester.run("unicode-bom", rule, {
             code: "var a = 123;",
             output: "\uFEFFvar a = 123;",
             options: ["always"],
-            errors: [expectedError]
+            errors: [{
+                ...expectedError,
+                line: 1,
+                column: 1,
+                endLine: 1,
+                endColumn: 4
+
+            }]
         },
         {
             code: " // here's a comment \nvar a = 123;",
             output: "\uFEFF // here's a comment \nvar a = 123;",
             options: ["always"],
-            errors: [expectedError]
+            errors: [{
+                ...expectedError,
+                line: 1,
+                column: 1,
+                endLine: 2,
+                endColumn: 4
+
+            }]
         },
         {
             code: "\uFEFF var a = 123;",
             output: " var a = 123;",
-            errors: [unexpectedError]
+            errors: [{
+                ...unexpectedError,
+                line: 1,
+                column: 1,
+                endLine: 1,
+                endColumn: 5
+
+            }]
         },
         {
             code: "\uFEFF var a = 123;",
             output: " var a = 123;",
             options: ["never"],
-            errors: [unexpectedError]
+            errors: [{
+                ...unexpectedError,
+                line: 1,
+                column: 1,
+                endLine: 1,
+                endColumn: 5
+
+            }]
         }
     ]
 });

--- a/tests/lib/rules/unicode-bom.js
+++ b/tests/lib/rules/unicode-bom.js
@@ -45,8 +45,8 @@ ruleTester.run("unicode-bom", rule, {
                 ...expectedError,
                 line: 1,
                 column: 1,
-                endLine: 1,
-                endColumn: 4
+                endLine: void 0,
+                endColumn: void 0
 
             }]
         },
@@ -58,8 +58,8 @@ ruleTester.run("unicode-bom", rule, {
                 ...expectedError,
                 line: 1,
                 column: 1,
-                endLine: 2,
-                endColumn: 4
+                endLine: void 0,
+                endColumn: void 0
 
             }]
         },
@@ -70,8 +70,8 @@ ruleTester.run("unicode-bom", rule, {
                 ...unexpectedError,
                 line: 1,
                 column: 1,
-                endLine: 1,
-                endColumn: 5
+                endLine: void 0,
+                endColumn: void 0
 
             }]
         },
@@ -83,8 +83,8 @@ ruleTester.run("unicode-bom", rule, {
                 ...unexpectedError,
                 line: 1,
                 column: 1,
-                endLine: 1,
-                endColumn: 5
+                endLine: void 0,
+                endColumn: void 0
 
             }]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->


[X] Other, please explain:

Refs #12334

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds `loc.end` to reports in `unicode-bom` rule.

#### Is there anything you'd like reviewers to focus on?
no