### PR TITLE
Chore: Code path analysis for class fields (fixes #14343)

### DIFF
--- a/tests/fixtures/code-path-analysis/class-field--conditional.js
+++ b/tests/fixtures/code-path-analysis/class-field--conditional.js
@@ -1,0 +1,20 @@
+/*expected
+initial->s1_1->s1_2->s1_4;
+s1_1->s1_3->s1_4->final;
+*/
+
+class x { a = b ? c : d }
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nClassDeclaration:enter\nIdentifier (x)\nClassBody:enter\nPropertyDefinition:enter\nIdentifier (a)\nConditionalExpression:enter\nIdentifier (b)"];
+    s1_2[label="Identifier (c)"];
+    s1_4[label="ConditionalExpression:exit\nPropertyDefinition:exit\nClassBody:exit\nClassDeclaration:exit\nProgram:exit"];
+    s1_3[label="Identifier (d)"];
+    initial->s1_1->s1_2->s1_4;
+    s1_1->s1_3->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/object-literal--conditional.js
+++ b/tests/fixtures/code-path-analysis/object-literal--conditional.js
@@ -1,0 +1,20 @@
+/*expected
+initial->s1_1->s1_2->s1_4;
+s1_1->s1_3->s1_4->final;
+*/
+
+x = { a: b ? c : d }
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nAssignmentExpression:enter\nIdentifier (x)\nObjectExpression:enter\nProperty:enter\nIdentifier (a)\nConditionalExpression:enter\nIdentifier
+    (b)"];
+    s1_2[label="Identifier (c)"];
+    s1_4[label="ConditionalExpression:exit\nProperty:exit\nObjectExpression:exit\nAssignmentExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    s1_3[label="Identifier (d)"];
+    initial->s1_1->s1_2->s1_4;
+    s1_1->s1_3->s1_4->final;
+}*/

--- a/tests/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -561,11 +561,11 @@ describe("CodePathAnalyzer", () => {
                     }
                 }));
                 const messages = linter.verify(source, {
-                    parserOptions: { ecmaVersion: 2021 },
+                    parserOptions: { ecmaVersion: 2022 },
                     rules: { test: 2 }
                 });
 
-                assert.strictEqual(messages.length, 0);
+                assert.strictEqual(messages.length, 0, "Unexpected linting error in code.");
                 assert.strictEqual(actual.length, expected.length, "a count of code paths is wrong.");
 
                 for (let i = 0; i < actual.length; ++i) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I added tests for code path analysis to show that analysis is working correctly for class fields. No other changes were necessary as I believe the standard traversal gives the code path analyzer all of the information it needs.

I started by adding a test that showed how we currently traverse an object literal with a property that is initialized by a conditional statement because this is the closest analog to how code path analysis should work with class fields.

I then added a test showing that a class field initialized with a conditional statement creates the correct code path, as it basically matches what happened in the object literal case.


#### Is there anything you'd like reviewers to focus on?

Am I missing anything?