### PR TITLE
Fix: keyword-spacing private name compat (refs #14857)

### DIFF
--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -403,7 +403,15 @@ module.exports = {
          */
         function checkSpacingForForInStatement(node) {
             checkSpacingAroundFirstToken(node);
-            checkSpacingAroundTokenBefore(node.right);
+
+            const inToken = sourceCode.getTokenBefore(node.right, astUtils.isNotOpeningParenToken);
+            const previousToken = sourceCode.getTokenBefore(inToken);
+
+            if (previousToken.type !== "PrivateIdentifier") {
+                checkSpacingBefore(inToken);
+            }
+
+            checkSpacingAfter(inToken);
         }
 
         /**
@@ -419,7 +427,15 @@ module.exports = {
             } else {
                 checkSpacingAroundFirstToken(node);
             }
-            checkSpacingAround(sourceCode.getTokenBefore(node.right, astUtils.isNotOpeningParenToken));
+
+            const ofToken = sourceCode.getTokenBefore(node.right, astUtils.isNotOpeningParenToken);
+            const previousToken = sourceCode.getTokenBefore(ofToken);
+
+            if (previousToken.type !== "PrivateIdentifier") {
+                checkSpacingBefore(ofToken);
+            }
+
+            checkSpacingAfter(ofToken);
         }
 
         /**

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -380,8 +380,8 @@ ruleTester.run("keyword-spacing", rule, {
         { code: "<Foo onClick={ class{}} />", options: [NEITHER], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
 
         // private names
-        { code: "class C {\n#x;\nfoo() {\nfor (this.#x of bar){}}}", options: [{ before: false }], parserOptions: { ecmaVersion: 2022, ecmaFeatures: { jsx: true } } },
-        { code: "class C {\n#x;\nfoo() {\nfor (this.#x in bar){}}}", options: [{ before: false }], parserOptions: { ecmaVersion: 2022, ecmaFeatures: { jsx: true } } },
+        { code: "class C {\n#x;\nfoo() {\nfor (this.#x of bar){}}}", options: [{ before: false }], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C {\n#x;\nfoo() {\nfor (this.#x in bar){}}}", options: [{ before: false }], parserOptions: { ecmaVersion: 2022 } },
 
         //----------------------------------------------------------------------
         // const

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -379,6 +379,10 @@ ruleTester.run("keyword-spacing", rule, {
         { code: "<Foo onClick={class {}} />", parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
         { code: "<Foo onClick={ class{}} />", options: [NEITHER], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
 
+        // private names
+        { code: "class C {\n#x;\nfoo() {\nfor (this.#x of bar){}}}", options: [{ before: false }], parserOptions: { ecmaVersion: 2022, ecmaFeatures: { jsx: true } } },
+        { code: "class C {\n#x;\nfoo() {\nfor (this.#x in bar){}}}", options: [{ before: false }], parserOptions: { ecmaVersion: 2022, ecmaFeatures: { jsx: true } } },
+
         //----------------------------------------------------------------------
         // const
         //----------------------------------------------------------------------


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixes incorrect behavior in `for-of` and `for-in` when a private identifier is used in the lefthand side.

https://github.com/eslint/eslint/pull/14591#pullrequestreview-701480702


#### Is there anything you'd like reviewers to focus on?

Did I miss anything?