### PR TITLE
feat: Treat Class/New Expressions as truthy in no-constant-condition

### DIFF
--- a/docs/rules/no-constant-condition.md
+++ b/docs/rules/no-constant-condition.md
@@ -32,6 +32,14 @@ if (x &&= false) {
     doSomethingNever();
 }
 
+if (class {}) {
+    doSomethingAlways();
+}
+
+if (new Boolean(x)) {
+    doSomethingAlways();
+}
+
 if (x ||= true) {
     doSomethingAlways();
 }

--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -139,6 +139,7 @@ module.exports = {
                 case "ArrowFunctionExpression":
                 case "FunctionExpression":
                 case "ObjectExpression":
+                case "ClassExpression":
                     return true;
                 case "TemplateLiteral":
                     return (inBooleanPosition && node.quasis.some(quasi => quasi.value.cooked.length)) ||
@@ -180,7 +181,8 @@ module.exports = {
                         isLeftShortCircuit ||
                         isRightShortCircuit;
                 }
-
+                case "NewExpression":
+                    return inBooleanPosition;
                 case "AssignmentExpression":
                     if (node.operator === "=") {
                         return isConstant(node.right, inBooleanPosition);

--- a/tests/lib/rules/no-constant-condition.js
+++ b/tests/lib/rules/no-constant-condition.js
@@ -174,7 +174,8 @@ ruleTester.run("no-constant-condition", rule, {
         "function* foo() {for (; ; yield) {}}",
         "function* foo() {while (true) {function* foo() {yield;}yield;}}",
         "function* foo() { for (let x = yield; x < 10; x++) {yield;}yield;}",
-        "function* foo() { for (let x = yield; ; x++) { yield; }}"
+        "function* foo() { for (let x = yield; ; x++) { yield; }}",
+        "if (new Number(x) + 1 === 2) {}"
     ],
     invalid: [
         { code: "for(;true;);", errors: [{ messageId: "unexpected", type: "Literal" }] },
@@ -387,6 +388,16 @@ ruleTester.run("no-constant-condition", rule, {
         { code: "if(0b1n);", parserOptions: { ecmaVersion: 11 }, errors: [{ messageId: "unexpected", type: "Literal" }] },
         { code: "if(0o1n);", parserOptions: { ecmaVersion: 11 }, errors: [{ messageId: "unexpected", type: "Literal" }] },
         { code: "if(0x1n);", parserOptions: { ecmaVersion: 11 }, errors: [{ messageId: "unexpected", type: "Literal" }] },
-        { code: "if(0x1n || foo);", parserOptions: { ecmaVersion: 11 }, errors: [{ messageId: "unexpected", type: "LogicalExpression" }] }
+        { code: "if(0x1n || foo);", parserOptions: { ecmaVersion: 11 }, errors: [{ messageId: "unexpected", type: "LogicalExpression" }] },
+
+        // Classes and instances are always truthy
+        { code: "if(class {}) {}", errors: [{ messageId: "unexpected" }] },
+        { code: "if(new Foo()) {}", errors: [{ messageId: "unexpected" }] },
+
+        // Boxed primitives are always truthy
+        { code: "if(new Boolean(foo)) {}", errors: [{ messageId: "unexpected" }] },
+        { code: "if(new String(foo)) {}", errors: [{ messageId: "unexpected" }] },
+        { code: "if(new Number(foo)) {}", errors: [{ messageId: "unexpected" }] }
+
     ]
 });


### PR DESCRIPTION
In working on #15296 I discovered a few constant expressions that that were not covered in `no-constant-condition`, so I figured I'd propose adding them here.

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In working on #15296 I discovered a few constant expressions that that were not covered in `no-constant-condition`, so I figured I'd propose adding them here. This change add the ability to detect `ClassExpression` and `NewExpression`s as always truthy. I especially like that it catches the unintuitive fact that boxed primitives are always truthy.

These will now report errors:

```
if(new Foo()) {
  // ...
}

if(new Number(x)) {
  // ...
}

if(class {}) {
  // ...
}
```
#### Is there anything you'd like reviewers to focus on?

There's some overlap here with [`no-new-wrappers`](https://eslint.org/docs/rules/no-new-wrappers) but I think it's sensible since this detects an actual bug that results from primitive boxing.

