### PR TITLE
feat: fix indent bug with semicolon-first style

### DIFF
--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -6171,6 +6171,16 @@ ruleTester.run("indent", rule, {
         {
             code: unIndent`
                 if (foo)
+                    bar()
+                else if (baz)
+                    qux()
+                ;quux()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo)
                     if (bar)
                         baz()
                     else
@@ -13020,6 +13030,24 @@ ruleTester.run("indent", rule, {
             `,
             options: [4],
             errors: expectedErrors([4, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar()
+                else if (baz)
+                    qux()
+                    ;quux()
+            `,
+            output: unIndent`
+                if (foo)
+                    bar()
+                else if (baz)
+                    qux()
+                ;quux()
+            `,
+            options: [4],
+            errors: expectedErrors([5, 0, 4, "Punctuator"])
         },
         {
             code: unIndent`

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -6082,6 +6082,252 @@ ruleTester.run("indent", rule, {
             `,
             options: [4, { FunctionExpression: { body: 2 }, StaticBlock: { body: 2 } }],
             parserOptions: { ecmaVersion: 2022 }
+        },
+
+        // https://github.com/eslint/eslint/issues/15930
+        {
+            code: unIndent`
+                if (2 > 1)
+                \tconsole.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: ["tab"]
+        },
+        {
+            code: unIndent`
+                if (2 > 1)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo) bar();
+                baz()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo) bar()
+                ;baz()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar();
+                baz();
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar()
+                ; baz()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar()
+                ;baz()
+                qux()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar()
+                ;else
+                    baz()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar()
+                else
+                    baz()
+                ;qux()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar)
+                        baz()
+                ;qux()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar)
+                        baz()
+                    else
+                        qux()
+                ;quux()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar()
+                    ;
+                baz()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    ;
+                baz()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                ;baz()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo);
+                else
+                    baz()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    ;
+                else
+                    baz()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                ;else
+                    baz()
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                do foo();
+                while (bar)
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                do foo()
+                ;while (bar)
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                do
+                    foo();
+                while (bar)
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                do
+                    foo()
+                ;while (bar)
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                do;
+                while (foo)
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                do
+                    ;
+                while (foo)
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                do
+                ;while (foo)
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                while (2 > 1)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                for (;;)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                for (a in b)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                for (a of b)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                label: for (a of b)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                label:
+                for (a of b)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4]
         }
     ],
 
@@ -12623,6 +12869,439 @@ ruleTester.run("indent", rule, {
                 [6, 12, 0, "Identifier"],
                 [7, 4, 0, "Punctuator"]
             ])
+        },
+
+        // https://github.com/eslint/eslint/issues/15930
+        {
+            code: unIndent`
+                if (2 > 1)
+                \tconsole.log('a')
+                \t;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            output: unIndent`
+                if (2 > 1)
+                \tconsole.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: ["tab"],
+            errors: expectedErrors("tab", [3, 0, 1, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (2 > 1)
+                    console.log('a')
+                    ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            output: unIndent`
+                if (2 > 1)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4],
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (foo) bar();
+                    baz()
+            `,
+            output: unIndent`
+                if (foo) bar();
+                baz()
+            `,
+            options: [4],
+            errors: expectedErrors([2, 0, 4, "Identifier"])
+        },
+        {
+            code: unIndent`
+                if (foo) bar()
+                    ;baz()
+            `,
+            output: unIndent`
+                if (foo) bar()
+                ;baz()
+            `,
+            options: [4],
+            errors: expectedErrors([2, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar();
+                    baz();
+            `,
+            output: unIndent`
+                if (foo)
+                    bar();
+                baz();
+            `,
+            options: [4],
+            errors: expectedErrors([3, 0, 4, "Identifier"])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar()
+                    ; baz()
+            `,
+            output: unIndent`
+                if (foo)
+                    bar()
+                ; baz()
+            `,
+            options: [4],
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar()
+                    ;baz()
+                    qux()
+            `,
+            output: unIndent`
+            if (foo)
+                bar()
+            ;baz()
+            qux()
+        `,
+            options: [4],
+            errors: expectedErrors([
+                [3, 0, 4, "Punctuator"],
+                [4, 0, 4, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar()
+                    ;else
+                    baz()
+            `,
+            output: unIndent`
+                if (foo)
+                    bar()
+                ;else
+                    baz()
+            `,
+            options: [4],
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar()
+                else
+                    baz()
+                    ;qux()
+            `,
+            output: unIndent`
+                if (foo)
+                    bar()
+                else
+                    baz()
+                ;qux()
+            `,
+            options: [4],
+            errors: expectedErrors([5, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar)
+                        baz()
+                    ;qux()
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar)
+                        baz()
+                ;qux()
+            `,
+            options: [4],
+            errors: expectedErrors([4, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar)
+                        baz()
+                    else
+                        qux()
+                    ;quux()
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar)
+                        baz()
+                    else
+                        qux()
+                ;quux()
+            `,
+            options: [4],
+            errors: expectedErrors([6, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar()
+                ;
+                baz()
+            `,
+            output: unIndent`
+                if (foo)
+                    bar()
+                    ;
+                baz()
+            `,
+            options: [4],
+            errors: expectedErrors([3, 4, 0, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                ;
+                baz()
+            `,
+            output: unIndent`
+                if (foo)
+                    ;
+                baz()
+            `,
+            options: [4],
+            errors: expectedErrors([2, 4, 0, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    ;baz()
+            `,
+            output: unIndent`
+                if (foo)
+                ;baz()
+            `,
+            options: [4],
+            errors: expectedErrors([2, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (foo);
+                    else
+                    baz()
+            `,
+            output: unIndent`
+                if (foo);
+                else
+                    baz()
+            `,
+            options: [4],
+            errors: expectedErrors([2, 0, 4, "Keyword"])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                ;
+                else
+                    baz()
+            `,
+            output: unIndent`
+                if (foo)
+                    ;
+                else
+                    baz()
+            `,
+            options: [4],
+            errors: expectedErrors([2, 4, 0, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    ;else
+                    baz()
+            `,
+            output: unIndent`
+                if (foo)
+                ;else
+                    baz()
+            `,
+            options: [4],
+            errors: expectedErrors([2, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                do foo();
+                    while (bar)
+            `,
+            output: unIndent`
+                do foo();
+                while (bar)
+            `,
+            options: [4],
+            errors: expectedErrors([2, 0, 4, "Keyword"])
+        },
+        {
+            code: unIndent`
+                do foo()
+                    ;while (bar)
+            `,
+            output: unIndent`
+                do foo()
+                ;while (bar)
+            `,
+            options: [4],
+            errors: expectedErrors([2, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                do
+                    foo();
+                    while (bar)
+            `,
+            output: unIndent`
+                do
+                    foo();
+                while (bar)
+            `,
+            options: [4],
+            errors: expectedErrors([3, 0, 4, "Keyword"])
+        },
+        {
+            code: unIndent`
+                do
+                    foo()
+                    ;while (bar)
+            `,
+            output: unIndent`
+            do
+                foo()
+            ;while (bar)
+        `,
+            options: [4],
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                do;
+                    while (foo)
+            `,
+            output: unIndent`
+                do;
+                while (foo)
+            `,
+            options: [4],
+            errors: expectedErrors([2, 0, 4, "Keyword"])
+        },
+        {
+            code: unIndent`
+                do
+                ;
+                while (foo)
+            `,
+            output: unIndent`
+                do
+                    ;
+                while (foo)
+            `,
+            options: [4],
+            errors: expectedErrors([2, 4, 0, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                do
+                    ;while (foo)
+            `,
+            output: unIndent`
+                do
+                ;while (foo)
+            `,
+            options: [4],
+            errors: expectedErrors([2, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                while (2 > 1)
+                    console.log('a')
+                    ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            output: unIndent`
+                while (2 > 1)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4],
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                for (;;)
+                    console.log('a')
+                    ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            output: unIndent`
+                for (;;)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4],
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                for (a in b)
+                    console.log('a')
+                    ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            output: unIndent`
+                for (a in b)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4],
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                for (a of b)
+                    console.log('a')
+                    ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            output: unIndent`
+                for (a of b)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4],
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                label: for (a of b)
+                    console.log('a')
+                    ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            output: unIndent`
+                label: for (a of b)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4],
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                label:
+                for (a of b)
+                    console.log('a')
+                    ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            output: unIndent`
+                label:
+                for (a of b)
+                    console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4],
+            errors: expectedErrors([4, 0, 4, "Punctuator"])
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #15930

This bug fix can produce more warnings and is therefore marked as `feat`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The removed lines of code had no effect (when I removed them, no test cases were failing) because [`"*"(node)`](https://github.com/eslint/eslint/blob/001b2a130f97f2e242a34ec316dc05c5fad31764/lib/rules/indent.js#L1603-L1611) overwrites indentation of that semicolon in a later step of the traversal. Therefore, I moved the logic that handles semi-first style into an `:exit` selector. I also added checks for the semi-first style to minimize the impact of this change.

#### Is there anything you'd like reviewers to focus on?

I noticed that `addBlocklessNodeIndent` is not applied to WithStatement nodes. I'll fix that separately. 

<!-- markdownlint-disable-file MD004 -->
