### PR TITLE
chore: Error: strict mode: "additionalItems" is ignored when "items" is not an array of schemas

### DIFF
--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -450,8 +450,7 @@ module.exports = {
                             type: "array",
                             items: { enum: Object.keys(StatementTypes) },
                             minItems: 1,
-                            uniqueItems: true,
-                            additionalItems: false
+                            uniqueItems: true
                         }
                     ]
                 }
@@ -466,8 +465,7 @@ module.exports = {
                 },
                 additionalProperties: false,
                 required: ["blankLine", "prev", "next"]
-            },
-            additionalItems: false
+            }
         },
 
         messages: {


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment:**

* **ESLint Version:** 8.11.0
* **Node Version:** 16.13.2
* **ajv version:** 8.10.0

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

If you run AJV in strict mode, you will get error:

```
Error: strict mode: "additionalItems" is ignored when "items" is not an array of schemas
```

see https://github.com/ajv-validator/ajv/blob/master/docs/json-schema.md



**Note:** Many another rule schemas are not 100% valid in strict mode. This is just one of them.