### PR TITLE
feat: add `destructuredArrayIgnorePattern` option in `no-unused-vars`

### DIFF
--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -262,6 +262,13 @@ function test({p: [_q, r]}) {
     r;
 }
 test();
+
+let _m, n;
+
+foo.forEach(item => {
+    [_m, n] = item;
+    console.log(n);
+});
 ```
 
 ### caughtErrors

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -238,6 +238,20 @@ function foo(x, _y) {
 foo();
 ```
 
+### destructuredArrayIgnorePattern
+
+The `destructuredArrayIgnorePattern` option specifies exceptions not to check for usage: destructuring assignments from an array whose names match a regexp pattern. For example, variables whose names begin with an underscore.
+
+Examples of **correct** code for the `{ "destructuredArrayIgnorePattern": "^_" }` option:
+
+```js
+/*eslint no-unused-vars: ["error", { "destructuredArrayIgnorePattern": "^_" }]*/
+
+const [a, _b, c] = ["a", "b", "c"]
+
+console.log(a + c);
+```
+
 ### caughtErrors
 
 The `caughtErrors` option is used for `catch` block arguments validation.

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -240,7 +240,7 @@ foo();
 
 ### destructuredArrayIgnorePattern
 
-The `destructuredArrayIgnorePattern` option specifies exceptions not to check for usage: destructuring assignments from an array whose names match a regexp pattern. For example, variables whose names begin with an underscore.
+The `destructuredArrayIgnorePattern` option specifies exceptions not to check for usage: elements of array destructuring patterns whose names match a regexp pattern. For example, variables whose names begin with an underscore.
 
 Examples of **correct** code for the `{ "destructuredArrayIgnorePattern": "^_" }` option:
 

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -247,9 +247,16 @@ Examples of **correct** code for the `{ "destructuredArrayIgnorePattern": "^_" }
 ```js
 /*eslint no-unused-vars: ["error", { "destructuredArrayIgnorePattern": "^_" }]*/
 
-const [a, _b, c] = ["a", "b", "c"]
+const [a, _b, c] = ["a", "b", "c"];
+console.log(a+c);
 
-console.log(a + c);
+const { x: [_a, foo] } = bar;
+console.log(foo);
+
+function baz([_c, x]) {
+    x;
+}
+baz();
 ```
 
 ### caughtErrors

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -264,7 +264,6 @@ function test({p: [_q, r]}) {
 test();
 
 let _m, n;
-
 foo.forEach(item => {
     [_m, n] = item;
     console.log(n);

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -257,6 +257,11 @@ function baz([_c, x]) {
     x;
 }
 baz();
+
+function test({p: [_q, r]}) {
+    r;
+}
+test();
 ```
 
 ### caughtErrors

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -269,6 +269,11 @@ foo.forEach(item => {
     [_m, n] = item;
     console.log(n);
 });
