### PR TITLE
feat: Support arbitrary module namespace names in the quotes rule

### DIFF
--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -223,8 +223,19 @@ module.exports = {
                 // ModuleSpecifier.
                 case "ImportDeclaration":
                 case "ExportNamedDeclaration":
-                case "ExportAllDeclaration":
                     return parent.source === node;
+
+                // ModuleExportName or ModuleSpecifier.
+                case "ExportAllDeclaration":
+                    return parent.exported === node || parent.source === node;
+
+                // ModuleExportName.
+                case "ImportSpecifier":
+                    return parent.imported === node;
+
+                // ModuleExportName.
+                case "ExportSpecifier":
+                    return parent.local === node || parent.exported === node;
 
                 // Others don't allow.
                 default:

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -77,6 +77,16 @@ ruleTester.run("quotes", rule, {
         { code: "import a from \"a\"; import b from 'b';", options: ["backtick"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export * from \"a\"; export * from 'b';", options: ["backtick"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
 
+        // `backtick` should not warn module export names.
+        { code: "import { \"a\" as b, 'c' as d } from 'mod';", options: ["backtick"], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "let a, c; export { a as \"b\", c as 'd' };", options: ["backtick"], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export { \"a\", 'b' } from 'mod';", options: ["backtick"], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export { a as \"b\", c as 'd' } from 'mod';", options: ["backtick"], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export { \"a\" as b, 'c' as d } from 'mod';", options: ["backtick"], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export { \"a\" as \"b\", 'c' as 'd' } from 'mod';", options: ["backtick"], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export * as \"a\" from 'mod';", options: ["backtick"], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export * as 'a' from 'mod';", options: ["backtick"], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+
         // `backtick` should not warn property/method names (not computed).
         { code: "var obj = {\"key0\": 0, 'key1': 1};", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
         { code: "class Foo { 'bar'(){} }", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15465, fixes `quotes`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `quotes` rule to not enforce backticks in a ModuleExportName position.

Before this change, `quotes` had false positives on `"foo"`, `"bar"`, `"baz"`, and `"qux"` in the following example:

```js
/* eslint quotes: ["error", "backtick"] */

import { "foo" as a } from "mod";

export { "bar" as "baz" } from "mod";

export * as "qux" from "mod";
```

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
