### PR TITLE
feat: update prefer-const for class static blocks

### DIFF
--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -12,7 +12,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint prefer-const: "error"*/
-/*eslint-env es6*/
 
 // it's initialized and never reassigned.
 let a = 3;
@@ -21,6 +20,14 @@ console.log(a);
 let a;
 a = 0;
 console.log(a);
+
+class C {
+    static {
+        let a;
+        a = 0;
+        console.log(a);
+    }
+}
 
 // `i` is redefined (not reassigned) on each loop step.
 for (let i in [1, 2, 3]) {
@@ -37,7 +44,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint prefer-const: "error"*/
-/*eslint-env es6*/
 
 // using const.
 const a = 0;
@@ -58,6 +64,15 @@ if (true) {
     a = 0;
 }
 console.log(a);
+
+// it's initialized in a different scope.
+let a;
+class C {
+    #x;
+    static {
+        a = obj => obj.#x;
+    }
+}
 
 // it's initialized at a place that we cannot write a variable declaration.
 let a;

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -17,7 +17,7 @@ const astUtils = require("./utils/ast-utils");
 //------------------------------------------------------------------------------
 
 const PATTERN_TYPE = /^(?:.+?Pattern|RestElement|SpreadProperty|ExperimentalRestProperty|Property)$/u;
-const DECLARATION_HOST_TYPE = /^(?:Program|BlockStatement|SwitchCase)$/u;
+const DECLARATION_HOST_TYPE = /^(?:Program|BlockStatement|StaticBlock|SwitchCase)$/u;
 const DESTRUCTURING_HOST_TYPE = /^(?:VariableDeclarator|AssignmentExpression)$/u;
 
 /**


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15016, fixes `prefer-const`

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR fixes false negatives of the `prefer-const` rule at the top level of class static blocks.

Example of a false negative:

```js
/* eslint prefer-const: "error" */

class C {
    static {
        let a;
        a = 0; 
    }
}
```

#### Is there anything you'd like reviewers to focus on?
