### PR TITLE
Fix: no-useless-computed-key edge cases with class fields (refs #14857)

### DIFF
--- a/docs/rules/no-useless-computed-key.md
+++ b/docs/rules/no-useless-computed-key.md
@@ -20,7 +20,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-useless-computed-key: "error"*/
-/*eslint-env es6*/
 
 var a = { ['0']: 0 };
 var a = { ['0+1,234']: 0 };
@@ -41,6 +40,18 @@ var c = { a: 0 };
 var c = { '0+1,234': 0 };
 ```
 
+Examples of additional **correct** code for this rule:
+
+```js
+/*eslint no-useless-computed-key: "error"*/
+
+var c = {
+    "__proto__": foo, // defines object's prototype
+
+    ["__proto__"]: bar // defines a property named "__proto__"
+};
+```
+
 ## Options
 
 This rule has an object option:
@@ -52,21 +63,61 @@ This rule has an object option:
 By default, this rule does not check class declarations and class expressions,
 as the default value for `enforceForClassMembers` is `false`.
 
-When `enforceForClassMembers` is set to `true`, the rule will also disallow unnecessary computed
-keys inside of class methods, getters and setters.
+When `enforceForClassMembers` is set to `true`, the rule will also disallow unnecessary computed keys inside of class fields, class methods, class getters, and class setters.
 
-Examples of **incorrect** code for `{ "enforceForClassMembers": true }`:
+Examples of **incorrect** code for this rule with the `{ "enforceForClassMembers": true }` option:
 
 ```js
 /*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": true }]*/
 
 class Foo {
+    ["foo"] = "bar";
+
     [0]() {}
     ['a']() {}
     get ['b']() {}
     set ['c'](value) {}
 
+    static ["foo"] = "bar";
+
     static ['a']() {}
+}
+```
+
+Examples of **correct** code for this rule with the `{ "enforceForClassMembers": true }` option:
+
+```js
+/*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": true }]*/
+
+class Foo {
+    "foo" = "bar";
+
+    0() {}
+    'a'() {}
+    get 'b'() {}
+    set 'c'(value) {}
+
+    static "foo" = "bar";
+
+    static 'a'() {}
+}
+```
+
+Examples of additional **correct** code for this rule with the `{ "enforceForClassMembers": true }` option:
+
+```js
+/*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": true }]*/
+
+class Foo {
+    ["constructor"]; // instance field named "constructor"
+
+    "constructor"() {} // the constructor of this class
+
+    ["constructor"]() {} // method named "constructor"
+
+    static ["constructor"]; // static field named "constructor"
+
+    static ["prototype"]; // runtime error, it would be a parsing error without `[]`
 }
 ```
 

--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -11,6 +11,76 @@
 const astUtils = require("./utils/ast-utils");
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Determines whether the computed key syntax is unnecessarily used for the given node.
+ * In particular, it determines whether removing the square brackets and using the content between them
+ * directly as the key (e.g. ['foo'] -> 'foo') would produce valid syntax and preserve the same behavior.
+ * Valid non-computed keys are only: identifiers, number literals and string literals.
+ * Only literals can preserve the same behavior, with a few exceptions for specific node types:
+ * Property
+ *   - { ["__proto__"]: foo } defines a property named "__proto__"
+ *     { "__proto__": foo } defines object's prototype
+ * PropertyDefinition
+ *   - class C { ["constructor"]; } defines an instance field named "constructor"
+ *     class C { "constructor"; } produces a parsing error
+ *   - class C { static ["constructor"]; } defines a static field named "constructor"
+ *     class C { static "constructor"; } produces a parsing error
+ *   - class C { static ["prototype"]; } produces a runtime error (doesn't break the whole script)
+ *     class C { static "prototype"; } produces a parsing error (breaks the whole script)
+ * MethodDefinition
+ *   - class C { ["constructor"]() {} } defines a prototype method named "constructor"
+ *     class C { "constructor"() {} } defines the constructor
+ *   - class C { static ["prototype"]() {} } produces a runtime error (doesn't break the whole script)
+ *     class C { static "prototype"() {} } produces a parsing error (breaks the whole script)
+ * @param {ASTNode} node The node to check. It can be `Property`, `PropertyDefinition` or `MethodDefinition`.
+ * @returns {void} `true` if the node has useless computed key.
+ */
+function hasUselessComputedKey(node) {
+    if (!node.computed) {
+        return false;
+    }
+
+    const { key } = node;
+
+    if (key.type !== "Literal") {
+        return false;
+    }
+
+    const { value } = key;
+
+    if (typeof value !== "number" && typeof value !== "string") {
+        return false;
+    }
+
+    switch (node.type) {
+        case "Property":
+            return value !== "__proto__";
+
+        case "PropertyDefinition":
+            if (node.static) {
+                return value !== "constructor" && value !== "prototype";
+            }
+
+            return value !== "constructor";
+
+        case "MethodDefinition":
+            if (node.static) {
+                return value !== "prototype";
+            }
+
+            return value !== "constructor";
+
+        /* istanbul ignore next */
+        default:
+            throw new Error(`Unexpected node type: ${node.type}`);
+    }
+
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -51,22 +121,9 @@ module.exports = {
          * @returns {void}
          */
         function check(node) {
-            if (!node.computed) {
-                return;
-            }
+            if (hasUselessComputedKey(node)) {
+                const { key } = node;
 
-            const key = node.key,
-                nodeType = typeof key.value;
-
-            let allowedKey;
-
-            if (node.type === "MethodDefinition") {
-                allowedKey = node.static ? "prototype" : "constructor";
-            } else {
-                allowedKey = "__proto__";
-            }
-
-            if (key.type === "Literal" && (nodeType === "string" || nodeType === "number") && key.value !== allowedKey) {
                 context.report({
                     node,
                     messageId: "unnecessarilyComputedProperty",

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -42,6 +42,9 @@ ruleTester.run("no-useless-computed-key", rule, {
         { code: "class Foo { static ['constructor']() {} }", options: [{ enforceForClassMembers: false }] },
         { code: "class Foo { ['prototype']() {} }", options: [{ enforceForClassMembers: false }] },
         { code: "class Foo { a }", options: [{ enforceForClassMembers: true }] },
+        { code: "class Foo { ['constructor'] }", options: [{ enforceForClassMembers: true }] },
+        { code: "class Foo { static ['constructor'] }", options: [{ enforceForClassMembers: true }] },
+        { code: "class Foo { static ['prototype'] }", options: [{ enforceForClassMembers: true }] },
 
         /*
          * Well-known browsers throw syntax error bigint literals on property names,
@@ -239,6 +242,22 @@ ruleTester.run("no-useless-computed-key", rule, {
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "2" },
+                type: "Property"
+            }]
+        }, {
+            code: "({ ['constructor']: 1 })",
+            output: "({ 'constructor': 1 })",
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "'constructor'" },
+                type: "Property"
+            }]
+        }, {
+            code: "({ ['prototype']: 1 })",
+            output: "({ 'prototype': 1 })",
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "'prototype'" },
                 type: "Property"
             }]
         }, {
@@ -462,6 +481,24 @@ ruleTester.run("no-useless-computed-key", rule, {
                 type: "MethodDefinition"
             }]
         }, {
+            code: "(class { ['__proto__']() {} })",
+            output: "(class { '__proto__'() {} })",
+            options: [{ enforceForClassMembers: true }],
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "'__proto__'" },
+                type: "MethodDefinition"
+            }]
+        }, {
+            code: "(class { static ['__proto__']() {} })",
+            output: "(class { static '__proto__'() {} })",
+            options: [{ enforceForClassMembers: true }],
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "'__proto__'" },
+                type: "MethodDefinition"
+            }]
+        }, {
             code: "(class { static ['constructor']() {} })",
             output: "(class { static 'constructor'() {} })",
             options: [{ enforceForClassMembers: true }],
@@ -513,6 +550,33 @@ ruleTester.run("no-useless-computed-key", rule, {
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'#foo'" },
+                type: "PropertyDefinition"
+            }]
+        }, {
+            code: "(class { ['__proto__'] })",
+            output: "(class { '__proto__' })",
+            options: [{ enforceForClassMembers: true }],
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "'__proto__'" },
+                type: "PropertyDefinition"
+            }]
+        }, {
+            code: "(class { static ['__proto__'] })",
+            output: "(class { static '__proto__' })",
+            options: [{ enforceForClassMembers: true }],
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "'__proto__'" },
+                type: "PropertyDefinition"
+            }]
+        }, {
+            code: "(class { ['prototype'] })",
+            output: "(class { 'prototype' })",
+            options: [{ enforceForClassMembers: true }],
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "'prototype'" },
                 type: "PropertyDefinition"
             }]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

refs #14857, fixes https://github.com/eslint/eslint/pull/14591#pullrequestreview-690053478

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Fixed the `no-useless-computed-key` rule to account for specific names like `"constructor"` in class fields.
* Updated the docs with class fields.


#### Is there anything you'd like reviewers to focus on?
