### PR TITLE
perf: don't prepare a fix for valid code in key-spacing

### DIFF
--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -427,19 +427,7 @@ module.exports = {
          * @returns {void}
          */
         function report(property, side, whitespace, expected, mode) {
-            const diff = whitespace.length - expected,
-                nextColon = getNextColon(property.key),
-                tokenBeforeColon = sourceCode.getTokenBefore(nextColon, { includeComments: true }),
-                tokenAfterColon = sourceCode.getTokenAfter(nextColon, { includeComments: true }),
-                isKeySide = side === "key",
-                isExtra = diff > 0,
-                diffAbs = Math.abs(diff),
-                spaces = Array(diffAbs + 1).join(" ");
-
-            const locStart = isKeySide ? tokenBeforeColon.loc.end : nextColon.loc.start;
-            const locEnd = isKeySide ? nextColon.loc.start : tokenAfterColon.loc.start;
-            const missingLoc = isKeySide ? tokenBeforeColon.loc : tokenAfterColon.loc;
-            const loc = isExtra ? { start: locStart, end: locEnd } : missingLoc;
+            const diff = whitespace.length - expected;
 
             if ((
                 diff && mode === "strict" ||
@@ -447,6 +435,19 @@ module.exports = {
                 diff > 0 && !expected && mode === "minimum") &&
                 !(expected && containsLineTerminator(whitespace))
             ) {
+                const nextColon = getNextColon(property.key),
+                    tokenBeforeColon = sourceCode.getTokenBefore(nextColon, { includeComments: true }),
+                    tokenAfterColon = sourceCode.getTokenAfter(nextColon, { includeComments: true }),
+                    isKeySide = side === "key",
+                    isExtra = diff > 0,
+                    diffAbs = Math.abs(diff),
+                    spaces = Array(diffAbs + 1).join(" ");
+
+                const locStart = isKeySide ? tokenBeforeColon.loc.end : nextColon.loc.start;
+                const locEnd = isKeySide ? nextColon.loc.start : tokenAfterColon.loc.start;
+                const missingLoc = isKeySide ? tokenBeforeColon.loc : tokenAfterColon.loc;
+                const loc = isExtra ? { start: locStart, end: locEnd } : missingLoc;
+
                 let fix;
 
                 if (isExtra) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Improves the performance of `key-spacing` rule.

I noticed that `key-spacing` takes significantly more time than other core rules (except for `indent`) while linting eslint codebase.

```
Rule                                          | Time (ms) | Relative
:---------------------------------------------|----------:|--------:
indent                                        |  8932.883 |    14.9%
jsdoc/check-line-alignment                    |  2495.443 |     4.2%
jsdoc/valid-types                             |  2189.563 |     3.6%
jsdoc/check-values                            |  1740.889 |     2.9%
jsdoc/check-syntax                            |  1739.052 |     2.9%
jsdoc/check-types                             |  1727.834 |     2.9%
jsdoc/check-tag-names                         |  1648.792 |     2.7%
jsdoc/newline-after-description               |  1605.039 |     2.7%
jsdoc/require-asterisk-prefix                 |  1565.982 |     2.6%
jsdoc/require-hyphen-before-param-description |  1557.490 |     2.6%
jsdoc/tag-lines                               |  1534.903 |     2.6%
jsdoc/check-access                            |  1528.069 |     2.5%
jsdoc/require-property-description            |  1515.929 |     2.5%
jsdoc/check-property-names                    |  1513.363 |     2.5%
jsdoc/empty-tags                              |  1508.546 |     2.5%
jsdoc/multiline-blocks                        |  1508.153 |     2.5%
jsdoc/check-alignment                         |  1507.435 |     2.5%
jsdoc/require-property-name                   |  1499.975 |     2.5%
jsdoc/no-multi-asterisks                      |  1489.551 |     2.5%
jsdoc/require-property                        |  1489.115 |     2.5%
jsdoc/require-property-type                   |  1484.048 |     2.5%
node/no-missing-require                       |  1055.094 |     1.8%
node/no-extraneous-require                    |   973.506 |     1.6%
node/no-unpublished-require                   |   914.645 |     1.5%
key-spacing                                   |   899.327 |     1.5%
eslint-plugin/no-identical-tests              |   805.156 |     1.3%
comma-style                                   |   485.955 |     0.8%
max-len                                       |   462.454 |     0.8%
node/no-restricted-require                    |   424.574 |     0.7%
no-loss-of-precision                          |   314.663 |     0.5%
no-dupe-keys                                  |   283.553 |     0.5%
object-curly-newline                          |   278.970 |     0.5%
...
```
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

It turned out that the rule spends the majоrity of time in calculating data that would be needed to auto-fix invalid code, but isn't needed for valid code, so I moved those lines into the conditional that handles invalid code. This change improved the performance of this rule by ~80%.

```
key-spacing                                   |   186.664 |     0.3%
```

#### Is there anything you'd like reviewers to focus on?
