### PR TITLE
feat: update max-statements for class static blocks

### DIFF
--- a/docs/rules/max-statements.md
+++ b/docs/rules/max-statements.md
@@ -112,6 +112,30 @@ let foo = () => {
 }
 ```
 
+Note that this rule does not apply to class static blocks, and that statements in class static blocks do not count as statements in the enclosing function.
+
+Examples of **correct** code for this rule with `{ "max": 2 }` option:
+
+```js
+/*eslint max-statements: ["error", 2]*/
+
+function foo() {
+    let one;
+    let two = class {
+        static {
+            let three;
+            let four;
+            let five;
+            if (six) {
+                let seven;
+                let eight;
+                let nine;
+            }
+        }
+    };
+}
+```
+
 ### ignoreTopLevelFunctions
 
 Examples of additional **correct** code for this rule with the `{ "max": 10 }, { "ignoreTopLevelFunctions": true }` options:

--- a/lib/rules/max-statements.js
+++ b/lib/rules/max-statements.js
@@ -123,6 +123,14 @@ module.exports = {
         function endFunction(node) {
             const count = functionStack.pop();
 
+            /*
+             * This rule does not apply to class static blocks, but we have to track them so
+             * that stataments in them do not count as statements in the enclosing function.
+             */
+            if (node.type === "StaticBlock") {
+                return;
+            }
+
             if (ignoreTopLevelFunctions && functionStack.length === 0) {
                 topLevelFunctions.push({ node, count });
             } else {
@@ -148,12 +156,14 @@ module.exports = {
             FunctionDeclaration: startFunction,
             FunctionExpression: startFunction,
             ArrowFunctionExpression: startFunction,
+            StaticBlock: startFunction,
 
             BlockStatement: countStatements,
 
             "FunctionDeclaration:exit": endFunction,
             "FunctionExpression:exit": endFunction,
             "ArrowFunctionExpression:exit": endFunction,
+            "StaticBlock:exit": endFunction,
 
             "Program:exit"() {
                 if (topLevelFunctions.length === 1) {

--- a/tests/lib/rules/max-statements.js
+++ b/tests/lib/rules/max-statements.js
@@ -33,7 +33,33 @@ ruleTester.run("max-statements", rule, {
         { code: "var foo = { thing() { var bar = 1; var baz = 2; } }", options: [2], parserOptions: { ecmaVersion: 6 } },
         { code: "var foo = { ['thing']() { var bar = 1; var baz = 2; } }", options: [2], parserOptions: { ecmaVersion: 6 } },
         { code: "var foo = { thing: () => { var bar = 1; var baz = 2; } }", options: [2], parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = { thing: function() { var bar = 1; var baz = 2; } }", options: [{ max: 2 }] }
+        { code: "var foo = { thing: function() { var bar = 1; var baz = 2; } }", options: [{ max: 2 }] },
+
+        // this rule does not apply to class static blocks, and statements in them should not count as statements in the enclosing function
+        { code: "class C { static { one; two; three; { four; five; six; } } }", options: [2], parserOptions: { ecmaVersion: 2022 } },
+        { code: "function foo() { class C { static { one; two; three; { four; five; six; } } } }", options: [2], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C { static { one; two; three; function foo() { 1; 2; } four; five; six; } }", options: [2], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C { static { { one; two; three; function foo() { 1; 2; } four; five; six; } } }", options: [2], parserOptions: { ecmaVersion: 2022 } },
+        {
+            code: "function top_level() { 1; /* 2 */ class C { static { one; two; three; { four; five; six; } } } 3;}",
+            options: [2, { ignoreTopLevelFunctions: true }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "function top_level() { 1; 2; } class C { static { one; two; three; { four; five; six; } } }",
+            options: [1, { ignoreTopLevelFunctions: true }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { one; two; three; { four; five; six; } } } function top_level() { 1; 2; } ",
+            options: [1, { ignoreTopLevelFunctions: true }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "function foo() { let one; let two = class { static { let three; let four; let five; if (six) { let seven; let eight; let nine; } } }; }",
+            options: [2],
+            parserOptions: { ecmaVersion: 2022 }
+        }
     ],
     invalid: [
         {
@@ -143,6 +169,30 @@ ruleTester.run("max-statements", rule, {
             code: "function foo() { 1; }",
             options: [{ max: 0 }],
             errors: [{ messageId: "exceed", data: { name: "Function 'foo'", count: 1, max: 0 } }]
+        },
+        {
+            code: "function foo() { foo_1; /* foo_ 2 */ class C { static { one; two; three; four; { five; six; seven; eight; } } } foo_3 }",
+            options: [2],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{ messageId: "exceed", data: { name: "Function 'foo'", count: 3, max: 2 } }]
+        },
+        {
+            code: "class C { static { one; two; three; four; function not_top_level() { 1; 2; 3; } five; six; seven; eight; } }",
+            options: [2, { ignoreTopLevelFunctions: true }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{ messageId: "exceed", data: { name: "Function 'not_top_level'", count: 3, max: 2 } }]
+        },
+        {
+            code: "class C { static { { one; two; three; four; function not_top_level() { 1; 2; 3; } five; six; seven; eight; } } }",
+            options: [2, { ignoreTopLevelFunctions: true }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{ messageId: "exceed", data: { name: "Function 'not_top_level'", count: 3, max: 2 } }]
+        },
+        {
+            code: "class C { static { { one; two; three; four; } function not_top_level() { 1; 2; 3; } { five; six; seven; eight; } } }",
+            options: [2, { ignoreTopLevelFunctions: true }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{ messageId: "exceed", data: { name: "Function 'not_top_level'", count: 3, max: 2 } }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15016, fixes `max-statements`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the `max-statements` rule so that it does not apply to class static blocks and does not count statements in them as statements of the enclosing function.

#### Is there anything you'd like reviewers to focus on?

Before this change, the behavior of this rule was:

```js
/* eslint max-statements: ["error", 2] */

function foo() {
    var x; // 1
    return class { // 2
        static {
            var y; // doesn't count
            var z; // doesn't count
            var p; // doesn't count
            {
                var q; // 3
                var r; // 4
                var s; // 5
            }
        }
    }
}
```

```
 Function 'foo' has too many statements (5). Maximum allowed is 2. (max-statements)
```

Statements at the top level of static blocks did not count at all. Statements in nested blocks of static blocks did count, as statements of the enclosing function.

This didn't make sense, and possible fixes were:

1. Treat static blocks as blocks in the enclosing function, and count all statements. In that case, `foo` would have 8 statements.
2. Treat static blocks as inner functions. In that case, `foo` would have 2 statements, while the static block itself would be reported as it would have 6 statements.
3. Ignore all statements in static blocks. In that case, `foo` would have 2 statements, while the static block and its nested blocks would be ignored.

I implemented option 3.

```js
/* eslint max-statements: ["error", 2] */

function foo() {
    var x; // 1
    return class { // 2
        static { // ignored, the rule does not apply
            var y; // doesn't count
            var z; // doesn't count
            var p; // doesn't count
            {
                var q; // doesn't count
                var r; // doesn't count
                var s; // doesn't count
            }
        }
    }
}
```

I think that static block shouldn't be seen as a block in the function (option 1). Both options 2 and 3 make sense to me, but the documentation for this rule states multiple times that it applies to "functions", so given the conversation in #15016, it looked like this rule should not apply to static blocks, or at least not by default.

