### PR TITLE
chore: use addEventListener instead of addListener

### DIFF
--- a/docs/src/assets/js/components-index.js
+++ b/docs/src/assets/js/components-index.js
@@ -6,7 +6,7 @@
 
     if (matchMedia) {
         const mq = window.matchMedia("(max-width: 1023px)");
-        mq.addListener(WidthChange);
+        mq.addEventListener('change', WidthChange);
         WidthChange(mq);
     }
 

--- a/docs/src/assets/js/main.js
+++ b/docs/src/assets/js/main.js
@@ -6,7 +6,7 @@
 
     if (toc && matchMedia) {
         const mq = window.matchMedia("(max-width: 1023px)");
-        mq.addListener(WidthChange);
+        mq.addEventListener('change', WidthChange);
         WidthChange(mq);
     }
 
@@ -53,7 +53,7 @@
 
     if (matchMedia) {
         const mq = window.matchMedia("(max-width: 1023px)");
-        mq.addListener(WidthChange);
+        mq.addEventListener('change', WidthChange);
         WidthChange(mq);
     }
 
@@ -93,7 +93,7 @@
 
     if (matchMedia) {
         const mq = window.matchMedia("(max-width: 1023px)");
-        mq.addListener(WidthChange);
+        mq.addEventListener('change', WidthChange);
         WidthChange(mq);
     }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Use **addEventListener()** instead of matchMedia().addListener() since matchMedia().addListener() is deprecated.

<!-- markdownlint-disable-file MD004 -->
