### PR TITLE
feat: lint files concurrently

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -140,6 +140,8 @@ The `ESLint` constructor takes an `options` object. If you omit the `options` ob
   Default is `[]`. An array of paths to directories to load custom rules from.
 * `options.useEslintrc` (`boolean`)<br>
   Default is `true`. If `false` is present, ESLint doesn't load configuration files (`.eslintrc.*` files). Only the configuration of the constructor options is valid.
+* `options.concurrency` (`number`)<br>
+  Default is 1. Sets the concurrency level to use when linting files.
 
 ##### Autofix
 

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -86,6 +86,7 @@ Miscellaneous:
   -h, --help                      Show help
   -v, --version                   Output the version number
   --print-config path::String     Print the configuration for the given file
+  --concurrency                   The concurrency level to use when linting files
 ```
 
 Options that accept array values can be specified by repeating the option or with a comma-delimited list (other than `--ignore-pattern` which does not allow the second style).
@@ -493,6 +494,10 @@ This option outputs the configuration to be used for the file passed. When prese
 Example:
 
     eslint --print-config file.js
+
+#### `--concurrency`
+
+This option sets the concurrency level when linting files. Linting may be faster for large when this option is greater than 1.
 
 ## Ignoring files from linting
 

--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -57,6 +57,7 @@ const validFixTypes = new Set(["directive", "problem", "suggestion", "layout"]);
 /** @typedef {import("../shared/types").Rule} Rule */
 /** @typedef {ReturnType<CascadingConfigArrayFactory.getConfigArrayForFile>} ConfigArray */
 /** @typedef {ReturnType<ConfigArray.extractConfig>} ExtractedConfig */
+/** @typedef {import("./file-enumerator").FileEnumerator} FileEnumerator */
 
 /**
  * The options to configure a CLI engine with.
@@ -558,6 +559,74 @@ function directoryExists(resolvedPath) {
     }
 }
 
+/**
+ * Iterates over all of the files matching the pattern calling the appropriate callback
+ * for each file path. If a file is ignored or a cached result exists, `onResult()` is called,
+ * otherwise `onFile()` is called.
+ * @param {Object} options the iteration options.
+ * @param {string[]} options.patterns the file path patterns to be used.
+ * @param {FileEnumerator} options.fileEnumerator the file enumerator to use.
+ * @param {ConfigArray[]} options.lastConfigArrays an array of configuration arrays.
+ * @param {LintResultCache} options.lintResultCache the lint cache.
+ * @param {Object} options.options the configuration options.
+ * @param {string} options.options.cwd the current working directory.
+ * @param {boolean|Function} options.options.fix whether to fix lint errors.
+ * @param {Function} options.onResult called with the result when an ignored or previously cached file is found.
+ * @param {Function} options.onFile called with the file path and file config when a file to be linted is found.
+ * @returns {void}
+ */
+function visitFilesToLint({
+    patterns,
+    fileEnumerator,
+    lastConfigArrays,
+    lintResultCache,
+    options: {
+        cwd,
+        fix
+    },
+    onResult = () => {},
+    onFile = () => {}
+}) {
+    for (const { config, filePath, ignored } of fileEnumerator.iterateFiles(patterns)) {
+        if (ignored) {
+            onResult(createIgnoreResult(filePath, cwd));
+            continue;
+        }
+
+        /*
+         * Store used configs for:
+         * - this method uses to collect used deprecated rules.
+         * - `getRules()` method uses to collect all loaded rules.
+         * - `--fix-type` option uses to get the loaded rule's meta data.
+         */
+        if (!lastConfigArrays.includes(config)) {
+            lastConfigArrays.push(config);
+        }
+
+        // Skip if there is cached result.
+        if (lintResultCache) {
+            const cachedResult =
+                lintResultCache.getCachedLintResults(filePath, config);
+
+            if (cachedResult) {
+                const hadMessages =
+                    cachedResult.messages &&
+                    cachedResult.messages.length > 0;
+
+                if (hadMessages && fix) {
+                    debug(`Reprocessing cached file to allow autofix: ${filePath}`);
+                } else {
+                    debug(`Skipping file since it hasn't changed: ${filePath}`);
+                    onResult(cachedResult);
+                    continue;
+                }
+            }
+        }
+
+        onFile(filePath, config);
+    }
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -733,6 +802,39 @@ class CLIEngine {
         });
     }
 
