### PR TITLE
Handle long pattern that throws ENAMETOOLONG.

### DIFF
--- a/lib/cli-engine/file-enumerator.js
+++ b/lib/cli-engine/file-enumerator.js
@@ -123,7 +123,7 @@ function statSafeSync(filePath) {
         return fs.statSync(filePath);
     } catch (error) {
         /* istanbul ignore next */
-        if (error.code !== "ENOENT") {
+        if (error.code !== "ENOENT" && error.code !== "ENAMETOOLONG") {
             throw error;
         }
         return null;

--- a/tests/lib/cli-engine/file-enumerator.js
+++ b/tests/lib/cli-engine/file-enumerator.js
@@ -63,6 +63,12 @@ describe("FileEnumerator", () => {
                 Array.from(enumerator.iterateFiles(["lib/*.js", ""])); // don't throw "file not found" error.
             });
 
+            it("should handle long glob arguments", () => {
+                const longGlob = "nested,".repeat(100).slice(0, -1);
+
+                Array.from(enumerator.iterateFiles([`lib/{${longGlob}}/*.js`])); // don't throw "name too long" error.
+            });
+
             describe("if 'lib/*.js' was given,", () => {
 
                 /** @type {Array<{config:(typeof import('../../../lib/cli-engine')).ConfigArray, filePath:string, ignored:boolean}>} */


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment:**

* **ESLint Version:** `v8.15.0`
* **Node Version:** reproduced on `v16.15.0` and `v18.0.0`
* **npm Version:** `8.6.0`

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

The default parser.

**Please show your full configuration:**

This issue is not configuration dependent and happens with any configuration. For example, the configuration for this project exhibits this issue:

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
{
  "env": {},
  "globals": {
    "ArrayBuffer": "readonly",
    "Atomics": "readonly",
    "BigInt": "readonly",
    "BigInt64Array": "readonly",
    "BigUint64Array": "readonly",
    "DataView": "readonly",
    "Float32Array": "readonly",
    "Float64Array": "readonly",
    "Int16Array": "readonly",
    "Int32Array": "readonly",
    "Int8Array": "readonly",
    "Map": "readonly",
    "Promise": "readonly",
    "Proxy": "readonly",
    "Reflect": "readonly",
    "Set": "readonly",
    "SharedArrayBuffer": "readonly",
    "Symbol": "readonly",
    "Uint16Array": "readonly",
    "Uint32Array": "readonly",
    "Uint8Array": "readonly",
    "Uint8ClampedArray": "readonly",
    "WeakMap": "readonly",
    "WeakSet": "readonly",
    "globalThis": "readonly",
    "Intl": "readonly",
    "TextDecoder": "readonly",
    "TextEncoder": "readonly",
    "URL": "readonly",
    "URLSearchParams": "readonly",
    "WebAssembly": "readonly",
    "clearInterval": "readonly",
    "clearTimeout": "readonly",
    "console": "readonly",
    "queueMicrotask": "readonly",
    "setInterval": "readonly",
    "setTimeout": "readonly",
    "Buffer": "readonly",
    "GLOBAL": "readonly",
    "clearImmediate": "readonly",
    "global": "readonly",
    "process": "readonly",
    "root": "readonly",
    "setImmediate": "readonly",
    "__dirname": "readonly",
    "__filename": "readonly",
    "exports": "writable",
    "module": "readonly",
    "require": "readonly"
  },
  "parser": null,
  "parserOptions": {
    "ecmaVersion": 2021,
    "ecmaFeatures": {
      "globalReturn": true
    },
    "sourceType": "script"
  },
  "plugins": [
    "node",
    "jsdoc",
    "eslint-comments",
    "internal-rules",
    "eslint-plugin"
  ],
  "reportUnusedDisableDirectives": true,
  "rules": {
    "eslint-plugin/prefer-message-ids": [
      "error"
    ],
    "eslint-plugin/prefer-output-null": [
      "error"
    ],
    "eslint-plugin/prefer-placeholders": [
      "error"
    ],
    "eslint-plugin/prefer-replace-text": [
      "error"
    ],
    "eslint-plugin/report-message-format": [
      "error",
      "[^a-z].*\\.$"
    ],
    "eslint-plugin/require-meta-docs-description": [
      "error"
    ],
    "eslint-plugin/test-case-property-ordering": [
      "error"
    ],
    "eslint-plugin/test-case-shorthand-strings": [
      "error"
    ],
    "internal-rules/multiline-comment-style": [
      "error"
    ],
    "eslint-plugin/consistent-output": [
      "error"
    ],
    "eslint-plugin/fixer-return": [
      "error"
    ],
    "eslint-plugin/no-deprecated-context-methods": [
      "error"
    ],
    "eslint-plugin/no-deprecated-report-api": [
      "error"
    ],
    "eslint-plugin/no-identical-tests": [
      "error"
    ],
    "eslint-plugin/no-missing-placeholders": [
      "error"
    ],
    "eslint-plugin/no-only-tests": [
      "error"
    ],
    "eslint-plugin/no-unused-placeholders": [
      "error"
    ],
    "eslint-plugin/no-useless-token-range": [
      "error"
    ],
    "eslint-plugin/prefer-object-rule": [
      "error"
    ],
    "eslint-plugin/require-meta-fixable": [
      "error"
    ],
    "eslint-plugin/require-meta-has-suggestions": [
      "error"
    ],
    "eslint-plugin/require-meta-schema": [
      "error"
    ],
    "eslint-plugin/require-meta-type": [
      "error"
    ],
    "array-bracket-spacing": [
      "error"
    ],
    "array-callback-return": [
      "error"
    ],
    "arrow-body-style": [
      "error",
      "as-needed"
    ],
    "arrow-parens": [
      "error",
      "as-needed"
    ],
    "arrow-spacing": [
      "error"
    ],
    "indent": [
      "error",
      4,
      {
        "SwitchCase": 1,
        "flatTernaryExpressions": false,
        "offsetTernaryExpressions": false,
        "ignoreComments": false
      }
    ],
    "block-spacing": [
      "error"
    ],
    "brace-style": [
      "error",
      "1tbs"
    ],
    "camelcase": [
      "error"
    ],
    "class-methods-use-this": [
      "error"
    ],
    "comma-dangle": [
      "error"
    ],
    "comma-spacing": [
      "error"
    ],
    "comma-style": [
      "error",
      "last"
    ],
    "computed-property-spacing": [
      "error"
    ],
    "consistent-return": [
      "error"
    ],
    "curly": [
      "error",
      "all"
    ],
    "default-case": [
      "error"
    ],
    "default-case-last": [
      "error"
    ],
    "default-param-last": [
      "error"
    ],
    "dot-location": [
      "error",
      "property"
    ],
    "dot-notation": [
      "error",
      {
        "allowKeywords": true,
        "allowPattern": ""
      }
    ],
    "eol-last": [
      "error"
    ],
    "eqeqeq": [
      "error"
    ],
    "eslint-comments/disable-enable-pair": [
      "error"
    ],
    "eslint-comments/no-unused-disable": [
      "error"
    ],
    "eslint-comments/require-description": [
      "error"
    ],
    "func-call-spacing": [
      "error"
    ],
    "func-style": [
      "error",
      "declaration"
    ],
    "function-call-argument-newline": [
      "error",
      "consistent"
    ],
    "function-paren-newline": [
      "error",
      "consistent"
    ],
    "generator-star-spacing": [
      "error"
    ],
    "grouped-accessor-pairs": [
      "error"
    ],
    "guard-for-in": [
      "error"
    ],
    "jsdoc/check-line-alignment": [
      "error",
      "never"
    ],
    "jsdoc/check-syntax": [
      "error"
    ],
    "jsdoc/check-values": [
      "error",
      {
        "allowedLicenses": true
      }
    ],
    "jsdoc/newline-after-description": [
      "error",
      "never"
    ],
    "jsdoc/no-bad-blocks": [
      "error"
    ],
    "jsdoc/require-asterisk-prefix": [
      "error"
    ],
    "jsdoc/require-description": [
      "error",
      {
        "checkConstructors": false,
        "checkGetters": true,
        "checkSetters": true
      }
    ],
    "jsdoc/require-hyphen-before-param-description": [
      "error",
      "never"
    ],
    "jsdoc/require-returns": [
      "error",
      {
        "forceRequireReturn": true,
        "forceReturnsWithAsync": true,
        "checkConstructors": false,
        "checkGetters": true
      }
    ],
    "jsdoc/require-throws": [
      "error"
    ],
    "jsdoc/tag-lines": [
      "error",
      "never",
      {
        "tags": {
          "example": {
            "lines": "always"
          },
          "fileoverview": {
            "lines": "any"
          }
        }
      }
    ],
    "jsdoc/no-undefined-types": [
      "off"
    ],
    "jsdoc/require-yields": [
      "off"
    ],
    "jsdoc/check-access": [
      "error"
    ],
    "jsdoc/check-alignment": [
      "error"
    ],
    "jsdoc/check-param-names": [
      "error"
    ],
    "jsdoc/check-property-names": [
      "error"
    ],
    "jsdoc/check-tag-names": [
      "error"
    ],
    "jsdoc/check-types": [
      "error"
    ],
    "jsdoc/empty-tags": [
      "error"
    ],
    "jsdoc/implements-on-classes": [
      "error"
    ],
    "jsdoc/multiline-blocks": [
      "error"
    ],
    "jsdoc/no-multi-asterisks": [
      "error"
    ],
    "jsdoc/require-jsdoc": [
      "error",
      {
        "require": {
          "ClassDeclaration": true,
          "ArrowFunctionExpression": false,
          "ClassExpression": false,
          "FunctionDeclaration": true,
          "FunctionExpression": false,
          "MethodDefinition": false
        },
        "checkConstructors": true,
        "checkGetters": true,
        "checkSetters": true,
        "enableFixer": true,
        "exemptEmptyConstructors": false,
        "exemptEmptyFunctions": false,
        "fixerMessage": ""
      }
    ],
    "jsdoc/require-param": [
      "error"
    ],
    "jsdoc/require-param-description": [
      "error"
    ],
    "jsdoc/require-param-name": [
      "error"
    ],
    "jsdoc/require-param-type": [
      "error"
    ],
    "jsdoc/require-property": [
      "error"
    ],
    "jsdoc/require-property-description": [
      "error"
    ],
    "jsdoc/require-property-name": [
      "error"
    ],
    "jsdoc/require-property-type": [
      "error"
    ],
    "jsdoc/require-returns-check": [
      "error"
    ],
    "jsdoc/require-returns-description": [
      "error"
    ],
    "jsdoc/require-returns-type": [
      "error"
    ],
    "jsdoc/require-yields-check": [
      "error"
    ],
    "jsdoc/valid-types": [
      "error"
    ],
    "key-spacing": [
      "error",
      {
        "beforeColon": false,
        "afterColon": true
      }
    ],
    "keyword-spacing": [
      "error"
    ],
    "lines-around-comment": [
      "error",
      {
        "beforeBlockComment": true,
        "afterBlockComment": false,
        "beforeLineComment": true,
        "afterLineComment": false,
        "allowBlockStart": false,
        "allowBlockEnd": false
      }
    ],
    "max-len": [
      "error",
      160,
      {
        "ignoreComments": true,
        "ignoreUrls": true,
        "ignoreStrings": true,
        "ignoreTemplateLiterals": true,
        "ignoreRegExpLiterals": true
      }
    ],
    "max-statements-per-line": [
      "error"
    ],
    "new-cap": [
      "error"
    ],
    "new-parens": [
      "error"
    ],
    "no-alert": [
      "error"
    ],
    "no-array-constructor": [
      "error"
    ],
    "no-caller": [
      "error"
    ],
    "no-confusing-arrow": [
      "error"
    ],
    "no-console": [
      "error"
    ],
    "no-constant-binary-expression": [
      "error"
    ],
    "no-constructor-return": [
      "error"
    ],
    "no-else-return": [
      "error",
      {
        "allowElseIf": false
      }
    ],
    "no-eval": [
      "error"
    ],
    "no-extend-native": [
      "error"
    ],
    "no-extra-bind": [
      "error"
    ],
    "no-floating-decimal": [
      "error"
    ],
    "no-implied-eval": [
      "error"
    ],
    "no-invalid-this": [
      "error"
    ],
    "no-iterator": [
      "error"
    ],
    "no-label-var": [
      "error"
    ],
    "no-labels": [
      "error"
    ],
    "no-lone-blocks": [
      "error"
    ],
    "no-loop-func": [
      "error"
    ],
    "no-mixed-spaces-and-tabs": [
      "error",
      false
    ],
    "no-multi-spaces": [
      "error"
    ],
    "no-multi-str": [
      "error"
    ],
    "no-multiple-empty-lines": [
      "error",
      {
        "max": 2,
        "maxBOF": 0,
        "maxEOF": 0
      }
    ],
    "no-nested-ternary": [
      "error"
    ],
    "no-new": [
      "error"
    ],
    "no-new-func": [
      "error"
    ],
    "no-new-object": [
      "error"
    ],
    "no-new-wrappers": [
      "error"
    ],
    "no-octal-escape": [
      "error"
    ],
    "no-param-reassign": [
      "error"
    ],
    "no-proto": [
      "error"
    ],
    "no-process-exit": [
      "off"
    ],
    "no-restricted-properties": [
      "error",
      {
        "property": "substring",
        "message": "Use .slice instead of .substring."
      },
      {
        "property": "substr",
        "message": "Use .slice instead of .substr."
      },
      {
        "object": "assert",
        "property": "equal",
        "message": "Use assert.strictEqual instead of assert.equal."
      },
      {
        "object": "assert",
        "property": "notEqual",
        "message": "Use assert.notStrictEqual instead of assert.notEqual."
      },
      {
        "object": "assert",
        "property": "deepEqual",
        "message": "Use assert.deepStrictEqual instead of assert.deepEqual."
      },
      {
        "object": "assert",
        "property": "notDeepEqual",
        "message": "Use assert.notDeepStrictEqual instead of assert.notDeepEqual."
      }
    ],
    "no-return-assign": [
      "error"
    ],
    "no-script-url": [
      "error"
    ],
    "no-self-compare": [
      "error"
    ],
    "no-sequences": [
      "error"
    ],
    "no-shadow": [
      "error"
    ],
    "no-tabs": [
      "error"
    ],
    "no-throw-literal": [
      "error"
    ],
    "no-trailing-spaces": [
      "error"
    ],
    "no-undef": [
      "error",
      {
        "typeof": true
      }
    ],
    "no-undef-init": [
      "error"
    ],
    "no-undefined": [
      "error"
    ],
    "no-underscore-dangle": [
      "error",
      {
        "allowAfterThis": true,
        "allowAfterSuper": false,
        "allowAfterThisConstructor": false,
        "enforceInMethodNames": false,
        "allowFunctionParams": true,
        "enforceInClassFields": false
      }
    ],
    "no-unmodified-loop-condition": [
      "error"
    ],
    "no-unneeded-ternary": [
      "error"
    ],
    "no-unreachable-loop": [
      "error"
    ],
    "no-unused-expressions": [
      "error"
    ],
    "no-unused-vars": [
      "error",
      {
        "vars": "all",
        "args": "after-used",
        "caughtErrors": "all"
      }
    ],
    "no-use-before-define": [
      "error"
    ],
    "no-useless-call": [
      "error"
    ],
    "no-useless-computed-key": [
      "error"
    ],
    "no-useless-concat": [
      "error"
    ],
    "no-useless-constructor": [
      "error"
    ],
    "no-useless-rename": [
      "error"
    ],
    "no-useless-return": [
      "error"
    ],
    "no-whitespace-before-property": [
      "error"
    ],
    "no-var": [
      "error"
    ],
    "node/callback-return": [
      "error",
      [
        "cb",
        "callback",
        "next"
      ]
    ],
    "node/handle-callback-err": [
      "error",
      "err"
    ],
    "node/no-deprecated-api": [
      "error"
    ],
    "node/no-mixed-requires": [
      "error"
    ],
    "node/no-new-require": [
      "error"
    ],
    "node/no-path-concat": [
      "error"
    ],
    "object-curly-newline": [
      "error",
      {
        "consistent": true,
        "multiline": true
      }
    ],
    "object-curly-spacing": [
      "error",
      "always"
    ],
    "object-property-newline": [
      "error",
      {
        "allowAllPropertiesOnSameLine": true,
        "allowMultiplePropertiesPerLine": false
      }
    ],
    "object-shorthand": [
      "error"
    ],
    "one-var-declaration-per-line": [
      "error"
    ],
    "operator-assignment": [
      "error"
    ],
    "operator-linebreak": [
      "error"
    ],
    "padding-line-between-statements": [
      "error",
      {
        "blankLine": "always",
        "prev": [
          "const",
          "let",
          "var"
        ],
        "next": "*"
      },
      {
        "blankLine": "any",
        "prev": [
          "const",
          "let",
          "var"
        ],
        "next": [
          "const",
          "let",
          "var"
        ]
      }
    ],
    "prefer-arrow-callback": [
      "error"
    ],
    "prefer-const": [
      "error"
    ],
    "prefer-exponentiation-operator": [
      "error"
    ],
    "prefer-numeric-literals": [
      "error"
    ],
    "prefer-promise-reject-errors": [
      "error"
    ],
    "prefer-regex-literals": [
      "error"
    ],
    "prefer-rest-params": [
      "error"
    ],
    "prefer-spread": [
      "error"
    ],
    "prefer-template": [
      "error"
    ],
    "quotes": [
      "error",
      "double",
      {
        "avoidEscape": true
      }
    ],
    "quote-props": [
      "error",
      "as-needed"
    ],
    "radix": [
      "error"
    ],
    "require-unicode-regexp": [
      "error"
    ],
    "rest-spread-spacing": [
      "error"
    ],
    "semi": [
      "error"
    ],
    "semi-spacing": [
      "error",
      {
        "before": false,
        "after": true
      }
    ],
    "semi-style": [
      "error"
    ],
    "space-before-blocks": [
      "error"
    ],
    "space-before-function-paren": [
      "error",
      {
        "anonymous": "never",
        "named": "never",
        "asyncArrow": "always"
      }
    ],
    "space-in-parens": [
      "error"
    ],
    "space-infix-ops": [
      "error"
    ],
    "space-unary-ops": [
      "error",
      {
        "words": true,
        "nonwords": false
      }
    ],
    "spaced-comment": [
      "error",
      "always",
      {
        "exceptions": [
          "-"
        ]
      }
    ],
    "strict": [
      "error",
      "global"
    ],
    "switch-colon-spacing": [
      "error"
    ],
    "symbol-description": [
      "error"
    ],
    "template-curly-spacing": [
      "error",
      "never"
    ],
    "template-tag-spacing": [
      "error"
    ],
    "unicode-bom": [
      "error"
    ],
    "wrap-iife": [
      "error"
    ],
    "yield-star-spacing": [
      "error"
    ],
    "yoda": [
      "error",
      "never",
      {
        "exceptRange": true,
        "onlyEquality": false
      }
    ],
    "eslint-comments/no-aggregating-enable": [
      "error"
    ],
    "eslint-comments/no-duplicate-disable": [
      "error"
    ],
    "eslint-comments/no-unlimited-disable": [
      "error"
    ],
    "eslint-comments/no-unused-enable": [
      "error"
    ],
    "jsdoc/check-examples": [
      "off"
    ],
    "jsdoc/check-indentation": [
      "off"
    ],
    "jsdoc/match-description": [
      "off"
    ],
    "jsdoc/match-name": [
      "off"
    ],
    "jsdoc/no-defaults": [
      "off"
    ],
    "jsdoc/no-missing-syntax": [
      "off"
    ],
    "jsdoc/no-restricted-syntax": [
      "off"
    ],
    "jsdoc/no-types": [
      "off"
    ],
    "jsdoc/require-description-complete-sentence": [
      "off"
    ],
    "jsdoc/require-example": [
      "off"
    ],
    "jsdoc/require-file-overview": [
      "off"
    ],
    "jsdoc/sort-tags": [
      "off"
    ],
    "node/no-extraneous-import": [
      "error"
    ],
    "node/no-extraneous-require": [
      "error"
    ],
    "node/no-exports-assign": [
      "error"
    ],
    "node/no-missing-import": [
      "error"
    ],
    "node/no-missing-require": [
      "error"
    ],
    "node/no-unpublished-bin": [
      "error"
    ],
    "node/no-unpublished-import": [
      "error"
    ],
    "node/no-unpublished-require": [
      "error"
    ],
    "node/no-unsupported-features/es-builtins": [
      "error"
    ],
    "node/no-unsupported-features/es-syntax": [
      "error",
      {
        "ignores": []
      }
    ],
    "node/no-unsupported-features/node-builtins": [
      "error"
    ],
    "node/process-exit-as-throw": [
      "error"
    ],
    "node/shebang": [
      "error"
    ],
    "constructor-super": [
      "error"
    ],
    "for-direction": [
      "error"
    ],
    "getter-return": [
      "error"
    ],
    "no-async-promise-executor": [
      "error"
    ],
    "no-case-declarations": [
      "error"
    ],
    "no-class-assign": [
      "error"
    ],
    "no-compare-neg-zero": [
      "error"
    ],
    "no-cond-assign": [
      "error"
    ],
    "no-const-assign": [
      "error"
    ],
    "no-constant-condition": [
      "error"
    ],
    "no-control-regex": [
      "error"
    ],
    "no-debugger": [
      "error"
    ],
    "no-delete-var": [
      "error"
    ],
    "no-dupe-args": [
      "error"
    ],
    "no-dupe-class-members": [
      "error"
    ],
    "no-dupe-else-if": [
      "error"
    ],
    "no-dupe-keys": [
      "error"
    ],
    "no-duplicate-case": [
      "error"
    ],
    "no-empty": [
      "error"
    ],
    "no-empty-character-class": [
      "error"
    ],
    "no-empty-pattern": [
      "error"
    ],
    "no-ex-assign": [
      "error"
    ],
    "no-extra-boolean-cast": [
      "error"
    ],
    "no-extra-semi": [
      "error"
    ],
    "no-fallthrough": [
      "error"
    ],
    "no-func-assign": [
      "error"
    ],
    "no-global-assign": [
      "error"
    ],
    "no-import-assign": [
      "error"
    ],
    "no-inner-declarations": [
      "error"
    ],
    "no-invalid-regexp": [
      "error"
    ],
    "no-irregular-whitespace": [
      "error"
    ],
    "no-loss-of-precision": [
      "error"
    ],
    "no-misleading-character-class": [
      "error"
    ],
    "no-new-symbol": [
      "error"
    ],
    "no-nonoctal-decimal-escape": [
      "error"
    ],
    "no-obj-calls": [
      "error"
    ],
    "no-octal": [
      "error"
    ],
    "no-prototype-builtins": [
      "error"
    ],
    "no-redeclare": [
      "error"
    ],
    "no-regex-spaces": [
      "error"
    ],
    "no-self-assign": [
      "error"
    ],
    "no-setter-return": [
      "error"
    ],
    "no-shadow-restricted-names": [
      "error"
    ],
    "no-sparse-arrays": [
      "error"
    ],
    "no-this-before-super": [
      "error"
    ],
    "no-unexpected-multiline": [
      "error"
    ],
    "no-unreachable": [
      "error"
    ],
    "no-unsafe-finally": [
      "error"
    ],
    "no-unsafe-negation": [
      "error"
    ],
    "no-unsafe-optional-chaining": [
      "error"
    ],
    "no-unused-labels": [
      "error"
    ],
    "no-useless-backreference": [
      "error"
    ],
    "no-useless-catch": [
      "error"
    ],
    "no-useless-escape": [
      "error"
    ],
    "no-with": [
      "error"
    ],
    "require-yield": [
      "error"
    ],
    "use-isnan": [
      "error"
    ],
    "valid-typeof": [
      "error"
    ]
  },
  "settings": {
    "jsdoc": {
      "mode": "typescript",
      "tagNamePreference": {
        "file": "fileoverview",
        "augments": "extends",
        "class": "constructor"
      },
      "preferredTypes": {
        "*": {
          "message": "Use a more precise type or if necessary use `any` or `ArbitraryCallbackResult`",
          "replacement": "any"
        },
        "Any": {
          "message": "Use a more precise type or if necessary use `any` or `ArbitraryCallbackResult`",
          "replacement": "any"
        },
        "function": {
          "message": "Point to a `@callback` namepath or `Function` if truly arbitrary in form",
          "replacement": "Function"
        },
        "Promise": {
          "message": "Specify the specific Promise type, including, if necessary, the type `any`"
        },
        ".<>": {
          "message": "Prefer type form without dot",
          "replacement": "<>"
        },
        "object": {
          "message": "Use the specific object type or `Object` if truly arbitrary",
          "replacement": "Object"
        },
        "array": "Array"
      }
    }
  },
  "ignorePatterns": [
    "/build/**",
    "/coverage/**",
    "/docs/**",
    "/jsdoc/**",
    "/templates/**",
    "/tests/bench/**",
    "/tests/fixtures/**",
    "/tests/performance/**",
    "/tmp/**",
    "/tools/internal-rules/node_modules/**",
    "test.js",
    "!.eslintrc.js"
  ]
}

```

</details>

**What did you do? Please include the actual source code causing the issue.**

I am using `eslint` on parts of my source tree such that I can parallelize linting of a large project across multiple workers. To do this, I've partitioned my source tree into buckets of work and then running `eslint` on the directories in a given bucket. For example:

```
eslint 'src/{Thing,OtherThing,Something,Else,In,Here,Many,Of,These}/*.js'
```

In reality, the glob pattern is quite large (e.g. 50 or 60 directories) and results in a long pattern being evaluated by `eslint`, specifically here:

https://github.com/eslint/eslint/blob/3f09aab709980ca974b721de474be2dd183409a2/lib/cli-engine/file-enumerator.js#L121-L131

**What did you expect to happen?**

I expected `eslint` to handle this pattern without issue, since the glob pattern is passed into `Minimatch` and each "resolved" file is then linted directly. This shouldn't behave any differently than passing each individual path (manually) to `eslint`.

**What actually happened? Please include the actual, raw output from ESLint.**

It looks like the pattern is passed into `fs.statSync` so that the correct type of iteration over the pattern/path can be performed (`_iterateFilesWithDirectory`, `_iterateFilesWithFile`, `_iterateFilesWithGlob`).

When running `fs.statSync` on a larger pattern, Node throws [`ENAMETOOLONG`](https://nodejs.org/api/os.html#:~:text=multihop%20was%20attempted.-,ENAMETOOLONG,-Indicates%20that%20the) from the OS itself, resulting in a failure:

```
$ ./bin/eslint.js 'lib/{eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint}/*.js'


Oops! Something went wrong! :(

ESLint: 8.15.0

Error: ENAMETOOLONG: name too long, stat '/Users/nickp/src/github.com/nickpresta/eslint/lib/{eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint}/*.js'
    at Object.statSync (node:fs:1559:3)
    at statSafeSync (/Users/nickp/src/github.com/nickpresta/eslint/lib/cli-engine/file-enumerator.js:123:19)
    at FileEnumerator._iterateFiles (/Users/nickp/src/github.com/nickpresta/eslint/lib/cli-engine/file-enumerator.js:341:22)
    at FileEnumerator.iterateFiles (/Users/nickp/src/github.com/nickpresta/eslint/lib/cli-engine/file-enumerator.js:297:59)
    at iterateFiles.next (<anonymous>)
    at CLIEngine.executeOnFiles (/Users/nickp/src/github.com/nickpresta/eslint/lib/cli-engine/cli-engine.js:788:48)
    at ESLint.lintFiles (/Users/nickp/src/github.com/nickpresta/eslint/lib/eslint/eslint.js:550:23)
    at Object.execute (/Users/nickp/src/github.com/nickpresta/eslint/lib/cli.js:301:36)
    at main (/Users/nickp/src/github.com/nickpresta/eslint/bin/eslint.js:138:52)
    at Object.<anonymous> (/Users/nickp/src/github.com/nickpresta/eslint/bin/eslint.js:142:2)
```

This can be reproduced in Node directly (no `eslint` issue):

```
$ node
Welcome to Node.js v18.0.0.
Type ".help" for more information.
> const {statSync} = require('fs');
undefined
> statSync('lib/{eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint}/*.js')
Uncaught:
Error: ENAMETOOLONG: name too long, stat 'lib/{eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint}/*.js'
    at statSync (node:fs:1559:3) {
  errno: -63,
  syscall: 'stat',
  code: 'ENAMETOOLONG',
  path: 'lib/{eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint,eslint}/*.js'
}
```

so while this isn't an issue with the code written by the `eslint` project directly, the underlying implementation is leaking through and `eslint` should be able to handle this case without issue.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In the `statSafeSync` function, I added another check for `ENAMETOOLONG` and opt to return `null` in that case instead of throwing the error. In the `_iterateFiles` function, returning `null` skips the check for the pattern being a directory or file and if the pattern wasn't a glob, it would result in `eslint` finding no files. The other place where `statSafeSync` is called is when iterating over files and an explicit check for `null` is performed and that file is skipped. In both cases, "skipping" over the file that would be too long (if it wasn't a glob pattern) seems fine since `eslint` can't process the file any further anyways.

#### Is there anything you'd like reviewers to focus on?

I tried searching for `eslint` issues and `ENAMETOOLONG` but wasn't able to find anything -- is there some context I may be missing about this error and does this approach hide any code paths or use cases I may not be aware of? Thanks for any help!

<!-- markdownlint-disable-file MD004 -->
