### PR TITLE
feat: Add  option to no-confusing-arrow rule

### DIFF
--- a/docs/rules/no-confusing-arrow.md
+++ b/docs/rules/no-confusing-arrow.md
@@ -41,12 +41,12 @@ var x = (a) => { return 1 ? 2 : 3; };
 
 ## Options
 
-This rule accepts a single options argument with the following defaults:
+This rule accepts two options argument with the following defaults:
 
 ```json
 {
     "rules": {
-        "no-confusing-arrow": ["error", {"allowParens": true}]
+        "no-confusing-arrow": ["error", {"allowParens": true,"onlyOneSimpleParam": false}]
     }
 }
 ```
@@ -62,6 +62,19 @@ Examples of **incorrect** code for this rule with the `{"allowParens": false}` o
 /*eslint no-confusing-arrow: ["error", {"allowParens": false}]*/
 /*eslint-env es6*/
 var x = a => (1 ? 2 : 3);
+var x = (a) => (1 ? 2 : 3);
+```
+
+`onlyOneSimpleParam` is a boolean setting that can be `true` or `false`(false):
+
+1. `true` warns if arrow functions with a single argument that is either an identifier or a primitive literal is used.
+2. `false` relaxes the rule.
+
+Examples of **incorrect** code for this rule with the `{"onlyOneSimpleParam": true}` option:
+
+```js
+/*eslint no-confusing-arrow: ["error", {"onlyOneSimpleParam": true}]*/
+/*eslint-env es6*/
 var x = (a) => (1 ? 2 : 3);
 ```
 

--- a/lib/rules/no-confusing-arrow.js
+++ b/lib/rules/no-confusing-arrow.js
@@ -41,7 +41,8 @@ module.exports = {
         schema: [{
             type: "object",
             properties: {
-                allowParens: { type: "boolean", default: true }
+                allowParens: { type: "boolean", default: true },
+                onlyOneSimpleParam: { type: "boolean", default: false }
             },
             additionalProperties: false
         }],
@@ -54,6 +55,7 @@ module.exports = {
     create(context) {
         const config = context.options[0] || {};
         const allowParens = config.allowParens || (config.allowParens === void 0);
+        const onlyOneSimpleParam = context.options[1];
         const sourceCode = context.getSourceCode();
 
 
@@ -65,7 +67,7 @@ module.exports = {
         function checkArrowFunc(node) {
             const body = node.body;
 
-            if (isConditional(body) && !(allowParens && astUtils.isParenthesised(sourceCode, body))) {
+            if (isConditional(body) && (!(allowParens && astUtils.isParenthesised(sourceCode, body)) || (onlyOneSimpleParam && node.params.length === 1 && node.params[0].type !== "ArrayPattern" && node.params[0].type !== "ObjectPattern"))) {
                 context.report({
                     node,
                     messageId: "confusing",

--- a/tests/lib/rules/no-confusing-arrow.js
+++ b/tests/lib/rules/no-confusing-arrow.js
@@ -30,7 +30,10 @@ ruleTester.run("no-confusing-arrow", rule, {
         { code: "var x = (a) => { return 1 ? 2 : 3; }", options: [{ allowParens: false }] },
 
         "var x = a => (1 ? 2 : 3)",
-        { code: "var x = a => (1 ? 2 : 3)", options: [{ allowParens: true }] }
+        { code: "var x = a => (1 ? 2 : 3)", options: [{ allowParens: true }] },
+
+        "var x = (a,b) => (1 ? 2 : 3)",
+        { code: "var x = (a,b) => (1 ? 2 : 3)", options: [{ onlyOneSimpleParam: false }] }
     ],
     invalid: [
         {
@@ -70,6 +73,24 @@ ruleTester.run("no-confusing-arrow", rule, {
         {
             code: "var x = (a) => 1 ? 2 : 3",
             output: "var x = (a) => (1 ? 2 : 3)",
+            errors: [{ messageId: "confusing" }]
+        },
+        {
+            code: "var x = (a) => 1 ? 2 : 3",
+            output: null,
+            options: [{ onlyOneSimpleParam: true, allowParens: false }],
+            errors: [{ messageId: "confusing" }]
+        },
+        {
+            code: "var x = (a) => 1 ? 2 : 3",
+            output: "var x = (a) => (1 ? 2 : 3)",
+            options: [{ onlyOneSimpleParam: true, allowParens: true }],
+            errors: [{ messageId: "confusing" }]
+        },
+        {
+            code: "var x = ({}) => 1 ? 2 : 3",
+            output: null,
+            options: [{ onlyOneSimpleParam: true, allowParens: false }],
             errors: [{ messageId: "confusing" }]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added `onlyOneSimpleParam` option in the `no-confusing-arrow` rule which when set to true, will warn if an arrow function is used with one single parameter(either primitive or identifier literal).

#### Is there anything you'd like reviewers to focus on?
Open for the feedback :)


Fixes: #15548 
<!-- markdownlint-disable-file MD004 -->
