### PR TITLE
test: add integration tests with built-in configs

### DIFF
--- a/tests/lib/cli-engine/file-enumerator.js
+++ b/tests/lib/cli-engine/file-enumerator.js
@@ -550,7 +550,7 @@ describe("FileEnumerator", () => {
         const files = {
             "file.js": "",
             ".eslintrc.json": JSON.stringify({
-                extends: ["eslint:recommended"]
+                extends: ["eslint:recommended", "eslint:all"]
             })
         };
         const { prepare, cleanup, getPath } = createCustomTeardown({ cwd: root, files });

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -412,6 +412,52 @@ describe("ESLint", () => {
             ]);
         });
 
+        it("should use eslint:recommended rules when eslint:recommended configuration is specified", async () => {
+            eslint = new ESLint({
+                useEslintrc: false,
+                overrideConfig: {
+                    extends: ["eslint:recommended"]
+                },
+                ignore: false,
+                cwd: getFixturePath()
+            });
+            const options = { filePath: "file.js" };
+            const results = await eslint.lintText("foo ()", options);
+
+            assert.strictEqual(results.length, 1);
+            assert.strictEqual(results[0].messages.length, 1);
+            assert.strictEqual(results[0].messages[0].ruleId, "no-undef");
+            assert.strictEqual(results[0].messages[0].severity, 2);
+        });
+
+        it("should use eslint:all rules when eslint:all configuration is specified", async () => {
+            eslint = new ESLint({
+                useEslintrc: false,
+                overrideConfig: {
+                    extends: ["eslint:all"]
+                },
+                ignore: false,
+                cwd: getFixturePath()
+            });
+            const options = { filePath: "file.js" };
+            const results = await eslint.lintText("foo ()", options);
+
+            assert.strictEqual(results.length, 1);
+
+            const { messages } = results[0];
+
+            // Some rules that should report errors in the given code. Not all, as we don't want to update this test when we add new rules.
+            const expectedRules = ["no-undef", "semi", "func-call-spacing"];
+
+            expectedRules.forEach(ruleId => {
+                const messageFromRule = messages.find(message => message.ruleId === ruleId);
+
+                assert.ok(messageFromRule, `Expected a message from rule '${ruleId}'`);
+                assert.strictEqual(messageFromRule.severity, 2);
+            });
+
+        });
+
         it("correctly autofixes semicolon-conflicting-fixes", async () => {
             eslint = new ESLint({
                 cwd: path.join(fixtureDir, ".."),

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -452,7 +452,10 @@ describe("ESLint", () => {
             expectedRules.forEach(ruleId => {
                 const messageFromRule = messages.find(message => message.ruleId === ruleId);
 
-                assert.ok(messageFromRule, `Expected a message from rule '${ruleId}'`);
+                assert.ok(
+                    typeof messageFromRule === "object" && messageFromRule !== null, // LintResult object
+                    `Expected a message from rule '${ruleId}'`
+                );
                 assert.strictEqual(messageFromRule.severity, 2);
             });
 

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -453,7 +453,7 @@ describe("ESLint", () => {
                 const messageFromRule = messages.find(message => message.ruleId === ruleId);
 
                 assert.ok(
-                    typeof messageFromRule === "object" && messageFromRule !== null, // LintResult object
+                    typeof messageFromRule === "object" && messageFromRule !== null, // LintMessage object
                     `Expected a message from rule '${ruleId}'`
                 );
                 assert.strictEqual(messageFromRule.severity, 2);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

I noticed we don't have any tests that would fail if there's something wrong with how is eslint passing `eslint:all` configuration to @eslint/eslintrc, or how @eslint/eslintrc handles that configuration. Such tests would be useful to catch possible regressions when there are some changes in that integration, like https://github.com/eslint/eslint/pull/15602.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Added tests for `ESlint#lintText()` with `eslint:all` and `eslint:recommended` configurations.
* Updated one test for FileEnumerator to include `eslint:all`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
