### PR TITLE
docs: trimmed rules h1s to just be rule names

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -809,17 +809,10 @@ target.checkRuleFiles = function() {
          * @param {string} id id to check for
          * @returns {boolean} true if present
          * @private
+         * @todo Will remove this check when the main heading is automatically generated from rule metadata.
          */
         function hasIdInTitle(id) {
-            const idOldAtEndOfTitleRegExp = new RegExp(`^# (.*?) \\(${id}\\)`, "u"); // original format
-            const idNewAtBeginningOfTitleRegExp = new RegExp(`^# ${id}: `, "u"); // new format is same as rules index
-            /*
-             * 1. Added support for new format.
-             * 2. Will remove support for old format after all docs files have new format.
-             * 3. Will remove this check when the main heading is automatically generated from rule metadata.
-             */
-
-            return idNewAtBeginningOfTitleRegExp.test(docText) || idOldAtEndOfTitleRegExp.test(docText);
+            return new RegExp(`^# ${id}`, "u").test(docText);
         }
 
         /**
@@ -879,7 +872,7 @@ target.checkRuleFiles = function() {
             errors++;
         } else {
 
-            // check for proper doc format
+            // check for proper doc h1 format
             if (!hasIdInTitle(basename)) {
                 console.error("Missing id in the doc page's title of rule %s", basename);
                 errors++;

--- a/docs/rules/accessor-pairs.md
+++ b/docs/rules/accessor-pairs.md
@@ -1,4 +1,6 @@
-# Enforces getter/setter pairs in objects and classes (accessor-pairs)
+# accessor-pairs
+
+Enforces getter/setter pairs in objects and classes.
 
 It's a common mistake in JavaScript to create an object with just a setter for a property but never have a corresponding getter defined for it. Without a getter, you cannot read the property, so it ends up not being used.
 

--- a/docs/rules/array-bracket-newline.md
+++ b/docs/rules/array-bracket-newline.md
@@ -1,4 +1,6 @@
-# enforce line breaks after opening and before closing array brackets (array-bracket-newline)
+# array-bracket-newline
+
+Enforces line breaks after opening and before closing array brackets.
 
 A number of style guides require or disallow line breaks inside of array brackets.
 

--- a/docs/rules/array-bracket-spacing.md
+++ b/docs/rules/array-bracket-spacing.md
@@ -1,4 +1,6 @@
-# Disallow or enforce spaces inside of brackets (array-bracket-spacing)
+# array-bracket-spacing
+
+Disallows or enforce spaces inside of brackets.
 
 A number of style guides require or disallow spaces between array brackets and other tokens. This rule
 applies to both array literals and destructuring assignments (ECMAScript 6).

--- a/docs/rules/array-callback-return.md
+++ b/docs/rules/array-callback-return.md
@@ -1,4 +1,6 @@
-# Enforces return statements in callbacks of array's methods (array-callback-return)
+# array-callback-return
+
+Enforces return statements in callbacks of array's methods.
 
 `Array` has several methods for filtering, mapping, and folding.
 If we forget to write `return` statement in a callback of those, it's probably a mistake. If you don't want to use a return or don't need the returned results, consider using [.forEach](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) instead.

--- a/docs/rules/array-element-newline.md
+++ b/docs/rules/array-element-newline.md
@@ -1,4 +1,6 @@
-# enforce line breaks between array elements (array-element-newline)
+# array-element-newline
+
+Enforces line breaks between array elements.
 
 A number of style guides require or disallow line breaks between array elements.
 

--- a/docs/rules/arrow-body-style.md
+++ b/docs/rules/arrow-body-style.md
@@ -1,4 +1,6 @@
-# Require braces in arrow function body (arrow-body-style)
+# arrow-body-style
+
+Requires braces in arrow function bodies.
 
 Arrow functions have two syntactic forms for their function bodies.  They may be defined with a *block* body (denoted by curly braces) `() => { ... }` or with a single expression `() => ...`, whose value is implicitly returned.
 

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -1,4 +1,6 @@
-# Require parens in arrow function arguments (arrow-parens)
+# arrow-parens
+
+Requires parens in arrow function arguments.
 
 Arrow functions can omit parentheses when they have exactly one parameter. In all other cases the parameter(s) must
 be wrapped in parentheses. This rule enforces the consistent use of parentheses in arrow functions.

--- a/docs/rules/arrow-spacing.md
+++ b/docs/rules/arrow-spacing.md
@@ -1,4 +1,6 @@
-# Require space before/after arrow function's arrow (arrow-spacing)
+# arrow-spacing
+
+Requires space before/after arrow function's arrow.
 
 This rule normalize style of spacing before/after an arrow function's arrow(`=>`).
 

--- a/docs/rules/block-scoped-var.md
+++ b/docs/rules/block-scoped-var.md
@@ -1,6 +1,6 @@
 # block-scoped-var
 
-Enforces treating var as block scoped.
+Enforces treating `var` as block scoped.
 
 The `block-scoped-var` rule generates warnings when variables are used outside of the block in which they were defined. This emulates C-style block scope.
 

--- a/docs/rules/block-scoped-var.md
+++ b/docs/rules/block-scoped-var.md
@@ -1,4 +1,6 @@
-# Treat var as Block Scoped (block-scoped-var)
+# block-scoped-var
+
+Enforces treating var as block scoped.
 
 The `block-scoped-var` rule generates warnings when variables are used outside of the block in which they were defined. This emulates C-style block scope.
 

--- a/docs/rules/block-spacing.md
+++ b/docs/rules/block-spacing.md
@@ -1,4 +1,6 @@
-# Disallow or enforce spaces inside of blocks after opening block and before closing block (block-spacing)
+# block-spacing
+
+Disallows or enforces spaces inside of blocks after opening blocks and before closing blocks.
 
 ## Rule Details
 

--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -1,4 +1,6 @@
-# Require Brace Style (brace-style)
+# brace-style
+
+Enforces consistent brace style for blocks.
 
 Brace style is closely related to [indent style](https://en.wikipedia.org/wiki/Indent_style) in programming and describes the placement of braces relative to their control statement and body. There are probably a dozen, if not more, brace styles in the world.
 

--- a/docs/rules/callback-return.md
+++ b/docs/rules/callback-return.md
@@ -1,4 +1,6 @@
-# Enforce Return After Callback (callback-return)
+# callback-return
+
+Enforces return after callback.
 
 This rule was **deprecated** in ESLint v7.0.0. Please use the corresponding rule in [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node).
 

--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -1,4 +1,6 @@
-# Require CamelCase (camelcase)
+# camelcase
+
+Enforces camelcase naming convention.
 
 When it comes to naming variables, style guides generally fall into one of two camps: camelcase (`variableName`) and underscores (`variable_name`). This rule focuses on using the camelcase approach. If your style guide calls for camelCasing your variable names, then this rule is for you!
 

--- a/docs/rules/capitalized-comments.md
+++ b/docs/rules/capitalized-comments.md
@@ -1,4 +1,6 @@
-# enforce or disallow capitalization of the first letter of a comment (capitalized-comments)
+# capitalized-comments
+
+Enforces or disallows capitalization of the first letter of a comment.
 
 Comments are useful for leaving information for future developers. In order for that information to be useful and not distracting, it is sometimes desirable for comments to follow a particular style. One element of comment formatting styles is whether the first word of a comment should be capitalized or lowercase.
 

--- a/docs/rules/class-methods-use-this.md
+++ b/docs/rules/class-methods-use-this.md
@@ -1,4 +1,6 @@
-# Enforce that class methods utilize `this` (class-methods-use-this)
+# class-methods-use-this
+
+Enforces that class methods utilize `this`.
 
 If a class method does not use `this`, it can *sometimes* be made into a static function. If you do convert the method into a static function, instances of the class that call that particular method have to be converted to a static call as well (`MyClass.callStaticMethod()`)
 

--- a/docs/rules/comma-dangle.md
+++ b/docs/rules/comma-dangle.md
@@ -1,4 +1,6 @@
-# require or disallow trailing commas (comma-dangle)
+# comma-dangle
+
+Requires or disallows trailing commas.
 
 Trailing commas in object literals are valid according to the ECMAScript 5 (and ECMAScript 3!) spec. However, IE8 (when not in IE8 document mode) and below will throw an error when it encounters trailing commas in JavaScript.
 

--- a/docs/rules/comma-spacing.md
+++ b/docs/rules/comma-spacing.md
@@ -1,4 +1,6 @@
-# Enforces spacing around commas (comma-spacing)
+# comma-spacing
+
+Enforces spacing around commas.
 
 Spacing around commas improves readability of a list of items. Although most of the style guidelines for languages prescribe adding a space after a comma and not before it, it is subjective to the preferences of a project.
 

--- a/docs/rules/comma-style.md
+++ b/docs/rules/comma-style.md
@@ -1,4 +1,6 @@
-# Comma style (comma-style)
+# comma-style
+
+Enforces consistent comma styles.
 
 The Comma Style rule enforces styles for comma-separated lists. There are two comma styles primarily used in JavaScript:
 

--- a/docs/rules/complexity.md
+++ b/docs/rules/complexity.md
@@ -1,4 +1,6 @@
-# Limit Cyclomatic Complexity (complexity)
+# complexity
+
+Enforces a maximum cyclomatic complexity.
 
 Cyclomatic complexity measures the number of linearly independent paths through a program's source code. This rule allows setting a cyclomatic complexity threshold.
 

--- a/docs/rules/computed-property-spacing.md
+++ b/docs/rules/computed-property-spacing.md
@@ -1,4 +1,6 @@
-# Disallow or enforce spaces inside of computed properties (computed-property-spacing)
+# computed-property-spacing
+
+Disallows or enforces spaces inside of computed properties.
 
 While formatting preferences are very personal, a number of style guides require
 or disallow spaces between computed properties in the following situations:

--- a/docs/rules/consistent-return.md
+++ b/docs/rules/consistent-return.md
@@ -1,4 +1,6 @@
-# require `return` statements to either always or never specify values (consistent-return)
+# consistent-return
+
+Requires `return` statements to either always or never specify values.
 
 Unlike statically-typed languages which enforce that a function returns a specified type of value, JavaScript allows different code paths in a function to return different types of values.
 

--- a/docs/rules/consistent-this.md
+++ b/docs/rules/consistent-this.md
@@ -1,4 +1,6 @@
-# Require Consistent This (consistent-this)
+# consistent-this
+
+Enforces consistent naming when capturing the current execution context.
 
 It is often necessary to capture the current execution context in order to make it available subsequently. A prominent example of this are jQuery callbacks:
 

--- a/docs/rules/constructor-super.md
+++ b/docs/rules/constructor-super.md
@@ -1,4 +1,6 @@
-# Verify calls of `super()` in constructors (constructor-super)
+# constructor-super
+
+Verifies calls of `super()` in constructors.
 
 Constructors of derived classes must call `super()`.
 Constructors of non derived classes must not call `super()`.

--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -1,4 +1,6 @@
-# Require Following Curly Brace Conventions (curly)
+# curly
+
+Requires following curly brace conventions.
 
 JavaScript allows the omission of curly braces when a block contains only one statement. However, it is considered by many to be best practice to _never_ omit curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity. So the following:
 

--- a/docs/rules/default-case-last.md
+++ b/docs/rules/default-case-last.md
@@ -1,4 +1,6 @@
-# Enforce default clauses in switch statements to be last (default-case-last)
+# default-case-last
+
+Enforces default clauses in switch statements to be last.
 
 A `switch` statement can optionally have a `default` clause.
 

--- a/docs/rules/default-case.md
+++ b/docs/rules/default-case.md
@@ -1,6 +1,6 @@
 # default-case
 
-Requires a default case in switch statements.
+Requires a `default` case in switch statements.
 
 Some code conventions require that all `switch` statements have a `default` case, even if the default case is empty, such as:
 
@@ -15,7 +15,7 @@ switch (foo) {
         break;
 
     default:
-        // do nothing
+    // do nothing
 }
 ```
 

--- a/docs/rules/default-case.md
+++ b/docs/rules/default-case.md
@@ -1,4 +1,6 @@
-# Require Default Case in Switch Statements (default-case)
+# default-case
+
+Requires a default case in switch statements.
 
 Some code conventions require that all `switch` statements have a `default` case, even if the default case is empty, such as:
 

--- a/docs/rules/default-param-last.md
+++ b/docs/rules/default-param-last.md
@@ -1,4 +1,6 @@
-# enforce default parameters to be last (default-param-last)
+# default-param-last
+
+Enforces default parameters to be last.
 
 Putting default parameter at last allows function calls to omit optional tail arguments.
 

--- a/docs/rules/dot-location.md
+++ b/docs/rules/dot-location.md
@@ -1,4 +1,6 @@
-# Enforce newline before and after dot (dot-location)
+# dot-location
+
+Enforces newline before and after dots.
 
 JavaScript allows you to place newlines before or after a dot in a member expression.
 

--- a/docs/rules/dot-notation.md
+++ b/docs/rules/dot-notation.md
@@ -1,4 +1,6 @@
-# Require Dot Notation (dot-notation)
+# dot-notation
+
+Enforces dot notation whenever possible.
 
 In JavaScript, one can access properties using the dot notation (`foo.bar`) or square-bracket notation (`foo["bar"]`). However, the dot notation is often preferred because it is easier to read, less verbose, and works better with aggressive JavaScript minimizers.
 

--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -1,4 +1,6 @@
-# require or disallow newline at the end of files (eol-last)
+# eol-last
+
+Requires or disallows newline at the end of files.
 
 Trailing newlines in non-empty files are a common UNIX idiom. Benefits of
 trailing newlines include the ability to concatenate or append to files as well

--- a/docs/rules/eqeqeq.md
+++ b/docs/rules/eqeqeq.md
@@ -1,4 +1,6 @@
-# Require === and !== (eqeqeq)
+# eqeqeq
+
+Requires the use of === and !==.
 
 It is considered good practice to use the type-safe equality operators `===` and `!==` instead of their regular counterparts `==` and `!=`.
 

--- a/docs/rules/eqeqeq.md
+++ b/docs/rules/eqeqeq.md
@@ -1,6 +1,6 @@
 # eqeqeq
 
-Requires the use of === and !==.
+Requires the use of `===` and `!==`.
 
 It is considered good practice to use the type-safe equality operators `===` and `!==` instead of their regular counterparts `==` and `!=`.
 

--- a/docs/rules/for-direction.md
+++ b/docs/rules/for-direction.md
@@ -1,4 +1,6 @@
-# Enforce "for" loop update clause moving the counter in the right direction. (for-direction)
+# for-direction
+
+Enforces "for" loop update clause moving the counter in the right direction.
 
 ## Rule Details
 

--- a/docs/rules/for-direction.md
+++ b/docs/rules/for-direction.md
@@ -1,6 +1,6 @@
 # for-direction
 
-Enforces "for" loop update clause moving the counter in the right direction.
+Enforces `for` loop update clause moving the counter in the right direction.
 
 ## Rule Details
 

--- a/docs/rules/func-call-spacing.md
+++ b/docs/rules/func-call-spacing.md
@@ -1,4 +1,6 @@
-# require or disallow spacing between function identifiers and their invocations (func-call-spacing)
+# func-call-spacing
+
+Requires or disallows spacing between function identifiers and their invocations.
 
 When calling a function, developers may insert optional whitespace between the function's name and the parentheses that invoke it. The following pairs of function calls are equivalent:
 

--- a/docs/rules/func-name-matching.md
+++ b/docs/rules/func-name-matching.md
@@ -1,4 +1,6 @@
-# require function names to match the name of the variable or property to which they are assigned (func-name-matching)
+# func-name-matching
+
+Requires function names to match the name of the variable or property to which they are assigned.
 
 ## Rule Details
 

--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -1,4 +1,6 @@
-# Require or disallow named `function` expressions (func-names)
+# func-names
+
+Requires or disallows named `function` expressions.
 
 A pattern that's becoming more common is to give function expressions names to aid in debugging. For example:
 

--- a/docs/rules/func-style.md
+++ b/docs/rules/func-style.md
@@ -1,4 +1,6 @@
-# enforce the consistent use of either `function` declarations or expressions (func-style)
+# func-style
+
+Enforces the consistent use of either `function` declarations or expressions.
 
 There are two ways of defining functions in JavaScript: `function` declarations and `function` expressions. Declarations contain the `function` keyword first, followed by a name and then its arguments and the function body, for example:
 

--- a/docs/rules/function-call-argument-newline.md
+++ b/docs/rules/function-call-argument-newline.md
@@ -1,4 +1,6 @@
-# enforce line breaks between arguments of a function call (function-call-argument-newline)
+# function-call-argument-newline
+
+Enforces line breaks between arguments of a function call.
 
 A number of style guides require or disallow line breaks between arguments of a function call.
 

--- a/docs/rules/function-paren-newline.md
+++ b/docs/rules/function-paren-newline.md
@@ -1,4 +1,6 @@
-# enforce consistent line breaks inside function parentheses (function-paren-newline)
+# function-paren-newline
+
+Enforces consistent line breaks inside function parentheses.
 
 Many style guides require or disallow newlines inside of function parentheses.
 

--- a/docs/rules/generator-star-spacing.md
+++ b/docs/rules/generator-star-spacing.md
@@ -1,6 +1,6 @@
 # generator-star-spacing
 
-Enforces spacing around the * in generator functions.
+Enforces spacing around the `*` in generator functions.
 
 Generators are a new type of function in ECMAScript 6 that can return multiple values over time.
 These special functions are indicated by placing an `*` after the `function` keyword.

--- a/docs/rules/generator-star-spacing.md
+++ b/docs/rules/generator-star-spacing.md
@@ -1,4 +1,6 @@
-# Enforce spacing around the * in generator functions (generator-star-spacing)
+# generator-star-spacing
+
+Enforces spacing around the * in generator functions.
 
 Generators are a new type of function in ECMAScript 6 that can return multiple values over time.
 These special functions are indicated by placing an `*` after the `function` keyword.

--- a/docs/rules/generator-star.md
+++ b/docs/rules/generator-star.md
@@ -1,4 +1,6 @@
-# generator-star: enforce consistent spacing around the asterisk in generator functions
+# generator-star
+
+Enforces consistent spacing around the asterisk in generator functions.
 
 (removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [generator-star-spacing](generator-star-spacing.md) rule.
 

--- a/docs/rules/getter-return.md
+++ b/docs/rules/getter-return.md
@@ -1,6 +1,6 @@
 # getter-return
 
-Enforces that a return statement is present in property getters.
+Enforces that a `return` statement is present in property getters.
 
 The get syntax binds an object property to a function that will be called when that property is looked up. It was first introduced in ECMAScript 5:
 

--- a/docs/rules/getter-return.md
+++ b/docs/rules/getter-return.md
@@ -1,4 +1,6 @@
-# Enforces that a return statement is present in property getters (getter-return)
+# getter-return
+
+Enforces that a return statement is present in property getters.
 
 The get syntax binds an object property to a function that will be called when that property is looked up. It was first introduced in ECMAScript 5:
 

--- a/docs/rules/global-require.md
+++ b/docs/rules/global-require.md
@@ -1,6 +1,6 @@
 # global-require
 
-Enforces require() on the top-level module scope.
+Enforces `require()` on the top-level module scope.
 
 This rule was **deprecated** in ESLint v7.0.0. Please use the corresponding rule in [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node).
 
@@ -14,7 +14,6 @@ While `require()` may be called anywhere in code, some style guides prescribe th
 
 ```js
 function foo() {
-
     if (condition) {
         var fs = require("fs");
     }
@@ -37,26 +36,34 @@ Examples of **incorrect** code for this rule:
 
 // calling require() inside of a function is not allowed
 function readFile(filename, callback) {
-    var fs = require('fs');
-    fs.readFile(filename, callback)
+    var fs = require("fs");
+    fs.readFile(filename, callback);
 }
 
 // conditional requires like this are also not allowed
-if (DEBUG) { require('debug'); }
+if (DEBUG) {
+    require("debug");
+}
 
 // a require() in a switch statement is also flagged
-switch(x) { case '1': require('1'); break; }
+switch (x) {
+    case "1":
+        require("1");
+        break;
+}
 
 // you may not require() inside an arrow function body
 var getModule = (name) => require(name);
 
 // you may not require() inside of a function body as well
-function getModule(name) { return require(name); }
+function getModule(name) {
+    return require(name);
+}
 
 // you may not require() inside of a try/catch block
 try {
     require(unsafeModule);
-} catch(e) {
+} catch (e) {
     console.log(e);
 }
 ```
@@ -67,19 +74,19 @@ Examples of **correct** code for this rule:
 /*eslint global-require: "error"*/
 
 // all these variations of require() are ok
-require('x');
-var y = require('y');
+require("x");
+var y = require("y");
 var z;
-z = require('z').initialize();
+z = require("z").initialize();
 
 // requiring a module and using it in a function is ok
-var fs = require('fs');
+var fs = require("fs");
 function readFile(filename, callback) {
-    fs.readFile(filename, callback)
+    fs.readFile(filename, callback);
 }
 
 // you can use a ternary to determine which module to require
-var logger = DEBUG ? require('dev-logger') : require('logger');
+var logger = DEBUG ? require("dev-logger") : require("logger");
 
 // if you want you can require() at the end of your module
 function doSomethingA() {}

--- a/docs/rules/global-require.md
+++ b/docs/rules/global-require.md
@@ -1,4 +1,6 @@
-# Enforce require() on the top-level module scope (global-require)
+# global-require
+
+Enforces require() on the top-level module scope.
 
 This rule was **deprecated** in ESLint v7.0.0. Please use the corresponding rule in [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node).
 

--- a/docs/rules/global-strict.md
+++ b/docs/rules/global-strict.md
@@ -1,4 +1,6 @@
-# global-strict: require or disallow strict mode directives in the global scope
+# global-strict
+
+Requires or disallows strict mode directives in the global scope.
 
 (removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [strict](strict.md) rule. The `"global"` option in the new rule is most similar to the removed rule.
 

--- a/docs/rules/grouped-accessor-pairs.md
+++ b/docs/rules/grouped-accessor-pairs.md
@@ -1,4 +1,6 @@
-# Require grouped accessor pairs in object literals and classes (grouped-accessor-pairs)
+# grouped-accessor-pairs
+
+Requires grouped accessor pairs in object literals and classes.
 
 A getter and setter for the same property don't necessarily have to be defined adjacent to each other.
 

--- a/docs/rules/guard-for-in.md
+++ b/docs/rules/guard-for-in.md
@@ -1,4 +1,6 @@
-# Require Guarding for-in (guard-for-in)
+# guard-for-in
+
+Requires `for in` loops to include an `if` statement.
 
 Looping over objects with a `for in` loop will include properties that are inherited through the prototype chain. This behavior can lead to unexpected items in your for loop.
 

--- a/docs/rules/handle-callback-err.md
+++ b/docs/rules/handle-callback-err.md
@@ -1,4 +1,6 @@
-# Enforce Callback Error Handling (handle-callback-err)
+# handle-callback-err
+
+Enforces callback error handling.
 
 This rule was **deprecated** in ESLint v7.0.0. Please use the corresponding rule in [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node).
 

--- a/docs/rules/id-blacklist.md
+++ b/docs/rules/id-blacklist.md
@@ -1,3 +1,5 @@
-# disallow specified identifiers (id-blacklist)
+# id-blacklist
+
+Disallows specified identifiers.
 
 This rule was **deprecated** in ESLint v7.5.0 and replaced by the [id-denylist](id-denylist.md) rule.

--- a/docs/rules/id-denylist.md
+++ b/docs/rules/id-denylist.md
@@ -1,4 +1,6 @@
-# disallow specified identifiers (id-denylist)
+# id-denylist
+
+Disallows specified identifiers.
 
 > "There are only two hard things in Computer Science: cache invalidation and naming things." — Phil Karlton
 

--- a/docs/rules/id-length.md
+++ b/docs/rules/id-length.md
@@ -1,4 +1,6 @@
-# enforce minimum and maximum identifier lengths (id-length)
+# id-length
+
+Enforces minimum and maximum identifier lengths.
 
 Very short identifier names like `e`, `x`, `_t` or very long ones like `hashGeneratorResultOutputContainerObject` can make code harder to read and potentially less maintainable. To prevent this, one may enforce a minimum and/or maximum identifier length.
 

--- a/docs/rules/id-match.md
+++ b/docs/rules/id-match.md
@@ -1,4 +1,6 @@
-# require identifiers to match a specified regular expression (id-match)
+# id-match
+
+Requires identifiers to match a specified regular expression.
 
 > "There are only two hard things in Computer Science: cache invalidation and naming things." — Phil Karlton
 

--- a/docs/rules/implicit-arrow-linebreak.md
+++ b/docs/rules/implicit-arrow-linebreak.md
@@ -1,4 +1,6 @@
-# Enforce the location of arrow function bodies with implicit returns (implicit-arrow-linebreak)
+# implicit-arrow-linebreak
+
+Enforces the location of arrow function bodies with implicit returns.
 
 An arrow function body can contain an implicit return as an expression instead of a block body. It can be useful to enforce a consistent location for the implicitly returned expression.
 

--- a/docs/rules/indent-legacy.md
+++ b/docs/rules/indent-legacy.md
@@ -1,4 +1,6 @@
-# enforce consistent indentation (indent-legacy)
+# indent-legacy
+
+Enforces consistent indentation.
 
 This rule was **deprecated** in ESLint v4.0.0.
 

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -1,4 +1,6 @@
-# enforce consistent indentation (indent)
+# indent
+
+Enforces consistent indentation.
 
 There are several common guidelines which require specific indentation of nested blocks and statements, like:
 

--- a/docs/rules/init-declarations.md
+++ b/docs/rules/init-declarations.md
@@ -1,4 +1,6 @@
-# require or disallow initialization in variable declarations (init-declarations)
+# init-declarations
+
+Requires or disallows initialization in variable declarations.
 
 In JavaScript, variables can be assigned during declaration, or at any point afterwards using an assignment statement. For example, in the following code, `foo` is initialized during declaration, while `bar` is initialized later.
 

--- a/docs/rules/jsx-quotes.md
+++ b/docs/rules/jsx-quotes.md
@@ -1,4 +1,6 @@
-# enforce the consistent use of either double or single quotes in JSX attributes (jsx-quotes)
+# jsx-quotes
+
+Enforces the consistent use of either double or single quotes in JSX attributes.
 
 JSX attribute values can contain string literals, which are delimited with single or double quotes.
 

--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -1,4 +1,6 @@
-# enforce consistent spacing between keys and values in object literal properties (key-spacing)
+# key-spacing
+
+Enforces consistent spacing between keys and values in object literal properties.
 
 This rule enforces spacing around the colon in object literal properties. It can verify each property individually, or it can ensure horizontal alignment of adjacent properties in an object literal.
 

--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -1,4 +1,6 @@
-# enforce consistent spacing before and after keywords (keyword-spacing)
+# keyword-spacing
+
+Enforces consistent spacing before and after keywords.
 
 Keywords are syntax elements of JavaScript, such as `try` and `if`.
 These keywords have special meaning to the language and so often appear in a different color in code editors.

--- a/docs/rules/line-comment-position.md
+++ b/docs/rules/line-comment-position.md
@@ -1,4 +1,6 @@
-# enforce position of line comments (line-comment-position)
+# line-comment-position
+
+Enforces position of line comments.
 
 Line comments can be positioned above or beside code. This rule helps teams maintain a consistent style.
 

--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -1,4 +1,6 @@
-# enforce consistent linebreak style (linebreak-style)
+# linebreak-style
+
+Enforces consistent linebreak style.
 
 When developing with a lot of people all having different editors, VCS applications and operating systems it may occur that
 different line endings are written by either of the mentioned (might especially happen when using the windows and mac versions of SourceTree together).

--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -1,4 +1,6 @@
-# require empty lines around comments (lines-around-comment)
+# lines-around-comment
+
+Requires empty lines around comments.
 
 Many style guides require empty lines before or after comments. The primary goal
 of these rules is to make the comments easier to read and improve readability of the code.

--- a/docs/rules/lines-around-directive.md
+++ b/docs/rules/lines-around-directive.md
@@ -1,4 +1,6 @@
-# require or disallow newlines around directives (lines-around-directive)
+# lines-around-directive
+
+Requires or disallow newlines around directives.
 
 This rule was **deprecated** in ESLint v4.0.0 and replaced by the [padding-line-between-statements](padding-line-between-statements.md) rule.
 

--- a/docs/rules/lines-between-class-members.md
+++ b/docs/rules/lines-between-class-members.md
@@ -1,4 +1,6 @@
-# require or disallow an empty line between class members (lines-between-class-members)
+# lines-between-class-members
+
+Requires or disallows an empty line between class members.
 
 This rule improves readability by enforcing lines between class members. It will not check empty lines before the first member and after the last member, since that is already taken care of by padded-blocks.
 

--- a/docs/rules/max-classes-per-file.md
+++ b/docs/rules/max-classes-per-file.md
@@ -1,4 +1,6 @@
-# enforce a maximum number of classes per file (max-classes-per-file)
+# max-classes-per-file
+
+Enforces a maximum number of classes per file.
 
 Files containing multiple classes can often result in a less navigable
 and poorly structured codebase. Best practice is to keep each file

--- a/docs/rules/max-depth.md
+++ b/docs/rules/max-depth.md
@@ -1,4 +1,6 @@
-# enforce a maximum depth that blocks can be nested (max-depth)
+# max-depth
+
+Enforces a maximum depth that blocks can be nested.
 
 Many developers consider code difficult to read if blocks are nested beyond a certain depth.
 

--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -1,4 +1,6 @@
-# enforce a maximum line length (max-len)
+# max-len
+
+Enforces a maximum line length.
 
 Very long lines of code in any language can be difficult to read. In order to aid in readability and maintainability many coders have developed a convention to limit lines of code to X number of characters (traditionally 80 characters).
 

--- a/docs/rules/max-lines-per-function.md
+++ b/docs/rules/max-lines-per-function.md
@@ -1,4 +1,6 @@
-# enforce a maximum function length (max-lines-per-function)
+# max-lines-per-function
+
+Enforces a maximum function length.
 
 Some people consider large functions a code smell. Large functions tend to do a lot of things and can make it hard following what's going on. Many coding style guides dictate a limit of the number of lines that a function can comprise of. This rule can help enforce that style.
 

--- a/docs/rules/max-lines.md
+++ b/docs/rules/max-lines.md
@@ -1,4 +1,6 @@
-# enforce a maximum file length (max-lines)
+# max-lines
+
+Enforces a maximum file length.
 
 Some people consider large files a code smell. Large files tend to do a lot of things and can make it hard following what's going. While there is not an objective maximum number of lines considered acceptable in a file, most people would agree it should not be in the thousands. Recommendations usually range from 100 to 500 lines.
 

--- a/docs/rules/max-nested-callbacks.md
+++ b/docs/rules/max-nested-callbacks.md
@@ -1,4 +1,6 @@
-# enforce a maximum depth that callbacks can be nested (max-nested-callbacks)
+# max-nested-callbacks
+
+Enforces a maximum depth that callbacks can be nested.
 
 Many JavaScript libraries use the callback pattern to manage asynchronous operations. A program of any complexity will most likely need to manage several asynchronous operations at various levels of concurrency. A common pitfall that is easy to fall into is nesting callbacks, which makes code more difficult to read the deeper the callbacks are nested.
 

--- a/docs/rules/max-params.md
+++ b/docs/rules/max-params.md
@@ -1,4 +1,6 @@
-# enforce a maximum number of parameters in function definitions (max-params)
+# max-params
+
+Enforces a maximum number of parameters in function definitions.
 
 Functions that take numerous parameters can be difficult to read and write because it requires the memorization of what each parameter is, its type, and the order they should appear in. As a result, many coders adhere to a convention that caps the number of parameters a function can take.
 

--- a/docs/rules/max-statements-per-line.md
+++ b/docs/rules/max-statements-per-line.md
@@ -1,4 +1,6 @@
-# enforce a maximum number of statements allowed per line (max-statements-per-line)
+# max-statements-per-line
+
+Enforces a maximum number of statements allowed per line.
 
 A line of code containing too many statements can be difficult to read. Code is generally read from the top down, especially when scanning, so limiting the number of statements allowed on a single line can be very beneficial for readability and maintainability.
 

--- a/docs/rules/max-statements.md
+++ b/docs/rules/max-statements.md
@@ -1,4 +1,6 @@
-# enforce a maximum number of statements allowed in function blocks (max-statements)
+# max-statements
+
+Enforces a maximum number of statements allowed in function blocks.
 
 The `max-statements` rule allows you to specify the maximum number of statements allowed in a function.
 

--- a/docs/rules/multiline-comment-style.md
+++ b/docs/rules/multiline-comment-style.md
@@ -1,4 +1,6 @@
-# enforce a particular style for multiline comments (multiline-comment-style)
+# multiline-comment-style
+
+Enforces a particular style for multiline comments.
 
 Many style guides require a particular style for comments that span multiple lines. For example, some style guides prefer the use of a single block comment for multiline comments, whereas other style guides prefer consecutive line comments.
 

--- a/docs/rules/multiline-ternary.md
+++ b/docs/rules/multiline-ternary.md
@@ -1,4 +1,6 @@
-# Enforce or disallow newlines between operands of ternary expressions (multiline-ternary)
+# multiline-ternary
+
+Enforces or disallows newlines between operands of ternary expressions.
 
 JavaScript allows operands of ternary expressions to be separated by newlines, which can improve the readability of your program.
 

--- a/docs/rules/new-cap.md
+++ b/docs/rules/new-cap.md
@@ -1,4 +1,6 @@
-# require constructor names to begin with a capital letter (new-cap)
+# new-cap
+
+Requires constructor names to begin with a capital letter.
 
 The `new` operator in JavaScript creates a new instance of a particular type of object. That type of object is represented by a constructor function. Since constructor functions are just regular functions, the only defining characteristic is that `new` is being used as part of the call. Native JavaScript functions begin with an uppercase letter to distinguish those functions that are to be used as constructors from functions that are not. Many style guides recommend following this pattern to more easily determine which functions are to be used as constructors.
 

--- a/docs/rules/new-parens.md
+++ b/docs/rules/new-parens.md
@@ -1,4 +1,6 @@
-# require parentheses when invoking a constructor with no arguments (new-parens)
+# new-parens
+
+Requires parentheses when invoking a constructor with no arguments.
 
 JavaScript allows the omission of parentheses when invoking a function via the `new` keyword and the constructor has no arguments. However, some coders believe that omitting the parentheses is inconsistent with the rest of the language and thus makes code less clear.
 

--- a/docs/rules/newline-after-var.md
+++ b/docs/rules/newline-after-var.md
@@ -1,4 +1,6 @@
-# require or disallow an empty line after variable declarations (newline-after-var)
+# newline-after-var
+
+Requires or disallows an empty line after variable declarations.
 
 This rule was **deprecated** in ESLint v4.0.0 and replaced by the [padding-line-between-statements](padding-line-between-statements.md) rule.
 

--- a/docs/rules/newline-before-return.md
+++ b/docs/rules/newline-before-return.md
@@ -1,4 +1,6 @@
-# require an empty line before `return` statements (newline-before-return)
+# newline-before-return
+
+Requires an empty line before `return` statements.
 
 This rule was **deprecated** in ESLint v4.0.0 and replaced by the [padding-line-between-statements](padding-line-between-statements.md) rule.
 

--- a/docs/rules/newline-per-chained-call.md
+++ b/docs/rules/newline-per-chained-call.md
@@ -1,4 +1,6 @@
-# require a newline after each call in a method chain (newline-per-chained-call)
+# newline-per-chained-call
+
+Requires a newline after each call in a method chain.
 
 Chained method calls on a single line without line breaks are harder to read, so some developers place a newline character after each method call in the chain to make it more readable and easy to maintain.
 

--- a/docs/rules/no-alert.md
+++ b/docs/rules/no-alert.md
@@ -1,4 +1,6 @@
-# Disallow Use of Alert (no-alert)
+# no-alert
+
+Disallows the use of `alert`, `confirm`, and `prompt`.
 
 JavaScript's `alert`, `confirm`, and `prompt` functions are widely considered to be obtrusive as UI elements and should be replaced by a more appropriate custom UI implementation. Furthermore, `alert` is often used while debugging code, which should be removed before deployment to production.
 

--- a/docs/rules/no-array-constructor.md
+++ b/docs/rules/no-array-constructor.md
@@ -1,4 +1,6 @@
-# disallow `Array` constructors (no-array-constructor)
+# no-array-constructor
+
+Disallows `Array` constructors.
 
 Use of the `Array` constructor to construct a new array is generally
 discouraged in favor of array literal notation because of the single-argument

--- a/docs/rules/no-arrow-condition.md
+++ b/docs/rules/no-arrow-condition.md
@@ -1,4 +1,6 @@
-# no-arrow-condition: disallow arrow functions where test conditions are expected
+# no-arrow-condition
+
+Disallows arrow functions where test conditions are expected.
 
 (removed) This rule was **removed** in ESLint v2.0 and **replaced** by a combination of the [no-confusing-arrow](no-confusing-arrow.md) and [no-constant-condition](no-constant-condition.md) rules.
 

--- a/docs/rules/no-async-promise-executor.md
+++ b/docs/rules/no-async-promise-executor.md
@@ -1,4 +1,6 @@
-# disallow using an async function as a Promise executor (no-async-promise-executor)
+# no-async-promise-executor
+
+Disallows using an async function as a Promise executor.
 
 The `new Promise` constructor accepts an *executor* function as an argument, which has `resolve` and `reject` parameters that can be used to control the state of the created Promise. For example:
 

--- a/docs/rules/no-await-in-loop.md
+++ b/docs/rules/no-await-in-loop.md
@@ -1,4 +1,6 @@
-# Disallow `await` inside of loops (no-await-in-loop)
+# no-await-in-loop
+
+Disallows `await` inside of loops.
 
 Performing an operation on each element of an iterable is a common task. However, performing an
 `await` as part of each operation is an indication that the program is not taking full advantage of

--- a/docs/rules/no-bitwise.md
+++ b/docs/rules/no-bitwise.md
@@ -1,4 +1,6 @@
-# disallow bitwise operators (no-bitwise)
+# no-bitwise
+
+Disallows bitwise operators.
 
 The use of bitwise operators in JavaScript is very rare and often `&` or `|` is simply a mistyped `&&` or `||`, which will lead to unexpected behavior.
 

--- a/docs/rules/no-buffer-constructor.md
+++ b/docs/rules/no-buffer-constructor.md
@@ -1,4 +1,6 @@
-# disallow use of the Buffer() constructor (no-buffer-constructor)
+# no-buffer-constructor
+
+Disallows use of the Buffer() constructor.
 
 This rule was **deprecated** in ESLint v7.0.0. Please use the corresponding rule in [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node).
 

--- a/docs/rules/no-buffer-constructor.md
+++ b/docs/rules/no-buffer-constructor.md
@@ -1,6 +1,6 @@
 # no-buffer-constructor
 
-Disallows use of the Buffer() constructor.
+Disallows use of the `Buffer()` constructor.
 
 This rule was **deprecated** in ESLint v7.0.0. Please use the corresponding rule in [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node).
 

--- a/docs/rules/no-caller.md
+++ b/docs/rules/no-caller.md
@@ -1,4 +1,6 @@
-# Disallow Use of caller/callee (no-caller)
+# no-caller
+
+Disallows use of caller/callee.
 
 The use of `arguments.caller` and `arguments.callee` make several code optimizations impossible. They have been deprecated in future versions of JavaScript and their use is forbidden in ECMAScript 5 while in strict mode.
 

--- a/docs/rules/no-caller.md
+++ b/docs/rules/no-caller.md
@@ -1,6 +1,6 @@
 # no-caller
 
-Disallows use of caller/callee.
+Disallows use of `caller`/`callee`.
 
 The use of `arguments.caller` and `arguments.callee` make several code optimizations impossible. They have been deprecated in future versions of JavaScript and their use is forbidden in ECMAScript 5 while in strict mode.
 

--- a/docs/rules/no-case-declarations.md
+++ b/docs/rules/no-case-declarations.md
@@ -1,4 +1,6 @@
-# Disallow lexical declarations in case/default clauses (no-case-declarations)
+# no-case-declarations
+
+Disallows lexical declarations in case/default clauses.
 
 This rule disallows lexical declarations (`let`, `const`, `function` and `class`)
 in `case`/`default` clauses. The reason is that the lexical declaration is visible

--- a/docs/rules/no-catch-shadow.md
+++ b/docs/rules/no-catch-shadow.md
@@ -1,4 +1,6 @@
-# Disallow Shadowing of Variables Inside of catch (no-catch-shadow)
+# no-catch-shadow
+
+Disallows shadowing of variables inside of catch.
 
 This rule was **deprecated** in ESLint v5.1.0.
 

--- a/docs/rules/no-class-assign.md
+++ b/docs/rules/no-class-assign.md
@@ -1,4 +1,6 @@
-# Disallow modifying variables of class declarations (no-class-assign)
+# no-class-assign
+
+Disallows modifying variables of class declarations.
 
 `ClassDeclaration` creates a variable, and we can modify the variable.
 

--- a/docs/rules/no-comma-dangle.md
+++ b/docs/rules/no-comma-dangle.md
@@ -1,4 +1,6 @@
-# no-comma-dangle: disallow trailing commas in object and array literals
+# no-comma-dangle
+
+Disallows trailing commas in object and array literals.
 
 (removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [comma-dangle](comma-dangle.md) rule.
 

--- a/docs/rules/no-compare-neg-zero.md
+++ b/docs/rules/no-compare-neg-zero.md
@@ -1,4 +1,6 @@
-# disallow comparing against -0 (no-compare-neg-zero)
+# no-compare-neg-zero
+
+Disallows comparing against -0.
 
 ## Rule Details
 

--- a/docs/rules/no-compare-neg-zero.md
+++ b/docs/rules/no-compare-neg-zero.md
@@ -1,10 +1,10 @@
 # no-compare-neg-zero
 
-Disallows comparing against -0.
+Disallows comparing against `-0`.
 
 ## Rule Details
 
-The rule should warn against code that tries to compare against -0, since that will not work as intended. That is, code like x === -0 will pass for both +0 and -0. The author probably intended Object.is(x, -0).
+The rule should warn against code that tries to compare against `-0`, since that will not work as intended. That is, code like `x === -0` will pass for both `+0` and `-0`. The author probably intended `Object.is(x, -0)`.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/no-cond-assign.md
+++ b/docs/rules/no-cond-assign.md
@@ -1,4 +1,6 @@
-# disallow assignment operators in conditional statements (no-cond-assign)
+# no-cond-assign
+
+Disallows assignment operators in conditional statements.
 
 In conditional statements, it is very easy to mistype a comparison operator (such as `==`) as an assignment operator (such as `=`). For example:
 

--- a/docs/rules/no-confusing-arrow.md
+++ b/docs/rules/no-confusing-arrow.md
@@ -1,4 +1,6 @@
-# Disallow arrow functions where they could be confused with comparisons (no-confusing-arrow)
+# no-confusing-arrow
+
+Disallows arrow functions where they could be confused with comparisons.
 
 Arrow functions (`=>`) are similar in syntax to some comparison operators (`>`, `<`, `<=`, and `>=`). This rule warns against using the arrow function syntax in places where it could be confused with a comparison operator.
 

--- a/docs/rules/no-console.md
+++ b/docs/rules/no-console.md
@@ -1,4 +1,6 @@
-# disallow the use of `console` (no-console)
+# no-console
+
+Disallows the use of `console`.
 
 In JavaScript that is designed to be executed in the browser, it's considered a best practice to avoid using methods on `console`. Such messages are considered to be for debugging purposes and therefore not suitable to ship to the client. In general, calls using `console` should be stripped before being pushed to production.
 

--- a/docs/rules/no-const-assign.md
+++ b/docs/rules/no-const-assign.md
@@ -1,4 +1,6 @@
-# Disallow modifying variables that are declared using `const` (no-const-assign)
+# no-const-assign
+
+Disallows modifying variables that are declared using `const`.
 
 We cannot modify variables that are declared using `const` keyword.
 It will raise a runtime error.

--- a/docs/rules/no-constant-condition.md
+++ b/docs/rules/no-constant-condition.md
@@ -1,4 +1,6 @@
-# disallow constant expressions in conditions (no-constant-condition)
+# no-constant-condition
+
+Disallows constant expressions in conditions.
 
 A constant expression (for example, a literal) as a test condition might be a typo or development trigger for a specific behavior. For example, the following code looks as if it is not ready for production.
 

--- a/docs/rules/no-constructor-return.md
+++ b/docs/rules/no-constructor-return.md
@@ -1,4 +1,6 @@
-# Disallow returning value in constructor (no-constructor-return)
+# no-constructor-return
+
+Disallows returning values in constructor.
 
 In JavaScript, returning a value in the constructor of a class may be a mistake. Forbidding this pattern prevents mistakes resulting from unfamiliarity with the language or a copy-paste error.
 

--- a/docs/rules/no-continue.md
+++ b/docs/rules/no-continue.md
@@ -1,4 +1,6 @@
-# disallow `continue` statements (no-continue)
+# no-continue
+
+Disallows `continue` statements.
 
 The `continue` statement terminates execution of the statements in the current iteration of the current or labeled loop, and continues execution of the loop with the next iteration. When used incorrectly it makes code less testable, less readable and less maintainable. Structured control flow statements such as `if` should be used instead.
 

--- a/docs/rules/no-control-regex.md
+++ b/docs/rules/no-control-regex.md
@@ -1,4 +1,6 @@
-# disallow control characters in regular expressions (no-control-regex)
+# no-control-regex
+
+Disallows control characters in regular expressions.
 
 Control characters are special, invisible characters in the ASCII range 0-31. These characters are rarely used in JavaScript strings so a regular expression containing these characters is most likely a mistake.
 

--- a/docs/rules/no-debugger.md
+++ b/docs/rules/no-debugger.md
@@ -1,4 +1,6 @@
-# disallow the use of `debugger` (no-debugger)
+# no-debugger
+
+Disallows the use of `debugger`.
 
 The `debugger` statement is used to tell the executing JavaScript environment to stop execution and start up a debugger at the current point in the code. This has fallen out of favor as a good practice with the advent of modern debugging and development tools. Production code should definitely not contain `debugger`, as it will cause the browser to stop executing code and open an appropriate debugger.
 

--- a/docs/rules/no-delete-var.md
+++ b/docs/rules/no-delete-var.md
@@ -1,4 +1,6 @@
-# disallow deleting variables (no-delete-var)
+# no-delete-var
+
+Disallows deleting variables.
 
 The purpose of the `delete` operator is to remove a property from an object. Using the `delete` operator on a variable might lead to unexpected behavior.
 

--- a/docs/rules/no-div-regex.md
+++ b/docs/rules/no-div-regex.md
@@ -1,4 +1,6 @@
-# Disallow Regular Expressions That Look Like Division (no-div-regex)
+# no-div-regex
+
+Disallows regular expressions that look like division.
 
 Require regex literals to escape division operators.
 

--- a/docs/rules/no-dupe-args.md
+++ b/docs/rules/no-dupe-args.md
@@ -1,4 +1,6 @@
-# disallow duplicate arguments in `function` definitions (no-dupe-args)
+# no-dupe-args
+
+Disallows duplicate arguments in `function` definitions.
 
 If more than one parameter has the same name in a function definition, the last occurrence "shadows" the preceding occurrences. A duplicated name might be a typing error.
 

--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -1,4 +1,6 @@
-# Disallow duplicate name in class members (no-dupe-class-members)
+# no-dupe-class-members
+
+Disallows duplicate name in class members.
 
 If there are declarations of the same name in class members, the last declaration overwrites other declarations silently.
 It can cause unexpected behaviors.

--- a/docs/rules/no-dupe-else-if.md
+++ b/docs/rules/no-dupe-else-if.md
@@ -1,4 +1,6 @@
-# Disallow duplicate conditions in `if-else-if` chains (no-dupe-else-if)
+# no-dupe-else-if
+
+Disallows duplicate conditions in `if-else-if` chains.
 
 `if-else-if` chains are commonly used when there is a need to execute only one branch (or at most one branch) out of several possible branches, based on certain conditions.
 

--- a/docs/rules/no-dupe-keys.md
+++ b/docs/rules/no-dupe-keys.md
@@ -1,4 +1,6 @@
-# disallow duplicate keys in object literals (no-dupe-keys)
+# no-dupe-keys
+
+Disallows duplicate keys in object literals.
 
 Multiple properties with the same key in object literals can cause unexpected behavior in your application.
 

--- a/docs/rules/no-duplicate-case.md
+++ b/docs/rules/no-duplicate-case.md
@@ -1,4 +1,6 @@
-# Rule to disallow a duplicate case label (no-duplicate-case)
+# no-duplicate-case
+
+Disallows duplicate case labels.
 
 If a `switch` statement has duplicate test expressions in `case` clauses, it is likely that a programmer copied a `case` clause but forgot to change the test expression.
 

--- a/docs/rules/no-duplicate-case.md
+++ b/docs/rules/no-duplicate-case.md
@@ -1,6 +1,6 @@
 # no-duplicate-case
 
-Disallows duplicate case labels.
+Disallows duplicate `case` labels.
 
 If a `switch` statement has duplicate test expressions in `case` clauses, it is likely that a programmer copied a `case` clause but forgot to change the test expression.
 

--- a/docs/rules/no-duplicate-imports.md
+++ b/docs/rules/no-duplicate-imports.md
@@ -1,4 +1,6 @@
-# Disallow duplicate imports (no-duplicate-imports)
+# no-duplicate-imports
+
+Disallows duplicate imports.
 
 Using a single `import` statement per module will make the code clearer because you can see everything being imported from that module on one line.
 

--- a/docs/rules/no-else-return.md
+++ b/docs/rules/no-else-return.md
@@ -1,4 +1,6 @@
-# Disallow return before else (no-else-return)
+# no-else-return
+
+Disallows return before else.
 
 If an `if` block contains a `return` statement, the `else` block becomes unnecessary. Its contents can be placed outside of the block.
 

--- a/docs/rules/no-else-return.md
+++ b/docs/rules/no-else-return.md
@@ -1,6 +1,6 @@
 # no-else-return
 
-Disallows return before else.
+Disallows `return` before `else`.
 
 If an `if` block contains a `return` statement, the `else` block becomes unnecessary. Its contents can be placed outside of the block.
 

--- a/docs/rules/no-empty-character-class.md
+++ b/docs/rules/no-empty-character-class.md
@@ -1,4 +1,6 @@
-# disallow empty character classes in regular expressions (no-empty-character-class)
+# no-empty-character-class
+
+Disallows empty character classes in regular expressions.
 
 Because empty character classes in regular expressions do not match anything, they might be typing mistakes.
 

--- a/docs/rules/no-empty-class.md
+++ b/docs/rules/no-empty-class.md
@@ -1,4 +1,6 @@
-# no-empty-class: disallow empty character classes in regular expressions
+# no-empty-class
+
+Disallows empty character classes in regular expressions.
 
 (removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [no-empty-character-class](no-empty-character-class.md) rule.
 

--- a/docs/rules/no-empty-function.md
+++ b/docs/rules/no-empty-function.md
@@ -1,4 +1,6 @@
-# Disallow empty functions (no-empty-function)
+# no-empty-function
+
+Disallows empty functions.
 
 Empty functions can reduce readability because readers need to guess whether it's intentional or not.
 So writing a clear comment for empty functions is a good practice.

--- a/docs/rules/no-empty-label.md
+++ b/docs/rules/no-empty-label.md
@@ -1,4 +1,6 @@
-# no-empty-label: disallow labels for anything other than loops and switches
+# no-empty-label
+
+Disallows labels for anything other than loops and switches.
 
 (removed) This rule was **removed** in ESLint v2.0 and **replaced** by the [no-labels](no-labels.md) rule.
 

--- a/docs/rules/no-empty-pattern.md
+++ b/docs/rules/no-empty-pattern.md
@@ -1,4 +1,6 @@
-# Disallow empty destructuring patterns (no-empty-pattern)
+# no-empty-pattern
+
+Disallows empty destructuring patterns.
 
 When using destructuring, it's possible to create a pattern that has no effect. This happens when empty curly braces are used to the right of an embedded object destructuring pattern, such as:
 

--- a/docs/rules/no-empty.md
+++ b/docs/rules/no-empty.md
@@ -1,4 +1,6 @@
-# disallow empty block statements (no-empty)
+# no-empty
+
+Disallows empty block statements.
 
 Empty block statements, while not technically errors, usually occur due to refactoring that wasn't completed. They can cause confusion when reading code.
 

--- a/docs/rules/no-eq-null.md
+++ b/docs/rules/no-eq-null.md
@@ -1,4 +1,6 @@
-# Disallow Null Comparisons (no-eq-null)
+# no-eq-null
+
+Disallows `null` comparisons without type-checking operators,
 
 Comparing to `null` without a type-checking operator (`==` or `!=`), can have unintended results as the comparison will evaluate to true when comparing to not just a `null`, but also an `undefined` value.
 

--- a/docs/rules/no-eval.md
+++ b/docs/rules/no-eval.md
@@ -1,4 +1,6 @@
-# Disallow eval() (no-eval)
+# no-eval
+
+Disallows eval().
 
 JavaScript's `eval()` function is potentially dangerous and is often misused. Using `eval()` on untrusted code can open a program up to several different injection attacks. The use of `eval()` in most contexts can be substituted for a better, alternative approach to a problem.
 

--- a/docs/rules/no-ex-assign.md
+++ b/docs/rules/no-ex-assign.md
@@ -1,4 +1,6 @@
-# disallow reassigning exceptions in `catch` clauses (no-ex-assign)
+# no-ex-assign
+
+Disallows reassigning exceptions in `catch` clauses.
 
 If a `catch` clause in a `try` statement accidentally (or purposely) assigns another value to the exception parameter, it impossible to refer to the error from that point on.
 Since there is no `arguments` object to offer alternative access to this data, assignment of the parameter is absolutely destructive.

--- a/docs/rules/no-extend-native.md
+++ b/docs/rules/no-extend-native.md
@@ -1,4 +1,6 @@
-# Disallow Extending of Native Objects (no-extend-native)
+# no-extend-native
+
+Disallows extending of native objects.
 
 In JavaScript, you can extend any object, including builtin or "native" objects. Sometimes people change the behavior of these native objects in ways that break the assumptions made about them in other parts of the code.
 

--- a/docs/rules/no-extra-bind.md
+++ b/docs/rules/no-extra-bind.md
@@ -1,4 +1,6 @@
-# Disallow unnecessary function binding (no-extra-bind)
+# no-extra-bind
+
+Disallows unnecessary function binding.
 
 The `bind()` method is used to create functions with specific `this` values and, optionally, binds arguments to specific values. When used to specify the value of `this`, it's important that the function actually uses `this` in its function body. For example:
 

--- a/docs/rules/no-extra-boolean-cast.md
+++ b/docs/rules/no-extra-boolean-cast.md
@@ -1,4 +1,6 @@
-# disallow unnecessary boolean casts (no-extra-boolean-cast)
+# no-extra-boolean-cast
+
+Disallows unnecessary boolean casts.
 
 In contexts such as an `if` statement's test where the result of the expression will already be coerced to a Boolean, casting to a Boolean via double negation (`!!`) or a `Boolean` call is unnecessary. For example, these `if` statements are equivalent:
 

--- a/docs/rules/no-extra-label.md
+++ b/docs/rules/no-extra-label.md
@@ -1,4 +1,6 @@
-# Disallow Unnecessary Labels (no-extra-label)
+# no-extra-label
+
+Disallows unnecessary labels.
 
 If a loop contains no nested loops or switches, labeling the loop is unnecessary.
 

--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -1,4 +1,6 @@
-# disallow unnecessary parentheses (no-extra-parens)
+# no-extra-parens
+
+Disallows unnecessary parentheses.
 
 This rule restricts the use of parentheses to only where they are necessary.
 

--- a/docs/rules/no-extra-semi.md
+++ b/docs/rules/no-extra-semi.md
@@ -1,4 +1,6 @@
-# disallow unnecessary semicolons (no-extra-semi)
+# no-extra-semi
+
+Disallows unnecessary semicolons.
 
 Typing mistakes and misunderstandings about where semicolons are required can lead to semicolons that are unnecessary. While not technically an error, extra semicolons can cause confusion when reading code.
 

--- a/docs/rules/no-extra-strict.md
+++ b/docs/rules/no-extra-strict.md
@@ -1,4 +1,6 @@
-# no-extra-strict: disallow strict mode directives when already in strict mode
+# no-extra-strict
+
+Disallows strict mode directives when already in strict mode.
 
 (removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [strict](strict.md) rule. The `"global"` or `"function"` options in the new rule are similar to the removed rule.
 

--- a/docs/rules/no-fallthrough.md
+++ b/docs/rules/no-fallthrough.md
@@ -1,4 +1,6 @@
-# Disallow Case Statement Fallthrough (no-fallthrough)
+# no-fallthrough
+
+Disallows case statement fallthroughs.
 
 The `switch` statement in JavaScript is one of the more error-prone constructs of the language thanks in part to the ability to "fall through" from one `case` to the next. For example:
 

--- a/docs/rules/no-floating-decimal.md
+++ b/docs/rules/no-floating-decimal.md
@@ -1,4 +1,6 @@
-# Disallow Floating Decimals (no-floating-decimal)
+# no-floating-decimal
+
+Disallows leading or trailing decimal points in numeric literals.
 
 Float values in JavaScript contain a decimal point, and there is no requirement that the decimal point be preceded or followed by a number. For example, the following are all valid JavaScript numbers:
 

--- a/docs/rules/no-func-assign.md
+++ b/docs/rules/no-func-assign.md
@@ -1,4 +1,6 @@
-# disallow reassigning `function` declarations (no-func-assign)
+# no-func-assign
+
+Disallows reassigning `function` declarations.
 
 JavaScript functions can be written as a FunctionDeclaration `function foo() { ... }` or as a FunctionExpression `var foo = function() { ... };`. While a JavaScript interpreter might tolerate it, overwriting/reassigning a function written as a FunctionDeclaration is often indicative of a mistake or issue.
 

--- a/docs/rules/no-global-assign.md
+++ b/docs/rules/no-global-assign.md
@@ -1,4 +1,6 @@
-# Disallow assignment to native objects or read-only global variables (no-global-assign)
+# no-global-assign
+
+Disallows assignment to native objects or read-only global variables.
 
 JavaScript environments contain a number of built-in global variables, such as `window` in browsers and `process` in Node.js. In almost all cases, you don't want to assign a value to these global variables as doing so could result in losing access to important functionality. For example, you probably don't want to do this in browser code:
 

--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -1,4 +1,6 @@
-# Disallow the type conversion with shorter notations. (no-implicit-coercion)
+# no-implicit-coercion
+
+Disallows shorthand type conversions.
 
 In JavaScript, there are a lot of different ways to convert value types.
 Some of them might be hard to read and understand.

--- a/docs/rules/no-implicit-globals.md
+++ b/docs/rules/no-implicit-globals.md
@@ -1,4 +1,6 @@
-# Disallow declarations in the global scope (no-implicit-globals)
+# no-implicit-globals
+
+Disallows declarations in the global scope.
 
 It is the best practice to avoid 'polluting' the global scope with variables that are intended to be local to the script.
 

--- a/docs/rules/no-implied-eval.md
+++ b/docs/rules/no-implied-eval.md
@@ -1,4 +1,6 @@
-# Disallow Implied eval() (no-implied-eval)
+# no-implied-eval
+
+Disallows the use of `eval()`-like methods.
 
 It's considered a good practice to avoid using `eval()` in JavaScript. There are security and performance implications involved with doing so, which is why many linters (including ESLint) recommend disallowing `eval()`. However, there are some other ways to pass a string and have it interpreted as JavaScript code that have similar concerns.
 

--- a/docs/rules/no-import-assign.md
+++ b/docs/rules/no-import-assign.md
@@ -1,4 +1,6 @@
-# disallow assigning to imported bindings (no-import-assign)
+# no-import-assign
+
+Disallows assigning to imported bindings.
 
 The updates of imported bindings by ES Modules cause runtime errors.
 

--- a/docs/rules/no-inline-comments.md
+++ b/docs/rules/no-inline-comments.md
@@ -1,4 +1,6 @@
-# disallow inline comments after code (no-inline-comments)
+# no-inline-comments
+
+Disallows inline comments after code.
 
 Some style guides disallow comments on the same line as code. Code can become difficult to read if comments immediately follow the code on the same line.
 On the other hand, it is sometimes faster and more obvious to put comments immediately following code.

--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -1,4 +1,6 @@
-# disallow variable or `function` declarations in nested blocks (no-inner-declarations)
+# no-inner-declarations
+
+Disallows variable or `function` declarations in nested blocks.
 
 In JavaScript, prior to ES6, a function declaration is only allowed in the first level of a program or the body of another function, though parsers sometimes [erroneously accept them elsewhere](https://code.google.com/p/esprima/issues/detail?id=422). This only applies to function declarations; named or anonymous function expressions can occur anywhere an expression is permitted.
 

--- a/docs/rules/no-invalid-regexp.md
+++ b/docs/rules/no-invalid-regexp.md
@@ -1,4 +1,6 @@
-# disallow invalid regular expression strings in `RegExp` constructors (no-invalid-regexp)
+# no-invalid-regexp
+
+Disallows invalid regular expression strings in `RegExp` constructors.
 
 An invalid pattern in a regular expression literal is a `SyntaxError` when the code is parsed, but an invalid string in `RegExp` constructors throws a `SyntaxError` only when the code is executed.
 

--- a/docs/rules/no-invalid-this.md
+++ b/docs/rules/no-invalid-this.md
@@ -1,4 +1,6 @@
-# Disallow `this` keywords outside of classes or class-like objects. (no-invalid-this)
+# no-invalid-this
+
+Disallows `this` keywords outside of classes or class-like objects.
 
 Under the strict mode, `this` keywords outside of classes or class-like objects might be `undefined` and raise a `TypeError`.
 

--- a/docs/rules/no-irregular-whitespace.md
+++ b/docs/rules/no-irregular-whitespace.md
@@ -1,4 +1,6 @@
-# disallow irregular whitespace (no-irregular-whitespace)
+# no-irregular-whitespace
+
+Disallows irregular whitespace characters.
 
 Invalid or irregular whitespace causes issues with ECMAScript 5 parsers and also makes code harder to debug in a similar nature to mixed tabs and spaces.
 

--- a/docs/rules/no-iterator.md
+++ b/docs/rules/no-iterator.md
@@ -1,4 +1,6 @@
-# Disallow Iterator (no-iterator)
+# no-iterator
+
+Disallows the use of the `__iterator__` property.
 
 The `__iterator__` property was a SpiderMonkey extension to JavaScript that could be used to create custom iterators that are compatible with JavaScript's `for in` and `for each` constructs. However, this property is now obsolete, so it should not be used. Here's an example of how this used to work:
 

--- a/docs/rules/no-label-var.md
+++ b/docs/rules/no-label-var.md
@@ -1,4 +1,6 @@
-# Disallow Labels That Are Variables Names (no-label-var)
+# no-label-var
+
+Disallows labels that are variable names.
 
 ## Rule Details
 

--- a/docs/rules/no-labels.md
+++ b/docs/rules/no-labels.md
@@ -1,4 +1,6 @@
-# Disallow Labeled Statements (no-labels)
+# no-labels
+
+Disallows labeled statements.
 
 Labeled statements in JavaScript are used in conjunction with `break` and `continue` to control flow around multiple loops. For example:
 

--- a/docs/rules/no-lone-blocks.md
+++ b/docs/rules/no-lone-blocks.md
@@ -1,4 +1,6 @@
-# Disallow Unnecessary Nested Blocks (no-lone-blocks)
+# no-lone-blocks
+
+Disallows unnecessary nested blocks.
 
 In JavaScript, prior to ES6, standalone code blocks delimited by curly braces do not create a new scope and have no use. For example, these curly braces do nothing to `foo`:
 

--- a/docs/rules/no-lonely-if.md
+++ b/docs/rules/no-lonely-if.md
@@ -1,4 +1,6 @@
-# disallow `if` statements as the only statement in `else` blocks (no-lonely-if)
+# no-lonely-if
+
+Disallows `if` statements as the only statement in `else` blocks.
 
 If an `if` statement is the only statement in the `else` block, it is often clearer to use an `else if` form.
 

--- a/docs/rules/no-loop-func.md
+++ b/docs/rules/no-loop-func.md
@@ -1,4 +1,6 @@
-# Disallow Functions in Loops (no-loop-func)
+# no-loop-func
+
+Disallows functions in loops.
 
 Writing functions within loops tends to result in errors due to the way the function creates a closure around the loop. For example:
 

--- a/docs/rules/no-loss-of-precision.md
+++ b/docs/rules/no-loss-of-precision.md
@@ -1,4 +1,6 @@
-# Disallow Number Literals That Lose Precision (no-loss-of-precision)
+# no-loss-of-precision
+
+Disallows number literals that lose precision.
 
 This rule would disallow the use of number literals that immediately lose precision at runtime when converted to a JS `Number` due to 64-bit floating-point rounding.
 

--- a/docs/rules/no-magic-numbers.md
+++ b/docs/rules/no-magic-numbers.md
@@ -1,4 +1,6 @@
-# Disallow Magic Numbers (no-magic-numbers)
+# no-magic-numbers
+
+Disallows magic numbers.
 
 'Magic numbers' are numbers that occur multiple times in code without an explicit meaning.
 They should preferably be replaced by named constants.

--- a/docs/rules/no-misleading-character-class.md
+++ b/docs/rules/no-misleading-character-class.md
@@ -1,4 +1,6 @@
-# Disallow characters which are made with multiple code points in character class syntax (no-misleading-character-class)
+# no-misleading-character-class
+
+Disallows characters which are made with multiple code points in character class syntax.
 
 Unicode includes the characters which are made with multiple code points.
 RegExp character class syntax (`/[abc]/`) cannot handle characters which are made by multiple code points as a character; those characters will be dissolved to each code point. For example, `❇️` is made by `❇` (`U+2747`) and VARIATION SELECTOR-16 (`U+FE0F`). If this character is in RegExp character class, it will match to either `❇` (`U+2747`) or VARIATION SELECTOR-16 (`U+FE0F`) rather than `❇️`.

--- a/docs/rules/no-mixed-operators.md
+++ b/docs/rules/no-mixed-operators.md
@@ -1,4 +1,6 @@
-# Disallow mixes of different operators (no-mixed-operators)
+# no-mixed-operators
+
+Disallows mixes of different operators.
 
 Enclosing complex expressions by parentheses clarifies the developer's intention, which makes the code more readable.
 This rule warns when different operators are used consecutively without parentheses in an expression.

--- a/docs/rules/no-mixed-requires.md
+++ b/docs/rules/no-mixed-requires.md
@@ -1,4 +1,6 @@
-# disallow `require` calls to be mixed with regular variable declarations (no-mixed-requires)
+# no-mixed-requires
+
+Disallows `require` calls to be mixed with regular variable declarations.
 
 This rule was **deprecated** in ESLint v7.0.0. Please use the corresponding rule in [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node).
 

--- a/docs/rules/no-mixed-spaces-and-tabs.md
+++ b/docs/rules/no-mixed-spaces-and-tabs.md
@@ -1,4 +1,6 @@
-# disallow mixed spaces and tabs for indentation (no-mixed-spaces-and-tabs)
+# no-mixed-spaces-and-tabs
+
+Disallows mixed spaces and tabs for indentation.
 
 Most code conventions require either tabs or spaces be used for indentation. As such, it's usually an error if a single line of code is indented with both tabs and spaces.
 

--- a/docs/rules/no-multi-assign.md
+++ b/docs/rules/no-multi-assign.md
@@ -1,4 +1,6 @@
-# Disallow Use of Chained Assignment Expressions (no-multi-assign)
+# no-multi-assign
+
+Disallows use of chained assignment expressions.
 
 Chaining the assignment of variables can lead to unexpected results and be difficult to read.
 

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -1,4 +1,6 @@
-# Disallow multiple spaces (no-multi-spaces)
+# no-multi-spaces
+
+Disallows multiple consecutive spaces.
 
 Multiple spaces in a row that are not used for indentation are typically mistakes. For example:
 

--- a/docs/rules/no-multi-str.md
+++ b/docs/rules/no-multi-str.md
@@ -1,4 +1,6 @@
-# Disallow Multiline Strings (no-multi-str)
+# no-multi-str
+
+Disallows multiline strings.
 
 It's possible to create multiline strings in JavaScript by using a slash before a newline, such as:
 

--- a/docs/rules/no-multiple-empty-lines.md
+++ b/docs/rules/no-multiple-empty-lines.md
@@ -1,4 +1,6 @@
-# disallow multiple empty lines (no-multiple-empty-lines)
+# no-multiple-empty-lines
+
+Disallows multiple empty lines.
 
 Some developers prefer to have multiple blank lines removed, while others feel that it helps improve readability. Whitespace is useful for separating logical sections of code, but excess whitespace takes up more of the screen.
 

--- a/docs/rules/no-native-reassign.md
+++ b/docs/rules/no-native-reassign.md
@@ -1,4 +1,6 @@
-# Disallow Reassignment of Native Objects (no-native-reassign)
+# no-native-reassign
+
+Disallows reassignment of native objects.
 
 This rule was **deprecated** in ESLint v3.3.0 and replaced by the [no-global-assign](no-global-assign.md) rule.
 

--- a/docs/rules/no-negated-condition.md
+++ b/docs/rules/no-negated-condition.md
@@ -1,4 +1,6 @@
-# disallow negated conditions (no-negated-condition)
+# no-negated-condition
+
+Disallows negated conditions.
 
 Negated conditions are more difficult to understand. Code can be made more readable by inverting the condition instead.
 

--- a/docs/rules/no-negated-in-lhs.md
+++ b/docs/rules/no-negated-in-lhs.md
@@ -1,4 +1,6 @@
-# disallow negating the left operand in `in` expressions (no-negated-in-lhs)
+# no-negated-in-lhs
+
+Disallows negating the left operand in `in` expressions.
 
 This rule was **deprecated** in ESLint v3.3.0 and replaced by the [no-unsafe-negation](no-unsafe-negation.md) rule.
 

--- a/docs/rules/no-nested-ternary.md
+++ b/docs/rules/no-nested-ternary.md
@@ -1,4 +1,6 @@
-# disallow nested ternary expressions (no-nested-ternary)
+# no-nested-ternary
+
+Disallows nested ternary expressions.
 
 Nesting ternary expressions can make code more difficult to understand.
 

--- a/docs/rules/no-new-func.md
+++ b/docs/rules/no-new-func.md
@@ -1,4 +1,6 @@
-# Disallow Function Constructor (no-new-func)
+# no-new-func
+
+Disallows `new` operators with the `Function` object.
 
 It's possible to create functions in JavaScript from strings at runtime using the `Function` constructor, such as:
 

--- a/docs/rules/no-new-object.md
+++ b/docs/rules/no-new-object.md
@@ -1,4 +1,6 @@
-# disallow `Object` constructors (no-new-object)
+# no-new-object
+
+Disallows `new` operators with the `Object` object.
 
 The `Object` constructor is used to create new generic objects in JavaScript, such as:
 

--- a/docs/rules/no-new-require.md
+++ b/docs/rules/no-new-require.md
@@ -1,4 +1,6 @@
-# Disallow new require (no-new-require)
+# no-new-require
+
+Disallows `new` operators with calls to `require`.
 
 This rule was **deprecated** in ESLint v7.0.0. Please use the corresponding rule in [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node).
 

--- a/docs/rules/no-new-symbol.md
+++ b/docs/rules/no-new-symbol.md
@@ -1,4 +1,6 @@
-# Disallow Symbol Constructor (no-new-symbol)
+# no-new-symbol
+
+Disallows `new` operators with the `Symbol` object.
 
 `Symbol` is not intended to be used with the `new` operator, but to be called as a function.
 

--- a/docs/rules/no-new-wrappers.md
+++ b/docs/rules/no-new-wrappers.md
@@ -1,4 +1,6 @@
-# Disallow Primitive Wrapper Instances (no-new-wrappers)
+# no-new-wrappers
+
+Disallows `new` operators with the `String`, `Number`, and `Boolean` objects.
 
 There are three primitive types in JavaScript that have wrapper objects: string, number, and boolean. These are represented by the constructors `String`, `Number`, and `Boolean`, respectively. The primitive wrapper types are used whenever one of these primitive values is read, providing them with object-like capabilities such as methods. Behind the scenes, an object of the associated wrapper type is created and then destroyed, which is why you can call methods on primitive values, such as:
 

--- a/docs/rules/no-new.md
+++ b/docs/rules/no-new.md
@@ -1,4 +1,6 @@
-# Disallow new For Side Effects (no-new)
+# no-new
+
+Disallows `new` operators outside of assignments or comparisons.
 
 The goal of using `new` with a constructor is typically to create an object of a particular type and store that object in a variable, such as:
 

--- a/docs/rules/no-nonoctal-decimal-escape.md
+++ b/docs/rules/no-nonoctal-decimal-escape.md
@@ -1,4 +1,6 @@
-# Disallow `\8` and `\9` escape sequences in string literals (no-nonoctal-decimal-escape)
+# no-nonoctal-decimal-escape
+
+Disallows `\8` and `\9` escape sequences in string literals.
 
 Although not being specified in the language until ECMAScript 2021, `\8` and `\9` escape sequences in string literals were allowed in most JavaScript engines, and treated as "useless" escapes:
 

--- a/docs/rules/no-obj-calls.md
+++ b/docs/rules/no-obj-calls.md
@@ -1,4 +1,6 @@
-# disallow calling global object properties as functions (no-obj-calls)
+# no-obj-calls
+
+Disallows calling global object properties as functions.
 
 ECMAScript provides several global objects that are intended to be used as-is. Some of these objects look as if they could be constructors due their capitalization (such as `Math` and `JSON`) but will throw an error if you try to execute them as functions.
 

--- a/docs/rules/no-octal-escape.md
+++ b/docs/rules/no-octal-escape.md
@@ -1,4 +1,6 @@
-# disallow octal escape sequences in string literals (no-octal-escape)
+# no-octal-escape
+
+Disallows octal escape sequences in string literals.
 
 As of the ECMAScript 5 specification, octal escape sequences in string literals are deprecated and should not be used. Unicode escape sequences should be used instead.
 

--- a/docs/rules/no-octal.md
+++ b/docs/rules/no-octal.md
@@ -1,4 +1,6 @@
-# disallow octal literals (no-octal)
+# no-octal
+
+Disallows octal literals.
 
 Octal literals are numerals that begin with a leading zero, such as:
 

--- a/docs/rules/no-param-reassign.md
+++ b/docs/rules/no-param-reassign.md
@@ -1,4 +1,6 @@
-# Disallow Reassignment of Function Parameters (no-param-reassign)
+# no-param-reassign
+
+Disallows reassignment of function parameters.
 
 Assignment to variables declared as function parameters can be misleading and lead to confusing behavior, as modifying function parameters will also mutate the `arguments` object. Often, assignment to function parameters is unintended and indicative of a mistake or programmer error.
 

--- a/docs/rules/no-path-concat.md
+++ b/docs/rules/no-path-concat.md
@@ -1,4 +1,6 @@
-# Disallow string concatenation when using `__dirname` and `__filename` (no-path-concat)
+# no-path-concat
+
+Disallows string concatenation when using `__dirname` and `__filename`.
 
 This rule was **deprecated** in ESLint v7.0.0. Please use the corresponding rule in [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node).
 

--- a/docs/rules/no-plusplus.md
+++ b/docs/rules/no-plusplus.md
@@ -1,4 +1,6 @@
-# disallow the unary operators `++` and `--` (no-plusplus)
+# no-plusplus
+
+Disallows the unary operators `++` and `--`.
 
 Because the unary `++` and `--` operators are subject to automatic semicolon insertion, differences in whitespace can change semantics of source code.
 

--- a/docs/rules/no-process-env.md
+++ b/docs/rules/no-process-env.md
@@ -1,4 +1,6 @@
-# Disallow process.env (no-process-env)
+# no-process-env
+
+Disallows the use of `process.env`.
 
 This rule was **deprecated** in ESLint v7.0.0. Please use the corresponding rule in [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node).
 

--- a/docs/rules/no-process-exit.md
+++ b/docs/rules/no-process-exit.md
@@ -1,4 +1,6 @@
-# Disallow process.exit() (no-process-exit)
+# no-process-exit
+
+Disallows the use of `process.exit()`.
 
 This rule was **deprecated** in ESLint v7.0.0. Please use the corresponding rule in [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node).
 

--- a/docs/rules/no-promise-executor-return.md
+++ b/docs/rules/no-promise-executor-return.md
@@ -1,4 +1,6 @@
-# Disallow returning values from Promise executor functions (no-promise-executor-return)
+# no-promise-executor-return
+
+Disallows returning values from Promise executor functions.
 
 The `new Promise` constructor accepts a single argument, called an *executor*.
 

--- a/docs/rules/no-proto.md
+++ b/docs/rules/no-proto.md
@@ -1,4 +1,6 @@
-# Disallow Use of `__proto__` (no-proto)
+# no-proto
+
+Disallows the use of the `__proto__` property.
 
 `__proto__` property has been deprecated as of ECMAScript 3.1 and shouldn't be used in the code. Use `Object.getPrototypeOf` and `Object.setPrototypeOf` instead.
 

--- a/docs/rules/no-prototype-builtins.md
+++ b/docs/rules/no-prototype-builtins.md
@@ -1,4 +1,6 @@
-# Disallow use of Object.prototypes builtins directly (no-prototype-builtins)
+# no-prototype-builtins
+
+Disallows calling some `Object.prototype` methods directly on objects.
 
 In ECMAScript 5.1, `Object.create` was added, which enables the creation of objects with a specified `[[Prototype]]`. `Object.create(null)` is a common pattern used to create objects that will be used as a Map. This can lead to errors when it is assumed that objects will have properties from `Object.prototype`. This rule prevents calling some `Object.prototype` methods directly from an object.
 

--- a/docs/rules/no-redeclare.md
+++ b/docs/rules/no-redeclare.md
@@ -1,4 +1,6 @@
-# disallow variable redeclaration (no-redeclare)
+# no-redeclare
+
+Disallows variable redeclarations.
 
 In JavaScript, it's possible to redeclare the same variable name using `var`. This can lead to confusion as to where the variable is actually declared and initialized.
 

--- a/docs/rules/no-regex-spaces.md
+++ b/docs/rules/no-regex-spaces.md
@@ -1,4 +1,6 @@
-# disallow multiple spaces in regular expression literals (no-regex-spaces)
+# no-regex-spaces
+
+Disallows multiple spaces in regular expression literals.
 
 Regular expressions can be very complex and difficult to understand, which is why it's important to keep them as simple as possible in order to avoid mistakes. One of the more error-prone things you can do with a regular expression is to use more than one space, such as:
 

--- a/docs/rules/no-reserved-keys.md
+++ b/docs/rules/no-reserved-keys.md
@@ -1,4 +1,6 @@
-# no-reserved-keys: disallow unquoted reserved words as property names in object literals
+# no-reserved-keys
+
+Disallows unquoted reserved words as property names in object literals.
 
 (removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [quote-props](quote-props.md) rule.
 

--- a/docs/rules/no-restricted-exports.md
+++ b/docs/rules/no-restricted-exports.md
@@ -1,4 +1,6 @@
-# Disallow specified names in exports (no-restricted-exports)
+# no-restricted-exports
+
+Disallows specified names in exports.
 
 In a project, certain names may be disallowed from being used as exported names for various reasons.
 

--- a/docs/rules/no-restricted-globals.md
+++ b/docs/rules/no-restricted-globals.md
@@ -1,4 +1,6 @@
-# Disallow specific global variables (no-restricted-globals)
+# no-restricted-globals
+
+Disallows specific global variables.
 
 Disallowing usage of specific global variables can be useful if you want to allow a set of global
 variables by enabling an environment, but still want to disallow some of those.

--- a/docs/rules/no-restricted-imports.md
+++ b/docs/rules/no-restricted-imports.md
@@ -1,4 +1,6 @@
-# Disallow specific imports (no-restricted-imports)
+# no-restricted-imports
+
+Disallows specific imports.
 
 Imports are an ES6/ES2015 standard for making the functionality of other modules available in your current module. In CommonJS this is implemented through the `require()` call which makes this ESLint rule roughly equivalent to its CommonJS counterpart `no-restricted-modules`.
 

--- a/docs/rules/no-restricted-modules.md
+++ b/docs/rules/no-restricted-modules.md
@@ -1,4 +1,6 @@
-# Disallow Node.js modules (no-restricted-modules)
+# no-restricted-modules
+
+Disallows Node.js modules.
 
 This rule was **deprecated** in ESLint v7.0.0. Please use the corresponding rule in [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node).
 

--- a/docs/rules/no-restricted-properties.md
+++ b/docs/rules/no-restricted-properties.md
@@ -1,4 +1,6 @@
-# disallow certain object properties (no-restricted-properties)
+# no-restricted-properties
+
+Disallows certain object properties.
 
 Certain properties on objects may be disallowed in a codebase. This is useful for deprecating an API or restricting usage of a module's methods. For example, you may want to disallow using `describe.only` when using Mocha or telling people to use `Object.assign` instead of `_.extend`.
 

--- a/docs/rules/no-restricted-syntax.md
+++ b/docs/rules/no-restricted-syntax.md
@@ -1,4 +1,6 @@
-# disallow specified syntax (no-restricted-syntax)
+# no-restricted-syntax
+
+Disallows specified syntax.
 
 JavaScript has a lot of language features, and not everyone likes all of them. As a result, some projects choose to disallow the use of certain language features altogether. For instance, you might decide to disallow the use of `try-catch` or `class`, or you might decide to disallow the use of the `in` operator.
 

--- a/docs/rules/no-return-assign.md
+++ b/docs/rules/no-return-assign.md
@@ -1,4 +1,6 @@
-# Disallow Assignment in return Statement (no-return-assign)
+# no-return-assign
+
+Disallows assignment operators in `return` statements.
 
 One of the interesting, and sometimes confusing, aspects of JavaScript is that assignment can happen at almost any point. Because of this, an errant equals sign can end up causing assignment when the true intent was to do a comparison. This is especially true when using a `return` statement. For example:
 

--- a/docs/rules/no-return-await.md
+++ b/docs/rules/no-return-await.md
@@ -1,4 +1,6 @@
-# Disallows unnecessary `return await` (no-return-await)
+# no-return-await
+
+Disallows unnecessary `return await`.
 
 Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited has resolved, at the cost of an extra microtask before resolving the outer Promise. `return await` can also be used in a try/catch statement to catch errors from another function that returns a Promise.
 

--- a/docs/rules/no-script-url.md
+++ b/docs/rules/no-script-url.md
@@ -1,4 +1,6 @@
-# Disallow Script URLs (no-script-url)
+# no-script-url
+
+Disallows `javascript:` URLs.
 
 Using `javascript:` URLs is considered by some as a form of `eval`. Code passed in `javascript:` URLs has to be parsed and evaluated by the browser in the same way that `eval` is processed.
 

--- a/docs/rules/no-self-assign.md
+++ b/docs/rules/no-self-assign.md
@@ -1,4 +1,6 @@
-# Disallow Self Assignment (no-self-assign)
+# no-self-assign
+
+Disallows assignments where both sides are exactly the same.
 
 Self assignments have no effect, so probably those are an error due to incomplete refactoring.
 Those indicate that what you should do is still remaining.

--- a/docs/rules/no-self-compare.md
+++ b/docs/rules/no-self-compare.md
@@ -1,4 +1,6 @@
-# Disallow Self Compare (no-self-compare)
+# no-self-compare
+
+Disallows comparisons where both sides are exactly the same.
 
 Comparing a variable against itself is usually an error, either a typo or refactoring error. It is confusing to the reader and may potentially introduce a runtime error.
 

--- a/docs/rules/no-sequences.md
+++ b/docs/rules/no-sequences.md
@@ -1,4 +1,6 @@
-# Disallow Use of the Comma Operator (no-sequences)
+# no-sequences
+
+Disallows use of the comma operator.
 
 The comma operator includes multiple expressions where only one is expected. It evaluates each operand from left to right and returns the value of the last operand. However, this frequently obscures side effects, and its use is often an accident. Here are some examples of sequences:
 

--- a/docs/rules/no-setter-return.md
+++ b/docs/rules/no-setter-return.md
@@ -1,4 +1,6 @@
-# Disallow returning values from setters (no-setter-return)
+# no-setter-return
+
+Disallows returning values from setters.
 
 Setters cannot return values.
 

--- a/docs/rules/no-shadow-restricted-names.md
+++ b/docs/rules/no-shadow-restricted-names.md
@@ -1,4 +1,6 @@
-# Disallow Shadowing of Restricted Names (no-shadow-restricted-names)
+# no-shadow-restricted-names
+
+Disallows identifiers from shadowing restricted names.
 
 ES5 §15.1.1 Value Properties of the Global Object (`NaN`, `Infinity`, `undefined`) as well as strict mode restricted identifiers `eval` and `arguments` are considered to be restricted names in JavaScript. Defining them to mean something else can have unintended consequences and confuse others reading the code. For example, there's nothing preventing you from writing:
 

--- a/docs/rules/no-shadow.md
+++ b/docs/rules/no-shadow.md
@@ -1,4 +1,6 @@
-# disallow variable declarations from shadowing variables declared in the outer scope (no-shadow)
+# no-shadow
+
+Disallows variable declarations from shadowing variables declared in the outer scope.
 
 Shadowing is the process by which a local variable shares the same name as a variable in its containing scope. For example:
 

--- a/docs/rules/no-space-before-semi.md
+++ b/docs/rules/no-space-before-semi.md
@@ -1,4 +1,6 @@
-# no-space-before-semi: disallow spaces before semicolons
+# no-space-before-semi
+
+Disallows spaces before semicolons.
 
 (removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [semi-spacing](semi-spacing.md) rule.
 

--- a/docs/rules/no-spaced-func.md
+++ b/docs/rules/no-spaced-func.md
@@ -1,4 +1,6 @@
-# disallow spacing between function identifiers and their applications (no-spaced-func)
+# no-spaced-func
+
+Disallows spacing between function identifiers and their applications.
 
 This rule was **deprecated** in ESLint v3.3.0 and replaced by the [func-call-spacing](func-call-spacing.md) rule.
 

--- a/docs/rules/no-sparse-arrays.md
+++ b/docs/rules/no-sparse-arrays.md
@@ -1,4 +1,6 @@
-# disallow sparse arrays (no-sparse-arrays)
+# no-sparse-arrays
+
+Disallows sparse arrays.
 
 Sparse arrays contain empty slots, most frequently due to multiple commas being used in an array literal, such as:
 

--- a/docs/rules/no-sync.md
+++ b/docs/rules/no-sync.md
@@ -1,4 +1,6 @@
-# Disallow Synchronous Methods (no-sync)
+# no-sync
+
+Disallows synchronous methods.
 
 This rule was **deprecated** in ESLint v7.0.0. Please use the corresponding rule in [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node).
 

--- a/docs/rules/no-tabs.md
+++ b/docs/rules/no-tabs.md
@@ -1,4 +1,6 @@
-# disallow all tabs (no-tabs)
+# no-tabs
+
+Disallows all tabs.
 
 Some style guides don't allow the use of tab characters at all, including within comments.
 

--- a/docs/rules/no-template-curly-in-string.md
+++ b/docs/rules/no-template-curly-in-string.md
@@ -1,4 +1,6 @@
-# Disallow template literal placeholder syntax in regular strings (no-template-curly-in-string)
+# no-template-curly-in-string
+
+Disallows template literal placeholder syntax in regular strings.
 
 ECMAScript 6 allows programmers to create strings containing variable or expressions using template literals, instead of string concatenation, by writing expressions like `${variable}` between two backtick quotes (\`). It can be easy to use the wrong quotes when wanting to use template literals, by writing `"${variable}"`, and end up with the literal value `"${variable}"` instead of a string containing the value of the injected expressions.
 

--- a/docs/rules/no-ternary.md
+++ b/docs/rules/no-ternary.md
@@ -1,4 +1,6 @@
-# disallow ternary operators (no-ternary)
+# no-ternary
+
+Disallows ternary operators.
 
 The ternary operator is used to conditionally assign a value to a variable. Some believe that the use of ternary operators leads to unclear code.
 

--- a/docs/rules/no-this-before-super.md
+++ b/docs/rules/no-this-before-super.md
@@ -1,4 +1,6 @@
-# Disallow use of `this`/`super` before calling `super()` in constructors. (no-this-before-super)
+# no-this-before-super
+
+Disallows use of `this`/`super` before calling `super()` in constructors.
 
 In the constructor of derived classes, if `this`/`super` are used before `super()` calls, it raises a reference error.
 

--- a/docs/rules/no-throw-literal.md
+++ b/docs/rules/no-throw-literal.md
@@ -1,4 +1,6 @@
-# Restrict what can be thrown as an exception (no-throw-literal)
+# no-throw-literal
+
+Restricts what can be thrown as an exception.
 
 It is considered good practice to only `throw` the `Error` object itself or an object using the `Error` object as base objects for user-defined exceptions.
 The fundamental benefit of `Error` objects is that they automatically keep track of where they were built and originated.

--- a/docs/rules/no-trailing-spaces.md
+++ b/docs/rules/no-trailing-spaces.md
@@ -1,4 +1,6 @@
-# disallow trailing whitespace at the end of lines (no-trailing-spaces)
+# no-trailing-spaces
+
+Disallows trailing whitespace at the end of lines.
 
 Sometimes in the course of editing files, you can end up with extra whitespace at the end of lines. These whitespace differences can be picked up by source control systems and flagged as diffs, causing frustration for developers. While this extra whitespace causes no functional issues, many code conventions require that trailing spaces be removed before check-in.
 

--- a/docs/rules/no-undef-init.md
+++ b/docs/rules/no-undef-init.md
@@ -1,4 +1,6 @@
-# Disallow Initializing to undefined (no-undef-init)
+# no-undef-init
+
+Disallows initializing variables to `undefined`.
 
 In JavaScript, a variable that is declared and not initialized to any value automatically gets the value of `undefined`. For example:
 

--- a/docs/rules/no-undef.md
+++ b/docs/rules/no-undef.md
@@ -1,4 +1,6 @@
-# Disallow Undeclared Variables (no-undef)
+# no-undef
+
+Disallows the use of undeclared variables unless mentioned in `/*global */` comments.
 
 This rule can help you locate potential ReferenceErrors resulting from misspellings of variable and parameter names, or accidental implicit globals (for example, from forgetting the `var` keyword in a `for` loop initializer).
 

--- a/docs/rules/no-undefined.md
+++ b/docs/rules/no-undefined.md
@@ -1,4 +1,6 @@
-# Disallow Use of `undefined` Variable (no-undefined)
+# no-undefined
+
+Disallows the use of `undefined` as an identifier.
 
 The `undefined` variable in JavaScript is actually a property of the global object. As such, in ECMAScript 3 it was possible to overwrite the value of `undefined`. While ECMAScript 5 disallows overwriting `undefined`, it's still possible to shadow `undefined`, such as:
 

--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -1,4 +1,6 @@
-# disallow dangling underscores in identifiers (no-underscore-dangle)
+# no-underscore-dangle
+
+Disallows dangling underscores in identifiers.
 
 As far as naming conventions for identifiers go, dangling underscores may be the most polarizing in JavaScript. Dangling underscores are underscores at either the beginning or end of an identifier, such as:
 

--- a/docs/rules/no-unexpected-multiline.md
+++ b/docs/rules/no-unexpected-multiline.md
@@ -1,4 +1,6 @@
-# disallow confusing multiline expressions (no-unexpected-multiline)
+# no-unexpected-multiline
+
+Disallows confusing multiline expressions.
 
 Semicolons are usually optional in JavaScript, because of automatic semicolon insertion (ASI). You can require or disallow semicolons with the [semi](./semi.md) rule.
 

--- a/docs/rules/no-unmodified-loop-condition.md
+++ b/docs/rules/no-unmodified-loop-condition.md
@@ -1,4 +1,6 @@
-# Disallow unmodified conditions of loops (no-unmodified-loop-condition)
+# no-unmodified-loop-condition
+
+Disallows unmodified conditions of loops.
 
 Variables in a loop condition often are modified in the loop.
 If not, it's possibly a mistake.

--- a/docs/rules/no-unneeded-ternary.md
+++ b/docs/rules/no-unneeded-ternary.md
@@ -1,4 +1,6 @@
-# disallow ternary operators when simpler alternatives exist (no-unneeded-ternary)
+# no-unneeded-ternary
+
+Disallows ternary operators when simpler alternatives exist.
 
 It's a common mistake in JavaScript to use a conditional expression to select between two Boolean values instead of using ! to convert the test to a Boolean.
 Here are some examples:

--- a/docs/rules/no-unreachable-loop.md
+++ b/docs/rules/no-unreachable-loop.md
@@ -1,4 +1,6 @@
-# Disallow loops with a body that allows only one iteration (no-unreachable-loop)
+# no-unreachable-loop
+
+Disallows loops with a body that allows only one iteration.
 
 A loop that can never reach the second iteration is a possible error in the code.
 

--- a/docs/rules/no-unreachable.md
+++ b/docs/rules/no-unreachable.md
@@ -1,4 +1,6 @@
-# disallow unreachable code after `return`, `throw`, `continue`, and `break` statements (no-unreachable)
+# no-unreachable
+
+Disallows unreachable code after `return`, `throw`, `continue`, and `break` statements.
 
 Because the `return`, `throw`, `break`, and `continue` statements unconditionally exit a block of code, any statements after them cannot be executed. Unreachable statements are usually a mistake.
 

--- a/docs/rules/no-unsafe-finally.md
+++ b/docs/rules/no-unsafe-finally.md
@@ -1,4 +1,6 @@
-# disallow control flow statements in `finally` blocks (no-unsafe-finally)
+# no-unsafe-finally
+
+Disallows control flow statements in `finally` blocks.
 
 JavaScript suspends the control flow statements of `try` and `catch` blocks until the execution of `finally` block finishes. So, when `return`, `throw`, `break`, or `continue` is used in `finally`, control flow statements inside `try` and `catch` are overwritten, which is considered as unexpected behavior. Such as:
 

--- a/docs/rules/no-unsafe-negation.md
+++ b/docs/rules/no-unsafe-negation.md
@@ -1,4 +1,6 @@
-# disallow negating the left operand of relational operators (no-unsafe-negation)
+# no-unsafe-negation
+
+Disallows negating the left operand of relational operators.
 
 Just as developers might type `-a + b` when they mean `-(a + b)` for the negative of a sum, they might type `!key in object` by mistake when they almost certainly mean `!(key in object)` to test that a key is not in an object. `!obj instanceof Ctor` is similar.
 

--- a/docs/rules/no-unsafe-optional-chaining.md
+++ b/docs/rules/no-unsafe-optional-chaining.md
@@ -1,4 +1,6 @@
-# disallow use of optional chaining in contexts where the `undefined` value is not allowed (no-unsafe-optional-chaining)
+# no-unsafe-optional-chaining
+
+Disallows use of optional chaining in contexts where the `undefined` value is not allowed.
 
 The optional chaining (`?.`) expression can short-circuit with a return value of `undefined`. Therefore, treating an evaluated optional chaining expression as a function, object, number, etc., can cause TypeError or unexpected results. For example:
 

--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -1,4 +1,6 @@
-# Disallow Unused Expressions (no-unused-expressions)
+# no-unused-expressions
+
+Disallows unused expressions.
 
 An unused expression which has no effect on the state of the program indicates a logic error.
 

--- a/docs/rules/no-unused-labels.md
+++ b/docs/rules/no-unused-labels.md
@@ -1,6 +1,6 @@
 # no-unused-labels
 
-Disallows Unused Labels.
+Disallows unused labels.
 
 Labels that are declared and not used anywhere in the code are most likely an error due to incomplete refactoring.
 

--- a/docs/rules/no-unused-labels.md
+++ b/docs/rules/no-unused-labels.md
@@ -1,4 +1,6 @@
-# Disallow Unused Labels (no-unused-labels)
+# no-unused-labels
+
+Disallows Unused Labels.
 
 Labels that are declared and not used anywhere in the code are most likely an error due to incomplete refactoring.
 

--- a/docs/rules/no-unused-private-class-members.md
+++ b/docs/rules/no-unused-private-class-members.md
@@ -1,4 +1,6 @@
-# Disallow Unused Private Class Members (no-unused-private-class-members)
+# no-unused-private-class-members
+
+Disallows unused private class members.
 
 Private class members that are declared and not used anywhere in the code are most likely an error due to incomplete refactoring. Such class members take up space in the code and can lead to confusion by readers.
 

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -1,4 +1,6 @@
-# Disallow Unused Variables (no-unused-vars)
+# no-unused-vars
+
+Disallows unused variables.
 
 Variables that are declared and not used anywhere in the code are most likely an error due to incomplete refactoring. Such variables take up space in the code and can lead to confusion by readers.
 

--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -1,4 +1,6 @@
-# Disallow Early Use (no-use-before-define)
+# no-use-before-define
+
+Disallows the use of variables before they are defined.
 
 In JavaScript, prior to ES6, variable and function declarations are hoisted to the top of a scope, so it's possible to use identifiers before their formal declarations in code. This can be confusing and some believe it is best to always declare variables and functions before using them.
 

--- a/docs/rules/no-useless-backreference.md
+++ b/docs/rules/no-useless-backreference.md
@@ -1,4 +1,6 @@
-# Disallow useless backreferences in regular expressions (no-useless-backreference)
+# no-useless-backreference
+
+Disallows useless backreferences in regular expressions.
 
 In JavaScript regular expressions, it's syntactically valid to define a backreference to a group that belongs to another alternative part of the pattern, a backreference to a group that appears after the backreference, a backreference to a group that contains that backreference, or a backreference to a group that is inside a negative lookaround. However, by the specification, in any of these cases the backreference always ends up matching only zero-length (the empty string), regardless of the context in which the backreference and the group appear.
 

--- a/docs/rules/no-useless-call.md
+++ b/docs/rules/no-useless-call.md
@@ -1,4 +1,6 @@
-# Disallow unnecessary `.call()` and `.apply()`. (no-useless-call)
+# no-useless-call
+
+Disallows unnecessary `.call()` and `.apply()`.
 
 The function invocation can be written by `Function.prototype.call()` and `Function.prototype.apply()`.
 But `Function.prototype.call()` and `Function.prototype.apply()` are slower than the normal function invocation.

--- a/docs/rules/no-useless-catch.md
+++ b/docs/rules/no-useless-catch.md
@@ -1,4 +1,6 @@
-# Disallow unnecessary catch clauses (no-useless-catch)
+# no-useless-catch
+
+Disallows unnecessary catch clauses.
 
 A `catch` clause that only rethrows the original error is redundant, and has no effect on the runtime behavior of the program. These redundant clauses can be a source of confusion and code bloat, so it's better to disallow these unnecessary `catch` clauses.
 

--- a/docs/rules/no-useless-computed-key.md
+++ b/docs/rules/no-useless-computed-key.md
@@ -1,4 +1,6 @@
-# Disallow unnecessary computed property keys in objects and classes (no-useless-computed-key)
+# no-useless-computed-key
+
+Disallows unnecessary computed property keys in objects and classes.
 
 It's unnecessary to use computed properties with literals such as:
 

--- a/docs/rules/no-useless-concat.md
+++ b/docs/rules/no-useless-concat.md
@@ -1,4 +1,6 @@
-# Disallow unnecessary concatenation of strings (no-useless-concat)
+# no-useless-concat
+
+Disallows unnecessary concatenation of strings.
 
 It's unnecessary to concatenate two strings together, such as:
 

--- a/docs/rules/no-useless-constructor.md
+++ b/docs/rules/no-useless-constructor.md
@@ -1,4 +1,6 @@
-# Disallow unnecessary constructor (no-useless-constructor)
+# no-useless-constructor
+
+Disallows unnecessary constructors.
 
 ES2015 provides a default class constructor if one is not specified. As such, it is unnecessary to provide an empty constructor or one that simply delegates into its parent class, as in the following examples:
 

--- a/docs/rules/no-useless-escape.md
+++ b/docs/rules/no-useless-escape.md
@@ -1,4 +1,6 @@
-# Disallow unnecessary escape usage (no-useless-escape)
+# no-useless-escape
+
+Disallows unnecessary escape characters.
 
 Escaping non-special characters in strings, template literals, and regular expressions doesn't have any effect, as demonstrated in the following example:
 

--- a/docs/rules/no-useless-rename.md
+++ b/docs/rules/no-useless-rename.md
@@ -1,4 +1,6 @@
-# Disallow renaming import, export, and destructured assignments to the same name (no-useless-rename)
+# no-useless-rename
+
+Disallows renaming import, export, and destructured assignments to the same name.
 
 ES2015 allows for the renaming of references in import and export statements as well as destructuring assignments. This gives programmers a concise syntax for performing these operations while renaming these references:
 

--- a/docs/rules/no-useless-return.md
+++ b/docs/rules/no-useless-return.md
@@ -1,4 +1,6 @@
-# Disallow redundant return statements (no-useless-return)
+# no-useless-return
+
+Disallows redundant return statements.
 
 A `return;` statement with nothing after it is redundant, and has no effect on the runtime behavior of a function. This can be confusing, so it's better to disallow these redundant statements.
 

--- a/docs/rules/no-var.md
+++ b/docs/rules/no-var.md
@@ -1,4 +1,6 @@
-# require `let` or `const` instead of `var` (no-var)
+# no-var
+
+Requires `let` or `const` instead of `var`.
 
 ECMAScript 6 allows programmers to create variables with block scope instead of function scope using the `let`
 and `const` keywords. Block scope is common in many other programming languages and helps programmers avoid mistakes

--- a/docs/rules/no-void.md
+++ b/docs/rules/no-void.md
@@ -1,4 +1,6 @@
-# Disallow use of the void operator. (no-void)
+# no-void
+
+Disallows use of the void operator.
 
 The `void` operator takes an operand and returns `undefined`: `void expression` will evaluate `expression` and return `undefined`. It can be used to ignore any side effects `expression` may produce:
 

--- a/docs/rules/no-warning-comments.md
+++ b/docs/rules/no-warning-comments.md
@@ -1,4 +1,6 @@
-# Disallow Warning Comments (no-warning-comments)
+# no-warning-comments
+
+Disallows specified warning terms in comments.
 
 Developers often add comments to code which is not complete or needs review. Most likely you want to fix or review the code, and then remove the comment, before you consider the code to be production ready.
 

--- a/docs/rules/no-whitespace-before-property.md
+++ b/docs/rules/no-whitespace-before-property.md
@@ -1,4 +1,6 @@
-# disallow whitespace before properties (no-whitespace-before-property)
+# no-whitespace-before-property
+
+Disallows whitespace before properties.
 
 JavaScript allows whitespace between objects and their properties. However, inconsistent spacing can make code harder to read and can lead to errors.
 

--- a/docs/rules/no-with.md
+++ b/docs/rules/no-with.md
@@ -1,4 +1,6 @@
-# disallow `with` statements (no-with)
+# no-with
+
+Disallows `with` statements.
 
 The `with` statement is potentially problematic because it adds members of an object to the current scope, making it impossible to tell what a variable inside the block actually refers to.
 

--- a/docs/rules/no-wrap-func.md
+++ b/docs/rules/no-wrap-func.md
@@ -1,4 +1,6 @@
-# no-wrap-func: disallow unnecessary parentheses around function expressions
+# no-wrap-func
+
+Disallows unnecessary parentheses around function expressions.
 
 (removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [no-extra-parens](no-extra-parens.md) rule. The `"functions"` option in the new rule is equivalent to the removed rule.
 

--- a/docs/rules/nonblock-statement-body-position.md
+++ b/docs/rules/nonblock-statement-body-position.md
@@ -1,4 +1,6 @@
-# enforce the location of single-line statements (nonblock-statement-body-position)
+# nonblock-statement-body-position
+
+Enforces the location of single-line statements.
 
 When writing `if`, `else`, `while`, `do-while`, and `for` statements, the body can be a single statement instead of a block. It can be useful to enforce a consistent location for these single statements.
 

--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -1,4 +1,6 @@
-# enforce consistent line breaks after opening and before closing braces (object-curly-newline)
+# object-curly-newline
+
+Enforces consistent line breaks after opening and before closing braces.
 
 A number of style guides require or disallow line breaks inside of object braces and other tokens.
 

--- a/docs/rules/object-curly-spacing.md
+++ b/docs/rules/object-curly-spacing.md
@@ -1,4 +1,6 @@
-# enforce consistent spacing inside braces (object-curly-spacing)
+# object-curly-spacing
+
+Enforces consistent spacing inside braces.
 
 While formatting preferences are very personal, a number of style guides require
 or disallow spaces between curly braces in the following situations:

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -1,4 +1,6 @@
-# enforce placing object properties on separate lines (object-property-newline)
+# object-property-newline
+
+Enforces placing object properties on separate lines.
 
 This rule permits you to restrict the locations of property specifications in object literals. You may prohibit any part of any property specification from appearing on the same line as any part of any other property specification. You may make this prohibition absolute, or, by invoking an object option, you may allow an exception, permitting an object literal to have all parts of all of its property specifications on a single line.
 

--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -1,4 +1,6 @@
-# Require Object Literal Shorthand Syntax (object-shorthand)
+# object-shorthand
+
+Requires or disallows method and property shorthand syntax for object literals.
 
 ECMAScript 6 provides a concise form for defining object literal methods and properties. This
 syntax can make defining complex object literals much cleaner.

--- a/docs/rules/one-var-declaration-per-line.md
+++ b/docs/rules/one-var-declaration-per-line.md
@@ -1,4 +1,6 @@
-# require or disallow newlines around variable declarations (one-var-declaration-per-line)
+# one-var-declaration-per-line
+
+Requires or disallows newlines around variable declarations.
 
 Some developers declare multiple var statements on the same line:
 

--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -1,4 +1,6 @@
-# enforce variables to be declared either together or separately in functions (one-var)
+# one-var
+
+Enforces variables to be declared either together or separately in functions.
 
 Variables can be declared at any point in JavaScript code using `var`, `let`, or `const`. There are many styles and preferences related to the declaration of variables, and one of those is deciding on how many variable declarations should be allowed in a single function.
 

--- a/docs/rules/operator-assignment.md
+++ b/docs/rules/operator-assignment.md
@@ -1,4 +1,6 @@
-# require or disallow assignment operator shorthand where possible (operator-assignment)
+# operator-assignment
+
+Requires or disallows assignment operator shorthand where possible.
 
 JavaScript provides shorthand operators that combine variable assignment and some simple mathematical operations. For example, `x = x + 4` can be shortened to `x += 4`. The supported shorthand forms are as follows:
 

--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -1,4 +1,6 @@
-# enforce consistent linebreak style for operators (operator-linebreak)
+# operator-linebreak
+
+Enforces consistent linebreak style for operators.
 
 When a statement is too long to fit on a single line, line breaks are generally inserted next to the operators separating expressions. The first style coming to mind would be to place the operator at the end of the line, following the English punctuation rules.
 

--- a/docs/rules/padded-blocks.md
+++ b/docs/rules/padded-blocks.md
@@ -1,4 +1,6 @@
-# require or disallow padding within blocks (padded-blocks)
+# padded-blocks
+
+Requires or disallows padding within blocks.
 
 Some style guides require block statements to start and end with blank lines. The goal is
 to improve readability by visually separating the block content and the surrounding code.

--- a/docs/rules/padding-line-between-statements.md
+++ b/docs/rules/padding-line-between-statements.md
@@ -1,4 +1,6 @@
-# Require or disallow padding lines between statements (padding-line-between-statements)
+# padding-line-between-statements
+
+Requires or disallows padding lines between statements.
 
 This rule requires or disallows blank lines between the given 2 kinds of statements.
 Properly blank lines help developers to understand the code.

--- a/docs/rules/prefer-arrow-callback.md
+++ b/docs/rules/prefer-arrow-callback.md
@@ -1,4 +1,6 @@
-# Require using arrow functions for callbacks (prefer-arrow-callback)
+# prefer-arrow-callback
+
+Requires using arrow functions for callbacks.
 
 Arrow functions can be an attractive alternative to function expressions for callbacks or function arguments.
 

--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -1,4 +1,6 @@
-# Suggest using `const` (prefer-const)
+# prefer-const
+
+Requires `const` declarations for variables that are never reassigned after declared.
 
 If a variable is never reassigned, using the `const` declaration is better.
 

--- a/docs/rules/prefer-destructuring.md
+++ b/docs/rules/prefer-destructuring.md
@@ -1,4 +1,6 @@
-# Prefer destructuring from arrays and objects (prefer-destructuring)
+# prefer-destructuring
+
+Requires destructuring from arrays and/or objects.
 
 With JavaScript ES6, a new syntax was added for creating variables from an array index or object property, called [destructuring](#further-reading).  This rule enforces usage of destructuring instead of accessing a property through a member expression.
 

--- a/docs/rules/prefer-exponentiation-operator.md
+++ b/docs/rules/prefer-exponentiation-operator.md
@@ -1,4 +1,6 @@
-# Disallow the use of `Math.pow` in favor of the `**` operator (prefer-exponentiation-operator)
+# prefer-exponentiation-operator
+
+Disallows the use of `Math.pow` in favor of the `**` operator.
 
 Introduced in ES2016, the infix exponentiation operator `**` is an alternative for the standard `Math.pow` function.
 

--- a/docs/rules/prefer-named-capture-group.md
+++ b/docs/rules/prefer-named-capture-group.md
@@ -1,4 +1,6 @@
-# Suggest using named capture group in regular expression (prefer-named-capture-group)
+# prefer-named-capture-group
+
+Suggest using named capture group in regular expression.
 
 ## Rule Details
 

--- a/docs/rules/prefer-numeric-literals.md
+++ b/docs/rules/prefer-numeric-literals.md
@@ -1,4 +1,6 @@
-# disallow `parseInt()` and `Number.parseInt()` in favor of binary, octal, and hexadecimal literals (prefer-numeric-literals)
+# prefer-numeric-literals
+
+Disallows `parseInt()` and `Number.parseInt()` in favor of binary, octal, and hexadecimal literals.
 
 The `parseInt()` and `Number.parseInt()` functions can be used to turn binary, octal, and hexadecimal strings into integers. As binary, octal, and hexadecimal literals are supported in ES6, this rule encourages use of those numeric literals instead of `parseInt()` or `Number.parseInt()`.
 

--- a/docs/rules/prefer-object-has-own.md
+++ b/docs/rules/prefer-object-has-own.md
@@ -1,4 +1,6 @@
-# Prefer `Object.hasOwn()` over `Object.prototype.hasOwnProperty.call()` (prefer-object-has-own)
+# prefer-object-has-own
+
+Prefer `Object.hasOwn()` over `Object.prototype.hasOwnProperty.call()`.
 
 It is very common to write code like:
 

--- a/docs/rules/prefer-object-spread.md
+++ b/docs/rules/prefer-object-spread.md
@@ -1,4 +1,6 @@
-# Prefer use of an object spread over `Object.assign` (prefer-object-spread)
+# prefer-object-spread
+
+Prefer use of an object spread over `Object.assign`.
 
 When Object.assign is called using an object literal as the first argument, this rule requires using the object spread syntax instead. This rule also warns on cases where an `Object.assign` call is made using a single argument that is an object literal, in this case, the `Object.assign` call is not needed.
 

--- a/docs/rules/prefer-promise-reject-errors.md
+++ b/docs/rules/prefer-promise-reject-errors.md
@@ -1,4 +1,6 @@
-# require using Error objects as Promise rejection reasons (prefer-promise-reject-errors)
+# prefer-promise-reject-errors
+
+Requires using Error objects as Promise rejection reasons.
 
 It is considered good practice to only pass instances of the built-in `Error` object to the `reject()` function for user-defined errors in Promises. `Error` objects automatically store a stack trace, which can be used to debug an error by determining where it came from. If a Promise is rejected with a non-`Error` value, it can be difficult to determine where the rejection occurred.
 

--- a/docs/rules/prefer-reflect.md
+++ b/docs/rules/prefer-reflect.md
@@ -1,4 +1,6 @@
-# Suggest using Reflect methods where applicable (prefer-reflect)
+# prefer-reflect
+
+Suggest using Reflect methods where applicable.
 
 This rule was **deprecated** in ESLint v3.9.0 and will not be replaced. The original intent of this rule now seems misguided as we have come to understand that `Reflect` methods are not actually intended to replace the `Object` counterparts the rule suggests, but rather exist as low-level primitives to be used with proxies in order to replicate the default behavior of various previously existing functionality.
 

--- a/docs/rules/prefer-regex-literals.md
+++ b/docs/rules/prefer-regex-literals.md
@@ -1,4 +1,6 @@
-# Disallow use of the `RegExp` constructor in favor of regular expression literals (prefer-regex-literals)
+# prefer-regex-literals
+
+Disallows use of the `RegExp` constructor in favor of regular expression literals.
 
 There are two ways to create a regular expression:
 

--- a/docs/rules/prefer-rest-params.md
+++ b/docs/rules/prefer-rest-params.md
@@ -1,4 +1,6 @@
-# Suggest using the rest parameters instead of `arguments` (prefer-rest-params)
+# prefer-rest-params
+
+Suggests using rest parameters instead of `arguments`.
 
 There are rest parameters in ES2015.
 We can use that feature for variadic functions instead of the `arguments` variable.

--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -1,4 +1,6 @@
-# Suggest using spread syntax instead of `.apply()`. (prefer-spread)
+# prefer-spread
+
+Suggests using spread syntax instead of `.apply()`.
 
 Before ES2015, one must use `Function.prototype.apply()` to call variadic functions.
 

--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -1,4 +1,6 @@
-# Suggest using template literals instead of string concatenation. (prefer-template)
+# prefer-template
+
+Suggests using template literals instead of string concatenation.
 
 In ES2015 (ES6), we can use template literals instead of string concatenation.
 

--- a/docs/rules/quote-props.md
+++ b/docs/rules/quote-props.md
@@ -1,4 +1,6 @@
-# require quotes around object literal property names (quote-props)
+# quote-props
+
+Requires quotes around object literal property names.
 
 Object literal property names can be defined in two ways: using literals or using strings. For example, these two objects are equivalent:
 

--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -1,4 +1,6 @@
-# enforce the consistent use of either backticks, double, or single quotes (quotes)
+# quotes
+
+Enforces the consistent use of either backticks, double, or single quotes.
 
 JavaScript allows you to define strings in one of three ways: double quotes, single quotes, and backticks (as of ECMAScript 6). For example:
 

--- a/docs/rules/radix.md
+++ b/docs/rules/radix.md
@@ -1,4 +1,6 @@
-# Require Radix Parameter (radix)
+# radix
+
+Enforces the consistent use of the radix argument when using `parseInt()`.
 
 When using the `parseInt()` function it is common to omit the second argument, the radix, and let the function try to determine from the first argument what type of number it is. By default, `parseInt()` will autodetect decimal and hexadecimal (via `0x` prefix). Prior to ECMAScript 5, `parseInt()` also autodetected octal literals, which caused problems because many developers assumed a leading `0` would be ignored.
 

--- a/docs/rules/require-atomic-updates.md
+++ b/docs/rules/require-atomic-updates.md
@@ -1,4 +1,6 @@
-# Disallow assignments that can lead to race conditions due to usage of `await` or `yield` (require-atomic-updates)
+# require-atomic-updates
+
+Disallows assignments that can lead to race conditions due to usage of `await` or `yield`.
 
 When writing asynchronous code, it is possible to create subtle race condition bugs. Consider the following example:
 

--- a/docs/rules/require-await.md
+++ b/docs/rules/require-await.md
@@ -1,4 +1,6 @@
-# Disallow async functions which have no `await` expression (require-await)
+# require-await
+
+Disallows async functions which have no `await` expression.
 
 Asynchronous functions in JavaScript behave differently than other functions in two important ways:
 

--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -1,4 +1,6 @@
-# require JSDoc comments (require-jsdoc)
+# require-jsdoc
+
+Requires JSDoc comments.
 
 This rule was [**deprecated**](https://eslint.org/blog/2018/11/jsdoc-end-of-life) in ESLint v5.10.0.
 

--- a/docs/rules/require-unicode-regexp.md
+++ b/docs/rules/require-unicode-regexp.md
@@ -1,4 +1,6 @@
-# Enforce the use of `u` flag on RegExp (require-unicode-regexp)
+# require-unicode-regexp
+
+Enforces the use of `u` flag on RegExp.
 
 RegExp `u` flag has two effects:
 

--- a/docs/rules/require-yield.md
+++ b/docs/rules/require-yield.md
@@ -1,4 +1,6 @@
-# Disallow generator functions that do not have `yield` (require-yield)
+# require-yield
+
+Disallows generator functions that do not have `yield`.
 
 ## Rule Details
 

--- a/docs/rules/rest-spread-spacing.md
+++ b/docs/rules/rest-spread-spacing.md
@@ -1,4 +1,6 @@
-# Enforce spacing between rest and spread operators and their expressions (rest-spread-spacing)
+# rest-spread-spacing
+
+Enforces spacing between rest and spread operators and their expressions.
 
 ES2015 introduced the rest and spread operators, which expand an iterable structure into its individual parts. Some examples of their usage are as follows:
 

--- a/docs/rules/semi-spacing.md
+++ b/docs/rules/semi-spacing.md
@@ -1,4 +1,6 @@
-# Enforce spacing before and after semicolons (semi-spacing)
+# semi-spacing
+
+Enforces spacing before and after semicolons.
 
 JavaScript allows you to place unnecessary spaces before or after a semicolon.
 

--- a/docs/rules/semi-style.md
+++ b/docs/rules/semi-style.md
@@ -1,4 +1,6 @@
-# Enforce location of semicolons (semi-style)
+# semi-style
+
+Enforces location of semicolons.
 
 Generally, semicolons are at the end of lines. However, in semicolon-less style, semicolons are at the beginning of lines. This rule enforces that semicolons are at the configured location.
 

--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -1,4 +1,6 @@
-# require or disallow semicolons instead of ASI (semi)
+# semi
+
+Requires or disallows semicolons instead of ASI.
 
 JavaScript doesn't require semicolons at the end of each statement. In many cases, the JavaScript engine can determine that a semicolon should be in a certain spot and will automatically add it. This feature is known as **automatic semicolon insertion (ASI)** and is considered one of the more controversial features of JavaScript. For example, the following lines are both valid:
 

--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -1,4 +1,6 @@
-# Import Sorting (sort-imports)
+# sort-imports
+
+Enforces sorted import declarations within modules.
 
 The import statement is used to import members (functions, objects or primitives) that have been exported from an external module. Using a specific member syntax:
 

--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -1,4 +1,6 @@
-# require object keys to be sorted (sort-keys)
+# sort-keys
+
+Requires object keys to be sorted.
 
 When declaring multiple properties, some developers prefer to sort property names alphabetically to more easily find and/or diff necessary properties at a later time. Others feel that it adds complexity and becomes burden to maintain.
 

--- a/docs/rules/sort-vars.md
+++ b/docs/rules/sort-vars.md
@@ -1,4 +1,6 @@
-# Variable Sorting (sort-vars)
+# sort-vars
+
+Requires variables within the same declaration block to be sorted.
 
 When declaring multiple variables within the same block, some developers prefer to sort variable names alphabetically to be able to find necessary variable easier at the later time. Others feel that it adds complexity and becomes burden to maintain.
 

--- a/docs/rules/space-after-function-name.md
+++ b/docs/rules/space-after-function-name.md
@@ -1,4 +1,6 @@
-# space-after-function-name: enforce consistent spacing after name in function definitions
+# space-after-function-name
+
+Enforces consistent spacing after name in function definitions.
 
 (removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [space-before-function-paren](space-before-function-paren.md) rule.
 

--- a/docs/rules/space-after-keywords.md
+++ b/docs/rules/space-after-keywords.md
@@ -1,4 +1,6 @@
-# space-after-keywords: enforce consistent spacing after keywords
+# space-after-keywords
+
+Enforces consistent spacing after keywords.
 
 (removed) This rule was **removed** in ESLint v2.0 and replaced by the [keyword-spacing](keyword-spacing.md) rule.
 

--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -1,4 +1,6 @@
-# Require Or Disallow Space Before Blocks (space-before-blocks)
+# space-before-blocks
+
+Requires Or disallows space before blocks.
 
 Consistency is an important part of any style guide.
 While it is a personal preference where to put the opening brace of blocks,

--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -1,4 +1,6 @@
-# Require or disallow a space before function parenthesis (space-before-function-paren)
+# space-before-function-paren
+
+Requires or disallows a space before function parenthesis.
 
 When formatting a function, whitespace is allowed between the function name or `function` keyword and the opening paren. Named functions also require a space between the `function` keyword and the function name, but anonymous functions require no whitespace. For example:
 

--- a/docs/rules/space-before-function-parentheses.md
+++ b/docs/rules/space-before-function-parentheses.md
@@ -1,4 +1,6 @@
-# space-before-function-parentheses: enforce consistent spacing before opening parenthesis in function definitions
+# space-before-function-parentheses
+
+Enforces consistent spacing before opening parenthesis in function definitions.
 
 (removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [space-before-function-paren](space-before-function-paren.md) rule. The name of the rule changed from "parentheses" to "paren" for consistency with the names of other rules.
 

--- a/docs/rules/space-before-keywords.md
+++ b/docs/rules/space-before-keywords.md
@@ -1,4 +1,6 @@
-# space-before-keywords: enforce consistent spacing before keywords
+# space-before-keywords
+
+Enforces consistent spacing before keywords.
 
 (removed) This rule was **removed** in ESLint v2.0 and **replaced** by the [keyword-spacing](keyword-spacing.md) rule.
 

--- a/docs/rules/space-in-brackets.md
+++ b/docs/rules/space-in-brackets.md
@@ -1,4 +1,6 @@
-# space-in-brackets: enforce consistent spacing inside braces of object literals and brackets of array literals
+# space-in-brackets
+
+Enforces consistent spacing inside braces of object literals and brackets of array literals.
 
 (removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [object-curly-spacing](object-curly-spacing.md) and [array-bracket-spacing](array-bracket-spacing.md) rules.
 

--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -1,4 +1,6 @@
-# Disallow or enforce spaces inside of parentheses (space-in-parens)
+# space-in-parens
+
+Disallows or enforce spaces inside of parentheses.
 
 Some style guides require or disallow spaces inside of parentheses:
 

--- a/docs/rules/space-infix-ops.md
+++ b/docs/rules/space-infix-ops.md
@@ -1,4 +1,6 @@
-# require spacing around infix operators (space-infix-ops)
+# space-infix-ops
+
+Requires spacing around infix operators.
 
 While formatting preferences are very personal, a number of style guides require spaces around operators, such as:
 

--- a/docs/rules/space-return-throw-case.md
+++ b/docs/rules/space-return-throw-case.md
@@ -1,4 +1,6 @@
-# space-return-throw-case: require spaces after `return`, `throw`, and `case` keywords
+# space-return-throw-case
+
+Requires spaces after `return`, `throw`, and `case` keywords.
 
 (removed) This rule was **removed** in ESLint v2.0 and **replaced** by the [keyword-spacing](keyword-spacing.md) rule.
 

--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -1,4 +1,6 @@
-# Require or disallow spaces before/after unary operators (space-unary-ops)
+# space-unary-ops
+
+Requires or disallow spaces before/after unary operators.
 
 Some style guides require or disallow spaces before or after unary operators. This is mainly a stylistic issue, however, some JavaScript expressions can be written without spacing which makes it harder to read and maintain.
 

--- a/docs/rules/space-unary-word-ops.md
+++ b/docs/rules/space-unary-word-ops.md
@@ -1,4 +1,6 @@
-# space-unary-word-ops: require spaces after unary word operators
+# space-unary-word-ops
+
+Requires spaces after unary word operators.
 
 (removed) This rule was **removed** in ESLint v0.10.0 and **replaced** by the [space-unary-ops](space-unary-ops.md) rule.
 

--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -1,4 +1,6 @@
-# Requires or disallows a whitespace (space or tab) beginning a comment (spaced-comment)
+# spaced-comment
+
+Enforces consistent spacing after the `//` or `/*` in a comment.
 
 Some style guides require or disallow a whitespace immediately after the initial `//` or `/*` of a comment.
 Whitespace after the `//` or `/*` makes it easier to read text in comments.

--- a/docs/rules/spaced-line-comment.md
+++ b/docs/rules/spaced-line-comment.md
@@ -1,4 +1,6 @@
-# spaced-line-comment: enforce consistent spacing after `//` in line comments
+# spaced-line-comment
+
+Enforces consistent spacing after `//` in line comments.
 
 (removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [spaced-comment](spaced-comment.md) rule.
 

--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -1,4 +1,6 @@
-# require or disallow strict mode directives (strict)
+# strict
+
+Requires or disallow strict mode directives.
 
 A strict mode directive is a `"use strict"` literal at the beginning of a script or function body. It enables strict mode semantics.
 

--- a/docs/rules/switch-colon-spacing.md
+++ b/docs/rules/switch-colon-spacing.md
@@ -1,4 +1,6 @@
-# Enforce spacing around colons of switch statements (switch-colon-spacing)
+# switch-colon-spacing
+
+Enforces spacing around colons of switch statements.
 
 Spacing around colons improves readability of `case`/`default` clauses.
 

--- a/docs/rules/symbol-description.md
+++ b/docs/rules/symbol-description.md
@@ -1,4 +1,6 @@
-# require symbol description (symbol-description)
+# symbol-description
+
+Requires symbol descriptions.
 
 The `Symbol` function may have an optional description:
 

--- a/docs/rules/template-curly-spacing.md
+++ b/docs/rules/template-curly-spacing.md
@@ -1,4 +1,6 @@
-# Enforce Usage of Spacing in Template Strings (template-curly-spacing)
+# template-curly-spacing
+
+Enforces usage of spacing in template strings.
 
 We can embed expressions in template strings with using a pair of `${` and `}`.
 

--- a/docs/rules/template-tag-spacing.md
+++ b/docs/rules/template-tag-spacing.md
@@ -1,4 +1,6 @@
-# Require or disallow spacing between template tags and their literals (template-tag-spacing)
+# template-tag-spacing
+
+Requires or disallow spacing between template tags and their literals.
 
 With ES6, it's possible to create functions called [tagged template literals](#further-reading) where the function parameters consist of a template literal's strings and expressions.
 

--- a/docs/rules/unicode-bom.md
+++ b/docs/rules/unicode-bom.md
@@ -1,4 +1,6 @@
-# Require or disallow the Unicode Byte Order Mark (BOM) (unicode-bom)
+# unicode-bom
+
+Requires or disallows the Unicode Byte Order Mark (BOM).
 
 The Unicode Byte Order Mark (BOM) is used to specify whether code units are big
 endian or little endian. That is, whether the most significant or least

--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -1,4 +1,6 @@
-# require calls to `isNaN()` when checking for `NaN` (use-isnan)
+# use-isnan
+
+Requires calls to `isNaN()` when checking for `NaN`.
 
 In JavaScript, `NaN` is a special value of the `Number` type. It's used to represent any of the "not-a-number" values represented by the double-precision 64-bit format as specified by the IEEE Standard for Binary Floating-Point Arithmetic.
 

--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -1,4 +1,6 @@
-# enforce valid JSDoc comments (valid-jsdoc)
+# valid-jsdoc
+
+Enforces valid JSDoc comments.
 
 This rule was [**deprecated**](https://eslint.org/blog/2018/11/jsdoc-end-of-life) in ESLint v5.10.0.
 

--- a/docs/rules/valid-typeof.md
+++ b/docs/rules/valid-typeof.md
@@ -1,4 +1,6 @@
-# enforce comparing `typeof` expressions against valid strings (valid-typeof)
+# valid-typeof
+
+Enforces comparing `typeof` expressions against valid strings.
 
 For a vast majority of use cases, the result of the `typeof` operator is one of the following string literals: `"undefined"`, `"object"`, `"boolean"`, `"number"`, `"string"`, `"function"`, `"symbol"`, and `"bigint"`. It is usually a typing mistake to compare the result of a `typeof` operator to other string literals.
 

--- a/docs/rules/vars-on-top.md
+++ b/docs/rules/vars-on-top.md
@@ -1,4 +1,6 @@
-# Require Variable Declarations to be at the top of their scope (vars-on-top)
+# vars-on-top
+
+Requires variable declarations to be at the top of their scope.
 
 The `vars-on-top` rule generates warnings when variable declarations are not used serially at the top of a function scope or the top of a program.
 By default variable declarations are always moved (“hoisted”) invisibly to the top of their containing scope by the JavaScript interpreter.

--- a/docs/rules/wrap-iife.md
+++ b/docs/rules/wrap-iife.md
@@ -1,4 +1,6 @@
-# Require IIFEs to be Wrapped (wrap-iife)
+# wrap-iife
+
+Requires IIFEs to be wrapped.
 
 You can immediately invoke function expressions, but not function declarations. A common technique to create an immediately-invoked function expression (IIFE) is to wrap a function declaration in parentheses. The opening parentheses causes the contained function to be parsed as an expression, rather than a declaration.
 

--- a/docs/rules/wrap-regex.md
+++ b/docs/rules/wrap-regex.md
@@ -1,4 +1,6 @@
-# Require Regex Literals to be Wrapped (wrap-regex)
+# wrap-regex
+
+Requires regex literals to be wrapped.
 
 When a regular expression is used in certain situations, it can end up looking like a division operator. For example:
 

--- a/docs/rules/yield-star-spacing.md
+++ b/docs/rules/yield-star-spacing.md
@@ -1,4 +1,6 @@
-# Enforce spacing around the `*` in `yield*` expressions (yield-star-spacing)
+# yield-star-spacing
+
+Enforces spacing around the `*` in `yield*` expressions.
 
 ## Rule Details
 

--- a/docs/rules/yoda.md
+++ b/docs/rules/yoda.md
@@ -1,4 +1,6 @@
-# Require or disallow Yoda Conditions (yoda)
+# yoda
+
+Requires or disallows "Yoda" conditions.
 
 Yoda conditions are so named because the literal value of the condition comes first while the variable comes second. For example, the following is a Yoda condition:
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Moves the description of each rule out of its h1 and into a one-line sentence after.

Fixes #15471.

#### Is there anything you'd like reviewers to focus on?

There were actually quite a few rules that had different text in their docs heading compared to their `meta.docs.description`. ~Separate from this PR I'd suggest adding testing to make sure they stay in sync. I _think_ a good heuristic to fix them all up would be to take the longer between the docs intro paragraph from this PR and the description from the rule itself.~ ~Aha, they're in the makefile! Fixing up now before un-drafting.~ ✅ 

I didn't add a check that the docs page description matches the rule meta docs, because they generally don't. But if you'd like me to make that change in this PR I'd be happy to.

<details>
<summary>Here's a quick script I used to get these changes mostly done...</summary>

```js
// docs/rules/migrate.mjs

import { promises as fs } from "fs";

const mdFiles = (await fs.readdir(".")).filter((x) => x.endsWith(".md"));
const problems = [];

for (const fileName of mdFiles) {
    try {
        await convertFile(fileName);
    } catch (error) {
        problems.push({ error, fileName });
    }
}

if (problems.length) {
    console.error("Problems!");

    for (const { error, fileName } of problems) {
        console.error(`${fileName}: ${error}`);
    }

    process.exitCode = 1;
}

async function convertFile(fileName) {
    const contents = (await fs.readFile(fileName)).toString();
    const [firstLine, ...remainingLines] = contents.split(/\n/);

    const { description, ruleName } = parseMetaFromLine(firstLine);

    const updatedLines = [`# ${ruleName}`, "", description, ...remainingLines];

    await fs.writeFile(fileName, updatedLines.join("\n"));
}

function parseMetaFromLine(line) {
    // Most rules start with the format:
    // # ${Description} (${rule-name})
    const descriptionFirst = line.match(/\# (.+) \((.+)\)/);
    if (descriptionFirst) {
        return {
            description: touchUpDescription(descriptionFirst[1]),
            ruleName: descriptionFirst[2],
        };
    }

    // ...except for a few oddities such as generator-star.md:
    // # ${rule-name}: ${Description}
    const ruleNameFirst = line.match(/# (.+): (.*)/);
    if (ruleNameFirst) {
        return {
            description: touchUpDescription(ruleNameFirst[2]),
            ruleName: ruleNameFirst[1],
        };
    }

    throw new Error("Unknown first line format.");
}

function touchUpDescription(description) {
    description = description[0].toUpperCase() + description.slice(1);

    // In retrospect, I wish I'd done replaces on "allow", "require", etc.
    let [firstWord, ...rest] = description.split(" ");
    if (firstWord.endsWith("e") || firstWord.endsWith("w")) {
        firstWord += "s";
    }
    description = [firstWord, ...rest].join(" ");

    if (!description.endsWith(".")) {
        description += ".";
    }

    return description;
}
```
</details>
