### PR TITLE
docs: the strict rule does not apply to class static blocks

### DIFF
--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -49,6 +49,8 @@ This rule disallows strict mode directives, no matter which option is specified,
 
 This rule disallows strict mode directives, no matter which option is specified, in functions with non-simple parameter lists (for example, parameter lists with default parameter values) because that is a syntax error in **ECMAScript 2016** and later. See the examples of the [function](#function) option.
 
+This rule does not apply to class static blocks, no matter which option is specified, because class static blocks do not have directives. Therefore, a `"use strict"` statement in a class static block is not a directive, and will be reported by the [no-unused-expressions](no-unused-expressions.md) rule.
+
 The `--fix` option on the command line does not insert new `"use strict"` statements, but only removes unneeded statements.
 
 ## Options

--- a/tests/lib/rules/strict.js
+++ b/tests/lib/rules/strict.js
@@ -88,7 +88,20 @@ ruleTester.run("strict", rule, {
         "function foo() { 'use strict'; return; }",
         { code: "'use strict'; function foo() { return; }", parserOptions: { ecmaFeatures: { globalReturn: true } } },
         { code: "function foo() { return; }", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
-        { code: "function foo() { return; }", parserOptions: { ecmaFeatures: { impliedStrict: true } } }
+        { code: "function foo() { return; }", parserOptions: { ecmaFeatures: { impliedStrict: true } } },
+
+        // class static blocks do not have directive prologues, therefore this rule should never require od disallow "use strict" statement in them.
+        { code: "'use strict'; class C { static { foo; } }", options: ["global"], parserOptions: { ecmaVersion: 2022 } },
+        { code: "'use strict'; class C { static { 'use strict'; } }", options: ["global"], parserOptions: { ecmaVersion: 2022 } },
+        { code: "'use strict'; class C { static { 'use strict'; 'use strict'; } }", options: ["global"], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C { static { foo; } }", options: ["function"], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C { static { 'use strict'; } }", options: ["function"], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C { static { 'use strict'; 'use strict'; } }", options: ["function"], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C { static { foo; } }", options: ["never"], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C { static { 'use strict'; } }", options: ["never"], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C { static { 'use strict'; 'use strict'; } }", options: ["never"], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C { static { 'use strict'; } }", options: ["safe"], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "class C { static { 'use strict'; } }", options: ["safe"], parserOptions: { ecmaVersion: 2022, ecmaFeatures: { impliedStrict: true } } }
 
     ],
     invalid: [
@@ -589,7 +602,60 @@ ruleTester.run("strict", rule, {
             options: ["function"],
             parserOptions: { ecmaVersion: 6 },
             errors: ["Use the function form of 'use strict'."]
-        }
+        },
 
+        // functions inside class static blocks should be checked
+        {
+            code: "'use strict'; class C { static { function foo() { \n'use strict'; } } }",
+            output: null,
+            options: ["global"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{ messageId: "global", line: 2 }]
+        },
+        {
+            code: "class C { static { function foo() { \n'use strict'; } } }",
+            output: null,
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{ messageId: "never", line: 2 }]
+        },
+        {
+            code: "class C { static { function foo() { \n'use strict'; } } }",
+            output: "class C { static { function foo() { \n } } }",
+            options: ["safe"],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: [{ messageId: "module", line: 2 }]
+        },
+        {
+            code: "class C { static { function foo() { \n'use strict'; } } }",
+            output: "class C { static { function foo() { \n } } }",
+            options: ["safe"],
+            parserOptions: { ecmaVersion: 2022, ecmaFeatures: { impliedStrict: true } },
+            errors: [{ messageId: "implied", line: 2 }]
+        },
+        {
+            code: "function foo() {'use strict'; class C { static { function foo() { \n'use strict'; } } } }",
+            output: "function foo() {'use strict'; class C { static { function foo() { \n } } } }",
+            options: ["function"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{ messageId: "unnecessary", line: 2 }]
+        },
+        {
+            code: "class C { static { function foo() { \n'use strict'; } } }",
+            output: "class C { static { function foo() { \n } } }",
+            options: ["function"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{ messageId: "unnecessaryInClasses", line: 2 }]
+        },
+        {
+            code: "class C { static { function foo() { \n'use strict';\n'use strict'; } } }",
+            output: "class C { static { function foo() { \n\n } } }",
+            options: ["function"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "unnecessaryInClasses", line: 2 },
+                { messageId: "multiple", line: 3 }
+            ]
+        }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15016, fixes `strict`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR documents that class static blocks do not have directives, and therefore the `strict` rule does not apply to them.

Also adds tests to confirm this behavior.

#### Is there anything you'd like reviewers to focus on?
