### PR TITLE
fix: do not report global built-in references in `id-match` rule

### DIFF
--- a/lib/rules/id-match.js
+++ b/lib/rules/id-match.js
@@ -6,6 +6,13 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("./utils/ast-utils");
+const globals = require("globals");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -84,6 +91,15 @@ module.exports = {
          * @private
          */
         function isInvalid(name) {
+            const builtInReferences = new Set(Object.keys(globals.builtin));
+            const scope = context.getScope();
+            const variable = astUtils.getVariableByName(scope, name);
+
+            // Do not report global and built-in references
+            if (variable && variable.scope.type === "global" && builtInReferences.has(name)) {
+                return false;
+            }
+
             return !regexp.test(name);
         }
 

--- a/tests/lib/rules/id-match.js
+++ b/tests/lib/rules/id-match.js
@@ -185,6 +185,17 @@ ruleTester.run("id-match", rule, {
             }]
         },
 
+        // Should not report for global references that are native objects - https://github.com/eslint/eslint/issues/15395
+        {
+            code: `
+            var foo = Object.keys(bar);
+            var a = Array.from(b);
+            `,
+            options: ["^\\$?[a-z]+([A-Z0-9][a-z0-9]+)*$", {
+                properties: true
+            }]
+        },
+
         // Class Methods
         {
             code: "class x { foo() {} }",
@@ -636,6 +647,33 @@ ruleTester.run("id-match", rule, {
             errors: [
                 {
                     message: "Identifier 'no_camelcased' does not match the pattern '^[^_]+$'.",
+                    type: "Identifier"
+                }
+            ]
+        },
+
+        // https://github.com/eslint/eslint/issues/15395
+        {
+            code: `
+            const foo_variable = 1;
+            class MyClass {
+            }
+            let a = new MyClass();
+            let b = {id: 1};
+            let c = Object.keys(b);
+            let d = Array.from(b);
+            `,
+            options: ["^\\$?[a-z]+([A-Z0-9][a-z0-9]+)*$", {
+                properties: true
+            }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Identifier 'foo_variable' does not match the pattern '^\\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.",
+                    type: "Identifier"
+                },
+                {
+                    message: "Identifier 'MyClass' does not match the pattern '^\\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.",
                     type: "Identifier"
                 }
             ]


### PR DESCRIPTION
Fixes #15395

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Resolve #15395

```js
/* eslint id-match: ['error', '^\\$?[a-z]+([A-Z0-9][a-z0-9]+)*$', { properties: true }] */


    const foo_variable = 1; // error
    class MyClass { } // error
    let a = new MyClass();
    let b = {id: 1};
    let c = Object.keys(b); // OK
    let d = Array.from(b); // OK
````

#### Is there anything you'd like reviewers to focus on?
No