### PR TITLE
feat: report class evaluation TDZ errors in no-use-before-define

### DIFF
--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -12,7 +12,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-use-before-define: "error"*/
-/*eslint-env es6*/
 
 alert(a);
 var a = 10;
@@ -29,13 +28,29 @@ var b = 1;
     alert(c);
     let c = 1;
 }
+
+{
+    class C extends C {}
+}
+
+{
+    class C {
+        static x = "foo";
+        [C.x]() {}
+    }
+}
+
+{
+    const C = class {
+        static x = C;
+    }
+}
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-use-before-define: "error"*/
-/*eslint-env es6*/
 
 var a;
 a = 10;
@@ -52,6 +67,24 @@ function g() {
 {
     let c;
     c++;
+}
+
+{
+    class C {
+        static x = C;
+    }
+}
+
+{
+    const C = class C {
+        static x = C;
+    }
+}
+
+{
+    const C = class {
+        x = C;
+    }
 }
 ```
 
@@ -103,10 +136,25 @@ Examples of **incorrect** code for the `{ "classes": false }` option:
 
 ```js
 /*eslint no-use-before-define: ["error", { "classes": false }]*/
-/*eslint-env es6*/
 
 new A();
 class A {
+}
+
+{
+    class C extends C {}
+}
+
+{
+    class C extends D {}
+    class D {}
+}
+
+{
+    class C {
+        static x = "foo";
+        [C.x]() {}
+    }
 }
 ```
 
@@ -114,7 +162,6 @@ Examples of **correct** code for the `{ "classes": false }` option:
 
 ```js
 /*eslint no-use-before-define: ["error", { "classes": false }]*/
-/*eslint-env es6*/
 
 function foo() {
     return new A();
@@ -139,6 +186,19 @@ const f = () => {};
 
 g();
 const g = function() {};
+
+{
+    const C = class {
+        static x = C;
+    }
+}
+
+{
+    const C = class {
+        static x = foo;
+    }
+    const foo = 1;
+}
 ```
 
 Examples of **correct** code for the `{ "variables": false }` option:
@@ -158,4 +218,11 @@ const f = () => {};
 
 const e = function() { return g(); }
 const g = function() {}
+
+{
+    const C = class {
+        x = foo;
+    }
+    const foo = 1;
+}
 ```

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -34,41 +34,6 @@ function parseOptions(options) {
 }
 
 /**
- * Checks whether or not a given variable is a function declaration.
- * @param {eslint-scope.Variable} variable A variable to check.
- * @returns {boolean} `true` if the variable is a function declaration.
- */
-function isFunction(variable) {
-    return variable.defs[0].type === "FunctionName";
-}
-
-/**
- * Checks whether or not a given variable is a class declaration in an upper function scope.
- * @param {eslint-scope.Variable} variable A variable to check.
- * @param {eslint-scope.Reference} reference A reference to check.
- * @returns {boolean} `true` if the variable is a class declaration.
- */
-function isOuterClass(variable, reference) {
-    return (
-        variable.defs[0].type === "ClassName" &&
-        variable.scope.variableScope !== reference.from.variableScope
-    );
-}
-
-/**
- * Checks whether or not a given variable is a variable declaration in an upper function scope.
- * @param {eslint-scope.Variable} variable A variable to check.
- * @param {eslint-scope.Reference} reference A reference to check.
- * @returns {boolean} `true` if the variable is a variable declaration.
- */
-function isOuterVariable(variable, reference) {
-    return (
-        variable.defs[0].type === "Variable" &&
-        variable.scope.variableScope !== reference.from.variableScope
-    );
-}
-
-/**
  * Checks whether or not a given location is inside of the range of a given node.
  * @param {ASTNode} node An node to check.
  * @param {number} location A location to check.
@@ -79,7 +44,81 @@ function isInRange(node, location) {
 }
 
 /**
- * Checks whether or not a given reference is inside of the initializers of a given variable.
+ * Checks whether or not a given location is inside of the range of a class static initializer.
+ * @param {ASTNode} node `ClassBody` node to check static initializers.
+ * @param {number} location A location to check.
+ * @returns {boolean} `true` if the location is inside of a class static initializer.
+ */
+function isInClassStaticInitializerRange(node, location) {
+    return node.body.some(classMember => (
+        classMember.type === "PropertyDefinition" &&
+        classMember.static &&
+        classMember.value &&
+        isInRange(classMember.value, location)
+    ));
+}
+
+/**
+ * Checks whether a given scope is the scope of a static class field initializer.
+ * @param {eslint-scope.Scope} scope A scope to check.
+ * @returns {boolean} `true` if the scope is a class static initializer scope.
+ */
+function isClassStaticInitializerScope(scope) {
+    if (scope.type === "class-field-initializer") {
+
+        // `scope.block` is PropertyDefinition#value node
+        const propertyDefinition = scope.block.parent;
+
+        return propertyDefinition.static;
+    }
+
+    return false;
+}
+
+/**
+ * Checks whether a given reference is evaluated in an execution context
+ * that isn't the one where the variable it refers to is defined.
+ * Execution contexts are:
+ * - top-level
+ * - functions
+ * - class field initializers (implicit functions)
+ * Static class field initializers are automatically run during the class definition evaluation,
+ * and therefore we'll consider them as a part of the parent execution context.
+ * Example:
+ *
+ *   const x = 1;
+ *
+ *   x; // returns `false`
+ *   () => x; // returns `true`
+ *   class C {
+ *       field = x; // returns `true`
+ *       static field = x; // returns `false`
+ *
+ *       method() {
+ *           x; // returns `true`
+ *       }
+ *   }
+ * @param {eslint-scope.Reference} reference A reference to check.
+ * @returns {boolean} `true` if the reference is from a separate execution context.
+ */
+function isFromSeparateExecutionContext(reference) {
+    const variable = reference.resolved;
+    let scope = reference.from;
+
+    // Scope#variableScope represents execution context
+    while (variable.scope.variableScope !== scope.variableScope) {
+        if (isClassStaticInitializerScope(scope.variableScope)) {
+            scope = scope.variableScope.upper;
+        } else {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Checks whether or not a given reference is evaluated during the initialization of its variable.
  *
  * This returns `true` in the following cases:
  *
@@ -88,17 +127,44 @@ function isInRange(node, location) {
  *     var {a = a} = obj
  *     for (var a in a) {}
  *     for (var a of a) {}
- * @param {Variable} variable A variable to check.
+ *     var C = class { [C]; }
+ *     var C = class { static foo = C; }
+ *     class C extends C {}
+ *     class C extends (class { static foo = C; }) {}
+ *     class C { [C]; }
  * @param {Reference} reference A reference to check.
- * @returns {boolean} `true` if the reference is inside of the initializers.
+ * @returns {boolean} `true` if the reference is evaluated during the initialization.
  */
-function isInInitializer(variable, reference) {
-    if (variable.scope !== reference.from) {
+function isEvaluatedDuringInitialization(reference) {
+    if (isFromSeparateExecutionContext(reference)) {
+
+        /*
+         * Even if the reference appears in the initializer, it isn't evaluated during the initialization.
+         * For example, `const x = () => x;` is valid.
+         */
         return false;
     }
 
-    let node = variable.identifiers[0].parent;
     const location = reference.identifier.range[1];
+    const definition = reference.resolved.defs[0];
+
+    if (definition.type === "ClassName") {
+
+        // `ClassDeclaration` or `ClassExpression`
+        const classDefinition = definition.node;
+
+        return (
+            isInRange(classDefinition, location) &&
+
+            /*
+             * Class binding is initialized before running static initializers.
+             * For example, `class C { static foo = C; }` is valid.
+             */
+            !isInClassStaticInitializerRange(classDefinition.body, location)
+        );
+    }
+
+    let node = definition.name.parent;
 
     while (node) {
         if (node.type === "VariableDeclarator") {
@@ -167,65 +233,77 @@ module.exports = {
         const options = parseOptions(context.options[0]);
 
         /**
-         * Determines whether a given use-before-define case should be reported according to the options.
-         * @param {eslint-scope.Variable} variable The variable that gets used before being defined
-         * @param {eslint-scope.Reference} reference The reference to the variable
-         * @returns {boolean} `true` if the usage should be reported
+         * Determines whether a given reference should be checked.
+         *
+         * Returns `false` if the reference is:
+         * - initialization's (e.g., `let a = 1`).
+         * - referring to an undefined variable (i.e., if it's an unresolved reference).
+         * - referring to a variable that is defined, but not in the given source code
+         *   (e.g., global environment variable or `arguments` in functions).
+         * - allowed by options.
+         * @param {eslint-scope.Reference} reference The reference
+         * @returns {boolean} `true` if the reference should be checked
          */
-        function isForbidden(variable, reference) {
-            if (isFunction(variable)) {
-                return options.functions;
+        function shouldCheck(reference) {
+            if (reference.init) {
+                return false;
             }
-            if (isOuterClass(variable, reference)) {
-                return options.classes;
+
+            const variable = reference.resolved;
+
+            if (!variable || variable.defs.length === 0) {
+                return false;
             }
-            if (isOuterVariable(variable, reference)) {
-                return options.variables;
+
+            const definitionType = variable.defs[0].type;
+
+            if (!options.functions && definitionType === "FunctionName") {
+                return false;
             }
+
+            if (
+                (
+                    !options.variables && definitionType === "Variable" ||
+                    !options.classes && definitionType === "ClassName"
+                ) &&
+
+                // don't skip checking the reference if it's in the same execution context, because of TDZ
+                isFromSeparateExecutionContext(reference)
+            ) {
+                return false;
+            }
+
             return true;
         }
 
         /**
-         * Finds and validates all variables in a given scope.
-         * @param {Scope} scope The scope object.
+         * Finds and validates all references in a given scope and its child scopes.
+         * @param {eslint-scope.Scope} scope The scope object.
          * @returns {void}
-         * @private
          */
-        function findVariablesInScope(scope) {
-            scope.references.forEach(reference => {
+        function checkReferencesInScope(scope) {
+            scope.references.filter(shouldCheck).forEach(reference => {
                 const variable = reference.resolved;
+                const definitionIdentifier = variable.defs[0].name;
 
-                /*
-                 * Skips when the reference is:
-                 * - initialization's.
-                 * - referring to an undefined variable.
-                 * - referring to a global environment variable (there're no identifiers).
-                 * - located preceded by the variable (except in initializers).
-                 * - allowed by options.
-                 */
-                if (reference.init ||
-                    !variable ||
-                    variable.identifiers.length === 0 ||
-                    (variable.identifiers[0].range[1] < reference.identifier.range[1] && !isInInitializer(variable, reference)) ||
-                    !isForbidden(variable, reference)
+                if (
+                    reference.identifier.range[1] < definitionIdentifier.range[1] ||
+                    isEvaluatedDuringInitialization(reference)
                 ) {
-                    return;
+                    context.report({
+                        node: reference.identifier,
+                        messageId: "usedBeforeDefined",
+                        data: reference.identifier
+                    });
                 }
-
-                // Reports.
-                context.report({
-                    node: reference.identifier,
-                    messageId: "usedBeforeDefined",
-                    data: reference.identifier
-                });
             });
 
-            scope.childScopes.forEach(findVariablesInScope);
+            scope.childScopes.forEach(checkReferencesInScope);
         }
 
         return {
             Program() {
-                findVariablesInScope(context.getScope());
+                checkReferencesInScope(context.getScope());
             }
         };
     }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

This bug fix produces only more warnings.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v8.0.0-rc.0
* **Node Version:** v12.22.4
* **npm Version:** v6.14.14

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: 2022
    }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint no-use-before-define: error */

class A extends A {} // TDZ error

class B {
    [B]() {} // TDZ error
}

const C = class {
    static foo = C; // TDZ error
}
```

```js
/* eslint no-use-before-define: ["error", { variables: false }] */

class D {
    static foo = x; // TDZ error
}

const x = 1;
```

**What did you expect to happen?**

`no-use-before-define` to report all references marked as "TDZ error" in the above examples.

**What actually happened? Please include the actual, raw output from ESLint.**

No errors.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `no-use-before-define` rule for [ClassDefinitionEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation) steps. Class heritage and computed properties are evaluated before initializing the class binding (`A` and `B` create _classBinding_ in the class scope; they also create an outer variable but the references from the class definition are to the inner one, and the outer one is initialized even later). Static initializers are run after the class binding is initialized (if it exists), but still before initializing `C` in `const C = class ...` and before declarations that appear after the class (`const x`).

#### Is there anything you'd like reviewers to focus on?

Examples that don't require new syntax are reproducible as false negatives in v7.32.0, too ([demo link](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLXVzZS1iZWZvcmUtZGVmaW5lOiBlcnJvciAqL1xuXG5jbGFzcyBBIGV4dGVuZHMgQSB7fSAvLyBURFogZXJyb3JcblxuY2xhc3MgQiB7XG4gICAgW0JdKCkge30gLy8gVERaIGVycm9yXG59XG4iLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjEyLCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7fSwiZW52Ijp7fX19)). This is a bug fix regarding `extends` and computed properties, and a sort of enhancement regarding static field initializers since they're implicit functions. This rule doesn't track function calls, but in this case we can know when they will be called. 
