### PR TITLE
Fix: no-undef-init should not apply to class fields (refs #14857)

### DIFF
--- a/docs/rules/no-undef-init.md
+++ b/docs/rules/no-undef-init.md
@@ -19,13 +19,12 @@ It's considered a best practice to avoid initializing variables to `undefined`.
 
 ## Rule Details
 
-This rule aims to eliminate variable declarations that initialize to `undefined`.
+This rule aims to eliminate `var` and `let` variable declarations that initialize to `undefined`.
 
 Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-undef-init: "error"*/
-/*eslint-env es6*/
 
 var foo = undefined;
 let bar = undefined;
@@ -35,11 +34,29 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-undef-init: "error"*/
-/*eslint-env es6*/
 
 var foo;
 let bar;
-const baz = undefined;
+```
+
+Please note that this rule does not check `const` declarations, destructuring patterns, function parameters, and class fields.
+
+Examples of additional **correct** code for this rule:
+
+```js
+/*eslint no-undef-init: "error"*/
+
+const foo = undefined;
+
+let { bar = undefined } = baz;
+
+[quux = undefined] = quuux;
+
+(foo = undefined) => {};
+
+class Foo {
+    bar = undefined;
+}
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-undef-init.js
+++ b/lib/rules/no-undef-init.js
@@ -33,91 +33,37 @@ module.exports = {
 
         const sourceCode = context.getSourceCode();
 
-        /**
-         * Get the node of init target.
-         * @param {ASTNode} node The node to get.
-         * @throws {Error} (Unreachable.)
-         * @returns {ASTNode} The node of init target.
-         */
-        function getIdNode(node) {
-            switch (node.type) {
-                case "VariableDeclarator":
-                    return node.id;
-                case "PropertyDefinition":
-                    return node.key;
-                default:
-                    throw new Error("unreachable");
-            }
-        }
-
-        /**
-         * Get the node of init value.
-         * @param {ASTNode} node The node to get.
-         * @throws {Error} (Unreachable.)
-         * @returns {ASTNode} The node of init value.
-         */
-        function getInitNode(node) {
-            switch (node.type) {
-                case "VariableDeclarator":
-                    return node.init;
-                case "PropertyDefinition":
-                    return node.value;
-                default:
-                    throw new Error("unreachable");
-            }
-        }
-
-        /**
-         * Get the parent kind of the node.
-         * @param {ASTNode} node The node to get.
-         * @throws {Error} (Unreachable.)
-         * @returns {string} The parent kind.
-         */
-        function getParentKind(node) {
-            switch (node.type) {
-                case "VariableDeclarator":
-                    return node.parent.kind;
-                case "PropertyDefinition":
-                    return "field";
-                default:
-                    throw new Error("unreachable");
-            }
-        }
-
         return {
 
-            "VariableDeclarator, PropertyDefinition"(node) {
-                const idNode = getIdNode(node),
-                    name = sourceCode.getText(idNode),
-                    initNode = getInitNode(node),
-                    initIsUndefined = initNode && initNode.type === "Identifier" && initNode.name === "undefined",
-                    parentKind = getParentKind(node),
+            VariableDeclarator(node) {
+                const name = sourceCode.getText(node.id),
+                    init = node.init && node.init.name,
                     scope = context.getScope(),
                     undefinedVar = astUtils.getVariableByName(scope, "undefined"),
                     shadowed = undefinedVar && undefinedVar.defs.length > 0,
-                    lastToken = sourceCode.getLastToken(node, astUtils.isNotSemicolonToken);
+                    lastToken = sourceCode.getLastToken(node);
 
-                if (initIsUndefined && parentKind !== "const" && !shadowed) {
+                if (init === "undefined" && node.parent.kind !== "const" && !shadowed) {
                     context.report({
                         node,
                         messageId: "unnecessaryUndefinedInit",
                         data: { name },
                         fix(fixer) {
-                            if (parentKind === "var") {
+                            if (node.parent.kind === "var") {
                                 return null;
                             }
 
-                            if (idNode.type === "ArrayPattern" || idNode.type === "ObjectPattern") {
+                            if (node.id.type === "ArrayPattern" || node.id.type === "ObjectPattern") {
 
                                 // Don't fix destructuring assignment to `undefined`.
                                 return null;
                             }
 
-                            if (sourceCode.commentsExistBetween(idNode, lastToken)) {
+                            if (sourceCode.commentsExistBetween(node.id, lastToken)) {
                                 return null;
                             }
 
-                            return fixer.removeRange([idNode.range[1], lastToken.range[1]]);
+                            return fixer.removeRange([node.id.range[1], node.range[1]]);
                         }
                     });
                 }

--- a/tests/lib/rules/no-undef-init.js
+++ b/tests/lib/rules/no-undef-init.js
@@ -22,7 +22,11 @@ ruleTester.run("no-undef-init", rule, {
     valid: [
         "var a;",
         { code: "const foo = undefined", parserOptions: { ecmaVersion: 6 } },
-        "var undefined = 5; var foo = undefined;"
+        "var undefined = 5; var foo = undefined;",
+
+        // doesn't apply to class fields
+        { code: "class C { field = undefined; }", parserOptions: { ecmaVersion: 2022 } }
+
     ],
     invalid: [
         {
@@ -148,32 +152,6 @@ ruleTester.run("no-undef-init", rule, {
             output: "let a//comment\n, b;",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ messageId: "unnecessaryUndefinedInit", data: { name: "a" }, type: "VariableDeclarator" }]
-        },
-
-        // Class fields
-        {
-            code: "class C { field = undefined; }",
-            output: "class C { field; }",
-            parserOptions: { ecmaVersion: 2022 },
-            errors: [{ messageId: "unnecessaryUndefinedInit", data: { name: "field" }, type: "PropertyDefinition" }]
-        },
-        {
-            code: "class C { field = undefined }",
-            output: "class C { field }",
-            parserOptions: { ecmaVersion: 2022 },
-            errors: [{ messageId: "unnecessaryUndefinedInit", data: { name: "field" }, type: "PropertyDefinition" }]
-        },
-        {
-            code: "class C { #field = undefined; }",
-            output: "class C { #field; }",
-            parserOptions: { ecmaVersion: 2022 },
-            errors: [{ messageId: "unnecessaryUndefinedInit", data: { name: "#field" }, type: "PropertyDefinition" }]
-        },
-        {
-            code: "class C { '#field' = undefined; }",
-            output: "class C { '#field'; }",
-            parserOptions: { ecmaVersion: 2022 },
-            errors: [{ messageId: "unnecessaryUndefinedInit", data: { name: "'#field'" }, type: "PropertyDefinition" }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

refs #14857, https://github.com/eslint/eslint/pull/14591#discussion_r656622751

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `no-undef-init` rule to not apply to class fields.

This reverts changes in this rule made in https://github.com/eslint/eslint/pull/14591:

* Rule: https://github.com/eslint/eslint/commit/b953a4ee12f120658a9ec27d1f8ca88dd3dfb599#diff-4b978af22a0bad14389ec82aea71dbf4f0c7feccea421b97b1f1129cf230fd51
* Test:  https://github.com/eslint/eslint/commit/b953a4ee12f120658a9ec27d1f8ca88dd3dfb599#diff-5147a3c0b4071aecf149cf66a781c2fd21f30565e8bf5a56f0667784a79d04aa
 
I also added one `valid` test to confirm that this rule no longer applies to class field.

#### Is there anything you'd like reviewers to focus on?
