### PR TITLE
Docs: add class fields in func-names documentation (refs #14857)

### DIFF
--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -17,14 +17,14 @@ This rule can enforce or disallow the use of named function expressions.
 This rule has a string option:
 
 * `"always"` (default) requires function expressions to have a name
-* `"as-needed"` requires function expressions to have a name, if the name cannot be assigned automatically in an ES6 environment
+* `"as-needed"` requires function expressions to have a name, if the name isn't assigned automatically per the ECMAScript specification.
 * `"never"` disallows named function expressions, except in recursive functions, where a name is needed
 
 This rule has an object option:
 
 * `"generators": "always" | "as-needed" | "never"`
     * `"always"` require named generators
-    * `"as-needed"` require named generators if the name cannot be assigned automatically in an ES6 environment.
+    * `"as-needed"` require named generators if the name isn't assigned automatically per the ECMAScript specification.
     * `"never"` disallow named generators where possible.
 
 When a value for `generators` is not provided the behavior for generator functions falls back to the base option.
@@ -97,6 +97,13 @@ var bar = function() {};
 const cat = {
   meow: function() {}
 }
+
+class C {
+    #bar = function() {};
+    baz = function() {};
+}
+
+quux ??= function() {};
 
 (function bar() {
     // ...


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

refs #14857, fixes https://github.com/eslint/eslint/pull/14591#issuecomment-875789724

#### What changes did you make? (Give an overview)

Updated documentation for the `func-names` rule to clarify that `as-needed` logic isn't tied to ES6, and added examples with class fields and logical assignment operators. 

#### Is there anything you'd like reviewers to focus on?

I believe the reason to specify ES6 was an expectation that future specifications might add more cases where the name is automatically assigned, e.g. `a.b = function() {}`, in which case the rule would become unpredictable for users and difficult to maintain (whether or not the name will be automatically assigned for the same syntax would depend on the targeted environment). However, that never happened, except for the cases with new syntax, so I think it's safe to say "per the ECMAScript specification" instead of "in an ES6 environment".
