### PR TITLE
test: ensure no-restricted-imports works with NodeJS subpath imports

### DIFF
--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -1083,6 +1083,17 @@ ruleTester.run("no-restricted-imports", rule, {
             column: 1,
             endColumn: 41
         }]
+    },
+    {
+        code: "import absoluteWithPatterns from '#foo/bar';",
+        options: [{ patterns: ["\\#foo"] }],
+        errors: [{
+            message: "'#foo/bar' import is restricted from being used by a pattern.",
+            type: "ImportDeclaration",
+            line: 1,
+            column: 1,
+            endColumn: 45
+        }]
     }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Adds a test.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds a test case to the `no-restricted-imports` rule to cover an edge case not accounted for—[NodeJS subpath imports](https://nodejs.org/api/packages.html#subpath-imports). No changes were made to the actual rule.

In NodeJS, you can define a subpath import by adding the following to your package.json:

```
"imports": {
  "#dep": "./dependencies"
},
```

This is very similar to the `paths` attribute in a `tsconfig.json`, except it's more restrictive in that the import must start with `#`.

This new test case just ensures `no-restricted-imports` works with these styles of imports. Selfishly, I use subpath imports and this rule so I'd like to ensure ESLint continues to work with my use case.

#### Is there anything you'd like reviewers to focus on?

No.

<!-- markdownlint-disable-file MD004 -->
