### PR TITLE
Fix: semicolon-less style in lines-between-class-members (refs #14857)

### DIFF
--- a/docs/rules/lines-between-class-members.md
+++ b/docs/rules/lines-between-class-members.md
@@ -9,6 +9,7 @@ Examples of **incorrect** code for this rule:
 ```js
 /* eslint lines-between-class-members: ["error", "always"]*/
 class MyClass {
+  x;
   foo() {
     //...
   }
@@ -23,6 +24,8 @@ Examples of **correct** code for this rule:
 ```js
 /* eslint lines-between-class-members: ["error", "always"]*/
 class MyClass {
+  x;
+
   foo() {
     //...
   }
@@ -30,6 +33,17 @@ class MyClass {
   bar() {
     //...
   }
+}
+```
+
+Examples of additional **correct** code for this rule:
+
+```js
+/* eslint lines-between-class-members: ["error", "always"]*/
+class MyClass {
+  x = 1
+
+  ;in = 2
 }
 ```
 
@@ -52,12 +66,15 @@ Examples of **incorrect** code for this rule with the string option:
 ```js
 /* eslint lines-between-class-members: ["error", "always"]*/
 class Foo{
+  x;
   bar(){}
   baz(){}
 }
 
 /* eslint lines-between-class-members: ["error", "never"]*/
 class Foo{
+  x;
+
   bar(){}
 
   baz(){}
@@ -69,6 +86,8 @@ Examples of **correct** code for this rule with the string option:
 ```js
 /* eslint lines-between-class-members: ["error", "always"]*/
 class Foo{
+  x;
+
   bar(){}
 
   baz(){}
@@ -76,6 +95,7 @@ class Foo{
 
 /* eslint lines-between-class-members: ["error", "never"]*/
 class Foo{
+  x;
   bar(){}
   baz(){}
 }
@@ -86,6 +106,7 @@ Examples of **correct** code for this rule with the object option:
 ```js
 /* eslint lines-between-class-members: ["error", "always", { "exceptAfterSingleLine": true }]*/
 class Foo{
+  x; // single line class member
   bar(){} // single line class member
   baz(){
     // multi line class member

--- a/lib/rules/lines-between-class-members.js
+++ b/lib/rules/lines-between-class-members.js
@@ -4,6 +4,10 @@
  */
 "use strict";
 
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
 const astUtils = require("./utils/ast-utils");
 
 //------------------------------------------------------------------------------
@@ -53,6 +57,51 @@ module.exports = {
         const sourceCode = context.getSourceCode();
 
         /**
+         * Gets a pair of tokens that should be used to check lines between two class member nodes.
+         *
+         * In most cases, this returns the very last token of the current node and
+         * the very first token of the next node.
+         * For example:
+         *
+         *     class C {
+         *         x = 1;   // curLast: `;` nextFirst: `in`
+         *         in = 2
+         *     }
+         *
+         * There is only one exception. If the given node ends with a semicolon, and it looks like
+         * a semicolon-less style's semicolon - one that is not on the same line as the preceding
+         * token, but is on the line where the next class member starts - this returns the preceding
+         * token and the semicolon as boundary tokens.
+         * For example:
+         *
+         *     class C {
+         *         x = 1    // curLast: `1` nextFirst: `;`
+         *         ;in = 2
+         *     }
+         * When determining the desired layout of the code, we should treat this semicolon as
+         * a part of the next class member node instead of the one it technically belongs to.
+         * @param {ASTNode} curNode Current class member node.
+         * @param {ASTNode} nextNode Next class member node.
+         * @returns {Token} The actual last token of `node`.
+         * @private
+         */
+        function getBoundaryTokens(curNode, nextNode) {
+            const lastToken = sourceCode.getLastToken(curNode);
+            const prevToken = sourceCode.getTokenBefore(lastToken);
+            const nextToken = sourceCode.getFirstToken(nextNode); // skip possible lone `;` between nodes
+
+            const isSemicolonLessStyle = (
+                astUtils.isSemicolonToken(lastToken) &&
+                !astUtils.isTokenOnSameLine(prevToken, lastToken) &&
+                astUtils.isTokenOnSameLine(lastToken, nextToken)
+            );
+
+            return isSemicolonLessStyle
+                ? { curLast: prevToken, nextFirst: lastToken }
+                : { curLast: lastToken, nextFirst: nextToken };
+        }
+
+        /**
          * Return the last token among the consecutive tokens that have no exceed max line difference in between, before the first token in the next member.
          * @param {Token} prevLastToken The last token in the previous member node.
          * @param {Token} nextFirstToken The first token in the next member node.
@@ -100,8 +149,7 @@ module.exports = {
 
                 for (let i = 0; i < body.length - 1; i++) {
                     const curFirst = sourceCode.getFirstToken(body[i]);
-                    const curLast = sourceCode.getLastToken(body[i]);
-                    const nextFirst = sourceCode.getFirstToken(body[i + 1]);
+                    const { curLast, nextFirst } = getBoundaryTokens(body[i], body[i + 1]);
                     const isMulti = !astUtils.isTokenOnSameLine(curFirst, curLast);
                     const skip = !isMulti && options[1].exceptAfterSingleLine;
                     const beforePadding = findLastConsecutiveTokenAfter(curLast, nextFirst, 1);

--- a/tests/lib/rules/lines-between-class-members.js
+++ b/tests/lib/rules/lines-between-class-members.js
@@ -62,7 +62,12 @@ ruleTester.run("lines-between-class-members", rule, {
 
         { code: "class foo{ bar(){}\nbaz(){}}", options: ["always", { exceptAfterSingleLine: true }] },
         { code: "class foo{ bar(){\n}\n\nbaz(){}}", options: ["always", { exceptAfterSingleLine: true }] },
-        { code: "class foo{\naaa;\n#bbb;\nccc(){\n}\n\n#ddd(){\n}\n}", options: ["always", { exceptAfterSingleLine: true }] }
+        { code: "class foo{\naaa;\n#bbb;\nccc(){\n}\n\n#ddd(){\n}\n}", options: ["always", { exceptAfterSingleLine: true }] },
+
+        // semicolon-less style (semicolons are at the beginning of lines)
+        { code: "class C { foo\n\n;bar }", options: ["always"] },
+        { code: "class C { foo\n;bar }", options: ["always", { exceptAfterSingleLine: true }] },
+        { code: "class C { foo\n;bar }", options: ["never"] }
     ],
     invalid: [
         {
@@ -164,6 +169,44 @@ ruleTester.run("lines-between-class-members", rule, {
             code: "class C {\nfield1 = () => {\n}\nfield2\nfield3\n}",
             output: "class C {\nfield1 = () => {\n}\n\nfield2\nfield3\n}",
             options: ["always", { exceptAfterSingleLine: true }],
+            errors: [alwaysError]
+        },
+        {
+            code: "class C { foo;bar }",
+            output: "class C { foo;\nbar }",
+            options: ["always"],
+            errors: [alwaysError]
+        },
+        {
+            code: "class C { foo;\nbar; }",
+            output: "class C { foo;\n\nbar; }",
+            options: ["always"],
+            errors: [alwaysError]
+        },
+        {
+            code: "class C { foo;\n;bar }",
+            output: "class C { foo;\n\n;bar }",
+            options: ["always"],
+            errors: [alwaysError]
+        },
+
+        // semicolon-less style (semicolons are at the beginning of lines)
+        {
+            code: "class C { foo\n;bar }",
+            output: "class C { foo\n\n;bar }",
+            options: ["always"],
+            errors: [alwaysError]
+        },
+        {
+            code: "class C { foo\n\n;bar }",
+            output: "class C { foo\n;bar }",
+            options: ["never"],
+            errors: [neverError]
+        },
+        {
+            code: "class C { foo\n;;bar }",
+            output: "class C { foo\n\n;;bar }",
+            options: ["always"],
             errors: [alwaysError]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

refs #14857, fixes https://github.com/eslint/eslint/pull/14591#issuecomment-875113378

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `lines-between-class-members` to support semicolon-less style.

For example:

```js
/* eslint lines-between-class-members: ["error", "always"]*/

class C {
  a // this is ok, although this field technically ends with the `;` below
  
  ;b

  c // this isn't ok either way, but the linebreak will be inserted here, not after `;`
  ;d
}
```

This matches the logic in `padding-line-between-statements` ([Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgcGFkZGluZy1saW5lLWJldHdlZW4tc3RhdGVtZW50czogW1xuICAgIFwiZXJyb3JcIixcbiAgICB7IGJsYW5rTGluZTogXCJhbHdheXNcIiwgcHJldjogXCIqXCIsIG5leHQ6IFwiKlwiIH1cbl0qL1xuXG5hIC8vIHRoaXMgaXMgb2ssIGFsdGhvdWdoIHRoaXMgc3RhdGVtZW50IHRlY2huaWNhbGx5IGVuZHMgd2l0aCB0aGUgYDtgIGJlbG93XG4gIFxuO2JcblxuYyAvLyB0aGlzIGlzbid0IG9rIGVpdGhlciB3YXksIGJ1dCB0aGUgbGluZWJyZWFrIHdpbGwgYmUgaW5zZXJ0ZWQgaGVyZSwgbm90IGFmdGVyIGA7YFxuO2QiLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjEyLCJzb3VyY2VUeXBlIjoibW9kdWxlIiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7fSwiZW52Ijp7fX19))

#### Is there anything you'd like reviewers to focus on?
