### PR TITLE
feat: check Unicode code point escapes in no-control-regex

### DIFF
--- a/docs/src/rules/no-control-regex.md
+++ b/docs/src/rules/no-control-regex.md
@@ -19,6 +19,7 @@ The following elements of regular expression patterns are considered possible er
 
 * Hexadecimal character escapes from `\x00` to `\x1F`.
 * Unicode character escapes from `\u0000` to `\u001F`.
+* Unicode code point escapes from `\u{0}` to `\u{1F}`.
 * Unescaped raw characters from U+0000 to U+001F.
 
 Control escapes such as `\t` and `\n` are allowed by this rule.
@@ -32,8 +33,9 @@ var pattern1 = /\x00/;
 var pattern2 = /\x0C/;
 var pattern3 = /\x1F/;
 var pattern4 = /\u000C/;
-var pattern5 = new RegExp("\x0C"); // raw U+000C character in the pattern
-var pattern6 = new RegExp("\\x0C"); // \x0C pattern
+var pattern5 = /\u{C}/u;
+var pattern6 = new RegExp("\x0C"); // raw U+000C character in the pattern
+var pattern7 = new RegExp("\\x0C"); // \x0C pattern
 ```
 
 Examples of **correct** code for this rule:
@@ -43,11 +45,12 @@ Examples of **correct** code for this rule:
 
 var pattern1 = /\x20/;
 var pattern2 = /\u0020/;
-var pattern3 = /\t/;
-var pattern4 = /\n/;
-var pattern5 = new RegExp("\x20");
-var pattern6 = new RegExp("\\t");
-var pattern7 = new RegExp("\\n");
+var pattern3 = /\u{20}/u;
+var pattern4 = /\t/;
+var pattern5 = /\n/;
+var pattern6 = new RegExp("\x20");
+var pattern7 = new RegExp("\\t");
+var pattern8 = new RegExp("\\n");
 ```
 
 ## Known Limitations

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -30,10 +30,12 @@ const collector = new (class {
         }
     }
 
-    collectControlChars(regexpStr) {
+    collectControlChars(regexpStr, flags) {
+        const uFlag = typeof flags === "string" && flags.includes("u");
+
         try {
             this._source = regexpStr;
-            this._validator.validatePattern(regexpStr); // Call onCharacter hook
+            this._validator.validatePattern(regexpStr, void 0, void 0, uFlag); // Call onCharacter hook
         } catch {
 
             // Ignore syntax errors in RegExp.
@@ -68,13 +70,15 @@ module.exports = {
 
         /**
          * Get the regex expression
-         * @param {ASTNode} node node to evaluate
-         * @returns {RegExp|null} Regex if found else null
+         * @param {ASTNode} node `Literal` node to evaluate
+         * @returns {{ pattern: string, flags: string | null } | null} Regex if found (the given node is either a regex literal
+         * or a string literal that is the pattern argument of a RegExp constructor call). Otherwise `null`. If flags cannot be determined,
+         * the `flags` property will be `null`.
          * @private
          */
-        function getRegExpPattern(node) {
+        function getRegExp(node) {
             if (node.regex) {
-                return node.regex.pattern;
+                return node.regex;
             }
             if (typeof node.value === "string" &&
                 (node.parent.type === "NewExpression" || node.parent.type === "CallExpression") &&
@@ -82,7 +86,15 @@ module.exports = {
                 node.parent.callee.name === "RegExp" &&
                 node.parent.arguments[0] === node
             ) {
-                return node.value;
+                const pattern = node.value;
+                const flags =
+                    node.parent.arguments.length > 1 &&
+                    node.parent.arguments[1].type === "Literal" &&
+                    typeof node.parent.arguments[1].value === "string"
+                        ? node.parent.arguments[1].value
+                        : null;
+
+                return { pattern, flags };
             }
 
             return null;
@@ -90,10 +102,11 @@ module.exports = {
 
         return {
             Literal(node) {
-                const pattern = getRegExpPattern(node);
+                const regExp = getRegExp(node);
 
-                if (pattern) {
-                    const controlCharacters = collector.collectControlChars(pattern);
+                if (regExp) {
+                    const { pattern, flags } = regExp;
+                    const controlCharacters = collector.collectControlChars(pattern, flags);
 
                     if (controlCharacters.length > 0) {
                         context.report({

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -26,7 +26,14 @@ ruleTester.run("no-control-regex", rule, {
         "var regex = RegExp('x1f')",
         "new RegExp('[')",
         "RegExp('[')",
-        "new (function foo(){})('\\x1f')"
+        "new (function foo(){})('\\x1f')",
+        { code: String.raw`/\u{20}/u`, parserOptions: { ecmaVersion: 2015 } },
+        String.raw`/\u{1F}/`,
+        String.raw`/\u{1F}/g`,
+        String.raw`new RegExp("\\u{20}", "u")`,
+        String.raw`new RegExp("\\u{1F}")`,
+        String.raw`new RegExp("\\u{1F}", "g")`,
+        String.raw`new RegExp("\\u{1F}", flags)` // when flags are unknown, this rule assumes there's no `u` flag
     ],
     invalid: [
         { code: String.raw`var regex = /\x1f/`, errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }] },
@@ -45,6 +52,38 @@ ruleTester.run("no-control-regex", rule, {
         {
             code: String.raw`var regex = /(?<\u{1d49c}>.)\x1f/`,
             parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
+        },
+        {
+            code: String.raw`new RegExp("\\u001F", flags)`,
+            errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
+        },
+        {
+            code: String.raw`/\u{1111}*\x1F/u`,
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
+        },
+        {
+            code: String.raw`new RegExp("\\u{1111}*\\x1F", "u")`,
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
+        },
+        {
+            code: String.raw`/\u{1F}/u`,
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
+        },
+        {
+            code: String.raw`/\u{1F}/gui`,
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
+        },
+        {
+            code: String.raw`new RegExp("\\u{1F}", "u")`,
+            errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
+        },
+        {
+            code: String.raw`new RegExp("\\u{1F}", "gui")`,
             errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #15809

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the `no-control-regex` rule to pass the `u` flag to the `regexpp` validator when the regex has the `u` flag. As a consequence, the rule will now:

* Report Unicode code point escapes, such as `/\u{C}/u`.
* Report errors in regular expressions that were not parsable without the `u` flag, such as `/\u{1111}*\x1F/u`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
