### PR TITLE
feat: false negative with `onlyDeclarations` + `properties` in id-match

### DIFF
--- a/lib/rules/id-match.js
+++ b/lib/rules/id-match.js
@@ -240,7 +240,11 @@ module.exports = {
 
                     // For https://github.com/eslint/eslint/issues/15123
                     if (parent.parent && parent.parent.type === "ObjectExpression") {
-                        if (checkProperties && parent.key === node && isInvalid(name)) {
+                        if (
+                            (checkProperties && onlyDeclarations && !parent.computed) &&
+                            parent.key === node &&
+                            isInvalid(name)
+                        ) {
                             report(node);
                         }
                     }

--- a/lib/rules/id-match.js
+++ b/lib/rules/id-match.js
@@ -238,6 +238,13 @@ module.exports = {
                         }
                     }
 
+                    // For https://github.com/eslint/eslint/issues/15123
+                    if (parent.parent && parent.parent.type === "ObjectExpression") {
+                        if (checkProperties && parent.key === node && isInvalid(name)) {
+                            report(node);
+                        }
+                    }
+
                     // never check properties or always ignore destructuring
                     if (!checkProperties || (ignoreDestructuring && isInsideObjectPattern(node))) {
                         return;

--- a/lib/rules/id-match.js
+++ b/lib/rules/id-match.js
@@ -211,6 +211,17 @@ module.exports = {
                         }
                     }
 
+                // For https://github.com/eslint/eslint/issues/15123
+                } else if (
+                    parent.type === "Property" &&
+                    parent.parent.type === "ObjectExpression" &&
+                    parent.key === node &&
+                    !parent.computed
+                ) {
+                    if (checkProperties && isInvalid(name)) {
+                        report(node);
+                    }
+
                 /*
                  * Properties have their own rules, and
                  * AssignmentPattern nodes can be treated like Properties:
@@ -234,17 +245,6 @@ module.exports = {
 
                         // ignore destructuring if the option is set, unless a new identifier is created
                         if (valueIsInvalid && !(assignmentKeyEqualsValue && ignoreDestructuring)) {
-                            report(node);
-                        }
-                    }
-
-                    // For https://github.com/eslint/eslint/issues/15123
-                    if (parent.parent && parent.parent.type === "ObjectExpression") {
-                        if (
-                            (checkProperties && onlyDeclarations && !parent.computed) &&
-                            parent.key === node &&
-                            isInvalid(name)
-                        ) {
                             report(node);
                         }
                     }

--- a/tests/lib/rules/id-match.js
+++ b/tests/lib/rules/id-match.js
@@ -237,6 +237,30 @@ ruleTester.run("id-match", rule, {
             }],
             parserOptions: { ecmaVersion: 2022 }
         },
+        {
+            code: `
+            const foo = {
+                [a]: 1,
+            };
+            `,
+            options: ["^[^a]", {
+                properties: false,
+                onlyDeclarations: false
+            }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+            const foo = {
+                [a]: 1,
+            };
+            `,
+            options: ["^[^a]", {
+                properties: true,
+                onlyDeclarations: true
+            }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
 
         // Class Methods
         {
@@ -861,6 +885,24 @@ ruleTester.run("id-match", rule, {
                 },
                 {
                     message: "Identifier 'bar_one' does not match the pattern '^[^_]+$'.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: `
+            const foo = {
+                [a]: 1,
+            };
+            `,
+            options: ["^[^a]", {
+                properties: true,
+                onlyDeclarations: false
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                {
+                    message: "Identifier 'a' does not match the pattern '^[^a]'.",
                     type: "Identifier"
                 }
             ]

--- a/tests/lib/rules/id-match.js
+++ b/tests/lib/rules/id-match.js
@@ -244,18 +244,6 @@ ruleTester.run("id-match", rule, {
             };
             `,
             options: ["^[^a]", {
-                properties: false,
-                onlyDeclarations: false
-            }],
-            parserOptions: { ecmaVersion: 2022 }
-        },
-        {
-            code: `
-            const foo = {
-                [a]: 1,
-            };
-            `,
-            options: ["^[^a]", {
                 properties: true,
                 onlyDeclarations: true
             }],

--- a/tests/lib/rules/id-match.js
+++ b/tests/lib/rules/id-match.js
@@ -197,6 +197,46 @@ ruleTester.run("id-match", rule, {
             }],
             parserOptions: { ecmaVersion: 2022 }
         },
+        {
+            code: `
+            const foo = {
+                foo_one: 1,
+                bar_one: 2,
+                fooBar: 3
+            };
+            `,
+            options: ["^[^_]+$", {
+                properties: false
+            }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+            const foo = {
+                foo_one: 1,
+                bar_one: 2,
+                fooBar: 3
+            };
+            `,
+            options: ["^[^_]+$", {
+                onlyDeclarations: true
+            }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+            const foo = {
+                foo_one: 1,
+                bar_one: 2,
+                fooBar: 3
+            };
+            `,
+            options: ["^[^_]+$", {
+                properties: false,
+                onlyDeclarations: false
+            }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
 
         // Class Methods
         {
@@ -788,6 +828,30 @@ ruleTester.run("id-match", rule, {
             options: ["^[^_]+$", {
                 properties: true,
                 onlyDeclarations: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                {
+                    message: "Identifier 'foo_one' does not match the pattern '^[^_]+$'.",
+                    type: "Identifier"
+                },
+                {
+                    message: "Identifier 'bar_one' does not match the pattern '^[^_]+$'.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: `
+            const foo = {
+                foo_one: 1,
+                bar_one: 2,
+                fooBar: 3
+            };
+            `,
+            options: ["^[^_]+$", {
+                properties: true,
+                onlyDeclarations: false
             }],
             parserOptions: { ecmaVersion: 2022 },
             errors: [

--- a/tests/lib/rules/id-match.js
+++ b/tests/lib/rules/id-match.js
@@ -774,7 +774,32 @@ ruleTester.run("id-match", rule, {
                     type: "PrivateIdentifier"
                 }
             ]
-        }
+        },
 
+        // https://github.com/eslint/eslint/issues/15123
+        {
+            code: `
+            const foo = {
+                foo_one: 1,
+                bar_one: 2,
+                fooBar: 3
+            };
+            `,
+            options: ["^[^_]+$", {
+                properties: true,
+                onlyDeclarations: true
+            }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [
+                {
+                    message: "Identifier 'foo_one' does not match the pattern '^[^_]+$'.",
+                    type: "Identifier"
+                },
+                {
+                    message: "Identifier 'bar_one' does not match the pattern '^[^_]+$'.",
+                    type: "Identifier"
+                }
+            ]
+        }
     ]
 });


### PR DESCRIPTION


<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixes #15123

Report invalid `property` names for `ObjectExpressions` when `property: true`, regardless the value of `onlyDeclaration` option.


## [Before - Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IFwiaWQtbWF0Y2hcIjogW1xuICAgICAgXCJlcnJvclwiLFxuICAgICAgXCJeW15fXSskXCIsXG4gICAgICB7XG4gICAgICAgICAgICBcInByb3BlcnRpZXNcIjogdHJ1ZSxcbiAgICAgICAgICAgIFwib25seURlY2xhcmF0aW9uc1wiOiB0cnVlXG4gICAgICB9XG5dICovXG5cbmNvbnN0IGZvbyA9IHtcbiAgICAgICAgICAgICAgICBmb29fb25lOiAxLFxuICAgICAgICAgICAgICAgIGJhcl9vbmU6IDIsXG4gICAgICAgICAgICAgICAgZm9vQmFyOiAzXG4gICAgIH07Iiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjoibGF0ZXN0Iiwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

## After

```js
/* eslint "id-match": [
      "error",
      "^[^_]+$",
      {
            "properties": true,
            "onlyDeclarations": true
      }
] */

const foo = {
                foo_one: 1, // error
                bar_one: 2, // error
                fooBar: 3 // ok
     };
```

#### Is there anything you'd like reviewers to focus on?
No