+    resolveFilesToLint(patterns) {
+        const {
+            fileEnumerator,
+            lastConfigArrays,
+            lintResultCache,
+            options: {
+                cwd,
+                fix
+            }
+        } = internalSlotsMap.get(this);
+
+        const filesToLint = [];
+        const results = [];
+
+        visitFilesToLint({
+            patterns,
+            fileEnumerator,
+            lastConfigArrays,
+            lintResultCache,
+            options: {
+                cwd,
+                fix
+            },
+            onResult: result => results.push(result),
+            onFile: filePath => filesToLint.push(filePath)
+        });
+
+        return {
+            filesToLint,
+            results
+        };
+    }
+
     /**
      * Executes the current configuration on an array of file and directory names.
      * @param {string[]} patterns An array of file and directory names.
@@ -774,68 +876,45 @@ class CLIEngine {
             }
         }
 
-        // Iterate source code files.
-        for (const { config, filePath, ignored } of fileEnumerator.iterateFiles(patterns)) {
-            if (ignored) {
-                results.push(createIgnoreResult(filePath, cwd));
-                continue;
-            }
+        visitFilesToLint({
+            patterns,
+            fileEnumerator,
+            lastConfigArrays,
+            lintResultCache,
+            options: {
+                cwd,
+                fix
+            },
+            onResult: result => results.push(result),
+            onFile: (filePath, config) => {
 
-            /*
-             * Store used configs for:
-             * - this method uses to collect used deprecated rules.
-             * - `getRules()` method uses to collect all loaded rules.
-             * - `--fix-type` option uses to get the loaded rule's meta data.
-             */
-            if (!lastConfigArrays.includes(config)) {
-                lastConfigArrays.push(config);
-            }
+                // Do lint.
+                const result = verifyText({
+                    text: fs.readFileSync(filePath, "utf8"),
+                    filePath,
+                    config,
+                    cwd,
+                    fix,
+                    allowInlineConfig,
+                    reportUnusedDisableDirectives,
+                    fileEnumerator,
+                    linter
+                });
 
