### PR TITLE
feat: support for private-in syntax (fixes #14811)

### DIFF
--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1833,6 +1833,10 @@ module.exports = {
             return true;
         }
 
+        if (rightToken.type === "PrivateIdentifier") {
+            return true;
+        }
+
         return false;
     },
 

--- a/tests/lib/rules/space-unary-ops.js
+++ b/tests/lib/rules/space-unary-ops.js
@@ -250,6 +250,11 @@ ruleTester.run("space-unary-ops", rule, {
             code: "function *foo () { yield(0) }",
             options: [{ words: false, overrides: { yield: false } }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class C { #x; *foo(bar) { yield#x in bar; } }",
+            options: [{ words: false }],
+            parserOptions: { ecmaVersion: 2022 }
         }
     ],
 
@@ -804,6 +809,19 @@ ruleTester.run("space-unary-ops", rule, {
                 type: "AwaitExpression",
                 line: 1,
                 column: 24
+            }]
+        },
+        {
+            code: "class C { #x; *foo(bar) { yield #x in bar; } }",
+            output: "class C { #x; *foo(bar) { yield#x in bar; } }",
+            options: [{ words: false }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "unexpectedAfterWord",
+                data: { word: "yield" },
+                type: "YieldExpression",
+                line: 1,
+                column: 27
             }]
         }
     ]

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -1495,7 +1495,10 @@ describe("ast-utils", () => {
             [["(", "123invalidtoken"], false],
             [["(", "1n"], true],
             [["1n", "+"], true],
-            [["1n", "in"], false]
+            [["1n", "in"], false],
+            [["return", "#x"], true],
+            [["yield", "#x"], true],
+            [["get", "#x"], true]
         ]);
 
         CASES.forEach((expectedResult, tokenStrings) => {


### PR DESCRIPTION
WIP

Remaining steps:

- [x] wait release acorn.
- [x] release espree.
- [x] update package.json with the new versions of espree. #15338

---

Fixes #14811.

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Upgrade the espree.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds support for ES2022 private-in.
I have changed the `space-unary-ops` rule that we know needs to be changed.

#### Is there anything you'd like reviewers to focus on?

I checked keyword-spacing rule, which is similar to space-unary-ops rule, but the rule already seems to work well with `return#x in obj`.

