### PR TITLE
fix: Processor blocks respect ignores

### DIFF
--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -217,6 +217,7 @@ function calculateStatsPerRun(results) {
  * @param {boolean} config.allowInlineConfig If `true` then it uses directive comments.
  * @param {boolean} config.reportUnusedDisableDirectives If `true` then it reports unused `eslint-disable` comments.
  * @param {FileEnumerator} config.fileEnumerator The file enumerator to check if a path is a target or not.
+ * @param {(filePath: string) => boolean} config.isPathIgnored Predicate to check if a path is ignored by the config.
  * @param {Linter} config.linter The linter instance to verify.
  * @returns {LintResult} The result of linting.
  * @private
@@ -230,6 +231,7 @@ function verifyText({
     allowInlineConfig,
     reportUnusedDisableDirectives,
     fileEnumerator,
+    isPathIgnored,
     linter
 }) {
     const filePath = providedFilePath || "<text>";
@@ -257,7 +259,7 @@ function verifyText({
              * @returns {boolean} `true` if the linter should adopt the code block.
              */
             filterCodeBlock(blockFilename) {
-                return fileEnumerator.isTargetPath(blockFilename);
+                return fileEnumerator.isTargetPath(blockFilename) && !isPathIgnored(blockFilename);
             }
         }
     );
@@ -831,6 +833,7 @@ class CLIEngine {
                 allowInlineConfig,
                 reportUnusedDisableDirectives,
                 fileEnumerator,
+                isPathIgnored: this.isPathIgnored.bind(this),
                 linter
             });
 
@@ -925,6 +928,7 @@ class CLIEngine {
                 allowInlineConfig,
                 reportUnusedDisableDirectives,
                 fileEnumerator,
+                isPathIgnored: this.isPathIgnored.bind(this),
                 linter
             }));
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

eslint/eslint-plugin-markdown#201 demonstrated that, for example, a .js processor block would be linted even if .js files or blocks were ignored.

This happened because the `filterCodeBlock` predicate was early returning if the block's extension matched without ever checking the block's path against the ignores.

This fixes the issue by checking `CLIEngine#isPathIgnored()` in the `filterCodeBlock` predicate.

#### Is there anything you'd like reviewers to focus on?

1. Does everyone agree that processor blocks circumventing ignores is a bug?
2. Is this a reasonable implementation? `CLIEngine` passing its `isPathIgnored` method to the `verifyText` helper increases coupling between the two.

<!-- markdownlint-disable-file MD004 -->
