### PR TITLE
Chore: fix counting of files in performance test

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -1100,9 +1100,12 @@ target.perf = function() {
 
                 // Count test target files.
                 const count = glob.sync(
-                    process.platform === "win32"
-                        ? PERF_MULTIFILES_TARGETS.slice(2).replace(/\\/gu, "/")
-                        : PERF_MULTIFILES_TARGETS
+                    (
+                        process.platform === "win32"
+                            ? PERF_MULTIFILES_TARGETS.replace(/\\/gu, "/")
+                            : PERF_MULTIFILES_TARGETS
+                    )
+                        .slice(1, -1) // strip quotes
                 ).length;
 
                 runPerformanceTest(


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Fixes counting of files in the multi-files performance test.

The test works good, it lints 450 files, but the message shows zero.

```
Multi Files (0 files):
```

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Path is relative, so it shouldn't slice off `C:` on Windows (I guess that was the intention).
* The pattern is prepared with quotes, and that's good for a command-line argument, but those quotes should be removed for `glob.sync()`.

#### Is there anything you'd like reviewers to focus on?
