### PR TITLE
chore: tweak URL rewriting for local previews

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -390,7 +390,7 @@ module.exports = function(eleventyConfig) {
      */
     eleventyConfig.setBrowserSyncConfig({
         middleware: (req, res, next) => {
-            if (!/(?:\.[^/]+|\/)$/u.test(req.url)) {
+            if (!/(?:\.[a-zA-Z][^/]*|\/)$/u.test(req.url)) {
                 req.url += ".html";
             }
             return next();


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Follow-up to https://github.com/eslint/eslint/pull/15967.

I noticed that links to migration documents like `.../migrating-to-8.0.0` don't work in local previews. Because of the dots in the URL, they are interpreted as files with an extension so they are not getting the `.html` suffix appended.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Tweaked the url rewriting logic to treat only dots followed by a `[a-zA-Z]` character as a file extension.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
