### PR TITLE
perf: fix lazy loading of core rules

### DIFF
--- a/lib/config/flat-config-array.js
+++ b/lib/config/flat-config-array.js
@@ -14,7 +14,6 @@ const { flatConfigSchema } = require("./flat-config-schema");
 const { RuleValidator } = require("./rule-validator");
 const { defaultConfig } = require("./default-config");
 const recommendedConfig = require("../../conf/eslint-recommended");
-const allConfig = require("../../conf/eslint-all");
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -79,7 +78,13 @@ class FlatConfigArray extends ConfigArray {
         }
 
         if (config === "eslint:all") {
-            return allConfig;
+
+            /*
+             * Load `eslint-all.js` here instead of at the top level to avoid loading all rule modules
+             * when it isn't necessary. `eslint-all.js` reads `meta` of rule objects to filter out deprecated ones,
+             * so requiring `eslint-all.js` module loads all rule modules as a consequence.
+             */
+            return require("../../conf/eslint-all");
         }
 
         return config;

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "node-polyfill-webpack-plugin": "^1.0.3",
     "npm-license": "^0.3.3",
     "nyc": "^15.0.1",
+    "pirates": "^4.0.5",
     "progress": "^2.0.3",
     "proxyquire": "^2.0.1",
     "puppeteer": "^9.1.1",

--- a/tests/_utils/test-lazy-loading-rules.js
+++ b/tests/_utils/test-lazy-loading-rules.js
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Tests lazy-loading of core rules
+ * @author Milos Djermanovic
+ */
+
+/*
+ * This module should be run as a child process, with `fork()`,
+ * because it is important to run this test with a separate, clean Node process
+ * in order to add hooks before any of the ESLint modules is loaded.
+ */
+
+"use strict";
+
+const path = require("path");
+const assert = require("assert");
+const { addHook } = require("pirates");
+
+const {
+    dir: rulesDirectoryPath,
+    name: rulesDirectoryIndexFilename
+} = path.parse(require.resolve("../../lib/rules"));
+
+// Show full stack trace. The default 10 is usually not enough to find the root cause of this problem.
+Error.stackTraceLimit = Infinity;
+
+const [cwd, pattern, usedRulesCommaSeparated] = process.argv.slice(2);
+
+assert.ok(cwd, "cwd argument isn't provided");
+assert.ok(pattern, "pattern argument isn't provided");
+assert.ok(usedRulesCommaSeparated, "used rules argument isn't provided");
+
+const usedRules = usedRulesCommaSeparated.split(",");
+
+// `require()` hook
+addHook(
+    (_code, filename) => {
+        throw new Error(`Unexpected attempt to load unused rule ${filename}`);
+    },
+    {
+
+        // returns `true` if the hook (the function passed in as the first argument) should be called for this filename
+        matcher(filename) {
+            const { dir, name } = path.parse(filename);
+
+            if (dir === rulesDirectoryPath && ![rulesDirectoryIndexFilename, ...usedRules].includes(name)) {
+                return true;
+            }
+
+            return false;
+        }
+
+    }
+);
+
+/*
+ * Everything related to loading any ESLint modules should be in this IIFE
+ */
+(async () => {
+    const { ESLint } = require("../..");
+    const eslint = new ESLint({ cwd });
+
+    await eslint.lintFiles([pattern]);
+})().catch(({ message, stack }) => {
+    process.send({ message, stack });
+    process.exit(1);
+});

--- a/tests/fixtures/lazy-loading-rules/.eslintrc.js
+++ b/tests/fixtures/lazy-loading-rules/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    root: true,
+    rules: {
+        semi: 2
+    }
+};

--- a/tests/fixtures/lazy-loading-rules/foo.js
+++ b/tests/fixtures/lazy-loading-rules/foo.js
@@ -1,0 +1,1 @@
+/* content is not necessary */


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Performance improvement.

