### PR TITLE
Fix: ignore lines with empty elements (fixes #12756)

### DIFF
--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -216,6 +216,8 @@ module.exports = {
                         previousItemToken = tokenAfterItem
                             ? sourceCode.getTokenBefore(tokenAfterItem)
                             : sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1];
+                    } else {
+                        previousItemToken = currentItemToken;
                     }
                 });
 

--- a/tests/lib/rules/comma-style.js
+++ b/tests/lib/rules/comma-style.js
@@ -18,7 +18,6 @@ const rule = require("../../../lib/rules/comma-style"),
 const ruleTester = new RuleTester();
 
 ruleTester.run("comma-style", rule, {
-
     valid: [
         "var foo = 1, bar = 3;",
         "var foo = {'a': 1, 'b': 2};",
@@ -42,9 +41,15 @@ ruleTester.run("comma-style", rule, {
         { code: "var foo = ['apples'\n,'oranges'];", options: ["first"] },
         { code: "var foo = 1, bar = 2;", options: ["first"] },
         { code: "var foo = 1 \n ,bar = 2;", options: ["first"] },
-        { code: "var foo = {'a': 1 \n ,'b': 2 \n,'c': 3};", options: ["first"] },
+        {
+            code: "var foo = {'a': 1 \n ,'b': 2 \n,'c': 3};",
+            options: ["first"]
+        },
         { code: "var foo = [1 \n ,2 \n, 3];", options: ["first"] },
-        { code: "function foo(){return {'a': 1\n,'b': 2}}", options: ["first"] },
+        {
+            code: "function foo(){return {'a': 1\n,'b': 2}}",
+            options: ["first"]
+        },
         { code: "function foo(){var a=[1\n, 2]}", options: ["first"] },
         { code: "new Foo(a,\nb);", options: ["first"] },
         "f(1\n, 2);",
@@ -63,21 +68,40 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "var a = 'a',\no = 'o',\narr = [1,\n2];",
-            options: ["first", { exceptions: { VariableDeclaration: true, ArrayExpression: true } }]
+            options: [
+                "first",
+                {
+                    exceptions: {
+                        VariableDeclaration: true,
+                        ArrayExpression: true
+                    }
+                }
+            ]
         },
         {
             code: "var ar ={fst:1,\nsnd: [1,\n2]};",
-            options: ["first", { exceptions: { ArrayExpression: true, ObjectExpression: true } }]
+            options: [
+                "first",
+                {
+                    exceptions: {
+                        ArrayExpression: true,
+                        ObjectExpression: true
+                    }
+                }
+            ]
         },
         {
             code: "var a = 'a',\nar ={fst:1,\nsnd: [1,\n2]};",
-            options: ["first", {
-                exceptions: {
-                    ArrayExpression: true,
-                    ObjectExpression: true,
-                    VariableDeclaration: true
+            options: [
+                "first",
+                {
+                    exceptions: {
+                        ArrayExpression: true,
+                        ObjectExpression: true,
+                        VariableDeclaration: true
+                    }
                 }
-            }]
+            ]
         },
         {
             code: "const foo = (a\n, b) => { return a + b; }",
@@ -118,90 +142,117 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
-            options: ["first", {
-                exceptions: {
-                    ObjectPattern: true
+            options: [
+                "first",
+                {
+                    exceptions: {
+                        ObjectPattern: true
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "new Foo(a,\nb);",
-            options: ["first", {
-                exceptions: {
-                    NewExpression: true
+            options: [
+                "first",
+                {
+                    exceptions: {
+                        NewExpression: true
+                    }
                 }
-            }]
+            ]
         },
         {
             code: "f(1\n, 2);",
-            options: ["last", {
-                exceptions: {
-                    CallExpression: true
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        CallExpression: true
+                    }
                 }
-            }]
+            ]
         },
         {
             code: "function foo(a\n, b) { return a + b; }",
-            options: ["last", {
-                exceptions: {
-                    FunctionDeclaration: true
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        FunctionDeclaration: true
+                    }
                 }
-            }]
+            ]
         },
         {
             code: "const foo = function (a\n, b) { return a + b; }",
-            options: ["last", {
-                exceptions: {
-                    FunctionExpression: true
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        FunctionExpression: true
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "function foo([a\n, b]) { return a + b; }",
-            options: ["last", {
-                exceptions: {
-                    ArrayPattern: true
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        ArrayPattern: true
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "const foo = (a\n, b) => { return a + b; }",
-            options: ["last", {
-                exceptions: {
-                    ArrowFunctionExpression: true
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        ArrowFunctionExpression: true
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "const foo = ([a\n, b]) => { return a + b; }",
-            options: ["last", {
-                exceptions: {
-                    ArrayPattern: true
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        ArrayPattern: true
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "import { a\n, b } from './source';",
-            options: ["last", {
-                exceptions: {
-                    ImportDeclaration: true
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        ImportDeclaration: true
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6,
                 sourceType: "module"
@@ -209,30 +260,86 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
-            options: ["last", {
-                exceptions: {
-                    ObjectPattern: true
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        ObjectPattern: true
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "new Foo(a,\nb);",
-            options: ["last", {
-                exceptions: {
-                    NewExpression: false
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        NewExpression: false
+                    }
                 }
-            }]
+            ]
         },
         {
             code: "new Foo(a\n,b);",
-            options: ["last", {
-                exceptions: {
-                    NewExpression: true
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        NewExpression: true
+                    }
                 }
-            }]
+            ]
+        },
+        "var foo = [\n , \n 1, \n 2 \n];",
+        {
+            code: "const [\n , \n , \n a, \n b, \n] = arr;",
+            output: "const [\n , \n , \n a, \n b, \n] = arr;",
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        ArrayPattern: false
+                    }
+                }
+            ],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "const [\n ,, \n a, \n b, \n] = arr;",
+            output: "const [\n ,, \n a, \n b, \n] = arr;",
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        ArrayPattern: false
+                    }
+                }
+            ],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "const arr = [\n 1 \n , \n ,2 \n]",
+            output: "const arr = [\n 1 \n , \n ,2 \n]",
+            options: ["first"],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "const arr = [\n ,'fifi' \n]",
+            output: "const arr = [\n ,'fifi' \n]",
+            options: ["first"],
+            parserOptions: {
+                ecmaVersion: 6
+            }
         }
     ],
 
@@ -240,364 +347,461 @@ ruleTester.run("comma-style", rule, {
         {
             code: "var foo = { a: 1. //comment \n, b: 2\n}",
             output: "var foo = { a: 1., //comment \n b: 2\n}",
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Property"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Property"
+                }
+            ]
         },
         {
             code: "var foo = { a: 1. //comment \n //comment1 \n //comment2 \n, b: 2\n}",
             output: "var foo = { a: 1., //comment \n //comment1 \n //comment2 \n b: 2\n}",
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Property"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Property"
+                }
+            ]
         },
         {
             code: "var foo = 1\n,\nbar = 2;",
             output: "var foo = 1,\nbar = 2;",
-            errors: [{
-                messageId: "unexpectedLineBeforeAndAfterComma",
-                type: "VariableDeclarator"
-            }]
+            errors: [
+                {
+                    messageId: "unexpectedLineBeforeAndAfterComma",
+                    type: "VariableDeclarator"
+                }
+            ]
         },
         {
             code: "var foo = 1 //comment\n,\nbar = 2;",
             output: "var foo = 1, //comment\nbar = 2;",
-            errors: [{
-                messageId: "unexpectedLineBeforeAndAfterComma",
-                type: "VariableDeclarator"
-            }]
+            errors: [
+                {
+                    messageId: "unexpectedLineBeforeAndAfterComma",
+                    type: "VariableDeclarator"
+                }
+            ]
         },
         {
             code: "var foo = 1 //comment\n, // comment 2\nbar = 2;",
             output: "var foo = 1, //comment // comment 2\nbar = 2;",
-            errors: [{
-                messageId: "unexpectedLineBeforeAndAfterComma",
-                type: "VariableDeclarator"
-            }]
+            errors: [
+                {
+                    messageId: "unexpectedLineBeforeAndAfterComma",
+                    type: "VariableDeclarator"
+                }
+            ]
         },
         {
             code: "new Foo(a\n,\nb);",
             output: "new Foo(a,\nb);",
-            options: ["last", {
-                exceptions: {
-                    NewExpression: false
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        NewExpression: false
+                    }
                 }
-            }],
+            ],
             errors: [{ messageId: "unexpectedLineBeforeAndAfterComma" }]
         },
         {
             code: "var foo = 1\n,bar = 2;",
             output: "var foo = 1,\nbar = 2;",
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "VariableDeclarator",
-                column: 1,
-                endColumn: 2
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "VariableDeclarator",
+                    column: 1,
+                    endColumn: 2
+                }
+            ]
         },
         {
             code: "f([1,2\n,3]);",
             output: "f([1,2,\n3]);",
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Literal"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Literal"
+                }
+            ]
         },
         {
             code: "f([1,2\n,]);",
             output: "f([1,2,\n]);",
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Punctuator"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Punctuator"
+                }
+            ]
         },
         {
             code: "f([,2\n,3]);",
             output: "f([,2,\n3]);",
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Literal"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Literal"
+                }
+            ]
         },
         {
             code: "var foo = ['apples'\n, 'oranges'];",
             output: "var foo = ['apples',\n 'oranges'];",
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Literal"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Literal"
+                }
+            ]
         },
         {
             code: "var [foo\n, bar] = ['apples', 'oranges'];",
             output: "var [foo,\n bar] = ['apples', 'oranges'];",
-            options: ["last", {
-                exceptions: {
-                    ArrayPattern: false
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        ArrayPattern: false
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6
             },
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Identifier"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Identifier"
+                }
+            ]
         },
         {
             code: "f(1\n, 2);",
             output: "f(1,\n 2);",
-            options: ["last", {
-                exceptions: {
-                    CallExpression: false
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        CallExpression: false
+                    }
                 }
-            }],
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Literal"
-            }]
+            ],
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Literal"
+                }
+            ]
         },
         {
             code: "function foo(a\n, b) { return a + b; }",
             output: "function foo(a,\n b) { return a + b; }",
-            options: ["last", {
-                exceptions: {
-                    FunctionDeclaration: false
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        FunctionDeclaration: false
+                    }
                 }
-            }],
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Identifier"
-            }]
+            ],
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Identifier"
+                }
+            ]
         },
         {
             code: "const foo = function (a\n, b) { return a + b; }",
             output: "const foo = function (a,\n b) { return a + b; }",
-            options: ["last", {
-                exceptions: {
-                    FunctionExpression: false
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        FunctionExpression: false
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6,
                 sourceType: "module"
             },
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Identifier"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Identifier"
+                }
+            ]
         },
         {
             code: "function foo([a\n, b]) { return a + b; }",
             output: "function foo([a,\n b]) { return a + b; }",
-            options: ["last", {
-                exceptions: {
-                    ArrayPattern: false
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        ArrayPattern: false
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6
             },
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Identifier"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Identifier"
+                }
+            ]
         },
         {
             code: "const foo = (a\n, b) => { return a + b; }",
             output: "const foo = (a,\n b) => { return a + b; }",
-            options: ["last", {
-                exceptions: {
-                    ArrowFunctionExpression: false
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        ArrowFunctionExpression: false
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6
             },
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Identifier"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Identifier"
+                }
+            ]
         },
         {
             code: "const foo = ([a\n, b]) => { return a + b; }",
             output: "const foo = ([a,\n b]) => { return a + b; }",
-            options: ["last", {
-                exceptions: {
-                    ArrayPattern: false
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        ArrayPattern: false
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6
             },
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Identifier"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Identifier"
+                }
+            ]
         },
         {
             code: "import { a\n, b } from './source';",
             output: "import { a,\n b } from './source';",
-            options: ["last", {
-                exceptions: {
-                    ImportDeclaration: false
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        ImportDeclaration: false
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6,
                 sourceType: "module"
             },
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "ImportSpecifier"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "ImportSpecifier"
+                }
+            ]
         },
         {
             code: "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
             output: "var {foo,\n bar} = {foo:'apples', bar:'oranges'};",
-            options: ["last", {
-                exceptions: {
-                    ObjectPattern: false
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        ObjectPattern: false
+                    }
                 }
-            }],
+            ],
             parserOptions: {
                 ecmaVersion: 6
             },
