### PR TITLE
feat: redesign options for the `quotes` rule

### DIFF
--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -68,8 +68,6 @@ QUOTE_SETTINGS.backtick.convert = function(str) {
     }) + newQuote;
 };
 
-const AVOID_ESCAPE = "avoid-escape";
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -87,30 +85,21 @@ module.exports = {
 
         fixable: "code",
 
-        schema: [
-            {
-                enum: ["single", "double", "backtick"]
-            },
-            {
-                anyOf: [
-                    {
-                        enum: ["avoid-escape"]
-                    },
-                    {
-                        type: "object",
-                        properties: {
-                            avoidEscape: {
-                                type: "boolean"
-                            },
-                            allowTemplateLiterals: {
-                                type: "boolean"
-                            }
-                        },
-                        additionalProperties: false
+        schema: [{
+            type: "object",
+            properties: {
+                precedence: {
+                    type: "array",
+                    minItems: 1,
+                    items: {
+                        enum: ["single", "double", "backtick"]
                     }
-                ]
+                },
+                avoidEscape: {
+                    type: "boolean"
+                }
             }
-        ],
+        }],
 
         messages: {
             wrongQuotes: "Strings must use {{description}}."
@@ -119,17 +108,11 @@ module.exports = {
 
     create(context) {
 
-        const quoteOption = context.options[0],
-            settings = QUOTE_SETTINGS[quoteOption || "double"],
-            options = context.options[1],
-            allowTemplateLiterals = options && options.allowTemplateLiterals === true,
+        const quoteOption = context.options[0] && context.options[0].precedence || ["double"],
+            settings = QUOTE_SETTINGS[quoteOption[0]],
+            options = context.options[0],
+            avoidEscape = options && options.avoidEscape === true,
             sourceCode = context.getSourceCode();
-        let avoidEscape = options && options.avoidEscape === true;
-
-        // deprecated
-        if (options === AVOID_ESCAPE) {
-            avoidEscape = true;
-        }
 
         /**
          * Determines if a given node is part of JSX syntax.
@@ -267,7 +250,7 @@ module.exports = {
                     rawVal = node.raw;
 
                 if (settings && typeof val === "string") {
-                    let isValid = (quoteOption === "backtick" && isAllowedAsNonBacktick(node)) ||
+                    let isValid = (quoteOption.includes("backtick") && isAllowedAsNonBacktick(node)) ||
                         isJSXLiteral(node) ||
                         astUtils.isSurroundedBy(rawVal, settings.quote);
 
@@ -283,7 +266,7 @@ module.exports = {
                                 description: settings.description
                             },
                             fix(fixer) {
-                                if (quoteOption === "backtick" && astUtils.hasOctalOrNonOctalDecimalEscapeSequence(rawVal)) {
+                                if (quoteOption.includes("backtick") && astUtils.hasOctalOrNonOctalDecimalEscapeSequence(rawVal)) {
 
                                     /*
                                      * An octal or non-octal decimal escape sequence in a template literal would
@@ -303,8 +286,7 @@ module.exports = {
 
                 // Don't throw an error if backticks are expected or a template literal feature is in use.
                 if (
-                    allowTemplateLiterals ||
-                    quoteOption === "backtick" ||
+                    quoteOption.includes("backtick") ||
                     isUsingFeatureOfTemplateLiteral(node)
                 ) {
                     return;

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -68,6 +68,38 @@ QUOTE_SETTINGS.backtick.convert = function(str) {
     }) + newQuote;
 };
 
+/**
+ * Normalize options from old syntax to new syntax
+ * @param {Array} options context.options
+ * @returns {Array} new syntax options
+ * @private
+ */
+function normalizeOptions(options) {
+    const [firstOption, secondOption] = options;
+    const newOptions = {};
+
+    if (typeof firstOption === "object") {
+        return options;
+    }
+
+    if (typeof firstOption === "string") {
+        newOptions.precedence = [firstOption];
+    }
+
+    if (
+        (typeof secondOption === "string" && secondOption === "avoid-escape") ||
+     (typeof secondOption === "object" && secondOption.avoidEscape)
+    ) {
+        newOptions.avoidEscape = true;
+    }
+
+    if (typeof secondOption === "object" && secondOption.allowTemplateLiterals) {
+        newOptions.precedence.push("backtick");
+    }
+
+    return [newOptions];
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -84,23 +116,49 @@ module.exports = {
         },
 
         fixable: "code",
-
-        schema: [{
-            type: "object",
-            properties: {
-                precedence: {
-                    type: "array",
-                    minItems: 1,
-                    items: {
+        schema: [
+            {
+                anyOf: [
+                    {
                         enum: ["single", "double", "backtick"]
+                    },
+                    {
+                        type: "object",
+                        properties: {
+                            precedence: {
+                                type: "array",
+                                minItems: 1,
+                                items: {
+                                    enum: ["single", "double", "backtick"]
+                                }
+                            },
+                            avoidEscape: {
+                                type: "boolean"
+                            }
+                        }
                     }
-                },
-                avoidEscape: {
-                    type: "boolean"
-                }
+                ]
+            },
+            {
+                anyOf: [
+                    {
+                        enum: ["avoid-escape"]
+                    },
+                    {
+                        type: "object",
+                        properties: {
+                            avoidEscape: {
+                                type: "boolean"
+                            },
+                            allowTemplateLiterals: {
+                                type: "boolean"
+                            }
+                        },
+                        additionalProperties: false
+                    }
+                ]
             }
-        }],
-
+        ],
         messages: {
             wrongQuotes: "Strings must use {{description}}."
         }
@@ -108,9 +166,12 @@ module.exports = {
 
     create(context) {
 
-        const quoteOption = context.options[0] && context.options[0].precedence || ["double"],
+        // TODO: remove support for old syntax in v9
+        const newSyntaxOptions = normalizeOptions(context.options);
+
+        const quoteOption = newSyntaxOptions[0] && newSyntaxOptions[0].precedence || ["double"],
             settings = QUOTE_SETTINGS[quoteOption[0]],
-            options = context.options[0],
+            options = newSyntaxOptions[0],
             avoidEscape = options && options.avoidEscape === true,
             sourceCode = context.getSourceCode();
 

--- a/tests/lib/init/config-initializer.js
+++ b/tests/lib/init/config-initializer.js
@@ -410,7 +410,7 @@ describe("configInitializer", () => {
             });
 
             it("should create the config based on examined files", () => {
-                assert.deepStrictEqual(config.rules.quotes, ["error", "double"]);
+                assert.strictEqual(config.rules.quotes, "error");
                 assert.strictEqual(config.rules.semi, "off");
             });
 

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -21,6 +21,71 @@ const ruleTester = new RuleTester();
 ruleTester.run("quotes", rule, {
     valid: [
         "var foo = \"bar\";",
+
+        // Old syntax options
+        { code: "var foo = 'bar';", options: ["single"] },
+        { code: "var foo = \"bar\";", options: ["double"] },
+        { code: "var foo = 1;", options: ["single"] },
+        { code: "var foo = 1;", options: ["double"] },
+        { code: "var foo = \"'\";", options: ["single", { avoidEscape: true }] },
+        { code: "var foo = '\"';", options: ["double", { avoidEscape: true }] },
+        { code: "var foo = <>Hello world</>;", options: ["single"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <>Hello world</>;", options: ["double"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <>Hello world</>;", options: ["double", { avoidEscape: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <>Hello world</>;", options: ["backtick"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div>Hello world</div>;", options: ["single"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div id=\"foo\"></div>;", options: ["single"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div>Hello world</div>;", options: ["double"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div>Hello world</div>;", options: ["double", { avoidEscape: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = `bar`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `bar 'baz'`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `bar \"baz\"`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = 1;", options: ["backtick"] },
+        { code: "var foo = \"a string containing `backtick` quotes\";", options: ["backtick", { avoidEscape: true }] },
+        { code: "var foo = <div id=\"foo\"></div>;", options: ["backtick"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div>Hello world</div>;", options: ["backtick"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "class C { \"f\"; \"m\"() {} }", options: ["double"], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C { 'f'; 'm'() {} }", options: ["single"], parserOptions: { ecmaVersion: 2022 } },
+
+        // Backticks are only okay if they have substitutions, contain a line break, or are tagged
+        { code: "var foo = `back\ntick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back\rtick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back\u2028tick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back\u2029tick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
+        {
+            code: "var foo = `back\\\\\ntick`;", // 2 backslashes followed by a newline
+            options: ["single"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        { code: "var foo = `back\\\\\\\\\ntick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `\n`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back${x}tick`;", options: ["double"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = tag`backtick`;", options: ["double"], parserOptions: { ecmaVersion: 6 } },
+
+        // Backticks are also okay if allowTemplateLiterals
+        { code: "var foo = `bar 'foo' baz` + 'bar';", options: ["single", { allowTemplateLiterals: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `bar 'foo' baz` + \"bar\";", options: ["double", { allowTemplateLiterals: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `bar 'foo' baz` + `bar`;", options: ["backtick", { allowTemplateLiterals: true }], parserOptions: { ecmaVersion: 6 } },
+
+        // `backtick` should not warn the directive prologues.
+        { code: "\"use strict\"; var foo = `backtick`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "\"use strict\"; 'use strong'; \"use asm\"; var foo = `backtick`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo() { \"use strict\"; \"use strong\"; \"use asm\"; var foo = `backtick`; }", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "(function() { 'use strict'; 'use strong'; 'use asm'; var foo = `backtick`; })();", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "(() => { \"use strict\"; \"use strong\"; \"use asm\"; var foo = `backtick`; })();", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+
+        // `backtick` should not warn import/export sources.
+        { code: "import \"a\"; import 'b';", options: ["backtick"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "import a from \"a\"; import b from 'b';", options: ["backtick"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "export * from \"a\"; export * from 'b';", options: ["backtick"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+
+        // `backtick` should not warn property/method names (not computed).
+        { code: "var obj = {\"key0\": 0, 'key1': 1};", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "class Foo { 'bar'(){} }", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "class Foo { static ''(){} }", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "class C { \"double\"; 'single'; }", options: ["backtick"], parserOptions: { ecmaVersion: 2022 } },
+
+        // New syntax options
         { code: "var foo = 'bar';", options: [{ precedence: ["single"] }] },
         { code: "var foo = \"bar\";", options: [{ precedence: ["double"] }] },
         { code: "var foo = 1;", options: [{ precedence: ["single"] }] },
@@ -84,6 +149,8 @@ ruleTester.run("quotes", rule, {
         { code: "class C { \"double\"; 'single'; }", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 2022 } }
     ],
     invalid: [
+
+        // Old syntax options
         {
             code: "var foo = 'bar';",
             output: "var foo = \"bar\";",
@@ -92,6 +159,629 @@ ruleTester.run("quotes", rule, {
                 data: { description: "doublequote" },
                 type: "Literal"
             }]
+        },
+        {
+            code: "var foo = \"bar\";",
+            output: "var foo = 'bar';",
+            options: ["single"],
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "singlequote" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "var foo = `bar`;",
+            output: "var foo = 'bar';",
+            options: ["single"],
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "singlequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "var foo = 'don\\'t';",
+            output: "var foo = \"don't\";",
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "var msg = \"Plugin '\" + name + \"' not found\"",
+            output: "var msg = 'Plugin \\'' + name + '\\' not found'",
+            options: ["single"],
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "singlequote" },
+                    type: "Literal",
+                    column: 11
+                },
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "singlequote" },
+                    type: "Literal",
+                    column: 31
+                }
+            ]
+        },
+        {
+            code: "var foo = 'bar';",
+            output: "var foo = \"bar\";",
+            options: ["double"],
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "var foo = `bar`;",
+            output: "var foo = \"bar\";",
+            options: ["double"],
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "var foo = \"bar\";",
+            output: "var foo = 'bar';",
+            options: ["single", { avoidEscape: true }],
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "singlequote" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "var foo = 'bar';",
+            output: "var foo = \"bar\";",
+            options: ["double", { avoidEscape: true }],
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "var foo = '\\\\';",
+            output: "var foo = \"\\\\\";",
+            options: ["double", { avoidEscape: true }],
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "var foo = \"bar\";",
+            output: "var foo = 'bar';",
+            options: ["single", { allowTemplateLiterals: true }],
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "singlequote" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "var foo = 'bar';",
+            output: "var foo = \"bar\";",
+            options: ["double", { allowTemplateLiterals: true }],
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "var foo = 'bar';",
+            output: "var foo = `bar`;",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "var foo = 'b${x}a$r';",
+            output: "var foo = `b\\${x}a$r`;",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "var foo = \"bar\";",
+            output: "var foo = `bar`;",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "var foo = \"bar\";",
+            output: "var foo = `bar`;",
+            options: ["backtick", { avoidEscape: true }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "var foo = 'bar';",
+            output: "var foo = `bar`;",
+            options: ["backtick", { avoidEscape: true }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
+        },
+
+        // "use strict" is *not* a directive prologue in these statements so is subject to the rule
+        {
+            code: "var foo = `backtick`; \"use strict\";",
+            output: "var foo = `backtick`; `use strict`;",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "{ \"use strict\"; var foo = `backtick`; }",
+            output: "{ `use strict`; var foo = `backtick`; }",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
+        },
+        {
+            code: "if (1) { \"use strict\"; var foo = `backtick`; }",
+            output: "if (1) { `use strict`; var foo = `backtick`; }",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "backtick" },
+                type: "Literal"
+            }]
+        },
+
+        // `backtick` should warn computed property names.
+        {
+            code: "var obj = {[\"key0\"]: 0, ['key1']: 1};",
+            output: "var obj = {[`key0`]: 0, [`key1`]: 1};",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                },
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "class Foo { ['a'](){} static ['b'](){} }",
+            output: "class Foo { [`a`](){} static [`b`](){} }",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                },
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
+        },
+
+        // https://github.com/eslint/eslint/issues/7084
+        {
+            code: "<div blah={\"blah\"} />",
+            output: "<div blah={'blah'} />",
+            options: ["single"],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "singlequote" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "<div blah={'blah'} />",
+            output: "<div blah={\"blah\"} />",
+            options: ["double"],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "doublequote" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "<div blah={'blah'} />",
+            output: "<div blah={`blah`} />",
+            options: ["backtick"],
+            parserOptions: { ecmaFeatures: { jsx: true }, ecmaVersion: 2015 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
+        },
+
+        // https://github.com/eslint/eslint/issues/7610
+        {
+            code: "`use strict`;",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "function foo() { `use strict`; foo(); }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "foo = function() { `use strict`; foo(); }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "() => { `use strict`; foo(); }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "() => { foo(); `use strict`; }",
+            output: "() => { foo(); \"use strict\"; }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "foo(); `use strict`;",
+            output: "foo(); \"use strict\";",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+
+        // https://github.com/eslint/eslint/issues/7646
+        {
+            code: "var foo = `foo\\nbar`;",
+            output: "var foo = \"foo\\nbar\";",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "var foo = `foo\\\nbar`;", // 1 backslash followed by a newline
+            output: "var foo = \"foo\\\nbar\";",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "var foo = `foo\\\\\\\nbar`;", // 3 backslashes followed by a newline
+            output: "var foo = \"foo\\\\\\\nbar\";",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "````",
+            output: "\"\"``",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "wrongQuotes",
+                data: { description: "doublequote" },
+                type: "TemplateLiteral",
+                line: 1,
+                column: 1
+            }]
+        },
+
+        // Strings containing octal escape sequences. Don't autofix to backticks.
+        {
+            code: "var foo = \"\\1\"",
+            output: "var foo = '\\1'",
+            options: ["single"],
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "singlequote" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = '\\1'",
+            output: "var foo = \"\\1\"",
+            options: ["double"],
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "doublequote" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var notoctal = '\\0'",
+            output: "var notoctal = `\\0`",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = '\\1'",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = \"\\1\"",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = '\\01'",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = '\\0\\1'",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = '\\08'",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = 'prefix \\33'",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = 'prefix \\75 suffix'",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var nonOctalDecimalEscape = '\\8'",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
+        },
+
+
+        // class members
+        {
+            code: "class C { 'foo'; }",
+            output: "class C { \"foo\"; }",
+            options: ["double"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "doublequote" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "class C { 'foo'() {} }",
+            output: "class C { \"foo\"() {} }",
+            options: ["double"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "doublequote" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "class C { \"foo\"; }",
+            output: "class C { 'foo'; }",
+            options: ["single"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "singlequote" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "class C { \"foo\"() {} }",
+            output: "class C { 'foo'() {} }",
+            options: ["single"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "singlequote" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "class C { [\"foo\"]; }",
+            output: "class C { [`foo`]; }",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "class C { foo = \"foo\"; }",
+            output: "class C { foo = `foo`; }",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                {
+                    messageId: "wrongQuotes",
+                    data: { description: "backtick" },
+                    type: "Literal"
+                }
+            ]
         },
         {
             code: "var foo = \"bar\";",
@@ -114,15 +804,6 @@ ruleTester.run("quotes", rule, {
                 messageId: "wrongQuotes",
                 data: { description: "singlequote" },
                 type: "TemplateLiteral"
-            }]
-        },
-        {
-            code: "var foo = 'don\\'t';",
-            output: "var foo = \"don't\";",
-            errors: [{
-                messageId: "wrongQuotes",
-                data: { description: "doublequote" },
-                type: "Literal"
             }]
         },
         {
@@ -385,112 +1066,6 @@ ruleTester.run("quotes", rule, {
                     type: "Literal"
                 }
             ]
-        },
-
-        // https://github.com/eslint/eslint/issues/7610
-        {
-            code: "`use strict`;",
-            output: null,
-            parserOptions: { ecmaVersion: 6 },
-            errors: [{
-                messageId: "wrongQuotes",
-                data: { description: "doublequote" },
-                type: "TemplateLiteral"
-            }]
-        },
-        {
-            code: "function foo() { `use strict`; foo(); }",
-            output: null,
-            parserOptions: { ecmaVersion: 6 },
-            errors: [{
-                messageId: "wrongQuotes",
-                data: { description: "doublequote" },
-                type: "TemplateLiteral"
-            }]
-        },
-        {
-            code: "foo = function() { `use strict`; foo(); }",
-            output: null,
-            parserOptions: { ecmaVersion: 6 },
-            errors: [{
-                messageId: "wrongQuotes",
-                data: { description: "doublequote" },
-                type: "TemplateLiteral"
-            }]
-        },
-        {
-            code: "() => { `use strict`; foo(); }",
-            output: null,
-            parserOptions: { ecmaVersion: 6 },
-            errors: [{
-                messageId: "wrongQuotes",
-                data: { description: "doublequote" },
-                type: "TemplateLiteral"
-            }]
-        },
-        {
-            code: "() => { foo(); `use strict`; }",
-            output: "() => { foo(); \"use strict\"; }",
-            parserOptions: { ecmaVersion: 6 },
-            errors: [{
-                messageId: "wrongQuotes",
-                data: { description: "doublequote" },
-                type: "TemplateLiteral"
-            }]
-        },
-        {
-            code: "foo(); `use strict`;",
-            output: "foo(); \"use strict\";",
-            parserOptions: { ecmaVersion: 6 },
-            errors: [{
-                messageId: "wrongQuotes",
-                data: { description: "doublequote" },
-                type: "TemplateLiteral"
-            }]
-        },
-
-        // https://github.com/eslint/eslint/issues/7646
-        {
-            code: "var foo = `foo\\nbar`;",
-            output: "var foo = \"foo\\nbar\";",
-            parserOptions: { ecmaVersion: 6 },
-            errors: [{
-                messageId: "wrongQuotes",
-                data: { description: "doublequote" },
-                type: "TemplateLiteral"
-            }]
-        },
-        {
-            code: "var foo = `foo\\\nbar`;", // 1 backslash followed by a newline
-            output: "var foo = \"foo\\\nbar\";",
-            parserOptions: { ecmaVersion: 6 },
-            errors: [{
-                messageId: "wrongQuotes",
-                data: { description: "doublequote" },
-                type: "TemplateLiteral"
-            }]
-        },
-        {
-            code: "var foo = `foo\\\\\\\nbar`;", // 3 backslashes followed by a newline
-            output: "var foo = \"foo\\\\\\\nbar\";",
-            parserOptions: { ecmaVersion: 6 },
-            errors: [{
-                messageId: "wrongQuotes",
-                data: { description: "doublequote" },
-                type: "TemplateLiteral"
-            }]
-        },
-        {
-            code: "````",
-            output: "\"\"``",
-            parserOptions: { ecmaVersion: 6 },
-            errors: [{
-                messageId: "wrongQuotes",
-                data: { description: "doublequote" },
-                type: "TemplateLiteral",
-                line: 1,
-                column: 1
-            }]
         },
 
         // Strings containing octal escape sequences. Don't autofix to backticks.

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -21,67 +21,67 @@ const ruleTester = new RuleTester();
 ruleTester.run("quotes", rule, {
     valid: [
         "var foo = \"bar\";",
-        { code: "var foo = 'bar';", options: ["single"] },
-        { code: "var foo = \"bar\";", options: ["double"] },
-        { code: "var foo = 1;", options: ["single"] },
-        { code: "var foo = 1;", options: ["double"] },
-        { code: "var foo = \"'\";", options: ["single", { avoidEscape: true }] },
-        { code: "var foo = '\"';", options: ["double", { avoidEscape: true }] },
-        { code: "var foo = <>Hello world</>;", options: ["single"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
-        { code: "var foo = <>Hello world</>;", options: ["double"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
-        { code: "var foo = <>Hello world</>;", options: ["double", { avoidEscape: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
-        { code: "var foo = <>Hello world</>;", options: ["backtick"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
-        { code: "var foo = <div>Hello world</div>;", options: ["single"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
-        { code: "var foo = <div id=\"foo\"></div>;", options: ["single"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
-        { code: "var foo = <div>Hello world</div>;", options: ["double"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
-        { code: "var foo = <div>Hello world</div>;", options: ["double", { avoidEscape: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
-        { code: "var foo = `bar`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = `bar 'baz'`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = `bar \"baz\"`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = 1;", options: ["backtick"] },
-        { code: "var foo = \"a string containing `backtick` quotes\";", options: ["backtick", { avoidEscape: true }] },
-        { code: "var foo = <div id=\"foo\"></div>;", options: ["backtick"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
-        { code: "var foo = <div>Hello world</div>;", options: ["backtick"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
-        { code: "class C { \"f\"; \"m\"() {} }", options: ["double"], parserOptions: { ecmaVersion: 2022 } },
-        { code: "class C { 'f'; 'm'() {} }", options: ["single"], parserOptions: { ecmaVersion: 2022 } },
+        { code: "var foo = 'bar';", options: [{ precedence: ["single"] }] },
+        { code: "var foo = \"bar\";", options: [{ precedence: ["double"] }] },
+        { code: "var foo = 1;", options: [{ precedence: ["single"] }] },
+        { code: "var foo = 1;", options: [{ precedence: ["double"] }] },
+        { code: "var foo = \"'\";", options: [{ precedence: ["single"], avoidEscape: true }] },
+        { code: "var foo = '\"';", options: [{ precedence: ["double"], avoidEscape: true }] },
+        { code: "var foo = <>Hello world</>;", options: [{ precedence: ["single"] }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <>Hello world</>;", options: [{ precedence: ["double"] }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <>Hello world</>;", options: [{ precedence: ["double"], avoidEscape: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <>Hello world</>;", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div>Hello world</div>;", options: [{ precedence: ["single"] }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div id=\"foo\"></div>;", options: [{ precedence: ["single"] }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div>Hello world</div>;", options: [{ precedence: ["double"] }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div>Hello world</div>;", options: [{ precedence: ["double"], avoidEscape: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = `bar`;", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `bar 'baz'`;", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `bar \"baz\"`;", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = 1;", options: [{ precedence: ["backtick"] }] },
+        { code: "var foo = \"a string containing `backtick` quotes\";", options: [{ precedence: ["backtick"], avoidEscape: true }] },
+        { code: "var foo = <div id=\"foo\"></div>;", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "var foo = <div>Hello world</div>;", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "class C { \"f\"; \"m\"() {} }", options: [{ precedence: ["double"] }], parserOptions: { ecmaVersion: 2022 } },
+        { code: "class C { 'f'; 'm'() {} }", options: [{ precedence: ["single"] }], parserOptions: { ecmaVersion: 2022 } },
 
         // Backticks are only okay if they have substitutions, contain a line break, or are tagged
-        { code: "var foo = `back\ntick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = `back\rtick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = `back\u2028tick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = `back\u2029tick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back\ntick`;", options: [{ precedence: ["single"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back\rtick`;", options: [{ precedence: ["single"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back\u2028tick`;", options: [{ precedence: ["single"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back\u2029tick`;", options: [{ precedence: ["single"] }], parserOptions: { ecmaVersion: 6 } },
         {
             code: "var foo = `back\\\\\ntick`;", // 2 backslashes followed by a newline
-            options: ["single"],
+            options: [{ precedence: ["single"] }],
             parserOptions: { ecmaVersion: 6 }
         },
-        { code: "var foo = `back\\\\\\\\\ntick`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = `\n`;", options: ["single"], parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = `back${x}tick`;", options: ["double"], parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = tag`backtick`;", options: ["double"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back\\\\\\\\\ntick`;", options: [{ precedence: ["single"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `\n`;", options: [{ precedence: ["single"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `back${x}tick`;", options: [{ precedence: ["double"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = tag`backtick`;", options: [{ precedence: ["double"] }], parserOptions: { ecmaVersion: 6 } },
 
         // Backticks are also okay if allowTemplateLiterals
-        { code: "var foo = `bar 'foo' baz` + 'bar';", options: ["single", { allowTemplateLiterals: true }], parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = `bar 'foo' baz` + \"bar\";", options: ["double", { allowTemplateLiterals: true }], parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = `bar 'foo' baz` + `bar`;", options: ["backtick", { allowTemplateLiterals: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `bar 'foo' baz` + 'bar';", options: [{ precedence: ["single", "backtick"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `bar 'foo' baz` + \"bar\";", options: [{ precedence: ["double", "backtick"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = `bar 'foo' baz` + `bar`;", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6 } },
 
         // `backtick` should not warn the directive prologues.
-        { code: "\"use strict\"; var foo = `backtick`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
-        { code: "\"use strict\"; 'use strong'; \"use asm\"; var foo = `backtick`;", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
-        { code: "function foo() { \"use strict\"; \"use strong\"; \"use asm\"; var foo = `backtick`; }", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
-        { code: "(function() { 'use strict'; 'use strong'; 'use asm'; var foo = `backtick`; })();", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
-        { code: "(() => { \"use strict\"; \"use strong\"; \"use asm\"; var foo = `backtick`; })();", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+        { code: "\"use strict\"; var foo = `backtick`;", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "\"use strict\"; 'use strong'; \"use asm\"; var foo = `backtick`;", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo() { \"use strict\"; \"use strong\"; \"use asm\"; var foo = `backtick`; }", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "(function() { 'use strict'; 'use strong'; 'use asm'; var foo = `backtick`; })();", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "(() => { \"use strict\"; \"use strong\"; \"use asm\"; var foo = `backtick`; })();", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6 } },
 
         // `backtick` should not warn import/export sources.
-        { code: "import \"a\"; import 'b';", options: ["backtick"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
-        { code: "import a from \"a\"; import b from 'b';", options: ["backtick"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
-        { code: "export * from \"a\"; export * from 'b';", options: ["backtick"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "import \"a\"; import 'b';", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "import a from \"a\"; import b from 'b';", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "export * from \"a\"; export * from 'b';", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
 
         // `backtick` should not warn property/method names (not computed).
-        { code: "var obj = {\"key0\": 0, 'key1': 1};", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
-        { code: "class Foo { 'bar'(){} }", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
-        { code: "class Foo { static ''(){} }", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
-        { code: "class C { \"double\"; 'single'; }", options: ["backtick"], parserOptions: { ecmaVersion: 2022 } }
+        { code: "var obj = {\"key0\": 0, 'key1': 1};", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "class Foo { 'bar'(){} }", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "class Foo { static ''(){} }", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 6 } },
+        { code: "class C { \"double\"; 'single'; }", options: [{ precedence: ["backtick"] }], parserOptions: { ecmaVersion: 2022 } }
     ],
     invalid: [
         {
@@ -96,7 +96,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = \"bar\";",
             output: "var foo = 'bar';",
-            options: ["single"],
+            options: [{ precedence: ["single"] }],
             errors: [{
                 messageId: "wrongQuotes",
                 data: { description: "singlequote" },
@@ -106,7 +106,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = `bar`;",
             output: "var foo = 'bar';",
-            options: ["single"],
+            options: [{ precedence: ["single"] }],
             parserOptions: {
                 ecmaVersion: 6
             },
@@ -128,7 +128,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var msg = \"Plugin '\" + name + \"' not found\"",
             output: "var msg = 'Plugin \\'' + name + '\\' not found'",
-            options: ["single"],
+            options: [{ precedence: ["single"] }],
             errors: [
                 {
                     messageId: "wrongQuotes",
@@ -147,7 +147,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = 'bar';",
             output: "var foo = \"bar\";",
-            options: ["double"],
+            options: [{ precedence: ["double"] }],
             errors: [{
                 messageId: "wrongQuotes",
                 data: { description: "doublequote" },
@@ -157,7 +157,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = `bar`;",
             output: "var foo = \"bar\";",
-            options: ["double"],
+            options: [{ precedence: ["double"] }],
             parserOptions: {
                 ecmaVersion: 6
             },
@@ -170,7 +170,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = \"bar\";",
             output: "var foo = 'bar';",
-            options: ["single", { avoidEscape: true }],
+            options: [{ precedence: ["single"], avoidEscape: true }],
             errors: [{
                 messageId: "wrongQuotes",
                 data: { description: "singlequote" },
@@ -180,7 +180,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = 'bar';",
             output: "var foo = \"bar\";",
-            options: ["double", { avoidEscape: true }],
+            options: [{ precedence: ["double"], avoidEscape: true }],
             errors: [{
                 messageId: "wrongQuotes",
                 data: { description: "doublequote" },
@@ -190,7 +190,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = '\\\\';",
             output: "var foo = \"\\\\\";",
-            options: ["double", { avoidEscape: true }],
+            options: [{ precedence: ["double"], avoidEscape: true }],
             errors: [{
                 messageId: "wrongQuotes",
                 data: { description: "doublequote" },
@@ -200,7 +200,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = \"bar\";",
             output: "var foo = 'bar';",
-            options: ["single", { allowTemplateLiterals: true }],
+            options: [{ precedence: ["single", "backtick"] }],
             errors: [{
                 messageId: "wrongQuotes",
                 data: { description: "singlequote" },
@@ -210,7 +210,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = 'bar';",
             output: "var foo = \"bar\";",
-            options: ["double", { allowTemplateLiterals: true }],
+            options: [{ precedence: ["double", "backtick"] }],
             errors: [{
                 messageId: "wrongQuotes",
                 data: { description: "doublequote" },
@@ -220,7 +220,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = 'bar';",
             output: "var foo = `bar`;",
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 2015 },
             errors: [{
                 messageId: "wrongQuotes",
@@ -231,7 +231,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = 'b${x}a$r';",
             output: "var foo = `b\\${x}a$r`;",
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 2015 },
             errors: [{
                 messageId: "wrongQuotes",
@@ -242,7 +242,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = \"bar\";",
             output: "var foo = `bar`;",
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 2015 },
             errors: [{
                 messageId: "wrongQuotes",
@@ -253,7 +253,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = \"bar\";",
             output: "var foo = `bar`;",
-            options: ["backtick", { avoidEscape: true }],
+            options: [{ precedence: ["backtick"], avoidEscape: true }],
             parserOptions: { ecmaVersion: 2015 },
             errors: [{
                 messageId: "wrongQuotes",
@@ -264,7 +264,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = 'bar';",
             output: "var foo = `bar`;",
-            options: ["backtick", { avoidEscape: true }],
+            options: [{ precedence: ["backtick"], avoidEscape: true }],
             parserOptions: { ecmaVersion: 2015 },
             errors: [{
                 messageId: "wrongQuotes",
@@ -277,7 +277,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = `backtick`; \"use strict\";",
             output: "var foo = `backtick`; `use strict`;",
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "wrongQuotes",
@@ -288,7 +288,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "{ \"use strict\"; var foo = `backtick`; }",
             output: "{ `use strict`; var foo = `backtick`; }",
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "wrongQuotes",
@@ -299,7 +299,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "if (1) { \"use strict\"; var foo = `backtick`; }",
             output: "if (1) { `use strict`; var foo = `backtick`; }",
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "wrongQuotes",
@@ -312,7 +312,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var obj = {[\"key0\"]: 0, ['key1']: 1};",
             output: "var obj = {[`key0`]: 0, [`key1`]: 1};",
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -330,7 +330,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "class Foo { ['a'](){} static ['b'](){} }",
             output: "class Foo { [`a`](){} static [`b`](){} }",
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -350,7 +350,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "<div blah={\"blah\"} />",
             output: "<div blah={'blah'} />",
-            options: ["single"],
+            options: [{ precedence: ["single"] }],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [
                 {
@@ -363,7 +363,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "<div blah={'blah'} />",
             output: "<div blah={\"blah\"} />",
-            options: ["double"],
+            options: [{ precedence: ["double"] }],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [
                 {
@@ -376,7 +376,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "<div blah={'blah'} />",
             output: "<div blah={`blah`} />",
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaFeatures: { jsx: true }, ecmaVersion: 2015 },
             errors: [
                 {
@@ -497,7 +497,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = \"\\1\"",
             output: "var foo = '\\1'",
-            options: ["single"],
+            options: [{ precedence: ["single"] }],
             errors: [
                 {
                     messageId: "wrongQuotes",
@@ -509,7 +509,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = '\\1'",
             output: "var foo = \"\\1\"",
-            options: ["double"],
+            options: [{ precedence: ["double"] }],
             errors: [
                 {
                     messageId: "wrongQuotes",
@@ -521,7 +521,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var notoctal = '\\0'",
             output: "var notoctal = `\\0`",
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -534,7 +534,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = '\\1'",
             output: null,
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -547,7 +547,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = \"\\1\"",
             output: null,
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -560,7 +560,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = '\\01'",
             output: null,
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -573,7 +573,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = '\\0\\1'",
             output: null,
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -586,7 +586,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = '\\08'",
             output: null,
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -599,7 +599,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = 'prefix \\33'",
             output: null,
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -612,7 +612,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var foo = 'prefix \\75 suffix'",
             output: null,
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -625,7 +625,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "var nonOctalDecimalEscape = '\\8'",
             output: null,
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -641,7 +641,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "class C { 'foo'; }",
             output: "class C { \"foo\"; }",
-            options: ["double"],
+            options: [{ precedence: ["double"] }],
             parserOptions: { ecmaVersion: 2022 },
             errors: [
                 {
@@ -654,7 +654,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "class C { 'foo'() {} }",
             output: "class C { \"foo\"() {} }",
-            options: ["double"],
+            options: [{ precedence: ["double"] }],
             parserOptions: { ecmaVersion: 2022 },
             errors: [
                 {
@@ -667,7 +667,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "class C { \"foo\"; }",
             output: "class C { 'foo'; }",
-            options: ["single"],
+            options: [{ precedence: ["single"] }],
             parserOptions: { ecmaVersion: 2022 },
             errors: [
                 {
@@ -680,7 +680,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "class C { \"foo\"() {} }",
             output: "class C { 'foo'() {} }",
-            options: ["single"],
+            options: [{ precedence: ["single"] }],
             parserOptions: { ecmaVersion: 2022 },
             errors: [
                 {
@@ -693,7 +693,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "class C { [\"foo\"]; }",
             output: "class C { [`foo`]; }",
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 2022 },
             errors: [
                 {
@@ -706,7 +706,7 @@ ruleTester.run("quotes", rule, {
         {
             code: "class C { foo = \"foo\"; }",
             output: "class C { foo = `foo`; }",
-            options: ["backtick"],
+            options: [{ precedence: ["backtick"] }],
             parserOptions: { ecmaVersion: 2022 },
             errors: [
                 {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fix https://github.com/eslint/eslint/issues/12156

Redesign options for the `quotes` rule as per https://github.com/eslint/eslint/issues/12156#issuecomment-601512762

`/* eslint quotes: ['error', { precedence: ['single', 'double', 'backtick'], avoidEscape: true } ]*/`

#### Is there anything you'd like reviewers to focus on?
