### PR TITLE
chore: add trailing slash to `pathPrefix`

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -30,12 +30,12 @@ module.exports = function(eleventyConfig) {
      * see changes before deployed.
      */
 
-    let pathPrefix = "/docs/head";
+    let pathPrefix = "/docs/head/";
 
     if (process.env.CONTEXT === "deploy-preview") {
-        pathPrefix = "";
+        pathPrefix = "/";
     } else if (process.env.BRANCH === "latest") {
-        pathPrefix = "/docs/latest";
+        pathPrefix = "/docs/latest/";
     }
 
     eleventyConfig.addGlobalData("GIT_BRANCH", process.env.BRANCH);
@@ -212,7 +212,7 @@ module.exports = function(eleventyConfig) {
 
         rules.forEach(rule => {
             const listItem = `<li class="related-rules__list__item">
-                <a href="${pathPrefix}/rules/${rule}">
+                <a href="${pathPrefix}rules/${rule}">
                     <span>${rule}</span>
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false">
                         <path d="M5 12H19M19 12L12 5M19 12L12 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

When I run `npm start` and open `http://localhost:2023`, I'm getting:

```
Cannot GET /docs/head
```

This is because eleventy redirects to `pathPrefix`, which is `/docs/head` without a trailing slash, and we are now appending `.html` to these URLs.

I'm guessing we didn't notice this in https://github.com/eslint/eslint/pull/15967 because a redirect from `http://localhost:2023/docs` to `http://localhost:2023/docs/` was already cached in the browser. 

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added a trailing slash to all variants of `pathPrefix` we are using.

#### Is there anything you'd like reviewers to focus on?

This could be done by tweaking URL rewriting logic instead, but in all examples in eleventy's docs `pathPrefix` does have a trailing slash (and the default is `"/"`, not `""`), so I think this is a correct solution.

https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix

https://www.11ty.dev/docs/filters/url/

<!-- markdownlint-disable-file MD004 -->
