### PR TITLE
feat: update keyword-spacing for class static blocks

### DIFF
--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -243,13 +243,14 @@ if(foo) {
 
 ### overrides
 
-Examples of **correct** code for this rule with the `{ "overrides": { "if": { "after": false }, "for": { "after": false }, "while": { "after": false } } }` option:
+Examples of **correct** code for this rule with the `{ "overrides": { "if": { "after": false }, "for": { "after": false }, "while": { "after": false }, "static": { "after": false } } }` option:
 
 ```js
 /*eslint keyword-spacing: ["error", { "overrides": {
   "if": { "after": false },
   "for": { "after": false },
-  "while": { "after": false }
+  "while": { "after": false },
+  "static": { "after": false }
 } }]*/
 
 if(foo) {
@@ -263,7 +264,13 @@ if(foo) {
 for(;;);
 
 while(true) {
-  //...
+    //...
+}
+
+class C {
+    static{
+        //...
+    }
 }
 ```
 

--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -63,6 +63,9 @@ if (a) {
     c();
 }
 
+class C {
+    static{} /*no error. this is checked by `keyword-spacing` rule.*/
+}
 
 function a() {}
 

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -590,6 +590,7 @@ module.exports = {
             ImportNamespaceSpecifier: checkSpacingForImportNamespaceSpecifier,
             MethodDefinition: checkSpacingForProperty,
             PropertyDefinition: checkSpacingForProperty,
+            StaticBlock: checkSpacingAroundFirstToken,
             Property: checkSpacingForProperty,
 
             // To avoid conflicts with `space-infix-ops`, e.g. `a > this.b`

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -978,6 +978,11 @@ ruleTester.run("keyword-spacing", rule, {
         { code: "class A { a;static[b]; }", options: [NEITHER], parserOptions: { ecmaVersion: 2022 } },
         { code: "class A { a; static #b; }", parserOptions: { ecmaVersion: 2022 } },
         { code: "class A { a;static#b; }", options: [NEITHER], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class A { a() {} static {} }", parserOptions: { ecmaVersion: 2022 } },
+        { code: "class A { a() {}static{} }", options: [NEITHER], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class A { a() {} static {} }", options: [override("static", BOTH)], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class A { a() {}static{} }", options: [override("static", NEITHER)], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class A { a() {}\nstatic\n{} }", options: [NEITHER], parserOptions: { ecmaVersion: 2022 } },
 
         // not conflict with `generator-star-spacing`
         { code: "class A { static* [a]() {} }", parserOptions: { ecmaVersion: 6 } },
@@ -986,6 +991,10 @@ ruleTester.run("keyword-spacing", rule, {
         // not conflict with `semi-spacing`
         { code: "class A { ;static a() {} }", parserOptions: { ecmaVersion: 6 } },
         { code: "class A { ; static a() {} }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A { ;static a; }", parserOptions: { ecmaVersion: 2022 } },
+        { code: "class A { ; static a ; }", options: [NEITHER], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class A { ;static {} }", parserOptions: { ecmaVersion: 2022 } },
+        { code: "class A { ; static{} }", options: [NEITHER], parserOptions: { ecmaVersion: 2022 } },
 
         //----------------------------------------------------------------------
         // super
@@ -3039,6 +3048,59 @@ ruleTester.run("keyword-spacing", rule, {
         {
             code: "class A { a; static #b; }",
             output: "class A { a; static#b; }",
+            options: [NEITHER],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: unexpectedAfter("static")
+        },
+        {
+            code: "class A { a() {}static{} }",
+            output: "class A { a() {} static {} }",
+            parserOptions: { ecmaVersion: 2022 },
+            errors: expectedBeforeAndAfter("static")
+        },
+        {
+            code: "class A { a() {}static{} }",
+            output: "class A { a() {} static {} }",
+            options: [override("static", BOTH)],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: expectedBeforeAndAfter("static")
+        },
+        {
+            code: "class A {  a() {}static {} }",
+            output: "class A {  a() {} static {} }",
+            parserOptions: { ecmaVersion: 2022 },
+            errors: expectedBefore("static")
+        },
+        {
+            code: "class A {  a() {} static{} }",
+            output: "class A {  a() {} static {} }",
+            parserOptions: { ecmaVersion: 2022 },
+            errors: expectedAfter("static")
+        },
+        {
+            code: "class A { a() {} static {} }",
+            output: "class A { a() {}static{} }",
+            options: [NEITHER],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: unexpectedBeforeAndAfter("static")
+        },
+        {
+            code: "class A { a() {} static {} }",
+            output: "class A { a() {}static{} }",
+            options: [override("static", NEITHER)],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: unexpectedBeforeAndAfter("static")
+        },
+        {
+            code: "class A { a() {} static{} }",
+            output: "class A { a() {}static{} }",
+            options: [NEITHER],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: unexpectedBefore("static")
+        },
+        {
+            code: "class A { a() {}static {} }",
+            output: "class A { a() {}static{} }",
             options: [NEITHER],
             parserOptions: { ecmaVersion: 2022 },
             errors: unexpectedAfter("static")

--- a/tests/lib/rules/semi-spacing.js
+++ b/tests/lib/rules/semi-spacing.js
@@ -483,6 +483,19 @@ ruleTester.run("semi-spacing", rule, {
                     endColumn: 16
                 }
             ]
+        },
+        {
+            code: "class C { foo;static {}}",
+            output: "class C { foo; static {}}",
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "missingWhitespaceAfter",
+                type: "PropertyDefinition",
+                line: 1,
+                column: 14,
+                endLine: 1,
+                endColumn: 15
+            }]
         }
     ]
 });

--- a/tests/lib/rules/space-before-blocks.js
+++ b/tests/lib/rules/space-before-blocks.js
@@ -202,7 +202,19 @@ ruleTester.run("space-before-blocks", rule, {
         { code: "switch(x) { case (9):{ break; } }", options: alwaysArgs },
         { code: "switch(x){ case (9): { break; } }", options: neverArgs },
         { code: "switch(x) { default:{ break; } }", options: alwaysArgs },
-        { code: "switch(x){ default: { break; } }", options: neverArgs }
+        { code: "switch(x){ default: { break; } }", options: neverArgs },
+
+        // not conflict with `keyword-spacing`
+        {
+            code: "(class{ static{} })",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "(class { static {} })",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        }
     ],
     invalid: [
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15016, fixes `keyword-spacing`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the `keyword-spacing` rule to check spacing around `static` of class static blocks.

Also added test to confirm that this doesn't conflict with `semi-spacing` and `space-before-blocks`.


#### Is there anything you'd like reviewers to focus on?