+
+let _o, p;
+_o = 1;
+[_o, p] = foo;
+p;
 ```
 
 ### caughtErrors

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -67,6 +67,9 @@ module.exports = {
                             },
                             caughtErrorsIgnorePattern: {
                                 type: "string"
+                            },
+                            destructuredArrayIgnorePattern: {
+                                type: "string"
                             }
                         },
                         additionalProperties: false
@@ -114,6 +117,10 @@ module.exports = {
                 if (firstOption.caughtErrorsIgnorePattern) {
                     config.caughtErrorsIgnorePattern = new RegExp(firstOption.caughtErrorsIgnorePattern, "u");
                 }
+
+                if (firstOption.destructuredArrayIgnorePattern) {
+                    config.destructuredArrayIgnorePattern = new RegExp(firstOption.destructuredArrayIgnorePattern, "u");
+                }
             }
         }
 
@@ -155,7 +162,16 @@ module.exports = {
          * @returns {UnusedVarMessageData} The message data to be used with this unused variable.
          */
         function getAssignedMessageData(unusedVar) {
-            const additional = config.varsIgnorePattern ? `. Allowed unused vars must match ${config.varsIgnorePattern.toString()}` : "";
+            const def = unusedVar.defs && unusedVar.defs[0];
+            let patternToMatch;
+
+            if (config.destructuredArrayIgnorePattern && def.type === "Variable" && def.node.id.type === "ArrayPattern") {
+                patternToMatch = config.destructuredArrayIgnorePattern;
+            } else if (config.varsIgnorePattern) {
+                patternToMatch = config.varsIgnorePattern;
+            }
+
+            const additional = patternToMatch ? `. Allowed unused vars must match ${patternToMatch.toString()}` : "";
 
             return {
                 varName: unusedVar.name,
@@ -622,6 +638,11 @@ module.exports = {
 
                             // skip ignored variables
                             if (config.varsIgnorePattern && config.varsIgnorePattern.test(def.name.name)) {
+                                continue;
+                            }
+
+                            // https://github.com/eslint/eslint/issues/15611
+                            if (type === "Variable" && def.node.id.type === "ArrayPattern" && config.destructuredArrayIgnorePattern && config.destructuredArrayIgnorePattern.test(def.name.name)) {
                                 continue;
                             }
                         }

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -163,15 +163,13 @@ module.exports = {
          */
         function getAssignedMessageData(unusedVar) {
             const def = unusedVar.defs && unusedVar.defs[0];
-            let patternToMatch;
+            let additional = "";
 
             if (config.destructuredArrayIgnorePattern && def.name.parent.type === "ArrayPattern") {
-                patternToMatch = config.destructuredArrayIgnorePattern;
+                additional = `. Allowed unused elements of array destructuring patterns must match ${config.destructuredArrayIgnorePattern.toString()}`;
             } else if (config.varsIgnorePattern) {
-                patternToMatch = config.varsIgnorePattern;
+                additional = `. Allowed unused vars must match ${config.varsIgnorePattern.toString()}`;
             }
-
-            const additional = patternToMatch ? `. Allowed unused vars must match ${patternToMatch.toString()}` : "";
 
             return {
                 varName: unusedVar.name,

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -165,7 +165,7 @@ module.exports = {
             const def = unusedVar.defs && unusedVar.defs[0];
             let patternToMatch;
 
-            if (config.destructuredArrayIgnorePattern && def.type === "Variable" && def.node.id.type === "ArrayPattern") {
+            if (config.destructuredArrayIgnorePattern && def.type === "Variable" && def.node.id.type === "ArrayPattern" && def.name.parent.parent.type !== "ObjectPattern") {
                 patternToMatch = config.destructuredArrayIgnorePattern;
             } else if (config.varsIgnorePattern) {
                 patternToMatch = config.varsIgnorePattern;
@@ -630,6 +630,11 @@ module.exports = {
                                 continue;
                             }
 
+                            // Allow cases like - `function baz([_b, foo]) { foo}`, `function baz({x: [_b, foo]}) {foo}`
+                            if (def.name.parent.type === "ArrayPattern" && config.destructuredArrayIgnorePattern && config.destructuredArrayIgnorePattern.test(def.name.name)) {
+                                continue;
+                            }
+
                             // if "args" option is "after-used", skip used variables
                             if (config.args === "after-used" && astUtils.isFunction(def.name.parent) && !isAfterLastUsedArg(variable)) {
                                 continue;
@@ -641,9 +646,17 @@ module.exports = {
                                 continue;
                             }
 
-                            // https://github.com/eslint/eslint/issues/15611
-                            if (type === "Variable" && def.node.id.type === "ArrayPattern" && config.destructuredArrayIgnorePattern && config.destructuredArrayIgnorePattern.test(def.name.name)) {
-                                continue;
+                            if (type === "Variable" && config.destructuredArrayIgnorePattern && config.destructuredArrayIgnorePattern.test(def.name.name)) {
+
+                                // Allow - `const [a, _b, c] = arr`, Disallow - `const [{ _a, foo }] = [obj];`
+                                if (def.node.id.type === "ArrayPattern" && def.name.parent.parent.type !== "ObjectPattern") {
+                                    continue;
+                                }
+
+                                // For cases like - `var { x: [_a, foo] } = obj;`
+                                if (def.node.id.type === "ObjectPattern" && def.name.parent.type === "ArrayPattern") {
+                                    continue;
+                                }
                             }
                         }
                     }

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -598,9 +598,10 @@ module.exports = {
 
                     if (def) {
                         const type = def.type;
+                        const ref = variable.references[0];
 
-                        // skip array patterns
-                        if (def.name.parent.type === "ArrayPattern" && config.destructuredArrayIgnorePattern && config.destructuredArrayIgnorePattern.test(def.name.name)) {
+                        // skip elements of array destructuring patterns
+                        if ((def.name.parent.type === "ArrayPattern" || (ref && ref.identifier.parent.type === "ArrayPattern")) && config.destructuredArrayIgnorePattern && config.destructuredArrayIgnorePattern.test(def.name.name)) {
                             continue;
                         }
 

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -165,7 +165,7 @@ module.exports = {
             const def = unusedVar.defs && unusedVar.defs[0];
             let patternToMatch;
 
-            if (config.destructuredArrayIgnorePattern && def.type === "Variable" && def.node.id.type === "ArrayPattern" && def.name.parent.parent.type !== "ObjectPattern") {
+            if (config.destructuredArrayIgnorePattern && def.name.parent.type === "ArrayPattern") {
                 patternToMatch = config.destructuredArrayIgnorePattern;
             } else if (config.varsIgnorePattern) {
                 patternToMatch = config.varsIgnorePattern;
@@ -601,6 +601,11 @@ module.exports = {
                     if (def) {
                         const type = def.type;
 
+                        // skip array patterns
+                        if (def.name.parent.type === "ArrayPattern" && config.destructuredArrayIgnorePattern && config.destructuredArrayIgnorePattern.test(def.name.name)) {
+                            continue;
+                        }
+
                         // skip catch variables
                         if (type === "CatchClause") {
                             if (config.caughtErrors === "none") {
@@ -630,11 +635,6 @@ module.exports = {
                                 continue;
                             }
 
-                            // Allow cases like - `function baz([_b, foo]) { foo}`, `function baz({x: [_b, foo]}) {foo}`
-                            if (def.name.parent.type === "ArrayPattern" && config.destructuredArrayIgnorePattern && config.destructuredArrayIgnorePattern.test(def.name.name)) {
-                                continue;
-                            }
-
                             // if "args" option is "after-used", skip used variables
                             if (config.args === "after-used" && astUtils.isFunction(def.name.parent) && !isAfterLastUsedArg(variable)) {
                                 continue;
@@ -644,19 +644,6 @@ module.exports = {
                             // skip ignored variables
                             if (config.varsIgnorePattern && config.varsIgnorePattern.test(def.name.name)) {
                                 continue;
-                            }
-
-                            if (type === "Variable" && config.destructuredArrayIgnorePattern && config.destructuredArrayIgnorePattern.test(def.name.name)) {
-
-                                // Allow - `const [a, _b, c] = arr`, Disallow - `const [{ _a, foo }] = [obj];`
-                                if (def.node.id.type === "ArrayPattern" && def.name.parent.parent.type !== "ObjectPattern") {
-                                    continue;
-                                }
-
-                                // For cases like - `var { x: [_a, foo] } = obj;`
-                                if (def.node.id.type === "ObjectPattern" && def.name.parent.type === "ArrayPattern") {
-                                    continue;
-                                }
                             }
                         }
                     }

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -162,10 +162,10 @@ module.exports = {
          * @returns {UnusedVarMessageData} The message data to be used with this unused variable.
          */
         function getAssignedMessageData(unusedVar) {
-            const def = unusedVar.defs && unusedVar.defs[0];
+            const def = unusedVar.defs[0];
             let additional = "";
 
-            if (config.destructuredArrayIgnorePattern && def.name.parent.type === "ArrayPattern") {
+            if (config.destructuredArrayIgnorePattern && def && def.name.parent.type === "ArrayPattern") {
                 additional = `. Allowed unused elements of array destructuring patterns must match ${config.destructuredArrayIgnorePattern.toString()}`;
             } else if (config.varsIgnorePattern) {
                 additional = `. Allowed unused vars must match ${config.varsIgnorePattern.toString()}`;
@@ -598,7 +598,7 @@ module.exports = {
 
                     if (def) {
                         const type = def.type;
-                        const refUsedInArrayPatterns = variable.references && variable.references.some(ref => ref.identifier.parent.type === "ArrayPattern");
+                        const refUsedInArrayPatterns = variable.references.some(ref => ref.identifier.parent.type === "ArrayPattern");
 
                         // skip elements of array destructuring patterns
                         if (

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -598,13 +598,13 @@ module.exports = {
 
                     if (def) {
                         const type = def.type;
-                        const ref = variable.references[0];
+                        const refUsedInArrayPatterns = variable.references && variable.references.some(ref => ref.identifier.parent.type === "ArrayPattern");
 
                         // skip elements of array destructuring patterns
                         if (
                             (
                                 def.name.parent.type === "ArrayPattern" ||
-                                (ref && ref.identifier.parent.type === "ArrayPattern")
+                                refUsedInArrayPatterns
                             ) &&
                             config.destructuredArrayIgnorePattern &&
                             config.destructuredArrayIgnorePattern.test(def.name.name)

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -601,7 +601,14 @@ module.exports = {
                         const ref = variable.references[0];
 
                         // skip elements of array destructuring patterns
-                        if ((def.name.parent.type === "ArrayPattern" || (ref && ref.identifier.parent.type === "ArrayPattern")) && config.destructuredArrayIgnorePattern && config.destructuredArrayIgnorePattern.test(def.name.name)) {
+                        if (
+                            (
+                                def.name.parent.type === "ArrayPattern" ||
+                                (ref && ref.identifier.parent.type === "ArrayPattern")
+                            ) &&
+                            config.destructuredArrayIgnorePattern &&
+                            config.destructuredArrayIgnorePattern.test(def.name.name)
+                        ) {
                             continue;
                         }
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -203,6 +203,40 @@ ruleTester.run("no-unused-vars", rule, {
             options: [{ destructuredArrayIgnorePattern: "^_" }],
             parserOptions: { ecmaVersion: 6 }
         },
+        {
+            code: `
+            // doesn't report _x
+            let _x, y;
+            _x = 1;
+            [_x, y] = foo;
+            y;
+
+            // doesn't report _a
+            let _a, b;
+            [_a, b] = foo;
+            _a = 1;
+            b;
+            `,
+            options: [{ destructuredArrayIgnorePattern: "^_" }],
+            parserOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: `
+            // doesn't report _x
+            let _x, y;
+            _x = 1;
+            [_x, y] = foo;
+            y;
+
+            // doesn't report _a
+            let _a, b;
+            _a = 1;
+            ({_a, ...b } = foo);
+            b;
+            `,
+            options: [{ destructuredArrayIgnorePattern: "^_", ignoreRestSiblings: true }],
+            parserOptions: { ecmaVersion: 2018 }
+        },
 
         // for-in loops (see #2342)
         "(function(obj) { var name; for ( name in obj ) return; })({});",

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -165,6 +165,8 @@ ruleTester.run("no-unused-vars", rule, {
         { code: "const [ a, _b, c ] = items;\nconsole.log(a+c);", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
         { code: "const { x: [_a, foo] } = bar;\nconsole.log(foo);", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
         { code: "function baz([_b, foo]) { foo; };\nbaz()", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function baz({x: [_b, foo]}) {foo};\nbaz()", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function baz([{x: [_b, foo]}]) {foo};\nbaz()", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
 
         // for-in loops (see #2342)
         "(function(obj) { var name; for ( name in obj ) return; })({});",
@@ -547,6 +549,23 @@ ruleTester.run("no-unused-vars", rule, {
                     ...assignedError("_a"),
                     line: 3,
                     column: 21
+                }
+            ]
+        },
+        {
+            code: `
+            function foo([{_a, bar}]) {
+                bar;
+            }
+            foo();
+            `,
+            options: [{ destructuredArrayIgnorePattern: "^_" }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [
+                {
+                    ...definedError("_a"),
+                    line: 2,
+                    column: 28
                 }
             ]
         },

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -162,12 +162,47 @@ ruleTester.run("no-unused-vars", rule, {
         { code: "function foo(_a) { } foo();", options: [{ args: "all", argsIgnorePattern: "^_" }] },
         { code: "function foo(a, _b) { return a; } foo();", options: [{ args: "after-used", argsIgnorePattern: "^_" }] },
         { code: "var [ firstItemIgnored, secondItem ] = items;\nconsole.log(secondItem);", options: [{ vars: "all", varsIgnorePattern: "[iI]gnored" }], parserOptions: { ecmaVersion: 6 } },
-        { code: "const [ a, _b, c ] = items;\nconsole.log(a+c);", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
-        { code: "const [ [a, _b, c] ] = items;\nconsole.log(a+c);", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
-        { code: "const { x: [_a, foo] } = bar;\nconsole.log(foo);", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
-        { code: "function baz([_b, foo]) { foo; };\nbaz()", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
-        { code: "function baz({x: [_b, foo]}) {foo};\nbaz()", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
-        { code: "function baz([{x: [_b, foo]}]) {foo};\nbaz()", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
+        {
+            code: "const [ a, _b, c ] = items;\nconsole.log(a+c);",
+            options: [{ destructuredArrayIgnorePattern: "^_" }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "const [ [a, _b, c] ] = items;\nconsole.log(a+c);",
+            options: [{ destructuredArrayIgnorePattern: "^_" }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "const { x: [_a, foo] } = bar;\nconsole.log(foo);",
+            options: [{ destructuredArrayIgnorePattern: "^_" }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function baz([_b, foo]) { foo; };\nbaz()",
+            options: [{ destructuredArrayIgnorePattern: "^_" }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function baz({x: [_b, foo]}) {foo};\nbaz()",
+            options: [{ destructuredArrayIgnorePattern: "^_" }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function baz([{x: [_b, foo]}]) {foo};\nbaz()",
+            options: [{ destructuredArrayIgnorePattern: "^_" }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: `
+            let _a, b;
+            foo.forEach(item => {
+                [_a, b] = item;
+                doSomething(b);
+            });
+            `,
+            options: [{ destructuredArrayIgnorePattern: "^_" }],
+            parserOptions: { ecmaVersion: 6 }
+        },
 
         // for-in loops (see #2342)
         "(function(obj) { var name; for ( name in obj ) return; })({});",
@@ -567,6 +602,29 @@ ruleTester.run("no-unused-vars", rule, {
                     ...definedError("_a"),
                     line: 2,
                     column: 28
+                }
+            ]
+        },
+        {
+            code: `
+            let _a, b;
+
+            foo.forEach(item => {
+                [a, b] = item;
+            });
+            `,
+            options: [{ destructuredArrayIgnorePattern: "^_" }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [
+                {
+                    ...definedError("_a"),
+                    line: 2,
+                    column: 17
+                },
+                {
+                    ...assignedError("b"),
+                    line: 2,
+                    column: 21
                 }
             ]
         },

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -162,9 +162,9 @@ ruleTester.run("no-unused-vars", rule, {
         { code: "function foo(_a) { } foo();", options: [{ args: "all", argsIgnorePattern: "^_" }] },
         { code: "function foo(a, _b) { return a; } foo();", options: [{ args: "after-used", argsIgnorePattern: "^_" }] },
         { code: "var [ firstItemIgnored, secondItem ] = items;\nconsole.log(secondItem);", options: [{ vars: "all", varsIgnorePattern: "[iI]gnored" }], parserOptions: { ecmaVersion: 6 } },
-
-        // https://github.com/eslint/eslint/issues/15611
         { code: "const [ a, _b, c ] = items;\nconsole.log(a+c);", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
+        { code: "const { x: [_a, foo] } = bar;\nconsole.log(foo);", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function baz([_b, foo]) { foo; };\nbaz()", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
 
         // for-in loops (see #2342)
         "(function(obj) { var name; for ( name in obj ) return; })({});",
@@ -531,6 +531,22 @@ ruleTester.run("no-unused-vars", rule, {
                     ...assignedError("barArray", ". Allowed unused vars must match /ignore/u"),
                     line: 5,
                     column: 19
+                }
+            ]
+        },
+        {
+            code: `
+            const array = [obj];
+            const [{_a, foo}] = array;
+            console.log(foo);
+            `,
+            options: [{ destructuredArrayIgnorePattern: "^_" }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [
+                {
+                    ...assignedError("_a"),
+                    line: 3,
+                    column: 21
                 }
             ]
         },

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -164,7 +164,7 @@ ruleTester.run("no-unused-vars", rule, {
         { code: "var [ firstItemIgnored, secondItem ] = items;\nconsole.log(secondItem);", options: [{ vars: "all", varsIgnorePattern: "[iI]gnored" }], parserOptions: { ecmaVersion: 6 } },
 
         // https://github.com/eslint/eslint/issues/15611
-        { code: "const [ _b ] = items;", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
+        { code: "const [ a, _b, c ] = items;\nconsole.log(a+c);", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
 
         // for-in loops (see #2342)
         "(function(obj) { var name; for ( name in obj ) return; })({});",

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -493,12 +493,12 @@ ruleTester.run("no-unused-vars", rule, {
             parserOptions: { ecmaVersion: 2020 },
             errors: [
                 {
-                    ...assignedError("a", ". Allowed unused vars must match /^_/u"),
+                    ...assignedError("a", ". Allowed unused elements of array destructuring patterns must match /^_/u"),
                     line: 3,
                     column: 20
                 },
                 {
-                    ...assignedError("c", ". Allowed unused vars must match /^_/u"),
+                    ...assignedError("c", ". Allowed unused elements of array destructuring patterns must match /^_/u"),
                     line: 3,
                     column: 27
                 }
@@ -516,12 +516,12 @@ ruleTester.run("no-unused-vars", rule, {
             parserOptions: { ecmaVersion: 2020 },
             errors: [
                 {
-                    ...assignedError("a", ". Allowed unused vars must match /^_/u"),
+                    ...assignedError("a", ". Allowed unused elements of array destructuring patterns must match /^_/u"),
                     line: 3,
                     column: 20
                 },
                 {
-                    ...assignedError("c", ". Allowed unused vars must match /^_/u"),
+                    ...assignedError("c", ". Allowed unused elements of array destructuring patterns must match /^_/u"),
                     line: 3,
                     column: 27
                 },

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -163,6 +163,7 @@ ruleTester.run("no-unused-vars", rule, {
         { code: "function foo(a, _b) { return a; } foo();", options: [{ args: "after-used", argsIgnorePattern: "^_" }] },
         { code: "var [ firstItemIgnored, secondItem ] = items;\nconsole.log(secondItem);", options: [{ vars: "all", varsIgnorePattern: "[iI]gnored" }], parserOptions: { ecmaVersion: 6 } },
         { code: "const [ a, _b, c ] = items;\nconsole.log(a+c);", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
+        { code: "const [ [a, _b, c] ] = items;\nconsole.log(a+c);", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
         { code: "const { x: [_a, foo] } = bar;\nconsole.log(foo);", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
         { code: "function baz([_b, foo]) { foo; };\nbaz()", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },
         { code: "function baz({x: [_b, foo]}) {foo};\nbaz()", options: [{ destructuredArrayIgnorePattern: "^_" }], parserOptions: { ecmaVersion: 6 } },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fix https://github.com/eslint/eslint/issues/15611

Added a new option `destructuredArrayIgnorePattern` to the `no-unused-vars` rule.

```js
// With the following option set within eslintrc rules
// "no-unused-vars": ["error", { "destructuredArrayIgnorePattern": "^_" }],

const array = ['a', 'b', 'c'];

const [a, _b, c] = array;  // No "no-unused-vars" error on _b

const newArray = [a, c];

```


#### Is there anything you'd like reviewers to focus on?

No
<!-- markdownlint-disable-file MD004 -->
