### PR TITLE
Update: `no-new-func` rule catching eval case of `MemberExpression`

### DIFF
--- a/docs/rules/no-new-func.md
+++ b/docs/rules/no-new-func.md
@@ -19,6 +19,8 @@ Examples of **incorrect** code for this rule:
 
 var x = new Function("a", "b", "return a + b");
 var x = Function("a", "b", "return a + b");
+var x = Function.call(null, "a", "b", "return a + b");
+var x = Function.apply(null, ["a", "b", "return a + b"]);
 ```
 
 Examples of **correct** code for this rule:

--- a/docs/rules/no-new-func.md
+++ b/docs/rules/no-new-func.md
@@ -8,6 +8,7 @@ var x = Function("a", "b", "return a + b");
 var x = Function.call(null, "a", "b", "return a + b");
 var x = Function.apply(null, ["a", "b", "return a + b"]);
 var x = Function.bind(null, "a", "b", "return a + b")();
+var f = Function.bind(null, "a", "b", "return a + b"); // assuming that the result of Function.bind(...) will be eventually called.
 ```
 
 This is considered by many to be a bad practice due to the difficulty in debugging and reading these types of functions. In addition, Content-Security-Policy (CSP) directives may disallow the use of eval() and similar methods for creating code from strings.

--- a/docs/rules/no-new-func.md
+++ b/docs/rules/no-new-func.md
@@ -26,6 +26,7 @@ var x = Function("a", "b", "return a + b");
 var x = Function.call(null, "a", "b", "return a + b");
 var x = Function.apply(null, ["a", "b", "return a + b"]);
 var x = Function.bind(null, "a", "b", "return a + b")();
+var f = Function.bind(null, "a", "b", "return a + b"); // assuming that the result of Function.bind(...) will be eventually called.
 ```
 
 Examples of **correct** code for this rule:

--- a/docs/rules/no-new-func.md
+++ b/docs/rules/no-new-func.md
@@ -1,12 +1,16 @@
 # Disallow Function Constructor (no-new-func)
 
-It's possible to create functions in JavaScript using the `Function` constructor, such as:
+It's possible to create functions in JavaScript from strings at runtime using `Function` constructors, such as:
 
 ```js
 var x = new Function("a", "b", "return a + b");
+var x = Function("a", "b", "return a + b");
+var x = Function.call(null, "a", "b", "return a + b");
+var x = Function.apply(null, ["a", "b", "return a + b"]);
+var x = Function.bind(null, "a", "b", "return a + b")();
 ```
 
-This is considered by many to be a bad practice due to the difficulty in debugging and reading these types of functions.
+This is considered by many to be a bad practice due to the difficulty in debugging and reading these types of functions. In addition, Content-Security-Policy (CSP) directives may disallow the use of eval() and similar methods for creating code from strings.
 
 ## Rule Details
 

--- a/docs/rules/no-new-func.md
+++ b/docs/rules/no-new-func.md
@@ -8,7 +8,6 @@ var x = Function("a", "b", "return a + b");
 var x = Function.call(null, "a", "b", "return a + b");
 var x = Function.apply(null, ["a", "b", "return a + b"]);
 var x = Function.bind(null, "a", "b", "return a + b")();
-var f = Function.bind(null, "a", "b", "return a + b"); // assuming that the result of Function.bind(...) will be eventually called.
 ```
 
 This is considered by many to be a bad practice due to the difficulty in debugging and reading these types of functions. In addition, Content-Security-Policy (CSP) directives may disallow the use of eval() and similar methods for creating code from strings.

--- a/docs/rules/no-new-func.md
+++ b/docs/rules/no-new-func.md
@@ -21,6 +21,7 @@ var x = new Function("a", "b", "return a + b");
 var x = Function("a", "b", "return a + b");
 var x = Function.call(null, "a", "b", "return a + b");
 var x = Function.apply(null, ["a", "b", "return a + b"]);
+var x = Function.bind(null, "a", "b", "return a + b")();
 ```
 
 Examples of **correct** code for this rule:

--- a/docs/rules/no-new-func.md
+++ b/docs/rules/no-new-func.md
@@ -1,6 +1,6 @@
 # Disallow Function Constructor (no-new-func)
 
-It's possible to create functions in JavaScript from strings at runtime using `Function` constructors, such as:
+It's possible to create functions in JavaScript from strings at runtime using the `Function` constructor, such as:
 
 ```js
 var x = new Function("a", "b", "return a + b");

