### PR TITLE
fix: Prevent false positives with no-constant-condition

### DIFF
--- a/tests/lib/rules/no-constant-condition.js
+++ b/tests/lib/rules/no-constant-condition.js
@@ -175,7 +175,17 @@ ruleTester.run("no-constant-condition", rule, {
         "function* foo() {while (true) {function* foo() {yield;}yield;}}",
         "function* foo() { for (let x = yield; x < 10; x++) {yield;}yield;}",
         "function* foo() { for (let x = yield; ; x++) { yield; }}",
-        "if (new Number(x) + 1 === 2) {}"
+        "if (new Number(x) + 1 === 2) {}",
+
+        // #15467
+        "if([a]==[b]) {}",
+        "if (+[...a]) {}",
+        "if (+[...[...a]]) {}",
+        "if (`${[...a]}`) {}",
+        "if (`${[a]}`) {}",
+        "if (+[a]) {}",
+        "if (0 - [a]) {}",
+        "if (1 * [a]) {}"
     ],
     invalid: [
         { code: "for(;true;);", errors: [{ messageId: "unexpected", type: "Literal" }] },
@@ -262,8 +272,6 @@ ruleTester.run("no-constant-condition", rule, {
 
         // #5228 , typeof conditions
         { code: "if(typeof x){}", errors: [{ messageId: "unexpected", type: "UnaryExpression" }] },
-        { code: "if(`${typeof x}`){}", errors: [{ messageId: "unexpected", type: "TemplateLiteral" }] },
-        { code: "if(`${''}${typeof x}`){}", errors: [{ messageId: "unexpected", type: "TemplateLiteral" }] },
         { code: "if(typeof 'abc' === 'string'){}", errors: [{ messageId: "unexpected", type: "BinaryExpression" }] },
         { code: "if(a = typeof b){}", errors: [{ messageId: "unexpected", type: "AssignmentExpression" }] },
         { code: "if(a, typeof b){}", errors: [{ messageId: "unexpected", type: "SequenceExpression" }] },
@@ -359,18 +367,6 @@ ruleTester.run("no-constant-condition", rule, {
             errors: [{ messageId: "unexpected", type: "BinaryExpression" }]
         },
         {
-            code: "if([a]==[a]) {}",
-            errors: [{ messageId: "unexpected", type: "BinaryExpression" }]
-        },
-        {
-            code: "if([a] - '') {}",
-            errors: [{ messageId: "unexpected", type: "BinaryExpression" }]
-        },
-        {
-            code: "if(+[a]) {}",
-            errors: [{ messageId: "unexpected", type: "UnaryExpression" }]
-        },
-        {
             code: "if(+1) {}",
             errors: [{ messageId: "unexpected", type: "UnaryExpression" }]
         },
@@ -397,7 +393,9 @@ ruleTester.run("no-constant-condition", rule, {
         // Boxed primitives are always truthy
         { code: "if(new Boolean(foo)) {}", errors: [{ messageId: "unexpected" }] },
         { code: "if(new String(foo)) {}", errors: [{ messageId: "unexpected" }] },
-        { code: "if(new Number(foo)) {}", errors: [{ messageId: "unexpected" }] }
+        { code: "if(new Number(foo)) {}", errors: [{ messageId: "unexpected" }] },
 
+        // Spreading a constant array
+        { code: "if(`${[...['a']]}`) {}", errors: [{ messageId: "unexpected" }] }
     ]
 });


### PR DESCRIPTION
Fixes #15467 by defining `isConstant` with `inBooleanPosition` set to `false` as meaning:

> For both string and number, if coerced to that type, the value will be constant.

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Make `no-constant-condition` more correct. See #15467 for more information.

#### Is there anything you'd like reviewers to focus on?

Would ESLint treat this as a breaking change? It will remove some false positives, but also -- in a few rare cases -- introduce a few false negatives.

<!-- markdownlint-disable-file MD004 -->
