### PR TITLE
feat: Fix suggestion for "no-template-curly-in-string"

### DIFF
--- a/lib/rules/no-template-curly-in-string.js
+++ b/lib/rules/no-template-curly-in-string.js
@@ -22,19 +22,34 @@ module.exports = {
         schema: [],
 
         messages: {
-            unexpectedTemplateExpression: "Unexpected template string expression."
-        }
+            unexpectedTemplateExpression: "Unexpected template string expression.",
+            convertToTemplate: "Convert to ES6 `template`."
+        },
+        hasSuggestions: true
     },
 
     create(context) {
         const regex = /\$\{[^}]+\}/u;
+        const sourceCode = context.getSourceCode();
 
         return {
             Literal(node) {
                 if (typeof node.value === "string" && regex.test(node.value)) {
                     context.report({
                         node,
-                        messageId: "unexpectedTemplateExpression"
+                        messageId: "unexpectedTemplateExpression",
+                        suggest: [
+                            {
+                                messageId: "convertToTemplate",
+                                fix: fixer => {
+                                    const text = sourceCode.getText(node);
+                                    const textNoQuotes = text.slice(1, -1);
+                                    const newText = `\`${textNoQuotes}\``;
+
+                                    return fixer.replaceText(node, newText);
+                                }
+                            }
+                        ]
                     });
                 }
             }

--- a/lib/rules/no-template-curly-in-string.js
+++ b/lib/rules/no-template-curly-in-string.js
@@ -43,8 +43,14 @@ module.exports = {
                                 messageId: "convertToTemplate",
                                 fix: fixer => {
                                     const text = sourceCode.getText(node);
+                                    const oldQuote = text[0];
                                     const textNoQuotes = text.slice(1, -1);
-                                    const newText = `\`${textNoQuotes}\``;
+                                    const escapeBackticks = textNoQuotes.replaceAll("`", "\\`");
+                                    const unescapeQuotes = escapeBackticks.replaceAll(`\\${oldQuote}`, oldQuote);
+                                    // eslint-disable-next-line require-unicode-regexp -- Needs fixing, adding the unicode flag results in "Incomplete quantifier" parsing error
+                                    const backTicksInsideCurly = /(?<=\${)\\`([^`]*)\\`(?=})/gi;
+                                    const unescapeTemplates = unescapeQuotes.replaceAll(backTicksInsideCurly, "`$1`");
+                                    const newText = `\`${unescapeTemplates}\``;
 
                                     return fixer.replaceText(node, newText);
                                 }
@@ -54,6 +60,5 @@ module.exports = {
                 }
             }
         };
-
     }
 };

--- a/lib/rules/no-template-curly-in-string.js
+++ b/lib/rules/no-template-curly-in-string.js
@@ -45,10 +45,11 @@ module.exports = {
                                     const text = sourceCode.getText(node);
                                     const oldQuote = text[0];
                                     const textNoQuotes = text.slice(1, -1);
-                                    const escapeBackticks = textNoQuotes.replaceAll("`", "\\`");
-                                    const unescapeQuotes = escapeBackticks.replaceAll(`\\${oldQuote}`, oldQuote);
-                                    const backTicksInsideCurly = /(?<=\$\{)\\`([^`]*)\\`(?=\})/giu;
-                                    const unescapeTemplates = unescapeQuotes.replaceAll(backTicksInsideCurly, "`$1`");
+                                    const escapeBackticks = textNoQuotes.replace(/`/gui, "\\`");
+                                    const regexUnescape = new RegExp(`\\\\${oldQuote}`, "gui");
+                                    const unescapeQuotes = escapeBackticks.replace(regexUnescape, oldQuote);
+                                    const backTicksInsideCurly = /(?<=\$\{)\\`([^`]*)\\`(?=\})/gui;
+                                    const unescapeTemplates = unescapeQuotes.replace(backTicksInsideCurly, "`$1`");
                                     const newText = `\`${unescapeTemplates}\``;
 
                                     return fixer.replaceText(node, newText);

--- a/lib/rules/no-template-curly-in-string.js
+++ b/lib/rules/no-template-curly-in-string.js
@@ -47,8 +47,7 @@ module.exports = {
                                     const textNoQuotes = text.slice(1, -1);
                                     const escapeBackticks = textNoQuotes.replaceAll("`", "\\`");
                                     const unescapeQuotes = escapeBackticks.replaceAll(`\\${oldQuote}`, oldQuote);
-                                    // eslint-disable-next-line require-unicode-regexp -- Needs fixing, adding the unicode flag results in "Incomplete quantifier" parsing error
-                                    const backTicksInsideCurly = /(?<=\${)\\`([^`]*)\\`(?=})/gi;
+                                    const backTicksInsideCurly = /(?<=\$\{)\\`([^`]*)\\`(?=\})/giu;
                                     const unescapeTemplates = unescapeQuotes.replaceAll(backTicksInsideCurly, "`$1`");
                                     const newText = `\`${unescapeTemplates}\``;
 

--- a/tests/lib/rules/no-template-curly-in-string.js
+++ b/tests/lib/rules/no-template-curly-in-string.js
@@ -74,6 +74,36 @@ ruleTester.run("no-template-curly-in-string", rule, {
             code: "'Hello, ${{foo: \"bar\"}.foo}'",
             parserOptions,
             errors: [{ messageId }]
+        },
+        {
+            code: "'\\'Hello\\', ${\\'name\\'}'",
+            parserOptions,
+            errors: [{ messageId }]
+        },
+        {
+            code: "'\"Hello\", ${\"name\"}'",
+            parserOptions,
+            errors: [{ messageId }]
+        },
+        {
+            code: "'`Hello`, ${`name`}'",
+            parserOptions,
+            errors: [{ messageId }]
+        },
+        {
+            code: "\"'Hello', ${'name'}\"",
+            parserOptions,
+            errors: [{ messageId }]
+        },
+        {
+            code: "\"\\\"Hello\\\", ${\\\"name\\\"}\"",
+            parserOptions,
+            errors: [{ messageId }]
+        },
+        {
+            code: "\"`Hello`, ${`name`}\"",
+            parserOptions,
+            errors: [{ messageId }]
         }
     ]
 });


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[x] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


#### What changes did you make? (Give an overview)
Added a suggestion to rule "no-template-curly-in-string", that will trim the 1st and last characters from an erroring snippets, and replace them with backticks to convert the string to a template. 

#### Is there anything you'd like reviewers to focus on?
I haven't made new tests for this functionality; I haven't used anything similar in the past and I don't have time today to look into it, so I'd rather make the PR as a draft today and have someone point me in the right direction. My tests were successful, but I understand that's not good enough.

<!-- markdownlint-disable-file MD004 -->