--- a/lib/rules/no-new-func.js
+++ b/lib/rules/no-new-func.js
@@ -38,12 +38,23 @@ module.exports = {
                     variable.references.forEach(ref => {
                         const node = ref.identifier;
                         const { parent } = node;
+                        var isEval = false;
 
-                        if (
-                            parent &&
-                            (parent.type === "NewExpression" || parent.type === "CallExpression") &&
-                            node === parent.callee
-                        ) {
+                        if (parent) {
+                            if (node === parent.callee && (
+                                parent.type === "NewExpression" ||
+                                parent.type === "CallExpression"
+                            )) {
+                                isEval = true;
+                            } else if (parent.type === "MemberExpression") {
+                                var gParent = parent.parent;
+                                if (gParent && gParent.type === "CallExpression") {
+                                    isEval = true;
+                                }
+                            }
+                        }
+
+                        if(isEval) {
                             context.report({
                                 node: parent,
                                 messageId: "noFunctionConstructor"

--- a/lib/rules/no-new-func.js
+++ b/lib/rules/no-new-func.js
@@ -46,10 +46,10 @@ module.exports = {
                                 parent.type === "CallExpression"
                             )) {
                                 isEval = true;
-                            } else if (parent.type === "MemberExpression") {
-                                const gParent = parent.parent;
+                            } else if (parent.type === "MemberExpression" && node === parent.object) {
+                                const maybeCallee = parent.parent.type === "ChainExpression" ? parent.parent : parent;
 
-                                if (gParent && gParent.type === "CallExpression") {
+                                if (maybeCallee.parent.type === "CallExpression" && maybeCallee.parent.callee === maybeCallee) {
                                     isEval = true;
                                 }
                             }

--- a/lib/rules/no-new-func.js
+++ b/lib/rules/no-new-func.js
@@ -38,26 +38,26 @@ module.exports = {
                     variable.references.forEach(ref => {
                         const node = ref.identifier;
                         const { parent } = node;
-                        let isEval = false;
+                        let evalNode;
 
                         if (parent) {
                             if (node === parent.callee && (
                                 parent.type === "NewExpression" ||
                                 parent.type === "CallExpression"
                             )) {
-                                isEval = true;
+                                evalNode = parent;
                             } else if (parent.type === "MemberExpression" && node === parent.object) {
                                 const maybeCallee = parent.parent.type === "ChainExpression" ? parent.parent : parent;
 
                                 if (maybeCallee.parent.type === "CallExpression" && maybeCallee.parent.callee === maybeCallee) {
-                                    isEval = true;
+                                    evalNode = parent.parent;
                                 }
                             }
                         }
 
-                        if (isEval) {
+                        if (evalNode) {
                             context.report({
-                                node: parent,
+                                node: evalNode,
                                 messageId: "noFunctionConstructor"
                             });
                         }

--- a/lib/rules/no-new-func.js
+++ b/lib/rules/no-new-func.js
@@ -50,7 +50,7 @@ module.exports = {
                                 const maybeCallee = parent.parent.type === "ChainExpression" ? parent.parent : parent;
 
                                 if (maybeCallee.parent.type === "CallExpression" && maybeCallee.parent.callee === maybeCallee) {
-                                    evalNode = parent.parent;
+                                    evalNode = maybeCallee.parent;
                                 }
                             }
                         }

--- a/lib/rules/no-new-func.js
+++ b/lib/rules/no-new-func.js
@@ -6,6 +6,18 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("./utils/ast-utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const callMethods = new Set(["apply", "bind", "call"]);
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -46,7 +58,11 @@ module.exports = {
                                 parent.type === "CallExpression"
                             )) {
                                 evalNode = parent;
-                            } else if (parent.type === "MemberExpression" && node === parent.object) {
+                            } else if (
+                                parent.type === "MemberExpression" &&
+                                node === parent.object &&
+                                callMethods.has(astUtils.getStaticPropertyName(parent))
+                            ) {
                                 const maybeCallee = parent.parent.type === "ChainExpression" ? parent.parent : parent;
 
                                 if (maybeCallee.parent.type === "CallExpression" && maybeCallee.parent.callee === maybeCallee) {

--- a/lib/rules/no-new-func.js
+++ b/lib/rules/no-new-func.js
@@ -38,7 +38,7 @@ module.exports = {
                     variable.references.forEach(ref => {
                         const node = ref.identifier;
                         const { parent } = node;
-                        var isEval = false;
+                        let isEval = false;
 
                         if (parent) {
                             if (node === parent.callee && (
@@ -47,14 +47,15 @@ module.exports = {
                             )) {
                                 isEval = true;
                             } else if (parent.type === "MemberExpression") {
-                                var gParent = parent.parent;
+                                const gParent = parent.parent;
+
                                 if (gParent && gParent.type === "CallExpression") {
                                     isEval = true;
                                 }
                             }
                         }
 
-                        if(isEval) {
+                        if (isEval) {
                             context.report({
                                 node: parent,
                                 messageId: "noFunctionConstructor"

--- a/tests/lib/rules/no-new-func.js
+++ b/tests/lib/rules/no-new-func.js
@@ -70,6 +70,13 @@ ruleTester.run("no-new-func", rule, {
             }]
         },
         {
+            code: "var a = Function.bind(null, \"b\", \"c\", \"return b+c\")();",
+            errors: [{
+                messageId: "noFunctionConstructor",
+                type: "MemberExpression"
+            }]
+        },
+        {
             code: "const fn = () => { class Function {} }; new Function('', '')",
             parserOptions: {
                 ecmaVersion: 2015

--- a/tests/lib/rules/no-new-func.js
+++ b/tests/lib/rules/no-new-func.js
@@ -56,6 +56,20 @@ ruleTester.run("no-new-func", rule, {
             }]
         },
         {
+            code: "var a = Function.call(null, \"b\", \"c\", \"return b+c\");",
+            errors: [{
+                messageId: "noFunctionConstructor",
+                type: "MemberExpression"
+            }]
+        },
+        {
+            code: "var a = Function.apply(null, [\"b\", \"c\", \"return b+c\"]);",
+            errors: [{
+                messageId: "noFunctionConstructor",
+                type: "MemberExpression"
+            }]
+        },
+        {
             code: "const fn = () => { class Function {} }; new Function('', '')",
             parserOptions: {
                 ecmaVersion: 2015

--- a/tests/lib/rules/no-new-func.js
+++ b/tests/lib/rules/no-new-func.js
@@ -38,7 +38,9 @@ ruleTester.run("no-new-func", rule, {
         "var fn = function () { function Function() {}; Function() }",
         "var x = function Function() { Function(); }",
         "call(Function)",
-        "new Class(Function)"
+        "new Class(Function)",
+        "foo[Function]()",
+        "foo(Function.bind)"
     ],
     invalid: [
         {
@@ -78,6 +80,14 @@ ruleTester.run("no-new-func", rule, {
         },
         {
             code: "var a = Function.bind(null, \"b\", \"c\", \"return b+c\");",
+            errors: [{
+                messageId: "noFunctionConstructor",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "var a = (Function?.call)(null, \"b\", \"c\", \"return b+c\");",
+            parserOptions: { ecmaVersion: 2021 },
             errors: [{
                 messageId: "noFunctionConstructor",
                 type: "CallExpression"

--- a/tests/lib/rules/no-new-func.js
+++ b/tests/lib/rules/no-new-func.js
@@ -77,6 +77,13 @@ ruleTester.run("no-new-func", rule, {
             }]
         },
         {
+            code: "var a = Function.bind(null, \"b\", \"c\", \"return b+c\");",
+            errors: [{
+                messageId: "noFunctionConstructor",
+                type: "MemberExpression"
+            }]
+        },
+        {
             code: "const fn = () => { class Function {} }; new Function('', '')",
             parserOptions: {
                 ecmaVersion: 2015

--- a/tests/lib/rules/no-new-func.js
+++ b/tests/lib/rules/no-new-func.js
@@ -40,7 +40,9 @@ ruleTester.run("no-new-func", rule, {
         "call(Function)",
         "new Class(Function)",
         "foo[Function]()",
-        "foo(Function.bind)"
+        "foo(Function.bind)",
+        "Function.toString()",
+        "Function[call]()"
     ],
     invalid: [
         {
@@ -80,6 +82,13 @@ ruleTester.run("no-new-func", rule, {
         },
         {
             code: "var a = Function.bind(null, \"b\", \"c\", \"return b+c\");",
+            errors: [{
+                messageId: "noFunctionConstructor",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "var a = Function[\"call\"](null, \"b\", \"c\", \"return b+c\");",
             errors: [{
                 messageId: "noFunctionConstructor",
                 type: "CallExpression"

--- a/tests/lib/rules/no-new-func.js
+++ b/tests/lib/rules/no-new-func.js
@@ -59,28 +59,28 @@ ruleTester.run("no-new-func", rule, {
             code: "var a = Function.call(null, \"b\", \"c\", \"return b+c\");",
             errors: [{
                 messageId: "noFunctionConstructor",
-                type: "MemberExpression"
+                type: "CallExpression"
             }]
         },
         {
             code: "var a = Function.apply(null, [\"b\", \"c\", \"return b+c\"]);",
             errors: [{
                 messageId: "noFunctionConstructor",
-                type: "MemberExpression"
+                type: "CallExpression"
             }]
         },
         {
             code: "var a = Function.bind(null, \"b\", \"c\", \"return b+c\")();",
             errors: [{
                 messageId: "noFunctionConstructor",
-                type: "MemberExpression"
+                type: "CallExpression"
             }]
         },
         {
             code: "var a = Function.bind(null, \"b\", \"c\", \"return b+c\");",
             errors: [{
                 messageId: "noFunctionConstructor",
-                type: "MemberExpression"
+                type: "CallExpression"
             }]
         },
         {


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[x] Include tests for this change
[x] Update documentation for this change

#### What changes did you make? (Give an overview)
The `no-new-func` rule should be able to catch calls to `Function.apply` (see the example below) concerning dynamic Function() constructor in the form of eval().
```js
var fn = Function.apply('sum', ['a', 'b', 'return a+b;']);
fn(1, 2);
```

#### Is there anything you'd like reviewers to focus on?
This would allow testing libraries to comply with CSP as demonstrated in https://github.com/plotly/plotly.js/pull/5868

cc: @alexcjohnson