### PR TITLE
chore: remove `lib/init` from eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,6 @@ const path = require("path");
 
 const INTERNAL_FILES = {
     CLI_ENGINE_PATTERN: "lib/cli-engine/**/*",
-    INIT_PATTERN: "lib/init/**/*",
     LINTER_PATTERN: "lib/linter/**/*",
     RULE_TESTER_PATTERN: "lib/rule-tester/**/*",
     RULES_PATTERN: "lib/rules/**/*",
@@ -114,17 +113,7 @@ module.exports = {
             files: [INTERNAL_FILES.CLI_ENGINE_PATTERN],
             rules: {
                 "node/no-restricted-require": ["error", [
-                    ...createInternalFilesPatterns(INTERNAL_FILES.CLI_ENGINE_PATTERN),
-                    resolveAbsolutePath("lib/init/index.js")
-                ]]
-            }
-        },
-        {
-            files: [INTERNAL_FILES.INIT_PATTERN],
-            rules: {
-                "node/no-restricted-require": ["error", [
-                    ...createInternalFilesPatterns(INTERNAL_FILES.INIT_PATTERN),
-                    resolveAbsolutePath("lib/rule-tester/index.js")
+                    ...createInternalFilesPatterns(INTERNAL_FILES.CLI_ENGINE_PATTERN)
                 ]]
             }
         },
@@ -135,7 +124,6 @@ module.exports = {
                     ...createInternalFilesPatterns(INTERNAL_FILES.LINTER_PATTERN),
                     "fs",
                     resolveAbsolutePath("lib/cli-engine/index.js"),
-                    resolveAbsolutePath("lib/init/index.js"),
                     resolveAbsolutePath("lib/rule-tester/index.js")
                 ]]
             }
@@ -147,7 +135,6 @@ module.exports = {
                     ...createInternalFilesPatterns(INTERNAL_FILES.RULES_PATTERN),
                     "fs",
                     resolveAbsolutePath("lib/cli-engine/index.js"),
-                    resolveAbsolutePath("lib/init/index.js"),
                     resolveAbsolutePath("lib/linter/index.js"),
                     resolveAbsolutePath("lib/rule-tester/index.js"),
                     resolveAbsolutePath("lib/source-code/index.js")
@@ -160,7 +147,6 @@ module.exports = {
                 "node/no-restricted-require": ["error", [
                     ...createInternalFilesPatterns(),
                     resolveAbsolutePath("lib/cli-engine/index.js"),
-                    resolveAbsolutePath("lib/init/index.js"),
                     resolveAbsolutePath("lib/linter/index.js"),
                     resolveAbsolutePath("lib/rule-tester/index.js"),
                     resolveAbsolutePath("lib/source-code/index.js")
@@ -174,7 +160,6 @@ module.exports = {
                     ...createInternalFilesPatterns(INTERNAL_FILES.SOURCE_CODE_PATTERN),
                     "fs",
                     resolveAbsolutePath("lib/cli-engine/index.js"),
-                    resolveAbsolutePath("lib/init/index.js"),
                     resolveAbsolutePath("lib/linter/index.js"),
                     resolveAbsolutePath("lib/rule-tester/index.js"),
                     resolveAbsolutePath("lib/rules/index.js")
@@ -186,8 +171,7 @@ module.exports = {
             rules: {
                 "node/no-restricted-require": ["error", [
                     ...createInternalFilesPatterns(INTERNAL_FILES.RULE_TESTER_PATTERN),
-                    resolveAbsolutePath("lib/cli-engine/index.js"),
-                    resolveAbsolutePath("lib/init/index.js")
+                    resolveAbsolutePath("lib/cli-engine/index.js")
                 ]]
             }
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Removes configurations related to `lib/init` from our `.eslintrc.js` config file. We removed `lib/init` in https://github.com/eslint/eslint/pull/15150, so that directory doesn't exist anymore and these configurations are unnecessary.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `.eslintrc.js`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
