### PR TITLE
feat: Add outputAssert to RuleTester (fixes #14936)

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -129,6 +129,7 @@ const RuleTesterParameters = [
     "options",
     "errors",
     "output",
+    "outputAssert",
     "only"
 ];
 
@@ -155,7 +156,8 @@ const suggestionObjectParameters = new Set([
     "desc",
     "messageId",
     "data",
-    "output"
+    "output",
+    "outputAssert"
 ]);
 const friendlySuggestionObjectParameterList = `[${[...suggestionObjectParameters].map(key => `'${key}'`).join(", ")}]`;
 
@@ -919,10 +921,27 @@ class RuleTester {
                                         );
                                     }
 
-                                    if (hasOwnProperty(expectedSuggestion, "output")) {
+                                    let assertEqual = assert.strictEqual;
+                                    let assertIsCustom = false;
+
+                                    if (hasOwnProperty(expectedSuggestion, "outputAssert")) {
+
+                                        if (typeof expectedSuggestion.outputAssert !== "function") {
+                                            assert.fail("outputAssert must be a function.");
+                                        }
+
+                                        assertEqual = expectedSuggestion.outputAssert;
+                                        assertIsCustom = true;
+                                    }
+
+                                    /*
+                                     * If either `output` or `outputAssert` are present, then
+                                     * we need to apply fixes and assert.
+                                     */
+                                    if (hasOwnProperty(expectedSuggestion, "output") || assertIsCustom) {
                                         const codeWithAppliedSuggestion = SourceCodeFixer.applyFixes(item.code, [actualSuggestion]).output;
 
-                                        assert.strictEqual(codeWithAppliedSuggestion, expectedSuggestion.output, `Expected the applied suggestion fix to match the test suggestion output for suggestion at index: ${index} on error with message: "${message.message}"`);
+                                        assertEqual(codeWithAppliedSuggestion, expectedSuggestion.output, `Expected the applied suggestion fix to match the test suggestion output for suggestion at index: ${index} on error with message: "${message.message}"`);
                                     }
                                 });
                             }
@@ -935,21 +954,37 @@ class RuleTester {
                 }
             }
 
-            if (hasOwnProperty(item, "output")) {
-                if (item.output === null) {
-                    assert.strictEqual(
+            let assertEqual = assert.strictEqual;
+            let assertIsCustom = false;
+
+            if (hasOwnProperty(item, "outputAssert")) {
+                if (typeof item.outputAssert !== "function") {
+                    assert.fail("outputAssert must be a function.");
+                }
+
+                assertEqual = item.outputAssert;
+                assertIsCustom = true;
+            }
+
+            /*
+             * If either `output` or `outputAssert` are present, then
+             * we need to apply fixes and assert.
+             */
+            if (hasOwnProperty(item, "output") || assertIsCustom) {
+                if (item.output === null && !assertIsCustom) {
+                    assertEqual(
                         result.output,
                         item.code,
                         "Expected no autofixes to be suggested"
                     );
                 } else {
-                    assert.strictEqual(result.output, item.output, "Output is incorrect.");
+                    assertEqual(result.output, item.output, "Output is incorrect.");
                 }
             } else {
-                assert.strictEqual(
+                assertEqual(
                     result.output,
                     item.code,
-                    "The rule fixed the code. Please add 'output' property."
+                    "The rule fixed the code. Please add 'output' or 'outputAssert' property."
                 );
             }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Implemented the `outputAssert` option as described in https://github.com/eslint/eslint/issues/14936#issuecomment-904906489

#### Is there anything you'd like reviewers to focus on?

Does this make sense for the use case?