### PR TITLE
fix: escaping for square brackets in ignore patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "homepage": "https://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
-    "@eslint/eslintrc": "github:eslint/eslintrc#chore/update-ignore",
+    "@eslint/eslintrc": "github:eslint/eslintrc",
     "@humanwhocodes/config-array": "^0.9.2",
     "ajv": "^6.10.0",
     "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "homepage": "https://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
-    "@eslint/eslintrc": "github:eslint/eslintrc",
+    "@eslint/eslintrc": "^1.2.1",
     "@humanwhocodes/config-array": "^0.9.2",
     "ajv": "^6.10.0",
     "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "homepage": "https://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
-    "@eslint/eslintrc": "^1.2.0",
+    "@eslint/eslintrc": "github:eslint/eslintrc#chore/update-ignore",
     "@humanwhocodes/config-array": "^0.9.2",
     "ajv": "^6.10.0",
     "chalk": "^4.0.0",

--- a/tests/fixtures/ignored-paths/.eslintIgnoreWithEscapedBrackets
+++ b/tests/fixtures/ignored-paths/.eslintIgnoreWithEscapedBrackets
@@ -1,0 +1,3 @@
+brackets/\[index.js
+brackets/index\].js
+brackets/\[index\].js

--- a/tests/fixtures/ignored-paths/.eslintIgnoreWithEscapedBrackets
+++ b/tests/fixtures/ignored-paths/.eslintIgnoreWithEscapedBrackets
@@ -1,3 +1,0 @@
-brackets/\[index.js
-brackets/index\].js
-brackets/\[index\].js

--- a/tests/fixtures/ignored-paths/.eslintignoreWithEscapedBrackets
+++ b/tests/fixtures/ignored-paths/.eslintignoreWithEscapedBrackets
@@ -1,0 +1,3 @@
+brackets/\[index.js
+brackets/index\].js
+brackets/\[index\].js

--- a/tests/fixtures/ignored-paths/brackets/[index.js
+++ b/tests/fixtures/ignored-paths/brackets/[index.js
@@ -1,0 +1,1 @@
+/* content is not necessary */

--- a/tests/fixtures/ignored-paths/brackets/[index].js
+++ b/tests/fixtures/ignored-paths/brackets/[index].js
@@ -1,0 +1,1 @@
+/* content is not necessary */

--- a/tests/fixtures/ignored-paths/brackets/index.js
+++ b/tests/fixtures/ignored-paths/brackets/index.js
@@ -1,0 +1,1 @@
+/* content is not necessary */

--- a/tests/fixtures/ignored-paths/brackets/index].js
+++ b/tests/fixtures/ignored-paths/brackets/index].js
@@ -1,0 +1,1 @@
+/* content is not necessary */


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #15642 by updating `@eslint/eslintrc` dependency, which in turn updates its `ignore` dependency to v5.2.0.

The root cause of the problem is a bug in ignore v4.0.6. The bug has been fixed in [v5.1.5](https://github.com/kaelzhang/node-ignore/releases/tag/5.1.5).

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated package.json with the new version of `@eslint/eslintrc` and added a representative test that fails with @eslint/eslintrc v1.2.0 / ignore v4.0.6.

#### Is there anything you'd like reviewers to focus on?

Marked as a draft because it's currently using `@eslint/eslintrc` from a branch.

<!-- markdownlint-disable-file MD004 -->
