### PR TITLE
docs: Use correct past tense "left" instead of "leaved"

### DIFF
--- a/docs/src/developer-guide/code-path-analysis.md
+++ b/docs/src/developer-guide/code-path-analysis.md
@@ -100,10 +100,10 @@ module.exports = function(context) {
         },
 
         /**
-         * This is called when a code path segment was leaved.
+         * This is called when a code path segment was left.
          * In this time, the segment does not have the next segments yet.
          *
-         * @param {CodePathSegment} segment - The leaved code path segment.
+         * @param {CodePathSegment} segment - The left code path segment.
          * @param {ASTNode} node - The current node.
          * @returns {void}
          */


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

The code path analysis documentation says that `onCodePathSegmentEnd`
is called when a segment was "leaved". It should use the correct past tense
and say "when it was left".


#### Is there anything you'd like reviewers to focus on?

N/A

<!-- markdownlint-disable-file MD004 -->
