### PR TITLE
feat: update no-use-before-define for class static blocks

### DIFF
--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -45,6 +45,14 @@ var b = 1;
         static x = C;
     }
 }
+
+{
+    const C = class {
+        static {
+            C.x = "foo";
+        }
+    }
+}
 ```
 
 Examples of **correct** code for this rule:
@@ -84,6 +92,14 @@ function g() {
 {
     const C = class {
         x = C;
+    }
+}
+
+{
+    const C = class C {
+        static {
+            C.x = "foo";
+        }
     }
 }
 ```
@@ -156,6 +172,15 @@ class A {
         [C.x]() {}
     }
 }
+
+{
+    class C {
+        static {
+            new D();
+        }
+    }
+    class D {}
+}
 ```
 
 Examples of **correct** code for the `{ "classes": false }` option:
@@ -196,6 +221,15 @@ const g = function() {};
 {
     const C = class {
         static x = foo;
+    }
+    const foo = 1;
+}
+
+{
+    class C {
+        static {
+            this.x = foo;
+        }
     }
     const foo = 1;
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15016, fixes `no-use-before-define`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated logic related to class definition evaluation with class static blocks.

```js
/* eslint no-use-before-define: "error" */

class C {
    static {
        C.x = 42; // ok
    }
}

const D = class {
    static {
        D.x = 42; // TDZ error
    }
}

class E {
    static {
        a; // TDZ error
    }
}
let a;
```


#### Is there anything you'd like reviewers to focus on?

This is ready for review but marked as draft since it's using `eslint-scope` from GitHub.
