### PR TITLE
feat: update class-methods-use-this for class static blocks

### DIFF
--- a/docs/rules/class-methods-use-this.md
+++ b/docs/rules/class-methods-use-this.md
@@ -83,6 +83,10 @@ class A {
     static foo() {
         // OK. static methods aren't expected to use this.
     }
+
+    static {
+        // OK. static blocks are exempt.
+    }
 }
 ```
 

--- a/lib/rules/class-methods-use-this.js
+++ b/lib/rules/class-methods-use-this.js
@@ -161,8 +161,17 @@ module.exports = {
             /*
              * Class field value are implicit functions.
              */
-            "PropertyDefinition:exit": popContext,
             "PropertyDefinition > *.key:exit": pushContext,
+            "PropertyDefinition:exit": popContext,
+
+            /*
+             * Class static blocks are implicit functions. They aren't required to use `this`,
+             * but we have to push context so that it captures any use of `this` in the static block
+             * separately from enclosing contexts, because static blocks have their own `this` and it
+             * shouldn't count as used `this` in enclosing contexts.
+             */
+            StaticBlock: pushContext,
+            "StaticBlock:exit": popContext,
 
             ThisExpression: markThisUsed,
             Super: markThisUsed,

--- a/tests/lib/rules/class-methods-use-this.js
+++ b/tests/lib/rules/class-methods-use-this.js
@@ -41,7 +41,8 @@ ruleTester.run("class-methods-use-this", rule, {
         { code: "class A { #bar() {} }", options: [{ exceptMethods: ["#bar"] }], parserOptions: { ecmaVersion: 2022 } },
         { code: "class A { foo = function () {} }", options: [{ enforceForClassFields: false }], parserOptions: { ecmaVersion: 2022 } },
         { code: "class A { foo = () => {} }", options: [{ enforceForClassFields: false }], parserOptions: { ecmaVersion: 2022 } },
-        { code: "class A { foo() { return class { [this.foo] = 1 }; } }", parserOptions: { ecmaVersion: 2022 } }
+        { code: "class A { foo() { return class { [this.foo] = 1 }; } }", parserOptions: { ecmaVersion: 2022 } },
+        { code: "class A { static {} }", parserOptions: { ecmaVersion: 2022 } }
     ],
     invalid: [
         {
@@ -199,6 +200,13 @@ ruleTester.run("class-methods-use-this", rule, {
         },
         {
             code: "class A { foo () { return function () { foo = this }; } }",
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "missingThis", data: { name: "method 'foo'" }, column: 11, endColumn: 15 }
+            ]
+        },
+        {
+            code: "class A { foo () { return class { static { this; } } } }",
             parserOptions: { ecmaVersion: 2022 },
             errors: [
                 { messageId: "missingThis", data: { name: "method 'foo'" }, column: 11, endColumn: 15 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15016, fixes `class-methods-use-this`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the `class-methods-use-this` rule to account for class static blocks.

This only fixes false negatives where use of `this` in a class static block mistakenly counts as used `this` in the enclosing context:

```js
/* eslint class-methods-use-this: error */

class A {
    foo () { // false negative, this method does not use `this`.
        return class {
            static {
                this;
            }
        } 
    }
}
```

The rule still correctly does not require that class static blocks use `this`.

#### Is there anything you'd like reviewers to focus on?