-            errors: [{
-                messageId: "expectedCommaLast",
-                type: "Property"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaLast",
+                    type: "Property"
+                }
+            ]
         },
         {
             code: "var foo = 1,\nbar = 2;",
             output: "var foo = 1\n,bar = 2;",
             options: ["first"],
-            errors: [{
-                messageId: "expectedCommaFirst",
-                type: "VariableDeclarator",
-                column: 12,
-                endColumn: 13
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaFirst",
+                    type: "VariableDeclarator",
+                    column: 12,
+                    endColumn: 13
+                }
+            ]
         },
         {
             code: "f([1,\n2,3]);",
             output: "f([1\n,2,3]);",
             options: ["first"],
-            errors: [{
-                messageId: "expectedCommaFirst",
-                type: "Literal"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaFirst",
+                    type: "Literal"
+                }
+            ]
         },
         {
             code: "var foo = ['apples', \n 'oranges'];",
             output: "var foo = ['apples' \n ,'oranges'];",
             options: ["first"],
-            errors: [{
-                messageId: "expectedCommaFirst",
-                type: "Literal"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaFirst",
+                    type: "Literal"
+                }
+            ]
         },
         {
             code: "var foo = {'a': 1, \n 'b': 2\n ,'c': 3};",
             output: "var foo = {'a': 1 \n ,'b': 2\n ,'c': 3};",
             options: ["first"],
-            errors: [{
-                messageId: "expectedCommaFirst",
-                type: "Property"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaFirst",
+                    type: "Property"
+                }
+            ]
         },
         {
             code: "var a = 'a',\no = 'o',\narr = [1,\n2];",
             output: "var a = 'a',\no = 'o',\narr = [1\n,2];",
             options: ["first", { exceptions: { VariableDeclaration: true } }],
-            errors: [{
-                messageId: "expectedCommaFirst",
-                type: "Literal"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaFirst",
+                    type: "Literal"
+                }
+            ]
         },
         {
             code: "var a = 'a',\nobj = {a: 'a',\nb: 'b'};",
             output: "var a = 'a',\nobj = {a: 'a'\n,b: 'b'};",
             options: ["first", { exceptions: { VariableDeclaration: true } }],
-            errors: [{
-                messageId: "expectedCommaFirst",
-                type: "Property"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaFirst",
+                    type: "Property"
+                }
+            ]
         },
         {
             code: "var a = 'a',\nobj = {a: 'a',\nb: 'b'};",
             output: "var a = 'a'\n,obj = {a: 'a',\nb: 'b'};",
             options: ["first", { exceptions: { ObjectExpression: true } }],
-            errors: [{
-                messageId: "expectedCommaFirst",
-                type: "VariableDeclarator"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaFirst",
+                    type: "VariableDeclarator"
+                }
+            ]
         },
         {
             code: "var a = 'a',\narr = [1,\n2];",
             output: "var a = 'a'\n,arr = [1,\n2];",
             options: ["first", { exceptions: { ArrayExpression: true } }],
-            errors: [{
-                messageId: "expectedCommaFirst",
-                type: "VariableDeclarator"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaFirst",
+                    type: "VariableDeclarator"
+                }
+            ]
         },
         {
             code: "var ar =[1,\n{a: 'a',\nb: 'b'}];",
             output: "var ar =[1,\n{a: 'a'\n,b: 'b'}];",
             options: ["first", { exceptions: { ArrayExpression: true } }],
-            errors: [{
-                messageId: "expectedCommaFirst",
-                type: "Property"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaFirst",
+                    type: "Property"
+                }
+            ]
         },
         {
             code: "var ar =[1,\n{a: 'a',\nb: 'b'}];",
             output: "var ar =[1\n,{a: 'a',\nb: 'b'}];",
             options: ["first", { exceptions: { ObjectExpression: true } }],
-            errors: [{
-                messageId: "expectedCommaFirst",
-                type: "ObjectExpression"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaFirst",
+                    type: "ObjectExpression"
+                }
+            ]
         },
         {
             code: "var ar ={fst:1,\nsnd: [1,\n2]};",
             output: "var ar ={fst:1,\nsnd: [1\n,2]};",
             options: ["first", { exceptions: { ObjectExpression: true } }],
-            errors: [{
-                messageId: "expectedCommaFirst",
-                type: "Literal"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaFirst",
+                    type: "Literal"
+                }
+            ]
         },
         {
             code: "var ar ={fst:1,\nsnd: [1,\n2]};",
             output: "var ar ={fst:1\n,snd: [1,\n2]};",
             options: ["first", { exceptions: { ArrayExpression: true } }],
-            errors: [{
-                messageId: "expectedCommaFirst",
-                type: "Property"
-            }]
+            errors: [
+                {
+                    messageId: "expectedCommaFirst",
+                    type: "Property"
+                }
+            ]
         },
         {
             code: "new Foo(a,\nb);",
             output: "new Foo(a\n,b);",
-            options: ["first", {
-                exceptions: {
-                    NewExpression: false
+            options: [
+                "first",
+                {
+                    exceptions: {
+                        NewExpression: false
+                    }
                 }
-            }],
+            ],
             errors: [{ messageId: "expectedCommaFirst" }]
         },
         {
             code: "var foo = [\n(bar\n)\n,\nbaz\n];",
             output: "var foo = [\n(bar\n),\nbaz\n];",
-            errors: [{
-                messageId: "unexpectedLineBeforeAndAfterComma",
-                type: "Identifier",
-                column: 1,
-                endColumn: 2
-            }]
+            errors: [
+                {
+                    messageId: "unexpectedLineBeforeAndAfterComma",
+                    type: "Identifier",
+                    column: 1,
+                    endColumn: 2
+                }
+            ]
         },
         {
             code: "[(foo),\n,\nbar]",
@@ -607,11 +811,14 @@ ruleTester.run("comma-style", rule, {
         {
             code: "new Foo(a\n,b);",
             output: "new Foo(a,\nb);",
-            options: ["last", {
-                exceptions: {
-                    NewExpression: false
+            options: [
+                "last",
+                {
+                    exceptions: {
+                        NewExpression: false
+                    }
                 }
-            }],
+            ],
             errors: [{ messageId: "expectedCommaLast" }]
         },
         {

--- a/tests/lib/rules/comma-style.js
+++ b/tests/lib/rules/comma-style.js
@@ -18,6 +18,7 @@ const rule = require("../../../lib/rules/comma-style"),
 const ruleTester = new RuleTester();
 
 ruleTester.run("comma-style", rule, {
+
     valid: [
         "var foo = 1, bar = 3;",
         "var foo = {'a': 1, 'b': 2};",
@@ -41,15 +42,9 @@ ruleTester.run("comma-style", rule, {
         { code: "var foo = ['apples'\n,'oranges'];", options: ["first"] },
         { code: "var foo = 1, bar = 2;", options: ["first"] },
         { code: "var foo = 1 \n ,bar = 2;", options: ["first"] },
-        {
-            code: "var foo = {'a': 1 \n ,'b': 2 \n,'c': 3};",
-            options: ["first"]
-        },
+        { code: "var foo = {'a': 1 \n ,'b': 2 \n,'c': 3};", options: ["first"] },
         { code: "var foo = [1 \n ,2 \n, 3];", options: ["first"] },
-        {
-            code: "function foo(){return {'a': 1\n,'b': 2}}",
-            options: ["first"]
-        },
+        { code: "function foo(){return {'a': 1\n,'b': 2}}", options: ["first"] },
         { code: "function foo(){var a=[1\n, 2]}", options: ["first"] },
         { code: "new Foo(a,\nb);", options: ["first"] },
         "f(1\n, 2);",
@@ -68,40 +63,21 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "var a = 'a',\no = 'o',\narr = [1,\n2];",
-            options: [
-                "first",
-                {
-                    exceptions: {
-                        VariableDeclaration: true,
-                        ArrayExpression: true
-                    }
-                }
-            ]
+            options: ["first", { exceptions: { VariableDeclaration: true, ArrayExpression: true } }]
         },
         {
             code: "var ar ={fst:1,\nsnd: [1,\n2]};",
-            options: [
-                "first",
-                {
-                    exceptions: {
-                        ArrayExpression: true,
-                        ObjectExpression: true
-                    }
-                }
-            ]
+            options: ["first", { exceptions: { ArrayExpression: true, ObjectExpression: true } }]
         },
         {
             code: "var a = 'a',\nar ={fst:1,\nsnd: [1,\n2]};",
-            options: [
-                "first",
-                {
-                    exceptions: {
-                        ArrayExpression: true,
-                        ObjectExpression: true,
-                        VariableDeclaration: true
-                    }
+            options: ["first", {
+                exceptions: {
+                    ArrayExpression: true,
+                    ObjectExpression: true,
+                    VariableDeclaration: true
                 }
-            ]
+            }]
         },
         {
             code: "const foo = (a\n, b) => { return a + b; }",
@@ -142,117 +118,90 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
-            options: [
-                "first",
-                {
-                    exceptions: {
-                        ObjectPattern: true
-                    }
+            options: ["first", {
+                exceptions: {
+                    ObjectPattern: true
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "new Foo(a,\nb);",
-            options: [
-                "first",
-                {
-                    exceptions: {
-                        NewExpression: true
-                    }
+            options: ["first", {
+                exceptions: {
+                    NewExpression: true
                 }
-            ]
+            }]
         },
         {
             code: "f(1\n, 2);",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        CallExpression: true
-                    }
+            options: ["last", {
+                exceptions: {
+                    CallExpression: true
                 }
-            ]
+            }]
         },
         {
             code: "function foo(a\n, b) { return a + b; }",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        FunctionDeclaration: true
-                    }
+            options: ["last", {
+                exceptions: {
+                    FunctionDeclaration: true
                 }
-            ]
+            }]
         },
         {
             code: "const foo = function (a\n, b) { return a + b; }",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        FunctionExpression: true
-                    }
+            options: ["last", {
+                exceptions: {
+                    FunctionExpression: true
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "function foo([a\n, b]) { return a + b; }",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        ArrayPattern: true
-                    }
+            options: ["last", {
+                exceptions: {
+                    ArrayPattern: true
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "const foo = (a\n, b) => { return a + b; }",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        ArrowFunctionExpression: true
-                    }
+            options: ["last", {
+                exceptions: {
+                    ArrowFunctionExpression: true
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "const foo = ([a\n, b]) => { return a + b; }",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        ArrayPattern: true
-                    }
+            options: ["last", {
+                exceptions: {
+                    ArrayPattern: true
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "import { a\n, b } from './source';",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        ImportDeclaration: true
-                    }
+            options: ["last", {
+                exceptions: {
+                    ImportDeclaration: true
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6,
                 sourceType: "module"
@@ -260,52 +209,40 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        ObjectPattern: true
-                    }
+            options: ["last", {
+                exceptions: {
+                    ObjectPattern: true
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "new Foo(a,\nb);",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        NewExpression: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    NewExpression: false
                 }
-            ]
+            }]
         },
         {
             code: "new Foo(a\n,b);",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        NewExpression: true
-                    }
+            options: ["last", {
+                exceptions: {
+                    NewExpression: true
                 }
-            ]
+            }]
         },
         "var foo = [\n , \n 1, \n 2 \n];",
         {
             code: "const [\n , \n , \n a, \n b, \n] = arr;",
             output: "const [\n , \n , \n a, \n b, \n] = arr;",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        ArrayPattern: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    ArrayPattern: false
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6
             }
@@ -313,14 +250,11 @@ ruleTester.run("comma-style", rule, {
         {
             code: "const [\n ,, \n a, \n b, \n] = arr;",
             output: "const [\n ,, \n a, \n b, \n] = arr;",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        ArrayPattern: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    ArrayPattern: false
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6
             }
@@ -341,467 +275,371 @@ ruleTester.run("comma-style", rule, {
                 ecmaVersion: 6
             }
         }
+
     ],
 
     invalid: [
         {
             code: "var foo = { a: 1. //comment \n, b: 2\n}",
             output: "var foo = { a: 1., //comment \n b: 2\n}",
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Property"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Property"
+            }]
         },
         {
             code: "var foo = { a: 1. //comment \n //comment1 \n //comment2 \n, b: 2\n}",
             output: "var foo = { a: 1., //comment \n //comment1 \n //comment2 \n b: 2\n}",
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Property"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Property"
+            }]
         },
         {
             code: "var foo = 1\n,\nbar = 2;",
             output: "var foo = 1,\nbar = 2;",
-            errors: [
-                {
-                    messageId: "unexpectedLineBeforeAndAfterComma",
-                    type: "VariableDeclarator"
-                }
-            ]
+            errors: [{
+                messageId: "unexpectedLineBeforeAndAfterComma",
+                type: "VariableDeclarator"
+            }]
         },
         {
             code: "var foo = 1 //comment\n,\nbar = 2;",
             output: "var foo = 1, //comment\nbar = 2;",
-            errors: [
-                {
-                    messageId: "unexpectedLineBeforeAndAfterComma",
-                    type: "VariableDeclarator"
-                }
-            ]
+            errors: [{
+                messageId: "unexpectedLineBeforeAndAfterComma",
+                type: "VariableDeclarator"
+            }]
         },
         {
             code: "var foo = 1 //comment\n, // comment 2\nbar = 2;",
             output: "var foo = 1, //comment // comment 2\nbar = 2;",
-            errors: [
-                {
-                    messageId: "unexpectedLineBeforeAndAfterComma",
-                    type: "VariableDeclarator"
-                }
-            ]
+            errors: [{
+                messageId: "unexpectedLineBeforeAndAfterComma",
+                type: "VariableDeclarator"
+            }]
         },
         {
             code: "new Foo(a\n,\nb);",
             output: "new Foo(a,\nb);",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        NewExpression: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    NewExpression: false
                 }
-            ],
+            }],
             errors: [{ messageId: "unexpectedLineBeforeAndAfterComma" }]
         },
         {
             code: "var foo = 1\n,bar = 2;",
             output: "var foo = 1,\nbar = 2;",
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "VariableDeclarator",
-                    column: 1,
-                    endColumn: 2
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "VariableDeclarator",
+                column: 1,
+                endColumn: 2
+            }]
         },
         {
             code: "f([1,2\n,3]);",
             output: "f([1,2,\n3]);",
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Literal"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Literal"
+            }]
         },
         {
             code: "f([1,2\n,]);",
             output: "f([1,2,\n]);",
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Punctuator"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Punctuator"
+            }]
         },
         {
             code: "f([,2\n,3]);",
             output: "f([,2,\n3]);",
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Literal"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = ['apples'\n, 'oranges'];",
             output: "var foo = ['apples',\n 'oranges'];",
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Literal"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Literal"
+            }]
         },
         {
             code: "var [foo\n, bar] = ['apples', 'oranges'];",
             output: "var [foo,\n bar] = ['apples', 'oranges'];",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        ArrayPattern: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    ArrayPattern: false
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6
             },
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Identifier"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Identifier"
+            }]
         },
         {
             code: "f(1\n, 2);",
             output: "f(1,\n 2);",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        CallExpression: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    CallExpression: false
                 }
-            ],
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Literal"
-                }
-            ]
+            }],
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Literal"
+            }]
         },
         {
             code: "function foo(a\n, b) { return a + b; }",
             output: "function foo(a,\n b) { return a + b; }",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        FunctionDeclaration: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    FunctionDeclaration: false
                 }
