### PR TITLE
feat: Support arbitrary module namespace names in keyword-spacing

### DIFF
--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -243,14 +243,15 @@ if(foo) {
 
 ### overrides
 
-Examples of **correct** code for this rule with the `{ "overrides": { "if": { "after": false }, "for": { "after": false }, "while": { "after": false }, "static": { "after": false } } }` option:
+Examples of **correct** code for this rule with the `{ "overrides": { "if": { "after": false }, "for": { "after": false }, "while": { "after": false }, "static": { "after": false }, "as": { "after": false } } }` option:
 
 ```js
 /*eslint keyword-spacing: ["error", { "overrides": {
   "if": { "after": false },
   "for": { "after": false },
   "while": { "after": false },
-  "static": { "after": false }
+  "static": { "after": false },
+  "as": { "after": false }
 } }]*/
 
 if(foo) {
@@ -272,6 +273,8 @@ class C {
         //...
     }
 }
+
+export { C as"my class" };
 ```
 
 ## When Not To Use It

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -469,6 +469,7 @@ module.exports = {
                 const asToken = sourceCode.getTokenBefore(node.exported);
 
                 checkSpacingBefore(asToken, PREV_TOKEN_M);
+                checkSpacingAfter(asToken, NEXT_TOKEN_M);
             }
 
             if (node.source) {
@@ -476,6 +477,35 @@ module.exports = {
 
                 checkSpacingBefore(fromToken, PREV_TOKEN_M);
                 checkSpacingAfter(fromToken, NEXT_TOKEN_M);
+            }
+        }
+
+        /**
+         * Reports `as` keyword of a given node if usage of spacing around this
+         * keyword is invalid.
+         * @param {ASTNode} node An `ImportSpecifier` node to check.
+         * @returns {void}
+         */
+        function checkSpacingForImportSpecifier(node) {
+            if (node.imported.range[0] !== node.local.range[0]) {
+                const asToken = sourceCode.getTokenBefore(node.local);
+
+                checkSpacingBefore(asToken, PREV_TOKEN_M);
+            }
+        }
+
+        /**
+         * Reports `as` keyword of a given node if usage of spacing around this
+         * keyword is invalid.
+         * @param {ASTNode} node An `ExportSpecifier` node to check.
+         * @returns {void}
+         */
+        function checkSpacingForExportSpecifier(node) {
+            if (node.local.range[0] !== node.exported.range[0]) {
+                const asToken = sourceCode.getTokenBefore(node.exported);
+
+                checkSpacingBefore(asToken, PREV_TOKEN_M);
+                checkSpacingAfter(asToken, NEXT_TOKEN_M);
             }
         }
 
@@ -588,6 +618,8 @@ module.exports = {
             YieldExpression: checkSpacingBeforeFirstToken,
 
             // Others
+            ImportSpecifier: checkSpacingForImportSpecifier,
+            ExportSpecifier: checkSpacingForExportSpecifier,
             ImportNamespaceSpecifier: checkSpacingForImportNamespaceSpecifier,
             MethodDefinition: checkSpacingForProperty,
             PropertyDefinition: checkSpacingForProperty,

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -126,14 +126,53 @@ ruleTester.run("keyword-spacing", rule, {
         // as
         //----------------------------------------------------------------------
 
+        // import { a as b }
+        { code: "import { a } from \"foo\"", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "import { a as b } from \"foo\"", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "import { \"a\" as b } from \"foo\"", parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "import{ a }from\"foo\"", options: [NEITHER], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "import{ a as b }from\"foo\"", options: [NEITHER], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "import{ \"a\"as b }from\"foo\"", options: [NEITHER], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "import{ \"a\" as b }from\"foo\"", options: [override("as", BOTH)], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "import { a as b } from \"foo\"", options: [override("as", NEITHER)], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "import { \"a\"as b } from \"foo\"", options: [override("as", NEITHER)], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+
+        // export { a as b }
+        { code: "let a; export { a };", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "export { \"a\" } from \"foo\";", parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "let a; export { a as b };", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "let a; export { a as \"b\" };", parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export { \"a\" as b } from \"foo\";", parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export { \"a\" as \"b\" } from \"foo\";", parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "let a; export{ a };", options: [NEITHER], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "export{ \"a\" }from\"foo\";", options: [NEITHER], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "let a; export{ a as b };", options: [NEITHER], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "let a; export{ a as\"b\" };", options: [NEITHER], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export{ \"a\"as b }from\"foo\";", options: [NEITHER], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export{ \"a\"as\"b\" }from\"foo\";", options: [NEITHER], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "let a; export{ a as \"b\" };", options: [override("as", BOTH)], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export{ \"a\" as b }from\"foo\";", options: [override("as", BOTH)], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export{ \"a\" as \"b\" }from\"foo\";", options: [override("as", BOTH)], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "let a; export { a as b };", options: [override("as", NEITHER)], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "let a; export { a as\"b\" };", options: [override("as", NEITHER)], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export { \"a\"as b } from \"foo\";", options: [override("as", NEITHER)], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+        { code: "export { \"a\"as\"b\" } from \"foo\";", options: [override("as", NEITHER)], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
+
+        // import * as a
         { code: "import * as a from \"foo\"", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "import*as a from\"foo\"", options: [NEITHER], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "import* as a from\"foo\"", options: [override("as", BOTH)], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "import *as a from \"foo\"", options: [override("as", NEITHER)], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+
+        // export * as a
         { code: "export * as a from \"foo\"", parserOptions: { ecmaVersion: 2020, sourceType: "module" } },
+        { code: "export * as \"a\" from \"foo\"", parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
         { code: "export*as a from\"foo\"", options: [NEITHER], parserOptions: { ecmaVersion: 2020, sourceType: "module" } },
+        { code: "export*as\"a\"from\"foo\"", options: [NEITHER], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
         { code: "export* as a from\"foo\"", options: [override("as", BOTH)], parserOptions: { ecmaVersion: 2020, sourceType: "module" } },
+        { code: "export* as \"a\"from\"foo\"", options: [override("as", BOTH)], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
         { code: "export *as a from \"foo\"", options: [override("as", NEITHER)], parserOptions: { ecmaVersion: 2020, sourceType: "module" } },
+        { code: "export *as\"a\" from \"foo\"", options: [override("as", NEITHER)], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
 
         //----------------------------------------------------------------------
         // async
@@ -654,15 +693,21 @@ ruleTester.run("keyword-spacing", rule, {
         { code: "import {foo} from \"foo\"", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export {foo} from \"foo\"", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export * from \"foo\"", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "export * as \"x\" from \"foo\"", parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
         { code: "import{foo}from\"foo\"", options: [NEITHER], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export{foo}from\"foo\"", options: [NEITHER], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export*from\"foo\"", options: [NEITHER], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "export*as x from\"foo\"", options: [NEITHER], parserOptions: { ecmaVersion: 2020, sourceType: "module" } },
+        { code: "export*as\"x\"from\"foo\"", options: [NEITHER], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
         { code: "import{foo} from \"foo\"", options: [override("from", BOTH)], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export{foo} from \"foo\"", options: [override("from", BOTH)], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export* from \"foo\"", options: [override("from", BOTH)], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "export*as\"x\" from \"foo\"", options: [override("from", BOTH)], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
         { code: "import {foo}from\"foo\"", options: [override("from", NEITHER)], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export {foo}from\"foo\"", options: [override("from", NEITHER)], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export *from\"foo\"", options: [override("from", NEITHER)], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "export * as x from\"foo\"", options: [override("from", NEITHER)], parserOptions: { ecmaVersion: 2020, sourceType: "module" } },
+        { code: "export * as \"x\"from\"foo\"", options: [override("from", NEITHER)], parserOptions: { ecmaVersion: 2022, sourceType: "module" } },
 
         //----------------------------------------------------------------------
         // function
@@ -1469,6 +1514,119 @@ ruleTester.run("keyword-spacing", rule, {
         // as
         //----------------------------------------------------------------------
 
+        // import { a as b }
+        {
+            code: "import { \"a\"as b } from \"foo\"",
+            output: "import { \"a\" as b } from \"foo\"",
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: expectedBefore("as")
+        },
+        {
+            code: "import{ \"a\" as b }from\"foo\"",
+            output: "import{ \"a\"as b }from\"foo\"",
+            options: [NEITHER],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: unexpectedBefore("as")
+        },
+        {
+            code: "import{ \"a\"as b }from\"foo\"",
+            output: "import{ \"a\" as b }from\"foo\"",
+            options: [override("as", BOTH)],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: expectedBefore("as")
+        },
+        {
+            code: "import { \"a\" as b } from \"foo\"",
+            output: "import { \"a\"as b } from \"foo\"",
+            options: [override("as", NEITHER)],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: unexpectedBefore("as")
+        },
+
+        // export { a as b }
+        {
+            code: "let a; export { a as\"b\" };",
+            output: "let a; export { a as \"b\" };",
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: expectedAfter("as")
+        },
+        {
+            code: "export { \"a\"as b } from \"foo\";",
+            output: "export { \"a\" as b } from \"foo\";",
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: expectedBefore("as")
+        },
+        {
+            code: "export { \"a\"as\"b\" } from \"foo\";",
+            output: "export { \"a\" as \"b\" } from \"foo\";",
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: expectedBeforeAndAfter("as")
+        },
+        {
+            code: "let a; export{ a as \"b\" };",
+            output: "let a; export{ a as\"b\" };",
+            options: [NEITHER],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: unexpectedAfter("as")
+        },
+        {
+            code: "export{ \"a\" as b }from\"foo\";",
+            output: "export{ \"a\"as b }from\"foo\";",
+            options: [NEITHER],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: unexpectedBefore("as")
+        },
+        {
+            code: "export{ \"a\" as \"b\" }from\"foo\";",
+            output: "export{ \"a\"as\"b\" }from\"foo\";",
+            options: [NEITHER],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: unexpectedBeforeAndAfter("as")
+        },
+        {
+            code: "let a; export{ a as\"b\" };",
+            output: "let a; export{ a as \"b\" };",
+            options: [override("as", BOTH)],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: expectedAfter("as")
+        },
+        {
+            code: "export{ \"a\"as b }from\"foo\";",
+            output: "export{ \"a\" as b }from\"foo\";",
+            options: [override("as", BOTH)],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: expectedBefore("as")
+        },
+        {
+            code: "export{ \"a\"as\"b\" }from\"foo\";",
+            output: "export{ \"a\" as \"b\" }from\"foo\";",
+            options: [override("as", BOTH)],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: expectedBeforeAndAfter("as")
+        },
+        {
+            code: "let a; export { a as \"b\" };",
+            output: "let a; export { a as\"b\" };",
+            options: [override("as", NEITHER)],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: unexpectedAfter("as")
+        },
+        {
+            code: "export { \"a\" as b } from \"foo\";",
+            output: "export { \"a\"as b } from \"foo\";",
+            options: [override("as", NEITHER)],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: unexpectedBefore("as")
+        },
+        {
+            code: "export { \"a\" as \"b\" } from \"foo\";",
+            output: "export { \"a\"as\"b\" } from \"foo\";",
+            options: [override("as", NEITHER)],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: unexpectedBeforeAndAfter("as")
+        },
+
+        // import * as a
         {
             code: "import *as a from \"foo\"",
             output: "import * as a from \"foo\"",
@@ -1524,11 +1682,19 @@ ruleTester.run("keyword-spacing", rule, {
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: unexpectedBefore("as")
         },
+
+        // export * as a
         {
             code: "export *as a from \"foo\"",
             output: "export * as a from \"foo\"",
             parserOptions: { ecmaVersion: 2020, sourceType: "module" },
             errors: expectedBefore("as")
+        },
+        {
+            code: "export *as\"a\" from \"foo\"",
+            output: "export * as \"a\" from \"foo\"",
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: expectedBeforeAndAfter("as")
         },
         {
             code: "export* as a from\"foo\"",
@@ -1538,6 +1704,13 @@ ruleTester.run("keyword-spacing", rule, {
             errors: unexpectedBefore("as")
         },
         {
+            code: "export* as \"a\"from\"foo\"",
+            output: "export*as\"a\"from\"foo\"",
+            options: [NEITHER],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: unexpectedBeforeAndAfter("as")
+        },
+        {
             code: "export*as a from\"foo\"",
             output: "export* as a from\"foo\"",
             options: [override("as", BOTH)],
@@ -1545,11 +1718,25 @@ ruleTester.run("keyword-spacing", rule, {
             errors: expectedBefore("as")
         },
         {
+            code: "export*as\"a\"from\"foo\"",
+            output: "export* as \"a\"from\"foo\"",
+            options: [override("as", BOTH)],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: expectedBeforeAndAfter("as")
+        },
+        {
             code: "export * as a from \"foo\"",
             output: "export *as a from \"foo\"",
             options: [override("as", NEITHER)],
             parserOptions: { ecmaVersion: 2020, sourceType: "module" },
             errors: unexpectedBefore("as")
+        },
+        {
+            code: "export * as \"a\" from \"foo\"",
+            output: "export *as\"a\" from \"foo\"",
+            options: [override("as", NEITHER)],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: unexpectedBeforeAndAfter("as")
         },
 
         //----------------------------------------------------------------------
@@ -2400,6 +2587,12 @@ ruleTester.run("keyword-spacing", rule, {
             errors: expectedBeforeAndAfter("from")
         },
         {
+            code: "export * as \"a\"from\"foo\"",
+            output: "export * as \"a\" from \"foo\"",
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: expectedBeforeAndAfter("from")
+        },
+        {
             code: "import{foo} from \"foo\"",
             output: "import{foo}from\"foo\"",
             options: [NEITHER],
@@ -2418,6 +2611,20 @@ ruleTester.run("keyword-spacing", rule, {
             output: "export*from\"foo\"",
             options: [NEITHER],
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: unexpectedBeforeAndAfter("from")
+        },
+        {
+            code: "export*as x from \"foo\"",
+            output: "export*as x from\"foo\"",
+            options: [NEITHER],
+            parserOptions: { ecmaVersion: 2020, sourceType: "module" },
+            errors: unexpectedAfter("from")
+        },
+        {
+            code: "export*as\"x\" from \"foo\"",
+            output: "export*as\"x\"from\"foo\"",
+            options: [NEITHER],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
             errors: unexpectedBeforeAndAfter("from")
         },
         {
@@ -2442,6 +2649,13 @@ ruleTester.run("keyword-spacing", rule, {
             errors: expectedBeforeAndAfter("from")
         },
         {
+            code: "export*as\"x\"from\"foo\"",
+            output: "export*as\"x\" from \"foo\"",
+            options: [override("from", BOTH)],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: expectedBeforeAndAfter("from")
+        },
+        {
             code: "import {foo} from \"foo\"",
             output: "import {foo}from\"foo\"",
             options: [override("from", NEITHER)],
@@ -2460,6 +2674,20 @@ ruleTester.run("keyword-spacing", rule, {
             output: "export *from\"foo\"",
             options: [override("from", NEITHER)],
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: unexpectedBeforeAndAfter("from")
+        },
+        {
+            code: "export * as x from \"foo\"",
+            output: "export * as x from\"foo\"",
+            options: [override("from", NEITHER)],
+            parserOptions: { ecmaVersion: 2020, sourceType: "module" },
+            errors: unexpectedAfter("from")
+        },
+        {
+            code: "export * as \"x\" from \"foo\"",
+            output: "export * as \"x\"from\"foo\"",
+            options: [override("from", NEITHER)],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
             errors: unexpectedBeforeAndAfter("from")
         },
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #15465, fixes `keyword-spacing`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `keyword-spacing` rule to check spacing around `as` in import/export specifiers.

For example, after this change each of these `as` will be reported:

```js
/* eslint keyword-spacing: "error" */

import { "a"as b } from "mod"; // Expected space(s) before "as"

export { b as"c" }; // Expected space(s) after "as"

export { "d"as e } from "mod"; // Expected space(s) before "as"

export * as"f" from "mod"; // Expected space(s) after "as"

```

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
