### PR TITLE
fix: Make no-unused-var function the same way in for..of loops as for..in loops

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -484,12 +484,12 @@ module.exports = {
         }
 
         /**
-         * Determine if an identifier is used either in for-in loops.
+         * Determine if an identifier is used either in for-in or for-of loops.
          * @param {Reference} ref The reference to check.
          * @returns {boolean} whether reference is used in the for-in loops
          * @private
          */
-        function isForInRef(ref) {
+        function isForInOfRef(ref) {
             let target = ref.identifier.parent;
 
 
@@ -498,7 +498,7 @@ module.exports = {
                 target = target.parent.parent;
             }
 
-            if (target.type !== "ForInStatement") {
+            if (target.type !== "ForInStatement" && target.type !== "ForOfStatement") {
                 return false;
             }
 
@@ -531,7 +531,7 @@ module.exports = {
             let rhsNode = null;
 
             return variable.references.some(ref => {
-                if (isForInRef(ref)) {
+                if (isForInOfRef(ref)) {
                     return true;
                 }
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -252,6 +252,15 @@ ruleTester.run("no-unused-vars", rule, {
         { code: "(function(obj) { for ( const name in obj ) { return true } })({})", parserOptions: { ecmaVersion: 6 } },
         { code: "(function(obj) { for ( const name in obj ) return true })({})", parserOptions: { ecmaVersion: 6 } },
 
+        // For-of loops
+        { code: "(function(iter) { let name; for ( name of iter ) return; })({});", parserOptions: { ecmaVersion: 6 } },
+        { code: "(function(iter) { let name; for ( name of iter ) { return; } })({});", parserOptions: { ecmaVersion: 6 } },
+        { code: "(function(iter) { for ( let name of iter ) { return true } })({})", parserOptions: { ecmaVersion: 6 } },
+        { code: "(function(iter) { for ( let name of iter ) return true })({})", parserOptions: { ecmaVersion: 6 } },
+
+        { code: "(function(iter) { for ( const name of iter ) { return true } })({})", parserOptions: { ecmaVersion: 6 } },
+        { code: "(function(iter) { for ( const name of iter ) return true })({})", parserOptions: { ecmaVersion: 6 } },
+
         // Sequence Expressions (See https://github.com/eslint/eslint/issues/14325)
         { code: "let x = 0; foo = (0, x++);", parserOptions: { ecmaVersion: 6 } },
         { code: "let x = 0; foo = (0, x += 1);", parserOptions: { ecmaVersion: 6 } },
@@ -695,6 +704,50 @@ ruleTester.run("no-unused-vars", rule, {
             errors: [{
                 line: 1,
                 column: 28,
+                messageId: "unusedVar",
+                data: {
+                    varName: "name",
+                    action: "assigned a value",
+                    additional: ""
+                }
+            }]
+        },
+
+        // For-of loops
+        {
+            code: "(function(iter) { var name; for ( name of iter ) { i(); return; } })({});",
+            env: { es6: true },
+            errors: [{
+                line: 1,
+                column: 35,
+                messageId: "unusedVar",
+                data: {
+                    varName: "name",
+                    action: "assigned a value",
+                    additional: ""
+                }
+            }]
+        },
+        {
+            code: "(function(iter) { var name; for ( name of iter ) { } })({});",
+            env: { es6: true },
+            errors: [{
+                line: 1,
+                column: 35,
+                messageId: "unusedVar",
+                data: {
+                    varName: "name",
+                    action: "assigned a value",
+                    additional: ""
+                }
+            }]
+        },
+        {
+            code: "(function(iter) { for ( var name of iter ) { } })({});",
+            env: { es6: true },
+            errors: [{
+                line: 1,
+                column: 29,
                 messageId: "unusedVar",
                 data: {
                     varName: "name",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Tweaked the `no-unused-vars` rule to treat `for..of` loops and `for..in` loops the same

Sorry for the labels 🙈 not sure if this is a bug or a feature 

**What rule do you want to change?**

no-unused-vars`

**Does this change cause the rule to produce more or fewer warnings?**

Fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**

`for..of` loops will be treated the same way as `for..in` loops

**Please provide some example code that this change will affect:**

```js
// without change
for (const name in object) { return true } // valid
for (const name of iterable) { return true } // invalid, `name` is unused

// with change
for (const name of iterable) { return true } // valid
```

**What does the rule currently do for this code?**

It will cause show a `no-unused-vars` error on the variable declaration in the for..of loop

**What will the rule do after it's changed?**

It will not show an error

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
