### PR TITLE
Fix: allow instance and proto def in no-dupe-class-members (refs #14857)

### DIFF
--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -25,7 +25,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-dupe-class-members: "error"*/
-/*eslint-env es6*/
 
 class Foo {
   bar() { }
@@ -41,13 +40,32 @@ class Foo {
   static bar() { }
   static bar() { }
 }
+
+class Foo {
+  bar;
+  bar;
+}
+
+class Foo {
+  static bar;
+  static bar;
+}
+
+class Foo {
+  static bar;
+  static bar() { }
+}
+
+class Foo {
+  static bar;
+  static get bar() { }
+}
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-dupe-class-members: "error"*/
-/*eslint-env es6*/
 
 class Foo {
   bar() { }
@@ -62,6 +80,24 @@ class Foo {
 class Foo {
   static bar() { }
   bar() { }
+}
+```
+
+The rule allows instance fields to have the same name as a method, getter, or setter since they define properties on different objects and thus do not overwrite properties defined by methods, getters, and setters.
+
+Examples of additional **correct** code for this rule:
+
+```js
+/*eslint no-dupe-class-members: "error"*/
+
+class Foo {
+  bar; // defines property 'bar' on instances of Foo
+  bar() { } // defines property 'bar' on Foo.prototype
+}
+
+class Foo {
+  bar; // defines property 'bar' on instances of Foo
+  get bar() { } // defines property 'bar' on Foo.prototype
 }
 ```
 

--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -11,6 +11,8 @@ const astUtils = require("./utils/ast-utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const initialState = Object.freeze({ method: false, get: false, set: false, field: false });
+
 module.exports = {
     meta: {
         type: "problem",
@@ -46,8 +48,8 @@ module.exports = {
 
             if (!stateMap[key]) {
                 stateMap[key] = {
-                    nonStatic: { init: false, get: false, set: false },
-                    static: { init: false, get: false, set: false }
+                    nonStatic: Object.assign(Object.create(null), initialState),
+                    static: Object.assign(Object.create(null), initialState)
                 };
             }
 
@@ -74,29 +76,70 @@ module.exports = {
             // Reports the node if its name has been declared already.
             "MethodDefinition, PropertyDefinition"(node) {
                 const name = astUtils.getStaticPropertyName(node);
-                const kind = node.type === "MethodDefinition" ? node.kind : "field";
+                let kind = null;
 
-                if (name === null || kind === "constructor") {
+                if (node.type === "MethodDefinition") {
+                    ({ kind } = node);
+                } else if (node.type === "PropertyDefinition") {
+                    kind = "field";
+                }
+
+                if (name === null || kind === null || kind === "constructor") {
                     return;
                 }
 
-                const state = getState(name, node.static);
+                const isStatic = node.static;
+                const state = getState(name, isStatic);
                 let isDuplicate = false;
 
-                if (kind === "get") {
-                    isDuplicate = (state.init || state.get);
-                    state.get = true;
-                } else if (kind === "set") {
-                    isDuplicate = (state.init || state.set);
-                    state.set = true;
-                } else {
-                    isDuplicate = (state.init || state.get || state.set);
-                    state.init = true;
+                switch (kind) {
+                    case "method":
+                        isDuplicate = (
+                            state.method ||
+                            state.get ||
+                            state.set ||
+                            (isStatic && state.field)
+                        );
+                        break;
+
+                    case "get":
+                        isDuplicate = (
+                            state.method ||
+                            state.get ||
+                            (isStatic && state.field)
+                        );
+                        break;
+
+                    case "set":
+                        isDuplicate = (
+                            state.method ||
+                            state.set ||
+                            (isStatic && state.field)
+                        );
+                        break;
+
+                    case "field":
+                        isDuplicate = (
+                            (
+                                isStatic &&
+                                (
+                                    state.method ||
+                                    state.get ||
+                                    state.set
+                                )
+                            ) ||
+                            state.field
+                        );
+                        break;
+
+                    // no default
                 }
 
                 if (isDuplicate) {
                     context.report({ node, messageId: "unexpected", data: { name } });
                 }
+
+                state[kind] = true;
             }
         };
     }

--- a/tests/lib/rules/no-dupe-class-members.js
+++ b/tests/lib/rules/no-dupe-class-members.js
@@ -23,6 +23,7 @@ ruleTester.run("no-dupe-class-members", rule, {
         "class A { foo() {} bar() {} }",
         "class A { static foo() {} foo() {} }",
         "class A { get foo() {} set foo(value) {} }",
+        "class A { static get foo() {} static set foo(value) {} }",
         "class A { static foo() {} get foo() {} set foo(value) {} }",
         "class A { foo() { } } class B { foo() { } }",
         "class A { [foo]() {} foo() {} }",
@@ -56,7 +57,15 @@ ruleTester.run("no-dupe-class-members", rule, {
         // private and public
         "class A { foo; static foo; }",
         "class A { foo; #foo; }",
-        "class A { '#foo'; #foo; }"
+        "class A { '#foo'; #foo; }",
+
+        // instance fields vs prototype definitions
+        "class A { foo; foo() {} }",
+        "class A { foo() {} foo; }",
+        "class A { foo; get foo() {} }",
+        "class A { get foo() {} foo; }",
+        "class A { foo; set foo(value) {} }",
+        "class A { set foo(value) {} foo; }"
     ],
     invalid: [
         {
@@ -65,6 +74,85 @@ ruleTester.run("no-dupe-class-members", rule, {
                 { type: "MethodDefinition", line: 1, column: 20, messageId: "unexpected", data: { name: "foo" } }
             ]
         },
+        {
+            code: "class A { get foo() {} get foo() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 24, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { set foo(value) {} set foo(value) {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 29, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { foo() {} get foo() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 20, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { get foo() {} foo() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 24, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { foo() {} set foo(value) {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 20, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { set foo(value) {} foo() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 29, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { static foo() {} static foo() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 27, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { static get foo() {} static get foo() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 31, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { static set foo(value) {} static set foo(value) {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 36, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { static foo() {} static get foo() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 27, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { static get foo() {} static foo() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 31, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { static foo() {} static set foo(value) {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 27, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { static set foo(value) {} static foo() {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 36, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+
         {
             code: "!class A { foo() {} foo() {} };",
             errors: [
@@ -205,28 +293,48 @@ ruleTester.run("no-dupe-class-members", rule, {
                 { type: "MethodDefinition", line: 1, column: 29, messageId: "unexpected", data: { name: "foo" } }
             ]
         },
+
+        // class fields
         {
-            code: "class A { static foo() {} static foo() {} }",
+            code: "class A { static foo; static foo; }",
             errors: [
-                { type: "MethodDefinition", line: 1, column: 27, messageId: "unexpected", data: { name: "foo" } }
+                { type: "PropertyDefinition", line: 1, column: 23, messageId: "unexpected", data: { name: "foo" } }
             ]
         },
         {
-            code: "class A { foo() {} get foo() {} }",
+            code: "class A { static foo; static foo() {} }",
             errors: [
-                { type: "MethodDefinition", line: 1, column: 20, messageId: "unexpected", data: { name: "foo" } }
+                { type: "MethodDefinition", line: 1, column: 23, messageId: "unexpected", data: { name: "foo" } }
             ]
         },
         {
-            code: "class A { set foo(value) {} foo() {} }",
+            code: "class A { static foo() {} static foo; }",
             errors: [
-                { type: "MethodDefinition", line: 1, column: 29, messageId: "unexpected", data: { name: "foo" } }
+                { type: "PropertyDefinition", line: 1, column: 27, messageId: "unexpected", data: { name: "foo" } }
             ]
         },
         {
-            code: "class A { foo; foo; }",
+            code: "class A { static foo; static get foo() {} }",
             errors: [
-                { type: "PropertyDefinition", line: 1, column: 16, messageId: "unexpected", data: { name: "foo" } }
+                { type: "MethodDefinition", line: 1, column: 23, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { static get foo() {} static foo; }",
+            errors: [
+                { type: "PropertyDefinition", line: 1, column: 31, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { static foo; static set foo(value) {} }",
+            errors: [
+                { type: "MethodDefinition", line: 1, column: 23, messageId: "unexpected", data: { name: "foo" } }
+            ]
+        },
+        {
+            code: "class A { static set foo(value) {} static foo; }",
+            errors: [
+                { type: "PropertyDefinition", line: 1, column: 36, messageId: "unexpected", data: { name: "foo" } }
             ]
         }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

refs #14857, fixes https://github.com/eslint/eslint/pull/14591#issuecomment-866757464

#### What changes did you make? (Give an overview)

Fixed the `no-dupe-class-members` to not report instance field and method/getter/setter with the same name as duplicates.

```js
class Foo {
  bar; // defines property 'bar' on instances of Foo
  bar() { } // defines property 'bar' on Foo.prototype
}

class Foo {
  bar; // defines property 'bar' on instances of Foo
  get bar() { } // defines property 'bar' on Foo.prototype
}

class Foo {
  bar; // defines property 'bar' on instances of Foo
  set bar(value) { } // defines property 'bar' on Foo.prototype
}
```

#### Is there anything you'd like reviewers to focus on?

* Does everyone agree that this shouldn't be reported, or at least not by default? Unlike all other combinations, these definitions do not target the same property. It can be argued that field definition mistakenly overrides prototype definitions in lookups, but reporting this might flag valid code such as:

```js
class Foo {
    handleClick = this.handleClick.bind(this);
    handleClick() {
        // ....
    }
}
```

* All added `invalid` tests are regression tests, this change produces only fewer warnings. Some tests that appear as deleted in the diff were just moved to a different position.