### PR TITLE
Chore: improve performance of `:function` selector

### DIFF
--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -98,6 +98,13 @@ function getPossibleTypes(parsedSelector) {
         case "adjacent":
             return getPossibleTypes(parsedSelector.right);
 
+        case "class":
+            if (parsedSelector.name === "function") {
+                return ["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"];
+            }
+
+            return null;
+
         default:
             return null;
 

--- a/tests/lib/linter/node-event-generator.js
+++ b/tests/lib/linter/node-event-generator.js
@@ -258,6 +258,20 @@ describe("NodeEventGenerator", () => {
         );
 
         assertEmissions(
+            "function foo(){} var x; (function (p){}); () => {};",
+            [":function", "ExpressionStatement > :function", "VariableDeclaration, :function[params.length=1]"],
+            ast => [
+                [":function", ast.body[0]], // function foo(){}
+                ["VariableDeclaration, :function[params.length=1]", ast.body[1]], // var x;
+                [":function", ast.body[2].expression], // function (p){}
+                ["ExpressionStatement > :function", ast.body[2].expression], // function (p){}
+                ["VariableDeclaration, :function[params.length=1]", ast.body[2].expression], // function (p){}
+                [":function", ast.body[3].expression], // () => {}
+                ["ExpressionStatement > :function", ast.body[3].expression] // () => {}
+            ]
+        );
+
+        assertEmissions(
             "foo;",
             [
                 "*",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:



<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

`:function` selector is costly because [getPossibleTypes](https://github.com/eslint/eslint/blob/35f3254d5f8027f75a6cb35b58bea10037003be8/lib/linter/node-event-generator.js#L66) doesn't assume that it matches only a particular set of node types, so `NodeEventGenerator` runs `esquery.matches()` on every node to check if it matches.

For example, running `no-shadow-restricted-names` on ESLint's codebase spends ~95% of the time in trying to match unrelated nodes with its [`"VariableDeclaration, :function, CatchClause"`](https://github.com/eslint/eslint/blob/35f3254d5f8027f75a6cb35b58bea10037003be8/lib/rules/no-shadow-restricted-names.js#L47) selector. Note that this isn't observable with `TIMING` because it tracks only time spent in visitors.

#### What changes did you make? (Give an overview)

As esquery [hardcodes](https://github.com/estools/esquery/blob/7c3800a4b2ff5c7b3eb3b2cf742865b7c908981f/esquery.js#L229-L232) `:function` to only three exact types, I added them as the only possible types for `:function`. This improves the performance of `no-shadow-restricted-names` by the said 95%, and will also improve the execution time for any other rule with the `:function` selector in tail positions. We're not using that selector much in core rules, but it's used in plugins.

#### Is there anything you'd like reviewers to focus on?

Does this make sense? I don't expect any maintenance problems with this as the meaning of `:function` in esquery is unlikely to change in the foreseeable future. 
