### PR TITLE
feat: added getLoadedRulesMeta() to ESLint class

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -11,6 +11,7 @@ While ESLint is designed to be run on the command line, it's possible to use ESL
     * [lintFiles()][eslint-lintfiles]
     * [lintText()][eslint-linttext]
     * [getRulesMetaForResults()][eslint-getrulesmetaforresults]
+    * [getLoadedRulesMeta()][eslint-getloadedrulesmeta]
     * [calculateConfigForFile()][eslint-calculateconfigforfile]
     * [isPathIgnored()][eslint-ispathignored]
     * [loadFormatter()][eslint-loadformatter]
@@ -216,6 +217,19 @@ This method returns an object containing meta information for each rule that tri
 
 * `results` (`LintResult[]`)<br>
   An array of [LintResult] objects returned from a call to `ESLint#lintFiles()` or `ESLint#lintText()`.
+
+#### Return Value
+
+* (`Object`)<br>
+  An object whose property names are the rule IDs from the `results` and whose property values are the rule's meta information (if available).
+
+### ◆ eslint.getLoadedRulesMeta()
+
+```js
+const loadedMeta = eslint.getLoadedRulesMeta();
+```
+
+This method returns an object containing meta information for each rule that was loaded.
 
 #### Return Value
 
@@ -904,6 +918,7 @@ ruleTester.run("my-rule", myRule, {
 [eslint-lintfiles]: #-eslintlintfilespatterns
 [eslint-linttext]: #-eslintlinttextcode-options
 [eslint-getrulesmetaforresults]: #-eslintgetrulesmetaforresultsresults
+[eslint-getloadedrulesmeta]: #-eslintgetloadedrulesmeta
 [eslint-calculateconfigforfile]: #-eslintcalculateconfigforfilefilepath
 [eslint-ispathignored]: #-eslintispathignoredfilepath
 [eslint-loadformatter]: #-eslintloadformatternameorpath

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -545,6 +545,24 @@ class ESLint {
     }
 
     /**
+     * Returns a clone of relevant meta data for all loaded rules.
+     * @returns {Object} A mapping of ruleIds to rule meta objects.
+     */
+     getLoadedRulesMeta() {
+        const { cliEngine } = privateMembersMap.get(this);
+        const rules = cliEngine.getRules()
+        const meta = new Map();
+        for (const [ruleId, rule] of rules) {
+            meta.set(ruleId, {
+                ...rule.meta.docs,
+                fixable: rule.meta.fixable || false,
+                hasSuggestions: rule.meta.hasSuggestions || false
+            })
+        }
+        return meta
+    }
+
+    /**
      * Executes the current configuration on an array of file and directory names.
      * @param {string[]} patterns An array of file and directory names.
      * @returns {Promise<LintResult[]>} The results of linting the file patterns given.

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -548,18 +548,20 @@ class ESLint {
      * Returns a clone of relevant meta data for all loaded rules.
      * @returns {Object} A mapping of ruleIds to rule meta objects.
      */
-     getLoadedRulesMeta() {
+    getLoadedRulesMeta() {
         const { cliEngine } = privateMembersMap.get(this);
-        const rules = cliEngine.getRules()
+        const rules = cliEngine.getRules();
         const meta = new Map();
+
         for (const [ruleId, rule] of rules) {
             meta.set(ruleId, {
                 ...rule.meta.docs,
                 fixable: rule.meta.fixable || false,
                 hasSuggestions: rule.meta.hasSuggestions || false
-            })
+            });
         }
-        return meta
+
+        return meta;
     }
 
     /**

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -4941,6 +4941,19 @@ describe("ESLint", () => {
         });
     });
 
+    describe("getLoadedRulesMeta()", () => {
+        it("should return meta data of built-in rules", async () => {
+            const engine = new ESLint({
+                useEslintrc: false
+            });
+
+            const rulesMeta = engine.getLoadedRulesMeta();
+            const preferConst = rulesMeta.get("prefer-const");
+
+            assert.strictEqual(preferConst.fixable, coreRules.get("prefer-const").meta.fixable);
+        });
+    });
+
     describe("outputFixes()", () => {
         afterEach(() => {
             sinon.verifyAndRestore();


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Add something to the core

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added the class method `getLoadedRulesMeta()` to ESLint class for accessing a deep copy of the loaded rules metadata.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
