### PR TITLE
feat!: allow changing warnIgnored via CLI

### DIFF
--- a/conf/default-cli-options.js
+++ b/conf/default-cli-options.js
@@ -28,5 +28,6 @@ module.exports = {
     fix: false,
     allowInlineConfig: true,
     reportUnusedDisableDirectives: void 0,
-    globInputPaths: true
+    globInputPaths: true,
+    warnIgnored: true
 };

--- a/docs/src/user-guide/configuring/ignoring-code.md
+++ b/docs/src/user-guide/configuring/ignoring-code.md
@@ -141,12 +141,12 @@ You'll see this warning:
 
 ```text
 foo.js
-  0:0  warning  File ignored because of a matching ignore pattern. Use "--no-ignore" to override.
+  0:0  warning  File ignored because of a matching ignore pattern. Use "--no-ignore" to override. Use \"--no-warning-on-ignored-files\" to suppress this warning.
 
 ✖ 1 problem (0 errors, 1 warning)
 ```
 
-This message occurs because ESLint is unsure if you wanted to actually lint the file or not. As the message indicates, you can use `--no-ignore` to omit using the ignore rules.
+This message occurs because ESLint is unsure if you wanted to actually lint the file or not. As the message indicates, you can use `--no-ignore` to omit using the ignore rules. If you want to suppress this warning (for example, if you're using `--max-warnings 0`), you can use `--no-warning-on-ignored-files`.
 
 Consider another scenario where you may want to run ESLint on a specific dot-file or dot-folder, but have forgotten to specifically allow those files in your `.eslintignore` file. You would run something like this:
 
@@ -156,9 +156,9 @@ You would see this warning:
 
 ```text
 .config/foo.js
-  0:0  warning  File ignored by default.  Use a negated ignore pattern (like "--ignore-pattern '!<relative/path/to/filename>'") to override
+  0:0  warning  File ignored by default.  Use a negated ignore pattern (like "--ignore-pattern '!<relative/path/to/filename>'") to override. Use \"--no-warning-on-ignored-files\" to suppress this warning.
 
 ✖ 1 problem (0 errors, 1 warning)
 ```
 
-This message occurs because, normally, this file would be ignored by ESLint's implicit ignore rules (as mentioned above). A negated ignore rule in your `.eslintignore` file would override the implicit rule and reinclude this file for linting. Additionally, in this specific case, `--no-ignore` could be used to lint the file as well.
+This message occurs because, normally, this file would be ignored by ESLint's implicit ignore rules (as mentioned above). A negated ignore rule in your `.eslintignore` file would override the implicit rule and reinclude this file for linting. Additionally, in this specific case, `--no-ignore` could be used to lint the file as well. If you _don't_ want to lint the ignored file and want to suppress the warning, you can use `--no-warning-on-ignored-files`.

--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -297,11 +297,11 @@ function createIgnoreResult(filePath, baseDir) {
     const isInNodeModules = baseDir && path.relative(baseDir, filePath).startsWith("node_modules");
 
     if (isHidden) {
-        message = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override.";
+        message = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override. Use \"--no-warning-on-ignored-files\" to suppress this warning.";
     } else if (isInNodeModules) {
-        message = "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override.";
+        message = "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override. Use \"--no-warning-on-ignored-files\" to suppress this warning.";
     } else {
-        message = "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override.";
+        message = "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override. Use \"--no-warning-on-ignored-files\" to suppress this warning.";
     }
 
     return {
@@ -759,7 +759,8 @@ class CLIEngine {
                 cache,
                 cwd,
                 fix,
-                reportUnusedDisableDirectives
+                reportUnusedDisableDirectives,
+                warnIgnored
             }
         } = internalSlotsMap.get(this);
         const results = [];
@@ -785,7 +786,9 @@ class CLIEngine {
         // Iterate source code files.
         for (const { config, filePath, ignored } of fileEnumerator.iterateFiles(patterns)) {
             if (ignored) {
-                results.push(createIgnoreResult(filePath, cwd));
+                if (warnIgnored) {
+                    results.push(createIgnoreResult(filePath, cwd));
+                }
                 continue;
             }
 
@@ -886,7 +889,8 @@ class CLIEngine {
                 allowInlineConfig,
                 cwd,
                 fix,
-                reportUnusedDisableDirectives
+                reportUnusedDisableDirectives,
+                warnIgnored: engineWarnIgnored
             }
         } = internalSlotsMap.get(this);
         const results = [];
@@ -897,7 +901,7 @@ class CLIEngine {
         // Clear the last used config arrays.
         lastConfigArrays.length = 0;
         if (resolvedFilename && this.isPathIgnored(resolvedFilename)) {
-            if (warnIgnored) {
+            if (warnIgnored ?? engineWarnIgnored) {
                 results.push(createIgnoreResult(resolvedFilename, cwd));
             }
         } else {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -84,7 +84,8 @@ function translateOptions({
     reportUnusedDisableDirectives,
     resolvePluginsRelativeTo,
     rule,
-    rulesdir
+    rulesdir,
+    warningOnIgnoredFiles
 }) {
     return {
         allowInlineConfig: inlineConfig,
@@ -120,7 +121,8 @@ function translateOptions({
         reportUnusedDisableDirectives: reportUnusedDisableDirectives ? "error" : void 0,
         resolvePluginsRelativeTo,
         rulePaths: rulesdir,
-        useEslintrc: eslintrc
+        useEslintrc: eslintrc,
+        warnIgnored: warningOnIgnoredFiles
     };
 }
 
@@ -294,8 +296,7 @@ const cli = {
 
         if (useStdin) {
             results = await engine.lintText(text, {
-                filePath: options.stdinFilename,
-                warnIgnored: true
+                filePath: options.stdinFilename
             });
         } else {
             results = await engine.lintFiles(files);

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -66,6 +66,7 @@ const { version } = require("../../package.json");
  * @property {string} [resolvePluginsRelativeTo] The folder where plugins should be resolved from, defaulting to the CWD.
  * @property {string[]} [rulePaths] An array of directories to load custom rules from.
  * @property {boolean} [useEslintrc] False disables looking for .eslintrc.* files.
+ * @property {boolean} [warnIgnored] Show warning when the file list includes ignored files. Defaults to `true`.
  */
 
 /**
@@ -168,6 +169,7 @@ function processOptions({
     resolvePluginsRelativeTo = null, // ← should be null by default because if it's a string then it suppresses RFC47 feature.
     rulePaths = [],
     useEslintrc = true,
+    warnIgnored = true,
     ...unknownOptions
 }) {
     const errors = [];
@@ -276,7 +278,9 @@ function processOptions({
     if (typeof useEslintrc !== "boolean") {
         errors.push("'useEslintrc' must be a boolean.");
     }
-
+    if (typeof warnIgnored !== "boolean") {
+        errors.push("'warnIgnored' must be a boolean.");
+    }
     if (errors.length > 0) {
         throw new ESLintInvalidOptionsError(errors);
     }
@@ -299,7 +303,8 @@ function processOptions({
         reportUnusedDisableDirectives,
         resolvePluginsRelativeTo,
         rulePaths,
-        useEslintrc
+        useEslintrc,
+        warnIgnored
     };
 }
 
@@ -568,7 +573,7 @@ class ESLint {
         }
         const {
             filePath,
-            warnIgnored = false,
+            warnIgnored,
             ...unknownOptions
         } = options || {};
 
@@ -581,7 +586,7 @@ class ESLint {
         if (filePath !== void 0 && !isNonEmptyString(filePath)) {
             throw new Error("'options.filePath' must be a non-empty string or undefined");
         }
-        if (typeof warnIgnored !== "boolean") {
+        if (typeof warnIgnored !== "boolean" && typeof warnIgnored !== "undefined") {
             throw new Error("'options.warnIgnored' must be a boolean or undefined");
         }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -55,6 +55,7 @@ const optionator = require("optionator");
  * @property {string} [stdinFilename] Specify filename to process STDIN as
  * @property {boolean} quiet Report errors only
  * @property {boolean} [version] Output the version number
+ * @property {boolean} warningOnIgnoredFiles Show warning when the file list includes ignored files
  * @property {string[]} _ Positional filenames or patterns
  */
 
@@ -283,6 +284,12 @@ module.exports = optionator({
             type: "Boolean",
             default: "false",
             description: "Output execution environment information"
+        },
+        {
+            option: "warning-on-ignored-files",
+            type: "Boolean",
+            default: "true",
+            description: "Show warning when the file list includes ignored files"
         },
         {
             option: "error-on-unmatched-pattern",

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -472,7 +472,17 @@ describe("cli", () => {
             const filePath = getFixturePath("passing.js");
             const exit = await cli.execute(`--ignore-path ${ignorePath} --no-ignore ${filePath}`);
 
-            // no warnings
+            // the file is linted, and no warnings are shown
+            assert.isFalse(log.info.called);
+            assert.strictEqual(exit, 0);
+        });
+
+        it("should suppress the warning when no-warning-on-ignored-files flag is passed", async () => {
+            const ignorePath = getFixturePath(".eslintignore");
+            const filePath = getFixturePath("passing.js");
+            const exit = await cli.execute(`--ignore-path ${ignorePath} --no-warning-on-ignored-files ${filePath}`);
+
+            // the file is ignored, and the warning is suppressed
             assert.isFalse(log.info.called);
             assert.strictEqual(exit, 0);
         });

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -192,7 +192,8 @@ describe("ESLint", () => {
                     reportUnusedDisableDirectives: "",
                     resolvePluginsRelativeTo: "",
                     rulePaths: "",
-                    useEslintrc: ""
+                    useEslintrc: "",
+                    warnIgnored: ""
                 }),
                 new RegExp(escapeStringRegExp([
                     "Invalid Options:",
@@ -214,7 +215,8 @@ describe("ESLint", () => {
                     "- 'reportUnusedDisableDirectives' must be any of \"error\", \"warn\", \"off\", and null.",
                     "- 'resolvePluginsRelativeTo' must be a non-empty string or null.",
                     "- 'rulePaths' must be an array of non-empty strings.",
-                    "- 'useEslintrc' must be a boolean."
+                    "- 'useEslintrc' must be a boolean.",
+                    "- 'warnIgnored' must be a boolean."
                 ].join("\n")), "u")
             );
         });
@@ -321,7 +323,7 @@ describe("ESLint", () => {
             assert.strictEqual(results.length, 1);
             assert.strictEqual(results[0].filePath, getFixturePath("passing.js"));
             assert.strictEqual(results[0].messages[0].severity, 1);
-            assert.strictEqual(results[0].messages[0].message, "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override.");
+            assert.strictEqual(results[0].messages[0].message, "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override. Use \"--no-warning-on-ignored-files\" to suppress this warning.");
             assert.strictEqual(results[0].messages[0].output, void 0);
             assert.strictEqual(results[0].errorCount, 0);
             assert.strictEqual(results[0].warningCount, 1);
@@ -348,7 +350,7 @@ describe("ESLint", () => {
             assert.strictEqual(results.length, 0);
         });
 
-        it("should suppress excluded file warnings by default", async () => {
+        it("should return a warning when given a filename by --stdin-filename in excluded files list by default", async () => {
             eslint = new ESLint({
                 ignorePath: getFixturePath(".eslintignore"),
                 cwd: getFixturePath("..")
@@ -356,7 +358,31 @@ describe("ESLint", () => {
             const options = { filePath: "fixtures/passing.js" };
             const results = await eslint.lintText("var bar = foo;", options);
 
-            // should not report anything because there are no errors
+            assert.strictEqual(results.length, 1);
+            assert.strictEqual(results[0].filePath, getFixturePath("passing.js"));
+            assert.strictEqual(results[0].messages[0].severity, 1);
+            assert.strictEqual(results[0].messages[0].message, "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override. Use \"--no-warning-on-ignored-files\" to suppress this warning.");
+            assert.strictEqual(results[0].messages[0].output, void 0);
+            assert.strictEqual(results[0].errorCount, 0);
+            assert.strictEqual(results[0].warningCount, 1);
+            assert.strictEqual(results[0].fatalErrorCount, 0);
+            assert.strictEqual(results[0].fixableErrorCount, 0);
+            assert.strictEqual(results[0].fixableWarningCount, 0);
+            assert.strictEqual(results[0].usedDeprecatedRules.length, 0);
+        });
+
+        it("should suppress the warning when given a filename by --stdin-filename in excluded files list if warnIgnored in ESLint options is false", async () => {
+            eslint = new ESLint({
+                ignorePath: getFixturePath(".eslintignore"),
+                cwd: getFixturePath(".."),
+                warnIgnored: false
+            });
+            const options = {
+                filePath: "fixtures/passing.js"
+            };
+
+            const results = await eslint.lintText("var bar = foo;", options);
+
             assert.strictEqual(results.length, 0);
         });
 
@@ -841,7 +867,7 @@ describe("ESLint", () => {
                 ignore: false
             });
             const results = await eslint.lintText("var bar = foo;", { filePath: "node_modules/passing.js", warnIgnored: true });
-            const expectedMsg = "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override.";
+            const expectedMsg = "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override. Use \"--no-warning-on-ignored-files\" to suppress this warning.";
 
             assert.strictEqual(results.length, 1);
             assert.strictEqual(results[0].filePath, getFixturePath("node_modules/passing.js"));
@@ -1095,7 +1121,7 @@ describe("ESLint", () => {
                 cwd: getFixturePath("cli-engine")
             });
             const results = await eslint.lintFiles(["node_modules/foo.js"]);
-            const expectedMsg = "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override.";
+            const expectedMsg = "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override. Use \"--no-warning-on-ignored-files\" to suppress this warning.";
 
             assert.strictEqual(results.length, 1);
             assert.strictEqual(results[0].errorCount, 0);
@@ -1104,6 +1130,16 @@ describe("ESLint", () => {
             assert.strictEqual(results[0].fixableErrorCount, 0);
             assert.strictEqual(results[0].fixableWarningCount, 0);
             assert.strictEqual(results[0].messages[0].message, expectedMsg);
+        });
+
+        it("should suppress the warning on explicitly passed file, when file is ignored by default and warnIgnored is false", async () => {
+            eslint = new ESLint({
+                cwd: getFixturePath("cli-engine"),
+                warnIgnored: false
+            });
+            const results = await eslint.lintFiles(["node_modules/foo.js"]);
+
+            assert.strictEqual(results.length, 0);
         });
 
         it("should report on globs with explicit inclusion of dotfiles, even though ignored by default", async () => {
@@ -1157,7 +1193,7 @@ describe("ESLint", () => {
                 }
             });
             const results = await eslint.lintFiles(["fixtures/files/.bar.js"]);
-            const expectedMsg = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override.";
+            const expectedMsg = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override. Use \"--no-warning-on-ignored-files\" to suppress this warning.";
 
             assert.strictEqual(results.length, 1);
             assert.strictEqual(results[0].errorCount, 0);
@@ -1166,6 +1202,23 @@ describe("ESLint", () => {
             assert.strictEqual(results[0].fixableErrorCount, 0);
             assert.strictEqual(results[0].fixableWarningCount, 0);
             assert.strictEqual(results[0].messages[0].message, expectedMsg);
+        });
+
+        it("should suppress the warning when .hidden files are passed explicitly without --no-ignore flag and warnIgnored is false", async () => {
+
+            eslint = new ESLint({
+                cwd: getFixturePath(".."),
+                useEslintrc: false,
+                overrideConfig: {
+                    rules: {
+                        quotes: [2, "single"]
+                    }
+                },
+                warnIgnored: false
+            });
+            const results = await eslint.lintFiles(["fixtures/files/.bar.js"]);
+
+            assert.strictEqual(results.length, 0);
         });
 
         // https://github.com/eslint/eslint/issues/12873
@@ -1180,7 +1233,7 @@ describe("ESLint", () => {
                 }
             });
             const results = await eslint.lintFiles(["hidden/.hiddenfolder/double-quotes.js"]);
-            const expectedMsg = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override.";
+            const expectedMsg = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override. Use \"--no-warning-on-ignored-files\" to suppress this warning.";
 
             assert.strictEqual(results.length, 1);
             assert.strictEqual(results[0].errorCount, 0);
@@ -1189,6 +1242,22 @@ describe("ESLint", () => {
             assert.strictEqual(results[0].fixableErrorCount, 0);
             assert.strictEqual(results[0].fixableWarningCount, 0);
             assert.strictEqual(results[0].messages[0].message, expectedMsg);
+        });
+
+        it("should suppress the warning when files within a .hidden folder are passed explicitly without the --no-ignore flag and warnIgnored is set to false", async () => {
+            eslint = new ESLint({
+                cwd: getFixturePath("cli-engine"),
+                useEslintrc: false,
+                overrideConfig: {
+                    rules: {
+                        quotes: [2, "single"]
+                    }
+                },
+                warnIgnored: false
+            });
+            const results = await eslint.lintFiles(["hidden/.hiddenfolder/double-quotes.js"]);
+
+            assert.strictEqual(results.length, 0);
         });
 
         it("should check .hidden files if they are passed explicitly with --no-ignore flag", async () => {
@@ -1484,12 +1553,24 @@ describe("ESLint", () => {
             assert.strictEqual(results.length, 1);
             assert.strictEqual(results[0].filePath, filePath);
             assert.strictEqual(results[0].messages[0].severity, 1);
-            assert.strictEqual(results[0].messages[0].message, "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override.");
+            assert.strictEqual(results[0].messages[0].message, "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override. Use \"--no-warning-on-ignored-files\" to suppress this warning.");
             assert.strictEqual(results[0].errorCount, 0);
             assert.strictEqual(results[0].warningCount, 1);
             assert.strictEqual(results[0].fatalErrorCount, 0);
             assert.strictEqual(results[0].fixableErrorCount, 0);
             assert.strictEqual(results[0].fixableWarningCount, 0);
+        });
+
+        it("should suppress a warning when an explicitly given file is ignored and warnIgnored is false", async () => {
+            eslint = new ESLint({
+                ignorePath: getFixturePath(".eslintignore"),
+                cwd: getFixturePath(),
+                warnIgnored: false
+            });
+            const filePath = getFixturePath("passing.js");
+            const results = await eslint.lintFiles([filePath]);
+
+            assert.strictEqual(results.length, 0);
         });
 
         it("should return two messages when given a file in excluded files list while ignore is off", async () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[x] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This is related to https://github.com/eslint/rfcs/pull/90 and https://github.com/eslint/eslint/issues/15010

- Added `--no-warning-on-ignored-files` CLI option
- Removed inconsistent `warnIgnored` defaults, replaced with a single `warnIgnored: true` default
- Updated warning messages to inform users about the ability to suppress the warning
- Added tests for `CLIEngine.executeOnText`, `CLIEngine.executeOnFiles`, `ESLint.lintText`, `ESLint.lintFiles` and CLI

#### Is there anything you'd like reviewers to focus on?

- Are there any tests missing?
- Making defaults consistent is technically a breaking change. What should be done in this case?

<!-- markdownlint-disable-file MD004 -->
