### PR TITLE
chore: Refactor rule docs format

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -126,8 +126,6 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addNunjucksAsyncShortcode("link", async function(link) {
         const { body: html, url } = await got(link);
         const metadata = await metascraper({ html, url });
-
-        const encodedURL = encodeURIComponent(link);
         const the_url = (new URL(link)); // same as url
         const domain = the_url.hostname;
 

--- a/docs/src/_includes/components/docs-toc.html
+++ b/docs/src/_includes/components/docs-toc.html
@@ -1,8 +1,8 @@
 <nav class="docs-toc c-toc" aria-labelledby="js-toc-label">
-    {%- if content | toc | safe -%}
+    {%- if all_content | toc | safe -%}
     <h2 class="c-toc__label" id="js-toc-label">Table of Contents</h2>
     <div class="c-toc__panel" id="js-toc-panel">
-        {{ content | toc | safe }}
+        {{ all_content | toc | safe }}
     </div>
     {%- endif -%}
 </nav>

--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -13,12 +13,39 @@ layout: base.njk
             {% include 'components/docs-index.html' %}
     </div>
 
+    {# Add in related rules and further reading sections to content so TOC is accurate #}
+    {% set all_content = content %}
+    {% if related_rules %}
+        {% set related_rules_content %}
+            <h2 id="related-rules">Related Rules</h2>
+            {% related_rules related_rules %}
+        {% endset %}
+
+        {% set all_content = [all_content, related_rules_content] | join %}
+    {% endif %}
+
+    {% if further_reading %}
+        {% set further_reading_content %}
+            <h2 id="further-reading">Further Reading</h2>
+            {# async shortcodes don't work here so need to manually insert later #}
+        {% endset %}
+
+        {% set all_content = [all_content, further_reading_content] | join %}
+    {% endif %}
+
     <div class="docs-content">
         <main id="main" tabindex="-1" class="docs-main">
             <h1>{{ title }}</h1>
             {% include 'components/docs-toc.html' %}
 
-            {{ content | safe }}
+            {{ all_content | safe }}
+
+            {# now insert the async-fetched link data if necessary #}
+            {% if further_reading %}
+                {% for url in further_reading %}
+                    {% link url %}
+                {% endfor %}            
+            {% endif %}
 
             <div class="docs-edit-link">
                 <a href="{{ edit_link }}" class="c-btn c-btn--secondary">Edit this page</a>

--- a/docs/src/rules/block-scoped-var.md
+++ b/docs/src/rules/block-scoped-var.md
@@ -3,6 +3,9 @@ title: block-scoped-var
 layout: doc
 edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/block-scoped-var.md
 rule_type: suggestion
+further_reading:
+- http://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html
+- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting
 ---
 
 Enforces treating `var` as block scoped.
@@ -111,8 +114,3 @@ class C {
     }
 }
 ```
-
-## Further Reading
-
-* [JavaScript Scoping and Hoisting](http://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html)
-* [var Hoisting](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting)

--- a/docs/src/rules/block-scoped-var.md
+++ b/docs/src/rules/block-scoped-var.md
@@ -4,7 +4,7 @@ layout: doc
 edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/block-scoped-var.md
 rule_type: suggestion
 further_reading:
-- http://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html
+- https://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting
 ---
 

--- a/docs/src/rules/no-ternary.md
+++ b/docs/src/rules/no-ternary.md
@@ -3,6 +3,9 @@ title: no-ternary
 layout: doc
 edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-ternary.md
 rule_type: suggestion
+related_rules:
+- no-nested-ternary
+- no-unneeded-ternary
 ---
 
 Disallows ternary operators.
@@ -50,8 +53,3 @@ function quux() {
     }
 }
 ```
-
-## Related Rules
-
-* [no-nested-ternary](no-nested-ternary)
-* [no-unneeded-ternary](no-unneeded-ternary)


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

To get the new docs site up and running, I've made a couple changes to the way rule pages are rendered:

1. Related rules are now represented in the `related_rules` frontmatter key instead of plain markdown
1. Further reading links are now represented in the `further_reading` frontmatter key instead of plain markdown

This allows us to automatically format this data in a pretty way on the website and ensures consistent ordering.

I updated two rules as examples: `no-ternary` and `block-scoped-var`. 

Related change in current website: https://github.com/eslint/website/pull/943

#### Is there anything you'd like reviewers to focus on?

With the new docs site, the title of the further reading URLs is fetched automatically. In the current website, we were hard-coding those, so with this approach we will lose the article title on the current website. I think this is a worthwhile tradeoff in the short-term.

Any concerns about this approach?


<!-- markdownlint-disable-file MD004 -->
