### PR TITLE
docs: Mention character classes in no-useless-escape

### DIFF
--- a/docs/rules/no-useless-escape.md
+++ b/docs/rules/no-useless-escape.md
@@ -26,7 +26,7 @@ Examples of **incorrect** code for this rule:
 `\#{foo}`;
 /\!/;
 /\@/;
-/[\[\]]/;
+/[\[]/;
 /[a-z\-]/;
 ```
 
@@ -47,7 +47,8 @@ Examples of **correct** code for this rule:
 /\\/g;
 /\t/g;
 /\w\$\*\^\./;
-/[[\]]/;
+/[[]/;
+/[\]]/;
 /[a-z-]/;
 ```
 

--- a/docs/rules/no-useless-escape.md
+++ b/docs/rules/no-useless-escape.md
@@ -26,7 +26,8 @@ Examples of **incorrect** code for this rule:
 `\#{foo}`;
 /\!/;
 /\@/;
-
+/[\[\]]/;
+/[a-z\-]/;
 ```
 
 Examples of **correct** code for this rule:
@@ -46,7 +47,8 @@ Examples of **correct** code for this rule:
 /\\/g;
 /\t/g;
 /\w\$\*\^\./;
-
+/[[\]]/;
+/[a-z-]/;
 ```
 
 ## When Not To Use It


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In regex literals, `/[\[]/` and `/[a\-]/` contain useless escapes within character classes, but these cases are not very well-known, so I’ve included them. A recent Stack Overflow question (<https://stackoverflow.com/q/70322972/4642212>) prompted this PR, but of course there’s also issue #13826 _right here_: getting a linter warning for these cases may be confusing. Therefore, I’ve explicitly mentioned this in the documentation. Note: this behavior is already part of the tests.

#### Is there anything you'd like reviewers to focus on?

Nothing specific.