### PR TITLE
docs: Switch to version-relative URLs

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -318,6 +318,10 @@ function generatePrerelease(prereleaseId) {
  */
 function publishRelease() {
     ReleaseOps.publishRelease();
+
+    // push to latest branch to trigger docs deploy
+    exec("git push origin HEAD:latest -f");
+
     publishSite();
 }
 

--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -16,13 +16,29 @@ const {
 module.exports = function(eleventyConfig) {
 
     /*
-     * The site is loaded from /docs on eslint.org and so we need to adjust
-     * the path prefix so URLs are evaluated correctly.
+     * The docs stored in the eslint repo are loaded through eslint.org at
+     * at /docs/head to show the most recent version of the documentation
+     * based on the HEAD commit. This gives users a preview of what's coming
+     * in the next release. This is the way that the site works locally so
+     * it's easier to see if URLs are broken.
+     *
+     * When a release is published, HEAD is pushed to the "latest" branch.
+     * Netlify deploys that branch as well, and in that case, we want the
+     * docs to be loaded from /docs/latest on eslint.org.
      *
      * The path prefix is turned off for deploy previews so we can properly
      * see changes before deployed.
      */
-    const pathPrefix = process.env.CONTEXT === "deploy-preview" ? "" : "/docs";
+
+    let pathPrefix = "/docs/head";
+
+    if (process.env.CONTEXT === "deploy-preview") {
+        pathPrefix = "";
+    } else if (process.env.BRANCH === "latest") {
+        pathPrefix = "/docs/latest";
+    }
+
+    eleventyConfig.addGlobalData("GIT_BRANCH", process.env.BRANCH);
 
     //------------------------------------------------------------------------------
     // Filters

--- a/docs/src/_includes/components/nav-version-switcher.html
+++ b/docs/src/_includes/components/nav-version-switcher.html
@@ -12,8 +12,8 @@
             <span class="label__text">Version</span>
         </label>
         <select name="version selector" id="nav-version-select" aria-describedby="nav-version-infobox" class="c-custom-select switcher__select auto-switcher">
-            <option value="HEAD" data-url="/docs/head" {% if GIT_BRANCH !="latest" %}selected{% endif %}>HEAD</option>
-            <option value="{{ eslintVersion }}" data-url="/docs/latest" {% if GIT_BRANCH=="latest" %}selected{% endif %}>v{{ eslintVersion }}</option>
+            <option value="HEAD" data-url="/docs/head/" {% if GIT_BRANCH !="latest" %}selected{% endif %}>HEAD</option>
+            <option value="{{ eslintVersion }}" data-url="/docs/latest/" {% if GIT_BRANCH=="latest" %}selected{% endif %}>v{{ eslintVersion }}</option>
             {% for version in versions.items %}
             <option value="{{ version.number }}"
                     data-url="{{ version.url }}">

--- a/docs/src/_includes/components/nav-version-switcher.html
+++ b/docs/src/_includes/components/nav-version-switcher.html
@@ -12,7 +12,8 @@
             <span class="label__text">Version</span>
         </label>
         <select name="version selector" id="nav-version-select" aria-describedby="nav-version-infobox" class="c-custom-select switcher__select auto-switcher">
-            <option value="{{ eslintVersion }}" selected>v{{ eslintVersion }}</option>
+            <option value="HEAD" data-url="/docs/head" {% if GIT_BRANCH !="latest" %}selected{% endif %}>HEAD</option>
+            <option value="{{ eslintVersion }}" data-url="/docs/latest" {% if GIT_BRANCH=="latest" %}selected{% endif %}>v{{ eslintVersion }}</option>
             {% for version in versions.items %}
             <option value="{{ version.number }}"
                     data-url="{{ version.url }}">

--- a/docs/src/_includes/components/version-switcher.html
+++ b/docs/src/_includes/components/version-switcher.html
@@ -12,7 +12,8 @@
             <span class="label__text">Version</span>
         </label>
         <select name="version selector" id="version-select" aria-describedby="version-infobox" class="c-custom-select switcher__select auto-switcher">
-            <option value="{{ eslintVersion }}" selected>v{{ eslintVersion }}</option>
+            <option value="HEAD" data-url="/docs/head"  {% if GIT_BRANCH != "latest" %}selected{% endif %}>HEAD</option>
+            <option value="{{ eslintVersion }}" data-url="/docs/latest"  {% if GIT_BRANCH == "latest" %}selected{% endif %}>v{{ eslintVersion }}</option>
             {% for version in versions.items %}
             <option value="{{ version.number }}"
                     data-url="{{ version.url }}">

--- a/docs/src/_includes/components/version-switcher.html
+++ b/docs/src/_includes/components/version-switcher.html
@@ -12,8 +12,8 @@
             <span class="label__text">Version</span>
         </label>
         <select name="version selector" id="version-select" aria-describedby="version-infobox" class="c-custom-select switcher__select auto-switcher">
-            <option value="HEAD" data-url="/docs/head"  {% if GIT_BRANCH != "latest" %}selected{% endif %}>HEAD</option>
-            <option value="{{ eslintVersion }}" data-url="/docs/latest"  {% if GIT_BRANCH == "latest" %}selected{% endif %}>v{{ eslintVersion }}</option>
+            <option value="HEAD" data-url="/docs/head/"  {% if GIT_BRANCH != "latest" %}selected{% endif %}>HEAD</option>
+            <option value="{{ eslintVersion }}" data-url="/docs/latest/"  {% if GIT_BRANCH == "latest" %}selected{% endif %}>v{{ eslintVersion }}</option>
             {% for version in versions.items %}
             <option value="{{ version.number }}"
                     data-url="{{ version.url }}">

--- a/docs/src/_includes/partials/versions-list.html
+++ b/docs/src/_includes/partials/versions-list.html
@@ -1,6 +1,6 @@
 <ul class="versions-list">
-    <li><a href="/docs/head" {% if GIT_BRANCH != "latest" %} data-current="true" {% endif %}>HEAD</a></li>
-    <li><a href="/docs/latest" {% if GIT_BRANCH == "latest" %} data-current="true" {% endif %}>v{{ eslintVersion }}</a></li>
+    <li><a href="/docs/head/" {% if GIT_BRANCH != "latest" %} data-current="true" {% endif %}>HEAD</a></li>
+    <li><a href="/docs/latest/" {% if GIT_BRANCH == "latest" %} data-current="true" {% endif %}>v{{ eslintVersion }}</a></li>
     {%- for version in versions.items -%}
     <li><a href="{{ version.url }}">v{{ version.number }}</a></li>
     {%- endfor -%}

--- a/docs/src/_includes/partials/versions-list.html
+++ b/docs/src/_includes/partials/versions-list.html
@@ -1,5 +1,7 @@
 <ul class="versions-list">
+    <li><a href="/docs/head" {% if GIT_BRANCH != "latest" %} data-current="true" {% endif %}>HEAD</a></li>
+    <li><a href="/docs/latest" {% if GIT_BRANCH == "latest" %} data-current="true" {% endif %}>v{{ eslintVersion }}</a></li>
     {%- for version in versions.items -%}
-    <li><a href="{{ version.url }}" {% if config.version == version.number %} data-current="true" {% endif %}>v{{ version.number }}</a></li>
+    <li><a href="{{ version.url }}">v{{ version.number }}</a></li>
     {%- endfor -%}
 </ul>


### PR DESCRIPTION
Implements /docs/head and /docs/latest as ways to load the docs from
the HEAD branch and from the latest release.

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This change allows us to use two entrypoints for the docs site:

1. `/docs/head` - this is auto-published every time a change has been pushed to the `main` branch. Local development will also use this path prefix.
2. `/docs/latest` - this is published whenever we do a release (related changes in Makefile.js)

This will allow us to use Netlify's branch deploy feature to automatically deploy the `latest` branch whenever it's updated while still seeing updates to the main branch live as they are merged.

Note: This will require updating the redirects on new.eslint.org to property route these URLs.

#### Is there anything you'd like reviewers to focus on?

Does this seem like it should work?

<!-- markdownlint-disable-file MD004 -->
