### PR TITLE
build: remove unwanted parallel and image-min for dev server

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
         "watch:eleventy": "eleventy --serve --port=2023",
         "build:sass": "sass --style=compressed src/assets/scss:src/assets/css --no-source-map",
         "build:eleventy": "npx @11ty/eleventy",
-        "start": "npm-run-all build:sass images --parallel watch:*",
+        "start": "npm-run-all build:sass --parallel watch:*",
         "build": "npm-run-all build:sass build:eleventy images"
     },
     "devDependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,8 +14,8 @@
         "watch:eleventy": "eleventy --serve --port=2023",
         "build:sass": "sass --style=compressed src/assets/scss:src/assets/css --no-source-map",
         "build:eleventy": "npx @11ty/eleventy",
-        "start": "npm-run-all build:sass --parallel watch:*  --parallel images",
-        "build": "npm-run-all build:sass --parallel build:*   --parallel images"
+        "start": "npm-run-all build:sass images --parallel watch:*",
+        "build": "npm-run-all build:sass build:eleventy images"
     },
     "devDependencies": {
         "@11ty/eleventy": "^1.0.1",


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

#### What changes did you make? (Give an overview)

Similar to 
- https://github.com/eslint/new.eslint.org/pull/223
Can't run `images` command in parallel for the docs same applies for `start` and `build` so revamp it 

#### Is there anything you'd like reviewers to focus on?

Check built version 
