### PR TITLE
feat: update one-var for class static blocks

### DIFF
--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -66,7 +66,6 @@ Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint one-var: ["error", "always"]*/
-/*eslint-env es6*/
 
 function foo() {
     var bar;
@@ -89,13 +88,31 @@ function foo() {
         var qux = true;
     }
 }
+
+class C {
+    static {
+        var foo;
+        var bar;
+    }
+
+    static {
+        var foo;
+        if (bar) {
+            var baz = true;
+        }
+    }
+
+    static {
+        let foo;
+        let bar;
+    }
+}
 ```
 
 Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint one-var: ["error", "always"]*/
-/*eslint-env es6*/
 
 function foo() {
     var bar,
@@ -127,6 +144,30 @@ function foo(){
         let qux;
     }
 }
+
+class C {
+    static {
+        var foo, bar;
+    }
+
+    static {
+        var foo, baz;
+        if (bar) {
+            baz = true;
+        }
+    }
+
+    static {
+        let foo, bar;
+    }
+
+    static {
+        let foo;
+        if (bar) {
+            let baz;
+        }
+    }
+}
 ```
 
 ### never
@@ -135,7 +176,6 @@ Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint one-var: ["error", "never"]*/
-/*eslint-env es6*/
 
 function foo() {
     var bar,
@@ -157,13 +197,19 @@ function foo(){
     let bar = true,
         baz = false;
 }
+
+class C {
+    static {
+        var foo, bar;
+        let baz, qux;
+    }
+}
 ```
 
 Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint one-var: ["error", "never"]*/
-/*eslint-env es6*/
 
 function foo() {
     var bar;
@@ -185,6 +231,15 @@ function foo() {
         let qux = true;
     }
 }
+
+class C {
+    static {
+        var foo;
+        var bar;
+        let baz;
+        let qux;
+    }
+}
 ```
 
 ### consecutive
@@ -193,7 +248,6 @@ Examples of **incorrect** code for this rule with the `"consecutive"` option:
 
 ```js
 /*eslint one-var: ["error", "consecutive"]*/
-/*eslint-env es6*/
 
 function foo() {
     var bar;
@@ -209,14 +263,21 @@ function foo(){
     var qux = 3;
     var quux;
 }
+
+class C {
+    static {
+        var foo;
+        var bar;
+        let baz;
+        let qux;
+    }
+}
 ```
 
 Examples of **correct** code for this rule with the `"consecutive"` option:
 
 ```js
 /*eslint one-var: ["error", "consecutive"]*/
-/*eslint-env es6*/
-
 
 function foo() {
     var bar,
@@ -231,6 +292,16 @@ function foo(){
 
     var qux = 3,
         quux;
+}
+
+class C {
+    static {
+        var foo, bar;
+        let baz, qux;
+        doSomething();
+        let quux;
+        var quuux;
+    }
 }
 ```
 

--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -541,6 +541,8 @@ module.exports = {
             FunctionDeclaration: startFunction,
             FunctionExpression: startFunction,
             ArrowFunctionExpression: startFunction,
+            StaticBlock: startFunction, // StaticBlock creates a new scope for `var` variables
+
             BlockStatement: startBlock,
             ForStatement: startBlock,
             ForInStatement: startBlock,
@@ -552,10 +554,12 @@ module.exports = {
             "ForInStatement:exit": endBlock,
             "SwitchStatement:exit": endBlock,
             "BlockStatement:exit": endBlock,
+
             "Program:exit": endFunction,
             "FunctionDeclaration:exit": endFunction,
             "FunctionExpression:exit": endFunction,
-            "ArrowFunctionExpression:exit": endFunction
+            "ArrowFunctionExpression:exit": endFunction,
+            "StaticBlock:exit": endFunction
         };
 
     }

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -35,7 +35,7 @@ const COMMENTS_IGNORE_PATTERN = /^\s*(?:eslint|jshint\s+|jslint\s+|istanbul\s+|g
 const LINEBREAKS = new Set(["\r\n", "\r", "\n", "\u2028", "\u2029"]);
 
 // A set of node types that can contain a list of statements
-const STATEMENT_LIST_PARENTS = new Set(["Program", "BlockStatement", "SwitchCase"]);
+const STATEMENT_LIST_PARENTS = new Set(["Program", "BlockStatement", "StaticBlock", "SwitchCase"]);
 
 const DECIMAL_INTEGER_PATTERN = /^(?:0|0[0-7]*[89]\d*|[1-9](?:_?\d)*)$/u;
 

--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -493,6 +493,143 @@ ruleTester.run("one-var", rule, {
         {
             code: "var foo = 1;\nlet bar = function() { var x; };\nvar baz = 2;",
             options: [{ var: "never" }]
+        },
+
+        // class static blocks
+        {
+            code: "class C { static { var a; let b; const c = 0; } }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "const a = 0; class C { static { const b = 0; } }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { const b = 0; } } const a = 0; ",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "let a; class C { static { let b; } }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { let b; } } let a;",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "var a; class C { static { var b; } }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { var b; } } var a; ",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "var a; class C { static { if (foo) { var b; } } }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { if (foo) { var b; } } } var a; ",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { const a = 0; if (foo) { const b = 0; } } }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { let a; if (foo) { let b; } } }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { const a = 0; const b = 0; } }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { let a; let b; } }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { var a; var b; } }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { let a; foo; let b; } }",
+            options: ["consecutive"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { let a; const b = 0; let c; } }",
+            options: ["consecutive"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { var a; foo; var b; } }",
+            options: ["consecutive"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { var a; let b; var c; } }",
+            options: ["consecutive"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { let a; if (foo) { let b; } } }",
+            options: ["consecutive"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { if (foo) { let b; } let a;  } }",
+            options: ["consecutive"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { const a = 0; if (foo) { const b = 0; } } }",
+            options: ["consecutive"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { if (foo) { const b = 0; } const a = 0; } }",
+            options: ["consecutive"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { var a; if (foo) var b; } }",
+            options: ["consecutive"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { if (foo) var b; var a; } }",
+            options: ["consecutive"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { if (foo) { var b; } var a; } }",
+            options: ["consecutive"],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { let a; let b = 0; } }",
+            options: [{ initialized: "consecutive" }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C { static { var a; var b = 0; } }",
+            options: [{ initialized: "consecutive" }],
+            parserOptions: { ecmaVersion: 2022 }
         }
     ],
     invalid: [
@@ -2115,6 +2252,129 @@ ruleTester.run("one-var", rule, {
             options: ["never"],
             errors: [{
                 messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+
+        // class static blocks
+        {
+            code: "class C { static { let x, y; } }",
+            output: "class C { static { let x; let y; } }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "split",
+                data: { type: "let" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "class C { static { var x, y; } }",
+            output: "class C { static { var x; var y; } }",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "split",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "class C { static { let x; let y; } }",
+            output: "class C { static { let x,  y; } }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "combine",
+                data: { type: "let" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "class C { static { var x; var y; } }",
+            output: "class C { static { var x,  y; } }",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "combine",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "class C { static { let x; foo; let y; } }",
+            output: null,
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "combine",
+                data: { type: "let" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "class C { static { var x; foo; var y; } }",
+            output: null,
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "combine",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "class C { static { var x; if (foo) { var y; } } }",
+            output: null,
+            options: ["always"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "combine",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "class C { static { let x; let y; } }",
+            output: "class C { static { let x,  y; } }",
+            options: ["consecutive"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "combine",
+                data: { type: "let" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "class C { static { var x; var y; } }",
+            output: "class C { static { var x,  y; } }",
+            options: ["consecutive"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "combine",
+                data: { type: "var" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "class C { static { let a = 0; let b = 1; } }",
+            output: "class C { static { let a = 0,  b = 1; } }",
+            options: [{ initialized: "consecutive" }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "combineInitialized",
+                data: { type: "let" },
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "class C { static { var a = 0; var b = 1; } }",
+            output: "class C { static { var a = 0,  b = 1; } }",
+            options: [{ initialized: "consecutive" }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{
+                messageId: "combineInitialized",
                 data: { type: "var" },
                 type: "VariableDeclaration"
             }]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15016, fixes `one-var`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR fixes false positives of the `one-var` rule with option `"always"` where the rule suggests combining declarations from a class static block with declarations from the upper scope.

```js
/* eslint one-var: ["error", "always"] */

let a;

class C {
    static {
        let b; // false positive
    }
}
```

Also enables autofixing declarations at the top level of class static blocks with option `"never"`.

#### Is there anything you'd like reviewers to focus on?

Documentation for this rule states that it applies to functions, but it actually applies everywhere: at the top level, in functions, and in all blocks for block-scoped variables.