-            ],
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Identifier"
-                }
-            ]
+            }],
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Identifier"
+            }]
         },
         {
             code: "const foo = function (a\n, b) { return a + b; }",
             output: "const foo = function (a,\n b) { return a + b; }",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        FunctionExpression: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    FunctionExpression: false
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6,
                 sourceType: "module"
             },
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Identifier"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Identifier"
+            }]
         },
         {
             code: "function foo([a\n, b]) { return a + b; }",
             output: "function foo([a,\n b]) { return a + b; }",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        ArrayPattern: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    ArrayPattern: false
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6
             },
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Identifier"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Identifier"
+            }]
         },
         {
             code: "const foo = (a\n, b) => { return a + b; }",
             output: "const foo = (a,\n b) => { return a + b; }",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        ArrowFunctionExpression: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    ArrowFunctionExpression: false
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6
             },
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Identifier"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Identifier"
+            }]
         },
         {
             code: "const foo = ([a\n, b]) => { return a + b; }",
             output: "const foo = ([a,\n b]) => { return a + b; }",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        ArrayPattern: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    ArrayPattern: false
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6
             },
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Identifier"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Identifier"
+            }]
         },
         {
             code: "import { a\n, b } from './source';",
             output: "import { a,\n b } from './source';",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        ImportDeclaration: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    ImportDeclaration: false
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6,
                 sourceType: "module"
             },
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "ImportSpecifier"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "ImportSpecifier"
+            }]
         },
         {
             code: "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
             output: "var {foo,\n bar} = {foo:'apples', bar:'oranges'};",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        ObjectPattern: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    ObjectPattern: false
                 }
