### PR TITLE
chore: keep `#` fragments in Further Reading links on new docs site

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -129,13 +129,27 @@ module.exports = function(eleventyConfig) {
         const the_url = (new URL(link)); // same as url
         const domain = the_url.hostname;
 
+        let href = metadata.url;
+
+        /*
+         * Restore `#` fragment from the original link. At this point, the fragment may have been lost
+         * during the process if `got` encountered redirects or if `metascraper` has found URL in the HTML document.
+         */
+        if (!href.includes("#")) {
+            const originalFragmentMatch = /#(?:.)+/u.exec(link);
+
+            if (originalFragmentMatch) {
+                href += originalFragmentMatch[0];
+            }
+        }
+
         return `
         <article class="resource">
             <div class="resource__image">
                 <img class="resource__img" width="75" height="75" src="${metadata.logo}" alt="Avatar image for ${domain}" />
             </div>
             <div class="resource__content">
-                <a href="${metadata.url}" class="resource__title"> ${metadata.title} </a><br>
+                <a href="${href}" class="resource__title"> ${metadata.title} </a><br>
                 <span class="resource__domain"> ${domain}</span>
             </div>
             <svg class="c-icon resource__icon" width="13" height="12" viewBox="0 0 13 12" fill="none">


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

We are using `got` and `metascraper` to determine final URLs for "Further Reading" links, but during the process `#` fragments from original links may have been lost.

For example, the last Further Reading link in `no-iterator` docs should point to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#Object_methods

* https://deploy-preview-15884--docs-eslint.netlify.app/rules/no-iterator/#further-reading - this is preview from a previous PR. The link is missing `#Object_methods` at the end.
* https://deploy-preview-15888--docs-eslint.netlify.app/rules/no-iterator/#further-reading - this is preview for this PR. The link has `#Object_methods` at the end.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the `link` shortcode to keep fragments from original links.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
