### PR TITLE
fix: update semi-style for class static blocks

### DIFF
--- a/docs/rules/semi-style.md
+++ b/docs/rules/semi-style.md
@@ -32,6 +32,13 @@ for (
 ) {
     foo()
 }
+
+class C {
+    static {
+        foo()
+        ;bar()
+    }
+}
 ```
 
 Examples of **correct** code for this rule with `"last"` option:
@@ -48,6 +55,13 @@ for (
     ++i
 ) {
     foo()
+}
+
+class C {
+    static {
+        foo();
+        bar()
+    }
 }
 ```
 
@@ -66,6 +80,13 @@ for (
 ) {
     foo()
 }
+
+class C {
+    static {
+        foo();
+        bar()
+    }
+}
 ```
 
 Examples of **correct** code for this rule with `"first"` option:
@@ -82,6 +103,13 @@ for (
     ++i
 ) {
     foo()
+}
+
+class C {
+    static {
+        foo()
+        ;bar()
+    }
 }
 ```
 

--- a/lib/rules/semi-style.js
+++ b/lib/rules/semi-style.js
@@ -25,7 +25,8 @@ const SELECTOR = [
 
 /**
  * Get the child node list of a given node.
- * This returns `Program#body`, `BlockStatement#body`, or `SwitchCase#consequent`.
+ * This returns `BlockStatement#body`, `StaticBlock#body`, `Program#body`,
+ * `ClassBody#body`, or `SwitchCase#consequent`.
  * This is used to check whether a node is the first/last child.
  * @param {Node} node A node to get child node list.
  * @returns {Node[]|null} The child node list.
@@ -33,7 +34,12 @@ const SELECTOR = [
 function getChildren(node) {
     const t = node.type;
 
-    if (t === "BlockStatement" || t === "Program" || t === "ClassBody") {
+    if (
+        t === "BlockStatement" ||
+        t === "StaticBlock" ||
+        t === "Program" ||
+        t === "ClassBody"
+    ) {
         return node.body;
     }
     if (t === "SwitchCase") {

--- a/tests/lib/rules/semi-style.js
+++ b/tests/lib/rules/semi-style.js
@@ -127,6 +127,202 @@ ruleTester.run("semi-style", rule, {
                 while (a)
             `,
             options: ["last"]
+        },
+
+        // Class static blocks
+        {
+            code: `
+                class C {
+                    static {}
+                }
+            `,
+            options: ["last"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        foo
+                    }
+                }
+            `,
+            options: ["last"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        foo
+                        bar
+                    }
+                }
+            `,
+            options: ["last"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        ;
+                    }
+                }
+            `,
+            options: ["last"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        foo;
+                    }
+                }
+            `,
+            options: ["last"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        foo;
+                        bar;
+                    }
+                }
+            `,
+            options: ["last"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        foo;
+                        bar;
+                        baz;
+                    }
+                }
+            `,
+            options: ["last"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {}
+                }
+            `,
+            options: ["first"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        foo
+                    }
+                }
+            `,
+            options: ["first"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        foo
+                        bar
+                    }
+                }
+            `,
+            options: ["first"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        ;
+                    }
+                }
+            `,
+            options: ["first"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        ;foo
+                    }
+                }
+            `,
+            options: ["first"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        foo;
+                    }
+                }
+            `,
+            options: ["first"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        foo
+                        ;bar
+                    }
+                }
+            `,
+            options: ["first"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        foo
+                        ;bar;
+                    }
+                }
+            `,
+            options: ["first"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        foo
+                        ;bar
+                        ;baz
+                    }
+                }
+            `,
+            options: ["first"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+                class C {
+                    static {
+                        foo
+                        ;bar
+                        ;baz;
+                    }
+                }
+            `,
+            options: ["first"],
+            parserOptions: { ecmaVersion: 2022 }
         }
     ],
     invalid: [
@@ -406,6 +602,56 @@ ruleTester.run("semi-style", rule, {
         {
             code: "class C { foo;\nbar }",
             output: "class C { foo\n;bar }",
+            options: ["first"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "expectedSemiColon",
+                data: {
+                    pos: "the beginning of the next line"
+                }
+            }]
+        },
+
+        // Class static blocks
+        {
+            code: "class C { static { foo\n; } }",
+            output: "class C { static { foo;\n} }",
+            options: ["last"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "expectedSemiColon",
+                data: {
+                    pos: "the end of the previous line"
+                }
+            }]
+        },
+        {
+            code: "class C { static { foo\n ;bar } }",
+            output: "class C { static { foo;\nbar } }",
+            options: ["last"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "expectedSemiColon",
+                data: {
+                    pos: "the end of the previous line"
+                }
+            }]
+        },
+        {
+            code: "class C { static { foo;\nbar\n ; } }",
+            output: "class C { static { foo;\nbar;\n} }",
+            options: ["last"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "expectedSemiColon",
+                data: {
+                    pos: "the end of the previous line"
+                }
+            }]
+        },
+        {
+            code: "class C { static { foo;\nbar } }",
+            output: "class C { static { foo\n;bar } }",
             options: ["first"],
             parserOptions: { ecmaVersion: 2022 },
             errors: [{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15016, fixes `semi-style`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed false positive in the `semi-style` rule: the last statement in a class static block should be allowed to have its semicolon on the same line when the option is `"first"`.

```js
/* eslint semi-style: ["error", "first"] */

if (foo) {  
    bar(); // allowed
}

class C {
    method() {
      bar(); // allowed
    }
  
    static {
      bar(); // should be allowed, too
    }
}
```

#### Is there anything you'd like reviewers to focus on?
