### PR TITLE
feat: update no-redeclare for class static blocks

### DIFF
--- a/docs/rules/no-redeclare.md
+++ b/docs/rules/no-redeclare.md
@@ -13,6 +13,18 @@ Examples of **incorrect** code for this rule:
 
 var a = 3;
 var a = 10;
+
+class C {
+    foo() {
+        var b = 3;
+        var b = 10;
+    }
+
+    static {
+        var c = 3;
+        var c = 10;
+    }
+}
 ```
 
 Examples of **correct** code for this rule:
@@ -21,8 +33,20 @@ Examples of **correct** code for this rule:
 /*eslint no-redeclare: "error"*/
 
 var a = 3;
-// ...
 a = 10;
+
+class C {
+    foo() {
+        var b = 3;
+        b = 10;
+    }
+
+    static {
+        var c = 3;
+        c = 10;
+    }
+}
+
 ```
 
 ## Options

--- a/lib/rules/no-redeclare.js
+++ b/lib/rules/no-redeclare.js
@@ -161,6 +161,8 @@ module.exports = {
             FunctionExpression: checkForBlock,
             ArrowFunctionExpression: checkForBlock,
 
+            StaticBlock: checkForBlock,
+
             BlockStatement: checkForBlock,
             ForStatement: checkForBlock,
             ForInStatement: checkForBlock,

--- a/tests/lib/rules/no-redeclare.js
+++ b/tests/lib/rules/no-redeclare.js
@@ -28,6 +28,72 @@ ruleTester.run("no-redeclare", rule, {
                 ecmaVersion: 6
             }
         },
+        {
+            code: "var a; class C { static { var a; } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
+        {
+            code: "class C { static { var a; } } var a; ",
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
+        {
+            code: "function a(){} class C { static { var a; } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
+        {
+            code: "var a; class C { static { function a(){} } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
+        {
+            code: "class C { static { var a; } static { var a; } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
+        {
+            code: "class C { static { function a(){} } static { function a(){} } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
+        {
+            code: "class C { static { var a; { function a(){} } } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
+        {
+            code: "class C { static { function a(){}; { function a(){} } } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
+        {
+            code: "class C { static { var a; { let a; } } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
+        {
+            code: "class C { static { let a; { let a; } } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
+        {
+            code: "class C { static { { let a; } { let a; } } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
         { code: "var Object = 0;", options: [{ builtinGlobals: false }] },
         { code: "var Object = 0;", options: [{ builtinGlobals: true }], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "var Object = 0;", options: [{ builtinGlobals: true }], parserOptions: { ecmaFeatures: { globalReturn: true } } },
@@ -80,6 +146,37 @@ ruleTester.run("no-redeclare", rule, {
         { code: "var a = 3; var a = 10; var a = 15;", errors: [{ message: "'a' is already defined.", type: "Identifier" }, { message: "'a' is already defined.", type: "Identifier" }] },
         { code: "var a; var a;", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "'a' is already defined.", type: "Identifier" }] },
         { code: "export var a; var a;", parserOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ message: "'a' is already defined.", type: "Identifier" }] },
+
+        // `var` redeclaration in class static blocks. Redeclaration of functions is not allowed in class static blocks.
+        {
+            code: "class C { static { var a; var a; } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            },
+            errors: [{ message: "'a' is already defined.", type: "Identifier" }]
+        },
+        {
+            code: "class C { static { var a; { var a; } } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            },
+            errors: [{ message: "'a' is already defined.", type: "Identifier" }]
+        },
+        {
+            code: "class C { static { { var a; } var a; } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            },
+            errors: [{ message: "'a' is already defined.", type: "Identifier" }]
+        },
+        {
+            code: "class C { static { { var a; } { var a; } } }",
+            parserOptions: {
+                ecmaVersion: 2022
+            },
+            errors: [{ message: "'a' is already defined.", type: "Identifier" }]
+        },
+
         {
             code: "var Object = 0;",
             options: [{ builtinGlobals: true }],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15016, fixes `no-redeclare`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updates the `no-redeclare` rule to report redeclarations in class static blocks.

```js
/* eslint no-redeclare: "error" */

class C {
    static {
        var a;
        var a; // should be error
    }
}
```


#### Is there anything you'd like reviewers to focus on?

This is ready for review but marked as draft since it's using `eslint-scope` from GitHub.
