### PR TITLE
chore: remove unused deprecation warnings

### DIFF
--- a/lib/shared/deprecation-warnings.js
+++ b/lib/shared/deprecation-warnings.js
@@ -17,14 +17,7 @@ const path = require("path");
 // Definitions for deprecation warnings.
 const deprecationWarningMessages = {
     ESLINT_LEGACY_ECMAFEATURES:
-        "The 'ecmaFeatures' config file property is deprecated and has no effect.",
-    ESLINT_PERSONAL_CONFIG_LOAD:
-        "'~/.eslintrc.*' config files have been deprecated. " +
-        "Please use a config file per project or the '--config' option.",
-    ESLINT_PERSONAL_CONFIG_SUPPRESS:
-        "'~/.eslintrc.*' config files have been deprecated. " +
-        "Please remove it or add 'root:true' to the config files in your " +
-        "projects in order to avoid loading '~/.eslintrc.*' accidentally."
+        "The 'ecmaFeatures' config file property is deprecated and has no effect."
 };
 
 const sourceFileErrorCache = new Set();


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain: remove unused code from the core

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR removes the two unused deprecation messages `ESLINT_PERSONAL_CONFIG_LOAD` and `ESLINT_PERSONAL_CONFIG_SUPPRESS` from deprecation-warnings.js. Both keys are orphaned since #13762. The file deprecation-warnings.js is not exported in package.json and is only imported internally in config-validator.js, where only one deprecation warning is being used at this time:

https://github.com/eslint/eslint/blob/58840ac844a61c72eabb603ecfb761812b82a7ed/lib/shared/config-validator.js#L286

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
