### PR TITLE
fix: Handle unexpected string type from npm spawn

### DIFF
--- a/lib/init/npm-utils.js
+++ b/lib/init/npm-utils.js
@@ -79,8 +79,16 @@ function fetchPeerDependencies(packageName) {
     }
     const fetchedText = npmProcess.stdout.trim();
 
-    return JSON.parse(fetchedText || "{}");
-
+    try {
+        return JSON.parse(fetchedText || "{}");
+    } catch (e) {
+        log.error(
+            'Failed to parse peer dependencies of ' + packageName +
+            ' due to unexpected return value of spawning "npm show --json ' +
+            packageName + ' peerDependencies": Result was "' + fetchedText + '".'
+        );
+        return null;
+    }
 
 }
 


### PR DESCRIPTION

Makes the code more robust to the issue observed in #15407.

I'm not 100% sure if that 

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

#### What changes did you make? (Give an overview)
Added a try/catch around a problematic line that was throwing an error.

#### Is there anything you'd like reviewers to focus on?
Whether the correct return value in the catch block should be null (matching the ENOENT case) or `{}` (matching the empty-string case). 
There are no included tests as it seems challenging to replicate the conditions triggering this in a test setup. 