### PR TITLE
Fixed typo in code comment

### DIFF
--- a/docs/src/rules/no-constant-binary-expression.md
+++ b/docs/src/rules/no-constant-binary-expression.md
@@ -12,7 +12,7 @@ Comparisons which will always evaluate to true or false and logical expressions 
 These errors are especially common in complex expressions where operator precedence is easy to misjudge. For example:
 
 ```js
-// One might think this would evaluate as `x + (b ?? c)`:
+// One might think this would evaluate as `a + (b ?? c)`:
 const x = a + b ?? c;
 
 // But it actually evaluates as `(a + b) ?? c`. Since `a + b` can never be null,


### PR DESCRIPTION
#### Prerequisites checklist

[X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update

The doco had a typo, and said `x` instead of `a` in a code comment.