-            ],
+            }],
             parserOptions: {
                 ecmaVersion: 6
             },
-            errors: [
-                {
-                    messageId: "expectedCommaLast",
-                    type: "Property"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaLast",
+                type: "Property"
+            }]
         },
         {
             code: "var foo = 1,\nbar = 2;",
             output: "var foo = 1\n,bar = 2;",
             options: ["first"],
-            errors: [
-                {
-                    messageId: "expectedCommaFirst",
-                    type: "VariableDeclarator",
-                    column: 12,
-                    endColumn: 13
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaFirst",
+                type: "VariableDeclarator",
+                column: 12,
+                endColumn: 13
+            }]
         },
         {
             code: "f([1,\n2,3]);",
             output: "f([1\n,2,3]);",
             options: ["first"],
-            errors: [
-                {
-                    messageId: "expectedCommaFirst",
-                    type: "Literal"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaFirst",
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = ['apples', \n 'oranges'];",
             output: "var foo = ['apples' \n ,'oranges'];",
             options: ["first"],
-            errors: [
-                {
-                    messageId: "expectedCommaFirst",
-                    type: "Literal"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaFirst",
+                type: "Literal"
+            }]
         },
         {
             code: "var foo = {'a': 1, \n 'b': 2\n ,'c': 3};",
             output: "var foo = {'a': 1 \n ,'b': 2\n ,'c': 3};",
             options: ["first"],
-            errors: [
-                {
-                    messageId: "expectedCommaFirst",
-                    type: "Property"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaFirst",
+                type: "Property"
+            }]
         },
         {
             code: "var a = 'a',\no = 'o',\narr = [1,\n2];",
             output: "var a = 'a',\no = 'o',\narr = [1\n,2];",
             options: ["first", { exceptions: { VariableDeclaration: true } }],
-            errors: [
-                {
-                    messageId: "expectedCommaFirst",
-                    type: "Literal"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaFirst",
+                type: "Literal"
+            }]
         },
         {
             code: "var a = 'a',\nobj = {a: 'a',\nb: 'b'};",
             output: "var a = 'a',\nobj = {a: 'a'\n,b: 'b'};",
             options: ["first", { exceptions: { VariableDeclaration: true } }],
-            errors: [
-                {
-                    messageId: "expectedCommaFirst",
-                    type: "Property"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaFirst",
+                type: "Property"
+            }]
         },
         {
             code: "var a = 'a',\nobj = {a: 'a',\nb: 'b'};",
             output: "var a = 'a'\n,obj = {a: 'a',\nb: 'b'};",
             options: ["first", { exceptions: { ObjectExpression: true } }],
-            errors: [
-                {
-                    messageId: "expectedCommaFirst",
-                    type: "VariableDeclarator"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaFirst",
+                type: "VariableDeclarator"
+            }]
         },
         {
             code: "var a = 'a',\narr = [1,\n2];",
             output: "var a = 'a'\n,arr = [1,\n2];",
             options: ["first", { exceptions: { ArrayExpression: true } }],
-            errors: [
-                {
-                    messageId: "expectedCommaFirst",
-                    type: "VariableDeclarator"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaFirst",
+                type: "VariableDeclarator"
+            }]
         },
         {
             code: "var ar =[1,\n{a: 'a',\nb: 'b'}];",
             output: "var ar =[1,\n{a: 'a'\n,b: 'b'}];",
             options: ["first", { exceptions: { ArrayExpression: true } }],
-            errors: [
-                {
-                    messageId: "expectedCommaFirst",
-                    type: "Property"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaFirst",
+                type: "Property"
+            }]
         },
         {
             code: "var ar =[1,\n{a: 'a',\nb: 'b'}];",
             output: "var ar =[1\n,{a: 'a',\nb: 'b'}];",
             options: ["first", { exceptions: { ObjectExpression: true } }],
-            errors: [
-                {
-                    messageId: "expectedCommaFirst",
-                    type: "ObjectExpression"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaFirst",
+                type: "ObjectExpression"
+            }]
         },
         {
             code: "var ar ={fst:1,\nsnd: [1,\n2]};",
             output: "var ar ={fst:1,\nsnd: [1\n,2]};",
             options: ["first", { exceptions: { ObjectExpression: true } }],
-            errors: [
-                {
-                    messageId: "expectedCommaFirst",
-                    type: "Literal"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaFirst",
+                type: "Literal"
+            }]
         },
         {
             code: "var ar ={fst:1,\nsnd: [1,\n2]};",
             output: "var ar ={fst:1\n,snd: [1,\n2]};",
             options: ["first", { exceptions: { ArrayExpression: true } }],
-            errors: [
-                {
-                    messageId: "expectedCommaFirst",
-                    type: "Property"
-                }
-            ]
+            errors: [{
+                messageId: "expectedCommaFirst",
+                type: "Property"
+            }]
         },
         {
             code: "new Foo(a,\nb);",
             output: "new Foo(a\n,b);",
-            options: [
-                "first",
-                {
-                    exceptions: {
-                        NewExpression: false
-                    }
+            options: ["first", {
+                exceptions: {
+                    NewExpression: false
                 }
-            ],
+            }],
             errors: [{ messageId: "expectedCommaFirst" }]
         },
         {
             code: "var foo = [\n(bar\n)\n,\nbaz\n];",
             output: "var foo = [\n(bar\n),\nbaz\n];",
-            errors: [
-                {
-                    messageId: "unexpectedLineBeforeAndAfterComma",
-                    type: "Identifier",
-                    column: 1,
-                    endColumn: 2
-                }
-            ]
+            errors: [{
+                messageId: "unexpectedLineBeforeAndAfterComma",
+                type: "Identifier",
+                column: 1,
+                endColumn: 2
+            }]
         },
         {
             code: "[(foo),\n,\nbar]",
@@ -811,14 +649,11 @@ ruleTester.run("comma-style", rule, {
         {
             code: "new Foo(a\n,b);",
             output: "new Foo(a,\nb);",
-            options: [
-                "last",
-                {
-                    exceptions: {
-                        NewExpression: false
-                    }
+            options: ["last", {
+                exceptions: {
+                    NewExpression: false
                 }
-            ],
+            }],
             errors: [{ messageId: "expectedCommaLast" }]
         },
         {

--- a/tests/lib/rules/comma-style.js
+++ b/tests/lib/rules/comma-style.js
@@ -237,7 +237,6 @@ ruleTester.run("comma-style", rule, {
         "var foo = [\n , \n 1, \n 2 \n];",
         {
             code: "const [\n , \n , \n a, \n b, \n] = arr;",
-            output: "const [\n , \n , \n a, \n b, \n] = arr;",
             options: ["last", {
                 exceptions: {
                     ArrayPattern: false
@@ -249,7 +248,6 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "const [\n ,, \n a, \n b, \n] = arr;",
-            output: "const [\n ,, \n a, \n b, \n] = arr;",
             options: ["last", {
                 exceptions: {
                     ArrayPattern: false
@@ -261,7 +259,6 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "const arr = [\n 1 \n , \n ,2 \n]",
-            output: "const arr = [\n 1 \n , \n ,2 \n]",
             options: ["first"],
             parserOptions: {
                 ecmaVersion: 6
@@ -269,7 +266,6 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "const arr = [\n ,'fifi' \n]",
-            output: "const arr = [\n ,'fifi' \n]",
             options: ["first"],
             parserOptions: {
                 ecmaVersion: 6


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).
- [X] The team has reached consensus on the changes proposed in this pull request. If not, I understand that the evaluation process will begin with this pull request and won't be merged until the team has reached consensus.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Bug fix
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Fix the issue here: #12756

This PR fixes a bug in the rule **comma-style**, it ignores lines that are only made of empty elements. 
This is an example:

```
const [
    ,
    a,
    b,
] = arr;

```

####  Is there anything you'd like reviewers to focus on?
No.