We have [`lazy-loading-rule-map`](https://github.com/eslint/eslint/blob/main/lib/rules/utils/lazy-loading-rule-map.js) which prevents loading all core rule modules when they are not necessary, and that part works well.

On the other hand, [`eslint-all.js`](https://github.com/eslint/eslint/blob/main/conf/eslint-all.js) loads all rule modules, because it needs `meta` of rules to filter out deprecated ones.

The problem is that `flat-config-array` always loads `eslint-all.js`:

https://github.com/eslint/eslint/blob/8d3c25f47b1a377993c42d44f0b1722193aa7361/lib/config/flat-config-array.js#L17

so, as a consequence, basically any use of ESLint loads all rules, which we were obviously trying to avoid.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Moved `require("../../conf/eslint-all")` from the top level of `flat-config-array.js` to the place where it's needed.

<details>
<summary> `npm run perf` before this change</summary>

```

> eslint@8.9.0 perf D:\projects\eslint
> node Makefile.js perf


Loading:
  Load performance Run #1:  622.997785ms
  Load performance Run #2:  685.887445ms
  Load performance Run #3:  617.0843ms
  Load performance Run #4:  689.034299ms
  Load performance Run #5:  615.789688ms

  Load Performance median:  622.997785ms


Single File:
  CPU Speed is 2095 with multiplier 13000000
  Performance Run #1:  11956.969383ms
  Performance Run #2:  11742.944261ms
  Performance Run #3:  11807.732589ms
  Performance Run #4:  12022.606126ms
  Performance Run #5:  11804.399046ms

  Performance budget exceeded: 11807.732589ms (limit: 6205.250596658711ms)


Multi Files (450 files):
  CPU Speed is 2095 with multiplier 39000000
  Performance Run #1:  31217.632838ms
  Performance Run #2:  31106.2355ms
  Performance Run #3:  31508.789833ms
  Performance Run #4:  30745.145445ms
  Performance Run #5:  30807.573268ms

  Performance budget exceeded: 31106.2355ms (limit: 18615.751789976133ms)


```

</details>

<details>
<summary> `npm run perf` after this change</summary>

```

> eslint@8.9.0 perf D:\projects\eslint
> node Makefile.js perf


Loading:
  Load performance Run #1:  313.853045ms
  Load performance Run #2:  306.604384ms
  Load performance Run #3:  344.540608ms
  Load performance Run #4:  304.535642ms
  Load performance Run #5:  306.038938ms

  Load Performance median:  306.604384ms


Single File:
  CPU Speed is 2095 with multiplier 13000000
  Performance Run #1:  11899.784524ms
  Performance Run #2:  11760.932493ms
  Performance Run #3:  11679.374794ms
  Performance Run #4:  11751.555466ms
  Performance Run #5:  12019.626415ms

  Performance budget exceeded: 11760.932493ms (limit: 6205.250596658711ms)


Multi Files (450 files):
  CPU Speed is 2095 with multiplier 39000000
  Performance Run #1:  31008.965526ms
  Performance Run #2:  30747.93309ms
  Performance Run #3:  30830.182326ms
  Performance Run #4:  31287.272178ms
  Performance Run #5:  31279.041194ms

  Performance budget exceeded: 31008.965526ms (limit: 18615.751789976133ms)


```

</details>

This improves Loading performance by 50%.

Single File and Multi File are not relevant for this change, as they run all rules anyways.

#### Is there anything you'd like reviewers to focus on?

I tried to write a test for this using proxyquire's [@global](https://github.com/thlorenz/proxyquire#globally-override-require), and eventually managed to make a test that fails without this change, but didn't manage to remove proxies after the test.

Update: I added a test that runs in a child process and seems to be working well. I've verified that the test would fail without the change in `flat-config-array.js`. I've also verified that the test would fail if `eslint-all.js` is loaded from `cli-engine.js` (as in https://github.com/eslint/eslint/pull/15602#discussion_r805862163).

<!-- markdownlint-disable-file MD004 -->
