### PR TITLE
Fix: camelcase ignoreGlobals shouldn't apply to undef vars (refs #14857)

### DIFF
--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -240,27 +240,26 @@ module.exports = {
 
             // Report camelcase of global variable references ------------------
             Program() {
-                if (ignoreGlobals) {
-                    return;
-                }
-
                 const scope = context.getScope();
 
-                // Defined globals in config files or directive comments.
-                for (const variable of scope.variables) {
-                    if (
-                        variable.identifiers.length > 0 ||
-                        isGoodName(variable.name)
-                    ) {
-                        continue;
-                    }
-                    for (const reference of variable.references) {
+                if (!ignoreGlobals) {
 
-                        /*
-                         * For backward compatibility, this rule reports read-only
-                         * references as well.
-                         */
-                        reportReferenceId(reference.identifier);
+                    // Defined globals in config files or directive comments.
+                    for (const variable of scope.variables) {
+                        if (
+                            variable.identifiers.length > 0 ||
+                            isGoodName(variable.name)
+                        ) {
+                            continue;
+                        }
+                        for (const reference of variable.references) {
+
+                            /*
+                             * For backward compatibility, this rule reports read-only
+                             * references as well.
+                             */
+                            reportReferenceId(reference.identifier);
+                        }
                     }
                 }
 

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -1012,6 +1012,28 @@ ruleTester.run("camelcase", rule, {
             ]
         },
         {
+            code: "undefined_variable;",
+            options: [{ ignoreGlobals: true }],
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "undefined_variable" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "implicit_global = 1;",
+            options: [{ ignoreGlobals: true }],
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "implicit_global" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
             code: "export * as snake_cased from 'mod'",
             parserOptions: { ecmaVersion: 2020, sourceType: "module" },
             errors: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

refs #14857, fixes https://github.com/eslint/eslint/pull/14591#discussion_r676212379

In ESLint v7.32.0, `ignoreGlobals` option in the `camelcase` rule doesn't apply to undefined variables.

```js
/* eslint camelcase: ["error", { ignoreGlobals: true }] */

undefined_variable; // error

implicit_global = 1; // error

```

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IGNhbWVsY2FzZTogW1wiZXJyb3JcIiwgeyBpZ25vcmVHbG9iYWxzOiB0cnVlIH1dICovXG5cbnVuZGVmaW5lZF92YXJpYWJsZTsgLy8gZXJyb3JcblxuaW1wbGljaXRfZ2xvYmFsID0gMTsgLy8gZXJyb3JcbiIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6MTIsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=) (still v7.32.0)

The refactoring made in https://github.com/eslint/eslint/pull/14591 to support class fields accidentally changed this behavior.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `camelcase` rule to restore the v7.32.0 behavior in regard to the `ignoreGlobals` option and undefined variables, and added missing test cases.

#### Is there anything you'd like reviewers to focus on?
