### PR TITLE
fix: extend the autofix range in comma-dangle to ensure the last element

### DIFF
--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -243,8 +243,18 @@ module.exports = {
                     node: lastItem,
                     loc: trailingToken.loc,
                     messageId: "unexpected",
-                    fix(fixer) {
-                        return fixer.remove(trailingToken);
+                    *fix(fixer) {
+                        yield fixer.remove(trailingToken);
+
+                        /*
+                         * Extend the range of the fix to include surrounding tokens to ensure
+                         * that the element after which the comma is removed stays _last_.
+                         * This intentionally makes conflicts in fix ranges with rules that may be
+                         * adding or removing elements in the same autofix pass.
+                         * https://github.com/eslint/eslint/issues/15660
+                         */
+                        yield fixer.insertTextBefore(sourceCode.getTokenBefore(trailingToken), "");
+                        yield fixer.insertTextAfter(sourceCode.getTokenAfter(trailingToken), "");
                     }
                 });
             }
@@ -282,8 +292,18 @@ module.exports = {
                         end: astUtils.getNextLocation(sourceCode, trailingToken.loc.end)
                     },
                     messageId: "missing",
-                    fix(fixer) {
-                        return fixer.insertTextAfter(trailingToken, ",");
+                    *fix(fixer) {
+                        yield fixer.insertTextAfter(trailingToken, ",");
+
+                        /*
+                         * Extend the range of the fix to include surrounding tokens to ensure
+                         * that the element after which the comma is inserted stays _last_.
+                         * This intentionally makes conflicts in fix ranges with rules that may be
+                         * adding or removing elements in the same autofix pass.
+                         * https://github.com/eslint/eslint/issues/15660
+                         */
+                        yield fixer.insertTextBefore(trailingToken, "");
+                        yield fixer.insertTextAfter(sourceCode.getTokenAfter(trailingToken), "");
                     }
                 });
             }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #15660

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Extended the fix range in the `comma-dangle` rule to ensure that the element after which the comma is added/removed stays the last element after that autofix pass.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
