### PR TITLE
docs: Dedent needlessly indented example in getter-return docs

### DIFF
--- a/docs/rules/getter-return.md
+++ b/docs/rules/getter-return.md
@@ -3,17 +3,17 @@
 The get syntax binds an object property to a function that will be called when that property is looked up. It was first introduced in ECMAScript 5:
 
 ```js
-    var p = {
-        get name(){
-            return "nicholas";
-        }
-    };
+var p = {
+    get name(){
+        return "nicholas";
+    }
+};
 
-    Object.defineProperty(p, "age", {
-        get: function (){
-            return 17;
-        }
-    });
+Object.defineProperty(p, "age", {
+    get: function (){
+        return 17;
+    }
+});
 ```
 
 Note that every `getter` is expected to return a value.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed indentation from code example.


#### Is there anything you'd like reviewers to focus on?


