### PR TITLE
Add `:has(..)` selector to documentation

### DIFF
--- a/docs/developer-guide/selectors.md
+++ b/docs/developer-guide/selectors.md
@@ -43,6 +43,7 @@ The following selectors are supported:
 * following sibling: `VariableDeclaration ~ VariableDeclaration`
 * adjacent sibling: `ArrayExpression > Literal + SpreadElement`
 * negation: `:not(ForStatement)`
+* has: `:has(ForStatement)`
 * matches-any: `:matches([attr] > :first-child, :last-child)`
 * class of AST node: `:statement`, `:expression`, `:declaration`, `:function`, or `:pattern`
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)
- [x] Documentation update

#### What changes did you make? (Give an overview)
Add `:has(..)` selector to documentation.

#### Is there anything you'd like reviewers to focus on?
No.