### PR TITLE
Fix: Allow node access to "./lib/rules" directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": "./lib/api.js",
+    "./lib/rules/*": "./lib/rules/*.js",
     "./use-at-your-own-risk": "./lib/unsupported-api.js"
   },
   "scripts": {


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[ X ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))

#### What changes did you make? (Give an overview)

Add access to `./lib/rules` directory in package.json's `exports`

After update to v8.0.1 my vscode console show the error attached bellow.
The proposed patch fixed that.

#### Prerequisites checklist

- [ X ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

**Tell us about your environment**

* **ESLint Version:**
  8.0.1
* **Node Version:**
 My vscode uses  v14.16.0, outside I use v16
 
* **npm Version:**
 8.0.0
**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**
 Both of them
 
**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    root: true,
    extends: [
        'eslint:recommended'
    ],
    env: {
        node: true,
        es2021: true
    },
    ignorePatterns: [ '**/lib/*.js' ],
    rules: {
        'no-unused-vars': [
            'warn', {
                vars: 'local',
                argsIgnorePattern: 'ev|res'
            }
        ],
        'no-mixed-spaces-and-tabs': 0,
        'require-atomic-updates': 0,
        'no-control-regex': 0,
        'object-shorthand': 1
    },
    parserOptions: {
        //sourceType: 'script',  BUG!?
        ecmaVersion: 2021,
    },
    overrides: [{
        files: [ '**/src/*.js', '**/ComProvs/*.js' ],
        plugins: [ '@babel', 'flowtype' ],
        extends: [ 'plugin:flowtype/recommended' ],
        parser: '@babel/eslint-parser',
        parserOptions: {
            //'source-type': 'script',
            //sourceType: 'script', // BUG!?
            ecmaVersion: 2021,
            babelOptions: { rootMode: 'upward' }
        },
        rules: {
            '@babel/new-cap': [
                'warn', { properties: false }
            ],
            '@babel/no-invalid-this': 0,
            '@babel/object-curly-spacing': 1,
            '@babel/semi': [
                'error',
                'always', { 'omitLastInOneLineBlock': true }
            ],
            '@babel/no-unused-expressions': 1,
        }
    }, {
        files: ['types/*.d.ts', '**/src/*.ts'],
        plugins: [ '@typescript-eslint' ],
        extends: [ 'plugin:@typescript-eslint/recommended' ]
    }, {
        files: [ '**/config/*.json5' ],
        plugins: [ 'json5' ],
    }, {
        files: [ '**/*.json' ],
        plugins: [ 'json' ],
        extends: [ 'plugin:json/recommended' ]
    }]
};
```
</details>

**What did you do? Please include the actual source code causing the issue.**
After updating eslint in my workspace (via yarn) and start vscode, eslint don't start.

**What did you expect to happen?**
Eslint works

**What actually happened? Please include the actual, raw output from ESLint.**

```[Info  - 4:38:37 PM] ESLint server is starting
[Info  - 4:38:37 PM] ESLint server running in node v14.16.0
[Info  - 4:38:37 PM] ESLint server is running.
[Info  - 4:38:37 PM] ESLint library loaded from: /home/sog/work/projects/urbit/node_modules/eslint/lib/api.js
(node:18882) UnhandledPromiseRejectionWarning: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/rules/no-unused-expressions' is not defined by "exports" in /home/sog/work/projects/urbit/node_modules/eslint/package.json
    at throwExportsNotFound (internal/modules/esm/resolve.js:290:9)
    at packageExportsResolve (internal/modules/esm/resolve.js:513:3)
    at resolveExports (internal/modules/cjs/loader.js:439:36)
    …
```
