### PR TITLE
feat: Export ast-utils for use in custom rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": "./lib/api.js",
+    "./ast-utils": "./lib/rules/utils/ast-utils.js",
     "./use-at-your-own-risk": "./lib/unsupported-api.js"
   },
   "scripts": {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Exports the built-in ast-utils so that customized rules can be made without reimplementing this functionality.

Some eslint rules starts by importing `ast-utils` like so:
```js
const astUtils = require("./utils/ast-utils");
```

This change allows custom rules to use the same library through eslint as a peer dependency:
```js
const astUtils = require("eslint/ast-utils");
```


#### Is there anything you'd like reviewers to focus on?
The [eslint-utils](https://www.npmjs.com/package/eslint-utils) module doesn't have all methods of ast-utils so cannot always be used as an alternative.
Exposing `ast-utils` through eslint makes it easier to customize rules and requires no extra dependencies since eslint is expected to be a peer dependency in projects using the rule.
