### PR TITLE
feat: `indent`: add `BinaryExpression` option

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -845,6 +845,47 @@ if (foo) {
 }
 ```
 
+### BinaryExpression
+
+Examples of **correct** code for this rule with the default `2, { "BinaryExpression": "ignore" }` option:
+
+```js
+/*eslint indent: ["error", 2, { "BinaryExpression": "ignore" }]*/
+
+function f() {
+  return foo
+      || bar
+        || baz
+    || quux;
+}
+```
+
+Examples of **correct** code for this rule with the default `2, { "BinaryExpression": 1 }` option:
+
+```js
+/*eslint indent: ["error", 2, { "BinaryExpression": 1 }]*/
+
+function f() {
+  return foo
+    || bar
+    || baz
+    || quux;
+}
+```
+
+Examples of **correct** code for this rule with the `2, { "BinaryExpression": 0 }` option:
+
+```js
+/*eslint indent: ["error", 2, { "BinaryExpression": 0 }]*/
+
+function f() {
+  return foo
+  || bar
+  || baz
+  || quux;
+}
+```
+
 ## Compatibility
 
 * **JSHint**: `indent`

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -91,6 +91,7 @@ This rule has an object option:
 * `"flatTernaryExpressions": true` (`false` by default) requires no indentation for ternary expressions which are nested in other ternary expressions.
 * `"offsetTernaryExpressions": true` (`false` by default) requires indentation for values of ternary expressions.
 * `"ignoreComments"` (default: false) can be used when comments do not need to be aligned with nodes on the previous or next line.
+* `"BinaryExpression"` `"ignore"` by default; enforces indentation level for BinaryExpressions like `||` or `&&`
 
 Level of indentation denotes the multiple of the indent specified. Example:
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1146,13 +1146,13 @@ module.exports = {
 
                 const tokenAfterOperator = sourceCode.getTokenAfter(operator);
 
-                offsets.ignoreToken(tokenAfterOperator);
 
                 if (options.BinaryExpression !== BINARY_EXPRESSION_DEFAULT_INDENT) {
                     addBlocklessNodeIndent(node);
                     offsets.setDesiredOffset(tokenAfterOperator, operator, options.BinaryExpression);
                 } else {
 
+                    offsets.ignoreToken(tokenAfterOperator);
                     offsets.ignoreToken(operator);
                     offsets.setDesiredOffset(tokenAfterOperator, operator, 0);
                 }

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -20,6 +20,8 @@ const astUtils = require("./utils/ast-utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const BINARY_EXPRESSION_DEFAULT_INDENT = "ignore";
+
 const KNOWN_NODES = new Set([
     "AssignmentExpression",
     "AssignmentPattern",
@@ -625,6 +627,18 @@ module.exports = {
                     ignoreComments: {
                         type: "boolean",
                         default: false
+                    },
+                    BinaryExpression: {
+                        default: BINARY_EXPRESSION_DEFAULT_INDENT,
+                        oneOf: [
+                            {
+                                enum: [BINARY_EXPRESSION_DEFAULT_INDENT]
+                            },
+                            {
+                                type: "integer",
+                                minimum: 0
+                            }
+                        ]
                     }
                 },
                 additionalProperties: false
@@ -670,7 +684,8 @@ module.exports = {
             ImportDeclaration: 1,
             flatTernaryExpressions: false,
             ignoredNodes: [],
-            ignoreComments: false
+            ignoreComments: false,
+            BinaryExpression: BINARY_EXPRESSION_DEFAULT_INDENT
         };
 
         if (context.options.length) {
@@ -1131,9 +1146,16 @@ module.exports = {
 
                 const tokenAfterOperator = sourceCode.getTokenAfter(operator);
 
-                offsets.ignoreToken(operator);
                 offsets.ignoreToken(tokenAfterOperator);
-                offsets.setDesiredOffset(tokenAfterOperator, operator, 0);
+
+                if (options.BinaryExpression !== BINARY_EXPRESSION_DEFAULT_INDENT) {
+                    addBlocklessNodeIndent(node);
+                    offsets.setDesiredOffset(tokenAfterOperator, operator, options.BinaryExpression);
+                } else {
+
+                    offsets.ignoreToken(operator);
+                    offsets.setDesiredOffset(tokenAfterOperator, operator, 0);
+                }
             },
 
             "BlockStatement, ClassBody"(node) {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -6085,7 +6085,31 @@ ruleTester.run("indent", rule, {
         },
         {
             code:
-                "module.exports = function IsUnclampedIntegerElementType(type) {\n" +
+                "module.exports = function binaryExpressionIgnore(type) {\n" +
+                "\treturn type === 'Int8'\n" +
+                "    || type === 'Uint8'\n" +
+                "    || type === 'Int16'\n" +
+                "    || type === 'Uint16'\n" +
+                "    || type === 'Int32'\n" +
+                "    || type === 'Uint32';\n" +
+                "};",
+            options: ["tab", { BinaryExpression: "ignore" }]
+        },
+        {
+            code:
+                "module.exports = function binaryExpressionZero(type) {\n" +
+                "\treturn type === 'Int8'\n" +
+                "\t|| type === 'Uint8'\n" +
+                "\t|| type === 'Int16'\n" +
+                "\t|| type === 'Uint16'\n" +
+                "\t|| type === 'Int32'\n" +
+                "\t|| type === 'Uint32';\n" +
+                "};",
+            options: ["tab", { BinaryExpression: 0 }]
+        },
+        {
+            code:
+                "module.exports = function binaryExpressionOne(type) {\n" +
                 "\treturn type === 'Int8'\n" +
                 "\t\t|| type === 'Uint8'\n" +
                 "\t\t|| type === 'Int16'\n" +
@@ -6094,6 +6118,18 @@ ruleTester.run("indent", rule, {
                 "\t\t|| type === 'Uint32';\n" +
                 "};",
             options: ["tab", { BinaryExpression: 1 }]
+        },
+        {
+            code:
+                "module.exports = function binaryExpressionTwo(type) {\n" +
+                "\treturn type === 'Int8'\n" +
+                "\t\t\t|| type === 'Uint8'\n" +
+                "\t\t\t|| type === 'Int16'\n" +
+                "\t\t\t|| type === 'Uint16'\n" +
+                "\t\t\t|| type === 'Int32'\n" +
+                "\t\t\t|| type === 'Uint32';\n" +
+                "};",
+            options: ["tab", { BinaryExpression: 2 }]
         }
     ],
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -6082,6 +6082,18 @@ ruleTester.run("indent", rule, {
             `,
             options: [4, { FunctionExpression: { body: 2 }, StaticBlock: { body: 2 } }],
             parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code:
