### PR TITLE
docs: Link to unit tests from rule documentation

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -648,6 +648,7 @@ target.gensite = function(prereleaseVersion) {
         if (test("-f", filename) && path.extname(filename) === ".md") {
 
             const rulesUrl = "https://github.com/eslint/eslint/tree/HEAD/lib/rules/",
+                testsUrl = "https://github.com/eslint/eslint/tree/HEAD/tests/lib/rules/",
                 docsUrl = "https://github.com/eslint/eslint/tree/HEAD/docs/rules/",
                 baseName = path.basename(filename),
                 sourceBaseName = `${path.basename(filename, ".md")}.js`,
@@ -731,6 +732,7 @@ target.gensite = function(prereleaseVersion) {
                 text += "\n## Resources\n\n";
                 if (!removed) {
                     text += `* [Rule source](${rulesUrl}${sourceBaseName})\n`;
+                    text += `* [Test source](${testsUrl}${sourceBaseName})\n`;
                 }
                 text += `* [Documentation source](${docsUrl}${baseName})\n`;
             }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In the Resources section at the bottom of each rule's documentation, we already link to the rule's implementation and the documentation's Markdown source. I've wished multiple times to have a handy link to the unit tests as well to see if a case is covered. This adds that link.

#### Is there anything you'd like reviewers to focus on?

For example, I ran `npm run gensite` locally, and here's the diff for the `accessor-pairs` documentation:

```diff
diff --git docs/rules/accessor-pairs.md docs/rules/accessor-pairs.md
index 8623782d..23de1f59 100644
--- docs/rules/accessor-pairs.md
+++ docs/rules/accessor-pairs.md
@@ -303,4 +303,5 @@ This rule was introduced in ESLint 0.22.0.
 ## Resources

 * [Rule source](https://github.com/eslint/eslint/tree/HEAD/lib/rules/accessor-pairs.js)
+* [Test source](https://github.com/eslint/eslint/tree/HEAD/tests/lib/rules/accessor-pairs.js)
 * [Documentation source](https://github.com/eslint/eslint/tree/HEAD/docs/rules/accessor-pairs.md)
```
