### PR TITLE
feat: update lines-around-comment for class static blocks

### DIFF
--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -15,8 +15,8 @@ This rule has an object option:
 * `"afterBlockComment": true` requires an empty line after block comments
 * `"beforeLineComment": true` requires an empty line before line comments
 * `"afterLineComment": true` requires an empty line after line comments
-* `"allowBlockStart": true` allows comments to appear at the start of block statements
-* `"allowBlockEnd": true` allows comments to appear at the end of block statements
+* `"allowBlockStart": true` allows comments to appear at the start of block statements, function bodies, classes, and class static blocks
+* `"allowBlockEnd": true` allows comments to appear at the end of block statements, function bodies, classes, and class static blocks
 * `"allowObjectStart": true` allows comments to appear at the start of object literals
 * `"allowObjectEnd": true` allows comments to appear at the end of object literals
 * `"allowArrayStart": true` allows comments to appear at the start of array literals
@@ -133,6 +133,25 @@ function foo(){
     var day = "great"
     return day;
 }
+
+if (bar) {
+    // what a great and wonderful day
+    foo();
+}
+
+class C {
+    // what a great and wonderful day
+
+    method() {
+        // what a great and wonderful day
+        foo();
+    }
+
+    static {
+        // what a great and wonderful day
+        foo();
+    }
+}
 ```
 
 Examples of **correct** code for this rule with the `{ "beforeBlockComment": true, "allowBlockStart": true }` options:
@@ -144,6 +163,25 @@ function foo(){
     /* what a great and wonderful day */
     var day = "great"
     return day;
+}
+
+if (bar) {
+    /* what a great and wonderful day */
+    foo();
+}
+
+class C {
+    /* what a great and wonderful day */
+
+    method() {
+        /* what a great and wonderful day */
+        foo();
+    }
+
+    static {
+        /* what a great and wonderful day */
+        foo();
+    }
 }
 ```
 
@@ -159,6 +197,26 @@ function foo(){
     return day;
     // what a great and wonderful day
 }
+
+if (bar) {
+    foo();
+    // what a great and wonderful day
+}
+
+class C {
+
+    method() {
+        foo();
+        // what a great and wonderful day
+    }
+
+    static {
+        foo();
+        // what a great and wonderful day
+    }
+
+    // what a great and wonderful day
+}
 ```
 
 Examples of **correct** code for this rule with the `{ "afterBlockComment": true, "allowBlockEnd": true }` option:
@@ -169,6 +227,29 @@ Examples of **correct** code for this rule with the `{ "afterBlockComment": true
 function foo(){
     var day = "great"
     return day;
+
+    /* what a great and wonderful day */
+}
+
+if (bar) {
+    foo();
+
+    /* what a great and wonderful day */
+}
+
+class C {
+
+    method() {
+        foo();
+
+        /* what a great and wonderful day */
+    }
+
+    static {
+        foo();
+
+        /* what a great and wonderful day */
+    }
 
     /* what a great and wonderful day */
 }

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -9,7 +9,8 @@
 //------------------------------------------------------------------------------
 
 const rule = require("../../../lib/rules/lines-around-comment"),
-    { RuleTester } = require("../../../lib/rule-tester");
+    { RuleTester } = require("../../../lib/rule-tester"),
+    { unIndent } = require("../../_utils");
 
 //------------------------------------------------------------------------------
 // Tests
@@ -262,6 +263,106 @@ ruleTester.run("lines-around-comment", rule, {
                 allowBlockStart: true
             }]
         },
