### PR TITLE
Update: added ignoreExpressions option to max-classes-per-file

### DIFF
--- a/docs/rules/max-classes-per-file.md
+++ b/docs/rules/max-classes-per-file.md
@@ -28,12 +28,12 @@ class Foo {}
 
 ## Options
 
-This rule may take in either an object or a number.
+This rule may be configured with either an object or a number.
 
 If the option is an object, it may contain one or both of:
 
 -   `ignoreExpressions`: a boolean option (defaulted to `false`) to ignore class expressions.
--   `maximum`: a numeric option (defaulted to 1) to specify the maximum number of classes.
+-   `max`: a numeric option (defaulted to 1) to specify the maximum number of classes.
 
 For example:
 
@@ -47,12 +47,12 @@ For example:
 {
     "max-classes-per-file": [
         "error",
-        { "ignoreExpressions": true, "maximum": 2 }
+        { "ignoreExpressions": true, "max": 2 }
     ]
 }
 ```
 
-Examples of **correct** code for this rule with the `maximum` option set to `2`:
+Examples of **correct** code for this rule with the `max` option set to `2`:
 
 ```js
 /* eslint max-classes-per-file: ["error", 2] */

--- a/docs/rules/max-classes-per-file.md
+++ b/docs/rules/max-classes-per-file.md
@@ -28,8 +28,12 @@ class Foo {}
 
 ## Options
 
-This rule has a numeric option (defaulted to 1) to specify the
-maximum number of classes.
+This rule may take in either an object or a number.
+
+If the option is an object, it may contain one or both of:
+
+-   `ignoreExpressions`: a boolean option (defaulted to `false`) to ignore class expressions.
+-   `maximum`: a numeric option (defaulted to 1) to specify the maximum number of classes.
 
 For example:
 
@@ -39,11 +43,36 @@ For example:
 }
 ```
 
-Examples of **correct** code for this rule with the numeric option set to `2`:
+```json
+{
+    "max-classes-per-file": [
+        "error",
+        { "ignoreExpressions": true, "maximum": 2 }
+    ]
+}
+```
+
+Examples of **correct** code for this rule with the `maximum` option set to `2`:
 
 ```js
 /* eslint max-classes-per-file: ["error", 2] */
 
 class Foo {}
 class Bar {}
