### PR TITLE
docs: Add Resources section to rule pages

### DIFF
--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -34,6 +34,17 @@ layout: base.njk
 
         {% set all_content = [all_content, further_reading_content] | join %}
     {% endif %}
+        
+    {% if rule_type %}
+        {% set resources_content %}
+            <h2 id="resources">Resources</h2>
+            <ul>
+                <li><a href="https://github.com/eslint/eslint/blob/main/lib/rules/{{ title }}.js">Rule source</a></li>
+                <li><a href="https://github.com/eslint/eslint/blob/main/tests/rules/{{ title }}.js">Tests source</a></li>
+            </ul>
+        {% endset %}
+        {% set all_content = [all_content, resources_content] | join %}
+    {% endif %}
 
     <div class="docs-content">
         <main id="main" tabindex="-1" class="docs-main">

--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -40,7 +40,7 @@ layout: base.njk
             <h2 id="resources">Resources</h2>
             <ul>
                 <li><a href="https://github.com/eslint/eslint/blob/main/lib/rules/{{ title }}.js">Rule source</a></li>
-                <li><a href="https://github.com/eslint/eslint/blob/main/tests/rules/{{ title }}.js">Tests source</a></li>
+                <li><a href="https://github.com/eslint/eslint/blob/main/tests/lib/rules/{{ title }}.js">Tests source</a></li>
             </ul>
         {% endset %}
         {% set all_content = [all_content, resources_content] | join %}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added the "Resources" section to rule pages.

#### Is there anything you'd like reviewers to focus on?

I only added "Rule source" and "Test source", but not "Documentation source" because we have a big "Edit Page" button right under this section. Is that okay?


<!-- markdownlint-disable-file MD004 -->
