### PR TITLE
Fix: require-atomic-updates property assignment message (fixes #15076)

### DIFF
--- a/lib/rules/require-atomic-updates.js
+++ b/lib/rules/require-atomic-updates.js
@@ -179,7 +179,8 @@ module.exports = {
         schema: [],
 
         messages: {
-            nonAtomicUpdate: "Possible race condition: `{{value}}` might be reassigned based on an outdated value of `{{value}}`."
+            nonAtomicUpdate: "Possible race condition: `{{value}}` might be reassigned based on an outdated value of `{{value}}`.",
+            nonAtomicObjectUpdate: "Possible race condition: `{{value}}` might be assigned based on an outdated state of `{{object}}`."
         }
     },
 
@@ -275,13 +276,25 @@ module.exports = {
                         const variable = reference.resolved;
 
                         if (segmentInfo.isOutdated(codePath.currentSegments, variable)) {
-                            context.report({
-                                node: node.parent,
-                                messageId: "nonAtomicUpdate",
-                                data: {
-                                    value: sourceCode.getText(node.parent.left)
-                                }
-                            });
+                            if (node.parent.left === reference.identifier) {
+                                context.report({
+                                    node: node.parent,
+                                    messageId: "nonAtomicUpdate",
+                                    data: {
+                                        value: variable.name
+                                    }
+                                });
+                            } else {
+                                context.report({
+                                    node: node.parent,
+                                    messageId: "nonAtomicObjectUpdate",
+                                    data: {
+                                        value: sourceCode.getText(node.parent.left),
+                                        object: variable.name
+                                    }
+                                });
+                            }
+
                         }
                     }
                 }

--- a/tests/lib/rules/require-atomic-updates.js
+++ b/tests/lib/rules/require-atomic-updates.js
@@ -24,20 +24,20 @@ const VARIABLE_ERROR = {
 };
 
 const STATIC_PROPERTY_ERROR = {
-    messageId: "nonAtomicUpdate",
-    data: { value: "foo.bar" },
+    messageId: "nonAtomicObjectUpdate",
+    data: { value: "foo.bar", object: "foo" },
     type: "AssignmentExpression"
 };
 
 const COMPUTED_PROPERTY_ERROR = {
-    messageId: "nonAtomicUpdate",
-    data: { value: "foo[bar].baz" },
+    messageId: "nonAtomicObjectUpdate",
+    data: { value: "foo[bar].baz", object: "foo" },
     type: "AssignmentExpression"
 };
 
 const PRIVATE_PROPERTY_ERROR = {
-    messageId: "nonAtomicUpdate",
-    data: { value: "foo.#bar" },
+    messageId: "nonAtomicObjectUpdate",
+    data: { value: "foo.#bar", object: "foo" },
     type: "AssignmentExpression"
 };
 
@@ -328,6 +328,36 @@ ruleTester.run("require-atomic-updates", rule, {
                 }
             `,
             errors: [STATIC_PROPERTY_ERROR]
+        },
+
+        // https://github.com/eslint/eslint/issues/15076
+        {
+            code: `
+                async () => {
+                    opts.spec = process.stdin;
+                    try {
+                        const { exit_code } = await run(opts);
+                        process.exitCode = exit_code;
+                    } catch (e) {
+                        process.exitCode = 1;
+                    }
+              };
+            `,
+            env: { node: true },
+            errors: [
+                {
+                    messageId: "nonAtomicObjectUpdate",
+                    data: { value: "process.exitCode", object: "process" },
+                    type: "AssignmentExpression",
+                    line: 6
+                },
+                {
+                    messageId: "nonAtomicObjectUpdate",
+                    data: { value: "process.exitCode", object: "process" },
+                    type: "AssignmentExpression",
+                    line: 8
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

fixes #15076 (fixes invalid error message; possible false positive is being discussed in https://github.com/eslint/eslint/issues/11899)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In the original code from #15076:

```js
'use strict';

const opts = {}; // stubbed for repro
const run = () => Promise.resolve({ exit_code: 0 }); // stubbed for repro

(async () => {
  if (opts._.length) {
    if (opts._[0] === '-') {
      opts.spec = process.stdin;
    } else {
      opts.spec = opts._;
    }
  }
  delete opts._;
  try {
    const { exit_code } = await run(opts);
    process.exitCode = exit_code;
  } catch (e) {
    console.error(e.stack);
    process.exitCode = 1;
  }
})();
```

instead of:

```
Possible race condition: `process.exitCode` might be reassigned based on an outdated value of `process.exitCode`  require-atomic-updates
```

the error message will be:

```
Possible race condition: `process.exitCode` might be assigned based on an outdated state of `process`  require-atomic-updates
```


#### Is there anything you'd like reviewers to focus on?