+```
+
+Examples of **correct** code for this rule with the `ignoreExpressions` option set to `true`:
+
+```js
+/* eslint max-classes-per-file: ["error", { ignoreExpressions: true }] */
+
+class VisitorFactory {
+    forDescriptor(descriptor) {
+        return class {
+            visit(node) {
+                return `Visiting ${descriptor}.`;
+            }
+        };
+    }
+}
 ```

--- a/lib/rules/max-classes-per-file.js
+++ b/lib/rules/max-classes-per-file.js
@@ -25,8 +25,25 @@ module.exports = {
 
         schema: [
             {
-                type: "integer",
-                minimum: 1
+                oneOf: [
+                    {
+                        type: "integer",
+                        minimum: 1
+                    },
+                    {
+                        type: "object",
+                        properties: {
+                            ignoreExpressions: {
+                                type: "boolean"
+                            },
+                            maxClasses: {
+                                type: "integer",
+                                minimum: 1
+                            }
+                        },
+                        additionalProperties: false
+                    }
+                ]
             }
         ],
 
@@ -35,8 +52,10 @@ module.exports = {
         }
     },
     create(context) {
-
-        const maxClasses = context.options[0] || 1;
+        const [option = {}] = context.options;
+        const [ignoreExpressions, maxClasses] = typeof option === "number"
+            ? [false, option || 1]
+            : [option.ignoreExpressions, option.maxClasses || 1];
 
         let classCount = 0;
 
@@ -56,8 +75,13 @@ module.exports = {
                     });
                 }
             },
-            "ClassDeclaration, ClassExpression"() {
+            "ClassDeclaration"() {
                 classCount++;
+            },
+            "ClassExpression"() {
+                if (!ignoreExpressions) {
+                    classCount++;
+                }
             }
         };
     }

--- a/lib/rules/max-classes-per-file.js
+++ b/lib/rules/max-classes-per-file.js
@@ -36,7 +36,7 @@ module.exports = {
                             ignoreExpressions: {
                                 type: "boolean"
                             },
-                            maxClasses: {
+                            max: {
                                 type: "integer",
                                 minimum: 1
                             }
@@ -53,9 +53,9 @@ module.exports = {
     },
     create(context) {
         const [option = {}] = context.options;
-        const [ignoreExpressions, maxClasses] = typeof option === "number"
+        const [ignoreExpressions, max] = typeof option === "number"
             ? [false, option || 1]
-            : [option.ignoreExpressions, option.maxClasses || 1];
+            : [option.ignoreExpressions, option.max || 1];
 
         let classCount = 0;
 

--- a/lib/rules/max-classes-per-file.js
+++ b/lib/rules/max-classes-per-file.js
@@ -64,13 +64,13 @@ module.exports = {
                 classCount = 0;
             },
             "Program:exit"(node) {
-                if (classCount > maxClasses) {
+                if (classCount > max) {
                     context.report({
                         node,
                         messageId: "maximumExceeded",
                         data: {
                             classCount,
-                            max: maxClasses
+                            max
                         }
                     });
                 }

--- a/tests/lib/rules/max-classes-per-file.js
+++ b/tests/lib/rules/max-classes-per-file.js
@@ -29,12 +29,39 @@ ruleTester.run("max-classes-per-file", rule, {
         {
             code: "class Foo {}\nclass Bar {}",
             options: [2]
+        },
+        {
+            code: "class Foo {}",
+            options: [{ maxClasses: 1 }]
+        },
+        {
+            code: "class Foo {}\nclass Bar {}",
+            options: [{ maxClasses: 2 }]
+        },
+        {
+            code: `
+                class Foo {}
+                const myExpression = class {}
+            `,
+            options: [{ ignoreExpressions: true, maxClasses: 1 }]
+        },
+        {
+            code: `
+                class Foo {}
+                class Bar {}
+                const myExpression = class {}
+            `,
+            options: [{ ignoreExpressions: true, maxClasses: 2 }]
         }
     ],
 
     invalid: [
         {
             code: "class Foo {}\nclass Bar {}",
+            errors: [{ messageId: "maximumExceeded", type: "Program" }]
+        },
+        {
+            code: "class Foo {}\nconst myExpression = class {}",
             errors: [{ messageId: "maximumExceeded", type: "Program" }]
         },
         {
@@ -53,6 +80,25 @@ ruleTester.run("max-classes-per-file", rule, {
         {
             code: "class Foo {} class Bar {} class Baz {}",
             options: [2],
+            errors: [{ messageId: "maximumExceeded", type: "Program" }]
+        },
+        {
+            code: `
+                class Foo {}
+                class Bar {}
+                const myExpression = class {}
+            `,
+            options: [{ ignoreExpressions: true, maxClasses: 1 }],
+            errors: [{ messageId: "maximumExceeded", type: "Program" }]
+        },
+        {
+            code: `
+                class Foo {}
+                class Bar {}
+                class Baz {}
+                const myExpression = class {}
+            `,
+            options: [{ ignoreExpressions: true, maxClasses: 2 }],
             errors: [{ messageId: "maximumExceeded", type: "Program" }]
         }
     ]

--- a/tests/lib/rules/max-classes-per-file.js
+++ b/tests/lib/rules/max-classes-per-file.js
@@ -32,18 +32,18 @@ ruleTester.run("max-classes-per-file", rule, {
         },
         {
             code: "class Foo {}",
-            options: [{ maxClasses: 1 }]
+            options: [{ max: 1 }]
         },
         {
             code: "class Foo {}\nclass Bar {}",
-            options: [{ maxClasses: 2 }]
+            options: [{ max: 2 }]
         },
         {
             code: `
                 class Foo {}
                 const myExpression = class {}
             `,
-            options: [{ ignoreExpressions: true, maxClasses: 1 }]
+            options: [{ ignoreExpressions: true, max: 1 }]
         },
         {
             code: `
@@ -51,7 +51,7 @@ ruleTester.run("max-classes-per-file", rule, {
                 class Bar {}
                 const myExpression = class {}
             `,
-            options: [{ ignoreExpressions: true, maxClasses: 2 }]
+            options: [{ ignoreExpressions: true, max: 2 }]
         }
     ],
 
@@ -88,7 +88,7 @@ ruleTester.run("max-classes-per-file", rule, {
                 class Bar {}
                 const myExpression = class {}
             `,
-            options: [{ ignoreExpressions: true, maxClasses: 1 }],
+            options: [{ ignoreExpressions: true, max: 1 }],
             errors: [{ messageId: "maximumExceeded", type: "Program" }]
         },
         {
@@ -98,7 +98,7 @@ ruleTester.run("max-classes-per-file", rule, {
                 class Baz {}
                 const myExpression = class {}
             `,
-            options: [{ ignoreExpressions: true, maxClasses: 2 }],
+            options: [{ ignoreExpressions: true, max: 2 }],
             errors: [{ messageId: "maximumExceeded", type: "Program" }]
         }
     ]


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


#### What changes did you make? (Give an overview)

Allowed `max-classes` to take in an object for its options, with a new `ignoreExpressions` option alongside the existing `maxClasses`.

Fixes #14855.

#### Is there anything you'd like reviewers to focus on?

These files are a few years old. Would you like me to update them to a newer format?