### PR TITLE
chore: read `ESLINT_MOCHA_TIMEOUT` env var in Makefile.js

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -79,7 +79,7 @@ const NODE = "node ", // intentional extra space
     PERF_MULTIFILES_TARGETS = `"${PERF_MULTIFILES_TARGET_DIR + path.sep}{lib,tests${path.sep}lib}${path.sep}**${path.sep}*.js"`,
 
     // Settings
-    MOCHA_TIMEOUT = 10000;
+    MOCHA_TIMEOUT = parseInt(process.env.ESLINT_MOCHA_TIMEOUT, 10) || 10000;
 
 //------------------------------------------------------------------------------
 // Helpers

--- a/docs/developer-guide/unit-tests.md
+++ b/docs/developer-guide/unit-tests.md
@@ -37,3 +37,7 @@ Running individual tests is useful when you're working on a specific bug and ite
 ## More Control on Unit Testing
 
 `npm run test:cli` is an alias of the Mocha cli in `./node_modules/.bin/mocha`. [Options](https://mochajs.org/#command-line-usage) are available to be provided to help to better control the test to run.
+
+The default timeout for tests in `npm test` is 10000ms. You may change the timeout by providing `ESLINT_MOCHA_TIMEOUT` environment variable, for example:
+
+    ESLINT_MOCHA_TIMEOUT=20000 npm test


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[x] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

This PR will close #15582.

#### What changes did you make? (Give an overview)

It allows `npm test` to override the default mocha tests timeout of 10000ms by reading `ESLINT_MOCHA_TIMEOUT` environment variable.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