+                "module.exports = function IsUnclampedIntegerElementType(type) {\n" +
+                "\treturn type === 'Int8'\n" +
+                "\t\t|| type === 'Uint8'\n" +
+                "\t\t|| type === 'Int16'\n" +
+                "\t\t|| type === 'Uint16'\n" +
+                "\t\t|| type === 'Int32'\n" +
+                "\t\t|| type === 'Uint32';\n" +
+                "};",
+            options: ["tab", { BinaryExpression: 2 }]
         }
     ],
 
@@ -12622,6 +12634,35 @@ ruleTester.run("indent", rule, {
                 [5, 4, 0, "Keyword"],
                 [6, 12, 0, "Identifier"],
                 [7, 4, 0, "Punctuator"]
+            ])
+        },
+
+        {
+            code:
+                "module.exports = function IsUnclampedIntegerElementType(type) {\n" +
+                "\treturn type === 'Int8'\n" +
+                "    || type === 'Uint8'\n" +
+                "    || type === 'Int16'\n" +
+                "    || type === 'Uint16'\n" +
+                "    || type === 'Int32'\n" +
+                "    || type === 'Uint32';\n" +
+                "};",
+            output:
+                "module.exports = function IsUnclampedIntegerElementType(type) {\n" +
+                "\treturn type === 'Int8'\n" +
+                "\t\t|| type === 'Uint8'\n" +
+                "\t\t|| type === 'Int16'\n" +
+                "\t\t|| type === 'Uint16'\n" +
+                "\t\t|| type === 'Int32'\n" +
+                "\t\t|| type === 'Uint32';\n" +
+                "};",
+            options: ["tab", { BinaryExpression: 2 }],
+            errors: expectedErrors("tab", [
+                [3, 2, "4 spaces", "Punctuator"],
+                [4, 2, "4 spaces", "Punctuator"],
+                [5, 2, "4 spaces", "Punctuator"],
+                [6, 2, "4 spaces", "Punctuator"],
+                [7, 2, "4 spaces", "Punctuator"]
             ])
         }
     ]

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -6093,7 +6093,7 @@ ruleTester.run("indent", rule, {
                 "\t\t|| type === 'Int32'\n" +
                 "\t\t|| type === 'Uint32';\n" +
                 "};",
-            options: ["tab", { BinaryExpression: 2 }]
+            options: ["tab", { BinaryExpression: 1 }]
         }
     ],
 
@@ -12656,7 +12656,7 @@ ruleTester.run("indent", rule, {
                 "\t\t|| type === 'Int32'\n" +
                 "\t\t|| type === 'Uint32';\n" +
                 "};",
-            options: ["tab", { BinaryExpression: 2 }],
+            options: ["tab", { BinaryExpression: 1 }],
             errors: expectedErrors("tab", [
                 [3, 2, "4 spaces", "Punctuator"],
                 [4, 2, "4 spaces", "Punctuator"],


### PR DESCRIPTION
Fixes #15509

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)


[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)
Added a `BinaryExpression` option. Defaults to `"ignore"`; can be set to a desired indentation level. I expect `1` to be most common.

#### Is there anything you'd like reviewers to focus on?
The tests currently set it to `2` - I'd love pointers on how I can add the indentation offset from the preceding line, and offset from there - meaning, i want to change the tests from 2 to 1, and have it pass.

I also will add correct/incorrect examples in the readme once the implementation seems on track.
