### PR TITLE
docs: no-unused-expressions - class static blocks don't have directives

### DIFF
--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -62,16 +62,6 @@ injectGlobal`body{ color: red; }`
 
 ```
 
-Note that one or more string expression statements (with or without semi-colons) will only be considered as unused if they are not in the beginning of a script, module, or function (alone and uninterrupted by other statements). Otherwise, they will be treated as part of a "directive prologue", a section potentially usable by JavaScript engines. This includes "strict mode" directives.
-
-```js
-"use strict";
-"use asm"
-"use stricter";
-"use babel"
-"any other strings like this in the prologue";
-```
-
 Examples of **correct** code for the default `{ "allowShortCircuit": false, "allowTernary": false }` options:
 
 ```js
@@ -94,6 +84,50 @@ new C
 delete a.b
 
 void a
+```
+
+Note that one or more string expression statements (with or without semi-colons) will only be considered as unused if they are not in the beginning of a script, module, or function (alone and uninterrupted by other statements). Otherwise, they will be treated as part of a "directive prologue", a section potentially usable by JavaScript engines. This includes "strict mode" directives.
+
+Examples of **correct** code for this rule in regard to directives:
+
+```js
+/*eslint no-unused-expressions: "error"*/
+
+"use strict";
+"use asm"
+"use stricter";
+"use babel"
+"any other strings like this in the directive prologue";
+"this is still the directive prologue";
+
+function foo() {
+    "bar";
+}
+
+class Foo {
+    someMethod() {
+        "use strict";
+    }
+}
+```
+
+Examples of **incorrect** code for this rule in regard to directives:
+
+```js
+/*eslint no-unused-expressions: "error"*/
+
+doSomething();
+"use strict"; // this isn't in a directive prologue, because there is a non-directive statement before it
+
+function foo() {
+    "bar" + 1;
+}
+
+class Foo {
+    static {
+        "use strict"; // class static blocks do not have directive prologues
+    }
+}
 ```
 
 ### allowShortCircuit

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -115,6 +115,12 @@ module.exports = {
             const parent = ancestors[ancestors.length - 1],
                 grandparent = ancestors[ancestors.length - 2];
 
+            /**
+             * https://tc39.es/ecma262/#directive-prologue
+             *
+             * Only `FunctionBody`, `ScriptBody` and `ModuleBody` can have directive prologue.
+             * Class static blocks do not have directive prologue.
+             */
             return (parent.type === "Program" || parent.type === "BlockStatement" &&
                     (/Function/u.test(grandparent.type))) &&
                     directives(parent).indexOf(node) >= 0;

--- a/tests/lib/rules/no-unused-expressions.js
+++ b/tests/lib/rules/no-unused-expressions.js
@@ -190,6 +190,29 @@ ruleTester.run("no-unused-expressions", rule, {
             options: [{ enforceForJSX: true }],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }]
+        },
+
+        // class static blocks do not have directive prologues
+        {
+            code: "class C { static { 'use strict'; } }",
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{ messageId: "unusedExpression", type: "ExpressionStatement" }]
+        },
+        {
+            code: "class C { static { \n'foo'\n'bar'\n } }",
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                {
+                    messageId: "unusedExpression",
+                    type: "ExpressionStatement",
+                    line: 2
+                },
+                {
+                    messageId: "unusedExpression",
+                    type: "ExpressionStatement",
+                    line: 3
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15016, fixes `no-unused-expressions`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Class static blocks don't have directive prologues. Therefore, directive-like statements in class static blocks, such as `"use strict"` at the beginning of a class static block, should be reported by the `no-unused-expressions` rule.

The behavior was already correct. I only updated the docs, added tests to confirm, and added a comment in the code.

#### Is there anything you'd like reviewers to focus on?
