### PR TITLE
feat!: Make line breaks invalid for key-spacing strict mode

### DIFF
--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -15,16 +15,6 @@ const astUtils = require("./utils/ast-utils");
 //------------------------------------------------------------------------------
 
 /**
- * Checks whether a string contains a line terminator as defined in
- * http://www.ecma-international.org/ecma-262/5.1/#sec-7.3
- * @param {string} str String to test.
- * @returns {boolean} True if str contains a line terminator.
- */
-function containsLineTerminator(str) {
-    return astUtils.LINEBREAK_MATCHER.test(str);
-}
-
-/**
  * Gets the last element of an array.
  * @param {Array} arr An array.
  * @returns {any} Last element of arr.
@@ -427,14 +417,14 @@ module.exports = {
          * @returns {void}
          */
         function report(property, side, whitespace, expected, mode) {
-            const diff = whitespace.length - expected,
+            const linebreaks = (whitespace.match(astUtils.LINEBREAK_MATCHER) || []).length;
+            const diff = whitespace.length - expected + linebreaks,
                 nextColon = getNextColon(property.key),
                 tokenBeforeColon = sourceCode.getTokenBefore(nextColon, { includeComments: true }),
                 tokenAfterColon = sourceCode.getTokenAfter(nextColon, { includeComments: true }),
                 isKeySide = side === "key",
                 isExtra = diff > 0,
-                diffAbs = Math.abs(diff),
-                spaces = Array(diffAbs + 1).join(" ");
+                spaces = Array(expected + 1).join(" ");
 
             const locStart = isKeySide ? tokenBeforeColon.loc.end : nextColon.loc.start;
             const locEnd = isKeySide ? nextColon.loc.start : tokenAfterColon.loc.start;
@@ -443,44 +433,24 @@ module.exports = {
 
             if ((
                 diff && mode === "strict" ||
-                diff < 0 && mode === "minimum" ||
-                diff > 0 && !expected && mode === "minimum") &&
-                !(expected && containsLineTerminator(whitespace))
+                 diff < 0 && mode === "minimum" ||
+                 diff > 0 && !expected && mode === "minimum")
             ) {
-                let fix;
+                let range;
 
-                if (isExtra) {
-                    let range;
-
-                    // Remove whitespace
-                    if (isKeySide) {
-                        range = [tokenBeforeColon.range[1], tokenBeforeColon.range[1] + diffAbs];
-                    } else {
-                        range = [tokenAfterColon.range[0] - diffAbs, tokenAfterColon.range[0]];
-                    }
-                    fix = function(fixer) {
-                        return fixer.removeRange(range);
-                    };
+                // Remove whitespace
+                if (isKeySide) {
+                    range = [tokenBeforeColon.range[1], nextColon.range[0]];
                 } else {
-
-                    // Add whitespace
-                    if (isKeySide) {
-                        fix = function(fixer) {
-                            return fixer.insertTextAfter(tokenBeforeColon, spaces);
-                        };
-                    } else {
-                        fix = function(fixer) {
-                            return fixer.insertTextBefore(tokenAfterColon, spaces);
-                        };
-                    }
+                    range = [nextColon.range[1], tokenAfterColon.range[0]];
                 }
 
                 let messageId = "";
 
                 if (isExtra) {
-                    messageId = side === "key" ? "extraKey" : "extraValue";
+                    messageId = isKeySide ? "extraKey" : "extraValue";
                 } else {
-                    messageId = side === "key" ? "missingKey" : "missingValue";
+                    messageId = isKeySide ? "missingKey" : "missingValue";
                 }
 
                 context.report({
@@ -491,7 +461,7 @@ module.exports = {
                         computed: property.computed ? "computed " : "",
                         key: getKey(property)
                     },
-                    fix
+                    fix: fixer => fixer.replaceTextRange(range, spaces)
                 });
             }
         }

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -147,7 +147,8 @@ ruleTester.run("key-spacing", rule, {
         ].join("\n"),
         options: [{
             beforeColon: true,
-            afterColon: true
+            afterColon: true,
+            mode: "minimum"
         }]
     }, {
         code: [
@@ -1292,15 +1293,28 @@ ruleTester.run("key-spacing", rule, {
             "obj = { key ",
             " :     longName };"
         ].join("\n"),
-        output: [
-            "obj = { key ",
-            " : longName };"
-        ].join("\n"),
+        output: "obj = { key : longName };",
         options: [{
             beforeColon: true,
             afterColon: true
         }],
         errors: [
+            { messageId: "extraKey", data: { computed: "", key: "key" }, line: 1, column: 12, type: "Identifier" },
+            { messageId: "extraValue", data: { computed: "", key: "key" }, line: 2, column: 2, type: "Identifier" }
+        ]
+    }, {
+        code: [
+            "obj = { key ",
+            " : ",
+            " longName };"
+        ].join("\n"),
+        output: "obj = { key : longName };",
+        options: [{
+            beforeColon: true,
+            afterColon: true
+        }],
+        errors: [
+            { messageId: "extraKey", data: { computed: "", key: "key" }, line: 1, column: 12, type: "Identifier" },
             { messageId: "extraValue", data: { computed: "", key: "key" }, line: 2, column: 2, type: "Identifier" }
         ]
     }, {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**
key-spacing

**Does this change cause the rule to produce more or fewer warnings?**
More warnings

**How will the change be implemented? (New option, new default behavior, etc.)?**
New default behavior

**Please provide some example code that this change will affect:**
With `key-spacing` rule set in default strict mode:

```json
"key-spacing": [ "error", { "afterColon": true, "beforeColon": true, "mode": "strict" } ]
```

**What does the rule currently do for this code?**
Following code is currently valid, but will became invalid with this change since line breaks is treated whitespace:
```js
const obj = {
	key :
	'value'
};

const obj = {
	key
	:
	'value'
};
```

**What will the rule do after it's changed?**
Following code is valid for this PR:
```js
// 'key-spacing': [ 'error', { 'afterColon': true, 'beforeColon': true, 'mode': 'strict' } ]
const obj = { key : 'value' };
const obj = {
	key : 'value'
};
```

For `mode` set to "minimum" the current behaviour is the same and first example is still valid.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Changed key-spacing rule and tests.

#### Is there anything you'd like reviewers to focus on?
I believe this is preferred behaviour, but if not maybe a new option should be added?