-            // Skip if there is cached result.
-            if (lintResultCache) {
-                const cachedResult =
-                    lintResultCache.getCachedLintResults(filePath, config);
+                results.push(result);
 
-                if (cachedResult) {
-                    const hadMessages =
-                        cachedResult.messages &&
-                        cachedResult.messages.length > 0;
 
-                    if (hadMessages && fix) {
-                        debug(`Reprocessing cached file to allow autofix: ${filePath}`);
-                    } else {
-                        debug(`Skipping file since it hasn't changed: ${filePath}`);
-                        results.push(cachedResult);
-                        continue;
-                    }
+                /*
+                 * Store the lint result in the LintResultCache.
+                 * NOTE: The LintResultCache will remove the file source and any
+                 * other properties that are difficult to serialize, and will
+                 * hydrate those properties back in on future lint runs.
+                 */
+                if (lintResultCache) {
+                    lintResultCache.setCachedLintResults(filePath, config, result);
                 }
             }
-
-            // Do lint.
-            const result = verifyText({
-                text: fs.readFileSync(filePath, "utf8"),
-                filePath,
-                config,
-                cwd,
-                fix,
-                allowInlineConfig,
-                reportUnusedDisableDirectives,
-                fileEnumerator,
-                linter
-            });
-
-            results.push(result);
-
-            /*
-             * Store the lint result in the LintResultCache.
-             * NOTE: The LintResultCache will remove the file source and any
-             * other properties that are difficult to serialize, and will
-             * hydrate those properties back in on future lint runs.
-             */
-            if (lintResultCache) {
-                lintResultCache.setCachedLintResults(filePath, config, result);
-            }
-        }
+        });
 
         // Persist the cache to disk.
         if (lintResultCache) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -84,7 +84,8 @@ function translateOptions({
     reportUnusedDisableDirectives,
     resolvePluginsRelativeTo,
     rule,
-    rulesdir
+    rulesdir,
+    concurrency
 }) {
     return {
         allowInlineConfig: inlineConfig,
@@ -120,7 +121,8 @@ function translateOptions({
         reportUnusedDisableDirectives: reportUnusedDisableDirectives ? "error" : void 0,
         resolvePluginsRelativeTo,
         rulePaths: rulesdir,
-        useEslintrc: eslintrc
+        useEslintrc: eslintrc,
+        concurrency
     };
 }
 

--- a/lib/eslint/eslint-concurrent.js
+++ b/lib/eslint/eslint-concurrent.js
@@ -1,0 +1,168 @@
+"use strict";
+
+const {
+    Worker,
+    isMainThread,
+    parentPort,
+    workerData
+} = require("worker_threads");
+
+/**
+ * Lints all of the supplied `filesToLint` using the supplied worker in chunks.
+ * @param {Worker} worker the worker to be used.
+ * @param {string[]} filesToLint the files to be linted.
+ * @param {number} chunkSize the size of the chunks to be sent to the worker.
+ * @param {import('../cli-engine/cli-engine').LintResult[]} results the array the linting results are to be appended to.
+ * @returns {void}
+ */
+async function lintInWorker(worker, filesToLint, chunkSize, results) {
+    if (filesToLint.length < 1) {
+        return;
+    }
+
+    const chunk = filesToLint.splice(0, chunkSize);
+
+    const chunkResults = await new Promise((resolve, reject) => {
+
+        /**
+         * Called when the worker thread issues an error.
+         * @param {unknown} error the error
+         * @returns {void}
+         */
+        function errorListener(error) {
+            reject(error);
+        }
+
+        /**
+         * Called if the worker thread terminates.
+         * @param {number} code the exit code (0 for OK)
+         * @returns {void}
+         */
+        function exitListener(code) {
+            if (code !== 0) {
+                reject(
+                    new Error(`ESLint worker stopped with exit code ${code}`)
+                );
+            }
+        }
+
+        worker.once("message", data => {
+            worker.removeListener("error", errorListener);
+            worker.removeListener("exit", exitListener);
+
+            if (data.type === "ERROR") {
+                const error = new Error(data.message);
+
+                error.stack = data.stack;
+                error.code = data.code;
+                reject(error);
+            } else {
+                resolve(data.results);
+            }
+        });
+        worker.on("error", errorListener);
+        worker.on("exit", exitListener);
+        worker.postMessage(chunk);
+    });
+
+    chunkResults.forEach(result => results.push(result));
+    await lintInWorker(worker, filesToLint, chunkSize, results);
+}
+
+/**
+ * Creates an array of Workers that can be used to lint files concurrently.
+ * @param {Object} options worker pool options
+ * @param {number} options.concurrency the worker pool size.
+ * @param {import('./eslint').ESLintOptions} options.eslintOptions the ESLint options.
+ * @returns {Worker[]} the worker pool.
+ */
+function createWorkers({ concurrency, eslintOptions }) {
+    const pool = [];
+
+    for (let i = 0; i < concurrency; i += 1) {
+        pool.push(
+            new Worker(__filename, {
+                workerData: {
+                    eslintOptions
+                }
+            })
+        );
+    }
+    return pool;
+}
+
+/**
+ * Concurrent linting class
+ */
+class ESLintConcurrent {
+
+    /**
+     * Creates a worker that lints files in a separate thread.
+     * @param {import('./eslint').ESLintOptions} eslintOptions the ESLint options to use
+     * @param {number} concurrency the size of the worker pool
+     */
+    constructor(eslintOptions, { concurrency, chunkSize }) {
+        this.pool = null;
+        this.eslintOptions = eslintOptions;
+        this.concurrency = concurrency;
+        this.chunkSize = chunkSize;
+    }
+
+    async lintFiles(filesToLint) {
+        if (this.pool === null) {
+            this.pool = createWorkers({
+                concurrency: this.concurrency,
+                eslintOptions: this.eslintOptions
+            });
+        }
+
+        const results = [];
+
+        await Promise.all(
+            this.pool.map(worker =>
+                lintInWorker(worker, filesToLint, this.chunkSize, results))
+        );
+
+        return results;
+    }
+
+    terminate() {
+        if (this.pool === null) {
+            return;
+        }
+
+        for (const worker of this.pool) {
+            worker.removeAllListeners();
+            worker.terminate();
+        }
+    }
+}
+
+module.exports = { ESLintConcurrent };
+
+if (!isMainThread) {
+    const { ESLint } = require("./eslint");
+
+    const { eslintOptions } = workerData;
+
+    const linter = new ESLint({
+        ...eslintOptions,
+        concurrency: 1
+    });
+
+    parentPort.on("message", filesToLint => {
+        linter
+            .lintFiles(filesToLint)
+            .then(results =>
+                parentPort.postMessage({
+                    type: "DATA",
+                    results
+                }))
+            .catch(error =>
+                parentPort.postMessage({
+                    type: "ERROR",
+                    message: error.message,
+                    stack: error.stack
+                }));
+    });
+}

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -23,6 +23,7 @@ const {
     }
 } = require("@eslint/eslintrc");
 const { version } = require("../../package.json");
+const { ESLintConcurrent } = require("./eslint-concurrent");
 
 //------------------------------------------------------------------------------
 // Typedefs
@@ -64,6 +65,7 @@ const { version } = require("../../package.json");
  * @property {string} [resolvePluginsRelativeTo] The folder where plugins should be resolved from, defaulting to the CWD.
  * @property {string[]} [rulePaths] An array of directories to load custom rules from.
  * @property {boolean} [useEslintrc] False disables looking for .eslintrc.* files.
+ * @property {number} [concurrency] Sets the concurrency level when linting files.
  */
 
 /**
@@ -180,6 +182,7 @@ function processOptions({
     resolvePluginsRelativeTo = null, // ← should be null by default because if it's a string then it suppresses RFC47 feature.
     rulePaths = [],
     useEslintrc = true,
+    concurrency = 1,
     ...unknownOptions
 }) {
     const errors = [];
@@ -288,6 +291,12 @@ function processOptions({
     if (typeof useEslintrc !== "boolean") {
         errors.push("'useEslintrc' must be a boolean.");
     }
+    if (typeof concurrency !== "number") {
+        errors.push("'concurrency' must be an integer.");
+    }
+    if (concurrency < 0 || Math.floor(concurrency) !== concurrency) {
+        errors.push("'concurrency' must be a positive integer.");
+    }
 
     if (errors.length > 0) {
         throw new ESLintInvalidOptionsError(errors);
@@ -311,7 +320,8 @@ function processOptions({
         reportUnusedDisableDirectives,
         resolvePluginsRelativeTo,
         rulePaths,
-        useEslintrc
+        useEslintrc,
+        concurrency
     };
 }
 
@@ -428,6 +438,37 @@ function compareResultsByFilePath(a, b) {
 }
 
 /**
+ * Lints files matching `patterns` with the correct concurrency.
+ * @param {CLIEngine} cliEngine the CLI engine to use for linting.
+ * @param {ESLintOptions} constructorOptions the ESLint constructor options.
+ * @param {number} concurrency the concurrency level.
+ * @param {string[]} patterns the file patterns to be linted.
+ * @returns {Promise<{ results: LintResult[] }>} the results of the linging.
+ */
+async function lintConcurrently(cliEngine, constructorOptions, concurrency, patterns) {
+    if (concurrency < 2) {
+        return cliEngine.executeOnFiles(patterns);
+    }
+
+    const { filesToLint, results } = cliEngine.resolveFilesToLint(patterns);
+
+    const eslintConcurrent = new ESLintConcurrent(constructorOptions, { concurrency, chunkSize: 10 });
+
+    try {
+        const fileResults = await eslintConcurrent.lintFiles(filesToLint);
+
+        return { results: results.concat(fileResults) };
+    } catch (error) {
+        if (error.name === "DataCloneError") {
+            return cliEngine.executeOnFiles(patterns);
+        }
+        throw error;
+    } finally {
+        eslintConcurrent.terminate();
+    }
+}
+
+/**
  * Main API.
  */
 class ESLint {
@@ -464,7 +505,8 @@ class ESLint {
         // Initialize private properties.
         privateMembersMap.set(this, {
             cliEngine,
-            options: processedOptions
+            options: processedOptions,
+            constructorOptions: options
         });
     }
 
@@ -552,11 +594,14 @@ class ESLint {
         if (!isNonEmptyString(patterns) && !isArrayOfNonEmptyString(patterns)) {
             throw new Error("'patterns' must be a non-empty string or an array of non-empty strings");
         }
-        const { cliEngine } = privateMembersMap.get(this);
+
+        const { cliEngine, options, constructorOptions } = privateMembersMap.get(this);
+
+        const results = await lintConcurrently(cliEngine, constructorOptions, options.concurrency, patterns);
 
         return processCLIEngineLintReport(
             cliEngine,
-            cliEngine.executeOnFiles(patterns)
+            results
         );
     }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -55,6 +55,7 @@ const optionator = require("optionator");
  * @property {string} [stdinFilename] Specify filename to process STDIN as
  * @property {boolean} quiet Report errors only
  * @property {boolean} [version] Output the version number
+ * @property {number} [concurrency] The concurrency level to be used
  * @property {string[]} _ Positional filenames or patterns
  */
 
@@ -318,6 +319,12 @@ module.exports = optionator({
             option: "print-config",
             type: "path::String",
             description: "Print the configuration for the given file"
+        },
+        {
+            option: "concurrency",
+            type: "Int",
+            default: "1",
+            description: "The concurrency level to be used when linting files"
         }
     ]
 });

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -389,4 +389,24 @@ describe("options", () => {
             assert.strictEqual(currentOptions.printConfig, "file.js");
         });
     });
