### PR TITLE
Chore: Update `escape-string-regexp` to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "debug": "^4.0.1",
     "doctrine": "^3.0.0",
     "enquirer": "^2.3.5",
-    "escape-string-regexp": "^4.0.0",
+    "escape-string-regexp": "^5.0.0",
     "eslint-scope": "^6.0.0",
     "eslint-utils": "^3.0.0",
     "eslint-visitor-keys": "^2.1.0",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:


#### What changes did you make? (Give an overview)


Upgrades a dependency now that we have dropped support for old Node versions.

Changelog: https://github.com/sindresorhus/escape-string-regexp/releases/tag/v5.0.0

#### Is there anything you'd like reviewers to focus on?

No.