### PR TITLE
fix: Correctly consume RuleTester statics

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -977,10 +977,10 @@ class RuleTester {
          * This creates a mocha test suite and pipes all supplied info through
          * one of the templates above.
          */
-        RuleTester.describe(ruleName, () => {
-            RuleTester.describe("valid", () => {
+        this.constructor.describe(ruleName, () => {
+            this.constructor.describe("valid", () => {
                 test.valid.forEach(valid => {
-                    RuleTester[valid.only ? "itOnly" : "it"](
+                    this.constructor[valid.only ? "itOnly" : "it"](
                         sanitize(typeof valid === "object" ? valid.name || valid.code : valid),
                         () => {
                             testValidTemplate(valid);
@@ -989,9 +989,9 @@ class RuleTester {
                 });
             });
 
-            RuleTester.describe("invalid", () => {
+            this.constructor.describe("invalid", () => {
                 test.invalid.forEach(invalid => {
-                    RuleTester[invalid.only ? "itOnly" : "it"](
+                    this.constructor[invalid.only ? "itOnly" : "it"](
                         sanitize(invalid.name || invalid.code),
                         () => {
                             testInvalidTemplate(invalid);

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2295,27 +2295,27 @@ describe("RuleTester", () => {
         });
     });
 
-    describe("naming test cases", () => {
-
-        /**
-         * Asserts that a particular value will be emitted from an EventEmitter.
-         * @param {EventEmitter} emitter The emitter that should emit a value
-         * @param {string} emitType The type of emission to listen for
-         * @param {any} expectedValue The value that should be emitted
-         * @returns {Promise<void>} A Promise that fulfills if the value is emitted, and rejects if something else is emitted.
-         * The Promise will be indefinitely pending if no value is emitted.
-         */
-        function assertEmitted(emitter, emitType, expectedValue) {
-            return new Promise((resolve, reject) => {
-                emitter.once(emitType, emittedValue => {
-                    if (emittedValue === expectedValue) {
-                        resolve();
-                    } else {
-                        reject(new Error(`Expected ${expectedValue} to be emitted but ${emittedValue} was emitted instead.`));
-                    }
-                });
+    /**
+     * Asserts that a particular value will be emitted from an EventEmitter.
+     * @param {EventEmitter} emitter The emitter that should emit a value
+     * @param {string} emitType The type of emission to listen for
+     * @param {any} expectedValue The value that should be emitted
+     * @returns {Promise<void>} A Promise that fulfills if the value is emitted, and rejects if something else is emitted.
+     * The Promise will be indefinitely pending if no value is emitted.
+     */
+    function assertEmitted(emitter, emitType, expectedValue) {
+        return new Promise((resolve, reject) => {
+            emitter.once(emitType, emittedValue => {
+                if (emittedValue === expectedValue) {
+                    resolve();
+                } else {
+                    reject(new Error(`Expected ${expectedValue} to be emitted but ${emittedValue} was emitted instead.`));
+                }
             });
-        }
+        });
+    }
+
+    describe("naming test cases", () => {
 
         it("should use the first argument as the name of the test suite", () => {
             const assertion = assertEmitted(ruleTesterTestEmitter, "describe", "this-is-a-rule-name");
@@ -2628,4 +2628,45 @@ describe("RuleTester", () => {
         });
     });
 
+    it("should allow subclasses to set the describe/it/itOnly statics and should correctly use those values", () => {
+        const assertionDescribe = assertEmitted(ruleTesterTestEmitter, "custom describe", "this-is-a-rule-name");
+        const assertionIt = assertEmitted(ruleTesterTestEmitter, "custom it", "valid(code);");
+        const assertionItOnly = assertEmitted(ruleTesterTestEmitter, "custom itOnly", "validOnly(code);");
+
+        /**
+         * Subclass for testing
+         */
+        class RuleTesterSubclass extends RuleTester { }
+        RuleTesterSubclass.describe = function(text, method) {
+            ruleTesterTestEmitter.emit("custom describe", text, method);
+            return method.call(this);
+        };
+        RuleTesterSubclass.it = function(text, method) {
+            ruleTesterTestEmitter.emit("custom it", text, method);
+            return method.call(this);
+        };
+        RuleTesterSubclass.itOnly = function(text, method) {
+            ruleTesterTestEmitter.emit("custom itOnly", text, method);
+            return method.call(this);
+        };
+
+        const ruleTesterSubclass = new RuleTesterSubclass();
+
+        ruleTesterSubclass.run("this-is-a-rule-name", require("../../fixtures/testers/rule-tester/no-var"), {
+            valid: [
+                "valid(code);",
+                {
+                    code: "validOnly(code);",
+                    only: true
+                }
+            ],
+            invalid: []
+        });
+
+        return Promise.all([
+            assertionDescribe,
+            assertionIt,
+            assertionItOnly
+        ]);
+    });
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment:**

* **ESLint Version:** latest
* **Node Version:** 16
* **npm Version:** 8

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?** espree

**Please show your full configuration:**
N/A

**What did you do? Please include the actual source code causing the issue.**

```js
const { RuleTester } = require("eslint")

class MyCustomRuleTesterSubclass extends RuleTester {}

const rule = (context) => ({});
const ruleTester = new MyCustomRuleTesterSubclass ();

MyCustomRuleTesterSubclass.it = (text, callback) => {
  console.log("MyCustomRuleTesterSubclass has been customized!")
}

ruleTester.run("repro", rule, {
  valid: ["var foo = 0;"],
  invalid: [],
});
```

[runkit repl](https://runkit.com/embed/zm577u8qq83d)

**What did you expect to happen?**

This test should log out `MyCustomRuleTesterSubclass has been customized!`

**What actually happened? Please include the actual, raw output from ESLint.**

No console log.

If you instead set the `it` directly on `RuleTester`, it works.

This bug is caused because `RuleTester` directly references itself within its instance method instead of using `this.constructor` to reference the correct static context:

https://github.com/eslint/eslint/blob/03ac8cfc773279c01a62897692160f9a883ff4f5/lib/rule-tester/rule-tester.js#L980-L1002

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Convert `RuleTester` to use `this.constructor` instead of `RuleTester` to access static members.
- Add tests to prevent regressions

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

This was reported by a user of `@typescript-eslint`.
Fixes: https://github.com/typescript-eslint/typescript-eslint/issues/4422