### PR TITLE
Update: include `ruleId` in error logs of crash (fixes #15037)

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -955,13 +955,31 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
 
         const ruleListeners = createRuleListeners(rule, ruleContext);
 
+        /**
+         * Include `ruleId` in error logs
+         * @param {Function} ruleListener A rule method that listens for a node.
+         * @returns {Function} ruleListener wrapped in error handler
+         */
+        function addRuleErrorHandler(ruleListener) {
+            return function ruleErrorHandler(...listenerArgs) {
+                try {
+                    return ruleListener(...listenerArgs);
+                } catch (e) {
+                    e.ruleId = ruleId;
+                    throw e;
+                }
+            };
+        }
+
         // add all the selectors from the rule as listeners
         Object.keys(ruleListeners).forEach(selector => {
+            const ruleListener = timing.enabled
+                ? timing.time(ruleId, ruleListeners[selector])
+                : ruleListeners[selector];
+
             emitter.on(
                 selector,
-                timing.enabled
-                    ? timing.time(ruleId, ruleListeners[selector])
-                    : ruleListeners[selector]
+                addRuleErrorHandler(ruleListener)
             );
         });
     });
@@ -1223,6 +1241,11 @@ class Linter {
             debug("Parser Options:", parserOptions);
             debug("Parser Path:", parserName);
             debug("Settings:", settings);
+
+            if (err.ruleId) {
+                err.message += `\nRule: "${err.ruleId}"`;
+            }
+
             throw err;
         }
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -87,7 +87,7 @@ describe("Linter", () => {
 
             assert.throws(() => {
                 linter.verify(code, config, filename);
-            }, `Intentional error.\nOccurred while linting ${filename}:1`);
+            }, `Intentional error.\nOccurred while linting ${filename}:1\nRule: "checker"`);
         });
 
         it("does not call rule listeners with a `this` value", () => {
@@ -5300,7 +5300,7 @@ var a = "test2";
 
             assert.throws(() => {
                 linter.verify("0", { rules: { "test-rule": "error" } });
-            }, /Fixable rules must set the `meta\.fixable` property to "code" or "whitespace".\nOccurred while linting <input>:1$/u);
+            }, /Fixable rules must set the `meta\.fixable` property to "code" or "whitespace".\nOccurred while linting <input>:1\nRule: "test-rule"$/u);
         });
 
         it("should throw an error if fix is passed and there is no metadata", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #15037.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added error handling around rule listener calls in `linter.js`. The error handler wrapper is added when `safe-emitter` listeners are created. This seemed like a good place for it since we have `ruleId` easily available.

When extending caught error in try-catch of  `runRules` calls it is checked whether `ruleId` is available. If it's found we include it in the `error.message`. This seems safe and low-risk. 

There were already few test cases available which nicely covered this case. I did not add any new test cases for this reason. 

Example error log generated by this implementation is found from issue description.

#### Is there anything you'd like reviewers to focus on?

Currently the `ruleId` is wrapped with quotes, as in `Rule: "some-plugin/some-rule"` / `Rule: "some-builtin-rule"`. I'm not sure whether quotes should be removed. 