### PR TITLE
fix: no-invalid-this false positive in class field initializer

### DIFF
--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -20,7 +20,7 @@ const astUtils = require("./utils/ast-utils");
  * That is, if `this` within the code path refers to `this` of surrounding code path.
  * @param {CodePath} codePath Code path.
  * @param {ASTNode} node Node that started the code path.
- * @returns {void}
+ * @returns {boolean} `true` if it is a code path with lexical `this` binding.
  */
 function isCodePathWithLexicalThis(codePath, node) {
     return codePath.origin === "function" && node.type === "ArrowFunctionExpression";

--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -12,6 +12,21 @@
 const astUtils = require("./utils/ast-utils");
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Determines if the given code path is a code path with lexical `this` binding.
+ * That is, if `this` within the code path refers to `this` of surrounding code path.
+ * @param {CodePath} codePath Code path.
+ * @param {ASTNode} node Node that started the code path.
+ * @returns {void}
+ */
+function isCodePathWithLexicalThis(codePath, node) {
+    return codePath.origin === "function" && node.type === "ArrowFunctionExpression";
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -72,70 +87,52 @@ module.exports = {
             return current;
         };
 
-        /**
-         * Pushs new checking context into the stack.
-         *
-         * The checking context is not initialized yet.
-         * Because most functions don't have `this` keyword.
-         * When `this` keyword was found, the checking context is initialized.
-         * @param {ASTNode} node A function node that was entered.
-         * @returns {void}
-         */
-        function enterFunction(node) {
-
-            // `this` can be invalid only under strict mode.
-            stack.push({
-                init: !context.getScope().isStrict,
-                node,
-                valid: true
-            });
-        }
-
-        /**
-         * Pops the current checking context from the stack.
-         * @returns {void}
-         */
-        function exitFunction() {
-            stack.pop();
-        }
-
         return {
 
-            /*
-             * `this` is invalid only under strict mode.
-             * Modules is always strict mode.
-             */
-            Program(node) {
-                const scope = context.getScope(),
-                    features = context.parserOptions.ecmaFeatures || {};
+            onCodePathStart(codePath, node) {
+                if (isCodePathWithLexicalThis(codePath, node)) {
+                    return;
+                }
 
+                if (codePath.origin === "program") {
+                    const scope = context.getScope();
+                    const features = context.parserOptions.ecmaFeatures || {};
+
+                    stack.push({
+                        init: true,
+                        node,
+                        valid: !(
+                            scope.isStrict ||
+                            node.sourceType === "module" ||
+                            (features.globalReturn && scope.childScopes[0].isStrict)
+                        )
+                    });
+
+                    return;
+                }
+
+                /*
+                 * `init: false` means that `valid` isn't determined yet.
+                 * Most functions don't use `this`, and the calculation for `valid`
+                 * is relatively costly, so we'll calculate it lazily when the first
+                 * `this` within the function is traversed. A special case are non-strict
+                 * functions, because `this` refers to the global object and therefore is
+                 * always valid, so we can set `init: true` right away.
+                 */
                 stack.push({
-                    init: true,
+                    init: !context.getScope().isStrict,
                     node,
-                    valid: !(
-                        scope.isStrict ||
-                        node.sourceType === "module" ||
-                        (features.globalReturn && scope.childScopes[0].isStrict)
-                    )
+                    valid: true
                 });
             },
 
-            "Program:exit"() {
+            onCodePathEnd(codePath, node) {
+                if (isCodePathWithLexicalThis(codePath, node)) {
+                    return;
+                }
+
                 stack.pop();
             },
-
-            FunctionDeclaration: enterFunction,
-            "FunctionDeclaration:exit": exitFunction,
-            FunctionExpression: enterFunction,
-            "FunctionExpression:exit": exitFunction,
-
-            // Field initializers are implicit functions.
-            "PropertyDefinition > *.value": enterFunction,
-            "PropertyDefinition > *.value:exit": exitFunction,
-
-            // Class static blocks are implicit functions.
-            StaticBlock: enterFunction,
-            "StaticBlock:exit": exitFunction,
 
             // Reports if `this` of the current context is invalid.
             ThisExpression(node) {

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -119,6 +119,15 @@ const patterns = [
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
+    {
+        code: "() => { this }; this;",
+        parserOptions: {
+            ecmaVersion: 6
+        },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
 
     // IIFE.
     {
@@ -746,6 +755,18 @@ const patterns = [
 
     // Class fields.
     {
+        code: "class C { field = this }",
+        parserOptions: { ecmaVersion: 2022 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "class C { static field = this }",
+        parserOptions: { ecmaVersion: 2022 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
         code: "class C { field = console.log(this); }",
         parserOptions: { ecmaVersion: 2022 },
         valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
@@ -774,6 +795,20 @@ const patterns = [
         parserOptions: { ecmaVersion: 2022 },
         valid: [NORMAL], // the global this in non-strict mode is OK.
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES],
+        errors: [{ messageId: "unexpectedThis", type: "ThisExpression" }]
+    },
+    {
+        code: "class C { foo = () => this; }",
+        parserOptions: { ecmaVersion: 2022 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: [],
+        errors: [{ messageId: "unexpectedThis", type: "ThisExpression" }]
+    },
+    {
+        code: "class C { foo = () => { this }; }",
+        parserOptions: { ecmaVersion: 2022 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: [],
         errors: [{ messageId: "unexpectedThis", type: "ThisExpression" }]
     },
 
@@ -815,6 +850,13 @@ const patterns = [
         parserOptions: { ecmaVersion: 2022 },
         valid: [],
         invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        errors: [{ messageId: "unexpectedThis", type: "ThisExpression" }]
+    },
+    {
+        code: "class C { static {} [this]; }",
+        parserOptions: { ecmaVersion: 2022 },
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES],
         errors: [{ messageId: "unexpectedThis", type: "ThisExpression" }]
     },
     {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #15477.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refactored `no-invalid-this` to use code path analysis, which is better for handling edge cases with `PropertyDefinition > *.value` and fixes the #15477 bug where `this` appears directly as a class field initializer.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