+        {
+            code: unIndent`
+                class C {
+                    static {
+                        // line comment
+                    }
+
+                    static {
+                        // line comment
+                        foo();
+                    }
+                }`,
+            options: [{
+                beforeLineComment: true,
+                allowBlockStart: true
+            }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: unIndent`
+                class C {
+                    static
+                    {
+                        // line comment
+                    }
+
+                    static
+                    {
+                        // line comment
+                        foo();
+                    }
+                }`,
+            options: [{
+                beforeLineComment: true,
+                allowBlockStart: true
+            }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: unIndent`
+                class C {
+                    static {
+                        /* block comment */
+                    }
+
+                    static {
+                        /* block
+                           comment */
+                    }
+
+                    static {
+                        /* block comment */
+                        foo();
+                    }
+
+                    static {
+                        /* block
+                           comment */
+                        foo();
+                    }
+                }`,
+            options: [{
+                beforeBlockComment: true,
+                allowBlockStart: true
+            }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: unIndent`
+                class C {
+                    static
+                    {
+                        /* block comment */
+                    }
+
+                    static
+                    {
+                        /* block
+                        comment */
+                    }
+
+                    static
+                    {
+                        /* block comment */
+                        foo();
+                    }
+
+                    static
+                    {
+                        /* block
+                        comment */
+                        foo();
+                    }
+                }`,
+            options: [{
+                beforeBlockComment: true,
+                allowBlockStart: true
+            }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
 
         // check for block end comments
         {
@@ -471,6 +572,54 @@ ruleTester.run("lines-around-comment", rule, {
                 afterBlockComment: true,
                 allowBlockEnd: true
             }]
+        },
+        {
+            code: unIndent`
+                class C {
+                    static {
+                        // line comment
+                    }
+
+                    static {
+                        foo();
+                        // line comment
+                    }
+                }`,
+            options: [{
+                afterLineComment: true,
+                allowBlockEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: unIndent`
+                class C {
+                    static {
+                        /* block comment */
+                    }
+
+                    static {
+                        /* block
+                           comment */
+                    }
+
+                    static {
+                        foo();
+                        /* block comment */
+                    }
+
+                    static {
+                        foo();
+                        /* block
+                           comment */
+                    }
+                }`,
+            options: [{
+                beforeBlockComment: false, // default is `true`
+                afterBlockComment: true,
+                allowBlockEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 }
         },
 
         // check for object start comments
@@ -1048,6 +1197,346 @@ ruleTester.run("lines-around-comment", rule, {
                 afterLineComment: true
             }],
             errors: [{ messageId: "after", type: "Line", line: 8 }]
+        },
+        {
+            code: unIndent`
+                class C {
+                    // line comment
+                    static{}
+                }`,
+            output: unIndent`
+                class C {
+                    // line comment
+
+                    static{}
+                }`,
+            options: [{
+                beforeLineComment: true,
+                afterLineComment: true,
+                allowBlockStart: true,
+                allowBlockEnd: true,
+                allowClassStart: true,
+                allowClassEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "after", type: "Line", line: 2 }
+            ]
+        },
+        {
+            code: unIndent`
+                class C {
+                    /* block
+                       comment */
+                    static{}
+                }`,
+            output: unIndent`
+                class C {
+                    /* block
+                       comment */
+
+                    static{}
+                }`,
+            options: [{
+                beforeBlockComment: true,
+                afterBlockComment: true,
+                allowBlockStart: true,
+                allowBlockEnd: true,
+                allowClassStart: true,
+                allowClassEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "after", type: "Block", line: 2 }
+            ]
+        },
+        {
+            code: unIndent`
+                class C {
+                    static
+                    // line comment
+                    {}
+                }`,
+            output: unIndent`
+            class C {
+                static
+
+                // line comment
+
+                {}
+            }`,
+            options: [{
+                beforeLineComment: true,
+                afterLineComment: true,
+                allowBlockStart: true,
+                allowBlockEnd: true,
+                allowClassStart: true,
+                allowClassEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "before", type: "Line", line: 3 },
+                { messageId: "after", type: "Line", line: 3 }
+            ]
+        },
+        {
+            code: unIndent`
+                class C {
+                    static
+                    /* block
+                       comment */
+                    {}
+                }`,
+            output: unIndent`
+            class C {
+                static
+
+                /* block
+                   comment */
+
+                {}
+            }`,
+            options: [{
+                beforeBlockComment: true,
+                afterBlockComment: true,
+                allowBlockStart: true,
+                allowBlockEnd: true,
+                allowClassStart: true,
+                allowClassEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "before", type: "Block", line: 3 },
+                { messageId: "after", type: "Block", line: 3 }
+            ]
+        },
+        {
+            code: unIndent`
+                class C {
+                    static {
+                        // line comment
+                        foo();
+                    }
+                }`,
+            output: unIndent`
+                class C {
+                    static {
+                        // line comment
+
+                        foo();
+                    }
+                }`,
+            options: [{
+                beforeLineComment: true,
+                afterLineComment: true,
+                allowBlockStart: true,
+                allowBlockEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "after", type: "Line", line: 3 }
+            ]
+        },
+        {
+            code: unIndent`
+                class C {
+                    static {
+                        /* block
+                           comment */
+                        foo();
+                    }
+                }`,
+            output: unIndent`
+                class C {
+                    static {
+                        /* block
+                           comment */
+
+                        foo();
+                    }
+                }`,
+            options: [{
+                beforeBlockComment: true,
+                afterBlockComment: true,
+                allowBlockStart: true,
+                allowBlockEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "after", type: "Block", line: 3 }
+            ]
+        },
+        {
+            code: unIndent`
+                class C {
+                    static {
+                        foo();
+                        // line comment
+                    }
+                }`,
+            output: unIndent`
+                class C {
+                    static {
+                        foo();
+
+                        // line comment
+                    }
+                }`,
+            options: [{
+                beforeLineComment: true,
+                afterLineComment: true,
+                allowBlockStart: true,
+                allowBlockEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "before", type: "Line", line: 4 }
+            ]
+        },
+        {
+            code: unIndent`
+                class C {
+                    static {
+                        foo();
+                        /* block
+                           comment */
+                    }
+                }`,
+            output: unIndent`
+                class C {
+                    static {
+                        foo();
+
+                        /* block
+                           comment */
+                    }
+                }`,
+            options: [{
+                beforeBlockComment: true,
+                afterBlockComment: true,
+                allowBlockStart: true,
+                allowBlockEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "before", type: "Block", line: 4 }
+            ]
+        },
+        {
+            code: unIndent`
+                class C {
+                    static {
+                        foo();
+                        // line comment
+                        bar();
+                    }
+                }`,
+            output: unIndent`
+                class C {
+                    static {
+                        foo();
+
+                        // line comment
+
+                        bar();
+                    }
+                }`,
+            options: [{
+                beforeLineComment: true,
+                afterLineComment: true,
+                allowBlockStart: true,
+                allowBlockEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "before", type: "Line", line: 4 },
+                { messageId: "after", type: "Line", line: 4 }
+            ]
+        },
+        {
+            code: unIndent`
+                class C {
+                    static {
+                        foo();
+                        /* block
+                           comment */
+                        bar();
+                    }
+                }`,
+            output: unIndent`
+                class C {
+                    static {
+                        foo();
+
+                        /* block
+                           comment */
+
+                        bar();
+                    }
+                }`,
+            options: [{
+                beforeBlockComment: true,
+                afterBlockComment: true,
+                allowBlockStart: true,
+                allowBlockEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "before", type: "Block", line: 4 },
+                { messageId: "after", type: "Block", line: 4 }
+            ]
+        },
+        {
+            code: unIndent`
+                class C {
+                    static{}
+                    // line comment
+                }`,
+            output: unIndent`
+                class C {
+                    static{}
+
+                    // line comment
+                }`,
+            options: [{
+                beforeLineComment: true,
+                afterLineComment: true,
+                allowBlockStart: true,
+                allowBlockEnd: true,
+                allowClassStart: true,
+                allowClassEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "before", type: "Line", line: 3 }
+            ]
+        },
+        {
+            code: unIndent`
+                class C {
+                    static{}
+                    /* block
+                       comment */
+                }`,
+            output: unIndent`
+                class C {
+                    static{}
+
+                    /* block
+                       comment */
+                }`,
+            options: [{
+                beforeBlockComment: true,
+                afterBlockComment: true,
+                allowBlockStart: true,
+                allowBlockEnd: true,
+                allowClassStart: true,
+                allowClassEnd: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                { messageId: "before", type: "Block", line: 3 }
+            ]
         },
 
         // object start comments


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15016, fixes `lines-around-comment`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the `lines-around-comment` rule so that options `"allowBlockStart"` and `"allowBlockEnd"` apply to class static blocks.

These options already apply to both block statements and function bodies.

```js
/*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowBlockStart": true }]*/

if (bar) {
    // allowed
    foo();
}
class C {    
    method() {
        // allowed
        foo();
    }
    static {
        // should be allowed, too
        foo();
    }
}
```

#### Is there anything you'd like reviewers to focus on?

By the existing code, these options also apply to `SwitchCase`, but that wasn't documented and it looks broken, so I didn't document that now.