### PR TITLE
Docs: Add jsdoc `type` annotation to sample rule

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -24,6 +24,9 @@ Here is the basic format of the source file for a rule:
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
     meta: {
         type: "suggestion",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

There are some exciting benefits to adding a jsdoc `type` annotation to the exported object in rule files.

The `type` annotation is supported by VSCode/Webstorm/other code editors. It uses the [TypeScript declaration](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c34d3c8c81ae7f507e9f3725c1462abf2680e717/types/eslint/index.d.ts#L433) so code editors can provide hints/information/autocomplete about rule structure/fields even when only using JavaScript.

<img width="391" alt="133895350-a19d0daf-593e-44b9-835f-bebf8b6a3d30" src="https://user-images.githubusercontent.com/698306/134086408-d526291e-547c-4d03-be02-c028db14b640.png">

https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#type

Idea from: https://github.com/eslint/generator-eslint/pull/113

#### Is there anything you'd like reviewers to focus on?

I have only updated the first rule example. I figured it wouldn't be worth updating every rule example. Should we update any other examples? Should we add a small section about this instead?