### PR TITLE
chore: fix 'replaced by' rule list

### DIFF
--- a/docs/src/_includes/components/rule-list.macro.html
+++ b/docs/src/_includes/components/rule-list.macro.html
@@ -1,0 +1,3 @@
+{%- macro ruleList(params) -%}
+    {% for rule in params.rules %}<a href="{{ ['/rules/', rule] | join | url }}" class="rule-list-item"><code>{{ rule }}</code></a>{% endfor %}
+{%- endmacro -%}

--- a/docs/src/_includes/components/rule.macro.html
+++ b/docs/src/_includes/components/rule.macro.html
@@ -1,3 +1,5 @@
+{% from 'components/rule-list.macro.html' import ruleList %}
+
 {%- macro rule(params) -%}
 <article class="rule {% if params.deprecated == true %}rule--deprecated{% endif %} {% if params.removed == true %}rule--removed{% endif %}">
     <div class="rule__content">
@@ -7,7 +9,7 @@
             <span class="rule__status">deprecated</span>
         </p>
         {%- if params.replacedBy|length -%}
-        <p class="rule__description">Replaced by <a href="{{ ['/rules/', params.replacedBy] | join | url }}"><code>{{ params.replacedBy }}</code></a></p>
+        <p class="rule__description">Replaced by {{ ruleList({ rules: params.replacedBy }) }}</p>
         {%- else -%}<p class="rule__description">{{ params.description }}</p>
         {%- endif -%}
         {%- elseif params.removed == true -%}
@@ -16,7 +18,7 @@
             <span class="rule__status">removed</span>
         </p>
         {%- if params.replacedBy -%}
-        <p class="rule__description">Replaced by <a href="{{ ['/rules/', params.replacedBy] | join | url }}"><code>{{ params.replacedBy }}</code></a></p>
+        <p class="rule__description">Replaced by {{ ruleList({ rules: params.replacedBy }) }}</p>
         {%- else -%}<p class="rule__description">{{ params.description }}</p>
         {%- endif -%}
         {%- else -%}

--- a/docs/src/assets/scss/components/rules.scss
+++ b/docs/src/assets/scss/components/rules.scss
@@ -67,6 +67,14 @@
     font-size: .875rem;
     margin-bottom: .25rem;
     margin-block-end: .25rem;
+}
+
+a.rule__name {
+    text-decoration: none;
+
+    &:hover {
+        text-decoration: underline;
+    }
 
     &::after {
         position: absolute;
@@ -77,14 +85,6 @@
         offset-block-start: 0;
         left: 0;
         offset-inline-start: 0;
-    }
-}
-
-a.rule__name {
-    text-decoration: none;
-
-    &:hover {
-        text-decoration: underline;
     }
 }
 
@@ -165,4 +165,11 @@ a.rule__name {
             background-color: var(--lighter-background-color);
         }
     }
+}
+
+a.rule-list-item+a.rule-list-item::before {
+    content: ",";
+    display: inline-block;
+    margin-left: 5px;
+    margin-right: 5px;
 }

--- a/docs/src/library/rule-list.md
+++ b/docs/src/library/rule-list.md
@@ -1,0 +1,25 @@
+---
+title: Rule list
+---
+
+The rule list is a macro defined in `components/rule-list.macro.html`. The macro accepts a list of rule names and renders comma-separated links.
+
+## Usage
+
+{% raw %}
+
+```html
+<!-- import the macro -->
+{% from 'components/rule-list.macro.html' import ruleList %}
+
+<!-- use the macro -->
+{{ ruleList({ rules: ['accessor-pairs', 'no-undef'] }) }}
+```
+
+{% endraw %}
+
+## Examples
+
+{% from 'components/rule-list.macro.html' import ruleList %}
+
+{{ ruleList({ rules: ['accessor-pairs', 'no-undef'] }) }}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Fixes two problems with 'Replaced by' lists of rules below deprecated and removed rules on the new docs site:

1. Replacement rule links are not clickable.
2. Our template treats `replacedBy` as a single rule name, but it's an array of rule names. This works by chance when there is only one replacement rule, but it doesn't work when there are two or more. See, for example, no-arrow-condition in the list of removed rules. Since the link isn't clickable in the head version, check the html source: `<a href="/docs/head/rules/no-confusing-arrow,no-constant-condition">`.

https://new.eslint.org/docs/head/rules/#deprecated 

https://new.eslint.org/docs/head/rules/#removed

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

1. We are using [`.rule__name::after`](https://github.com/eslint/eslint/blob/ed49f15fad96060501927ca27ebda1a4c736ed04/docs/src/assets/scss/components/rules.scss#L71-L80) to extend the clickable range of a `.rule__name` link. But, in deprecated and removed rules, `.rule__name` is a paragraph, and this makes the 'replaced by' links unclickable. I moved this into `a.rule__name::after`.
2. Added a macro that accepts a list of rules and renders comma-separated links.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
