### PR TITLE
feat: update max-depth for class static blocks

### DIFF
--- a/docs/rules/max-depth.md
+++ b/docs/rules/max-depth.md
@@ -20,7 +20,6 @@ Examples of **incorrect** code for this rule with the default `{ "max": 4 }` opt
 
 ```js
 /*eslint max-depth: ["error", 4]*/
-/*eslint-env es6*/
 
 function foo() {
     for (;;) { // Nested 1 deep
@@ -40,13 +39,54 @@ Examples of **correct** code for this rule with the default `{ "max": 4 }` optio
 
 ```js
 /*eslint max-depth: ["error", 4]*/
-/*eslint-env es6*/
 
 function foo() {
     for (;;) { // Nested 1 deep
         while (true) { // Nested 2 deep
             if (true) { // Nested 3 deep
                 if (true) { // Nested 4 deep
+                }
+            }
+        }
+    }
+}
+```
+
+Note that class static blocks do not count as nested blocks, and that the depth in them is calculated separately from the enclosing context.
+
+Examples of **incorrect** code for this rule with `{ "max": 2 }` option:
+
+```js
+/*eslint max-depth: ["error", 2]*/
+
+function foo() {
+    if (true) { // Nested 1 deep
+        class C {
+            static {
+                if (true) { // Nested 1 deep
+                    if (true) { // Nested 2 deep
+                        if (true) { // Nested 3 deep
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+Examples of **correct** code for this rule with `{ "max": 2 }` option:
+
+```js
+/*eslint max-depth: ["error", 2]*/
+
+function foo() {
+    if (true) { // Nested 1 deep
+        class C {
+            static {
+                if (true) { // Nested 1 deep
+                    if (true) { // Nested 2 deep
+                    }
                 }
             }
         }

--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -118,6 +118,7 @@ module.exports = {
             FunctionDeclaration: startFunction,
             FunctionExpression: startFunction,
             ArrowFunctionExpression: startFunction,
+            StaticBlock: startFunction,
 
             IfStatement(node) {
                 if (node.parent.type !== "IfStatement") {
@@ -146,6 +147,7 @@ module.exports = {
             "FunctionDeclaration:exit": endFunction,
             "FunctionExpression:exit": endFunction,
             "ArrowFunctionExpression:exit": endFunction,
+            "StaticBlock:exit": endFunction,
             "Program:exit": endFunction
         };
 

--- a/tests/lib/rules/max-depth.js
+++ b/tests/lib/rules/max-depth.js
@@ -26,7 +26,18 @@ ruleTester.run("max-depth", rule, {
         "function foo() { if (true) { if (false) { if (true) { } } } }",
 
         // object property options
-        { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [{ max: 3 }] }
+        { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [{ max: 3 }] },
+
+        { code: "class C { static { if (1) { if (2) {} } } }", options: [2], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C { static { if (1) { if (2) {} } if (1) { if (2) {} } } }", options: [2], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C { static { if (1) { if (2) {} } } static { if (1) { if (2) {} } } }", options: [2], parserOptions: { ecmaVersion: 2022 } },
+        { code: "if (1) { class C { static { if (1) { if (2) {} } } } }", options: [2], parserOptions: { ecmaVersion: 2022 } },
+        { code: "function foo() { if (1) { class C { static { if (1) { if (2) {} } } } } }", options: [2], parserOptions: { ecmaVersion: 2022 } },
+        {
+            code: "function foo() { if (1) { if (2) { class C { static { if (1) { if (2) {} } if (1) { if (2) {} } } } } } if (1) { if (2) {} } }",
+            options: [2],
+            parserOptions: { ecmaVersion: 2022 }
+        }
     ],
     invalid: [
         { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [2], errors: [{ messageId: "tooDeeply", data: { depth: 3, maxDepth: 2 }, type: "IfStatement" }] },
@@ -41,6 +52,51 @@ ruleTester.run("max-depth", rule, {
         { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [{ max: 2 }], errors: [{ messageId: "tooDeeply", data: { depth: 3, maxDepth: 2 }, type: "IfStatement" }] },
 
         { code: "function foo() { if (a) { if (b) { if (c) { if (d) { if (e) {} } } } } }", options: [{}], errors: [{ messageId: "tooDeeply", data: { depth: 5, maxDepth: 4 } }] },
-        { code: "function foo() { if (true) {} }", options: [{ max: 0 }], errors: [{ messageId: "tooDeeply", data: { depth: 1, maxDepth: 0 } }] }
+        { code: "function foo() { if (true) {} }", options: [{ max: 0 }], errors: [{ messageId: "tooDeeply", data: { depth: 1, maxDepth: 0 } }] },
+
+        {
+            code: "class C { static { if (1) { if (2) { if (3) {} } } } }",
+            options: [2],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "tooDeeply",
+                data: { depth: 3, maxDepth: 2 },
+                line: 1,
+                column: 38
+            }]
+        },
+        {
+            code: "if (1) { class C { static { if (1) { if (2) { if (3) {} } } } } }",
+            options: [2],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "tooDeeply",
+                data: { depth: 3, maxDepth: 2 },
+                line: 1,
+                column: 47
+            }]
+        },
+        {
+            code: "function foo() { if (1) { class C { static { if (1) { if (2) { if (3) {} } } } } } }",
+            options: [2],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "tooDeeply",
+                data: { depth: 3, maxDepth: 2 },
+                line: 1,
+                column: 64
+            }]
+        },
+        {
+            code: "function foo() { if (1) { class C { static { if (1) { if (2) {} } } } if (2) { if (3) {} } } }",
+            options: [2],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "tooDeeply",
+                data: { depth: 3, maxDepth: 2 },
+                line: 1,
+                column: 80
+            }]
+        }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15016, fixes `max-depth`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the `max-depth` rule to treat class static blocks as separate contexts when calculating depth.

Before this change:

```js
/* eslint max-depth: ["error", 2] */

function foo() {
    if (true) { // 1, ok
        class C {
            static { // does not count as a nested block, but it's still the same context
                if (true) { // 2, ok
                    if (true) { // 3, report as depth 3
                        if (true) { // 4, report as depth 4
                        }
                    }
                }
            }
        }
    }
}
```

After this change:

```js
/* eslint max-depth: ["error", 2] */

function foo() {
    if (true) { // 1, ok
        class C {
            static { // separate context
                if (true) { // 1, ok
                    if (true) { // 2, ok
                        if (true) { // 3, report as depth 3
                        }
                    }
                }
            }
        }
    }
}
```

#### Is there anything you'd like reviewers to focus on?

This is somewhat similar to https://github.com/eslint/eslint/pull/15315, but unlike `max-statements` this rule does not report functions. It reports blocks that are nested too deeply, relative to something (program, or function body). I think it makes sense to report blocks inside static blocks, and to calculate depth relative to the top level of static blocks.
