### PR TITLE
feat: update eslint-scope to ignore `"use strict"` directives in ES3

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "debug": "^4.3.2",
     "doctrine": "^3.0.0",
     "escape-string-regexp": "^4.0.0",
-    "eslint-scope": "^7.1.0",
+    "eslint-scope": "github:eslint/eslint-scope#prepare-7.1.1",
     "eslint-utils": "^3.0.0",
     "eslint-visitor-keys": "^3.2.0",
     "espree": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "debug": "^4.3.2",
     "doctrine": "^3.0.0",
     "escape-string-regexp": "^4.0.0",
-    "eslint-scope": "github:eslint/eslint-scope#prepare-7.1.1",
+    "eslint-scope": "^7.1.1",
     "eslint-utils": "^3.0.0",
     "eslint-visitor-keys": "^3.2.0",
     "espree": "^9.3.0",

--- a/tests/lib/rules/no-eval.js
+++ b/tests/lib/rules/no-eval.js
@@ -139,6 +139,13 @@ ruleTester.run("no-eval", rule, {
             code: "class A { static {} [this.eval()]; }",
             parserOptions: { ecmaVersion: 2022 },
             errors: [{ messageId: "unexpected" }]
+        },
+
+        // in es3, "use strict" directives do not apply
+        {
+            code: "function foo() { 'use strict'; this.eval(); }",
+            parserOptions: { ecmaVersion: 3 },
+            errors: [{ messageId: "unexpected" }]
         }
     ]
 });

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -865,6 +865,14 @@ const patterns = [
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES],
         errors: [{ messageId: "unexpectedThis", type: "ThisExpression" }]
+    },
+
+    // in es3, "use strict" directives do not apply
+    {
+        code: "function foo() { 'use strict'; this.eval(); }",
+        parserOptions: { ecmaVersion: 3 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT],
+        invalid: []
     }
 ];
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Updates `eslint-scope` to include https://github.com/eslint/eslint-scope/pull/87.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated package.json, and added tests for two core rules that will be affected by this change:

* `no-invalid-this` will have fewer warnings.
* `no-eval` will have more warnings.

#### Is there anything you'd like reviewers to focus on?

Marked as draft as it currently uses eslint-scope from GitHub.

<!-- markdownlint-disable-file MD004 -->
