### PR TITLE
feat: Normalize ecmaVersion to eslint-scope when using custom parser

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -626,7 +626,7 @@ function analyzeScope(ast, parserOptions, visitorKeys) {
         ignoreEval: true,
         nodejsScope: ecmaFeatures.globalReturn,
         impliedStrict: ecmaFeatures.impliedStrict,
-        ecmaVersion,
+        ecmaVersion: typeof ecmaVersion === "number" ? ecmaVersion : 6,
         sourceType: parserOptions.sourceType || "script",
         childVisitorKeys: visitorKeys || evk.KEYS,
         fallback: Traverser.getKeys

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -4137,9 +4137,22 @@ var a = "test2";
                         blockScope = context.getScope();
                     }
                 }));
+                linter.defineParser("custom-parser", {
+                    parse: (...args) => espree.parse(...args)
+                });
 
+                // standard parser with latest
                 linter.verify("{}", {
                     rules: { "block-scope": 2 },
+                    parserOptions: { ecmaVersion: "latest" }
+                });
+
+                assert.strictEqual(blockScope.type, "block");
+
+                // custom parser with latest
+                linter.verify("{}", {
+                    rules: { "block-scope": 2 },
+                    parser: "custom-parser",
                     parserOptions: { ecmaVersion: "latest" }
                 });
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -4141,7 +4141,7 @@ var a = "test2";
                     parse: (...args) => espree.parse(...args)
                 });
 
-                // standard parser with latest
+                // Use standard parser
                 linter.verify("{}", {
                     rules: { "block-scope": 2 },
                     parserOptions: { ecmaVersion: "latest" }
@@ -4149,7 +4149,13 @@ var a = "test2";
 
                 assert.strictEqual(blockScope.type, "block");
 
-                // custom parser with latest
+                linter.verify("{}", {
+                    rules: { "block-scope": 2 },
+                    parserOptions: {} // ecmaVersion defaults to 5
+                });
+                assert.strictEqual(blockScope.type, "global");
+
+                // Use custom parser
                 linter.verify("{}", {
                     rules: { "block-scope": 2 },
                     parser: "custom-parser",
@@ -4160,6 +4166,7 @@ var a = "test2";
 
                 linter.verify("{}", {
                     rules: { "block-scope": 2 },
+                    parser: "custom-parser",
                     parserOptions: {} // ecmaVersion defaults to 5
                 });
                 assert.strictEqual(blockScope.type, "global");


### PR DESCRIPTION


<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Add something to the core

Fixes #15256

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Change to pass 6 to eslint-scope when ecmaVersion is non number.
This allows the scope to be analyzed as ES6 if the user uses a custom parser and `ecmaVersion: latest`.

#### Is there anything you'd like reviewers to focus on?
