### PR TITLE
Docs: LintMessage.line and column are possibly undefined

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -376,9 +376,9 @@ The `LintMessage` value is the information of each linting error. The `messages`
   `true` if this is a fatal error unrelated to a rule, like a parsing error.
 * `message` (`string`)<br>
   The error message.
-* `line` (`number`)<br>
+* `line` (`number | undefined`)<br>
   The 1-based line number of the begin point of this message.
-* `column` (`number`)<br>
+* `column` (`number | undefined`)<br>
   The 1-based column number of the begin point of this message.
 * `endLine` (`number | undefined`)<br>
   The 1-based line number of the end point of this message. This property is undefined if this message is not a range.

--- a/lib/shared/types.js
+++ b/lib/shared/types.js
@@ -83,12 +83,12 @@ module.exports = {};
 
 /**
  * @typedef {Object} LintMessage
- * @property {number} column The 1-based column number.
+ * @property {number|undefined} column The 1-based column number.
  * @property {number} [endColumn] The 1-based column number of the end location.
  * @property {number} [endLine] The 1-based line number of the end location.
  * @property {boolean} fatal If `true` then this is a fatal error.
  * @property {{range:[number,number], text:string}} [fix] Information for autofix.
- * @property {number} line The 1-based line number.
+ * @property {number|undefined} line The 1-based line number.
  * @property {string} message The error message.
  * @property {string|null} ruleId The ID of the rule which makes this message.
  * @property {0|1|2} severity The severity of this message.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In `lib/linter/linter.js`, the `parse()` function's exception handler translates the exception's message to a `LintMessage`. It also passes through the exception's `lineNumber` and `column`, but the exception is not guaranteed to have those properties. In that case, `LintMessage.line` and `column` can be `undefined`.

https://github.com/eslint/eslint/blob/f966fe6286b6f668812f5155b79d4ee2a8b584b3/lib/linter/linter.js#L693-L711

In eslint/eslint-plugin-markdown#191, the processor would crash when attempting to map messages without a line.

#### Is there anything you'd like reviewers to focus on?

Normally widening a type like this would be a breaking change, but since this is only updating the docs to reflect reality, I think this can be a semver-patch change.

For the JSDoc type, I used `{number|undefined} line` instead of `{number} [line]` because `line` and `column` are always present but may have the value `undefined`.