### PR TITLE
feat: cli init: support modules installation via yarn or pnpm

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -417,11 +417,12 @@ function hasESLintVersionConflict(answers) {
 /**
  * Install modules.
  * @param {string[]} modules Modules to be installed.
+ * @param {'npm'|'yarn'|'pnpm'} packageManager Package manager to use
  * @returns {void}
  */
-function installModules(modules) {
+function installModules(modules, packageManager = "npm") {
     log.info(`Installing ${modules.join(", ")}`);
-    npmUtils.installSyncSaveDev(modules);
+    npmUtils.installSyncSaveDev(modules, packageManager);
 }
 
 /* istanbul ignore next: no need to test enquirer */
@@ -442,23 +443,29 @@ function askInstallModules(modules, packageJsonExists) {
     log.info(modules.join(" "));
     return enquirer.prompt([
         {
-            type: "toggle",
-            name: "executeInstallation",
-            message: "Would you like to install them now with npm?",
-            enabled: "Yes",
-            disabled: "No",
-            initial: 1,
+            type: "select",
+            name: "installationChoice",
+            message: "Would you like to install them?",
+            initial: 0,
+            choices: [
+                { message: "No", name: "no" },
+                { message: "Yes, with npm", name: "npm" },
+                { message: "Yes, with yarn", name: "yarn" },
+                { message: "Yes, with pnpm", name: "pnpm" }
+            ],
             skip() {
                 return !(modules.length && packageJsonExists);
             },
             result(input) {
                 return this.skipped ? null : input;
             }
+
         }
-    ]).then(({ executeInstallation }) => {
-        if (executeInstallation) {
-            installModules(modules);
+    ]).then(({ installationChoice }) => {
+        if (installationChoice === "no") {
+            return;
         }
+        installModules(modules, installationChoice);
     });
 }
 

--- a/lib/init/npm-utils.js
+++ b/lib/init/npm-utils.js
@@ -46,11 +46,17 @@ function findPackageJson(startDir) {
 /**
  * Install node modules synchronously and save to devDependencies in package.json
  * @param {string|string[]} packages Node module or modules to install
+ * @param {'npm'|'yarn'|'pnpm'} packageManager Package manager to use
  * @returns {void}
  */
-function installSyncSaveDev(packages) {
+function installSyncSaveDev(packages, packageManager = "npm") {
     const packageList = Array.isArray(packages) ? packages : [packages];
-    const npmProcess = spawn.sync("npm", ["i", "--save-dev"].concat(packageList), { stdio: "inherit" });
+    const args = {
+        npm: ["install", "--save-dev"],
+        yarn: ["add", "--dev"],
+        pnpm: ["add", "--save-dev"]
+    }[packageManager];
+    const npmProcess = spawn.sync(packageManager, args.concat(packageList), { stdio: "inherit" });
     const error = npmProcess.error;
 
     if (error && error.code === "ENOENT") {

--- a/tests/lib/init/config-initializer.js
+++ b/tests/lib/init/config-initializer.js
@@ -254,6 +254,7 @@ describe("configInitializer", () => {
                 const config = { extends: "google" };
 
                 init.installModules(init.getModulesList(config));
+
                 assert(npmInstallStub.calledOnce);
                 assert(npmInstallStub.firstCall.args[0].some(name => name.startsWith("eslint-config-google@")));
             });
@@ -284,6 +285,24 @@ describe("configInitializer", () => {
                         "eslint-plugin-react@^7.0.1"
                     ]
                 );
+            });
+
+            it("should use npm by default", () => {
+                const config = { extends: "airbnb" };
+
+                init.installModules(init.getModulesList(config));
+
+                assert(npmInstallStub.calledOnce);
+                assert(npmInstallStub.firstCall.args[1] === "npm");
+            });
+
+            it("should use a custom package manager if required", () => {
+                const config = { extends: "airbnb" };
+
+                init.installModules(init.getModulesList(config), "yarn");
+
+                assert(npmInstallStub.calledOnce);
+                assert(npmInstallStub.firstCall.args[1] === "yarn");
             });
 
             describe("hasESLintVersionConflict (Note: peerDependencies always `eslint: \"^3.19.0\"` by stubs)", () => {

--- a/tests/lib/init/npm-utils.js
+++ b/tests/lib/init/npm-utils.js
@@ -171,13 +171,27 @@ describe("npmUtils", () => {
     });
 
     describe("installSyncSaveDev()", () => {
-        it("should invoke npm to install a single desired package", () => {
+        it("should invoke npm by default to install a single desired package", () => {
             const stub = sinon.stub(spawn, "sync").returns({ stdout: "" });
 
             npmUtils.installSyncSaveDev("desired-package");
+
             assert(stub.calledOnce);
             assert.strictEqual(stub.firstCall.args[0], "npm");
-            assert.deepStrictEqual(stub.firstCall.args[1], ["i", "--save-dev", "desired-package"]);
+            assert.deepStrictEqual(stub.firstCall.args[1], ["install", "--save-dev", "desired-package"]);
+
+            stub.restore();
+        });
+
+        it("should invoke another package manager if precised to install a single desired package", () => {
+            const stub = sinon.stub(spawn, "sync").returns({ stdout: "" });
+
+            npmUtils.installSyncSaveDev("desired-package", "pnpm");
+
+            assert(stub.calledOnce);
+            assert.strictEqual(stub.firstCall.args[0], "pnpm");
+            assert.deepStrictEqual(stub.firstCall.args[1], ["add", "--save-dev", "desired-package"]);
+
             stub.restore();
         });
 
@@ -185,9 +199,11 @@ describe("npmUtils", () => {
             const stub = sinon.stub(spawn, "sync").returns({ stdout: "" });
 
             npmUtils.installSyncSaveDev(["first-package", "second-package"]);
+
             assert(stub.calledOnce);
             assert.strictEqual(stub.firstCall.args[0], "npm");
-            assert.deepStrictEqual(stub.firstCall.args[1], ["i", "--save-dev", "first-package", "second-package"]);
+            assert.deepStrictEqual(stub.firstCall.args[1], ["install", "--save-dev", "first-package", "second-package"]);
+
             stub.restore();
         });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [x] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

When running `npx eslint --init`, we get asked questions that generates an eslint config, which might required additional packages to be installed. We then get asked whether we want ESLint to install them for us, but we can only install them with @npm.

I'm a fan of @pnpm and we use @yarnpkg over here at @toucantoco so I figured out it'd be nice to add support for these alternatives too!

Here's a demo: https://asciinema.org/a/446868

#### Is there anything you'd like reviewers to focus on?

Everything is self-explanatory I think
