### PR TITLE
feat: update no-inner-declarations for class static blocks

### DIFF
--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -56,7 +56,7 @@ function doSomething() {
 
 ## Rule Details
 
-This rule requires that function declarations and, optionally, variable declarations be in the root of a program or the body of a function.
+This rule requires that function declarations and, optionally, variable declarations be in the root of a program, or in the root of the body of a function, or in the root of the body of a class static block.
 
 ## Options
 
@@ -83,6 +83,14 @@ function doSomethingElse() {
 }
 
 if (foo) function f(){}
+
+class C {
+    static {
+        if (test) {
+            function doSomething() { }
+        }
+    }
+}
 ```
 
 Examples of **correct** code for this rule with the default `"functions"` option:
@@ -94,6 +102,12 @@ function doSomething() { }
 
 function doSomethingElse() {
     function doAnotherThing() { }
+}
+
+class C {
+    static {
+        function doSomething() { }
+    }
 }
 
 if (test) {
@@ -125,17 +139,23 @@ function doAnotherThing() {
     }
 }
 
-
 if (foo) var a;
 
 if (foo) function f(){}
+
+class C {
+    static {
+        if (test) {
+            var something;
+        }
+    }
+}
 ```
 
 Examples of **correct** code for this rule with the `"both"` option:
 
 ```js
 /*eslint no-inner-declarations: ["error", "both"]*/
-/*eslint-env es6*/
 
 var bar = 42;
 
@@ -145,6 +165,12 @@ if (test) {
 
 function doAnotherThing() {
     var baz = 81;
+}
+
+class C {
+    static {
+        var something;
+    }
 }
 ```
 

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -15,8 +15,32 @@ const astUtils = require("./utils/ast-utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const validParent = new Set(["Program", "ExportNamedDeclaration", "ExportDefaultDeclaration"]);
+const validParent = new Set(["Program", "StaticBlock", "ExportNamedDeclaration", "ExportDefaultDeclaration"]);
 const validBlockStatementParent = new Set(["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"]);
+
+/**
+ * Finds the nearest enclosing context where this rule allows declarations and returns its description.
+ * @param {ASTNode} node Node to search from.
+ * @returns {string} Description. One of "program", "function body", "class static block body".
+ */
+function getAllowedBodyDescription(node) {
+    let { parent } = node;
+
+    while (parent) {
+
+        if (parent.type === "StaticBlock") {
+            return "class static block body";
+        }
+
+        if (astUtils.isFunction(parent)) {
+            return "function body";
+        }
+
+        ({ parent } = parent);
+    }
+
+    return "program";
+}
 
 module.exports = {
     meta: {
@@ -59,14 +83,12 @@ module.exports = {
                 return;
             }
 
-            const upperFunction = astUtils.getUpperFunction(parent);
-
             context.report({
                 node,
                 messageId: "moveDeclToRoot",
                 data: {
                     type: (node.type === "FunctionDeclaration" ? "function" : "variable"),
-                    body: (upperFunction === null ? "program" : "function body")
+                    body: getAllowedBodyDescription(node)
                 }
             });
         }

--- a/tests/lib/rules/no-inner-declarations.js
+++ b/tests/lib/rules/no-inner-declarations.js
@@ -73,8 +73,27 @@ ruleTester.run("no-inner-declarations", rule, {
         {
             code: "module.exports = function foo(){}",
             options: ["both"]
+        },
+        {
+            code: "class C { method() { function foo() {} } }",
+            options: ["both"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { method() { var x; } }",
+            options: ["both"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { function foo() {} } }",
+            options: ["both"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { var x; } }",
+            options: ["both"],
+            parserOptions: { ecmaVersion: 2022 }
         }
-
     ],
 
     // Examples of code that should trigger the rule
@@ -271,7 +290,54 @@ ruleTester.run("no-inner-declarations", rule, {
                 },
                 type: "VariableDeclaration"
             }]
+        }, {
+            code: "class C { method() { if(test) { var foo; } } }",
+            options: ["both"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "function body"
+                },
+                type: "VariableDeclaration"
+            }]
+        }, {
+            code: "class C { static { if (test) { function foo() {} } } }",
+            options: ["both"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "function",
+                    body: "class static block body"
+                },
+                type: "FunctionDeclaration"
+            }]
+        }, {
+            code: "class C { static { if (test) { var foo; } } }",
+            options: ["both"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "class static block body"
+                },
+                type: "VariableDeclaration"
+            }]
+        }, {
+            code: "class C { static { if (test) { if (anotherTest) { var foo; } } } }",
+            options: ["both"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "moveDeclToRoot",
+                data: {
+                    type: "variable",
+                    body: "class static block body"
+                },
+                type: "VariableDeclaration"
+            }]
         }
-
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15016, fixes `no-inner-declarations`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the `no-inner-declarations` rule to allow declarations at the top level of class static blocks.

```js
/* eslint no-inner-declarations: ["error", "both"] */

class C {
    method() {
        function f() {} // ok
      
        var x; // ok
    }
  
    static {
        function f() {} // should be ok, too
      
        var x; // should be ok, too
    }
}
```

#### Is there anything you'd like reviewers to focus on?
