### PR TITLE
Chore: fix failing cli test

### DIFF
--- a/tests/fixtures/rules/wrong/custom-rule.js
+++ b/tests/fixtures/rules/wrong/custom-rule.js
@@ -1,5 +1,3 @@
 module.exports = function() {
-
-    "use strict";
-    return (null).something;
+    throw new Error("Boom!");
 };

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -512,7 +512,7 @@ describe("cli", () => {
                 const exit = await cli.execute(code);
 
                 assert.strictEqual(exit, 2);
-            }, /Error while loading rule 'custom-rule': Cannot read property/u);
+            }, /Error while loading rule 'custom-rule': Boom!/u);
         });
 
         it("should return a warning when rule is matched", async () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

One of the tests expects that `null.something` throws error with a certain message, but that message has been sligthly changed in the latest Node 16 and thus the test fails:

https://github.com/eslint/eslint/pull/15039/checks?check_run_id=3549061940

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the test to not rely on v8 error messages.

#### Is there anything you'd like reviewers to focus on?
