### PR TITLE
feat: include `.cjs` and `.mjs` File Extensions by Default

### DIFF
--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -144,7 +144,7 @@ Examples:
 #### `--ext`
 
 This option allows you to specify which file extensions ESLint will use when searching for target files in the directories you specify.
-By default, ESLint lints `*.js` files and the files that match the `overrides` entries of your configuration.
+By default, ESLint lints `*.js`, `*.cjs` and `*.mjs` files and also the files that match the `overrides` entries of your configuration.
 
 Examples:
 

--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -728,7 +728,7 @@ class CLIEngine {
             return patterns.filter(Boolean);
         }
 
-        const extensions = (options.extensions || [".js"]).map(ext => ext.replace(/^\./u, ""));
+        const extensions = (options.extensions || FileEnumerator.defaultExtensions).map(ext => ext.replace(/^\./u, ""));
         const dirSuffix = `/**/*.{${extensions.join(",")}}`;
 
         return patterns.filter(Boolean).map(pathname => {

--- a/lib/cli-engine/file-enumerator.js
+++ b/lib/cli-engine/file-enumerator.js
@@ -47,7 +47,6 @@ const {
         CascadingConfigArrayFactory
     }
 } = require("@eslint/eslintrc");
-const { CLIEngine } = require("./cli-engine.js");
 const debug = require("debug")("eslint:file-enumerator");
 
 //------------------------------------------------------------------------------
@@ -207,11 +206,6 @@ class AllFilesIgnoredError extends Error {
  * matched by given glob patterns and that configuration.
  */
 class FileEnumerator {
-    /**
-     * The extensions of the files to include by default.
-     */
-    // `.js`, `.cjs` and `.mjs` are the default extensions.
-    static defaultExtensions = [".js", ".cjs", ".mjs"];
 
     /**
      * Initialize this enumerator.
@@ -257,7 +251,7 @@ class FileEnumerator {
             return extensionRegExp.test(filePath);
         }
 
-        for (let extension of FileEnumerator.defaultExtensions) {
+        for (const extension of FileEnumerator.defaultExtensions) {
             if (filePath.endsWith(extension)) {
                 return true;
             }
@@ -542,6 +536,12 @@ class FileEnumerator {
         return !direct && defaultIgnores(filePath, dotfiles);
     }
 }
+
+/**
+ * The extensions of the files to include by default.
+ */
+// `.js`, `.cjs` and `.mjs` are the default extensions.
+FileEnumerator.defaultExtensions = [".js", ".cjs", ".mjs"];
 
 //------------------------------------------------------------------------------
 // Public Interface

--- a/lib/cli-engine/file-enumerator.js
+++ b/lib/cli-engine/file-enumerator.js
@@ -47,6 +47,7 @@ const {
         CascadingConfigArrayFactory
     }
 } = require("@eslint/eslintrc");
+const { CLIEngine } = require("./cli-engine.js");
 const debug = require("debug")("eslint:file-enumerator");
 
 //------------------------------------------------------------------------------
@@ -206,6 +207,11 @@ class AllFilesIgnoredError extends Error {
  * matched by given glob patterns and that configuration.
  */
 class FileEnumerator {
+    /**
+     * The extensions of the files to include by default.
+     */
+    // `.js`, `.cjs` and `.mjs` are the default extensions.
+    static defaultExtensions = [".js", ".cjs", ".mjs"];
 
     /**
      * Initialize this enumerator.
@@ -251,9 +257,10 @@ class FileEnumerator {
             return extensionRegExp.test(filePath);
         }
 
-        // `.js` file is target by default.
-        if (filePath.endsWith(".js")) {
-            return true;
+        for (let extension of FileEnumerator.defaultExtensions) {
+            if (filePath.endsWith(extension)) {
+                return true;
+            }
         }
 
         // use `overrides[].files` to check additional targets.

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -5110,9 +5110,9 @@ describe("CLIEngine", () => {
     describe("resolveFileGlobPatterns", () => {
 
         [
-            [".", ["**/*.{js}"]],
-            ["./", ["**/*.{js}"]],
-            ["../", ["../**/*.{js}"]],
+            [".", ["**/*.{js,cjs,mjs}"]],
+            ["./", ["**/*.{js,cjs,mjs}"]],
+            ["../", ["../**/*.{js,cjs,mjs}"]],
             ["", []]
         ].forEach(([input, expected]) => {
 
@@ -5133,7 +5133,7 @@ describe("CLIEngine", () => {
             };
             const result = new CLIEngine(opts).resolveFileGlobPatterns(patterns);
 
-            assert.deepStrictEqual(result, ["one-js-file/**/*.{js}"]);
+            assert.deepStrictEqual(result, ["one-js-file/**/*.{js,cjs,mjs}"]);
         });
 
         it("should not convert path with globInputPaths option false", () => {
@@ -5153,7 +5153,7 @@ describe("CLIEngine", () => {
                 cwd: getFixturePath("glob-util")
             };
             const result = new CLIEngine(opts).resolveFileGlobPatterns(patterns);
-            const expected = [`${getFixturePath("glob-util", "one-js-file").replace(/\\/gu, "/")}/**/*.{js}`];
+            const expected = [`${getFixturePath("glob-util", "one-js-file").replace(/\\/gu, "/")}/**/*.{js,cjs,mjs}`];
 
             assert.deepStrictEqual(result, expected);
         });
@@ -5187,7 +5187,7 @@ describe("CLIEngine", () => {
             };
             const result = new CLIEngine(opts).resolveFileGlobPatterns(patterns);
 
-            assert.deepStrictEqual(result, ["one-js-file/**/*.{js}", "two-js-files/**/*.{js}"]);
+            assert.deepStrictEqual(result, ["one-js-file/**/*.{js,cjs,mjs}", "two-js-files/**/*.{js,cjs,mjs}"]);
         });
 
         it("should remove leading './' from glob patterns", () => {
@@ -5197,7 +5197,7 @@ describe("CLIEngine", () => {
             };
             const result = new CLIEngine(opts).resolveFileGlobPatterns(patterns);
 
-            assert.deepStrictEqual(result, ["one-js-file/**/*.{js}"]);
+            assert.deepStrictEqual(result, ["one-js-file/**/*.{js,cjs,mjs}"]);
         });
 
         it("should convert a directory name with a trailing '/' into a glob pattern", () => {
@@ -5207,7 +5207,7 @@ describe("CLIEngine", () => {
             };
             const result = new CLIEngine(opts).resolveFileGlobPatterns(patterns);
 
-            assert.deepStrictEqual(result, ["one-js-file/**/*.{js}"]);
+            assert.deepStrictEqual(result, ["one-js-file/**/*.{js,cjs,mjs}"]);
         });
 
         it("should return filenames as they are", () => {

--- a/tests/lib/cli-engine/file-enumerator.js
+++ b/tests/lib/cli-engine/file-enumerator.js
@@ -182,6 +182,52 @@ describe("FileEnumerator", () => {
             });
         });
 
+        describe("with a directory 'lib' that contains 'common.cjs' and 'module.mjs'", () => {
+            const root = path.join(os.tmpdir(), "eslint/file-enumerator");
+            const files = {
+                "lib/common.cjs": "",
+                "lib/module.mjs": "",
+                "lib/other.txt": "",
+                ".eslintrc.json": JSON.stringify({
+                })
+            };
+            const { prepare, cleanup, getPath } = createCustomTeardown({ cwd: root, files });
+
+            /** @type {FileEnumerator} */
+            let enumerator;
+
+            beforeEach(async () => {
+                await prepare();
+                enumerator = new FileEnumerator({ cwd: getPath() });
+            });
+
+            afterEach(cleanup);
+
+            describe("if 'lib' were ", () => {
+
+                /** @type {Array<{config:(typeof import('../../../lib/cli-engine')).ConfigArray, filePath:string, ignored:boolean}>} */
+                let list;
+
+                beforeEach(() => {
+                    list = [...enumerator.iterateFiles(["lib"])];
+                });
+
+                it("should list two files.", () => {
+                    assert.strictEqual(list.length, 2);
+                });
+
+                it("should list 'lib/common.cjs' and 'lib/module.mjs'.", () => {
+                    assert.deepStrictEqual(
+                        list.map(entry => entry.filePath),
+                        [
+                            path.join(root, "lib/common.cjs"),
+                            path.join(root, "lib/module.mjs")
+                        ]
+                    );
+                });
+            });
+        });
+
         // This group moved from 'tests/lib/util/glob-utils.js' when refactoring to keep the cumulated test cases.
         describe("with 'tests/fixtures/glob-utils' files", () => {
             let fixtureDir;


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] ~~Other, please explain:~~

#### What changes did you make? (Give an overview)
According to `Node.js`' docs, the `.cjs` and `.mjs` file extensions are now commonly used file extensions for flagging a module as `CommonJS` or as `ESModule`.
Thus, I changed `eslint`'s behaviour to lint `.cjs` and `.mjs` by efault as well.

#### Is there anything you'd like reviewers to focus on?
Please have a look at the constant variable I introduced in `file-enumerator.js`. Do you think it's a good idea to have a list of file extensions in such a constant instead of maintaining two different lists in `FileEnumerator.isTargetPath` and `CLIEngine.resolveFileGlobPatterns`?
