### PR TITLE
perf: rule indent perf improvement

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -17,6 +17,26 @@ const createTree = require("functional-red-black-tree");
 const astUtils = require("./utils/ast-utils");
 
 //------------------------------------------------------------------------------
+// helpers
+//------------------------------------------------------------------------------
+
+
+/**
+ * find an element from the last of an array.
+ * @param {Array} arr the array to find in
+ * @param {()=>bool} fn testing function
+ * @returns {any} the element found or null
+ */
+function findLast(arr, fn) {
+    for (let i = arr.length - 1; i >= 0; i--) {
+        if (fn(arr[i], i)) {
+            return arr[i];
+        }
+    }
+    return null;
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -1082,7 +1102,7 @@ module.exports = {
         const baseOffsetListeners = {
             "ArrayExpression, ArrayPattern"(node) {
                 const openingBracket = sourceCode.getFirstToken(node);
-                const closingBracket = sourceCode.getTokenAfter([...node.elements].reverse().find(_ => _) || openingBracket, astUtils.isClosingBracketToken);
+                const closingBracket = sourceCode.getTokenAfter(findLast(node.elements, Boolean) || openingBracket, astUtils.isClosingBracketToken);
 
                 addElementListIndent(node.elements, openingBracket, closingBracket, options.ArrayExpression);
             },


### PR DESCRIPTION
findlast() has a better perf than `arr.reverse().find()`.

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [ ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ x] Other, please explain: perf improvement

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Rule indent perf improvement (~8%) by replaced the `[...arr].reverse().find()` to `findLast()`.
```sh
➜  eslint git:(perf/indent) TIMING=1 npx eslint lib/
Rule                       | Time (ms) | Relative
:--------------------------|----------:|--------:
indent                     |  1481.680 |    11.6%
jsdoc/valid-types          |   625.039 |     4.9%
jsdoc/check-line-alignment |   488.173 |     3.8%
jsdoc/check-types          |   432.765 |     3.4%
jsdoc/check-tag-names      |   374.602 |     2.9%
jsdoc/check-values         |   325.926 |     2.6%
jsdoc/empty-tags           |   284.247 |     2.2%
jsdoc/tag-lines            |   283.479 |     2.2%
jsdoc/check-property-names |   278.930 |     2.2%
jsdoc/check-syntax         |   278.869 |     2.2%
```

```sh
➜  eslint git:(ba6317b40) TIMING=1 npx eslint lib/                
Rule                                          | Time (ms) | Relative
:---------------------------------------------|----------:|--------:
indent                                        |  1617.142 |    10.9%
jsdoc/valid-types                             |   707.696 |     4.8%
jsdoc/check-line-alignment                    |   570.198 |     3.9%
jsdoc/check-types                             |   483.207 |     3.3%
jsdoc/check-tag-names                         |   442.887 |     3.0%
jsdoc/check-values                            |   374.154 |     2.5%
jsdoc/require-hyphen-before-param-description |   349.224 |     2.4%
jsdoc/check-alignment                         |   330.083 |     2.2%
node/no-missing-require                       |   329.396 |     2.2%
jsdoc/tag-lines                               |   329.230 |     2.2%
```

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
not really