### PR TITLE
Update: fix no-unreachable logic for class fields (refs #14857)

### DIFF
--- a/docs/rules/no-unreachable.md
+++ b/docs/rules/no-unreachable.md
@@ -10,9 +10,21 @@ function fn() {
 }
 ```
 
+Another kind of mistake is defining instance fields in a subclass whose constructor doesn't call `super()`. Instance fields of a subclass are only added to the instance after `super()`. If there are no `super()` calls, their definitions are never applied and therefore are unreachable code.
+
+```js
+class C extends B {
+    #x; // this will never be added to instances
+
+    constructor() {
+        return {};
+    }
+}
+```
+
 ## Rule Details
 
-This rule disallows unreachable code after `return`, `throw`, `continue`, and `break` statements.
+This rule disallows unreachable code after `return`, `throw`, `continue`, and `break` statements. This rule also flags definitions of instance fields in subclasses whose constructors don't have `super()` calls.
 
 Examples of **incorrect** code for this rule:
 
@@ -71,5 +83,59 @@ switch (foo) {
     case 1:
         break;
         var x;
+}
+```
+
+Examples of additional **incorrect** code for this rule:
+
+```js
+/*eslint no-unreachable: "error"*/
+
+class C extends B {
+    #x; // unreachable
+    #y = 1; // unreachable
+    a; // unreachable
+    b = 1; // unreachable
+
+    constructor() {
+        return {};
+    }
+}
+```
+
+Examples of additional **correct** code for this rule:
+
+```js
+/*eslint no-unreachable: "error"*/
+
+class D extends B {
+    #x;
+    #y = 1;
+    a;
+    b = 1;
+
+    constructor() {
+        super();
+    }
+}
+
+class E extends B {
+    #x;
+    #y = 1;
+    a;
+    b = 1;
+
+    // implicit constructor always calls `super()`
+}
+
+class F extends B {
+    static #x;
+    static #y = 1;
+    static a;
+    static b = 1;
+
+    constructor() {
+        return {};
+    }
 }
 ```

--- a/lib/rules/no-unreachable.js
+++ b/lib/rules/no-unreachable.js
@@ -9,9 +9,8 @@
 //------------------------------------------------------------------------------
 
 /**
- * @typedef {Object} ClassInfo
- * @property {ClassInfo | null} upper The class info that encloses this class.
- * @property {boolean} hasConstructor The flag about having user-defined constructor.
+ * @typedef {Object} ConstructorInfo
+ * @property {ConstructorInfo | null} upper Info about the constructor that encloses this constructor.
  * @property {boolean} hasSuperCall The flag about having `super()` expressions.
  */
 
@@ -127,8 +126,8 @@ module.exports = {
     create(context) {
         let currentCodePath = null;
 
-        /** @type {ClassInfo | null} */
-        let classInfo = null;
+        /** @type {ConstructorInfo | null} */
+        let constructorInfo = null;
 
         /** @type {ConsecutiveRange} */
         const range = new ConsecutiveRange(context.getSourceCode());
@@ -225,36 +224,39 @@ module.exports = {
                 reportIfUnreachable();
             },
 
-            // Address class fields.
-            "ClassDeclaration, ClassExpression"() {
-                classInfo = {
-                    upper: classInfo,
-                    hasConstructor: false,
+            /*
+             * Instance fields defined in a subclass are never created if the constructor of the subclass
+             * doesn't call `super()`, so their definitions are unreachable code.
+             */
+            "MethodDefinition[kind='constructor']"() {
+                constructorInfo = {
+                    upper: constructorInfo,
                     hasSuperCall: false
                 };
             },
-            "ClassDeclaration, ClassExpression:exit"(node) {
-                const { hasConstructor, hasSuperCall } = classInfo;
-                const hasExtends = Boolean(node.superClass);
+            "MethodDefinition[kind='constructor']:exit"(node) {
+                const { hasSuperCall } = constructorInfo;
 
-                classInfo = classInfo.upper;
+                constructorInfo = constructorInfo.upper;
 
-                if (hasConstructor && hasExtends && !hasSuperCall) {
-                    for (const element of node.body.body) {
-                        if (element.type === "PropertyDefinition") {
+                // skip typescript constructors without the body
+                if (!node.value.body) {
+                    return;
+                }
+
+                const classDefinition = node.parent.parent;
+
+                if (classDefinition.superClass && !hasSuperCall) {
+                    for (const element of classDefinition.body.body) {
+                        if (element.type === "PropertyDefinition" && !element.static) {
                             reportIfUnreachable(element);
                         }
                     }
                 }
             },
-            "MethodDefinition[kind='constructor']"() {
-                if (classInfo) {
-                    classInfo.hasConstructor = true;
-                }
-            },
             "CallExpression > Super.callee"() {
-                if (classInfo) {
-                    classInfo.hasSuperCall = true;
+                if (constructorInfo) {
+                    constructorInfo.hasSuperCall = true;
                 }
             }
         };

--- a/tests/lib/rules/no-unreachable.js
+++ b/tests/lib/rules/no-unreachable.js
@@ -81,6 +81,10 @@ ruleTester.run("no-unreachable", rule, {
         {
             code: "class C extends B { foo = reachable; constructor() { super(); } }",
             parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C extends B { static foo = reachable; constructor() {} }",
+            parserOptions: { ecmaVersion: 2022 }
         }
     ],
     invalid: [
@@ -348,6 +352,36 @@ ruleTester.run("no-unreachable", rule, {
             errors: [
                 { messageId: "unreachableCode", column: 21, endColumn: 25 },
                 { messageId: "unreachableCode", column: 43, endColumn: 47 }
+            ]
+        },
+        {
+            code: "(class extends B { foo; constructor() {} bar; })",
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "unreachableCode", column: 20, endColumn: 24 },
+                { messageId: "unreachableCode", column: 42, endColumn: 46 }
+            ]
+        },
+        {
+            code: "class B extends A { x; constructor() { class C extends D { [super().x]; constructor() {} } } }",
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "unreachableCode", column: 60, endColumn: 72 }
+            ]
+        },
+        {
+            code: "class B extends A { x; constructor() { class C extends super().x { y; constructor() {} } } }",
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "unreachableCode", column: 68, endColumn: 70 }
+            ]
+        },
+        {
+            code: "class B extends A { x; static y; z; static q; constructor() {} }",
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "unreachableCode", column: 21, endColumn: 23 },
+                { messageId: "unreachableCode", column: 34, endColumn: 36 }
             ]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

refs #14857, fixes https://github.com/eslint/eslint/pull/14591#pullrequestreview-700195963 and https://github.com/eslint/eslint/pull/14591#issuecomment-874951639.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `no-unreachable` rule to report only instance fields (i.e., not report static fields) when the constructor of a subclass doesn't call `super()`, Also to correctly handle edge cases where `super()` call appears in an inner class definition inside the constructor, and to skip typescript's constructors without the body (similar to https://github.com/eslint/eslint/pull/13842).

#### Is there anything you'd like reviewers to focus on?
