### PR TITLE
fix: improve fixer of `prefer-template` rule

### DIFF
--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -187,7 +187,7 @@ module.exports = {
                 return sourceCode.getText(currentNode);
             }
 
-            if (isConcatenation(currentNode) && hasStringLiteral(currentNode) && hasNonStringLiteral(currentNode)) {
+            if (isConcatenation(currentNode) && hasStringLiteral(currentNode)) {
                 const plusSign = sourceCode.getFirstTokenBetween(currentNode.left, currentNode.right, token => token.value === "+");
                 const textBeforePlus = getTextBetween(currentNode.left, plusSign);
                 const textAfterPlus = getTextBetween(plusSign, currentNode.right);

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -223,6 +223,187 @@ ruleTester.run("prefer-template", rule, {
             code: "foo + '\\0'",
             output: "`${foo  }\\0`",
             errors
+        },
+
+        // https://github.com/eslint/eslint/issues/15083
+        {
+            code: `"default-src 'self' https://*.google.com;"
+            + "frame-ancestors 'none';"
+            + "report-to " + foo + ";"`,
+            output: `\`default-src 'self' https://*.google.com;\`
+            + \`frame-ancestors 'none';\`
+            + \`report-to \${  foo  };\``,
+            errors
+        },
+        {
+            code: "'a' + 'b' + foo",
+            output: "`a` + `b${  foo}`",
+            errors
+        },
+        {
+            code: "'a' + 'b' + foo + 'c' + 'd'",
+            output: "`a` + `b${  foo  }c` + `d`",
+            errors
+        },
+        {
+            code: "'a' + 'b + c' + foo + 'd' + 'e'",
+            output: "`a` + `b + c${  foo  }d` + `e`",
+            errors
+        },
+        {
+            code: "'a' + 'b' + foo + ('c' + 'd')",
+            output: "`a` + `b${  foo  }c` + `d`",
+            errors
+        },
+        {
+            code: "'a' + 'b' + foo + ('a' + 'b')",
+            output: "`a` + `b${  foo  }a` + `b`",
+            errors
+        },
+        {
+            code: "'a' + 'b' + foo + ('c' + 'd') + ('e' + 'f')",
+            output: "`a` + `b${  foo  }c` + `d` + `e` + `f`",
+            errors
+        },
+        {
+            code: "foo + ('a' + 'b') + ('c' + 'd')",
+            output: "`${foo  }a` + `b` + `c` + `d`",
+            errors
+        },
+        {
+            code: "'a' + foo + ('b' + 'c') + ('d' + bar + 'e')",
+            output: "`a${  foo  }b` + `c` + `d${  bar  }e`",
+            errors
+        },
+        {
+            code: "foo + ('b' + 'c') + ('d' + bar + 'e')",
+            output: "`${foo  }b` + `c` + `d${  bar  }e`",
+            errors
+        },
+        {
+            code: "'a' + 'b' + foo + ('c' + 'd' + 'e')",
+            output: "`a` + `b${  foo  }c` + `d` + `e`",
+            errors
+        },
+        {
+            code: "'a' + 'b' + foo + ('c' + bar + 'd')",
+            output: "`a` + `b${  foo  }c${  bar  }d`",
+            errors
+        },
+        {
+            code: "'a' + 'b' + foo + ('c' + bar + ('d' + 'e') + 'f')",
+            output: "`a` + `b${  foo  }c${  bar  }d` + `e` + `f`",
+            errors
+        },
+        {
+            code: "'a' + 'b' + foo + ('c' + bar + 'e') + 'f' + test",
+            output: "`a` + `b${  foo  }c${  bar  }e` + `f${  test}`",
+            errors
+        },
+        {
+            code: "'a' + foo + ('b' + bar + 'c') + ('d' + test)",
+            output: "`a${  foo  }b${  bar  }c` + `d${  test}`",
+            errors
+        },
+        {
+            code: "'a' + foo + ('b' + 'c') + ('d' + bar)",
+            output: "`a${  foo  }b` + `c` + `d${  bar}`",
+            errors
+        },
+        {
+            code: "foo + ('a' + bar + 'b') + 'c' + test",
+            output: "`${foo  }a${  bar  }b` + `c${  test}`",
+            errors
+        },
+        {
+            code: "'a' + '`b`' + c",
+            output: "`a` + `\\`b\\`${  c}`",
+            errors
+        },
+        {
+            code: "'a' + '`b` + `c`' + d",
+            output: "`a` + `\\`b\\` + \\`c\\`${  d}`",
+            errors
+        },
+        {
+            code: "'a' + b + ('`c`' + '`d`')",
+            output: "`a${  b  }\\`c\\`` + `\\`d\\``",
+            errors
+        },
+        {
+            code: "'`a`' + b + ('`c`' + '`d`')",
+            output: "`\\`a\\`${  b  }\\`c\\`` + `\\`d\\``",
+            errors
+        },
+        {
+            code: "foo + ('`a`' + bar + '`b`') + '`c`' + test",
+            output: "`${foo  }\\`a\\`${  bar  }\\`b\\`` + `\\`c\\`${  test}`",
+            errors
+        },
+        {
+            code: "'a' + ('b' + 'c') + d",
+            output: "`a` + `b` + `c${  d}`",
+            errors
+        },
+        {
+            code: "'a' + ('`b`' + '`c`') + d",
+            output: "`a` + `\\`b\\`` + `\\`c\\`${  d}`",
+            errors
+        },
+        {
+            code: "a + ('b' + 'c') + d",
+            output: "`${a  }b` + `c${  d}`",
+            errors
+        },
+        {
+            code: "a + ('b' + 'c') + (d + 'e')",
+            output: "`${a  }b` + `c${  d  }e`",
+            errors
+        },
+        {
+            code: "a + ('`b`' + '`c`') + d",
+            output: "`${a  }\\`b\\`` + `\\`c\\`${  d}`",
+            errors
+        },
+        {
+            code: "a + ('`b` + `c`' + '`d`') + e",
+            output: "`${a  }\\`b\\` + \\`c\\`` + `\\`d\\`${  e}`",
+            errors
+        },
+        {
+            code: "'a' + ('b' + 'c' + 'd') + e",
+            output: "`a` + `b` + `c` + `d${  e}`",
+            errors
+        },
+        {
+            code: "'a' + ('b' + 'c' + 'd' + (e + 'f') + 'g' +'h' + 'i') + j",
+            output: "`a` + `b` + `c` + `d${  e  }fg` +`h` + `i${  j}`",
+            errors
+        },
+        {
+            code: "a + (('b' + 'c') + 'd')",
+            output: "`${a  }b` + `c` + `d`",
+            errors
+        },
+        {
+            code: "(a + 'b') + ('c' + 'd') + e",
+            output: "`${a  }b` + `c` + `d${  e}`",
+            errors
+        },
+        {
+            code: "var foo = \"Hello \" + \"world \" + \"another \" + test",
+            output: "var foo = `Hello ` + `world ` + `another ${  test}`",
+            errors
+        },
+        {
+            code: "'Hello ' + '\"world\" ' + test",
+            output: "`Hello ` + `\"world\" ${  test}`",
+            errors
+        },
+        {
+            code: "\"Hello \" + \"'world' \" + test",
+            output: "`Hello ` + `'world' ${  test}`",
+            errors
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add auto fixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Resolve https://github.com/eslint/eslint/issues/15083

**Before**

code: `var foo = "Hello " + "world " + test` => fixed code: var foo = `${"Hello " + "world "}${test}`

**After**

code: `var foo = "Hello " + "world " + test `=> fixed code: var foo = ``Hello world ${  test}``

#### Is there anything you'd like reviewers to focus on?
No