### PR TITLE
Chore: Fix Makefile call to linter.getRules()

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -638,7 +638,8 @@ target.gensite = function(prereleaseVersion) {
         };
     }
 
-    const rules = require(".").linter.getRules();
+    const { Linter } = require(".");
+    const rules = new Linter().getRules();
 
     const RECOMMENDED_TEXT = "\n\n(recommended) The `\"extends\": \"eslint:recommended\"` property in a configuration file enables this rule.";
     const FIXABLE_TEXT = "\n\n(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.";


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Fix the release script

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The first attempt to release `v8.0.0-beta.0` failed when `Makefile.js` tried to call `linter.getRules()`.

https://github.com/eslint/eslint/blob/0c86b68a6e2435eb03b681b51b099b552b521adc/Makefile.js#L641

The `linter` object was removed in v8.0.0, so we need to create an instance of `Linter`.

#### Is there anything you'd like reviewers to focus on?

There's another `getRules()` call later in the script when it's generating formatter examples, but that's called from `CLIEngine`, so it should work. At some point we ought to migrate `Makefile.js` to the `ESLint` API.