+
+    describe("--concurrency", () => {
+        it("should return correct value for .concurrency when passed", () => {
+            const currentOptions = options.parse("--concurrency 10");
+
+            assert.strictEqual(currentOptions.concurrency, 10);
+        });
+
+        it("should return 1 for .concurrency when not passed", () => {
+            const currentOptions = options.parse("");
+
+            assert.strictEqual(currentOptions.concurrency, 1);
+        });
+
+        it("should throw an error when supplied with a non-integer", () => {
+            assert.throws(() => {
+                options.parse("--concurrency 10.2");
+            }, /Invalid value for option 'concurrency' - expected type Int/u);
+        });
+    });
 });


### PR DESCRIPTION
added a conncurency option that sets the number of threads to be used when linting files.

fixes #3565

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I have added a `concurrency` option that sets the number of worker threads used when linting files. This defaults to `1`.

How the concurrency works:

- When `concurrency > 1`, all of the files that are to be linted are fetched up-front.
- A pool of `concurrency` worker threads is created, each containing an `ESLint` instance with `concurrency = 1`.
- Chunks of files to lint are passed to these worker threads until all files have been linted.
- When the workers finish, they pass the result array back to the main thread where the results are combined.

This is a fairly simple solution to check that the maintainers are happy with the general approach. I'm sure that there are lots of things that I've missed — please point these out!

