### PR TITLE
Build: Remove Node 16 CI prerelease workaround (refs #14933)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,6 @@ jobs:
         node-version: ${{ matrix.node }}
     - name: Install Packages
       run: npm install
-      # TODO(btmills): Remove Node 16 --force branching after releasing v8.0.0 final.
-      if: ${{ !startswith(matrix.node, '16') }}
-    - name: Install Packages
-      run: npm install --force
-      if: ${{ startswith(matrix.node, '16') }}
     - name: Test
       run: node Makefile mocha
     - name: Fuzz Test


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Remove CI prerelease workaround

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Several dev dependencies have a peer dependency on the local ESLint. Prereleases don't satisfy regular version range constraints, so the new peer dependency resolution algorithm in Node 16 rejects `v8.0.0-beta.0` as a valid peer dependency. Until we're done with prereleases, we can use the `--force` flag to force npm to accept that the prerelease satisfies the peer dependency.

#### Is there anything you'd like reviewers to focus on?

Once we release `v8.0.0` stable, we can merge this PR.