### PR TITLE
Update: support class fields in func-name-matching (refs #14857)

### DIFF
--- a/docs/rules/func-name-matching.md
+++ b/docs/rules/func-name-matching.md
@@ -15,6 +15,10 @@ obj.foo = function bar() {};
 obj['foo'] = function bar() {};
 var obj = {foo: function bar() {}};
 ({['foo']: function bar() {}});
+
+class C {
+    foo = function bar() {};
+}
 ```
 
 ```js
@@ -26,6 +30,10 @@ obj.foo = function foo() {};
 obj['foo'] = function foo() {};
 var obj = {foo: function foo() {}};
 ({['foo']: function foo() {}});
+
+class C {
+    foo = function foo() {};
+}
 ```
 
 Examples of **correct** code for this rule:
@@ -54,6 +62,21 @@ obj['x' + 2] = function bar(){};
 var [ bar ] = [ function bar(){} ];
 ({[foo]: function bar() {}})
 
+class C {
+    foo = function foo() {};
+    baz = function() {};
+}
+
+// private names are ignored
+class D {
+    #foo = function foo() {};
+    #bar = function foo() {};
+    baz() {
+        this.#foo = function foo() {};
+        this.#foo = function bar() {};
+    }
+}
+
 module.exports = function foo(name) {};
 module['exports'] = function foo(name) {};
 ```
@@ -80,6 +103,21 @@ var obj = {foo: function() {}};
 obj['x' + 2] = function bar(){};
 var [ bar ] = [ function bar(){} ];
 ({[foo]: function bar() {}})
+
+class C {
+    foo = function bar() {};
+    baz = function() {};
+}
+
+// private names are ignored
+class D {
+    #foo = function foo() {};
+    #bar = function foo() {};
+    baz() {
+        this.#foo = function foo() {};
+        this.#foo = function bar() {};
+    }
+}
 
 module.exports = function foo(name) {};
 module['exports'] = function foo(name) {};

--- a/lib/rules/func-name-matching.js
+++ b/lib/rules/func-name-matching.js
@@ -196,21 +196,25 @@ module.exports = {
                 const isProp = node.left.type === "MemberExpression";
                 const name = isProp ? astUtils.getStaticPropertyName(node.left) : node.left.name;
 
-                if (node.right.id && isIdentifier(name) && shouldWarn(name, node.right.id.name)) {
+                if (node.right.id && name && isIdentifier(name) && shouldWarn(name, node.right.id.name)) {
                     report(node, name, node.right.id.name, isProp);
                 }
             },
 
-            Property(node) {
-                if (node.value.type !== "FunctionExpression" || !node.value.id || node.computed && !isStringLiteral(node.key)) {
+            "Property, PropertyDefinition[value]"(node) {
+                if (!(node.value.type === "FunctionExpression" && node.value.id)) {
                     return;
                 }
 
-                if (node.key.type === "Identifier") {
+                if (node.key.type === "Identifier" && !node.computed) {
                     const functionName = node.value.id.name;
                     let propertyName = node.key.name;
 
-                    if (considerPropertyDescriptor && propertyName === "value") {
+                    if (
+                        considerPropertyDescriptor &&
+                        propertyName === "value" &&
+                        node.parent.type === "ObjectExpression"
+                    ) {
                         if (isPropertyCall("Object", "defineProperty", node.parent.parent) || isPropertyCall("Reflect", "defineProperty", node.parent.parent)) {
                             const property = node.parent.parent.arguments[1];
 

--- a/tests/lib/rules/func-name-matching.js
+++ b/tests/lib/rules/func-name-matching.js
@@ -262,6 +262,248 @@ ruleTester.run("func-name-matching", rule, {
         {
             code: "foo({ value: function value() {} })",
             options: ["always", { considerPropertyDescriptor: true }]
+        },
+
+        // class fields, private names are ignored
+        {
+            code: "class C { x = function () {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { x = function () {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { 'x' = function () {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { 'x' = function () {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x = function () {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x = function () {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { [x] = function () {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { [x] = function () {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { ['x'] = function () {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { ['x'] = function () {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { x = function x() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { x = function y() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { 'x' = function x() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { 'x' = function y() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x = function x() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x = function x() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x = function y() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x = function y() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { [x] = function x() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { [x] = function x() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { [x] = function y() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { [x] = function y() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { ['x'] = function x() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { ['x'] = function y() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { 'xy ' = function foo() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { 'xy ' = function xy() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { ['xy '] = function foo() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { ['xy '] = function xy() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { 1 = function x0() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { 1 = function x1() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { [1] = function x0() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { [1] = function x1() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { [f()] = function g() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { [f()] = function f() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static x = function x() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static x = function y() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { x = (function y() {})(); }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { x = (function x() {})(); }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "(class { x = function x() {}; })",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "(class { x = function y() {}; })",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x; foo() { this.#x = function x() {}; } }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x; foo() { this.#x = function x() {}; } }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x; foo() { this.#x = function y() {}; } }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x; foo() { this.#x = function y() {}; } }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x; foo() { a.b.#x = function x() {}; } }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x; foo() { a.b.#x = function x() {}; } }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x; foo() { a.b.#x = function y() {}; } }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { #x; foo() { a.b.#x = function y() {}; } }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
         }
     ],
     invalid: [
@@ -553,6 +795,88 @@ ruleTester.run("func-name-matching", rule, {
             parserOptions: { ecmaVersion: 2020 },
             errors: [
                 { messageId: "notMatchProperty", data: { funcName: "bar", name: "bar" } }
+            ]
+        },
+
+        // class fields
+        {
+            code: "class C { x = function y() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "matchProperty", data: { funcName: "y", name: "x" } }
+            ]
+        },
+        {
+            code: "class C { x = function x() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "notMatchProperty", data: { funcName: "x", name: "x" } }
+            ]
+        },
+        {
+            code: "class C { 'x' = function y() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "matchProperty", data: { funcName: "y", name: "x" } }
+            ]
+        },
+        {
+            code: "class C { 'x' = function x() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "notMatchProperty", data: { funcName: "x", name: "x" } }
+            ]
+        },
+        {
+            code: "class C { ['x'] = function y() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "matchProperty", data: { funcName: "y", name: "x" } }
+            ]
+        },
+        {
+            code: "class C { ['x'] = function x() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "notMatchProperty", data: { funcName: "x", name: "x" } }
+            ]
+        },
+        {
+            code: "class C { static x = function y() {}; }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "matchProperty", data: { funcName: "y", name: "x" } }
+            ]
+        },
+        {
+            code: "class C { static x = function x() {}; }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "notMatchProperty", data: { funcName: "x", name: "x" } }
+            ]
+        },
+        {
+            code: "(class { x = function y() {}; })",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "matchProperty", data: { funcName: "y", name: "x" } }
+            ]
+        },
+        {
+            code: "(class { x = function x() {}; })",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "notMatchProperty", data: { funcName: "x", name: "x" } }
             ]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

refs #14857, fixes https://github.com/eslint/eslint/pull/14591#issuecomment-877324627

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the `func-name-matching` rule to:

* ignore assignments to private fields, such as `this.#x = function foo() {};`, instead of crashing (this is a bug fix).
* check and report class field definitions, e.g. `class C { foo = function bar() {}; }`  (this is an enhancement). Private fields are ignored.

#### Is there anything you'd like reviewers to focus on?
