### PR TITLE
Update: add configurable comment behavior to no-empty

### DIFF
--- a/docs/rules/no-empty.md
+++ b/docs/rules/no-empty.md
@@ -61,6 +61,8 @@ This rule has an object option for exceptions:
 
 * `"allowEmptyCatch": true` allows empty `catch` clauses (that is, which do not contain a comment)
 
+* `"allowEmptyWithComments": false` makes a block who only contains comments invalid.
+
 ### allowEmptyCatch
 
 Examples of additional **correct** code for this rule with the `{ "allowEmptyCatch": true }` option:
@@ -77,6 +79,19 @@ try {
 catch (ex) {}
 finally {
     /* continue regardless of error */
+}
+```
+
+### allowEmptyWithComments
+
+Example of additional **incorrect** code for this rule with the `{ "allowEmptyWithComments": false }` option:
+
+```js
+/* eslint no-empty: ["error", { "allowEmptyWithComments": false }] */
+try {
+    doSomething();
+} catch (ex) {
+  // Handle it
 }
 ```
 

--- a/lib/rules/no-empty.js
+++ b/lib/rules/no-empty.js
@@ -31,6 +31,10 @@ module.exports = {
                     allowEmptyCatch: {
                         type: "boolean",
                         default: false
+                    },
+                    allowEmptyWithComments: {
+                        type: "boolean",
+                        default: true
                     }
                 },
                 additionalProperties: false
@@ -44,7 +48,8 @@ module.exports = {
 
     create(context) {
         const options = context.options[0] || {},
-            allowEmptyCatch = options.allowEmptyCatch || false;
+            allowEmptyCatch = options.allowEmptyCatch || false,
+            allowEmptyWithComments = options.allowEmptyWithComments ?? true;
 
         const sourceCode = context.getSourceCode();
 
@@ -65,8 +70,8 @@ module.exports = {
                     return;
                 }
 
-                // any other block is only allowed to be empty, if it contains a comment
-                if (sourceCode.getCommentsInside(node).length > 0) {
+                // Allow empty blocks with comments if the `allowEmptyWithComments` option is set to true.
+                if (allowEmptyWithComments && sourceCode.getCommentsInside(node).length > 0) {
                     return;
                 }
 

--- a/lib/rules/no-empty.js
+++ b/lib/rules/no-empty.js
@@ -49,7 +49,7 @@ module.exports = {
     create(context) {
         const options = context.options[0] || {},
             allowEmptyCatch = options.allowEmptyCatch || false,
-            allowEmptyWithComments = options.allowEmptyWithComments ?? true;
+            allowEmptyWithComments = typeof options.allowEmptyWithComments === "undefined" ? true : options.allowEmptyWithComments;
 
         const sourceCode = context.getSourceCode();
 

--- a/tests/lib/rules/no-empty.js
+++ b/tests/lib/rules/no-empty.js
@@ -41,7 +41,8 @@ ruleTester.run("no-empty", rule, {
         "if (foo) { bar() } else { /**/ \n}",
         "if (foo) { bar() } else { // \n}",
         { code: "try { foo(); } catch (ex) {}", options: [{ allowEmptyCatch: true }] },
-        { code: "try { foo(); } catch (ex) {} finally { bar(); }", options: [{ allowEmptyCatch: true }] }
+        { code: "try { foo(); } catch (ex) {} finally { bar(); }", options: [{ allowEmptyCatch: true }] },
+        { code: "try { foo(); } catch (ex) {//empty \n}", options: [{ allowEmptyWithComments: false, allowEmptyCatch: true }] }
     ],
     invalid: [
         { code: "try {} catch (ex) {throw ex}", errors: [{ messageId: "unexpected", data: { type: "block" }, type: "BlockStatement" }] },
@@ -73,6 +74,13 @@ ruleTester.run("no-empty", rule, {
             code: "try { foo(); } catch (ex) {} finally {}",
             errors: [
                 { messageId: "unexpected", data: { type: "block" }, type: "BlockStatement" },
+                { messageId: "unexpected", data: { type: "block" }, type: "BlockStatement" }
+            ]
+        },
+        {
+            code: "try { foo(); } catch (ex) {//empty \n}",
+            options: [{ allowEmptyWithComments: false }],
+            errors: [
                 { messageId: "unexpected", data: { type: "block" }, type: "BlockStatement" }
             ]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**What rule do you want to change?**
`no-empty`

**Does this change cause the rule to produce more or fewer warnings?**
more

**How will the change be implemented? (New option, new default behavior, etc.)?**
A new option, whose default is the current behavior.
Currently, an empty block containing only comments doesn't produce any warning. 
This is fine most of the time, but if for example you want to make sure that catch block don't contain `// todo: handle error`, it can be useful to make this behavior configurable.
This change adds an option to do just that, and if not provided, its default is to allow empty blocks with comments, so that the current behavior remains the default.

**Please provide some example code that this change will affect:**

```js
for(const foo of bar){
 // Keep me in the loop
}
```
```js
try {
   throwError()
} catch {
  // TODO: Handle this error.
}
```

**What does the rule currently do for this code?**
Currently it doesn't produce any error / warning.

**What will the rule do after it's changed?**
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->
Now, it will do the same, unless the `allowEmptyWithComments` option is set to false, in which case it will produce an error / warning
<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
I implemented the new option in `lib/rules/no-empty.js`
I wrote additional tests in `tests/lib/rules/no-empty.js`
I updated the documentation in `docs/rules/no-empty.md`

#### Is there anything you'd like reviewers to focus on?
Their well being !