### PR TITLE
fix: function-paren-newline crash on "new new Foo();"

### DIFF
--- a/lib/rules/function-paren-newline.js
+++ b/lib/rules/function-paren-newline.js
@@ -191,10 +191,11 @@ module.exports = {
         function getParenTokens(node) {
             switch (node.type) {
                 case "NewExpression":
-                    if (!node.arguments.length && !(
-                        astUtils.isOpeningParenToken(sourceCode.getLastToken(node, { skip: 1 })) &&
+                    if (node.callee.type === "NewExpression" ||
+                        !node.arguments.length && !(
+                            astUtils.isOpeningParenToken(sourceCode.getLastToken(node, { skip: 1 })) &&
                         astUtils.isClosingParenToken(sourceCode.getLastToken(node))
-                    )) {
+                        )) {
 
                         // If the NewExpression does not have parens (e.g. `new Foo`), return null.
                         return null;

--- a/lib/rules/function-paren-newline.js
+++ b/lib/rules/function-paren-newline.js
@@ -191,11 +191,13 @@ module.exports = {
         function getParenTokens(node) {
             switch (node.type) {
                 case "NewExpression":
-                    if (node.callee.type === "NewExpression" ||
-                        !node.arguments.length && !(
+                    if (!node.arguments.length &&
+                        !(
                             astUtils.isOpeningParenToken(sourceCode.getLastToken(node, { skip: 1 })) &&
-                        astUtils.isClosingParenToken(sourceCode.getLastToken(node))
-                        )) {
+                            astUtils.isClosingParenToken(sourceCode.getLastToken(node)) &&
+                            node.callee.range[1] < node.range[1]
+                        )
+                    ) {
 
                         // If the NewExpression does not have parens (e.g. `new Foo`), return null.
                         return null;

--- a/tests/lib/rules/function-paren-newline.js
+++ b/tests/lib/rules/function-paren-newline.js
@@ -1177,6 +1177,18 @@ ruleTester.run("function-paren-newline", rule, {
         },
         {
             code: `
+                new new C()(
+                );
+            `,
+            output: `
+                new new C()();
+            `,
+            options: ["never"],
+            errors: [LEFT_UNEXPECTED_ERROR, RIGHT_UNEXPECTED_ERROR]
+        },
+
+        {
+            code: `
                 function baz(
                     foo,
                     bar

--- a/tests/lib/rules/function-paren-newline.js
+++ b/tests/lib/rules/function-paren-newline.js
@@ -30,6 +30,7 @@ const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 ruleTester.run("function-paren-newline", rule, {
 
     valid: [
+        "new new Foo();",
 
         // multiline option (default)
         "function baz(foo, bar) {}",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`function-paren-newline` crashes when see the code like this:

```js
new new Boolean();
```

This code has no sense, but this is correct JavaScript:

<img width="446" alt="image" src="https://user-images.githubusercontent.com/1573141/167269417-436fc394-6456-4b0b-a773-264f1f24a034.png">

It throws [TypeError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) when trying to execute first `new` after second one returns instance of an object.

```sh
coderaiser@cloudcmd:~/putout/packages/plugin-remove-useless-new$ eslint new-new.js

Oops! Something went wrong! :(

ESLint: 8.15.0

TypeError: Cannot read properties of null (reading 'range')
Occurred while linting /Users/coderaiser/putout/packages/plugin-remove-useless-new/new-new.js:1
Rule: "function-paren-newline"
    at SourceCode.getTokenAfter (/Users/coderaiser/putout/node_modules/eslint/lib/source-code/token-store/index.js:315:18)
    at validateParens (/Users/coderaiser/putout/node_modules/eslint/lib/rules/function-paren-newline.js:109:52)
    at ArrowFunctionExpression,CallExpression,FunctionDeclaration,FunctionExpression,ImportExpression,NewExpression (/Users/coderaiser/putout/node_modules/eslint/lib/rules/function-paren-newline.js:277:21)
    at ruleErrorHandler (/Users/coderaiser/putout/node_modules/eslint/lib/linter/linter.js:1114:28)
    at /Users/coderaiser/putout/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/coderaiser/putout/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/Users/coderaiser/putout/node_modules/eslint/lib/linter/node-event-generator.js:297:26)
    at NodeEventGenerator.applySelectors (/Users/coderaiser/putout/node_modules/eslint/lib/linter/node-event-generator.js:326:22)
    at NodeEventGenerator.enterNode (/Users/coderaiser/putout/node_modules/eslint/lib/linter/node-event-generator.js:340:14)
coderaiser@cloudcmd:~/putout/packages/plugin-remove-useless-new$ cat new-new.js
new new Boolean();
```


#### Is there anything you'd like reviewers to focus on?

The problem occurs on `AwaitExpression` switch case when we fall through to `CallExpression` case 
https://github.com/eslint/eslint/blob/9b17d6fac6983d2fed4cd005acba17be0a183970/lib/rules/function-paren-newline.js#L192-L209

<!-- markdownlint-disable-file MD004 -->