Performance:

Below is a table indicating how the linting time for the `eslint` repository varies with concurrency. Results will probably vary considerably according to the number of files to be linted, the machine spec, the plugins used, etc.).

| Concurrency | Time to run `eslint **/*.js` (s) |
|------|------|
| 1 | 65 |
| 2 | 34 |
| 3 | 26 |
| 4 | 28 |
| 5 | 27 |
| 6 | 29 |

This is all based on running on my local machine (8 cores). Clearly there is great benefit in `concurrency > 1` but there are diminishing returns above `concurrency = 3`, presumably because of resource contention.

Caching:

One thing I do know is that caching doesn't quite work correctly. With the current implementation, workers read from the cache when they start linting a batch of files and then write back when the batch is finished. Any updates to the cache in the meantime (e.g. from another thread) are lost. This means that to populate the cache fully you have to run `eslint` multiple times.  With `concurrency = 5` the cache is still only ~85% filled after 10 runs.

Some options to fix this include:

- Read the cache file contents again immediately before writing, merge the current results and then write. This decreases the window of time during which changes will be lost.
- Say that concurrency and caching cannot be used together.
- Refactor the cache code so that we read the cache once before we start, accumulate all of the changes in all of the different threads and then write the result at the end.

Some guidance on the best approach to take would be appreciated.

Testing:

I have added tests for the new CLI argument but I haven't added any tests specifically for concurrent linting. Ideally I'd like to run pretty much all of the tests with and without concurrency but some guidance on how that might be achieved would be welcome. I have manually adjusted the code to force a concurrency of 2 for a test run and all but three tests pass — two of these are because they `spy` on function interactions that are now in workers. Running the tests with concurrency is also slower than without because of the overhead of continually spawning and terminating workers.

Notes:

- NodeJS worker threads seem to be supported in all of the NodeJS versions listed in the `package.json` `engines` field.
- You can only pass data that can be serialised using the [Structured Clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) to worker threads. There are some properties of `ESLintOptions` that can be functions (e.g. the `plugins` and `fix` properties). When the options cannot be cloned the current implementation falls back to linting in a single thread.

#### Is there anything you'd like reviewers to focus on?

- Advice on how to deal with the caching issues described above.
- Advice on how / where to test this.

<!-- markdownlint-disable-file MD004 -->
