### PR TITLE
chore: add incorrect and correct in all rule docs

### DIFF
--- a/docs/src/rules/accessor-pairs.md
+++ b/docs/src/rules/accessor-pairs.md
@@ -81,6 +81,8 @@ Object.defineProperty(o, 'c', {
 
 Examples of **correct** code for the default `{ "setWithoutGet": true }` option:
 
+::: correct
+
 ```js
 /*eslint accessor-pairs: "error"*/
 
@@ -104,6 +106,8 @@ Object.defineProperty(o, 'c', {
 });
 
 ```
+
+:::
 
 ### getWithoutSet
 
@@ -145,6 +149,8 @@ Object.defineProperty(o, 'c', {
 
 Examples of **correct** code for the `{ "getWithoutSet": true }` option:
 
+::: correct
+
 ```js
 /*eslint accessor-pairs: ["error", { "getWithoutSet": true }]*/
 var o = {
@@ -167,6 +173,8 @@ Object.defineProperty(o, 'c', {
 });
 
 ```
+
+:::
 
 ### enforceForClassMembers
 
@@ -232,6 +240,8 @@ When `enforceForClassMembers` is set to `false`, this rule ignores classes.
 
 Examples of **correct** code for `{ "getWithoutSet": true, "setWithoutGet": true, "enforceForClassMembers": false }`:
 
+::: correct
+
 ```js
 /*eslint accessor-pairs: ["error", {
     "getWithoutSet": true, "setWithoutGet": true, "enforceForClassMembers": false
@@ -261,6 +271,8 @@ const Quux = class {
     }
 }
 ```
+
+:::
 
 ## Known Limitations
 

--- a/docs/src/rules/accessor-pairs.md
+++ b/docs/src/rules/accessor-pairs.md
@@ -58,6 +58,8 @@ This rule always checks object literals and property descriptors. By default, it
 
 Examples of **incorrect** code for the default `{ "setWithoutGet": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint accessor-pairs: "error"*/
 
@@ -74,6 +76,8 @@ Object.defineProperty(o, 'c', {
     }
 });
 ```
+
+:::
 
 Examples of **correct** code for the default `{ "setWithoutGet": true }` option:
 
@@ -105,6 +109,8 @@ Object.defineProperty(o, 'c', {
 
 Examples of **incorrect** code for the `{ "getWithoutSet": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint accessor-pairs: ["error", { "getWithoutSet": true }]*/
 
@@ -134,6 +140,8 @@ Object.defineProperty(o, 'c', {
     }
 });
 ```
+
+:::
 
 Examples of **correct** code for the `{ "getWithoutSet": true }` option:
 
@@ -169,6 +177,8 @@ When `enforceForClassMembers` is set to `true` (default):
 
 Examples of **incorrect** code for `{ "getWithoutSet": true, "enforceForClassMembers": true }`:
 
+::: incorrect
+
 ```js
 /*eslint accessor-pairs: ["error", { "getWithoutSet": true, "enforceForClassMembers": true }]*/
 
@@ -194,7 +204,11 @@ const Baz = class {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for `{ "setWithoutGet": true, "enforceForClassMembers": true }`:
+
+::: incorrect
 
 ```js
 /*eslint accessor-pairs: ["error", { "setWithoutGet": true, "enforceForClassMembers": true }]*/
@@ -211,6 +225,8 @@ const Bar = class {
     }
 }
 ```
+
+:::
 
 When `enforceForClassMembers` is set to `false`, this rule ignores classes.
 

--- a/docs/src/rules/array-bracket-newline.md
+++ b/docs/src/rules/array-bracket-newline.md
@@ -34,6 +34,8 @@ Or an object option (Requires line breaks if any of properties is satisfied. Oth
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint array-bracket-newline: ["error", "always"]*/
 
@@ -47,7 +49,11 @@ var e = [function foo() {
 }];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint array-bracket-newline: ["error", "always"]*/
@@ -70,11 +76,15 @@ var e = [
     }
 ];
 ```
+
+:::
 
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint array-bracket-newline: ["error", "never"]*/
 
@@ -97,7 +107,11 @@ var e = [
 ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint array-bracket-newline: ["error", "never"]*/
@@ -112,9 +126,13 @@ var e = [function foo() {
 }];
 ```
 
+:::
+
 ### consistent
 
 Examples of **incorrect** code for this rule with the `"consistent"` option:
+
+::: incorrect
 
 ```js
 /*eslint array-bracket-newline: ["error", "consistent"]*/
@@ -133,7 +151,11 @@ var d = [
     }]
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"consistent"` option:
+
+::: correct
 
 ```js
 /*eslint array-bracket-newline: ["error", "consistent"]*/
@@ -155,9 +177,13 @@ var f = [
 ];
 ```
 
+:::
+
 ### multiline
 
 Examples of **incorrect** code for this rule with the default `{ "multiline": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint array-bracket-newline: ["error", { "multiline": true }]*/
@@ -177,7 +203,11 @@ var e = [function foo() {
 }];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "multiline": true }` option:
+
+::: correct
 
 ```js
 /*eslint array-bracket-newline: ["error", { "multiline": true }]*/
@@ -196,9 +226,13 @@ var e = [
 ];
 ```
 
+:::
+
 ### minItems
 
 Examples of **incorrect** code for this rule with the `{ "minItems": 2 }` option:
+
+::: incorrect
 
 ```js
 /*eslint array-bracket-newline: ["error", { "minItems": 2 }]*/
@@ -218,7 +252,11 @@ var e = [
 ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "minItems": 2 }` option:
+
+::: correct
 
 ```js
 /*eslint array-bracket-newline: ["error", { "minItems": 2 }]*/
@@ -237,9 +275,13 @@ var e = [function foo() {
 }];
 ```
 
+:::
+
 ### multiline and minItems
 
 Examples of **incorrect** code for this rule with the `{ "multiline": true, "minItems": 2 }` options:
+
+::: incorrect
 
 ```js
 /*eslint array-bracket-newline: ["error", { "multiline": true, "minItems": 2 }]*/
@@ -257,7 +299,11 @@ var e = [function foo() {
 }];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "multiline": true, "minItems": 2 }` options:
+
+::: correct
 
 ```js
 /*eslint array-bracket-newline: ["error", { "multiline": true, "minItems": 2 }]*/
@@ -277,6 +323,8 @@ var e = [
     }
 ];
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/array-bracket-spacing.md
+++ b/docs/src/rules/array-bracket-spacing.md
@@ -58,6 +58,8 @@ This rule has built-in exceptions:
 
 Examples of **incorrect** code for this rule with the default `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint array-bracket-spacing: ["error", "never"]*/
 /*eslint-env es6*/
@@ -75,7 +77,11 @@ var [ x, ...y ] = z;
 var [ ,,x, ] = z;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"never"` option:
+
+::: correct
 
 ```js
 /*eslint array-bracket-spacing: ["error", "never"]*/
@@ -102,9 +108,13 @@ var [x, ...y] = z;
 var [,,x,] = z;
 ```
 
+:::
+
 ### always
 
 Examples of **incorrect** code for this rule with the `"always"` option:
+
+::: incorrect
 
 ```js
 /*eslint array-bracket-spacing: ["error", "always"]*/
@@ -126,7 +136,11 @@ var [x, ...y] = z;
 var [,,x,] = z;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint array-bracket-spacing: ["error", "always"]*/
@@ -153,9 +167,13 @@ var [ x, ...y ] = z;
 var [ ,,x, ] = z;
 ```
 
+:::
+
 ### singleValue
 
 Examples of **incorrect** code for this rule with the `"always", { "singleValue": false }` options:
+
+::: incorrect
 
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "singleValue": false }]*/
@@ -170,7 +188,11 @@ var foo = [ [ 1, 2 ] ];
 var foo = [ { 'foo': 'bar' } ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always", { "singleValue": false }` options:
+
+::: correct
 
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "singleValue": false }]*/
@@ -181,9 +203,13 @@ var foo = [[ 1, 1 ]];
 var foo = [{ 'foo': 'bar' }];
 ```
 
+:::
+
 ### objectsInArrays
 
 Examples of **incorrect** code for this rule with the `"always", { "objectsInArrays": false }` options:
+
+::: incorrect
 
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "objectsInArrays": false }]*/
@@ -194,7 +220,11 @@ var arr = [ {
 } ]
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always", { "objectsInArrays": false }` options:
+
+::: correct
 
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "objectsInArrays": false }]*/
@@ -205,9 +235,13 @@ var arr = [{
 }];
 ```
 
+:::
+
 ### arraysInArrays
 
 Examples of **incorrect** code for this rule with the `"always", { "arraysInArrays": false }` options:
+
+::: incorrect
 
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "arraysInArrays": false }]*/
@@ -216,7 +250,11 @@ var arr = [ [ 1, 2 ], 2, 3, 4 ];
 var arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always", { "arraysInArrays": false }` options:
+
+::: correct
 
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "arraysInArrays": false }]*/
@@ -224,6 +262,8 @@ Examples of **correct** code for this rule with the `"always", { "arraysInArrays
 var arr = [[ 1, 2 ], 2, 3, 4 ];
 var arr = [[ 1, 2 ], 2, [ 3, 4 ]];
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/array-callback-return.md
+++ b/docs/src/rules/array-callback-return.md
@@ -40,6 +40,8 @@ This rule finds callback functions of the following methods, then checks usage o
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint array-callback-return: "error"*/
 
@@ -62,7 +64,11 @@ var bar = foo.filter(function(x) {
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint array-callback-return: "error"*/
@@ -82,6 +88,8 @@ var foo = Array.from(nodes, function(node) {
 var bar = foo.map(node => node.getAttribute("id"));
 ```
 
+:::
+
 ## Options
 
 This rule accepts a configuration object with two options:
@@ -93,6 +101,8 @@ This rule accepts a configuration object with two options:
 
 Examples of **correct** code for the `{ "allowImplicit": true }` option:
 
+::: correct
+
 ```js
 /*eslint array-callback-return: ["error", { allowImplicit: true }]*/
 var undefAllTheThings = myArray.map(function(item) {
@@ -100,9 +110,13 @@ var undefAllTheThings = myArray.map(function(item) {
 });
 ```
 
+:::
+
 ### checkForEach
 
 Examples of **incorrect** code for the `{ "checkForEach": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint array-callback-return: ["error", { checkForEach: true }]*/
@@ -125,7 +139,11 @@ myArray.forEach(item => {
 });
 ```
 
+:::
+
 Examples of **correct** code for the `{ "checkForEach": true }` option:
+
+::: correct
 
 ```js
 /*eslint array-callback-return: ["error", { checkForEach: true }]*/
@@ -150,6 +168,8 @@ myArray.forEach(item => {
     handleItem(item);
 });
 ```
+
+:::
 
 ## Known Limitations
 

--- a/docs/src/rules/array-element-newline.md
+++ b/docs/src/rules/array-element-newline.md
@@ -55,6 +55,8 @@ Alternatively, different configurations can be specified for array expressions a
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint array-element-newline: ["error", "always"]*/
 
@@ -74,7 +76,11 @@ var g = [
 ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint array-element-newline: ["error", "always"]*/
@@ -101,9 +107,13 @@ var e = [
 ];
 ```
 
+:::
+
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint array-element-newline: ["error", "never"]*/
@@ -127,7 +137,11 @@ var e = [
 ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint array-element-newline: ["error", "never"]*/
@@ -150,9 +164,13 @@ var g = [
 ];
 ```
 
+:::
+
 ### consistent
 
 Examples of **incorrect** code for this rule with the `"consistent"` option:
+
+::: incorrect
 
 ```js
 /*eslint array-element-newline: ["error", "consistent"]*/
@@ -173,7 +191,11 @@ var b = [
 ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"consistent"` option:
+
+::: correct
 
 ```js
 /*eslint array-element-newline: ["error", "consistent"]*/
@@ -213,9 +235,13 @@ var h = [
 ];
 ```
 
+:::
+
 ### multiline
 
 Examples of **incorrect** code for this rule with the `{ "multiline": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint array-element-newline: ["error", { "multiline": true }]*/
@@ -231,7 +257,11 @@ var e = [
 ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "multiline": true }` option:
+
+::: correct
 
 ```js
 /*eslint array-element-newline: ["error", { "multiline": true }]*/
@@ -250,9 +280,13 @@ var e = [
 ];
 ```
 
+:::
+
 ### minItems
 
 Examples of **incorrect** code for this rule with the `{ "minItems": 3 }` option:
+
+::: incorrect
 
 ```js
 /*eslint array-element-newline: ["error", { "minItems": 3 }]*/
@@ -270,7 +304,11 @@ var e = [
 ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "minItems": 3 }` option:
+
+::: correct
 
 ```js
 /*eslint array-element-newline: ["error", { "minItems": 3 }]*/
@@ -290,9 +328,13 @@ var e = [
 ];
 ```
 
+:::
+
 ### multiline and minItems
 
 Examples of **incorrect** code for this rule with the `{ "multiline": true, "minItems": 3 }` options:
+
+::: incorrect
 
 ```js
 /*eslint array-element-newline: ["error", { "multiline": true, "minItems": 3 }]*/
@@ -309,7 +351,11 @@ var e = [
 ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "multiline": true, "minItems": 3 }` options:
+
+::: correct
 
 ```js
 /*eslint array-element-newline: ["error", { "multiline": true, "minItems": 3 }]*/
@@ -330,9 +376,13 @@ var e = [
 ];
 ```
 
+:::
+
 ### ArrayExpression and ArrayPattern
 
 Examples of **incorrect** code for this rule with the `{ "ArrayExpression": "always", "ArrayPattern": "never" }` options:
+
+::: incorrect
 
 ```js
 /*eslint array-element-newline: ["error", { "ArrayExpression": "always", "ArrayPattern": "never" }]*/
@@ -360,7 +410,11 @@ j = function bar() {
 }] = arr
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "ArrayExpression": "always", "ArrayPattern": "never" }` options:
+
+::: correct
 
 ```js
 /*eslint array-element-newline: ["error", { "ArrayExpression": "always", "ArrayPattern": "never" }]*/
@@ -387,6 +441,8 @@ var [i = function foo() {
     dosomething()
 }] = arr
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/arrow-body-style.md
+++ b/docs/src/rules/arrow-body-style.md
@@ -33,13 +33,19 @@ The second one is an object for more fine-grained configuration when the first o
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint arrow-body-style: ["error", "always"]*/
 /*eslint-env es6*/
 let foo = () => 0;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 let foo = () => {
@@ -51,9 +57,13 @@ let foo = (retv, name) => {
 };
 ```
 
+:::
+
 ### as-needed
 
 Examples of **incorrect** code for this rule with the default `"as-needed"` option:
+
+::: incorrect
 
 ```js
 /*eslint arrow-body-style: ["error", "as-needed"]*/
@@ -72,7 +82,11 @@ let foo = () => {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"as-needed"` option:
+
+::: correct
 
 ```js
 /*eslint arrow-body-style: ["error", "as-needed"]*/
@@ -98,11 +112,15 @@ let foo = () => {
 let foo = () => ({ bar: 0 });
 ```
 
+:::
+
 #### requireReturnForObjectLiteral
 
 > This option is only applicable when used in conjunction with the `"as-needed"` option.
 
 Examples of **incorrect** code for this rule with the `{ "requireReturnForObjectLiteral": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint arrow-body-style: ["error", "as-needed", { "requireReturnForObjectLiteral": true }]*/
@@ -111,7 +129,11 @@ let foo = () => ({});
 let foo = () => ({ bar: 0 });
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "requireReturnForObjectLiteral": true }` option:
+
+::: correct
 
 ```js
 /*eslint arrow-body-style: ["error", "as-needed", { "requireReturnForObjectLiteral": true }]*/
@@ -121,9 +143,13 @@ let foo = () => {};
 let foo = () => { return { bar: 0 }; };
 ```
 
+:::
+
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint arrow-body-style: ["error", "never"]*/
@@ -138,7 +164,11 @@ let foo = (retv, name) => {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint arrow-body-style: ["error", "never"]*/
@@ -147,3 +177,5 @@ Examples of **correct** code for this rule with the `"never"` option:
 let foo = () => 0;
 let foo = () => ({ foo: 0 });
 ```
+
+:::

--- a/docs/src/rules/arrow-parens.md
+++ b/docs/src/rules/arrow-parens.md
@@ -72,6 +72,8 @@ Object properties for variants of the `"as-needed"` option:
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint arrow-parens: ["error", "always"]*/
 /*eslint-env es6*/
@@ -84,7 +86,11 @@ a.then(foo => a);
 a(foo => { if (true) {} });
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint arrow-parens: ["error", "always"]*/
@@ -97,6 +103,8 @@ Examples of **correct** code for this rule with the default `"always"` option:
 a.then((foo) => {});
 a.then((foo) => { if (true) {} });
 ```
+
+:::
 
 #### If Statements
 
@@ -159,6 +167,8 @@ var f = (a) => b ? c: d;
 
 Examples of **incorrect** code for this rule with the `"as-needed"` option:
 
+::: incorrect
+
 ```js
 /*eslint arrow-parens: ["error", "as-needed"]*/
 /*eslint-env es6*/
@@ -174,7 +184,11 @@ const g = /* comment */ (a) => a + a;
 const h = (a) /* comment */ => a + a;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"as-needed"` option:
+
+::: correct
 
 ```js
 /*eslint arrow-parens: ["error", "as-needed"]*/
@@ -195,9 +209,13 @@ const g = (/* comment */ a) => a + a;
 const h = (a /* comment */) => a + a;
 ```
 
+:::
+
 ### requireForBlockBody
 
 Examples of **incorrect** code for the `{ "requireForBlockBody": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint arrow-parens: [2, "as-needed", { "requireForBlockBody": true }]*/
@@ -213,7 +231,11 @@ a.map(x => {
 a.then(foo => {});
 ```
 
+:::
+
 Examples of **correct** code for the `{ "requireForBlockBody": true }` option:
+
+::: correct
 
 ```js
 /*eslint arrow-parens: [2, "as-needed", { "requireForBlockBody": true }]*/
@@ -232,3 +254,5 @@ a((foo) => { if (true) {} });
 ([a, b]) => a;
 ({a, b}) => a;
 ```
+
+:::

--- a/docs/src/rules/arrow-spacing.md
+++ b/docs/src/rules/arrow-spacing.md
@@ -31,6 +31,8 @@ The default configuration is `{ "before": true, "after": true }`.
 
 Examples of **incorrect** code for this rule with the default `{ "before": true, "after": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint arrow-spacing: "error"*/
 /*eslint-env es6*/
@@ -45,7 +47,11 @@ a=> a;
 () =>{'\n'};
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "before": true, "after": true }` option:
+
+::: correct
 
 ```js
 /*eslint arrow-spacing: "error"*/
@@ -57,7 +63,11 @@ a => a;
 () => {'\n'};
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "before": false, "after": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": false }]*/
@@ -68,7 +78,11 @@ Examples of **incorrect** code for this rule with the `{ "before": false, "after
 ()=> {'\n'};
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "before": false, "after": false }` option:
+
+::: correct
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": false }]*/
@@ -79,7 +93,11 @@ Examples of **correct** code for this rule with the `{ "before": false, "after":
 ()=>{'\n'};
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "before": false, "after": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": true }]*/
@@ -90,7 +108,11 @@ Examples of **incorrect** code for this rule with the `{ "before": false, "after
 ()=>{'\n'};
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "before": false, "after": true }` option:
+
+::: correct
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": true }]*/
@@ -100,3 +122,5 @@ Examples of **correct** code for this rule with the `{ "before": false, "after":
 (a)=> {};
 ()=> {'\n'};
 ```
+
+:::

--- a/docs/src/rules/block-scoped-var.md
+++ b/docs/src/rules/block-scoped-var.md
@@ -18,6 +18,8 @@ This rule aims to reduce the usage of variables outside of their binding context
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint block-scoped-var: "error"*/
 
@@ -62,7 +64,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint block-scoped-var: "error"*/
@@ -114,3 +120,5 @@ class C {
     }
 }
 ```
+
+:::

--- a/docs/src/rules/block-spacing.md
+++ b/docs/src/rules/block-spacing.md
@@ -27,6 +27,8 @@ This rule has a string option:
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint block-spacing: "error"*/
 
@@ -41,7 +43,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint block-spacing: "error"*/
@@ -54,9 +60,13 @@ class C {
 }
 ```
 
+:::
+
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint block-spacing: ["error", "never"]*/
@@ -69,7 +79,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint block-spacing: ["error", "never"]*/
@@ -81,6 +95,8 @@ class C {
     static {this.bar = 0;}
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/brace-style.md
+++ b/docs/src/rules/brace-style.md
@@ -72,6 +72,8 @@ This rule has an object option for an exception:
 
 Examples of **incorrect** code for this rule with the default `"1tbs"` option:
 
+::: incorrect
+
 ```js
 /*eslint brace-style: "error"*/
 
@@ -109,7 +111,11 @@ class C
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"1tbs"` option:
+
+::: correct
 
 ```js
 /*eslint brace-style: "error"*/
@@ -145,7 +151,11 @@ if (foo) bar();
 else if (baz) boom();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"1tbs", { "allowSingleLine": true }` options:
+
+::: correct
 
 ```js
 /*eslint brace-style: ["error", "1tbs", { "allowSingleLine": true }]*/
@@ -186,9 +196,13 @@ class C {
 class D { static { foo(); } }
 ```
 
+:::
+
 ### stroustrup
 
 Examples of **incorrect** code for this rule with the `"stroustrup"` option:
+
+::: incorrect
 
 ```js
 /*eslint brace-style: ["error", "stroustrup"]*/
@@ -226,7 +240,11 @@ if (foo) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"stroustrup"` option:
+
+::: correct
 
 ```js
 /*eslint brace-style: ["error", "stroustrup"]*/
@@ -264,7 +282,11 @@ if (foo) bar();
 else if (baz) boom();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"stroustrup", { "allowSingleLine": true }` options:
+
+::: correct
 
 ```js
 /*eslint brace-style: ["error", "stroustrup", { "allowSingleLine": true }]*/
@@ -286,9 +308,13 @@ class C {
 class D { static { foo(); } }
 ```
 
+:::
+
 ### allman
 
 Examples of **incorrect** code for this rule with the `"allman"` option:
+
+::: incorrect
 
 ```js
 /*eslint brace-style: ["error", "allman"]*/
@@ -322,7 +348,11 @@ if (foo) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"allman"` option:
+
+::: correct
 
 ```js
 /*eslint brace-style: ["error", "allman"]*/
@@ -368,7 +398,11 @@ if (foo) bar();
 else if (baz) boom();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"allman", { "allowSingleLine": true }` options:
+
+::: correct
 
 ```js
 /*eslint brace-style: ["error", "allman", { "allowSingleLine": true }]*/
@@ -393,6 +427,8 @@ class C
 
 class D { static { foo(); } }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/callback-return.md
+++ b/docs/src/rules/callback-return.md
@@ -44,6 +44,8 @@ The rule takes a single option - an array of possible callback names - which may
 
 Examples of **incorrect** code for this rule with the default `["callback", "cb", "next"]` option:
 
+::: incorrect
+
 ```js
 /*eslint callback-return: "error"*/
 
@@ -55,7 +57,11 @@ function foo(err, callback) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `["callback", "cb", "next"]` option:
+
+::: correct
 
 ```js
 /*eslint callback-return: "error"*/
@@ -68,9 +74,13 @@ function foo(err, callback) {
 }
 ```
 
+:::
+
 ### Supplied callback names
 
 Examples of **incorrect** code for this rule with the option `["done", "send.error", "send.success"]`:
+
+::: incorrect
 
 ```js
 /*eslint callback-return: ["error", ["done", "send.error", "send.success"]]*/
@@ -90,7 +100,11 @@ function bar(err, send) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the option `["done", "send.error", "send.success"]`:
+
+::: correct
 
 ```js
 /*eslint callback-return: ["error", ["done", "send.error", "send.success"]]*/
@@ -109,6 +123,8 @@ function bar(err, send) {
     send.success();
 }
 ```
+
+:::
 
 ## Known Limitations
 

--- a/docs/src/rules/camelcase.md
+++ b/docs/src/rules/camelcase.md
@@ -31,6 +31,8 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule with the default `{ "properties": "always" }` option:
 
+::: incorrect
+
 ```js
 /*eslint camelcase: "error"*/
 
@@ -69,7 +71,11 @@ var { foo: no_camelcased } = bar;
 var { foo: bar_baz = 1 } = quz;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "properties": "always" }` option:
+
+::: correct
 
 ```js
 /*eslint camelcase: "error"*/
@@ -109,9 +115,13 @@ var { foo: isCamelCased = 1 } = quz;
 
 ```
 
+:::
+
 ### properties: "never"
 
 Examples of **correct** code for this rule with the `{ "properties": "never" }` option:
+
+::: correct
 
 ```js
 /*eslint camelcase: ["error", {properties: "never"}]*/
@@ -121,9 +131,13 @@ var obj = {
 };
 ```
 
+:::
+
 ### ignoreDestructuring: false
 
 Examples of **incorrect** code for this rule with the default `{ "ignoreDestructuring": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint camelcase: "error"*/
@@ -139,9 +153,13 @@ var { category_id: category_alias } = query;
 var { category_id: categoryId, ...other_props } = query;
 ```
 
+:::
+
 ### ignoreDestructuring: true
 
 Examples of **incorrect** code for this rule with the `{ "ignoreDestructuring": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint camelcase: ["error", {ignoreDestructuring: true}]*/
@@ -151,7 +169,11 @@ var { category_id: category_alias } = query;
 var { category_id, ...other_props } = query;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "ignoreDestructuring": true }` option:
+
+::: correct
 
 ```js
 /*eslint camelcase: ["error", {ignoreDestructuring: true}]*/
@@ -163,9 +185,13 @@ var { category_id = 1 } = query;
 var { category_id: category_id } = query;
 ```
 
+:::
+
 Please note that this option applies only to identifiers inside destructuring patterns. It doesn't additionally allow any particular use of the created variables later in the code apart from the use that is already allowed by default or by other options.
 
 Examples of additional **incorrect** code for this rule with the `{ "ignoreDestructuring": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint camelcase: ["error", {ignoreDestructuring: true}]*/
@@ -174,9 +200,13 @@ var { some_property } = obj; // allowed by {ignoreDestructuring: true}
 var foo = some_property + 1; // error, ignoreDestructuring does not apply to this statement
 ```
 
+:::
+
 A common use case for this option is to avoid useless renaming when the identifier is not intended to be used later in the code.
 
 Examples of additional **correct** code for this rule with the `{ "ignoreDestructuring": true }` option:
+
+::: correct
 
 ```js
 /*eslint camelcase: ["error", {ignoreDestructuring: true}]*/
@@ -185,9 +215,13 @@ var { some_property, ...rest } = obj;
 // do something with 'rest', nothing with 'some_property'
 ```
 
+:::
+
 Another common use case for this option is in combination with `{ "properties": "never" }`, when the identifier is intended to be used only as a property shorthand.
 
 Examples of additional **correct** code for this rule with the `{ "properties": "never", "ignoreDestructuring": true }` options:
+
+::: correct
 
 ```js
 /*eslint camelcase: ["error", {"properties": "never", ignoreDestructuring: true}]*/
@@ -196,9 +230,13 @@ var { some_property } = obj;
 doSomething({ some_property });
 ```
 
+:::
+
 ### ignoreImports: false
 
 Examples of **incorrect** code for this rule with the default `{ "ignoreImports": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint camelcase: "error"*/
@@ -206,9 +244,13 @@ Examples of **incorrect** code for this rule with the default `{ "ignoreImports"
 import { snake_cased } from 'mod';
 ```
 
+:::
+
 ### ignoreImports: true
 
 Examples of **incorrect** code for this rule with the `{ "ignoreImports": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint camelcase: ["error", {ignoreImports: true}]*/
@@ -218,7 +260,11 @@ import default_import from 'mod';
 import * as namespaced_import from 'mod';
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "ignoreImports": true }` option:
+
+::: correct
 
 ```js
 /*eslint camelcase: ["error", {ignoreImports: true}]*/
@@ -226,9 +272,13 @@ Examples of **correct** code for this rule with the `{ "ignoreImports": true }` 
 import { snake_cased } from 'mod';
 ```
 
+:::
+
 ### ignoreGlobals: false
 
 Examples of **incorrect** code for this rule with the default `{ "ignoreGlobals": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint camelcase: ["error", {ignoreGlobals: false}]*/
@@ -237,9 +287,13 @@ Examples of **incorrect** code for this rule with the default `{ "ignoreGlobals"
 const foo = no_camelcased;
 ```
 
+:::
+
 ### ignoreGlobals: true
 
 Examples of **correct** code for this rule with the `{ "ignoreGlobals": true }` option:
+
+::: correct
 
 ```js
 /*eslint camelcase: ["error", {ignoreGlobals: true}]*/
@@ -248,9 +302,13 @@ Examples of **correct** code for this rule with the `{ "ignoreGlobals": true }` 
 const foo = no_camelcased;
 ```
 
+:::
+
 ### allow
 
 Examples of **correct** code for this rule with the `allow` option:
+
+::: correct
 
 ```js
 /*eslint camelcase: ["error", {allow: ["UNSAFE_componentWillMount"]}]*/
@@ -259,6 +317,8 @@ function UNSAFE_componentWillMount() {
     // ...
 }
 ```
+
+:::
 
 ```js
 /*eslint camelcase: ["error", {allow: ["^UNSAFE_"]}]*/

--- a/docs/src/rules/capitalized-comments.md
+++ b/docs/src/rules/capitalized-comments.md
@@ -21,6 +21,8 @@ By default, this rule will require a non-lowercase letter at the beginning of co
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /* eslint capitalized-comments: ["error"] */
 
@@ -28,7 +30,11 @@ Examples of **incorrect** code for this rule:
 
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 
@@ -53,6 +59,8 @@ Examples of **correct** code for this rule:
 // https://github.com
 
 ```
+
+:::
 
 ### Options
 
@@ -88,6 +96,8 @@ Note that configuration comments and comments which start with URLs are never re
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /* eslint capitalized-comments: ["error", "always"] */
 
@@ -95,7 +105,11 @@ Examples of **incorrect** code for this rule:
 
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /* eslint capitalized-comments: ["error", "always"] */
@@ -122,11 +136,15 @@ Examples of **correct** code for this rule:
 
 ```
 
+:::
+
 #### `"never"`
 
 Using the `"never"` option means that this rule will report any comments which start with an uppercase letter.
 
 Examples of **incorrect** code with the `"never"` option:
+
+::: incorrect
 
 ```js
 /* eslint capitalized-comments: ["error", "never"] */
@@ -135,7 +153,11 @@ Examples of **incorrect** code with the `"never"` option:
 
 ```
 
+:::
+
 Examples of **correct** code with the `"never"` option:
+
+::: correct
 
 ```js
 /* eslint capitalized-comments: ["error", "never"] */
@@ -148,11 +170,15 @@ Examples of **correct** code with the `"never"` option:
 
 ```
 
+:::
+
 #### `ignorePattern`
 
 The `ignorePattern` object takes a string value, which is used as a regular expression applied to the first word of a comment.
 
 Examples of **correct** code with the `"ignorePattern"` option set to `"pragma"`:
+
+::: correct
 
 ```js
 /* eslint capitalized-comments: ["error", "always", { "ignorePattern": "pragma" }] */
@@ -163,11 +189,15 @@ function foo() {
 
 ```
 
+:::
+
 #### `ignoreInlineComments`
 
 Setting the `ignoreInlineComments` option to `true` means that comments in the middle of code (with a token on the same line as the beginning of the comment, and another token on the same line as the end of the comment) will not be reported by this rule.
 
 Examples of **correct** code with the `"ignoreInlineComments"` option set to `true`:
+
+::: correct
 
 ```js
 /* eslint capitalized-comments: ["error", "always", { "ignoreInlineComments": true }] */
@@ -177,11 +207,15 @@ function foo(/* ignored */ a) {
 
 ```
 
+:::
+
 #### `ignoreConsecutiveComments`
 
 If the `ignoreConsecutiveComments` option is set to `true`, then comments which otherwise violate the rule will not be reported as long as they immediately follow another comment. This can be applied more than once.
 
 Examples of **correct** code with `ignoreConsecutiveComments` set to `true`:
+
+::: correct
 
 ```js
 /* eslint capitalized-comments: ["error", "always", { "ignoreConsecutiveComments": true }] */
@@ -197,7 +231,11 @@ Examples of **correct** code with `ignoreConsecutiveComments` set to `true`:
  */
 ```
 
+:::
+
 Examples of **incorrect** code with `ignoreConsecutiveComments` set to `true`:
+
+::: incorrect
 
 ```js
 /* eslint capitalized-comments: ["error", "always", { "ignoreConsecutiveComments": true }] */
@@ -205,6 +243,8 @@ Examples of **incorrect** code with `ignoreConsecutiveComments` set to `true`:
 // this comment is invalid, but only on this line.
 // this comment does NOT get reported, since it is a consecutive comment.
 ```
+
+:::
 
 ### Using Different Options for Line and Block Comments
 
@@ -230,6 +270,8 @@ If you wish to have a different configuration for line comments and block commen
 
 Examples of **incorrect** code with different line and block comment configuration:
 
+::: incorrect
+
 ```js
 /* eslint capitalized-comments: ["error", "always", { "block": { "ignorePattern": "blockignore" } }] */
 
@@ -238,7 +280,11 @@ Examples of **incorrect** code with different line and block comment configurati
 
 ```
 
+:::
+
 Examples of **correct** code with different line and block comment configuration:
+
+::: correct
 
 ```js
 /* eslint capitalized-comments: ["error", "always", { "block": { "ignorePattern": "blockignore" } }] */
@@ -247,6 +293,8 @@ Examples of **correct** code with different line and block comment configuration
 /* blockignore lowercase block comment, this is correct due to ignorePattern */
 
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/class-methods-use-this.md
+++ b/docs/src/rules/class-methods-use-this.md
@@ -61,6 +61,8 @@ This rule is aimed to flag class methods that do not use `this`.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint class-methods-use-this: "error"*/
 /*eslint-env es6*/
@@ -72,7 +74,11 @@ class A {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint class-methods-use-this: "error"*/
@@ -100,6 +106,8 @@ class A {
 }
 ```
 
+:::
+
 ## Options
 
 This rule has two options:
@@ -117,6 +125,8 @@ The `exceptMethods` option allows you to pass an array of method names for which
 
 Examples of **incorrect** code for this rule when used without exceptMethods:
 
+::: incorrect
+
 ```js
 /*eslint class-methods-use-this: "error"*/
 
@@ -126,7 +136,11 @@ class A {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule when used with exceptMethods:
+
+::: correct
 
 ```js
 /*eslint class-methods-use-this: ["error", { "exceptMethods": ["foo", "#bar"] }] */
@@ -139,6 +153,8 @@ class A {
 }
 ```
 
+:::
+
 ### enforceForClassFields
 
 ```js
@@ -149,6 +165,8 @@ The `enforceForClassFields` option enforces that arrow functions and function ex
 
 Examples of **incorrect** code for this rule with the `{ "enforceForClassFields": true }` option (default):
 
+::: incorrect
+
 ```js
 /*eslint class-methods-use-this: ["error", { "enforceForClassFields": true }] */
 
@@ -157,7 +175,11 @@ class A {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "enforceForClassFields": true }` option (default):
+
+::: correct
 
 ```js
 /*eslint class-methods-use-this: ["error", { "enforceForClassFields": true }] */
@@ -167,7 +189,11 @@ class A {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "enforceForClassFields": false }` option:
+
+::: correct
 
 ```js
 /*eslint class-methods-use-this: ["error", { "enforceForClassFields": false }] */
@@ -176,3 +202,5 @@ class A {
     foo = () => {}
 }
 ```
+
+:::

--- a/docs/src/rules/comma-dangle.md
+++ b/docs/src/rules/comma-dangle.md
@@ -82,6 +82,8 @@ The default for each option is `"never"` unless otherwise specified.
 
 Examples of **incorrect** code for this rule with the default `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint comma-dangle: ["error", "never"]*/
 
@@ -98,7 +100,11 @@ foo({
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"never"` option:
+
+::: correct
 
 ```js
 /*eslint comma-dangle: ["error", "never"]*/
@@ -115,11 +121,15 @@ foo({
   qux: "quux"
 });
 ```
+
+:::
 
 ### always
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint comma-dangle: ["error", "always"]*/
 
@@ -136,7 +146,11 @@ foo({
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint comma-dangle: ["error", "always"]*/
@@ -153,11 +167,15 @@ foo({
   qux: "quux",
 });
 ```
+
+:::
 
 ### always-multiline
 
 Examples of **incorrect** code for this rule with the `"always-multiline"` option:
 
+::: incorrect
+
 ```js
 /*eslint comma-dangle: ["error", "always-multiline"]*/
 
@@ -184,7 +202,11 @@ foo({
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always-multiline"` option:
+
+::: correct
 
 ```js
 /*eslint comma-dangle: ["error", "always-multiline"]*/
@@ -210,11 +232,15 @@ foo({
   qux: "quux",
 });
 ```
+
+:::
 
 ### only-multiline
 
 Examples of **incorrect** code for this rule with the `"only-multiline"` option:
 
+::: incorrect
+
 ```js
 /*eslint comma-dangle: ["error", "only-multiline"]*/
 
@@ -227,7 +253,11 @@ var arr = [1,
 
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"only-multiline"` option:
+
+::: correct
 
 ```js
 /*eslint comma-dangle: ["error", "only-multiline"]*/
@@ -269,10 +299,14 @@ foo({
 });
 ```
 
+:::
+
 ### functions
 
 Examples of **incorrect** code for this rule with the `{"functions": "never"}` option:
 
+::: incorrect
+
 ```js
 /*eslint comma-dangle: ["error", {"functions": "never"}]*/
 
@@ -282,9 +316,13 @@ function foo(a, b,) {
 foo(a, b,);
 new foo(a, b,);
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{"functions": "never"}` option:
 
+::: correct
+
 ```js
 /*eslint comma-dangle: ["error", {"functions": "never"}]*/
 
@@ -295,7 +333,11 @@ foo(a, b);
 new foo(a, b);
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{"functions": "always"}` option:
+
+::: incorrect
 
 ```js
 /*eslint comma-dangle: ["error", {"functions": "always"}]*/
@@ -307,7 +349,11 @@ foo(a, b);
 new foo(a, b);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{"functions": "always"}` option:
+
+::: correct
 
 ```js
 /*eslint comma-dangle: ["error", {"functions": "always"}]*/
@@ -318,6 +364,8 @@ function foo(a, b,) {
 foo(a, b,);
 new foo(a, b,);
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/comma-spacing.md
+++ b/docs/src/rules/comma-spacing.md
@@ -50,6 +50,8 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule with the default `{ "before": false, "after": true }` options:
 
+::: incorrect
+
 ```js
 /*eslint comma-spacing: ["error", { "before": false, "after": true }]*/
 
@@ -62,7 +64,11 @@ function foo(a ,b){}
 a ,b
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "before": false, "after": true }` options:
+
+::: correct
 
 ```js
 /*eslint comma-spacing: ["error", { "before": false, "after": true }]*/
@@ -78,7 +84,11 @@ function foo(a, b){}
 a, b
 ```
 
+:::
+
 Example of **correct** code for this rule with initial null element for the default `{ "before": false, "after": true }` options:
+
+::: correct
 
 ```js
 /*eslint comma-spacing: ["error", { "before": false, "after": true }]*/
@@ -87,9 +97,13 @@ Example of **correct** code for this rule with initial null element for the defa
 var arr = [ , 2, 3 ]
 ```
 
+:::
+
 ### before
 
 Examples of **incorrect** code for this rule with the `{ "before": true, "after": false }` options:
+
+::: incorrect
 
 ```js
 /*eslint comma-spacing: ["error", { "before": true, "after": false }]*/
@@ -102,7 +116,11 @@ function foo(a,b){}
 a, b
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "before": true, "after": false }` options:
+
+::: correct
 
 ```js
 /*eslint comma-spacing: ["error", { "before": true, "after": false }]*/
@@ -118,7 +136,11 @@ function foo(a ,b){}
 a ,b
 ```
 
+:::
+
 Examples of **correct** code for this rule with initial null element for the `{ "before": true, "after": false }` options:
+
+::: correct
 
 ```js
 /*eslint comma-spacing: ["error", { "before": true, "after": false }]*/
@@ -126,6 +148,8 @@ Examples of **correct** code for this rule with initial null element for the `{ 
 
 var arr = [,2 ,3]
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/comma-style.md
+++ b/docs/src/rules/comma-style.md
@@ -58,6 +58,8 @@ A way to determine the node types as defined by [ESTree](https://github.com/estr
 
 Examples of **incorrect** code for this rule with the default `"last"` option:
 
+::: incorrect
+
 ```js
 /*eslint comma-style: ["error", "last"]*/
 
@@ -79,7 +81,11 @@ function bar() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"last"` option:
+
+::: correct
 
 ```js
 /*eslint comma-style: ["error", "last"]*/
@@ -100,9 +106,13 @@ function bar() {
 }
 ```
 
+:::
+
 ### first
 
 Examples of **incorrect** code for this rule with the `"first"` option:
+
+::: incorrect
 
 ```js
 /*eslint comma-style: ["error", "first"]*/
@@ -121,7 +131,11 @@ function bar() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"first"` option:
+
+::: correct
 
 ```js
 /*eslint comma-style: ["error", "first"]*/
@@ -142,11 +156,15 @@ function bar() {
 }
 ```
 
+:::
+
 ### exceptions
 
 An example use case is to enforce comma style *only* in var statements.
 
 Examples of **incorrect** code for this rule with sample `"first", { "exceptions": { … } }` options:
+
+::: incorrect
 
 ```js
 /*eslint comma-style: ["error", "first", { "exceptions": { "ArrayExpression": true, "ObjectExpression": true } }]*/
@@ -155,7 +173,11 @@ var o = {},
     a = [];
 ```
 
+:::
+
 Examples of **correct** code for this rule with sample `"first", { "exceptions": { … } }` options:
+
+::: correct
 
 ```js
 /*eslint comma-style: ["error", "first", { "exceptions": { "ArrayExpression": true, "ObjectExpression": true } }]*/
@@ -165,6 +187,8 @@ var o = {fst:1,
                2]}
   , a = [];
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/complexity.md
+++ b/docs/src/rules/complexity.md
@@ -41,6 +41,8 @@ This rule is aimed at reducing code complexity by capping the amount of cyclomat
 
 Examples of **incorrect** code for a maximum of 2:
 
+::: incorrect
+
 ```js
 /*eslint complexity: ["error", 2]*/
 
@@ -60,7 +62,11 @@ function b() {
 }
 ```
 
+:::
+
 Examples of **correct** code for a maximum of 2:
+
+::: correct
 
 ```js
 /*eslint complexity: ["error", 2]*/
@@ -78,9 +84,13 @@ function b() {
 }
 ```
 
+:::
+
 Class field initializers and class static blocks are implicit functions. Therefore, their complexity is calculated separately for each initializer and each static block, and it doesn't contribute to the complexity of the enclosing code.
 
 Examples of additional **incorrect** code for a maximum of 2:
+
+::: incorrect
 
 ```js
 /*eslint complexity: ["error", 2]*/
@@ -98,7 +108,11 @@ class D { // this static block has complexity = 3
 }
 ```
 
+:::
+
 Examples of additional **correct** code for a maximum of 2:
+
+::: correct
 
 ```js
 /*eslint complexity: ["error", 2]*/
@@ -124,6 +138,8 @@ function foo() { // this function has complexity = 1
     }
 }
 ```
+
+:::
 
 ## Options
 

--- a/docs/src/rules/computed-property-spacing.md
+++ b/docs/src/rules/computed-property-spacing.md
@@ -57,6 +57,8 @@ Object option:
 
 Examples of **incorrect** code for this rule with the default `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint computed-property-spacing: ["error", "never"]*/
 /*eslint-env es6*/
@@ -70,7 +72,11 @@ const { [ a ]: someProp } = obj;
 ({ [ b ]: anotherProp } = anotherObj);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"never"` option:
+
+::: correct
 
 ```js
 /*eslint computed-property-spacing: ["error", "never"]*/
@@ -85,9 +91,13 @@ const { [a]: someProp } = obj;
 ({ [b]: anotherProp } = anotherObj);
 ```
 
+:::
+
 ### always
 
 Examples of **incorrect** code for this rule with the `"always"` option:
+
+::: incorrect
 
 ```js
 /*eslint computed-property-spacing: ["error", "always"]*/
@@ -103,7 +113,11 @@ const { [a]: someProp } = obj;
 ({ [b ]: anotherProp } = anotherObj);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint computed-property-spacing: ["error", "always"]*/
@@ -117,11 +131,15 @@ const { [ a ]: someProp } = obj;
 ({ [ b ]: anotherProp } = anotherObj);
 ```
 
+:::
+
 #### enforceForClassMembers
 
 With `enforceForClassMembers` set to `true` (default), the rule also disallows/enforces spaces inside of computed keys of class methods, getters and setters.
 
 Examples of **incorrect** code for this rule with `"never"` and `{ "enforceForClassMembers": true }` (default):
+
+::: incorrect
 
 ```js
 /*eslint computed-property-spacing: ["error", "never", { "enforceForClassMembers": true }]*/
@@ -141,7 +159,11 @@ const Bar = class {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with `"never"` and `{ "enforceForClassMembers": true }` (default):
+
+::: correct
 
 ```js
 /*eslint computed-property-spacing: ["error", "never", { "enforceForClassMembers": true }]*/
@@ -161,7 +183,11 @@ const Bar = class {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with `"never"` and `{ "enforceForClassMembers": false }`:
+
+::: correct
 
 ```js
 /*eslint computed-property-spacing: ["error", "never", { "enforceForClassMembers": false }]*/
@@ -180,6 +206,8 @@ const Bar = class {
   static set [ c ](value) {}
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/consistent-return.md
+++ b/docs/src/rules/consistent-return.md
@@ -38,6 +38,8 @@ This rule requires `return` statements to either always or never specify values.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint consistent-return: "error"*/
 
@@ -56,7 +58,11 @@ function doSomething(condition) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint consistent-return: "error"*/
@@ -78,6 +84,8 @@ function Foo() {
 }
 ```
 
+:::
+
 ## Options
 
 This rule has an object option:
@@ -88,6 +96,8 @@ This rule has an object option:
 ### treatUndefinedAsUnspecified
 
 Examples of **incorrect** code for this rule with the default `{ "treatUndefinedAsUnspecified": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint consistent-return: ["error", { "treatUndefinedAsUnspecified": false }]*/
@@ -107,7 +117,11 @@ function bar(condition) {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "treatUndefinedAsUnspecified": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint consistent-return: ["error", { "treatUndefinedAsUnspecified": true }]*/
@@ -126,9 +140,13 @@ function bar(condition) {
     return true;
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{ "treatUndefinedAsUnspecified": true }` option:
 
+::: correct
+
 ```js
 /*eslint consistent-return: ["error", { "treatUndefinedAsUnspecified": true }]*/
 
@@ -146,6 +164,8 @@ function bar(condition) {
     // no return statement
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/consistent-this.md
+++ b/docs/src/rules/consistent-this.md
@@ -34,6 +34,8 @@ This rule has one or more string options:
 
 Examples of **incorrect** code for this rule with the default `"that"` option:
 
+::: incorrect
+
 ```js
 /*eslint consistent-this: ["error", "that"]*/
 
@@ -46,7 +48,11 @@ that = 42;
 self = this;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"that"` option:
+
+::: correct
 
 ```js
 /*eslint consistent-this: ["error", "that"]*/
@@ -62,7 +68,11 @@ that = this;
 foo.bar = this;
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the default `"that"` option, if the variable is not initialized:
+
+::: incorrect
 
 ```js
 /*eslint consistent-this: ["error", "that"]*/
@@ -73,7 +83,11 @@ function f() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"that"` option, if the variable is not initialized:
+
+::: correct
 
 ```js
 /*eslint consistent-this: ["error", "that"]*/
@@ -85,6 +99,8 @@ var foo, that;
 foo = 42;
 that = this;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/constructor-super.md
+++ b/docs/src/rules/constructor-super.md
@@ -21,6 +21,8 @@ This rule is aimed to flag invalid/missing `super()` calls.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint constructor-super: "error"*/
 /*eslint-env es6*/
@@ -47,7 +49,11 @@ class A extends null {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint constructor-super: "error"*/
@@ -63,6 +69,8 @@ class A extends B {
     }
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/curly.md
+++ b/docs/src/rules/curly.md
@@ -35,6 +35,8 @@ This rule is aimed at preventing bugs and increasing code clarity by ensuring th
 
 Examples of **incorrect** code for the default `"all"` option:
 
+::: incorrect
+
 ```js
 /*eslint curly: "error"*/
 
@@ -48,7 +50,11 @@ if (foo) {
 } else qux();
 ```
 
+:::
+
 Examples of **correct** code for the default `"all"` option:
+
+::: correct
 
 ```js
 /*eslint curly: "error"*/
@@ -68,11 +74,15 @@ if (foo) {
 }
 ```
 
+:::
+
 ### multi
 
 By default, this rule warns whenever `if`, `else`, `for`, `while`, or `do` are used without block statements as their body. However, you can specify that block statements should be used only when there are multiple statements in the block and warn when there is only one statement in the block.
 
 Examples of **incorrect** code for the `"multi"` option:
+
+::: incorrect
 
 ```js
 /*eslint curly: ["error", "multi"]*/
@@ -95,7 +105,11 @@ for (var i=0; i < items.length; i++) {
 }
 ```
 
+:::
+
 Examples of **correct** code for the `"multi"` option:
+
+::: correct
 
 ```js
 /*eslint curly: ["error", "multi"]*/
@@ -110,11 +124,15 @@ while (true) {
 }
 ```
 
+:::
+
 ### multi-line
 
 Alternatively, you can relax the rule to allow brace-less single-line `if`, `else if`, `else`, `for`, `while`, or `do`, while still enforcing the use of curly braces for other instances.
 
 Examples of **incorrect** code for the `"multi-line"` option:
+
+::: incorrect
 
 ```js
 /*eslint curly: ["error", "multi-line"]*/
@@ -129,7 +147,11 @@ if (foo) foo(
   baz);
 ```
 
+:::
+
 Examples of **correct** code for the `"multi-line"` option:
+
+::: correct
 
 ```js
 /*eslint curly: ["error", "multi-line"]*/
@@ -158,11 +180,15 @@ while (true) {
 }
 ```
 
+:::
+
 ### multi-or-nest
 
 You can use another configuration that forces brace-less `if`, `else if`, `else`, `for`, `while`, or `do` if their body contains only one single-line statement. And forces braces in all other cases.
 
 Examples of **incorrect** code for the `"multi-or-nest"` option:
+
+::: incorrect
 
 ```js
 /*eslint curly: ["error", "multi-or-nest"]*/
@@ -192,7 +218,11 @@ for (var i = 0; foo; i++) {
 }
 ```
 
+:::
+
 Examples of **correct** code for the `"multi-or-nest"` option:
+
+::: correct
 
 ```js
 /*eslint curly: ["error", "multi-or-nest"]*/
@@ -221,9 +251,13 @@ for (var i = 0; foo; i++)
     doSomething();
 ```
 
+:::
+
 For single-line statements preceded by a comment, braces are allowed but not required.
 
 Examples of additional **correct** code for the `"multi-or-nest"` option:
+
+::: correct
 
 ```js
 /*eslint curly: ["error", "multi-or-nest"]*/
@@ -238,12 +272,16 @@ if (foo) {
 }
 ```
 
+:::
+
 ### consistent
 
 When using any of the `multi*` options, you can add an option to enforce all bodies of a `if`,
 `else if` and `else` chain to be with or without braces.
 
 Examples of **incorrect** code for the `"multi", "consistent"` options:
+
+::: incorrect
 
 ```js
 /*eslint curly: ["error", "multi", "consistent"]*/
@@ -274,7 +312,11 @@ if (foo) {
 }
 ```
 
+:::
+
 Examples of **correct** code for the `"multi", "consistent"` options:
+
+::: correct
 
 ```js
 /*eslint curly: ["error", "multi", "consistent"]*/
@@ -304,6 +346,8 @@ if (foo)
     foo++;
 
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/default-case-last.md
+++ b/docs/src/rules/default-case-last.md
@@ -29,6 +29,8 @@ This rule does not enforce the existence of `default` clauses. See [default-case
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint default-case-last: "error"*/
 
@@ -79,7 +81,11 @@ switch (foo) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint default-case-last: "error"*/
@@ -126,3 +132,5 @@ if (foo !== 0) {
 }
 doSomethingAnyway();
 ```
+
+:::

--- a/docs/src/rules/default-case.md
+++ b/docs/src/rules/default-case.md
@@ -52,6 +52,8 @@ This rule aims to require `default` case in `switch` statements. You may optiona
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint default-case: "error"*/
 
@@ -63,7 +65,11 @@ switch (a) {
 
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint default-case: "error"*/
@@ -95,6 +101,8 @@ switch (a) {
 }
 ```
 
+:::
+
 ## Options
 
 This rule accepts a single options argument:
@@ -104,6 +112,8 @@ This rule accepts a single options argument:
 ### commentPattern
 
 Examples of **correct** code for the `{ "commentPattern": "^skip\\sdefault" }` option:
+
+::: correct
 
 ```js
 /*eslint default-case: ["error", { "commentPattern": "^skip\\sdefault" }]*/
@@ -124,6 +134,8 @@ switch(a) {
     // skip default case
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/default-param-last.md
+++ b/docs/src/rules/default-param-last.md
@@ -25,6 +25,8 @@ This rule enforces default parameters to be the last of parameters.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /* eslint default-param-last: ["error"] */
 
@@ -33,10 +35,16 @@ function f(a = 0, b) {}
 function f(a, b = 0, c) {}
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /* eslint default-param-last: ["error"] */
 
 function f(a, b = 0) {}
 ```
+
+:::

--- a/docs/src/rules/dot-location.md
+++ b/docs/src/rules/dot-location.md
@@ -41,6 +41,8 @@ The default `"object"` option requires the dot to be on the same line as the obj
 
 Examples of **incorrect** code for the default `"object"` option:
 
+::: incorrect
+
 ```js
 /*eslint dot-location: ["error", "object"]*/
 
@@ -48,7 +50,11 @@ var foo = object
 .property;
 ```
 
+:::
+
 Examples of **correct** code for the default `"object"` option:
+
+::: correct
 
 ```js
 /*eslint dot-location: ["error", "object"]*/
@@ -64,11 +70,15 @@ property;
 var baz = object.property;
 ```
 
+:::
+
 ### property
 
 The `"property"` option requires the dot to be on the same line as the property.
 
 Examples of **incorrect** code for the `"property"` option:
+
+::: incorrect
 
 ```js
 /*eslint dot-location: ["error", "property"]*/
@@ -77,7 +87,11 @@ var foo = object.
 property;
 ```
 
+:::
+
 Examples of **correct** code for the `"property"` option:
+
+::: correct
 
 ```js
 /*eslint dot-location: ["error", "property"]*/
@@ -86,6 +100,8 @@ var foo = object
 .property;
 var bar = object.property;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/dot-notation.md
+++ b/docs/src/rules/dot-notation.md
@@ -21,13 +21,19 @@ This rule is aimed at maintaining code consistency and improving code readabilit
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint dot-notation: "error"*/
 
 var x = foo["bar"];
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint dot-notation: "error"*/
@@ -36,6 +42,8 @@ var x = foo.bar;
 
 var x = foo[bar];    // Property name is a variable, square-bracket notation required
 ```
+
+:::
 
 ## Options
 
@@ -48,6 +56,8 @@ This rule accepts a single options argument:
 
 Examples of **correct** code for the `{ "allowKeywords": false }` option:
 
+::: correct
+
 ```js
 /*eslint dot-notation: ["error", { "allowKeywords": false }]*/
 
@@ -55,7 +65,11 @@ var foo = { "class": "CS 101" }
 var x = foo["class"]; // Property name is a reserved word, square-bracket notation required
 ```
 
+:::
+
 Examples of additional **correct** code for the `{ "allowKeywords": false }` option:
+
+::: correct
 
 ```js
 /*eslint dot-notation: ["error", { "allowKeywords": false }]*/
@@ -68,11 +82,15 @@ class C {
 }
 ```
 
+:::
+
 ### allowPattern
 
 For example, when preparing data to be sent to an external API, it is often required to use property names that include underscores.  If the `camelcase` rule is in effect, these [snake case](https://en.wikipedia.org/wiki/Snake_case) properties would not be allowed.  By providing an `allowPattern` to the `dot-notation` rule, these snake case properties can be accessed with bracket notation.
 
 Examples of **correct** code for the sample `{ "allowPattern": "^[a-z]+(_[a-z]+)+$" }` option:
+
+::: correct
 
 ```js
 /*eslint camelcase: "error"*/
@@ -87,3 +105,5 @@ data["fooBar"] = 42;
 var data = {};
 data["foo_bar"] = 42; // no warning
 ```
+
+:::

--- a/docs/src/rules/eol-last.md
+++ b/docs/src/rules/eol-last.md
@@ -25,6 +25,8 @@ the end of the file. If you still want this behavior, consider enabling
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint eol-last: ["error", "always"]*/
 
@@ -33,7 +35,11 @@ function doSomething() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint eol-last: ["error", "always"]*/
@@ -42,6 +48,8 @@ function doSomething() {
   var foo = 2;
 }\n
 ```
+
+:::
 
 ## Options
 

--- a/docs/src/rules/eqeqeq.md
+++ b/docs/src/rules/eqeqeq.md
@@ -26,6 +26,8 @@ This rule is aimed at eliminating the type-unsafe equality operators.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint eqeqeq: "error"*/
 
@@ -36,6 +38,8 @@ if ("" == text) { }
 if (obj.getStuff() != undefined) { }
 ```
 
+:::
+
 The `--fix` option on the command line automatically fixes some problems reported by this rule. A problem is only fixed if one of the operands is a `typeof` expression, or if both operands are literals with the same type.
 
 ## Options
@@ -45,6 +49,8 @@ The `--fix` option on the command line automatically fixes some problems reporte
 The `"always"` option (default) enforces the use of `===` and `!==` in every situation (except when you opt-in to more specific handling of `null` [see below]).
 
 Examples of **incorrect** code for the `"always"` option:
+
+::: incorrect
 
 ```js
 /*eslint eqeqeq: ["error", "always"]*/
@@ -61,7 +67,11 @@ foo == null
 
 ```
 
+:::
+
 Examples of **correct** code for the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint eqeqeq: ["error", "always"]*/
@@ -77,6 +87,8 @@ true === true
 foo === null
 
 ```
+
+:::
 
 This rule optionally takes a second argument, which should be an object with the following supported properties:
 
@@ -95,6 +107,8 @@ The `"smart"` option enforces the use of `===` and `!==` except for these cases:
 
 Examples of **incorrect** code for the `"smart"` option:
 
+::: incorrect
+
 ```js
 /*eslint eqeqeq: ["error", "smart"]*/
 
@@ -109,7 +123,11 @@ bananas != 1
 value == undefined
 ```
 
+:::
+
 Examples of **correct** code for the `"smart"` option:
+
+::: correct
 
 ```js
 /*eslint eqeqeq: ["error", "smart"]*/
@@ -120,6 +138,8 @@ typeof foo == 'undefined'
 true == true
 foo == null
 ```
+
+:::
 
 ### allow-null
 

--- a/docs/src/rules/for-direction.md
+++ b/docs/src/rules/for-direction.md
@@ -15,6 +15,8 @@ A `for` loop with a stop condition that can never be reached, such as one with a
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint for-direction: "error"*/
 for (var i = 0; i < 10; i--) {
@@ -27,10 +29,16 @@ for (var i = 0; i > 10; i++) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint for-direction: "error"*/
 for (var i = 0; i < 10; i++) {
 }
 ```
+
+:::

--- a/docs/src/rules/func-call-spacing.md
+++ b/docs/src/rules/func-call-spacing.md
@@ -41,6 +41,8 @@ Further, in `"always"` mode, a second object option is available that contains a
 
 Examples of **incorrect** code for this rule with the default `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint func-call-spacing: ["error", "never"]*/
 
@@ -50,18 +52,26 @@ fn
 ();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"never"` option:
+
+::: correct
 
 ```js
 /*eslint func-call-spacing: ["error", "never"]*/
 
 fn();
 ```
+
+:::
 
 ### always
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint func-call-spacing: ["error", "always"]*/
 
@@ -71,13 +81,19 @@ fn
 ();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint func-call-spacing: ["error", "always"]*/
 
 fn ();
 ```
+
+:::
 
 #### allowNewlines
 
@@ -85,13 +101,19 @@ By default, `"always"` does not allow newlines. To permit newlines when in `"alw
 
 Examples of **incorrect** code for this rule with `allowNewlines` option enabled:
 
+::: incorrect
+
 ```js
 /*eslint func-call-spacing: ["error", "always", { "allowNewlines": true }]*/
 
 fn();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `allowNewlines` option enabled:
+
+::: correct
 
 ```js
 /*eslint func-call-spacing: ["error", "always", { "allowNewlines": true }]*/
@@ -101,6 +123,8 @@ fn (); // Newlines are never required.
 fn
 ();
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/func-name-matching.md
+++ b/docs/src/rules/func-name-matching.md
@@ -13,6 +13,8 @@ This rule requires function names to match the name of the variable or property 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint func-name-matching: "error"*/
 
@@ -27,6 +29,8 @@ class C {
     foo = function bar() {};
 }
 ```
+
+:::
 
 ```js
 /*eslint func-name-matching: ["error", "never"] */
@@ -44,6 +48,8 @@ class C {
 ```
 
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint func-name-matching: "error"*/
@@ -87,6 +93,8 @@ class D {
 module.exports = function foo(name) {};
 module['exports'] = function foo(name) {};
 ```
+
+:::
 
 ```js
 /*eslint func-name-matching: ["error", "never"] */
@@ -140,6 +148,8 @@ A boolean value that defaults to `false`. If `considerPropertyDescriptor` is set
 
 Examples of **correct** code for the `{ considerPropertyDescriptor: true }` option:
 
+::: correct
+
 ```js
 /*eslint func-name-matching: ["error", { "considerPropertyDescriptor": true }]*/
 /*eslint func-name-matching: ["error", "always", { "considerPropertyDescriptor": true }]*/ // these are equivalent
@@ -150,7 +160,11 @@ Object.defineProperties(obj, {baz:{value: function baz() {} }});
 Reflect.defineProperty(obj, 'foo', {value: function foo() {}});
 ```
 
+:::
+
 Examples of **incorrect** code for the `{ considerPropertyDescriptor: true }` option:
+
+::: incorrect
 
 ```js
 /*eslint func-name-matching: ["error", { "considerPropertyDescriptor": true }]*/
@@ -162,11 +176,15 @@ Object.defineProperties(obj, {baz:{value: function foo() {} }});
 Reflect.defineProperty(obj, 'foo', {value: function value() {}});
 ```
 
+:::
+
 ### includeCommonJSModuleExports
 
 A boolean value that defaults to `false`. If `includeCommonJSModuleExports` is set to true, `module.exports` and `module["exports"]` will be checked by this rule.
 
 Examples of **incorrect** code for the `{ includeCommonJSModuleExports: true }` option:
+
+::: incorrect
 
 ```js
 /*eslint func-name-matching: ["error", { "includeCommonJSModuleExports": true }]*/
@@ -175,6 +193,8 @@ Examples of **incorrect** code for the `{ includeCommonJSModuleExports: true }` 
 module.exports = function foo(name) {};
 module['exports'] = function foo(name) {};
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/func-names.md
+++ b/docs/src/rules/func-names.md
@@ -45,6 +45,8 @@ Please note that `"always"` and `"as-needed"` require function expressions and f
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint func-names: ["error", "always"]*/
 
@@ -61,7 +63,11 @@ const cat = {
 export default function() {}
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint func-names: ["error", "always"]*/
@@ -79,11 +85,15 @@ const cat = {
 export default function foo() {}
 ```
 
+:::
+
 ### as-needed
 
 ECMAScript 6 introduced a `name` property on all functions. The value of `name` is determined by evaluating the code around the function to see if a name can be inferred. For example, a function assigned to a variable will automatically have a `name` property equal to the name of the variable. The value of `name` is then used in stack traces for easier debugging.
 
 Examples of **incorrect** code for this rule with the `"as-needed"` option:
+
+::: incorrect
 
 ```js
 /*eslint func-names: ["error", "as-needed"]*/
@@ -97,7 +107,11 @@ Foo.prototype.bar = function() {};
 export default function() {}
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"as-needed"` option:
+
+::: correct
 
 ```js
 /*eslint func-names: ["error", "as-needed"]*/
@@ -122,9 +136,13 @@ quux ??= function() {};
 export default function foo() {}
 ```
 
+:::
+
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint func-names: ["error", "never"]*/
@@ -136,7 +154,11 @@ Foo.prototype.bar = function bar() {};
 }())
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint func-names: ["error", "never"]*/
@@ -148,9 +170,13 @@ Foo.prototype.bar = function() {};
 }())
 ```
 
+:::
+
 ### generators
 
 Examples of **incorrect** code for this rule with the `"always", { "generators": "as-needed" }` options:
+
+::: incorrect
 
 ```js
 /*eslint func-names: ["error", "always", { "generators": "as-needed" }]*/
@@ -160,7 +186,11 @@ Examples of **incorrect** code for this rule with the `"always", { "generators":
 }())
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always", { "generators": "as-needed" }` options:
+
+::: correct
 
 ```js
 /*eslint func-names: ["error", "always", { "generators": "as-needed" }]*/
@@ -168,39 +198,59 @@ Examples of **correct** code for this rule with the `"always", { "generators": "
 var foo = function*() {};
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"always", { "generators": "never" }` options:
+
+::: incorrect
 
 ```js
 /*eslint func-names: ["error", "always", { "generators": "never" }]*/
 
 var foo = bar(function *baz() {});
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"always", { "generators": "never" }` options:
 
+::: correct
+
 ```js
 /*eslint func-names: ["error", "always", { "generators": "never" }]*/
 
 var foo = bar(function *() {});
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"as-needed", { "generators": "never" }` options:
+
+::: incorrect
 
 ```js
 /*eslint func-names: ["error", "as-needed", { "generators": "never" }]*/
 
 var foo = bar(function *baz() {});
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"as-needed", { "generators": "never" }` options:
 
+::: correct
+
 ```js
 /*eslint func-names: ["error", "as-needed", { "generators": "never" }]*/
 
 var foo = bar(function *() {});
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"never", { "generators": "always" }` options:
+
+::: incorrect
 
 ```js
 /*eslint func-names: ["error", "never", { "generators": "always" }]*/
@@ -208,13 +258,19 @@ Examples of **incorrect** code for this rule with the `"never", { "generators": 
 var foo = bar(function *() {});
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never", { "generators": "always" }` options:
+
+::: correct
 
 ```js
 /*eslint func-names: ["error", "never", { "generators": "always" }]*/
 
 var foo = bar(function *baz() {});
 ```
+
+:::
 
 ## Compatibility
 

--- a/docs/src/rules/func-style.md
+++ b/docs/src/rules/func-style.md
@@ -70,6 +70,8 @@ This rule has an object option for an exception:
 
 Examples of **incorrect** code for this rule with the default `"expression"` option:
 
+::: incorrect
+
 ```js
 /*eslint func-style: ["error", "expression"]*/
 
@@ -78,7 +80,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"expression"` option:
+
+::: correct
 
 ```js
 /*eslint func-style: ["error", "expression"]*/
@@ -92,9 +98,13 @@ var foo = () => {};
 // allowed as allowArrowFunctions : false is applied only for declaration
 ```
 
+:::
+
 ### declaration
 
 Examples of **incorrect** code for this rule with the `"declaration"` option:
+
+::: incorrect
 
 ```js
 /*eslint func-style: ["error", "declaration"]*/
@@ -106,7 +116,11 @@ var foo = function() {
 var foo = () => {};
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"declaration"` option:
+
+::: correct
 
 ```js
 /*eslint func-style: ["error", "declaration"]*/
@@ -121,15 +135,21 @@ SomeObject.foo = function() {
 };
 ```
 
+:::
+
 ### allowArrowFunctions
 
 Examples of additional **correct** code for this rule with the `"declaration", { "allowArrowFunctions": true }` options:
+
+::: correct
 
 ```js
 /*eslint func-style: ["error", "declaration", { "allowArrowFunctions": true }]*/
 
 var foo = () => {};
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/function-call-argument-newline.md
+++ b/docs/src/rules/function-call-argument-newline.md
@@ -32,6 +32,8 @@ This rule has a string option:
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint function-call-argument-newline: ["error", "always"]*/
 
@@ -47,7 +49,11 @@ baz("one", "two", (x) => {
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint function-call-argument-newline: ["error", "always"]*/
@@ -82,9 +88,13 @@ baz(
 );
 ```
 
+:::
+
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint function-call-argument-newline: ["error", "never"]*/
@@ -110,7 +120,11 @@ baz(
 );
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint function-call-argument-newline: ["error", "never"]*/
@@ -133,9 +147,13 @@ baz("one", "two", (x) => {
 });
 ```
 
+:::
+
 ### consistent
 
 Examples of **incorrect** code for this rule with the `"consistent"` option:
+
+::: incorrect
 
 ```js
 /*eslint function-call-argument-newline: ["error", "consistent"]*/
@@ -155,7 +173,11 @@ baz("one", "two",
 );
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"consistent"` option:
+
+::: correct
 
 ```js
 /*eslint function-call-argument-newline: ["error", "consistent"]*/
@@ -200,6 +222,8 @@ baz(
     }
 );
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/function-paren-newline.md
+++ b/docs/src/rules/function-paren-newline.md
@@ -46,6 +46,8 @@ Example configurations:
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /* eslint function-paren-newline: ["error", "always"] */
 
@@ -58,7 +60,11 @@ var foo = (bar, baz) => {};
 foo(bar, baz);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /* eslint function-paren-newline: ["error", "always"] */
@@ -83,7 +89,11 @@ foo(
 );
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /* eslint function-paren-newline: ["error", "never"] */
@@ -108,7 +118,11 @@ foo(
 );
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /* eslint function-paren-newline: ["error", "never"] */
@@ -128,7 +142,11 @@ foo(bar,
   baz);
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the default `"multiline"` option:
+
+::: incorrect
 
 ```js
 /* eslint function-paren-newline: ["error", "multiline"] */
@@ -155,7 +173,11 @@ foo(
 );
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"multiline"` option:
+
+::: correct
 
 ```js
 /* eslint function-paren-newline: ["error", "multiline"] */
@@ -182,7 +204,11 @@ foo(function() {
 });
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"consistent"` option:
+
+::: incorrect
 
 ```js
 /* eslint function-paren-newline: ["error", "consistent"] */
@@ -209,7 +235,11 @@ foo(
   });
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"consistent"` option:
+
+::: correct
 
 ```js
 /* eslint function-paren-newline: ["error", "consistent"] */
@@ -235,7 +265,11 @@ foo(
 );
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"multiline-arguments"` option:
+
+::: incorrect
 
 ```js
 /* eslint function-paren-newline: ["error", "multiline-arguments"] */
@@ -262,7 +296,11 @@ foo(
 );
 ```
 
+:::
+
 Examples of **correct** code for this rule with the consistent `"multiline-arguments"` option:
+
+::: correct
 
 ```js
 /* eslint function-paren-newline: ["error", "multiline-arguments"] */
@@ -285,7 +323,11 @@ foo(
 );
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "minItems": 3 }` option:
+
+::: incorrect
 
 ```js
 /* eslint function-paren-newline: ["error", { "minItems": 3 }] */
@@ -308,7 +350,11 @@ foo(bar,
   baz);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "minItems": 3 }` option:
+
+::: correct
 
 ```js
 /* eslint function-paren-newline: ["error", { "minItems": 3 }] */
@@ -331,6 +377,8 @@ foo(
   bar, baz, qux
 );
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/generator-star-spacing.md
+++ b/docs/src/rules/generator-star-spacing.md
@@ -113,6 +113,8 @@ Overrides can be either an object with "before" and "after", or a shorthand stri
 
 Examples of **correct** code for this rule with the `"before"` option:
 
+::: correct
+
 ```js
 /*eslint generator-star-spacing: ["error", {"before": true, "after": false}]*/
 /*eslint-env es6*/
@@ -124,9 +126,13 @@ var anonymous = function *() {};
 var shorthand = { *generator() {} };
 ```
 
+:::
+
 ### after
 
 Examples of **correct** code for this rule with the `"after"` option:
+
+::: correct
 
 ```js
 /*eslint generator-star-spacing: ["error", {"before": false, "after": true}]*/
@@ -139,9 +145,13 @@ var anonymous = function* () {};
 var shorthand = { * generator() {} };
 ```
 
+:::
+
 ### both
 
 Examples of **correct** code for this rule with the `"both"` option:
+
+::: correct
 
 ```js
 /*eslint generator-star-spacing: ["error", {"before": true, "after": true}]*/
@@ -154,9 +164,13 @@ var anonymous = function * () {};
 var shorthand = { * generator() {} };
 ```
 
+:::
+
 ### neither
 
 Examples of **correct** code for this rule with the `"neither"` option:
+
+::: correct
 
 ```js
 /*eslint generator-star-spacing: ["error", {"before": false, "after": false}]*/
@@ -169,7 +183,11 @@ var anonymous = function*() {};
 var shorthand = { *generator() {} };
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with overrides present:
+
+::: incorrect
 
 ```js
 /*eslint generator-star-spacing: ["error", {
@@ -189,7 +207,11 @@ var shorthand = { *generator() {} };
 class Class { static* method() {} }
 ```
 
+:::
+
 Examples of **correct** code for this rule with overrides present:
+
+::: correct
 
 ```js
 /*eslint generator-star-spacing: ["error", {
@@ -208,6 +230,8 @@ var shorthand = { * generator() {} };
 
 class Class { static * method() {} }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/getter-return.md
+++ b/docs/src/rules/getter-return.md
@@ -36,6 +36,8 @@ This rule enforces that a return statement is present in property getters.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint getter-return: "error"*/
 
@@ -58,7 +60,11 @@ class P{
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint getter-return: "error"*/
@@ -82,6 +88,8 @@ class P{
 }
 ```
 
+:::
+
 ## Options
 
 This rule has an object option:
@@ -89,6 +97,8 @@ This rule has an object option:
 * `"allowImplicit": false` (default) disallows implicitly returning `undefined` with a `return` statement.
 
 Examples of **correct** code for the `{ "allowImplicit": true }` option:
+
+::: correct
 
 ```js
 /*eslint getter-return: ["error", { allowImplicit: true }]*/
@@ -98,6 +108,8 @@ p = {
     }
 };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/global-require.md
+++ b/docs/src/rules/global-require.md
@@ -35,6 +35,8 @@ This rule requires all calls to `require()` to be at the top level of the module
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint global-require: "error"*/
 /*eslint-env es6*/
@@ -73,7 +75,11 @@ try {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint global-require: "error"*/
@@ -99,6 +105,8 @@ function doSomethingB() {}
 var x = require("x"),
     z = require("z");
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/grouped-accessor-pairs.md
+++ b/docs/src/rules/grouped-accessor-pairs.md
@@ -55,6 +55,8 @@ This rule does not enforce the existence of the pair for a getter or a setter. S
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint grouped-accessor-pairs: "error"*/
 
@@ -99,7 +101,11 @@ const Bar = class {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint grouped-accessor-pairs: "error"*/
@@ -145,6 +151,8 @@ const Bar = class {
 }
 ```
 
+:::
+
 ## Options
 
 This rule has a string option:
@@ -157,6 +165,8 @@ This rule has a string option:
 
 Examples of **incorrect** code for this rule with the `"getBeforeSet"` option:
 
+::: incorrect
+
 ```js
 /*eslint grouped-accessor-pairs: ["error", "getBeforeSet"]*/
 
@@ -187,9 +197,13 @@ const Bar = class {
     }
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"getBeforeSet"` option:
 
+::: correct
+
 ```js
 /*eslint grouped-accessor-pairs: ["error", "getBeforeSet"]*/
 
@@ -220,11 +234,15 @@ const Bar = class {
     }
 }
 ```
+
+:::
 
 ### setBeforeGet
 
 Examples of **incorrect** code for this rule with the `"setBeforeGet"` option:
 
+::: incorrect
+
 ```js
 /*eslint grouped-accessor-pairs: ["error", "setBeforeGet"]*/
 
@@ -255,9 +273,13 @@ const Bar = class {
     }
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"setBeforeGet"` option:
 
+::: correct
+
 ```js
 /*eslint grouped-accessor-pairs: ["error", "setBeforeGet"]*/
 
@@ -288,6 +310,8 @@ const Bar = class {
     }
 }
 ```
+
+:::
 
 ## Known Limitations
 

--- a/docs/src/rules/guard-for-in.md
+++ b/docs/src/rules/guard-for-in.md
@@ -28,6 +28,8 @@ This rule is aimed at preventing unexpected behavior that could arise from using
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint guard-for-in: "error"*/
 
@@ -36,7 +38,11 @@ for (key in foo) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint guard-for-in: "error"*/
@@ -53,3 +59,5 @@ for (key in foo) {
     }
 }
 ```
+
+:::

--- a/docs/src/rules/handle-callback-err.md
+++ b/docs/src/rules/handle-callback-err.md
@@ -32,6 +32,8 @@ The rule takes a single string option: the name of the error parameter. The defa
 
 Examples of **incorrect** code for this rule with the default `"err"` parameter name:
 
+::: incorrect
+
 ```js
 /*eslint handle-callback-err: "error"*/
 
@@ -41,7 +43,11 @@ function loadData (err, data) {
 
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"err"` parameter name:
+
+::: correct
 
 ```js
 /*eslint handle-callback-err: "error"*/
@@ -58,7 +64,11 @@ function generateError (err) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with a sample `"error"` parameter name:
+
+::: correct
 
 ```js
 /*eslint handle-callback-err: ["error", "error"]*/
@@ -70,6 +80,8 @@ function loadData (error, data) {
     doSomething();
 }
 ```
+
+:::
 
 ### regular expression
 

--- a/docs/src/rules/id-denylist.md
+++ b/docs/src/rules/id-denylist.md
@@ -42,6 +42,8 @@ For example, to restrict the use of common generic identifiers:
 
 Examples of **incorrect** code for this rule with sample `"data", "callback"` restricted identifiers:
 
+::: incorrect
+
 ```js
 /*eslint id-denylist: ["error", "data", "callback"] */
 
@@ -76,7 +78,11 @@ class Foo {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with sample `"data", "callback"` restricted identifiers:
+
+::: correct
 
 ```js
 /*eslint id-denylist: ["error", "data", "callback"] */
@@ -117,6 +123,8 @@ class Foo {
     #method( {);
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/id-length.md
+++ b/docs/src/rules/id-length.md
@@ -26,6 +26,8 @@ This rule enforces a minimum and/or maximum identifier length convention.
 
 Examples of **incorrect** code for this rule with the default options:
 
+::: incorrect
+
 ```js
 /*eslint id-length: "error"*/     // default is minimum 2-chars ({ "min": 2 })
 /*eslint-env es6*/
@@ -55,7 +57,11 @@ var { prop: a} = {};
 ({ prop: obj.x } = {});
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default options:
+
+::: correct
 
 ```js
 /*eslint id-length: "error"*/     // default is minimum 2-chars ({ "min": 2 })
@@ -93,6 +99,8 @@ var data = { "x": 1 };  // excused because of quotes
 data["y"] = 3;  // excused because of calculated property access
 ```
 
+:::
+
 This rule has an object option:
 
 * `"min"` (default: 2) enforces a minimum identifier length
@@ -105,6 +113,8 @@ This rule has an object option:
 ### min
 
 Examples of **incorrect** code for this rule with the `{ "min": 4 }` option:
+
+::: incorrect
 
 ```js
 /*eslint id-length: ["error", { "min": 4 }]*/
@@ -130,7 +140,11 @@ var { prop: [x]} = {};
 ({ prop: obj.x } = {});
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "min": 4 }` option:
+
+::: correct
 
 ```js
 /*eslint id-length: ["error", { "min": 4 }]*/
@@ -160,9 +174,13 @@ var data = { "x": 1 };  // excused because of quotes
 data["y"] = 3;  // excused because of calculated property access
 ```
 
+:::
+
 ### max
 
 Examples of **incorrect** code for this rule with the `{ "max": 10 }` option:
+
+::: incorrect
 
 ```js
 /*eslint id-length: ["error", { "max": 10 }]*/
@@ -181,7 +199,11 @@ try {
 var [reallyLongFirstElementName] = arr;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "max": 10 }` option:
+
+::: correct
 
 ```js
 /*eslint id-length: ["error", { "max": 10 }]*/
@@ -200,9 +222,13 @@ try {
 var [first] = arr;
 ```
 
+:::
+
 ### properties
 
 Examples of **correct** code for this rule with the `{ "properties": "never" }` option:
+
+::: correct
 
 ```js
 /*eslint id-length: ["error", { "properties": "never" }]*/
@@ -213,9 +239,13 @@ var myObj = { a: 1 };
 ({ prop: obj.i } = {});
 ```
 
+:::
+
 ### exceptions
 
 Examples of additional **correct** code for this rule with the `{ "exceptions": ["x"] }` option:
+
+::: correct
 
 ```js
 /*eslint id-length: ["error", { "exceptions": ["x"] }]*/
@@ -236,9 +266,13 @@ const { x } = foo;
 const { a: x } = foo;
 ```
 
+:::
+
 ### exceptionPatterns
 
 Examples of additional **correct** code for this rule with the `{ "exceptionPatterns": ["E|S", "[x-z]"] }` option:
+
+::: correct
 
 ```js
 /*eslint id-length: ["error", { "exceptionPatterns": ["E|S", "[x-z]"] }]*/
@@ -258,3 +292,5 @@ var [E] = arr;
 const { y } = foo;
 const { a: z } = foo;
 ```
+
+:::

--- a/docs/src/rules/id-match.md
+++ b/docs/src/rules/id-match.md
@@ -32,6 +32,8 @@ For example, to enforce a camelcase naming convention:
 
 Examples of **incorrect** code for this rule with the `"^[a-z]+([A-Z][a-z]+)*$"` option:
 
+::: incorrect
+
 ```js
 /*eslint id-match: ["error", "^[a-z]+([A-Z][a-z]+)*$"]*/
 
@@ -58,7 +60,11 @@ class myClass {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"^[a-z]+([A-Z][a-z]+)*$"` option:
+
+::: correct
 
 ```js
 /*eslint id-match: ["error", "^[a-z]+([A-Z][a-z]+)*$"]*/
@@ -82,6 +88,8 @@ class myClass {
 }
 ```
 
+:::
+
 This rule has an object option:
 
 * `"properties": false` (default) does not check object properties
@@ -97,6 +105,8 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule with the `"^[a-z]+([A-Z][a-z]+)*$", { "properties": true }` options:
 
+::: incorrect
+
 ```js
 /*eslint id-match: ["error", "^[a-z]+([A-Z][a-z]+)*$", { "properties": true }]*/
 
@@ -105,9 +115,13 @@ var obj = {
 };
 ```
 
+:::
+
 ### classFields
 
 Examples of **incorrect** code for this rule with the `"^[a-z]+([A-Z][a-z]+)*$", { "classFields": true }` options:
+
+::: incorrect
 
 ```js
 /*eslint id-match: ["error", "^[a-z]+([A-Z][a-z]+)*$", { "properties": true }]*/
@@ -121,9 +135,13 @@ class myClass {
 }
 ```
 
+:::
+
 ### onlyDeclarations
 
 Examples of **correct** code for this rule with the `"^[a-z]+([A-Z][a-z]+)*$", { "onlyDeclarations": true }` options:
+
+::: correct
 
 ```js
 /*eslint id-match: [2, "^[a-z]+([A-Z][a-z]+)*$", { "onlyDeclarations": true }]*/
@@ -131,9 +149,13 @@ Examples of **correct** code for this rule with the `"^[a-z]+([A-Z][a-z]+)*$", {
 do_something(__dirname);
 ```
 
+:::
+
 ### ignoreDestructuring: false
 
 Examples of **incorrect** code for this rule with the default `"^[^_]+$", { "ignoreDestructuring": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint id-match: [2, "^[^_]+$", { "ignoreDestructuring": false }]*/
@@ -149,9 +171,13 @@ var { category_id: category_alias } = query;
 var { category_id: categoryId, ...other_props } = query;
 ```
 
+:::
+
 ### ignoreDestructuring: true
 
 Examples of **incorrect** code for this rule with the `"^[^_]+$", { "ignoreDestructuring": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint id-match: [2, "^[^_]+$", { "ignoreDestructuring": true }]*/
@@ -161,7 +187,11 @@ var { category_id: category_alias } = query;
 var { category_id, ...other_props } = query;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"^[^_]+$", { "ignoreDestructuring": true }` option:
+
+::: correct
 
 ```js
 /*eslint id-match: [2, "^[^_]+$", { "ignoreDestructuring": true }]*/
@@ -172,6 +202,8 @@ var { category_id = 1 } = query;
 
 var { category_id: category_id } = query;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/implicit-arrow-linebreak.md
+++ b/docs/src/rules/implicit-arrow-linebreak.md
@@ -26,6 +26,8 @@ This rule accepts a string option:
 
 Examples of **incorrect** code for this rule with the default `"beside"` option:
 
+::: incorrect
+
 ```js
 /* eslint implicit-arrow-linebreak: ["error", "beside"] */
 
@@ -45,7 +47,11 @@ Examples of **incorrect** code for this rule with the default `"beside"` option:
 );
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"beside"` option:
+
+::: correct
 
 ```js
 /* eslint implicit-arrow-linebreak: ["error", "beside"] */
@@ -72,7 +78,11 @@ Examples of **correct** code for this rule with the default `"beside"` option:
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"below"` option:
+
+::: incorrect
 
 ```js
 /* eslint implicit-arrow-linebreak: ["error", "below"] */
@@ -84,7 +94,11 @@ Examples of **incorrect** code for this rule with the `"below"` option:
 (foo) => bar => baz;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"below"` option:
+
+::: correct
 
 ```js
 /* eslint implicit-arrow-linebreak: ["error", "below"] */
@@ -99,6 +113,8 @@ Examples of **correct** code for this rule with the `"below"` option:
   bar =>
     baz;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/indent-legacy.md
+++ b/docs/src/rules/indent-legacy.md
@@ -57,6 +57,8 @@ Or for tabbed indentation:
 
 Examples of **incorrect** code for this rule with the default options:
 
+::: incorrect
+
 ```js
 /*eslint indent: "error"*/
 
@@ -68,7 +70,11 @@ if (a) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default options:
+
+::: correct
 
 ```js
 /*eslint indent: "error"*/
@@ -80,6 +86,8 @@ if (a) {
     }
 }
 ```
+
+:::
 
 This rule has an object option:
 
@@ -119,6 +127,8 @@ Level of indentation denotes the multiple of the indent specified. Example:
 
 Examples of **incorrect** code for this rule with the `"tab"` option:
 
+::: incorrect
+
 ```js
 /*eslint indent: ["error", "tab"]*/
 
@@ -130,7 +140,11 @@ function foo(d) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"tab"` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", "tab"]*/
@@ -143,9 +157,13 @@ if (a) {
 }
 ```
 
+:::
+
 ### SwitchCase
 
 Examples of **incorrect** code for this rule with the `2, { "SwitchCase": 1 }` options:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "SwitchCase": 1 }]*/
@@ -158,7 +176,11 @@ case "b":
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "SwitchCase": 1 }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "SwitchCase": 1 }]*/
@@ -171,9 +193,13 @@ switch(a){
 }
 ```
 
+:::
+
 ### VariableDeclarator
 
 Examples of **incorrect** code for this rule with the `2, { "VariableDeclarator": 1 }` options:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": 1 }]*/
@@ -190,7 +216,11 @@ const a = 1,
     c = 3;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 1 }` options:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": 1 }]*/
@@ -207,7 +237,11 @@ const a = 1,
   c = 3;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 2 }` options:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": 2 }]*/
@@ -224,7 +258,11 @@ const a = 1,
     c = 3;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "VariableDeclarator": { "var": 2, "let": 2, "const": 3 } }` options:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": { "var": 2, "let": 2, "const": 3 } }]*/
@@ -241,9 +279,13 @@ const a = 1,
       c = 3;
 ```
 
+:::
+
 ### outerIIFEBody
 
 Examples of **incorrect** code for this rule with the options `2, { "outerIIFEBody": 0 }`:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "outerIIFEBody": 0 }]*/
@@ -261,7 +303,11 @@ console.log('foo');
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the options `2, {"outerIIFEBody": 0}`:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "outerIIFEBody": 0 }]*/
@@ -279,9 +325,13 @@ if(y) {
 }
 ```
 
+:::
+
 ### MemberExpression
 
 Examples of **incorrect** code for this rule with the `2, { "MemberExpression": 1 }` options:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "MemberExpression": 1 }]*/
@@ -291,7 +341,11 @@ foo
 .baz()
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "MemberExpression": 1 }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "MemberExpression": 1 }]*/
@@ -305,9 +359,13 @@ var bip = aardvark.badger
                   .coyote;
 ```
 
+:::
+
 ### FunctionDeclaration
 
 Examples of **incorrect** code for this rule with the `2, { "FunctionDeclaration": {"body": 1, "parameters": 2} }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "FunctionDeclaration": {"body": 1, "parameters": 2} }]*/
@@ -319,7 +377,11 @@ function foo(bar,
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "FunctionDeclaration": {"body": 1, "parameters": 2} }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "FunctionDeclaration": {"body": 1, "parameters": 2} }]*/
@@ -331,7 +393,11 @@ function foo(bar,
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `2, { "FunctionDeclaration": {"parameters": "first"} }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, {"FunctionDeclaration": {"parameters": "first"}}]*/
@@ -342,7 +408,11 @@ function foo(bar, baz,
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "FunctionDeclaration": {"parameters": "first"} }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, {"FunctionDeclaration": {"parameters": "first"}}]*/
@@ -353,9 +423,13 @@ function foo(bar, baz,
 }
 ```
 
+:::
+
 ### FunctionExpression
 
 Examples of **incorrect** code for this rule with the `2, { "FunctionExpression": {"body": 1, "parameters": 2} }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "FunctionExpression": {"body": 1, "parameters": 2} }]*/
@@ -367,7 +441,11 @@ var foo = function(bar,
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "FunctionExpression": {"body": 1, "parameters": 2} }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "FunctionExpression": {"body": 1, "parameters": 2} }]*/
@@ -379,7 +457,11 @@ var foo = function(bar,
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `2, { "FunctionExpression": {"parameters": "first"} }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, {"FunctionExpression": {"parameters": "first"}}]*/
@@ -390,7 +472,11 @@ var foo = function(bar, baz,
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "FunctionExpression": {"parameters": "first"} }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, {"FunctionExpression": {"parameters": "first"}}]*/
@@ -401,9 +487,13 @@ var foo = function(bar, baz,
 }
 ```
 
+:::
+
 ### CallExpression
 
 Examples of **incorrect** code for this rule with the `2, { "CallExpression": {"arguments": 1} }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "CallExpression": {"arguments": 1} }]*/
@@ -414,7 +504,11 @@ foo(bar,
 );
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "CallExpression": {"arguments": 1} }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "CallExpression": {"arguments": 1} }]*/
@@ -425,7 +519,11 @@ foo(bar,
 );
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `2, { "CallExpression": {"arguments": "first"} }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, {"CallExpression": {"arguments": "first"}}]*/
@@ -434,7 +532,11 @@ foo(bar, baz,
   baz, boop, beep);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "CallExpression": {"arguments": "first"} }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, {"CallExpression": {"arguments": "first"}}]*/
@@ -443,9 +545,13 @@ foo(bar, baz,
     baz, boop, beep);
 ```
 
+:::
+
 ### ArrayExpression
 
 Examples of **incorrect** code for this rule with the `2, { "ArrayExpression": 1 }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "ArrayExpression": 1 }]*/
@@ -457,7 +563,11 @@ baz,
 ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "ArrayExpression": 1 }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "ArrayExpression": 1 }]*/
@@ -469,7 +579,11 @@ var foo = [
 ];
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `2, { "ArrayExpression": "first" }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, {"ArrayExpression": "first"}]*/
@@ -480,7 +594,11 @@ var foo = [bar,
 ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "ArrayExpression": "first" }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, {"ArrayExpression": "first"}]*/
@@ -491,9 +609,13 @@ var foo = [bar,
 ];
 ```
 
+:::
+
 ### ObjectExpression
 
 Examples of **incorrect** code for this rule with the `2, { "ObjectExpression": 1 }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "ObjectExpression": 1 }]*/
@@ -505,7 +627,11 @@ baz: 2,
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "ObjectExpression": 1 }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "ObjectExpression": 1 }]*/
@@ -517,7 +643,11 @@ var foo = {
 };
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `2, { "ObjectExpression": "first" }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, {"ObjectExpression": "first"}]*/
@@ -526,7 +656,11 @@ var foo = { bar: 1,
   baz: 2 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "ObjectExpression": "first" }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, {"ObjectExpression": "first"}]*/
@@ -534,6 +668,8 @@ Examples of **correct** code for this rule with the `2, { "ObjectExpression": "f
 var foo = { bar: 1,
             baz: 2 };
 ```
+
+:::
 
 ## Compatibility
 

--- a/docs/src/rules/indent.md
+++ b/docs/src/rules/indent.md
@@ -51,6 +51,8 @@ Or for tabbed indentation:
 
 Examples of **incorrect** code for this rule with the default options:
 
+::: incorrect
+
 ```js
 /*eslint indent: "error"*/
 
@@ -62,7 +64,11 @@ if (a) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default options:
+
+::: correct
 
 ```js
 /*eslint indent: "error"*/
@@ -74,6 +80,8 @@ if (a) {
     }
 }
 ```
+
+:::
 
 This rule has an object option:
 
@@ -120,6 +128,8 @@ Level of indentation denotes the multiple of the indent specified. Example:
 
 Examples of **incorrect** code for this rule with the `"tab"` option:
 
+::: incorrect
+
 ```js
 /*eslint indent: ["error", "tab"]*/
 
@@ -131,7 +141,11 @@ function foo(d) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"tab"` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", "tab"]*/
@@ -144,11 +158,15 @@ if (a) {
 }
 ```
 
+:::
+
 ### ignoredNodes
 
 The following configuration ignores the indentation of `ConditionalExpression` ("ternary expression") nodes:
 
 Examples of **correct** code for this rule with the `4, { "ignoredNodes": ["ConditionalExpression"] }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 4, { "ignoredNodes": ["ConditionalExpression"] }]*/
@@ -162,9 +180,13 @@ var a = foo
 : baz;
 ```
 
+:::
+
 The following configuration ignores indentation in the body of IIFEs.
 
 Examples of **correct** code for this rule with the `4, { "ignoredNodes": ["CallExpression > FunctionExpression.callee > BlockStatement.body"] }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 4, { "ignoredNodes": ["CallExpression > FunctionExpression.callee > BlockStatement.body"] }]*/
@@ -177,11 +199,15 @@ bar();
 })
 ```
 
+:::
+
 All AST node types can be found at [ESTree](https://github.com/estree/estree) specification. You can use [AST Explorer](https://astexplorer.net/) with the espree parser to examine AST tree of a code snippet.
 
 ### SwitchCase
 
 Examples of **incorrect** code for this rule with the `2, { "SwitchCase": 1 }` options:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "SwitchCase": 1 }]*/
@@ -194,7 +220,11 @@ case "b":
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "SwitchCase": 1 }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "SwitchCase": 1 }]*/
@@ -207,9 +237,13 @@ switch(a){
 }
 ```
 
+:::
+
 ### VariableDeclarator
 
 Examples of **incorrect** code for this rule with the `2, { "VariableDeclarator": 1 }` options:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": 1 }]*/
@@ -226,7 +260,11 @@ const a = 1,
     c = 3;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 1 }` options:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": 1 }]*/
@@ -243,7 +281,11 @@ const a = 1,
   c = 3;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 2 }` options:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": 2 }]*/
@@ -260,7 +302,11 @@ const a = 1,
     c = 3;
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `2, { "VariableDeclarator": "first" }` options:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": "first" }]*/
@@ -277,7 +323,11 @@ const a = 1,
   c = 3;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "VariableDeclarator": "first" }` options:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": "first" }]*/
@@ -294,7 +344,11 @@ const a = 1,
       c = 3;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "VariableDeclarator": { "var": 2, "let": 2, "const": 3 } }` options:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": { "var": 2, "let": 2, "const": 3 } }]*/
@@ -311,9 +365,13 @@ const a = 1,
       c = 3;
 ```
 
+:::
+
 ### outerIIFEBody
 
 Examples of **incorrect** code for this rule with the options `2, { "outerIIFEBody": 0 }`:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "outerIIFEBody": 0 }]*/
@@ -331,7 +389,11 @@ console.log('foo');
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the options `2, { "outerIIFEBody": 0 }`:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "outerIIFEBody": 0 }]*/
@@ -349,7 +411,11 @@ if (y) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the options `2, { "outerIIFEBody":  "off" }`:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "outerIIFEBody": "off" }]*/
@@ -375,9 +441,13 @@ if (y) {
 }
 ```
 
+:::
+
 ### MemberExpression
 
 Examples of **incorrect** code for this rule with the `2, { "MemberExpression": 1 }` options:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "MemberExpression": 1 }]*/
@@ -387,7 +457,11 @@ foo
 .baz()
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "MemberExpression": 1 }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "MemberExpression": 1 }]*/
@@ -397,9 +471,13 @@ foo
   .baz();
 ```
 
+:::
+
 ### FunctionDeclaration
 
 Examples of **incorrect** code for this rule with the `2, { "FunctionDeclaration": {"body": 1, "parameters": 2} }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "FunctionDeclaration": {"body": 1, "parameters": 2} }]*/
@@ -411,7 +489,11 @@ function foo(bar,
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "FunctionDeclaration": {"body": 1, "parameters": 2} }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "FunctionDeclaration": {"body": 1, "parameters": 2} }]*/
@@ -423,7 +505,11 @@ function foo(bar,
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `2, { "FunctionDeclaration": {"parameters": "first"} }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, {"FunctionDeclaration": {"parameters": "first"}}]*/
@@ -434,7 +520,11 @@ function foo(bar, baz,
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "FunctionDeclaration": {"parameters": "first"} }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, {"FunctionDeclaration": {"parameters": "first"}}]*/
@@ -445,9 +535,13 @@ function foo(bar, baz,
 }
 ```
 
+:::
+
 ### FunctionExpression
 
 Examples of **incorrect** code for this rule with the `2, { "FunctionExpression": {"body": 1, "parameters": 2} }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "FunctionExpression": {"body": 1, "parameters": 2} }]*/
@@ -459,7 +553,11 @@ var foo = function(bar,
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "FunctionExpression": {"body": 1, "parameters": 2} }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "FunctionExpression": {"body": 1, "parameters": 2} }]*/
@@ -471,7 +569,11 @@ var foo = function(bar,
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `2, { "FunctionExpression": {"parameters": "first"} }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, {"FunctionExpression": {"parameters": "first"}}]*/
@@ -482,7 +584,11 @@ var foo = function(bar, baz,
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "FunctionExpression": {"parameters": "first"} }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, {"FunctionExpression": {"parameters": "first"}}]*/
@@ -493,10 +599,14 @@ var foo = function(bar, baz,
 }
 ```
 
+:::
+
 ### StaticBlock
 
 Examples of **incorrect** code for this rule with the `2, { "StaticBlock": {"body": 1} }` option:
 
+::: incorrect
+
 ```js
 /*eslint indent: ["error", 2, { "StaticBlock": {"body": 1} }]*/
 
@@ -506,9 +616,13 @@ class C {
   }
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `2, { "StaticBlock": {"body": 1} }` option:
 
+::: correct
+
 ```js
 /*eslint indent: ["error", 2, { "StaticBlock": {"body": 1} }]*/
 
@@ -519,7 +633,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `2, { "StaticBlock": {"body": 2} }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "StaticBlock": {"body": 2} }]*/
@@ -531,7 +649,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "StaticBlock": {"body": 2} }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "StaticBlock": {"body": 2} }]*/
@@ -542,10 +664,14 @@ class C {
   }
 }
 ```
+
+:::
 
 ### CallExpression
 
 Examples of **incorrect** code for this rule with the `2, { "CallExpression": {"arguments": 1} }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "CallExpression": {"arguments": 1} }]*/
@@ -556,7 +682,11 @@ foo(bar,
 );
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "CallExpression": {"arguments": 1} }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "CallExpression": {"arguments": 1} }]*/
@@ -567,7 +697,11 @@ foo(bar,
 );
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `2, { "CallExpression": {"arguments": "first"} }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, {"CallExpression": {"arguments": "first"}}]*/
@@ -576,7 +710,11 @@ foo(bar, baz,
   baz, boop, beep);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "CallExpression": {"arguments": "first"} }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, {"CallExpression": {"arguments": "first"}}]*/
@@ -585,9 +723,13 @@ foo(bar, baz,
     baz, boop, beep);
 ```
 
+:::
+
 ### ArrayExpression
 
 Examples of **incorrect** code for this rule with the `2, { "ArrayExpression": 1 }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "ArrayExpression": 1 }]*/
@@ -599,7 +741,11 @@ baz,
 ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "ArrayExpression": 1 }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "ArrayExpression": 1 }]*/
@@ -611,7 +757,11 @@ var foo = [
 ];
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `2, { "ArrayExpression": "first" }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, {"ArrayExpression": "first"}]*/
@@ -622,7 +772,11 @@ var foo = [bar,
 ];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "ArrayExpression": "first" }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, {"ArrayExpression": "first"}]*/
@@ -633,9 +787,13 @@ var foo = [bar,
 ];
 ```
 
+:::
+
 ### ObjectExpression
 
 Examples of **incorrect** code for this rule with the `2, { "ObjectExpression": 1 }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "ObjectExpression": 1 }]*/
@@ -647,7 +805,11 @@ baz: 2,
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "ObjectExpression": 1 }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "ObjectExpression": 1 }]*/
@@ -659,7 +821,11 @@ var foo = {
 };
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `2, { "ObjectExpression": "first" }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, {"ObjectExpression": "first"}]*/
@@ -668,7 +834,11 @@ var foo = { bar: 1,
   baz: 2 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "ObjectExpression": "first" }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, {"ObjectExpression": "first"}]*/
@@ -677,9 +847,13 @@ var foo = { bar: 1,
             baz: 2 };
 ```
 
+:::
+
 ### ImportDeclaration
 
 Examples of **correct** code for this rule with the `4, { "ImportDeclaration": 1 }` option (the default):
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 4, { "ImportDeclaration": 1 }]*/
@@ -696,7 +870,11 @@ import {
 } from 'qux';
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `4, { "ImportDeclaration": "first" }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 4, { "ImportDeclaration": "first" }]*/
@@ -707,7 +885,11 @@ import { foo,
 } from 'qux';
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `4, { "ImportDeclaration": "first" }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 4, { "ImportDeclaration": "first" }]*/
@@ -718,10 +900,14 @@ import { foo,
 } from 'qux';
 ```
 
+:::
+
 ### flatTernaryExpressions
 
 Examples of **incorrect** code for this rule with the default `4, { "flatTernaryExpressions": false }` option:
 
+::: incorrect
+
 ```js
 /*eslint indent: ["error", 4, { "flatTernaryExpressions": false }]*/
 
@@ -730,9 +916,13 @@ var a =
     baz ? qux :
     boop;
 ```
+
+:::
 
 Examples of **correct** code for this rule with the default `4, { "flatTernaryExpressions": false }` option:
 
+::: correct
+
 ```js
 /*eslint indent: ["error", 4, { "flatTernaryExpressions": false }]*/
 
@@ -742,7 +932,11 @@ var a =
             boop;
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `4, { "flatTernaryExpressions": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 4, { "flatTernaryExpressions": true }]*/
@@ -753,7 +947,11 @@ var a =
             boop;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `4, { "flatTernaryExpressions": true }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 4, { "flatTernaryExpressions": true }]*/
@@ -763,10 +961,14 @@ var a =
     baz ? qux :
     boop;
 ```
+
+:::
 
 ### offsetTernaryExpressions
 
 Examples of **incorrect** code for this rule with the default `2, { "offsetTernaryExpressions": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "offsetTernaryExpressions": false }]*/
@@ -780,7 +982,11 @@ condition
     }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `2, { "offsetTernaryExpressions": false }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "offsetTernaryExpressions": false }]*/
@@ -798,7 +1004,11 @@ condition
     }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `2, { "offsetTernaryExpressions": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint indent: ["error", 2, { "offsetTernaryExpressions": true }]*/
@@ -816,7 +1026,11 @@ condition
     }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `2, { "offsetTernaryExpressions": true }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 2, { "offsetTernaryExpressions": true }]*/
@@ -834,9 +1048,13 @@ condition
       }
 ```
 
+:::
+
 ### ignoreComments
 
 Examples of additional **correct** code for this rule with the `4, { "ignoreComments": true }` option:
+
+::: correct
 
 ```js
 /*eslint indent: ["error", 4, { "ignoreComments": true }] */
@@ -848,6 +1066,8 @@ if (foo) {
     doSomethingElse();
 }
 ```
+
+:::
 
 ## Compatibility
 

--- a/docs/src/rules/init-declarations.md
+++ b/docs/src/rules/init-declarations.md
@@ -70,6 +70,8 @@ Variables must not be initialized at declaration, except in for loops, where it 
 
 Examples of **incorrect** code for the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint init-declarations: ["error", "always"]*/
 /*eslint-env es6*/
@@ -80,7 +82,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint init-declarations: ["error", "always"]*/
@@ -93,9 +99,13 @@ function foo() {
 }
 ```
 
+:::
+
 ### never
 
 Examples of **incorrect** code for the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint init-declarations: ["error", "never"]*/
@@ -109,7 +119,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint init-declarations: ["error", "never"]*/
@@ -122,16 +136,22 @@ function foo() {
 }
 ```
 
+:::
+
 The `"never"` option ignores `const` variable initializations.
 
 ### ignoreForLoopInit
 
 Examples of **correct** code for the `"never", { "ignoreForLoopInit": true }` options:
 
+::: correct
+
 ```js
 /*eslint init-declarations: ["error", "never", { "ignoreForLoopInit": true }]*/
 for (var i = 0; i < 1; i++) {}
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/jsx-quotes.md
+++ b/docs/src/rules/jsx-quotes.md
@@ -41,13 +41,19 @@ This rule has a string option:
 
 Examples of **incorrect** code for this rule with the default `"prefer-double"` option:
 
+::: incorrect
+
 ```xml
 /*eslint jsx-quotes: ["error", "prefer-double"]*/
 
 <a b='c' />
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"prefer-double"` option:
+
+::: correct
 
 ```xml
 /*eslint jsx-quotes: ["error", "prefer-double"]*/
@@ -56,9 +62,13 @@ Examples of **correct** code for this rule with the default `"prefer-double"` op
 <a b='"' />
 ```
 
+:::
+
 ### prefer-single
 
 Examples of **incorrect** code for this rule with the `"prefer-single"` option:
+
+::: incorrect
 
 ```xml
 /*eslint jsx-quotes: ["error", "prefer-single"]*/
@@ -66,7 +76,11 @@ Examples of **incorrect** code for this rule with the `"prefer-single"` option:
 <a b="c" />
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"prefer-single"` option:
+
+::: correct
 
 ```xml
 /*eslint jsx-quotes: ["error", "prefer-single"]*/
@@ -74,6 +88,8 @@ Examples of **correct** code for this rule with the `"prefer-single"` option:
 <a b='c' />
 <a b="'" />
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/key-spacing.md
+++ b/docs/src/rules/key-spacing.md
@@ -41,21 +41,31 @@ Please note that you can either use the top-level options or the grouped options
 
 Examples of **incorrect** code for this rule with the default `{ "beforeColon": false }` option:
 
+::: incorrect
+
 ```js
 /*eslint key-spacing: ["error", { "beforeColon": false }]*/
 
 var obj = { "foo" : 42 };
 ```
+
+:::
 
 Examples of **correct** code for this rule with the default `{ "beforeColon": false }` option:
 
+::: correct
+
 ```js
 /*eslint key-spacing: ["error", { "beforeColon": false }]*/
 
 var obj = { "foo": 42 };
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "beforeColon": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint key-spacing: ["error", { "beforeColon": true }]*/
@@ -63,33 +73,49 @@ Examples of **incorrect** code for this rule with the `{ "beforeColon": true }` 
 var obj = { "foo": 42 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "beforeColon": true }` option:
+
+::: correct
 
 ```js
 /*eslint key-spacing: ["error", { "beforeColon": true }]*/
 
 var obj = { "foo" : 42 };
 ```
+
+:::
 
 ### afterColon
 
 Examples of **incorrect** code for this rule with the default `{ "afterColon": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint key-spacing: ["error", { "afterColon": true }]*/
 
 var obj = { "foo":42 };
 ```
+
+:::
 
 Examples of **correct** code for this rule with the default `{ "afterColon": true }` option:
 
+::: correct
+
 ```js
 /*eslint key-spacing: ["error", { "afterColon": true }]*/
 
 var obj = { "foo": 42 };
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "afterColon": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint key-spacing: ["error", { "afterColon": false }]*/
@@ -97,17 +123,25 @@ Examples of **incorrect** code for this rule with the `{ "afterColon": false }` 
 var obj = { "foo": 42 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "afterColon": false }` option:
+
+::: correct
 
 ```js
 /*eslint key-spacing: ["error", { "afterColon": false }]*/
 
 var obj = { "foo":42 };
 ```
+
+:::
 
 ### mode
 
 Examples of **incorrect** code for this rule with the default `{ "mode": "strict" }` option:
+
+::: incorrect
 
 ```js
 /*eslint key-spacing: ["error", { "mode": "strict" }]*/
@@ -118,7 +152,11 @@ call({
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "mode": "strict" }` option:
+
+::: correct
 
 ```js
 /*eslint key-spacing: ["error", { "mode": "strict" }]*/
@@ -129,7 +167,11 @@ call({
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "mode": "minimum" }` option:
+
+::: correct
 
 ```js
 /*eslint key-spacing: ["error", { "mode": "minimum" }]*/
@@ -140,9 +182,13 @@ call({
 });
 ```
 
+:::
+
 ### align
 
 Examples of **incorrect** code for this rule with the `{ "align": "value" }` option:
+
+::: incorrect
 
 ```js
 /*eslint key-spacing: ["error", { "align": "value" }]*/
@@ -154,7 +200,11 @@ var obj = {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "align": "value" }` option:
+
+::: correct
 
 ```js
 /*eslint key-spacing: ["error", { "align": "value" }]*/
@@ -173,7 +223,11 @@ var obj = {
 var obj = { a: "foo", longPropertyName: "bar" };
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "align": "colon" }` option:
+
+::: incorrect
 
 ```js
 /*eslint key-spacing: ["error", { "align": "colon" }]*/
@@ -184,7 +238,11 @@ call({
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "align": "colon" }` option:
+
+::: correct
 
 ```js
 /*eslint key-spacing: ["error", { "align": "colon" }]*/
@@ -194,6 +252,8 @@ call({
     bat   : 2 * 2
 });
 ```
+
+:::
 
 ### align
 
@@ -213,6 +273,8 @@ align: {
 
 Examples of **correct** code for this rule with sample `{ "align": { } }` options:
 
+::: correct
+
 ```js
 /*eslint key-spacing: ["error", {
     "align": {
@@ -227,6 +289,8 @@ var obj = {
     "seven" : 7
 }
 ```
+
+:::
 
 ```js
 /*eslint key-spacing: ["error", {
@@ -263,6 +327,8 @@ var myObj = {
 
 Examples of **incorrect** code for this rule with sample `{ "align": { }, "multiLine": { } }` options:
 
+::: incorrect
+
 ```js
 /*eslint key-spacing: ["error", {
     "multiLine": {
@@ -285,7 +351,11 @@ var obj = {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with sample `{ "align": { }, "multiLine": { } }` options:
+
+::: correct
 
 ```js
 /*eslint key-spacing: ["error", {
@@ -311,9 +381,13 @@ var obj = {
 }
 ```
 
+:::
+
 ### singleLine and multiLine
 
 Examples of **correct** code for this rule with sample `{ "singleLine": { }, "multiLine": { } }` options:
+
+::: correct
 
 ```js
 /*eslint "key-spacing": [2, {
@@ -333,6 +407,8 @@ var obj2 = {
     three : 3
 };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/keyword-spacing.md
+++ b/docs/src/rules/keyword-spacing.md
@@ -44,6 +44,8 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule with the default `{ "before": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint keyword-spacing: ["error", { "before": true }]*/
 
@@ -56,7 +58,11 @@ if (foo) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "before": true }` option:
+
+::: correct
 
 ```js
 /*eslint keyword-spacing: ["error", { "before": true }]*/
@@ -111,7 +117,11 @@ if (10+this.foo<= this.bar) {}
 let a = <A foo={this.foo} bar={function(){}} />
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "before": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint keyword-spacing: ["error", { "before": false }]*/
@@ -125,7 +135,11 @@ if (foo) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "before": false }` option:
+
+::: correct
 
 ```js
 /*eslint keyword-spacing: ["error", { "before": false }]*/
@@ -139,9 +153,13 @@ if (foo) {
 }
 ```
 
+:::
+
 ### after
 
 Examples of **incorrect** code for this rule with the default `{ "after": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint keyword-spacing: ["error", { "after": true }]*/
@@ -155,7 +173,11 @@ if(foo) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "after": true }` option:
+
+::: correct
 
 ```js
 /*eslint keyword-spacing: ["error", { "after": true }]*/
@@ -222,7 +244,11 @@ function* foo(a) {
 let a = <A foo={this.foo} bar={function(){}} />
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "after": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint keyword-spacing: ["error", { "after": false }]*/
@@ -236,7 +262,11 @@ if (foo) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "after": false }` option:
+
+::: correct
 
 ```js
 /*eslint keyword-spacing: ["error", { "after": false }]*/
@@ -250,9 +280,13 @@ if(foo) {
 }
 ```
 
+:::
+
 ### overrides
 
 Examples of **correct** code for this rule with the `{ "overrides": { "if": { "after": false }, "for": { "after": false }, "while": { "after": false }, "static": { "after": false }, "as": { "after": false } } }` option:
+
+::: correct
 
 ```js
 /*eslint keyword-spacing: ["error", { "overrides": {
@@ -285,6 +319,8 @@ class C {
 
 export { C as"my class" };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/line-comment-position.md
+++ b/docs/src/rules/line-comment-position.md
@@ -33,29 +33,43 @@ The `position` option has two settings:
 
 Examples of **correct** code for the `{ "position": "above" }` option:
 
+::: correct
+
 ```js
 /*eslint line-comment-position: ["error", { "position": "above" }]*/
 // valid comment
 1 + 1;
 ```
 
+:::
+
 Examples of **incorrect** code for the `{ "position": "above" }` option:
+
+::: incorrect
 
 ```js
 /*eslint line-comment-position: ["error", { "position": "above" }]*/
 1 + 1; // invalid comment
 ```
 
+:::
+
 #### position: beside
 
 Examples of **correct** code for the `{ "position": "beside" }` option:
+
+::: correct
 
 ```js
 /*eslint line-comment-position: ["error", { "position": "beside" }]*/
 1 + 1; // valid comment
 ```
 
+:::
+
 Examples of **incorrect** code for the `{ "position": "beside" }` option:
+
+::: incorrect
 
 ```js
 /*eslint line-comment-position: ["error", { "position": "beside" }]*/
@@ -63,23 +77,33 @@ Examples of **incorrect** code for the `{ "position": "beside" }` option:
 1 + 1;
 ```
 
+:::
+
 ### ignorePattern
 
 By default this rule ignores comments starting with the following words: `eslint`, `jshint`, `jslint`, `istanbul`, `global`, `exported`, `jscs`, `falls through`. An alternative regular expression can be provided.
 
 Examples of **correct** code for the `ignorePattern` option:
 
+::: correct
+
 ```js
 /*eslint line-comment-position: ["error", { "ignorePattern": "pragma" }]*/
 1 + 1; // pragma valid comment
 ```
 
+:::
+
 Examples of **incorrect** code for the `ignorePattern` option:
+
+::: incorrect
 
 ```js
 /*eslint line-comment-position: ["error", { "ignorePattern": "pragma" }]*/
 1 + 1; // invalid comment
 ```
+
+:::
 
 ### applyDefaultIgnorePatterns
 
@@ -87,17 +111,25 @@ Default ignore patterns are applied even when `ignorePattern` is provided. If yo
 
 Examples of **correct** code for the `{ "applyDefaultIgnorePatterns": false }` option:
 
+::: correct
+
 ```js
 /*eslint line-comment-position: ["error", { "ignorePattern": "pragma", "applyDefaultIgnorePatterns": false }]*/
 1 + 1; // pragma valid comment
 ```
 
+:::
+
 Examples of **incorrect** code for the `{ "applyDefaultIgnorePatterns": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint line-comment-position: ["error", { "ignorePattern": "pragma", "applyDefaultIgnorePatterns": false }]*/
 1 + 1; // falls through
 ```
+
+:::
 
 **Deprecated:** the object property `applyDefaultPatterns` is deprecated. Please use the property `applyDefaultIgnorePatterns` instead.
 

--- a/docs/src/rules/linebreak-style.md
+++ b/docs/src/rules/linebreak-style.md
@@ -32,6 +32,8 @@ This rule has a string option:
 
 Examples of **incorrect** code for this rule with the default `"unix"` option:
 
+::: incorrect
+
 ```js
 /*eslint linebreak-style: ["error", "unix"]*/
 
@@ -39,7 +41,11 @@ var a = 'a'; // \r\n
 
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"unix"` option:
+
+::: correct
 
 ```js
 /*eslint linebreak-style: ["error", "unix"]*/
@@ -52,9 +58,13 @@ function foo(params) { // \n
 }// \n
 ```
 
+:::
+
 ### windows
 
 Examples of **incorrect** code for this rule with the `"windows"` option:
+
+::: incorrect
 
 ```js
 /*eslint linebreak-style: ["error", "windows"]*/
@@ -62,7 +72,11 @@ Examples of **incorrect** code for this rule with the `"windows"` option:
 var a = 'a'; // \n
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"windows"` option:
+
+::: correct
 
 ```js
 /*eslint linebreak-style: ["error", "windows"]*/
@@ -74,6 +88,8 @@ function foo(params) { // \r\n
     // do stuff \r\n
 } // \r\n
 ```
+
+:::
 
 ### Using this rule with version control systems
 

--- a/docs/src/rules/lines-around-comment.md
+++ b/docs/src/rules/lines-around-comment.md
@@ -42,6 +42,8 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule with the default `{ "beforeBlockComment": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint lines-around-comment: ["error", { "beforeBlockComment": true }]*/
 
@@ -49,9 +51,13 @@ var night = "long";
 /* what a great and wonderful day */
 var day = "great"
 ```
+
+:::
 
 Examples of **correct** code for this rule with the default `{ "beforeBlockComment": true }` option:
 
+::: correct
+
 ```js
 /*eslint lines-around-comment: ["error", { "beforeBlockComment": true }]*/
 
@@ -60,11 +66,15 @@ var night = "long";
 /* what a great and wonderful day */
 var day = "great"
 ```
+
+:::
 
 ### afterBlockComment
 
 Examples of **incorrect** code for this rule with the `{ "afterBlockComment": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint lines-around-comment: ["error", { "afterBlockComment": true }]*/
 
@@ -73,9 +83,13 @@ var night = "long";
 /* what a great and wonderful day */
 var day = "great"
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{ "afterBlockComment": true }` option:
 
+::: correct
+
 ```js
 /*eslint lines-around-comment: ["error", { "afterBlockComment": true }]*/
 
@@ -85,11 +99,15 @@ var night = "long";
 
 var day = "great"
 ```
+
+:::
 
 ### beforeLineComment
 
 Examples of **incorrect** code for this rule with the `{ "beforeLineComment": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint lines-around-comment: ["error", { "beforeLineComment": true }]*/
 
@@ -97,9 +115,13 @@ var night = "long";
 // what a great and wonderful day
 var day = "great"
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{ "beforeLineComment": true }` option:
 
+::: correct
+
 ```js
 /*eslint lines-around-comment: ["error", { "beforeLineComment": true }]*/
 
@@ -108,11 +130,15 @@ var night = "long";
 // what a great and wonderful day
 var day = "great"
 ```
+
+:::
 
 ### afterLineComment
 
 Examples of **incorrect** code for this rule with the `{ "afterLineComment": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint lines-around-comment: ["error", { "afterLineComment": true }]*/
 
@@ -120,9 +146,13 @@ var night = "long";
 // what a great and wonderful day
 var day = "great"
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{ "afterLineComment": true }` option:
 
+::: correct
+
 ```js
 /*eslint lines-around-comment: ["error", { "afterLineComment": true }]*/
 
@@ -131,10 +161,14 @@ var night = "long";
 
 var day = "great"
 ```
+
+:::
 
 ### allowBlockStart
 
 Examples of **correct** code for this rule with the `{ "beforeLineComment": true, "allowBlockStart": true }` options:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowBlockStart": true }]*/
@@ -165,7 +199,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "beforeBlockComment": true, "allowBlockStart": true }` options:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowBlockStart": true }]*/
@@ -196,9 +234,13 @@ class C {
 }
 ```
 
+:::
+
 ### allowBlockEnd
 
 Examples of **correct** code for this rule with the `{ "afterLineComment": true, "allowBlockEnd": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterLineComment": true, "allowBlockEnd": true }]*/
@@ -230,7 +272,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "afterBlockComment": true, "allowBlockEnd": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterBlockComment": true, "allowBlockEnd": true }]*/
@@ -266,10 +312,14 @@ class C {
 }
 ```
 
+:::
+
 ### allowClassStart
 
 Examples of **incorrect** code for this rule with the `{ "beforeLineComment": true, "allowClassStart": false }` option:
 
+::: incorrect
+
 ```js
 /*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowClassStart": false }]*/
 
@@ -278,9 +328,13 @@ class foo {
     day() {}
 };
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{ "beforeLineComment": true, "allowClassStart": false }` option:
 
+::: correct
+
 ```js
 /*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowClassStart": false }]*/
 
@@ -291,7 +345,11 @@ class foo {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "beforeLineComment": true, "allowClassStart": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowClassStart": true }]*/
@@ -302,7 +360,11 @@ class foo {
 };
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "beforeBlockComment": true, "allowClassStart": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowClassStart": false }]*/
@@ -312,9 +374,13 @@ class foo {
     day() {}
 };
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{ "beforeBlockComment": true, "allowClassStart": false }` option:
 
+::: correct
+
 ```js
 /*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowClassStart": false }]*/
 
@@ -325,7 +391,11 @@ class foo {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "beforeBlockComment": true, "allowClassStart": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowClassStart": true }]*/
@@ -336,9 +406,13 @@ class foo {
 };
 ```
 
+:::
+
 ### allowClassEnd
 
 Examples of **correct** code for this rule with the `{ "afterLineComment": true, "allowClassEnd": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterLineComment": true, "allowClassEnd": true }]*/
@@ -349,7 +423,11 @@ class foo {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "afterBlockComment": true, "allowClassEnd": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterBlockComment": true, "allowClassEnd": true }]*/
@@ -361,9 +439,13 @@ class foo {
 };
 ```
 
+:::
+
 ### allowObjectStart
 
 Examples of **correct** code for this rule with the `{ "beforeLineComment": true, "allowObjectStart": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowObjectStart": true }]*/
@@ -384,7 +466,11 @@ const {
 } = {day: "great"};
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "beforeBlockComment": true, "allowObjectStart": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowObjectStart": true }]*/
@@ -405,9 +491,13 @@ const {
 } = {day: "great"};
 ```
 
+:::
+
 ### allowObjectEnd
 
 Examples of **correct** code for this rule with the `{ "afterLineComment": true, "allowObjectEnd": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterLineComment": true, "allowObjectEnd": true }]*/
@@ -428,7 +518,11 @@ const {
 } = {day: "great"};
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "afterBlockComment": true, "allowObjectEnd": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterBlockComment": true, "allowObjectEnd": true }]*/
@@ -452,9 +546,13 @@ const {
 } = {day: "great"};
 ```
 
+:::
+
 ### allowArrayStart
 
 Examples of **correct** code for this rule with the `{ "beforeLineComment": true, "allowArrayStart": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowArrayStart": true }]*/
@@ -471,7 +569,11 @@ const [
 ] = ["great", "not great"];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "beforeBlockComment": true, "allowArrayStart": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowArrayStart": true }]*/
@@ -488,9 +590,13 @@ const [
 ] = ["great", "not great"];
 ```
 
+:::
+
 ### allowArrayEnd
 
 Examples of **correct** code for this rule with the `{ "afterLineComment": true, "allowArrayEnd": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterLineComment": true, "allowArrayEnd": true }]*/
@@ -507,7 +613,11 @@ const [
 ] = ["great", "not great"];
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "afterBlockComment": true, "allowArrayEnd": true }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterBlockComment": true, "allowArrayEnd": true }]*/
@@ -526,11 +636,15 @@ const [
 ] = ["great", "not great"];
 ```
 
+:::
+
 ### ignorePattern
 
 By default this rule ignores comments starting with the following words: `eslint`, `jshint`, `jslint`, `istanbul`, `global`, `exported`, `jscs`. To ignore more comments in addition to the defaults, set the `ignorePattern` option to a string pattern that will be passed to the [`RegExp` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp).
 
 Examples of **correct** code for the `ignorePattern` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error"]*/
@@ -545,7 +659,11 @@ foo();
 /* a valid comment using pragma in it */
 ```
 
+:::
+
 Examples of **incorrect** code for the `ignorePattern` option:
+
+::: incorrect
 
 ```js
 /*eslint lines-around-comment: ["error", { "ignorePattern": "pragma" }] */
@@ -554,11 +672,15 @@ Examples of **incorrect** code for the `ignorePattern` option:
 /* something else */
 ```
 
+:::
+
 ### applyDefaultIgnorePatterns
 
 Default ignore patterns are applied even when `ignorePattern` is provided. If you want to omit default patterns, set this option to `false`.
 
 Examples of **correct** code for the `{ "applyDefaultIgnorePatterns": false }` option:
+
+::: correct
 
 ```js
 /*eslint lines-around-comment: ["error", { "ignorePattern": "pragma", applyDefaultIgnorePatterns: false }] */
@@ -567,7 +689,11 @@ foo();
 /* a valid comment using pragma in it */
 ```
 
+:::
+
 Examples of **incorrect** code for the `{ "applyDefaultIgnorePatterns": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint lines-around-comment: ["error", { "applyDefaultIgnorePatterns": false }] */
@@ -576,6 +702,8 @@ foo();
 /* eslint mentioned in comment */
 
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/lines-around-directive.md
+++ b/docs/src/rules/lines-around-directive.md
@@ -64,6 +64,8 @@ This is the default option.
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /* eslint lines-around-directive: ["error", "always"] */
 
@@ -89,9 +91,13 @@ function foo() {
   var bar;
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"always"` option:
 
+::: correct
+
 ```js
 /* eslint lines-around-directive: ["error", "always"] */
 
@@ -123,11 +129,15 @@ function foo() {
   var bar;
 }
 ```
+
+:::
 
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
+::: incorrect
+
 ```js
 /* eslint lines-around-directive: ["error", "never"] */
 
@@ -160,9 +170,13 @@ function foo() {
   var bar;
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"never"` option:
 
+::: correct
+
 ```js
 /* eslint lines-around-directive: ["error", "never"] */
 
@@ -188,11 +202,15 @@ function foo() {
   var bar;
 }
 ```
+
+:::
 
 ### before & after
 
 Examples of **incorrect** code for this rule with the `{ "before": "never", "after": "always" }` option:
 
+::: incorrect
+
 ```js
 /* eslint lines-around-directive: ["error", { "before": "never", "after": "always" }] */
 
@@ -221,9 +239,13 @@ function foo() {
   var bar;
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{ "before": "never", "after": "always" }`  option:
 
+::: correct
+
 ```js
 /* eslint lines-around-directive: ["error", { "before": "never", "after": "always" }] */
 
@@ -254,7 +276,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "before": "always", "after": "never" }` option:
+
+::: incorrect
 
 ```js
 /* eslint lines-around-directive: ["error", { "before": "always", "after": "never" }] */
@@ -285,9 +311,13 @@ function foo() {
   var bar;
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{ "before": "always", "after": "never" }` option:
 
+::: correct
+
 ```js
 /* eslint lines-around-directive: ["error", { "before": "always", "after": "never" }] */
 
@@ -315,6 +345,8 @@ function foo() {
   var bar;
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/lines-between-class-members.md
+++ b/docs/src/rules/lines-between-class-members.md
@@ -18,6 +18,8 @@ This rule improves readability by enforcing lines between class members. It will
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /* eslint lines-between-class-members: ["error", "always"]*/
 class MyClass {
@@ -30,9 +32,13 @@ class MyClass {
   }
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /* eslint lines-between-class-members: ["error", "always"]*/
 class MyClass {
@@ -48,7 +54,11 @@ class MyClass {
 }
 ```
 
+:::
+
 Examples of additional **correct** code for this rule:
+
+::: correct
 
 ```js
 /* eslint lines-between-class-members: ["error", "always"]*/
@@ -58,6 +68,8 @@ class MyClass {
   ;in = 2
 }
 ```
+
+:::
 
 ### Options
 
@@ -75,6 +87,8 @@ Object option:
 
 Examples of **incorrect** code for this rule with the string option:
 
+::: incorrect
+
 ```js
 /* eslint lines-between-class-members: ["error", "always"]*/
 class Foo{
@@ -92,9 +106,13 @@ class Foo{
   baz(){}
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the string option:
 
+::: correct
+
 ```js
 /* eslint lines-between-class-members: ["error", "always"]*/
 class Foo{
@@ -113,7 +131,11 @@ class Foo{
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the object option:
+
+::: correct
 
 ```js
 /* eslint lines-between-class-members: ["error", "always", { "exceptAfterSingleLine": true }]*/
@@ -127,6 +149,8 @@ class Foo{
   qux(){}
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/max-classes-per-file.md
+++ b/docs/src/rules/max-classes-per-file.md
@@ -18,6 +18,8 @@ of classes and no more.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint max-classes-per-file: "error"*/
 
@@ -25,13 +27,19 @@ class Foo {}
 class Bar {}
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint max-classes-per-file: "error"*/
 
 class Foo {}
 ```
+
+:::
 
 ## Options
 
@@ -61,6 +69,8 @@ For example:
 
 Examples of **correct** code for this rule with the `max` option set to `2`:
 
+::: correct
+
 ```js
 /* eslint max-classes-per-file: ["error", 2] */
 
@@ -68,7 +78,11 @@ class Foo {}
 class Bar {}
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `ignoreExpressions` option set to `true`:
+
+::: correct
 
 ```js
 /* eslint max-classes-per-file: ["error", { ignoreExpressions: true }] */
@@ -83,3 +97,5 @@ class VisitorFactory {
     }
 }
 ```
+
+:::

--- a/docs/src/rules/max-depth.md
+++ b/docs/src/rules/max-depth.md
@@ -33,6 +33,8 @@ This rule has a number or object option:
 
 Examples of **incorrect** code for this rule with the default `{ "max": 4 }` option:
 
+::: incorrect
+
 ```js
 /*eslint max-depth: ["error", 4]*/
 
@@ -50,7 +52,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "max": 4 }` option:
+
+::: correct
 
 ```js
 /*eslint max-depth: ["error", 4]*/
@@ -67,9 +73,13 @@ function foo() {
 }
 ```
 
+:::
+
 Note that class static blocks do not count as nested blocks, and that the depth in them is calculated separately from the enclosing context.
 
 Examples of **incorrect** code for this rule with `{ "max": 2 }` option:
+
+::: incorrect
 
 ```js
 /*eslint max-depth: ["error", 2]*/
@@ -90,7 +100,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with `{ "max": 2 }` option:
+
+::: correct
 
 ```js
 /*eslint max-depth: ["error", 2]*/
@@ -108,3 +122,5 @@ function foo() {
     }
 }
 ```
+
+:::

--- a/docs/src/rules/max-len.md
+++ b/docs/src/rules/max-len.md
@@ -42,13 +42,19 @@ This rule has a number or object option:
 
 Examples of **incorrect** code for this rule with the default `{ "code": 80 }` option:
 
+::: incorrect
+
 ```js
 /*eslint max-len: ["error", { "code": 80 }]*/
 
 var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficult": "to read" };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "code": 80 }` option:
+
+::: correct
 
 ```js
 /*eslint max-len: ["error", { "code": 80 }]*/
@@ -60,9 +66,13 @@ var foo = {
 };
 ```
 
+:::
+
 ### tabWidth
 
 Examples of **incorrect** code for this rule with the default `{ "tabWidth": 4 }` option:
+
+::: incorrect
 
 ```js
 /*eslint max-len: ["error", { "code": 80, "tabWidth": 4 }]*/
@@ -70,7 +80,11 @@ Examples of **incorrect** code for this rule with the default `{ "tabWidth": 4 }
 \t  \t  var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" } };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "tabWidth": 4 }` option:
+
+::: correct
 
 ```js
 /*eslint max-len: ["error", { "code": 80, "tabWidth": 4 }]*/
@@ -81,9 +95,13 @@ Examples of **correct** code for this rule with the default `{ "tabWidth": 4 }` 
 \t  \t  };
 ```
 
+:::
+
 ### comments
 
 Examples of **incorrect** code for this rule with the `{ "comments": 65 }` option:
+
+::: incorrect
 
 ```js
 /*eslint max-len: ["error", { "comments": 65 }]*/
@@ -93,9 +111,13 @@ Examples of **incorrect** code for this rule with the `{ "comments": 65 }` optio
 **/
 ```
 
+:::
+
 ### ignoreComments
 
 Examples of **correct** code for this rule with the `{ "ignoreComments": true }` option:
+
+::: correct
 
 ```js
 /*eslint max-len: ["error", { "ignoreComments": true }]*/
@@ -105,9 +127,13 @@ Examples of **correct** code for this rule with the `{ "ignoreComments": true }`
 **/
 ```
 
+:::
+
 ### ignoreTrailingComments
 
 Examples of **correct** code for this rule with the `{ "ignoreTrailingComments": true }` option:
+
+::: correct
 
 ```js
 /*eslint max-len: ["error", { "ignoreTrailingComments": true }]*/
@@ -115,9 +141,13 @@ Examples of **correct** code for this rule with the `{ "ignoreTrailingComments":
 var foo = 'bar'; // This is a really really really really really really really long comment
 ```
 
+:::
+
 ### ignoreUrls
 
 Examples of **correct** code for this rule with the `{ "ignoreUrls": true }` option:
+
+::: correct
 
 ```js
 /*eslint max-len: ["error", { "ignoreUrls": true }]*/
@@ -125,9 +155,13 @@ Examples of **correct** code for this rule with the `{ "ignoreUrls": true }` opt
 var url = 'https://www.example.com/really/really/really/really/really/really/really/long';
 ```
 
+:::
+
 ### ignoreStrings
 
 Examples of **correct** code for this rule with the `{ "ignoreStrings": true }` option:
+
+::: correct
 
 ```js
 /*eslint max-len: ["error", { "ignoreStrings": true }]*/
@@ -135,9 +169,13 @@ Examples of **correct** code for this rule with the `{ "ignoreStrings": true }` 
 var longString = 'this is a really really really really really long string!';
 ```
 
+:::
+
 ### ignoreTemplateLiterals
 
 Examples of **correct** code for this rule with the `{ "ignoreTemplateLiterals": true }` option:
+
+::: correct
 
 ```js
 /*eslint max-len: ["error", { "ignoreTemplateLiterals": true }]*/
@@ -145,9 +183,13 @@ Examples of **correct** code for this rule with the `{ "ignoreTemplateLiterals":
 var longTemplateLiteral = `this is a really really really really really long template literal!`;
 ```
 
+:::
+
 ### ignoreRegExpLiterals
 
 Examples of **correct** code for this rule with the `{ "ignoreRegExpLiterals": true }` option:
+
+::: correct
 
 ```js
 /*eslint max-len: ["error", { "ignoreRegExpLiterals": true }]*/
@@ -155,12 +197,18 @@ Examples of **correct** code for this rule with the `{ "ignoreRegExpLiterals": t
 var longRegExpLiteral = /this is a really really really really really long regular expression!/;
 ```
 
+:::
+
 ### ignorePattern
 
 Examples of **correct** code for this rule with the `ignorePattern` option:
+
+::: correct
 
 ```js
 /*eslint max-len: ["error", { "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\(" }]*/
 
 var dep = require('really/really/really/really/really/really/really/really/long/module');
 ```
+
+:::

--- a/docs/src/rules/max-lines-per-function.md
+++ b/docs/src/rules/max-lines-per-function.md
@@ -77,12 +77,16 @@ is equivalent to
 
 Examples of **incorrect** code for this rule with a max value of `2`:
 
+::: incorrect
+
 ```js
 /*eslint max-lines-per-function: ["error", 2]*/
 function foo() {
     var x = 0;
 }
 ```
+
+:::
 
 ```js
 /*eslint max-lines-per-function: ["error", 2]*/
@@ -103,12 +107,16 @@ function foo() {
 
 Examples of **correct** code for this rule with a max value of `3`:
 
+::: correct
+
 ```js
 /*eslint max-lines-per-function: ["error", 3]*/
 function foo() {
     var x = 0;
 }
 ```
+
+:::
 
 ```js
 /*eslint max-lines-per-function: ["error", 3]*/
@@ -131,6 +139,8 @@ function foo() {
 
 Examples of **incorrect** code for this rule with the `{ "skipBlankLines": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint max-lines-per-function: ["error", {"max": 2, "skipBlankLines": true}]*/
 function foo() {
@@ -139,7 +149,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "skipBlankLines": true }` option:
+
+::: correct
 
 ```js
 /*eslint max-lines-per-function: ["error", {"max": 3, "skipBlankLines": true}]*/
@@ -149,9 +163,13 @@ function foo() {
 }
 ```
 
+:::
+
 ### skipComments
 
 Examples of **incorrect** code for this rule with the `{ "skipComments": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint max-lines-per-function: ["error", {"max": 2, "skipComments": true}]*/
@@ -161,7 +179,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "skipComments": true }` option:
+
+::: correct
 
 ```js
 /*eslint max-lines-per-function: ["error", {"max": 3, "skipComments": true}]*/
@@ -171,9 +193,13 @@ function foo() {
 }
 ```
 
+:::
+
 ### IIFEs
 
 Examples of **incorrect** code for this rule with the `{ "IIFEs": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint max-lines-per-function: ["error", {"max": 2, "IIFEs": true}]*/
@@ -186,7 +212,11 @@ Examples of **incorrect** code for this rule with the `{ "IIFEs": true }` option
 })();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "IIFEs": true }` option:
+
+::: correct
 
 ```js
 /*eslint max-lines-per-function: ["error", {"max": 3, "IIFEs": true}]*/
@@ -198,6 +228,8 @@ Examples of **correct** code for this rule with the `{ "IIFEs": true }` option:
     var x = 0;
 })();
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/max-lines.md
+++ b/docs/src/rules/max-lines.md
@@ -38,12 +38,16 @@ This rule has a number or object option:
 
 Examples of **incorrect** code for this rule with a max value of `2`:
 
+::: incorrect
+
 ```js
 /*eslint max-lines: ["error", 2]*/
 var a,
     b,
     c;
 ```
+
+:::
 
 ```js
 /*eslint max-lines: ["error", 2]*/
@@ -61,11 +65,15 @@ var a,
 
 Examples of **correct** code for this rule with a max value of `2`:
 
+::: correct
+
 ```js
 /*eslint max-lines: ["error", 2]*/
 var a,
     b, c;
 ```
+
+:::
 
 ```js
 /*eslint max-lines: ["error", 2]*/
@@ -83,6 +91,8 @@ var a, b, c;
 
 Examples of **incorrect** code for this rule with the `{ "skipBlankLines": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint max-lines: ["error", {"max": 2, "skipBlankLines": true}]*/
 
@@ -91,7 +101,11 @@ var a,
     c;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "skipBlankLines": true }` option:
+
+::: correct
 
 ```js
 /*eslint max-lines: ["error", {"max": 2, "skipBlankLines": true}]*/
@@ -99,11 +113,15 @@ Examples of **correct** code for this rule with the `{ "skipBlankLines": true }`
 var a,
     b, c;
 ```
+
+:::
 
 ### skipComments
 
 Examples of **incorrect** code for this rule with the `{ "skipComments": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint max-lines: ["error", {"max": 2, "skipComments": true}]*/
 // a comment
@@ -112,7 +130,11 @@ var a,
     c;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "skipComments": true }` option:
+
+::: correct
 
 ```js
 /*eslint max-lines: ["error", {"max": 2, "skipComments": true}]*/
@@ -120,6 +142,8 @@ Examples of **correct** code for this rule with the `{ "skipComments": true }` o
 var a,
     b, c;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/max-nested-callbacks.md
+++ b/docs/src/rules/max-nested-callbacks.md
@@ -49,6 +49,8 @@ This rule has a number or object option:
 
 Examples of **incorrect** code for this rule with the `{ "max": 3 }` option:
 
+::: incorrect
+
 ```js
 /*eslint max-nested-callbacks: ["error", 3]*/
 
@@ -63,7 +65,11 @@ foo1(function() {
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "max": 3 }` option:
+
+::: correct
 
 ```js
 /*eslint max-nested-callbacks: ["error", 3]*/
@@ -86,3 +92,5 @@ function handleFoo4() {
     foo5();
 }
 ```
+
+:::

--- a/docs/src/rules/max-params.md
+++ b/docs/src/rules/max-params.md
@@ -39,6 +39,8 @@ This rule has a number or object option:
 
 Examples of **incorrect** code for this rule with the default `{ "max": 3 }` option:
 
+::: incorrect
+
 ```js
 /*eslint max-params: ["error", 3]*/
 /*eslint-env es6*/
@@ -52,7 +54,11 @@ let foo = (bar, baz, qux, qxx) => {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "max": 3 }` option:
+
+::: correct
 
 ```js
 /*eslint max-params: ["error", 3]*/
@@ -66,3 +72,5 @@ let foo = (bar, baz, qux) => {
     doSomething();
 };
 ```
+
+:::

--- a/docs/src/rules/max-statements-per-line.md
+++ b/docs/src/rules/max-statements-per-line.md
@@ -33,6 +33,8 @@ The "max" object property is optional (default: 1).
 
 Examples of **incorrect** code for this rule with the default `{ "max": 1 }` option:
 
+::: incorrect
+
 ```js
 /*eslint max-statements-per-line: ["error", { "max": 1 }]*/
 
@@ -45,7 +47,11 @@ var foo = function foo() { bar = 1; };
 (function foo() { bar = 1; })();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "max": 1 }` option:
+
+::: correct
 
 ```js
 /*eslint max-statements-per-line: ["error", { "max": 1 }]*/
@@ -59,7 +65,11 @@ var foo = function foo() { };
 (function foo() { })();
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "max": 2 }` option:
+
+::: incorrect
 
 ```js
 /*eslint max-statements-per-line: ["error", { "max": 2 }]*/
@@ -73,7 +83,11 @@ var foo = function foo() { bar = 1; };
 (function foo() { bar = 1; baz = 2; })();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "max": 2 }` option:
+
+::: correct
 
 ```js
 /*eslint max-statements-per-line: ["error", { "max": 2 }]*/
@@ -86,6 +100,8 @@ function foo() { bar = 1; }
 var foo = function foo() { bar = 1; };
 (function foo() { var bar = 1; })();
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/max-statements.md
+++ b/docs/src/rules/max-statements.md
@@ -45,6 +45,8 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule with the default `{ "max": 10 }` option:
 
+::: incorrect
+
 ```js
 /*eslint max-statements: ["error", 10]*/
 /*eslint-env es6*/
@@ -80,7 +82,11 @@ let foo = () => {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "max": 10 }` option:
+
+::: correct
 
 ```js
 /*eslint max-statements: ["error", 10]*/
@@ -127,9 +133,13 @@ let foo = () => {
 }
 ```
 
+:::
+
 Note that this rule does not apply to class static blocks, and that statements in class static blocks do not count as statements in the enclosing function.
 
 Examples of **correct** code for this rule with `{ "max": 2 }` option:
+
+::: correct
 
 ```js
 /*eslint max-statements: ["error", 2]*/
@@ -151,9 +161,13 @@ function foo() {
 }
 ```
 
+:::
+
 ### ignoreTopLevelFunctions
 
 Examples of additional **correct** code for this rule with the `{ "max": 10 }, { "ignoreTopLevelFunctions": true }` options:
+
+::: correct
 
 ```js
 /*eslint max-statements: ["error", 10, { "ignoreTopLevelFunctions": true }]*/
@@ -172,3 +186,5 @@ function foo() {
   var foo11 = 11;
 }
 ```
+
+:::

--- a/docs/src/rules/multiline-comment-style.md
+++ b/docs/src/rules/multiline-comment-style.md
@@ -27,6 +27,8 @@ The rule always ignores directive comments such as `/* eslint-disable */`. Addit
 
 Examples of **incorrect** code for this rule with the default `"starred-block"` option:
 
+::: incorrect
+
 ```js
 
 /* eslint multiline-comment-style: ["error", "starred-block"] */
@@ -57,7 +59,11 @@ foo();
 
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"starred-block"` option:
+
+::: correct
 
 ```js
 /* eslint multiline-comment-style: ["error", "starred-block"] */
@@ -71,7 +77,11 @@ foo();
 // single-line comment
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"bare-block"` option:
+
+::: incorrect
 
 ```js
 /* eslint multiline-comment-style: ["error", "bare-block"] */
@@ -87,7 +97,11 @@ foo();
 foo();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"bare-block"` option:
+
+::: correct
 
 ```js
 /* eslint multiline-comment-style: ["error", "bare-block"] */
@@ -97,7 +111,11 @@ Examples of **correct** code for this rule with the `"bare-block"` option:
 foo();
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"separate-lines"` option:
+
+::: incorrect
 
 ```js
 
@@ -115,7 +133,11 @@ foo();
 
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"separate-lines"` option:
+
+::: correct
 
 ```js
 /* eslint multiline-comment-style: ["error", "separate-lines"] */
@@ -125,6 +147,8 @@ Examples of **correct** code for this rule with the `"separate-lines"` option:
 foo();
 
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/multiline-ternary.md
+++ b/docs/src/rules/multiline-ternary.md
@@ -46,6 +46,8 @@ This is the default option.
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint multiline-ternary: ["error", "always"]*/
 
@@ -58,7 +60,11 @@ foo > bar ?
     value : value2;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint multiline-ternary: ["error", "always"]*/
@@ -74,9 +80,13 @@ foo > bar ?
     value3;
 ```
 
+:::
+
 ### always-multiline
 
 Examples of **incorrect** code for this rule with the `"always-multiline"` option:
+
+::: incorrect
 
 ```js
 /*eslint multiline-ternary: ["error", "always-multiline"]*/
@@ -91,7 +101,11 @@ foo > bar &&
     bar > baz ? value1 : value2;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always-multiline"` option:
+
+::: correct
 
 ```js
 /*eslint multiline-ternary: ["error", "always-multiline"]*/
@@ -118,9 +132,13 @@ foo > bar &&
         value2;
 ```
 
+:::
+
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint multiline-ternary: ["error", "never"]*/
@@ -137,7 +155,11 @@ foo >
     value2;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint multiline-ternary: ["error", "never"]*/
@@ -150,6 +172,8 @@ foo > bar ? (
     baz > qux ? value1 : value2
 ) : value3;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/new-cap.md
+++ b/docs/src/rules/new-cap.md
@@ -30,6 +30,8 @@ This rule requires constructor names to begin with a capital letter. Certain bui
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint new-cap: "error"*/
 
@@ -37,6 +39,8 @@ function foo(arg) {
     return Boolean(arg);
 }
 ```
+
+:::
 
 ## Options
 
@@ -57,13 +61,19 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule with the default `{ "newIsCap": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint new-cap: ["error", { "newIsCap": true }]*/
 
 var friend = new person();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "newIsCap": true }` option:
+
+::: correct
 
 ```js
 /*eslint new-cap: ["error", { "newIsCap": true }]*/
@@ -71,7 +81,11 @@ Examples of **correct** code for this rule with the default `{ "newIsCap": true 
 var friend = new Person();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "newIsCap": false }` option:
+
+::: correct
 
 ```js
 /*eslint new-cap: ["error", { "newIsCap": false }]*/
@@ -79,9 +93,13 @@ Examples of **correct** code for this rule with the `{ "newIsCap": false }` opti
 var friend = new person();
 ```
 
+:::
+
 ### capIsNew
 
 Examples of **incorrect** code for this rule with the default `{ "capIsNew": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint new-cap: ["error", { "capIsNew": true }]*/
@@ -89,7 +107,11 @@ Examples of **incorrect** code for this rule with the default `{ "capIsNew": tru
 var colleague = Person();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "capIsNew": true }` option:
+
+::: correct
 
 ```js
 /*eslint new-cap: ["error", { "capIsNew": true }]*/
@@ -97,7 +119,11 @@ Examples of **correct** code for this rule with the default `{ "capIsNew": true 
 var colleague = new Person();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "capIsNew": false }` option:
+
+::: correct
 
 ```js
 /*eslint new-cap: ["error", { "capIsNew": false }]*/
@@ -105,9 +131,13 @@ Examples of **correct** code for this rule with the `{ "capIsNew": false }` opti
 var colleague = Person();
 ```
 
+:::
+
 ### newIsCapExceptions
 
 Examples of additional **correct** code for this rule with the `{ "newIsCapExceptions": ["events"] }` option:
+
+::: correct
 
 ```js
 /*eslint new-cap: ["error", { "newIsCapExceptions": ["events"] }]*/
@@ -117,9 +147,13 @@ var events = require('events');
 var emitter = new events();
 ```
 
+:::
+
 ### newIsCapExceptionPattern
 
 Examples of additional **correct** code for this rule with the `{ "newIsCapExceptionPattern": "^person\\.." }` option:
+
+::: correct
 
 ```js
 /*eslint new-cap: ["error", { "newIsCapExceptionPattern": "^person\\.." }]*/
@@ -129,7 +163,11 @@ var friend = new person.acquaintance();
 var bestFriend = new person.friend();
 ```
 
+:::
+
 Examples of additional **correct** code for this rule with the `{ "newIsCapExceptionPattern": "\\.bar$" }` option:
+
+::: correct
 
 ```js
 /*eslint new-cap: ["error", { "newIsCapExceptionPattern": "\\.bar$" }]*/
@@ -137,9 +175,13 @@ Examples of additional **correct** code for this rule with the `{ "newIsCapExcep
 var friend = new person.bar();
 ```
 
+:::
+
 ### capIsNewExceptions
 
 Examples of additional **correct** code for this rule with the `{ "capIsNewExceptions": ["Person"] }` option:
+
+::: correct
 
 ```js
 /*eslint new-cap: ["error", { "capIsNewExceptions": ["Person"] }]*/
@@ -149,9 +191,13 @@ function foo(arg) {
 }
 ```
 
+:::
+
 ### capIsNewExceptionPattern
 
 Examples of additional **correct** code for this rule with the `{ "capIsNewExceptionPattern": "^person\\.." }` option:
+
+::: correct
 
 ```js
 /*eslint new-cap: ["error", { "capIsNewExceptionPattern": "^person\\.." }]*/
@@ -160,7 +206,11 @@ var friend = person.Acquaintance();
 var bestFriend = person.Friend();
 ```
 
+:::
+
 Examples of additional **correct** code for this rule with the `{ "capIsNewExceptionPattern": "\\.Bar$" }` option:
+
+::: correct
 
 ```js
 /*eslint new-cap: ["error", { "capIsNewExceptionPattern": "\\.Bar$" }]*/
@@ -168,7 +218,11 @@ Examples of additional **correct** code for this rule with the `{ "capIsNewExcep
 foo.Bar();
 ```
 
+:::
+
 Examples of additional **correct** code for this rule with the `{ "capIsNewExceptionPattern": "^Foo" }` option:
+
+::: correct
 
 ```js
 /*eslint new-cap: ["error", { "capIsNewExceptionPattern": "^Foo" }]*/
@@ -180,9 +234,13 @@ var y = Foobar(42);
 var z = Foo.Bar(42);
 ```
 
+:::
+
 ### properties
 
 Examples of **incorrect** code for this rule with the default `{ "properties": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint new-cap: ["error", { "properties": true }]*/
@@ -190,7 +248,11 @@ Examples of **incorrect** code for this rule with the default `{ "properties": t
 var friend = new person.acquaintance();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "properties": true }` option:
+
+::: correct
 
 ```js
 /*eslint new-cap: ["error", { "properties": true }]*/
@@ -198,13 +260,19 @@ Examples of **correct** code for this rule with the default `{ "properties": tru
 var friend = new person.Acquaintance();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "properties": false }` option:
+
+::: correct
 
 ```js
 /*eslint new-cap: ["error", { "properties": false }]*/
 
 var friend = new person.acquaintance();
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/new-parens.md
+++ b/docs/src/rules/new-parens.md
@@ -30,6 +30,8 @@ This rule takes one option.
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint new-parens: "error"*/
 
@@ -37,7 +39,11 @@ var person = new Person;
 var person = new (Person);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint new-parens: "error"*/
@@ -46,9 +52,13 @@ var person = new Person();
 var person = new (Person)();
 ```
 
+:::
+
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint new-parens: ["error", "never"]*/
@@ -57,7 +67,11 @@ var person = new Person();
 var person = new (Person)();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint new-parens: ["error", "never"]*/
@@ -66,3 +80,5 @@ var person = new Person;
 var person = (new Person);
 var person = new Person("Name");
 ```
+
+:::

--- a/docs/src/rules/newline-after-var.md
+++ b/docs/src/rules/newline-after-var.md
@@ -46,6 +46,8 @@ This rule has a string option:
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint newline-after-var: ["error", "always"]*/
 /*eslint-env es6*/
@@ -67,9 +69,13 @@ var name = "world";
 // var name = require("world");
 console.log(greet, name);
 ```
+
+:::
 
 Examples of **correct** code for this rule with the default `"always"` option:
 
+::: correct
+
 ```js
 /*eslint newline-after-var: ["error", "always"]*/
 /*eslint-env es6*/
@@ -95,11 +101,15 @@ var name = "world";
 
 console.log(greet, name);
 ```
+
+:::
 
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint newline-after-var: ["error", "never"]*/
 /*eslint-env es6*/
@@ -125,9 +135,13 @@ var name = "world";
 
 console.log(greet, name);
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"never"` option:
 
+::: correct
+
 ```js
 /*eslint newline-after-var: ["error", "never"]*/
 /*eslint-env es6*/
@@ -149,3 +163,5 @@ var name = "world";
 // var name = require("world");
 console.log(greet, name);
 ```
+
+:::

--- a/docs/src/rules/newline-before-return.md
+++ b/docs/src/rules/newline-before-return.md
@@ -48,6 +48,8 @@ This rule requires an empty line before `return` statements to increase code cla
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint newline-before-return: "error"*/
 
@@ -68,7 +70,11 @@ function foo(bar) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint newline-before-return: "error"*/
@@ -117,6 +123,8 @@ function foo() {
     return;
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/newline-per-chained-call.md
+++ b/docs/src/rules/newline-per-chained-call.md
@@ -71,6 +71,8 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule with the default `{ "ignoreChainWithDepth": 2 }` option:
 
+::: incorrect
+
 ```js
 /*eslint newline-per-chained-call: ["error", { "ignoreChainWithDepth": 2 }]*/
 
@@ -88,7 +90,11 @@ _
 obj.method().method2().method3();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "ignoreChainWithDepth": 2 }` option:
+
+::: correct
 
 ```js
 /*eslint newline-per-chained-call: ["error", { "ignoreChainWithDepth": 2 }]*/
@@ -121,6 +127,8 @@ obj
   .method2()
   .method3().prop;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-alert.md
+++ b/docs/src/rules/no-alert.md
@@ -22,6 +22,8 @@ This rule is aimed at catching debugging code that should be removed and popup U
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-alert: "error"*/
 
@@ -32,7 +34,11 @@ confirm("Are you sure?");
 prompt("What's your name?", "John Doe");
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-alert: "error"*/
@@ -48,3 +54,5 @@ function foo() {
     alert();
 }
 ```
+
+:::

--- a/docs/src/rules/no-array-constructor.md
+++ b/docs/src/rules/no-array-constructor.md
@@ -22,6 +22,8 @@ This rule disallows `Array` constructors.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-array-constructor: "error"*/
 
@@ -30,7 +32,11 @@ Array(0, 1, 2)
 new Array(0, 1, 2)
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-array-constructor: "error"*/
@@ -41,6 +47,8 @@ new Array(someOtherArray.length)
 
 [0, 1, 2]
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-arrow-condition.md
+++ b/docs/src/rules/no-arrow-condition.md
@@ -39,6 +39,8 @@ var x = a <= 1 ? 2 : 3
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-arrow-condition: "error"*/
 /*eslint-env es6*/
@@ -51,3 +53,5 @@ a => 1 ? 2 : 3
 var x = a => 1 ? 2 : 3
 var x = (a) => 1 ? 2 : 3
 ```
+
+:::

--- a/docs/src/rules/no-async-promise-executor.md
+++ b/docs/src/rules/no-async-promise-executor.md
@@ -34,6 +34,8 @@ This rule aims to disallow async Promise executor functions.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 const foo = new Promise(async (resolve, reject) => {
   readFile('foo.txt', function(err, result) {
@@ -50,7 +52,11 @@ const result = new Promise(async (resolve, reject) => {
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 const foo = new Promise((resolve, reject) => {
@@ -65,6 +71,8 @@ const foo = new Promise((resolve, reject) => {
 
 const result = Promise.resolve(foo);
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-await-in-loop.md
+++ b/docs/src/rules/no-await-in-loop.md
@@ -48,6 +48,8 @@ This rule disallows the use of `await` within loop bodies.
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint no-await-in-loop: "error"*/
 
@@ -62,7 +64,11 @@ async function foo(things) {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule:
+
+::: incorrect
 
 ```js
 /*eslint no-await-in-loop: "error"*/
@@ -76,6 +82,8 @@ async function foo(things) {
   return baz(results);
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-bitwise.md
+++ b/docs/src/rules/no-bitwise.md
@@ -19,6 +19,8 @@ This rule disallows bitwise operators.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-bitwise: "error"*/
 
@@ -49,7 +51,11 @@ x >>= y;
 x >>>= y;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-bitwise: "error"*/
@@ -65,6 +71,8 @@ var x = y < z;
 x += y;
 ```
 
+:::
+
 ## Options
 
 This rule has an object option:
@@ -76,18 +84,26 @@ This rule has an object option:
 
 Examples of **correct** code for this rule with the `{ "allow": ["~"] }` option:
 
+::: correct
+
 ```js
 /*eslint no-bitwise: ["error", { "allow": ["~"] }] */
 
 ~[1,2,3].indexOf(1) === -1;
 ```
 
+:::
+
 ### int32Hint
 
 Examples of **correct** code for this rule with the `{ "int32Hint": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-bitwise: ["error", { "int32Hint": true }] */
 
 var b = a|0;
 ```
+
+:::

--- a/docs/src/rules/no-buffer-constructor.md
+++ b/docs/src/rules/no-buffer-constructor.md
@@ -21,6 +21,8 @@ This rule disallows calling and constructing the `Buffer()` constructor.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 new Buffer(5);
 new Buffer([1, 2, 3]);
@@ -32,7 +34,11 @@ new Buffer(res.body.amount);
 new Buffer(res.body.values);
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 Buffer.alloc(5);
@@ -42,6 +48,8 @@ Buffer.from([1, 2, 3]);
 Buffer.alloc(res.body.amount);
 Buffer.from(res.body.values);
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-caller.md
+++ b/docs/src/rules/no-caller.md
@@ -21,6 +21,8 @@ This rule is aimed at discouraging the use of deprecated and sub-optimal code by
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-caller: "error"*/
 
@@ -37,7 +39,11 @@ function foo(n) {
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-caller: "error"*/
@@ -54,3 +60,5 @@ function foo(n) {
     return !(n > 1) ? 1 : factorial(n - 1) * n;
 });
 ```
+
+:::

--- a/docs/src/rules/no-case-declarations.md
+++ b/docs/src/rules/no-case-declarations.md
@@ -25,6 +25,8 @@ This rule aims to prevent access to uninitialized lexical bindings as well as ac
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-case-declarations: "error"*/
 /*eslint-env es6*/
@@ -44,7 +46,11 @@ switch (foo) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-case-declarations: "error"*/
@@ -76,6 +82,8 @@ switch (foo) {
     }
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-catch-shadow.md
+++ b/docs/src/rules/no-catch-shadow.md
@@ -29,6 +29,8 @@ This rule is aimed at preventing unexpected behavior in your program that may ar
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-catch-shadow: "error"*/
 
@@ -50,9 +52,13 @@ try {
 
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint no-catch-shadow: "error"*/
 
@@ -74,6 +80,8 @@ try {
 
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-class-assign.md
+++ b/docs/src/rules/no-class-assign.md
@@ -26,6 +26,8 @@ This rule is aimed to flag modifying variables of class declarations.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-class-assign: "error"*/
 /*eslint-env es6*/
@@ -33,6 +35,8 @@ Examples of **incorrect** code for this rule:
 class A { }
 A = 0;
 ```
+
+:::
 
 ```js
 /*eslint no-class-assign: "error"*/
@@ -67,6 +71,8 @@ let A = class A {
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint no-class-assign: "error"*/
 /*eslint-env es6*/
@@ -74,6 +80,8 @@ Examples of **correct** code for this rule:
 let A = class A { }
 A = 0; // A is a variable.
 ```
+
+:::
 
 ```js
 /*eslint no-class-assign: "error"*/

--- a/docs/src/rules/no-comma-dangle.md
+++ b/docs/src/rules/no-comma-dangle.md
@@ -24,6 +24,8 @@ This rule is aimed at detecting trailing commas in object literals. As such, it 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 var foo = {
     bar: "baz",
@@ -38,7 +40,11 @@ foo({
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 var foo = {
@@ -53,6 +59,8 @@ foo({
   qux: "quux"
 });
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-compare-neg-zero.md
+++ b/docs/src/rules/no-compare-neg-zero.md
@@ -15,6 +15,8 @@ The rule should warn against code that tries to compare against `-0`, since that
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /* eslint no-compare-neg-zero: "error" */
 
@@ -23,7 +25,11 @@ if (x === -0) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /* eslint no-compare-neg-zero: "error" */
@@ -32,6 +38,8 @@ if (x === 0) {
     // doSomething()...
 }
 ```
+
+:::
 
 ```js
 /* eslint no-compare-neg-zero: "error" */

--- a/docs/src/rules/no-cond-assign.md
+++ b/docs/src/rules/no-cond-assign.md
@@ -37,6 +37,8 @@ This rule has a string option:
 
 Examples of **incorrect** code for this rule with the default `"except-parens"` option:
 
+::: incorrect
+
 ```js
 /*eslint no-cond-assign: "error"*/
 
@@ -55,7 +57,11 @@ function setHeight(someNode) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"except-parens"` option:
+
+::: correct
 
 ```js
 /*eslint no-cond-assign: "error"*/
@@ -82,11 +88,15 @@ function setHeight(someNode) {
     } while ((someNode = someNode.parentNode) !== null);
 }
 ```
+
+:::
 
 ### always
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint no-cond-assign: ["error", "always"]*/
 
@@ -121,7 +131,11 @@ function setHeight(someNode) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint no-cond-assign: ["error", "always"]*/
@@ -132,3 +146,5 @@ if (x === 0) {
     var b = 1;
 }
 ```
+
+:::

--- a/docs/src/rules/no-confusing-arrow.md
+++ b/docs/src/rules/no-confusing-arrow.md
@@ -31,6 +31,8 @@ var x = a <= 1 ? 2 : 3;
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-confusing-arrow: "error"*/
 /*eslint-env es6*/
@@ -39,7 +41,11 @@ var x = a => 1 ? 2 : 3;
 var x = (a) => 1 ? 2 : 3;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-confusing-arrow: "error"*/
@@ -51,6 +57,8 @@ var x = (a) => {
 };
 var x = a => { return 1 ? 2 : 3; };
 ```
+
+:::
 
 ## Options
 
@@ -74,6 +82,8 @@ This rule accepts two options argument with the following defaults:
 
 Examples of **incorrect** code for this rule with the `{"allowParens": false}` option:
 
+::: incorrect
+
 ```js
 /*eslint no-confusing-arrow: ["error", {"allowParens": false}]*/
 /*eslint-env es6*/
@@ -81,12 +91,16 @@ var x = a => (1 ? 2 : 3);
 var x = (a) => (1 ? 2 : 3);
 ```
 
+:::
+
 `onlyOneSimpleParam` is a boolean setting that can be `true` or `false`(default):
 
 1. `true` relaxes the rule and doesn't report errors if the arrow function has 0 or more than 1 parameters, or the parameter is not an identifier.
 2. `false` warns regardless of parameters.
 
 Examples of **correct** code for this rule with the `{"onlyOneSimpleParam": true}` option:
+
+::: correct
 
 ```js
 /*eslint no-confusing-arrow: ["error", {"onlyOneSimpleParam": true}]*/
@@ -98,3 +112,5 @@ Examples of **correct** code for this rule with the `{"onlyOneSimpleParam": true
 ([a]) => 1 ? 2 : 3;
 (...a) => 1 ? 2 : 3;
 ```
+
+:::

--- a/docs/src/rules/no-console.md
+++ b/docs/src/rules/no-console.md
@@ -23,6 +23,8 @@ This rule disallows calls or assignments to methods of the `console` object.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /* eslint no-console: "error" */
 
@@ -32,7 +34,11 @@ console.error("Log an error level message.");
 console.log = foo();
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /* eslint no-console: "error" */
@@ -40,6 +46,8 @@ Examples of **correct** code for this rule:
 // custom console
 Console.log("Hello world!");
 ```
+
+:::
 
 ## Options
 
@@ -49,12 +57,16 @@ This rule has an object option for exceptions:
 
 Examples of additional **correct** code for this rule with a sample `{ "allow": ["warn", "error"] }` option:
 
+::: correct
+
 ```js
 /* eslint no-console: ["error", { allow: ["warn", "error"] }] */
 
 console.warn("Log a warn level message.");
 console.error("Log an error level message.");
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-const-assign.md
+++ b/docs/src/rules/no-const-assign.md
@@ -20,6 +20,8 @@ This rule is aimed to flag modifying variables that are declared using `const` k
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-const-assign: "error"*/
 /*eslint-env es6*/
@@ -27,6 +29,8 @@ Examples of **incorrect** code for this rule:
 const a = 0;
 a = 1;
 ```
+
+:::
 
 ```js
 /*eslint no-const-assign: "error"*/
@@ -46,6 +50,8 @@ const a = 0;
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint no-const-assign: "error"*/
 /*eslint-env es6*/
@@ -53,6 +59,8 @@ Examples of **correct** code for this rule:
 const a = 0;
 console.log(a);
 ```
+
+:::
 
 ```js
 /*eslint no-const-assign: "error"*/

--- a/docs/src/rules/no-constant-binary-expression.md
+++ b/docs/src/rules/no-constant-binary-expression.md
@@ -38,6 +38,8 @@ It also identifies `||`, `&&` and `??` logical expressions which will either alw
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-constant-binary-expression: "error"*/
 
@@ -54,7 +56,11 @@ const objIsEmpty = someObj === {};
 const arrIsEmpty = someArr === [];
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-constant-binary-expression: "error"*/
@@ -71,3 +77,5 @@ const objIsEmpty = Object.keys(someObj).length === 0;
 
 const arrIsEmpty = someArr.length === 0;
 ```
+
+:::

--- a/docs/src/rules/no-constant-condition.md
+++ b/docs/src/rules/no-constant-condition.md
@@ -28,6 +28,8 @@ This rule disallows constant expressions in the test condition of:
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-constant-condition: "error"*/
 
@@ -78,7 +80,11 @@ do {
 var result = 0 ? a : b;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-constant-condition: "error"*/
@@ -102,6 +108,8 @@ do {
 var result = x !== 0 ? a : b;
 ```
 
+:::
+
 ## Options
 
 ### checkLoops
@@ -109,6 +117,8 @@ var result = x !== 0 ? a : b;
 Set to `true` by default. Setting this option to `false` allows constant expressions in loops.
 
 Examples of **correct** code for when `checkLoops` is `false`:
+
+::: correct
 
 ```js
 /*eslint no-constant-condition: ["error", { "checkLoops": false }]*/
@@ -134,3 +144,5 @@ do {
     }
 } while (true)
 ```
+
+:::

--- a/docs/src/rules/no-constructor-return.md
+++ b/docs/src/rules/no-constructor-return.md
@@ -15,6 +15,8 @@ This rule disallows return statements in the constructor of a class. Note that r
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-constructor-return: "error"*/
 
@@ -34,7 +36,11 @@ class B {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-constructor-return: "error"*/
@@ -55,3 +61,5 @@ class D {
     }
 }
 ```
+
+:::

--- a/docs/src/rules/no-continue.md
+++ b/docs/src/rules/no-continue.md
@@ -28,6 +28,8 @@ This rule disallows `continue` statements.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-continue: "error"*/
 
@@ -42,6 +44,8 @@ for(i = 0; i < 10; i++) {
     a += i;
 }
 ```
+
+:::
 
 ```js
 /*eslint no-continue: "error"*/
@@ -60,6 +64,8 @@ labeledLoop: for(i = 0; i < 10; i++) {
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint no-continue: "error"*/
 
@@ -72,6 +78,8 @@ for(i = 0; i < 10; i++) {
     }
 }
 ```
+
+:::
 
 ## Compatibility
 

--- a/docs/src/rules/no-control-regex.md
+++ b/docs/src/rules/no-control-regex.md
@@ -29,6 +29,8 @@ Control escapes such as `\t` and `\n` are allowed by this rule.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-control-regex: "error"*/
 
@@ -41,7 +43,11 @@ var pattern6 = new RegExp("\x0C"); // raw U+000C character in the pattern
 var pattern7 = new RegExp("\\x0C"); // \x0C pattern
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-control-regex: "error"*/
@@ -55,6 +61,8 @@ var pattern6 = new RegExp("\x20");
 var pattern7 = new RegExp("\\t");
 var pattern8 = new RegExp("\\n");
 ```
+
+:::
 
 ## Known Limitations
 

--- a/docs/src/rules/no-debugger.md
+++ b/docs/src/rules/no-debugger.md
@@ -22,6 +22,8 @@ This rule disallows `debugger` statements.
 
 Example of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-debugger: "error"*/
 
@@ -31,7 +33,11 @@ function isTruthy(x) {
 }
 ```
 
+:::
+
 Example of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-debugger: "error"*/
@@ -40,6 +46,8 @@ function isTruthy(x) {
     return Boolean(x); // set a breakpoint at this line
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-delete-var.md
+++ b/docs/src/rules/no-delete-var.md
@@ -19,9 +19,13 @@ If ESLint parses code in strict mode, the parser (instead of this rule) reports 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-delete-var: "error"*/
 
 var x;
 delete x;
 ```
+
+:::

--- a/docs/src/rules/no-div-regex.md
+++ b/docs/src/rules/no-div-regex.md
@@ -24,16 +24,24 @@ This is used to disambiguate the division operator to not confuse users.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-div-regex: "error"*/
 
 function bar() { return /=foo/; }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-div-regex: "error"*/
 
 function bar() { return /[=]foo/; }
 ```
+
+:::

--- a/docs/src/rules/no-dupe-args.md
+++ b/docs/src/rules/no-dupe-args.md
@@ -19,6 +19,8 @@ If ESLint parses code in strict mode, the parser (instead of this rule) reports 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-dupe-args: "error"*/
 
@@ -31,7 +33,11 @@ var bar = function (a, b, a) {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-dupe-args: "error"*/
@@ -44,3 +50,5 @@ var bar = function (a, b, c) {
     console.log(a, b, c);
 };
 ```
+
+:::

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -32,6 +32,8 @@ This rule is aimed to flag the use of duplicate names in class members.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-dupe-class-members: "error"*/
 
@@ -61,7 +63,11 @@ class Foo {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-dupe-class-members: "error"*/
@@ -91,6 +97,8 @@ class Foo {
   bar() { }
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-dupe-else-if.md
+++ b/docs/src/rules/no-dupe-else-if.md
@@ -44,6 +44,8 @@ This rule disallows duplicate conditions in the same `if-else-if` chain.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-dupe-else-if: "error"*/
 
@@ -78,7 +80,11 @@ if (n === 1) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-dupe-else-if: "error"*/
@@ -114,9 +120,13 @@ if (n === 1) {
 }
 ```
 
+:::
+
 This rule can also detect some cases where the conditions are not identical, but the branch can never execute due to the logic of `||` and `&&` operators.
 
 Examples of additional **incorrect** code for this rule:
+
+::: incorrect
 
 ```js
 /*eslint no-dupe-else-if: "error"*/
@@ -161,6 +171,8 @@ if (a) {
     baz();
 }
 ```
+
+:::
 
 Please note that this rule does not compare conditions from the chain with conditions inside statements, and will not warn in the cases such as follows:
 

--- a/docs/src/rules/no-dupe-keys.md
+++ b/docs/src/rules/no-dupe-keys.md
@@ -24,6 +24,8 @@ This rule disallows duplicate keys in object literals.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-dupe-keys: "error"*/
 
@@ -43,7 +45,11 @@ var foo = {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-dupe-keys: "error"*/
@@ -53,3 +59,5 @@ var foo = {
     quxx: "qux"
 };
 ```
+
+:::

--- a/docs/src/rules/no-duplicate-case.md
+++ b/docs/src/rules/no-duplicate-case.md
@@ -17,6 +17,8 @@ This rule disallows duplicate test expressions in `case` clauses of `switch` sta
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-duplicate-case: "error"*/
 
@@ -57,7 +59,11 @@ switch (a) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-duplicate-case: "error"*/
@@ -98,6 +104,8 @@ switch (a) {
         break;
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-duplicate-imports.md
+++ b/docs/src/rules/no-duplicate-imports.md
@@ -23,6 +23,8 @@ This rule requires that all imports from a single module that can be merged exis
 
 Example of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-duplicate-imports: "error"*/
 
@@ -31,7 +33,11 @@ import something from 'another-module';
 import { find } from 'module';
 ```
 
+:::
+
 Example of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-duplicate-imports: "error"*/
@@ -40,7 +46,11 @@ import { merge, find } from 'module';
 import something from 'another-module';
 ```
 
+:::
+
 Example of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-duplicate-imports: "error"*/
@@ -50,6 +60,8 @@ import { merge } from 'module';
 import * as something from 'module';
 ```
 
+:::
+
 ## Options
 
 This rule takes one optional argument, an object with a single key, `includeExports` which is a `boolean`. It defaults to `false`.
@@ -57,6 +69,8 @@ This rule takes one optional argument, an object with a single key, `includeExpo
 If re-exporting from an imported module, you should add the imports to the `import`-statement, and export that directly, not use `export ... from`.
 
 Example of **incorrect** code for this rule with the `{ "includeExports": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-duplicate-imports: ["error", { "includeExports": true }]*/
@@ -66,7 +80,11 @@ import { merge } from 'module';
 export { find } from 'module';
 ```
 
+:::
+
 Example of **correct** code for this rule with the `{ "includeExports": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-duplicate-imports: ["error", { "includeExports": true }]*/
@@ -76,7 +94,11 @@ import { merge, find } from 'module';
 export { find };
 ```
 
+:::
+
 Example of **correct** code for this rule with the `{ "includeExports": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-duplicate-imports: ["error", { "includeExports": true }]*/
@@ -89,3 +111,5 @@ export * as something from 'module';
 // cannot be written differently
 export * from 'module';
 ```
+
+:::

--- a/docs/src/rules/no-else-return.md
+++ b/docs/src/rules/no-else-return.md
@@ -36,6 +36,8 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-else-return: "error"*/
 
@@ -91,7 +93,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-else-return: "error"*/
@@ -133,9 +139,13 @@ function foo() {
 }
 ```
 
+:::
+
 ### `allowElseIf: false`
 
 Examples of **incorrect** code for this rule:
+
+::: incorrect
 
 ```js
 /*eslint no-else-return: ["error", {allowElseIf: false}]*/
@@ -149,7 +159,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-else-return: ["error", {allowElseIf: false}]*/
@@ -164,3 +178,5 @@ function foo() {
     }
 }
 ```
+
+:::

--- a/docs/src/rules/no-empty-character-class.md
+++ b/docs/src/rules/no-empty-character-class.md
@@ -21,6 +21,8 @@ This rule disallows empty character classes in regular expressions.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-empty-character-class: "error"*/
 
@@ -28,7 +30,11 @@ Examples of **incorrect** code for this rule:
 "abcdefg".match(/^abc[]/); // null
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-empty-character-class: "error"*/
@@ -39,6 +45,8 @@ Examples of **correct** code for this rule:
 /^abc[a-z]/.test("abcdefg"); // true
 "abcdefg".match(/^abc[a-z]/); // ["abcd"]
 ```
+
+:::
 
 ## Known Limitations
 

--- a/docs/src/rules/no-empty-class.md
+++ b/docs/src/rules/no-empty-class.md
@@ -21,6 +21,8 @@ This rule is aimed at highlighting possible typos and unexpected behavior in reg
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 var foo = /^abc[]/;
 
@@ -29,7 +31,11 @@ var foo = /^abc[]/;
 bar.match(/^abc[]/);
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 var foo = /^abc/;
@@ -38,3 +44,5 @@ var foo = /^abc[a-z]/;
 
 var bar = new RegExp("^abc[]");
 ```
+
+:::

--- a/docs/src/rules/no-empty-function.md
+++ b/docs/src/rules/no-empty-function.md
@@ -33,6 +33,8 @@ A function will not be considered a problem if it contains a comment.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-empty-function: "error"*/
 /*eslint-env es6*/
@@ -82,7 +84,11 @@ class A {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-empty-function: "error"*/
@@ -173,6 +179,8 @@ class A {
 }
 ```
 
+:::
+
 ## Options
 
 This rule has an option to allow specific kinds of functions to be empty.
@@ -193,6 +201,8 @@ This rule has an option to allow specific kinds of functions to be empty.
 
 Examples of **correct** code for the `{ "allow": ["functions"] }` option:
 
+::: correct
+
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["functions"] }]*/
 
@@ -205,9 +215,13 @@ var obj = {
 };
 ```
 
+:::
+
 ### allow: arrowFunctions
 
 Examples of **correct** code for the `{ "allow": ["arrowFunctions"] }` option:
+
+::: correct
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["arrowFunctions"] }]*/
@@ -216,9 +230,13 @@ Examples of **correct** code for the `{ "allow": ["arrowFunctions"] }` option:
 var foo = () => {};
 ```
 
+:::
+
 ### allow: generatorFunctions
 
 Examples of **correct** code for the `{ "allow": ["generatorFunctions"] }` option:
+
+::: correct
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["generatorFunctions"] }]*/
@@ -233,9 +251,13 @@ var obj = {
 };
 ```
 
+:::
+
 ### allow: methods
 
 Examples of **correct** code for the `{ "allow": ["methods"] }` option:
+
+::: correct
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["methods"] }]*/
@@ -251,9 +273,13 @@ class A {
 }
 ```
 
+:::
+
 ### allow: generatorMethods
 
 Examples of **correct** code for the `{ "allow": ["generatorMethods"] }` option:
+
+::: correct
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["generatorMethods"] }]*/
@@ -269,9 +295,13 @@ class A {
 }
 ```
 
+:::
+
 ### allow: getters
 
 Examples of **correct** code for the `{ "allow": ["getters"] }` option:
+
+::: correct
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["getters"] }]*/
@@ -287,9 +317,13 @@ class A {
 }
 ```
 
+:::
+
 ### allow: setters
 
 Examples of **correct** code for the `{ "allow": ["setters"] }` option:
+
+::: correct
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["setters"] }]*/
@@ -305,9 +339,13 @@ class A {
 }
 ```
 
+:::
+
 ### allow: constructors
 
 Examples of **correct** code for the `{ "allow": ["constructors"] }` option:
+
+::: correct
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["constructors"] }]*/
@@ -318,9 +356,13 @@ class A {
 }
 ```
 
+:::
+
 ### allow: asyncFunctions
 
 Examples of **correct** code for the `{ "allow": ["asyncFunctions"] }` options:
+
+::: correct
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["asyncFunctions"] }]*/
@@ -329,9 +371,13 @@ Examples of **correct** code for the `{ "allow": ["asyncFunctions"] }` options:
 async function a(){}
 ```
 
+:::
+
 ### allow: asyncMethods
 
 Examples of **correct** code for the `{ "allow": ["asyncMethods"] }` options:
+
+::: correct
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["asyncMethods"] }]*/
@@ -346,6 +392,8 @@ class A {
     static async foo() {}
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-empty-label.md
+++ b/docs/src/rules/no-empty-label.md
@@ -21,6 +21,8 @@ This error occurs when a label is used to mark a statement that is not an iterat
 
 Example of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-empty-label: "error"*/
 
@@ -28,7 +30,11 @@ labeled:
 var x = 10;
 ```
 
+:::
+
 Example of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-empty-label: "error"*/
@@ -38,6 +44,8 @@ for (var i=10; i; i--) {
     // ...
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-empty-pattern.md
+++ b/docs/src/rules/no-empty-pattern.md
@@ -38,6 +38,8 @@ This rule aims to flag any empty patterns in destructured objects and arrays, an
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-empty-pattern: "error"*/
 
@@ -51,7 +53,11 @@ function foo({a: {}}) {}
 function foo({a: []}) {}
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-empty-pattern: "error"*/
@@ -61,3 +67,5 @@ var {a = []} = foo;
 function foo({a = {}}) {}
 function foo({a = []}) {}
 ```
+
+:::

--- a/docs/src/rules/no-empty.md
+++ b/docs/src/rules/no-empty.md
@@ -19,6 +19,8 @@ This rule disallows empty block statements. This rule ignores block statements w
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-empty: "error"*/
 
@@ -40,7 +42,11 @@ try {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-empty: "error"*/
@@ -66,6 +72,8 @@ try {
 }
 ```
 
+:::
+
 ## Options
 
 This rule has an object option for exceptions:
@@ -75,6 +83,8 @@ This rule has an object option for exceptions:
 ### allowEmptyCatch
 
 Examples of additional **correct** code for this rule with the `{ "allowEmptyCatch": true }` option:
+
+::: correct
 
 ```js
 /* eslint no-empty: ["error", { "allowEmptyCatch": true }] */
@@ -90,6 +100,8 @@ finally {
     /* continue regardless of error */
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-eq-null.md
+++ b/docs/src/rules/no-eq-null.md
@@ -21,6 +21,8 @@ The `no-eq-null` rule aims reduce potential bug and unwanted behavior by ensurin
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-eq-null: "error"*/
 
@@ -33,7 +35,11 @@ while (qux != null) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-eq-null: "error"*/
@@ -46,6 +52,8 @@ while (qux !== null) {
   baz();
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-eval.md
+++ b/docs/src/rules/no-eval.md
@@ -26,6 +26,8 @@ This rule is aimed at preventing potentially dangerous, unnecessary, and slow co
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-eval: "error"*/
 
@@ -42,7 +44,11 @@ foo("var a = 0");
 this.eval("var a = 0");
 ```
 
+:::
+
 Example of additional **incorrect** code for this rule when `browser` environment is set to `true`:
+
+::: incorrect
 
 ```js
 /*eslint no-eval: "error"*/
@@ -51,7 +57,11 @@ Example of additional **incorrect** code for this rule when `browser` environmen
 window.eval("var a = 0");
 ```
 
+:::
+
 Example of additional **incorrect** code for this rule when `node` environment is set to `true`:
+
+::: incorrect
 
 ```js
 /*eslint no-eval: "error"*/
@@ -60,7 +70,11 @@ Example of additional **incorrect** code for this rule when `node` environment i
 global.eval("var a = 0");
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-eval: "error"*/
@@ -89,6 +103,8 @@ class A {
 }
 ```
 
+:::
+
 ## Options
 
 This rule has an option to allow indirect calls to `eval`.
@@ -102,6 +118,8 @@ Indirect calls to `eval` are less dangerous than direct calls to `eval` because 
 
 Example of **incorrect** code for this rule with the `{"allowIndirect": true}` option:
 
+::: incorrect
+
 ```js
 /*eslint no-eval: "error"*/
 
@@ -110,7 +128,11 @@ var obj = { x: "foo" },
     value = eval("obj." + key);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{"allowIndirect": true}` option:
+
+::: correct
 
 ```js
 /*eslint no-eval: "error"*/
@@ -122,6 +144,8 @@ foo("var a = 0");
 
 this.eval("var a = 0");
 ```
+
+:::
 
 ```js
 /*eslint no-eval: "error"*/

--- a/docs/src/rules/no-ex-assign.md
+++ b/docs/src/rules/no-ex-assign.md
@@ -20,6 +20,8 @@ This rule disallows reassigning exceptions in `catch` clauses.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-ex-assign: "error"*/
 
@@ -30,7 +32,11 @@ try {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-ex-assign: "error"*/
@@ -41,3 +47,5 @@ try {
     var foo = 10;
 }
 ```
+
+:::

--- a/docs/src/rules/no-extend-native.md
+++ b/docs/src/rules/no-extend-native.md
@@ -37,12 +37,16 @@ Disallows directly modifying the prototype of builtin objects.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-extend-native: "error"*/
 
 Object.prototype.a = "a";
 Object.defineProperty(Array.prototype, "times", { value: 999 });
 ```
+
+:::
 
 ## Options
 
@@ -52,11 +56,15 @@ This rule accepts an `exceptions` option, which can be used to specify a list of
 
 Examples of **correct** code for the sample `{ "exceptions": ["Object"] }` option:
 
+::: correct
+
 ```js
 /*eslint no-extend-native: ["error", { "exceptions": ["Object"] }]*/
 
 Object.prototype.a = "a";
 ```
+
+:::
 
 ## Known Limitations
 

--- a/docs/src/rules/no-extra-bind.md
+++ b/docs/src/rules/no-extra-bind.md
@@ -45,6 +45,8 @@ This rule is aimed at avoiding the unnecessary use of `bind()` and as such will 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-extra-bind: "error"*/
 /*eslint-env es6*/
@@ -74,7 +76,11 @@ var x = function () {
 }.bind(baz);
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-extra-bind: "error"*/
@@ -87,6 +93,8 @@ var x = function (a) {
     return a + 1;
 }.bind(foo, bar);
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-extra-boolean-cast.md
+++ b/docs/src/rules/no-extra-boolean-cast.md
@@ -33,6 +33,8 @@ This rule disallows unnecessary boolean casts.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-extra-boolean-cast: "error"*/
 
@@ -65,7 +67,11 @@ for (; !!foo; ) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-extra-boolean-cast: "error"*/
@@ -80,6 +86,8 @@ function foo() {
 var foo = bar ? !!baz : !!bat;
 ```
 
+:::
+
 ## Options
 
 This rule has an object option:
@@ -89,6 +97,8 @@ This rule has an object option:
 ### enforceForLogicalOperands
 
 Examples of **incorrect** code for this rule with `"enforceForLogicalOperands"` option set to `true`:
+
+::: incorrect
 
 ```js
 /*eslint no-extra-boolean-cast: ["error", {"enforceForLogicalOperands": true}]*/
@@ -110,7 +120,11 @@ foo && Boolean(bar) ? baz : bat
 var foo = new Boolean(!!bar || baz)
 ```
 
+:::
+
 Examples of **correct** code for this rule with `"enforceForLogicalOperands"` option set to `true`:
+
+::: correct
 
 ```js
 /*eslint no-extra-boolean-cast: ["error", {"enforceForLogicalOperands": true}]*/
@@ -133,3 +147,5 @@ var foo = new Boolean(bar || baz)
 
 var foo = !!bar || baz;
 ```
+
+:::

--- a/docs/src/rules/no-extra-label.md
+++ b/docs/src/rules/no-extra-label.md
@@ -30,6 +30,8 @@ This rule is aimed at eliminating unnecessary labels.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-extra-label: "error"*/
 
@@ -47,7 +49,11 @@ C: switch (a) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-extra-label: "error"*/
@@ -83,6 +89,8 @@ C: switch (a) {
         break;
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -47,6 +47,8 @@ This rule has an object option for exceptions to the `"all"` option:
 
 Examples of **incorrect** code for this rule with the default `"all"` option:
 
+::: incorrect
+
 ```js
 /* eslint no-extra-parens: "error" */
 
@@ -73,7 +75,11 @@ class B {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"all"` option:
+
+::: correct
 
 ```js
 /* eslint no-extra-parens: "error" */
@@ -105,9 +111,13 @@ class B {
 }
 ```
 
+:::
+
 ### conditionalAssign
 
 Examples of **correct** code for this rule with the `"all"` and `{ "conditionalAssign": false }` options:
+
+::: correct
 
 ```js
 /* eslint no-extra-parens: ["error", "all", { "conditionalAssign": false }] */
@@ -121,9 +131,13 @@ do; while ((foo = bar()))
 for (;(a = b););
 ```
 
+:::
+
 ### returnAssign
 
 Examples of **correct** code for this rule with the `"all"` and `{ "returnAssign": false }` options:
+
+::: correct
 
 ```js
 /* eslint no-extra-parens: ["error", "all", { "returnAssign": false }] */
@@ -141,9 +155,13 @@ b => (b = 1);
 b => b ? (c = d) : (c = e);
 ```
 
+:::
+
 ### nestedBinaryExpressions
 
 Examples of **correct** code for this rule with the `"all"` and `{ "nestedBinaryExpressions": false }` options:
+
+::: correct
 
 ```js
 /* eslint no-extra-parens: ["error", "all", { "nestedBinaryExpressions": false }] */
@@ -153,9 +171,13 @@ x = a + (b * c);
 x = (a * b) / c;
 ```
 
+:::
+
 ### ignoreJSX
 
 Examples of **correct** code for this rule with the `all` and `{ "ignoreJSX": "all" }` options:
+
+::: correct
 
 ```js
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "all" }] */
@@ -167,16 +189,24 @@ const Component = (
 )
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `all` and `{ "ignoreJSX": "multi-line" }` options:
+
+::: incorrect
 
 ```js
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "multi-line" }] */
 const Component = (<div />)
 const Component = (<div><p /></div>)
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `all` and `{ "ignoreJSX": "multi-line" }` options:
 
+::: correct
+
 ```js
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "multi-line" }] */
 const Component = (
@@ -191,7 +221,11 @@ const Component = (
 )
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `all` and `{ "ignoreJSX": "single-line" }` options:
+
+::: incorrect
 
 ```js
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "single-line" }] */
@@ -207,17 +241,25 @@ const Component = (
 )
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `all` and `{ "ignoreJSX": "single-line" }` options:
+
+::: correct
 
 ```js
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "single-line" }] */
 const Component = (<div />)
 const Component = (<div><p /></div>)
 ```
+
+:::
 
 ### enforceForArrowConditionals
 
 Examples of **correct** code for this rule with the `"all"` and `{ "enforceForArrowConditionals": false }` options:
+
+::: correct
 
 ```js
 /* eslint no-extra-parens: ["error", "all", { "enforceForArrowConditionals": false }] */
@@ -226,9 +268,13 @@ const b = a => 1 ? 2 : 3;
 const d = c => (1 ? 2 : 3);
 ```
 
+:::
+
 ### enforceForSequenceExpressions
 
 Examples of **correct** code for this rule with the `"all"` and `{ "enforceForSequenceExpressions": false }` options:
+
+::: correct
 
 ```js
 /* eslint no-extra-parens: ["error", "all", { "enforceForSequenceExpressions": false }] */
@@ -240,9 +286,13 @@ if ((val = foo(), val < 10)) {}
 while ((val = foo(), val < 10));
 ```
 
+:::
+
 ### enforceForNewInMemberExpressions
 
 Examples of **correct** code for this rule with the `"all"` and `{ "enforceForNewInMemberExpressions": false }` options:
+
+::: correct
 
 ```js
 /* eslint no-extra-parens: ["error", "all", { "enforceForNewInMemberExpressions": false }] */
@@ -254,9 +304,13 @@ const quux = (new Bar())[baz];
 (new Bar()).doSomething();
 ```
 
+:::
+
 ### enforceForFunctionPrototypeMethods
 
 Examples of **correct** code for this rule with the `"all"` and `{ "enforceForFunctionPrototypeMethods": false }` options:
+
+::: correct
 
 ```js
 /* eslint no-extra-parens: ["error", "all", { "enforceForFunctionPrototypeMethods": false }] */
@@ -270,9 +324,13 @@ const baz = (function () {}.call());
 const quux = (function () {}.apply());
 ```
 
+:::
+
 ### functions
 
 Examples of **incorrect** code for this rule with the `"functions"` option:
+
+::: incorrect
 
 ```js
 /* eslint no-extra-parens: ["error", "functions"] */
@@ -282,7 +340,11 @@ Examples of **incorrect** code for this rule with the `"functions"` option:
 var y = (function () {return 1;});
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"functions"` option:
+
+::: correct
 
 ```js
 /* eslint no-extra-parens: ["error", "functions"] */
@@ -303,3 +365,5 @@ a = (b * c);
 
 typeof (a);
 ```
+
+:::

--- a/docs/src/rules/no-extra-semi.md
+++ b/docs/src/rules/no-extra-semi.md
@@ -22,6 +22,8 @@ This rule disallows unnecessary semicolons.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-extra-semi: "error"*/
 
@@ -44,7 +46,11 @@ class C {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-extra-semi: "error"*/
@@ -71,6 +77,8 @@ class C {
     }
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-extra-strict.md
+++ b/docs/src/rules/no-extra-strict.md
@@ -28,6 +28,8 @@ This rule is aimed at preventing unnecessary `"use strict";` directives. As such
 
 Example of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 "use strict";
 
@@ -37,7 +39,11 @@ Example of **incorrect** code for this rule:
 }());
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 "use strict";
@@ -46,6 +52,8 @@ Examples of **correct** code for this rule:
     var foo = true;
 }());
 ```
+
+:::
 
 ```js
 (function () {

--- a/docs/src/rules/no-fallthrough.md
+++ b/docs/src/rules/no-fallthrough.md
@@ -86,6 +86,8 @@ This rule is aimed at eliminating unintentional fallthrough of one case to the o
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-fallthrough: "error"*/
 
@@ -98,7 +100,11 @@ switch(foo) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-fallthrough: "error"*/
@@ -159,6 +165,8 @@ switch(foo) {
 }
 ```
 
+:::
+
 Note that the last `case` statement in these examples does not cause a warning because there is nothing to fall through into.
 
 ## Options
@@ -170,6 +178,8 @@ This rule accepts a single options argument:
 ### commentPattern
 
 Examples of **correct** code for the `{ "commentPattern": "break[\\s\\w]*omitted" }` option:
+
+::: correct
 
 ```js
 /*eslint no-fallthrough: ["error", { "commentPattern": "break[\\s\\w]*omitted" }]*/
@@ -192,6 +202,8 @@ switch(foo) {
         doSomething();
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-floating-decimal.md
+++ b/docs/src/rules/no-floating-decimal.md
@@ -25,6 +25,8 @@ This rule is aimed at eliminating floating decimal points and will warn whenever
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-floating-decimal: "error"*/
 
@@ -33,7 +35,11 @@ var num = 2.;
 var num = -.7;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-floating-decimal: "error"*/
@@ -42,6 +48,8 @@ var num = 0.5;
 var num = 2.0;
 var num = -0.7;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-func-assign.md
+++ b/docs/src/rules/no-func-assign.md
@@ -22,6 +22,8 @@ This rule disallows reassigning `function` declarations.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-func-assign: "error"*/
 
@@ -37,7 +39,11 @@ var a = function hello() {
 };
 ```
 
+:::
+
 Examples of **incorrect** code for this rule, unlike the corresponding rule in JSHint:
+
+::: incorrect
 
 ```js
 /*eslint no-func-assign: "error"*/
@@ -46,7 +52,11 @@ foo = bar;
 function foo() {}
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-func-assign: "error"*/
@@ -62,3 +72,5 @@ function foo() {
     var foo = bar;  // `foo` is shadowed.
 }
 ```
+
+:::

--- a/docs/src/rules/no-global-assign.md
+++ b/docs/src/rules/no-global-assign.md
@@ -32,12 +32,16 @@ ESLint has the capability to configure global variables as read-only.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-global-assign: "error"*/
 
 Object = null
 undefined = 1
 ```
+
+:::
 
 ```js
 /*eslint no-global-assign: "error"*/
@@ -57,6 +61,8 @@ a = 1
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint no-global-assign: "error"*/
 
@@ -64,6 +70,8 @@ a = 1
 var b = 1
 b = 2
 ```
+
+:::
 
 ```js
 /*eslint no-global-assign: "error"*/

--- a/docs/src/rules/no-implicit-coercion.md
+++ b/docs/src/rules/no-implicit-coercion.md
@@ -54,6 +54,8 @@ Note that operator `+` in `allow` list would allow `+foo` (number coercion) as w
 
 Examples of **incorrect** code for the default `{ "boolean": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint no-implicit-coercion: "error"*/
 
@@ -62,7 +64,11 @@ var b = ~foo.indexOf(".");
 // bitwise not is incorrect only with `indexOf`/`lastIndexOf` method calling.
 ```
 
+:::
+
 Examples of **correct** code for the default `{ "boolean": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-implicit-coercion: "error"*/
@@ -73,9 +79,13 @@ var b = foo.indexOf(".") !== -1;
 var n = ~foo; // This is a just bitwise not.
 ```
 
+:::
+
 ### number
 
 Examples of **incorrect** code for the default `{ "number": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-implicit-coercion: "error"*/
@@ -84,7 +94,11 @@ var n = +foo;
 var n = 1 * foo;
 ```
 
+:::
+
 Examples of **correct** code for the default `{ "number": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-implicit-coercion: "error"*/
@@ -94,9 +108,13 @@ var n = parseFloat(foo);
 var n = parseInt(foo, 10);
 ```
 
+:::
+
 ### string
 
 Examples of **incorrect** code for the default `{ "string": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-implicit-coercion: "error"*/
@@ -107,7 +125,11 @@ foo += "";
 foo += ``;
 ```
 
+:::
+
 Examples of **correct** code for the default `{ "string": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-implicit-coercion: "error"*/
@@ -116,11 +138,15 @@ var s = String(foo);
 foo = String(foo);
 ```
 
+:::
+
 ### disallowTemplateShorthand
 
 This option is **not** affected by the `string` option.
 
 Examples of **incorrect** code for the `{ "disallowTemplateShorthand": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-implicit-coercion: ["error", { "disallowTemplateShorthand": true }]*/
@@ -128,7 +154,11 @@ Examples of **incorrect** code for the `{ "disallowTemplateShorthand": true }` o
 var s = `${foo}`;
 ```
 
+:::
+
 Examples of **correct** code for the `{ "disallowTemplateShorthand": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-implicit-coercion: ["error", { "disallowTemplateShorthand": true }]*/
@@ -144,7 +174,11 @@ var s = `${foo}${bar}`;
 var s = tag`${foo}`;
 ```
 
+:::
+
 Examples of **correct** code for the default `{ "disallowTemplateShorthand": false }` option:
+
+::: correct
 
 ```js
 /*eslint no-implicit-coercion: ["error", { "disallowTemplateShorthand": false }]*/
@@ -152,11 +186,15 @@ Examples of **correct** code for the default `{ "disallowTemplateShorthand": fal
 var s = `${foo}`;
 ```
 
+:::
+
 ### allow
 
 Using `allow` list, we can override and allow specific operators.
 
 Examples of **correct** code for the sample `{ "allow": ["!!", "~"] }` option:
+
+::: correct
 
 ```js
 /*eslint no-implicit-coercion: [2, { "allow": ["!!", "~"] } ]*/
@@ -164,6 +202,8 @@ Examples of **correct** code for the sample `{ "allow": ["!!", "~"] }` option:
 var b = !!foo;
 var b = ~foo.indexOf(".");
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-implicit-globals.md
+++ b/docs/src/rules/no-implicit-globals.md
@@ -46,6 +46,8 @@ This rule disallows `var` and `function` declarations at the top-level script sc
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-implicit-globals: "error"*/
 
@@ -54,7 +56,11 @@ var foo = 1;
 function bar() {}
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-implicit-globals: "error"*/
@@ -71,7 +77,11 @@ window.bar = function() {};
 })();
 ```
 
+:::
+
 Examples of **correct** code for this rule with `"parserOptions": { "sourceType": "module" }` in the ESLint configuration:
+
+::: correct
 
 ```js
 /*eslint no-implicit-globals: "error"*/
@@ -80,6 +90,8 @@ Examples of **correct** code for this rule with `"parserOptions": { "sourceType"
 var foo = 1;
 function bar() {}
 ```
+
+:::
 
 ### Global variable leaks
 
@@ -90,6 +102,8 @@ This does not apply to ES modules since the module code is implicitly in `strict
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-implicit-globals: "error"*/
 
@@ -99,6 +113,8 @@ Bar.prototype.baz = function () {
     a = 1; // Intended to be this.a = 1;
 };
 ```
+
+:::
 
 ### Read-only global variables
 
@@ -113,6 +129,8 @@ or in a `/*global */` comment.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-implicit-globals: "error"*/
 
@@ -123,6 +141,8 @@ foo = 1;
 Array = [];
 var Object;
 ```
+
+:::
 
 ### `const`, `let` and `class` declarations
 
@@ -137,6 +157,8 @@ If the variable is intended to be local to the script, wrap the code with a bloc
 
 Examples of **correct** code for this rule with `"lexicalBindings"` option set to `false` (default):
 
+::: correct
+
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": false}]*/
 
@@ -147,7 +169,11 @@ let baz;
 class Bar {}
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with `"lexicalBindings"` option set to `true`:
+
+::: incorrect
 
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
@@ -159,7 +185,11 @@ let baz;
 class Bar {}
 ```
 
+:::
+
 Examples of **correct** code for this rule with `"lexicalBindings"` option set to `true`:
+
+::: correct
 
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
@@ -177,6 +207,8 @@ Examples of **correct** code for this rule with `"lexicalBindings"` option set t
 }());
 ```
 
+:::
+
 If you intend to create a global `const` or `let` variable or a global `class` declaration, to be used from other scripts,
 be aware that there are certain differences when compared to the traditional methods, which are `var` declarations and assigning to a property of the global `window` object:
 
@@ -191,6 +223,8 @@ Even the `typeof` check is not safe from TDZ reference exceptions.
 
 Examples of **incorrect** code for this rule with `"lexicalBindings"` option set to `true`:
 
+::: incorrect
+
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
 
@@ -203,7 +237,11 @@ const MyGlobalFunction = (function() {
 }());
 ```
 
+:::
+
 Examples of **correct** code for this rule with `"lexicalBindings"` option set to `true`:
+
+::: correct
 
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
@@ -216,6 +254,8 @@ window.MyGlobalFunction = (function() {
     }
 }());
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-implied-eval.md
+++ b/docs/src/rules/no-implied-eval.md
@@ -34,6 +34,8 @@ This rule aims to eliminate implied `eval()` through the use of `setTimeout()`, 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-implied-eval: "error"*/
 
@@ -48,7 +50,11 @@ window.setTimeout("count = 5", 10);
 window.setInterval("foo = bar", 10);
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-implied-eval: "error"*/
@@ -61,6 +67,8 @@ setInterval(function() {
     alert("Hi!");
 }, 100);
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-import-assign.md
+++ b/docs/src/rules/no-import-assign.md
@@ -17,6 +17,8 @@ This rule warns the assignments, increments, and decrements of imported bindings
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-import-assign: "error"*/
 
@@ -31,7 +33,11 @@ mod_ns = {}      // ERROR: 'mod_ns' is readonly.
 Object.assign(mod_ns, { foo: "foo" }) // ERROR: The members of 'mod_ns' are readonly.
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-import-assign: "error"*/
@@ -49,6 +55,8 @@ function test(obj) {
 }
 test(mod_ns) // Not errored because it doesn't know that 'test' updates the member of the argument.
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-inline-comments.md
+++ b/docs/src/rules/no-inline-comments.md
@@ -16,6 +16,8 @@ This rule disallows comments on the same line as code.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-inline-comments: "error"*/
 
@@ -31,7 +33,11 @@ function getRandomNumber(){
 var c = 3; /* A block comment after code */
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-inline-comments: "error"*/
@@ -43,11 +49,15 @@ var bar = 5;
 //This is a comment below a line of code
 ```
 
+:::
+
 ### JSX exception
 
 Comments inside the curly braces in JSX are allowed to be on the same line as the braces, but only if they are not on the same line with other code, and the braces do not enclose an actual expression.
 
 Examples of **incorrect** code for this rule:
+
+::: incorrect
 
 ```js
 /*eslint no-inline-comments: "error"*/
@@ -63,7 +73,11 @@ var bar = (
 );
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-inline-comments: "error"*/
@@ -95,6 +109,8 @@ var quux = (
 )
 ```
 
+:::
+
 ## Options
 
 ### ignorePattern
@@ -103,16 +119,24 @@ To make this rule ignore specific comments, set the `ignorePattern` option to a 
 
 Examples of **correct** code for the `ignorePattern` option:
 
+::: correct
+
 ```js
 /*eslint no-inline-comments: ["error", { "ignorePattern": "webpackChunkName:\\s.+" }]*/
 
 import(/* webpackChunkName: "my-chunk-name" */ './locale/en');
 ```
 
+:::
+
 Examples of **incorrect** code for the `ignorePattern` option:
+
+::: incorrect
 
 ```js
 /*eslint no-inline-comments: ["error", { "ignorePattern": "something" }] */
 
 var foo = 4; // other thing
 ```
+
+:::

--- a/docs/src/rules/no-inner-declarations.md
+++ b/docs/src/rules/no-inner-declarations.md
@@ -78,6 +78,8 @@ This rule has a string option:
 
 Examples of **incorrect** code for this rule with the default `"functions"` option:
 
+::: incorrect
+
 ```js
 /*eslint no-inner-declarations: "error"*/
 
@@ -102,7 +104,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"functions"` option:
+
+::: correct
 
 ```js
 /*eslint no-inner-declarations: "error"*/
@@ -131,9 +137,13 @@ if (test) {
 if (foo) var a;
 ```
 
+:::
+
 ### both
 
 Examples of **incorrect** code for this rule with the `"both"` option:
+
+::: incorrect
 
 ```js
 /*eslint no-inner-declarations: ["error", "both"]*/
@@ -161,7 +171,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"both"` option:
+
+::: correct
 
 ```js
 /*eslint no-inner-declarations: ["error", "both"]*/
@@ -182,6 +196,8 @@ class C {
     }
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-invalid-regexp.md
+++ b/docs/src/rules/no-invalid-regexp.md
@@ -19,6 +19,8 @@ This rule disallows invalid regular expression strings in `RegExp` constructors.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-invalid-regexp: "error"*/
 
@@ -29,7 +31,11 @@ RegExp('.', 'z')
 new RegExp('\\')
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-invalid-regexp: "error"*/
@@ -40,6 +46,8 @@ new RegExp
 
 this.RegExp('[')
 ```
+
+:::
 
 Please note that this rule validates regular expressions per the latest ECMAScript specification, regardless of your parser settings.
 
@@ -55,6 +63,8 @@ This rule has an object option for exceptions:
 
 Examples of **correct** code for this rule with the `{ "allowConstructorFlags": ["a", "z"] }` option:
 
+::: correct
+
 ```js
 /*eslint no-invalid-regexp: ["error", { "allowConstructorFlags": ["a", "z"] }]*/
 
@@ -62,3 +72,5 @@ new RegExp('.', 'a')
 
 new RegExp('.', 'az')
 ```
+
+:::

--- a/docs/src/rules/no-invalid-this.md
+++ b/docs/src/rules/no-invalid-this.md
@@ -50,6 +50,8 @@ With `"parserOptions": { "sourceType": "module" }` in the ESLint configuration, 
 
 Examples of **incorrect** code for this rule in strict mode:
 
+::: incorrect
+
 ```js
 /*eslint no-invalid-this: "error"*/
 /*eslint-env es6*/
@@ -92,7 +94,11 @@ foo.forEach(function() {
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule in strict mode:
+
+::: correct
 
 ```js
 /*eslint no-invalid-this: "error"*/
@@ -222,6 +228,8 @@ function foo() {
 }
 ```
 
+:::
+
 ## Options
 
 This rule has an object option, with one option:
@@ -235,6 +243,8 @@ By default, this rule always allows the use of `this` in functions which name st
 Set `"capIsConstructor"` to `false` if you want those functions to be treated as 'regular' functions.
 
 Examples of **incorrect** code for this rule with `"capIsConstructor"` option set to `false`:
+
+::: incorrect
 
 ```js
 /*eslint no-invalid-this: ["error", { "capIsConstructor": false }]*/
@@ -258,7 +268,11 @@ Baz = function() {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with `"capIsConstructor"` option set to `false`:
+
+::: correct
 
 ```js
 /*eslint no-invalid-this: ["error", { "capIsConstructor": false }]*/
@@ -270,6 +284,8 @@ obj.Foo = function Foo() {
     this.a = 0;
 };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-irregular-whitespace.md
+++ b/docs/src/rules/no-irregular-whitespace.md
@@ -70,6 +70,8 @@ This rule has an object option for exceptions:
 
 Examples of **incorrect** code for this rule with the default `{ "skipStrings": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint no-irregular-whitespace: "error"*/
 
@@ -115,7 +117,11 @@ function thing() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "skipStrings": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-irregular-whitespace: "error"*/
@@ -133,9 +139,13 @@ function thing() {
 }
 ```
 
+:::
+
 ### skipComments
 
 Examples of additional **correct** code for this rule with the `{ "skipComments": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-irregular-whitespace: ["error", { "skipComments": true }]*/
@@ -149,9 +159,13 @@ Description <NBSP>: some descriptive text
 */
 ```
 
+:::
+
 ### skipRegExps
 
 Examples of additional **correct** code for this rule with the `{ "skipRegExps": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-irregular-whitespace: ["error", { "skipRegExps": true }]*/
@@ -161,9 +175,13 @@ function thing() {
 }
 ```
 
+:::
+
 ### skipTemplates
 
 Examples of additional **correct** code for this rule with the `{ "skipTemplates": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-irregular-whitespace: ["error", { "skipTemplates": true }]*/
@@ -173,6 +191,8 @@ function thing() {
     return `template <NBSP>string`;
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-iterator.md
+++ b/docs/src/rules/no-iterator.md
@@ -27,6 +27,8 @@ This rule is aimed at preventing errors that may arise from using the `__iterato
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-iterator: "error"*/
 
@@ -40,10 +42,16 @@ foo["__iterator__"] = function () {};
 
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-iterator: "error"*/
 
 var __iterator__ = foo; // Not using the `__iterator__` property.
 ```
+
+:::

--- a/docs/src/rules/no-label-var.md
+++ b/docs/src/rules/no-label-var.md
@@ -17,6 +17,8 @@ This rule aims to create clearer code by disallowing the bad practice of creatin
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-label-var: "error"*/
 
@@ -29,7 +31,11 @@ x:
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-label-var: "error"*/
@@ -47,6 +53,8 @@ q:
   }
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-labels.md
+++ b/docs/src/rules/no-labels.md
@@ -33,6 +33,8 @@ This rule aims to eliminate the use of labeled statements in JavaScript. It will
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-labels: "error"*/
 
@@ -68,7 +70,11 @@ label:
     }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-labels: "error"*/
@@ -86,6 +92,8 @@ while (true) {
 }
 ```
 
+:::
+
 ## Options
 
 The options allow labels with loop or switch statements:
@@ -100,6 +108,8 @@ However, this way is ultra rare, not well-known, so this would be confusing deve
 
 Examples of **correct** code for the `{ "allowLoop": true }` option:
 
+::: correct
+
 ```js
 /*eslint no-labels: ["error", { "allowLoop": true }]*/
 
@@ -109,9 +119,13 @@ label:
     }
 ```
 
+:::
+
 ### allowSwitch
 
 Examples of **correct** code for the `{ "allowSwitch": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-labels: ["error", { "allowSwitch": true }]*/
@@ -122,6 +136,8 @@ label:
             break label;
     }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-lone-blocks.md
+++ b/docs/src/rules/no-lone-blocks.md
@@ -23,6 +23,8 @@ This rule aims to eliminate unnecessary and potentially confusing blocks at the 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-lone-blocks: "error"*/
 
@@ -59,7 +61,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with ES6 environment:
+
+::: correct
 
 ```js
 /*eslint no-lone-blocks: "error"*/
@@ -107,7 +113,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with ES6 environment and strict mode via `"parserOptions": { "sourceType": "module" }` in the ESLint configuration or `"use strict"` directive in the code:
+
+::: correct
 
 ```js
 /*eslint no-lone-blocks: "error"*/
@@ -119,3 +129,5 @@ Examples of **correct** code for this rule with ES6 environment and strict mode 
     function foo() {}
 }
 ```
+
+:::

--- a/docs/src/rules/no-lonely-if.md
+++ b/docs/src/rules/no-lonely-if.md
@@ -37,6 +37,8 @@ This rule disallows `if` statements as the only statement in `else` blocks.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-lonely-if: "error"*/
 
@@ -59,7 +61,11 @@ if (condition) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-lonely-if: "error"*/
@@ -87,6 +93,8 @@ if (condition) {
     doSomething();
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-loop-func.md
+++ b/docs/src/rules/no-loop-func.md
@@ -41,6 +41,8 @@ This rule disallows any function within a loop that contains unsafe references (
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-loop-func: "error"*/
 /*eslint-env es6*/
@@ -73,7 +75,11 @@ for (let i = 0; i < 10; ++i) {
 foo = 100;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-loop-func: "error"*/
@@ -102,3 +108,5 @@ for (let i=10; i; i--) {
 }
 //... no modifications of foo after this loop ...
 ```
+
+:::

--- a/docs/src/rules/no-loss-of-precision.md
+++ b/docs/src/rules/no-loss-of-precision.md
@@ -17,6 +17,8 @@ In JS, `Number`s are stored as double-precision floating-point numbers according
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-loss-of-precision: "error"*/
 
@@ -28,7 +30,11 @@ const x = 0X20000000000001
 const x = 0X2_000000000_0001;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-loss-of-precision: "error"*/
@@ -41,3 +47,5 @@ const x = 0x1FFFFFFFFFFFFF
 const x = 9007199254740991
 const x = 9007_1992547409_91
 ```
+
+:::

--- a/docs/src/rules/no-magic-numbers.md
+++ b/docs/src/rules/no-magic-numbers.md
@@ -22,12 +22,16 @@ are declared as constants to make their meaning explicit.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-magic-numbers: "error"*/
 
 var dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * 0.25);
 ```
+
+:::
 
 ```js
 /*eslint no-magic-numbers: "error"*/
@@ -47,6 +51,8 @@ SECONDS = 60;
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint no-magic-numbers: "error"*/
 
@@ -55,6 +61,8 @@ var TAX = 0.25;
 var dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * TAX);
 ```
+
+:::
 
 ## Options
 
@@ -68,6 +76,8 @@ If it's a string, the text must be parsed as `bigint` literal (e.g., `"100n"`).
 
 Examples of **correct** code for the sample `{ "ignore": [1] }` option:
 
+::: correct
+
 ```js
 /*eslint no-magic-numbers: ["error", { "ignore": [1] }]*/
 
@@ -75,13 +85,19 @@ var data = ['foo', 'bar', 'baz'];
 var dataLast = data.length && data[data.length - 1];
 ```
 
+:::
+
 Examples of **correct** code for the sample `{ "ignore": ["1n"] }` option:
+
+::: correct
 
 ```js
 /*eslint no-magic-numbers: ["error", { "ignore": ["1n"] }]*/
 
 foo(1n);
 ```
+
+:::
 
 ### ignoreArrayIndexes
 
@@ -94,6 +110,8 @@ Arrays are objects, so they can have property names such as `"-1"` or `"2.5"`. H
 Additionally, since the maximum [array length](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/length) is 2<sup>32</sup> - 1, all values above 2<sup>32</sup> - 2 also represent just normal property names and are thus not considered to be array indexes.
 
 Examples of **correct** code for the `{ "ignoreArrayIndexes": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-magic-numbers: ["error", { "ignoreArrayIndexes": true }]*/
@@ -115,7 +133,11 @@ a = data[10n]; // same as data[10], 10n will be coerced to "10"
 a = data[4294967294]; // max array index
 ```
 
+:::
+
 Examples of **incorrect** code for the `{ "ignoreArrayIndexes": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-magic-numbers: ["error", { "ignoreArrayIndexes": true }]*/
@@ -135,11 +157,15 @@ a = data[4294967295]; // above the max array index
 a = data[1e500]; // same as data["Infinity"]
 ```
 
+:::
+
 ### ignoreDefaultValues
 
 A boolean to specify if numbers used in default value assignments are considered okay. `false` by default.
 
 Examples of **correct** code for the `{ "ignoreDefaultValues": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-magic-numbers: ["error", { "ignoreDefaultValues": true }]*/
@@ -148,6 +174,8 @@ const { tax = 0.25 } = accountancy;
 
 function mapParallel(concurrency = 3) { /***/ }
 ```
+
+:::
 
 ```js
 /*eslint no-magic-numbers: ["error", { "ignoreDefaultValues": true }]*/
@@ -162,6 +190,8 @@ A boolean to specify if we should check for the const keyword in variable declar
 
 Examples of **incorrect** code for the `{ "enforceConst": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint no-magic-numbers: ["error", { "enforceConst": true }]*/
 
@@ -171,11 +201,15 @@ var dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * TAX);
 ```
 
+:::
+
 ### detectObjects
 
 A boolean to specify if we should detect numbers when setting object properties for example. `false` by default.
 
 Examples of **incorrect** code for the `{ "detectObjects": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-magic-numbers: ["error", { "detectObjects": true }]*/
@@ -188,7 +222,11 @@ var dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * magic.tax);
 ```
 
+:::
+
 Examples of **correct** code for the `{ "detectObjects": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-magic-numbers: ["error", { "detectObjects": true }]*/
@@ -202,3 +240,5 @@ var magic = {
 var dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * magic.tax);
 ```
+
+:::

--- a/docs/src/rules/no-misleading-character-class.md
+++ b/docs/src/rules/no-misleading-character-class.md
@@ -59,6 +59,8 @@ This rule reports the regular expressions which include multiple code point char
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-misleading-character-class: error */
 
@@ -70,7 +72,11 @@ Examples of **incorrect** code for this rule:
 /^[👍]$/
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-misleading-character-class: error */
@@ -78,6 +84,8 @@ Examples of **correct** code for this rule:
 /^[abc]$/
 /^[👍]$/u
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-mixed-operators.md
+++ b/docs/src/rules/no-mixed-operators.md
@@ -41,6 +41,8 @@ If you use both this and [no-extra-parens](no-extra-parens) rule together, you n
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-mixed-operators: "error"*/
 
@@ -48,7 +50,11 @@ var foo = a && b < 0 || c > 0 || d + 1 === 0;
 var foo = a + b * c;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-mixed-operators: "error"*/
@@ -60,6 +66,8 @@ var foo = a && (b < 0 || c > 0 || d + 1 === 0);
 var foo = a + (b * c);
 var foo = (a + b) * c;
 ```
+
+:::
 
 ## Options
 
@@ -106,12 +114,16 @@ In this case, this rule checks if bitwise operators and logical operators are mi
 
 Examples of **incorrect** code for this rule with `{"groups": [["&", "|", "^", "~", "<<", ">>", ">>>"], ["&&", "||"]]}` option:
 
+::: incorrect
+
 ```js
 /*eslint no-mixed-operators: ["error", {"groups": [["&", "|", "^", "~", "<<", ">>", ">>>"], ["&&", "||"]]}]*/
 
 var foo = a && b < 0 || c > 0 || d + 1 === 0;
 var foo = a & b | c;
 ```
+
+:::
 
 ```js
 /*eslint no-mixed-operators: ["error", {"groups": [["&&", "||", "?:"]]}]*/
@@ -124,6 +136,8 @@ var baz = a ? b : c || d;
 ```
 
 Examples of **correct** code for this rule with `{"groups": [["&", "|", "^", "~", "<<", ">>", ">>>"], ["&&", "||"]]}` option:
+
+::: correct
 
 ```js
 /*eslint no-mixed-operators: ["error", {"groups": [["&", "|", "^", "~", "<<", ">>", ">>>"], ["&&", "||"]]}]*/
@@ -138,6 +152,8 @@ var foo = a + b * c;
 var foo = a + (b * c);
 var foo = (a + b) * c;
 ```
+
+:::
 
 ```js
 /*eslint no-mixed-operators: ["error", {"groups": [["&&", "||", "?:"]]}]*/
@@ -155,6 +171,8 @@ var baz = (a ? b : c) || d;
 
 Examples of **correct** code for this rule with `{"allowSamePrecedence": true}` option:
 
+::: correct
+
 ```js
 /*eslint no-mixed-operators: ["error", {"allowSamePrecedence": true}]*/
 
@@ -162,7 +180,11 @@ Examples of **correct** code for this rule with `{"allowSamePrecedence": true}` 
 var foo = a + b - c;
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with `{"allowSamePrecedence": false}` option:
+
+::: incorrect
 
 ```js
 /*eslint no-mixed-operators: ["error", {"allowSamePrecedence": false}]*/
@@ -171,7 +193,11 @@ Examples of **incorrect** code for this rule with `{"allowSamePrecedence": false
 var foo = a + b - c;
 ```
 
+:::
+
 Examples of **correct** code for this rule with `{"allowSamePrecedence": false}` option:
+
+::: correct
 
 ```js
 /*eslint no-mixed-operators: ["error", {"allowSamePrecedence": false}]*/
@@ -179,6 +205,8 @@ Examples of **correct** code for this rule with `{"allowSamePrecedence": false}`
 // + and - have the same precedence.
 var foo = (a + b) - c;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-mixed-requires.md
+++ b/docs/src/rules/no-mixed-requires.md
@@ -46,6 +46,8 @@ Configuring this rule with one boolean option `true` is deprecated.
 
 Examples of **incorrect** code for this rule with the default `{ "grouping": false, "allowCall": false }` options:
 
+::: incorrect
+
 ```js
 /*eslint no-mixed-requires: "error"*/
 
@@ -57,7 +59,11 @@ var async = require('async'),
     eslint = require('eslint');
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "grouping": false, "allowCall": false }` options:
+
+::: correct
 
 ```js
 /*eslint no-mixed-requires: "error"*/
@@ -78,9 +84,13 @@ var foo = require('foo' + VERSION),
     baz = require();
 ```
 
+:::
+
 ### grouping
 
 Examples of **incorrect** code for this rule with the `{ "grouping": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-mixed-requires: ["error", { "grouping": true }]*/
@@ -94,9 +104,13 @@ var foo = require('foo'),
     bar = require(getBarModuleName());
 ```
 
+:::
+
 ### allowCall
 
 Examples of **incorrect** code for this rule with the `{ "allowCall": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-mixed-requires: ["error", { "allowCall": true }]*/
@@ -106,7 +120,11 @@ var async = require('async'),
     eslint = require('eslint');
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "allowCall": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-mixed-requires: ["error", { "allowCall": true }]*/
@@ -115,6 +133,8 @@ var async = require('async'),
     debug = require('diagnostics')('my-module'),
     eslint = require('eslint');
 ```
+
+:::
 
 ## Known Limitations
 

--- a/docs/src/rules/no-mixed-spaces-and-tabs.md
+++ b/docs/src/rules/no-mixed-spaces-and-tabs.md
@@ -19,6 +19,8 @@ This rule disallows mixed spaces and tabs for indentation.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-mixed-spaces-and-tabs: "error"*/
 
@@ -37,7 +39,11 @@ function main() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-mixed-spaces-and-tabs: "error"*/
@@ -48,6 +54,8 @@ function add(x, y) {
 }
 ```
 
+:::
+
 ## Options
 
 This rule has a string option.
@@ -57,6 +65,8 @@ This rule has a string option.
 ### smart-tabs
 
 Examples of **correct** code for this rule with the `"smart-tabs"` option:
+
+::: correct
 
 ```js
 /*eslint no-mixed-spaces-and-tabs: ["error", "smart-tabs"]*/
@@ -69,3 +79,5 @@ function main() {
         y = 7;
 }
 ```
+
+:::

--- a/docs/src/rules/no-multi-assign.md
+++ b/docs/src/rules/no-multi-assign.md
@@ -25,6 +25,8 @@ This rule disallows using multiple assignments within a single statement.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-multi-assign: "error"*/
 
@@ -43,7 +45,11 @@ class Foo {
 a = b = "quux";
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-multi-assign: "error"*/
@@ -67,6 +73,8 @@ a = "quux";
 b = "quux";
 ```
 
+:::
+
 ## Options
 
 This rule has an object option:
@@ -76,6 +84,8 @@ This rule has an object option:
 ### ignoreNonDeclaration
 
 Examples of **correct** code for the `{ "ignoreNonDeclaration": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-multi-assign: ["error", { "ignoreNonDeclaration": true }]*/
@@ -89,7 +99,11 @@ const y = {};
 x.one = y.one = 1;
 ```
 
+:::
+
 Examples of **incorrect** code for the `{ "ignoreNonDeclaration": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-multi-assign: ["error", { "ignoreNonDeclaration": true }]*/
@@ -102,3 +116,5 @@ class Foo {
     a = b = 10;
 }
 ```
+
+:::

--- a/docs/src/rules/no-multi-spaces.md
+++ b/docs/src/rules/no-multi-spaces.md
@@ -39,6 +39,8 @@ This rule aims to disallow multiple whitespace around logical expressions, condi
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-multi-spaces: "error"*/
 
@@ -53,7 +55,11 @@ var arr = [1,  2];
 a ?  b: c
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-multi-spaces: "error"*/
@@ -69,6 +75,8 @@ var arr = [1, 2];
 a ? b: c
 ```
 
+:::
+
 ## Options
 
 This rule's configuration consists of an object with the following properties:
@@ -80,6 +88,8 @@ This rule's configuration consists of an object with the following properties:
 
 Examples of **incorrect** code for this rule with the `{ "ignoreEOLComments": false }` (default) option:
 
+::: incorrect
+
 ```js
 /*eslint no-multi-spaces: ["error", { ignoreEOLComments: false }]*/
 
@@ -89,7 +99,11 @@ var x = 5;      /* multiline
  */
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "ignoreEOLComments": false }` (default) option:
+
+::: correct
 
 ```js
 /*eslint no-multi-spaces: ["error", { ignoreEOLComments: false }]*/
@@ -100,7 +114,11 @@ var x = 5; /* multiline
  */
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "ignoreEOLComments": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-multi-spaces: ["error", { ignoreEOLComments: true }]*/
@@ -115,6 +133,8 @@ var x = 5;      /* multiline
  */
 ```
 
+:::
+
 ### exceptions
 
 To avoid contradictions with other rules that require multiple spaces, this rule has an `exceptions` option to ignore certain nodes.
@@ -124,6 +144,8 @@ This option is an object that expects property names to be AST node types as def
 Only the `Property` node type is ignored by default, because for the [key-spacing](key-spacing) rule some alignment options require multiple spaces in properties of object literals.
 
 Examples of **correct** code for the default `"exceptions": { "Property": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-multi-spaces: "error"*/
@@ -135,7 +157,11 @@ var obj = {
 };
 ```
 
+:::
+
 Examples of **incorrect** code for the `"exceptions": { "Property": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-multi-spaces: ["error", { exceptions: { "Property": false } }]*/
@@ -147,7 +173,11 @@ var obj = {
 };
 ```
 
+:::
+
 Examples of **correct** code for the `"exceptions": { "BinaryExpression": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-multi-spaces: ["error", { exceptions: { "BinaryExpression": true } }]*/
@@ -155,7 +185,11 @@ Examples of **correct** code for the `"exceptions": { "BinaryExpression": true }
 var a = 1  *  2;
 ```
 
+:::
+
 Examples of **correct** code for the `"exceptions": { "VariableDeclarator": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-multi-spaces: ["error", { exceptions: { "VariableDeclarator": true } }]*/
@@ -164,7 +198,11 @@ var someVar      = 'foo';
 var someOtherVar = 'barBaz';
 ```
 
+:::
+
 Examples of **correct** code for the `"exceptions": { "ImportDeclaration": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-multi-spaces: ["error", { exceptions: { "ImportDeclaration": true } }]*/
@@ -172,6 +210,8 @@ Examples of **correct** code for the `"exceptions": { "ImportDeclaration": true 
 import mod          from 'mod';
 import someOtherMod from 'some-other-mod';
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-multi-str.md
+++ b/docs/src/rules/no-multi-str.md
@@ -22,6 +22,8 @@ This rule is aimed at preventing the use of multiline strings.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-multi-str: "error"*/
 
@@ -29,7 +31,11 @@ var x = "some very \
 long text";
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-multi-str: "error"*/
@@ -39,3 +45,5 @@ var x = "some very long text";
 var x = "some very " +
         "long text";
 ```
+
+:::

--- a/docs/src/rules/no-multiple-empty-lines.md
+++ b/docs/src/rules/no-multiple-empty-lines.md
@@ -27,6 +27,8 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule with the default `{ "max": 2 }` option:
 
+::: incorrect
+
 ```js
 /*eslint no-multiple-empty-lines: "error"*/
 
@@ -35,9 +37,13 @@ var foo = 5;
 
 var bar = 3;
 ```
+
+:::
 
 Examples of **correct** code for this rule with the default `{ "max": 2 }` option:
 
+::: correct
+
 ```js
 /*eslint no-multiple-empty-lines: "error"*/
 
@@ -45,11 +51,15 @@ var foo = 5;
 
 var bar = 3;
 ```
+
+:::
 
 ### maxEOF
 
 Examples of **incorrect** code for this rule with the `{ max: 2, maxEOF: 0 }` options:
 
+::: incorrect
+
 ```js
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/
 
@@ -58,9 +68,13 @@ var foo = 5;
 var bar = 3;
 
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{ max: 2, maxEOF: 0 }` options:
 
+::: correct
+
 ```js
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/
 
@@ -69,9 +83,13 @@ var foo = 5;
 var bar = 3;
 ```
 
+:::
+
 **Note**: Although this ensures zero empty lines at the EOF, most editors will still show one empty line at the end if the file ends with a line break, as illustrated below. There is no empty line at the end of a file after the last `\n`, although editors may show an additional line. A true additional line would be represented by `\n\n`.
 
-**Incorrect**:
+**incorrect**:
+
+::: incorrect
 
 ```js
 1    /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/⏎
@@ -84,7 +102,11 @@ var bar = 3;
 8
 ```
 
-**Correct**:
+:::
+
+**correct**:
+
+::: correct
 
 ```js
 1    /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/⏎
@@ -96,9 +118,13 @@ var bar = 3;
 7
 ```
 
+:::
+
 ### maxBOF
 
 Examples of **incorrect** code for this rule with the `{ max: 2, maxBOF: 1 }` options:
+
+::: incorrect
 
 ```js
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxBOF": 1 }]*/
@@ -108,7 +134,11 @@ var foo = 5;
 var bar = 3;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ max: 2, maxBOF: 1 }` options:
+
+::: correct
 
 ```js
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxBOF": 1}]*/
@@ -117,6 +147,8 @@ var foo = 5;
 
 var bar = 3;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-native-reassign.md
+++ b/docs/src/rules/no-native-reassign.md
@@ -32,12 +32,16 @@ ESLint has the capability to configure global variables as read-only.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-native-reassign: "error"*/
 
 Object = null
 undefined = 1
 ```
+
+:::
 
 ```js
 /*eslint no-native-reassign: "error"*/
@@ -57,6 +61,8 @@ a = 1
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint no-native-reassign: "error"*/
 
@@ -64,6 +70,8 @@ a = 1
 var b = 1
 b = 2
 ```
+
+:::
 
 ```js
 /*eslint no-native-reassign: "error"*/

--- a/docs/src/rules/no-negated-condition.md
+++ b/docs/src/rules/no-negated-condition.md
@@ -18,6 +18,8 @@ This rule disallows negated conditions in either of the following:
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-negated-condition: "error"*/
 
@@ -42,7 +44,11 @@ if (a !== b) {
 !a ? c : b
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-negated-condition: "error"*/
@@ -63,3 +69,5 @@ if (a != b) {
 
 a ? b : c
 ```
+
+:::

--- a/docs/src/rules/no-negated-in-lhs.md
+++ b/docs/src/rules/no-negated-in-lhs.md
@@ -17,6 +17,8 @@ This rule disallows negating the left operand in `in` expressions.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-negated-in-lhs: "error"*/
 
@@ -26,7 +28,11 @@ if(!key in object) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-negated-in-lhs: "error"*/
@@ -40,6 +46,8 @@ if(('' + !key) in object) {
     // in a rare situation when that is the intended meaning
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-nested-ternary.md
+++ b/docs/src/rules/no-nested-ternary.md
@@ -22,6 +22,8 @@ The `no-nested-ternary` rule disallows nested ternary expressions.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-nested-ternary: "error"*/
 
@@ -30,7 +32,11 @@ var thing = foo ? bar : baz === qux ? quxx : foobar;
 foo ? baz === qux ? quxx() : foobar() : bar();
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-nested-ternary: "error"*/
@@ -47,3 +53,5 @@ if (foo) {
   thing = foobar;
 }
 ```
+
+:::

--- a/docs/src/rules/no-new-func.md
+++ b/docs/src/rules/no-new-func.md
@@ -25,6 +25,8 @@ This error is raised to highlight the use of a bad practice. By passing a string
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-new-func: "error"*/
 
@@ -36,7 +38,11 @@ var x = Function.bind(null, "a", "b", "return a + b")();
 var f = Function.bind(null, "a", "b", "return a + b"); // assuming that the result of Function.bind(...) will be eventually called.
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-new-func: "error"*/
@@ -45,6 +51,8 @@ var x = function (a, b) {
     return a + b;
 };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-new-object.md
+++ b/docs/src/rules/no-new-object.md
@@ -32,6 +32,8 @@ This rule disallows `Object` constructors.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-new-object: "error"*/
 
@@ -40,7 +42,11 @@ var myObject = new Object();
 new Object();
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-new-object: "error"*/
@@ -52,6 +58,8 @@ var myObject = {};
 var Object = function Object() {};
 new Object();
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-new-require.md
+++ b/docs/src/rules/no-new-require.md
@@ -35,13 +35,19 @@ This rule aims to eliminate use of the `new require` expression.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-new-require: "error"*/
 
 var appHeader = new require('app-header');
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-new-require: "error"*/
@@ -49,6 +55,8 @@ Examples of **correct** code for this rule:
 var AppHeader = require('app-header');
 var appHeader = new AppHeader();
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-new-symbol.md
+++ b/docs/src/rules/no-new-symbol.md
@@ -27,6 +27,8 @@ This rule is aimed at preventing the accidental calling of `Symbol` with the `ne
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-new-symbol: "error"*/
 /*eslint-env es6*/
@@ -34,7 +36,11 @@ Examples of **incorrect** code for this rule:
 var foo = new Symbol('foo');
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-new-symbol: "error"*/
@@ -48,6 +54,8 @@ function bar(Symbol) {
 }
 
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-new-wrappers.md
+++ b/docs/src/rules/no-new-wrappers.md
@@ -53,6 +53,8 @@ This rule aims to eliminate the use of `String`, `Number`, and `Boolean` with th
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-new-wrappers: "error"*/
 
@@ -65,7 +67,11 @@ var numberObject = new Number;
 var booleanObject = new Boolean;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-new-wrappers: "error"*/
@@ -75,6 +81,8 @@ var num = Number(someValue);
 
 var object = new MyString();
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-new.md
+++ b/docs/src/rules/no-new.md
@@ -27,13 +27,19 @@ This rule is aimed at maintaining consistency and convention by disallowing cons
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-new: "error"*/
 
 new Thing();
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-new: "error"*/
@@ -42,3 +48,5 @@ var thing = new Thing();
 
 Thing();
 ```
+
+:::

--- a/docs/src/rules/no-nonoctal-decimal-escape.md
+++ b/docs/src/rules/no-nonoctal-decimal-escape.md
@@ -34,6 +34,8 @@ This rule disallows `\8` and `\9` escape sequences in string literals.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-nonoctal-decimal-escape: "error"*/
 
@@ -50,7 +52,11 @@ var baz = "Don't use \8 and \9 escapes.";
 var quux = "\0\8";
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-nonoctal-decimal-escape: "error"*/
@@ -67,3 +73,5 @@ var baz = "Don't use \\8 and \\9 escapes.";
 
 var quux = "\0\u0038";
 ```
+
+:::

--- a/docs/src/rules/no-obj-calls.md
+++ b/docs/src/rules/no-obj-calls.md
@@ -33,6 +33,8 @@ This rule also disallows using these objects as constructors with the `new` oper
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-obj-calls: "error"*/
 /*eslint-env es2017*/
@@ -54,7 +56,11 @@ var atomics = Atomics();
 var newAtomics = new Atomics();
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-obj-calls: "error"*/
@@ -70,3 +76,5 @@ var value = Reflect.get({ x: 1, y: 2 }, "x");
 
 var first = Atomics.load(foo, 0);
 ```
+
+:::

--- a/docs/src/rules/no-octal-escape.md
+++ b/docs/src/rules/no-octal-escape.md
@@ -21,13 +21,19 @@ If ESLint parses code in strict mode, the parser (instead of this rule) reports 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-octal-escape: "error"*/
 
 var foo = "Copyright \251";
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-octal-escape: "error"*/
@@ -36,3 +42,5 @@ var foo = "Copyright \u00A9";   // unicode
 
 var foo = "Copyright \xA9";     // hexadecimal
 ```
+
+:::

--- a/docs/src/rules/no-octal.md
+++ b/docs/src/rules/no-octal.md
@@ -25,6 +25,8 @@ If ESLint parses code in strict mode, the parser (instead of this rule) reports 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-octal: "error"*/
 
@@ -32,13 +34,19 @@ var num = 071;
 var result = 5 + 07;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-octal: "error"*/
 
 var num  = "071";
 ```
+
+:::
 
 ## Compatibility
 

--- a/docs/src/rules/no-param-reassign.md
+++ b/docs/src/rules/no-param-reassign.md
@@ -19,6 +19,8 @@ This rule aims to prevent unintended behavior caused by modification or reassign
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-param-reassign: "error"*/
 
@@ -39,7 +41,11 @@ function foo(bar) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-param-reassign: "error"*/
@@ -49,6 +55,8 @@ function foo(bar) {
 }
 ```
 
+:::
+
 ## Options
 
 This rule takes one option, an object, with a boolean property `"props"`, and  arrays `"ignorePropertyModificationsFor"` and `"ignorePropertyModificationsForRegex"`. `"props"` is `false` by default. If `"props"` is set to `true`, this rule warns against the modification of parameter properties unless they're included in `"ignorePropertyModificationsFor"` or `"ignorePropertyModificationsForRegex"`, which is an empty array by default.
@@ -56,6 +64,8 @@ This rule takes one option, an object, with a boolean property `"props"`, and  a
 ### props
 
 Examples of **correct** code for the default `{ "props": false }` option:
+
+::: correct
 
 ```js
 /*eslint no-param-reassign: ["error", { "props": false }]*/
@@ -81,7 +91,11 @@ function foo(bar) {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for the `{ "props": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-param-reassign: ["error", { "props": true }]*/
@@ -107,7 +121,11 @@ function foo(bar) {
 }
 ```
 
+:::
+
 Examples of **correct** code for the `{ "props": true }` option with `"ignorePropertyModificationsFor"` set:
+
+::: correct
 
 ```js
 /*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsFor": ["bar"] }]*/
@@ -133,7 +151,11 @@ function foo(bar) {
 }
 ```
 
+:::
+
 Examples of **correct** code for the `{ "props": true }` option with `"ignorePropertyModificationsForRegex"` set:
+
+::: correct
 
 ```js
 /*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsForRegex": ["^bar"] }]*/
@@ -158,6 +180,8 @@ function foo(barBaz) {
     for (barBaz.aaa of baz) {}
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-path-concat.md
+++ b/docs/src/rules/no-path-concat.md
@@ -37,6 +37,8 @@ This rule aims to prevent string concatenation of directory paths in Node.js
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-path-concat: "error"*/
 
@@ -46,13 +48,19 @@ var fullPath = __filename + "/foo.js";
 
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-path-concat: "error"*/
 
 var fullPath = dirname + "/foo.js";
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-plusplus.md
+++ b/docs/src/rules/no-plusplus.md
@@ -34,6 +34,8 @@ This rule disallows the unary operators `++` and `--`.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-plusplus: "error"*/
 
@@ -48,7 +50,11 @@ for (i = 0; i < l; i++) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-plusplus: "error"*/
@@ -64,6 +70,8 @@ for (i = 0; i < l; i += 1) {
 }
 ```
 
+:::
+
 ## Options
 
 This rule has an object option.
@@ -73,6 +81,8 @@ This rule has an object option.
 ### allowForLoopAfterthoughts
 
 Examples of **correct** code for this rule with the `{ "allowForLoopAfterthoughts": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }]*/
@@ -90,7 +100,11 @@ for (i = 0, j = l; i < l; i++, j--) {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "allowForLoopAfterthoughts": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }]*/
@@ -105,3 +119,5 @@ for (i = l; i--;) {
 
 for (i = 0; i < l;) i++;
 ```
+
+:::

--- a/docs/src/rules/no-process-env.md
+++ b/docs/src/rules/no-process-env.md
@@ -20,6 +20,8 @@ This rule is aimed at discouraging use of `process.env` to avoid global dependen
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-process-env: "error"*/
 
@@ -28,7 +30,11 @@ if(process.env.NODE_ENV === "development") {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-process-env: "error"*/
@@ -39,6 +45,8 @@ if(config.env === "development") {
     //...
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-process-exit.md
+++ b/docs/src/rules/no-process-exit.md
@@ -36,6 +36,8 @@ This rule aims to prevent the use of `process.exit()` in Node.js JavaScript. As 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-process-exit: "error"*/
 
@@ -43,7 +45,11 @@ process.exit(1);
 process.exit(0);
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-process-exit: "error"*/
@@ -51,6 +57,8 @@ Examples of **correct** code for this rule:
 Process.exit();
 var exit = process.exit;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-promise-executor-return.md
+++ b/docs/src/rules/no-promise-executor-return.md
@@ -37,6 +37,8 @@ Only `return` without a value is allowed, as it's a control flow statement.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-promise-executor-return: "error"*/
 
@@ -66,7 +68,11 @@ new Promise(() => {
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-promise-executor-return: "error"*/
@@ -97,3 +103,5 @@ new Promise((resolve, reject) => {
 
 Promise.resolve(1);
 ```
+
+:::

--- a/docs/src/rules/no-proto.md
+++ b/docs/src/rules/no-proto.md
@@ -17,6 +17,8 @@ When an object is created with the `new` operator, `__proto__` is set to the ori
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-proto: "error"*/
 
@@ -29,7 +31,11 @@ obj.__proto__ = b;
 obj["__proto__"] = b;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-proto: "error"*/
@@ -40,6 +46,8 @@ Object.setPrototypeOf(obj, b);
 
 var c = { __proto__: a };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-prototype-builtins.md
+++ b/docs/src/rules/no-prototype-builtins.md
@@ -21,6 +21,8 @@ This rule disallows calling some `Object.prototype` methods directly on object i
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-prototype-builtins: "error"*/
 
@@ -31,7 +33,11 @@ var isPrototypeOfBar = foo.isPrototypeOf(bar);
 var barIsEnumerable = foo.propertyIsEnumerable("bar");
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-prototype-builtins: "error"*/
@@ -42,6 +48,8 @@ var isPrototypeOfBar = Object.prototype.isPrototypeOf.call(foo, bar);
 
 var barIsEnumerable = {}.propertyIsEnumerable.call(foo, "bar");
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-redeclare.md
+++ b/docs/src/rules/no-redeclare.md
@@ -19,6 +19,8 @@ This rule is aimed at eliminating variables that have multiple declarations in t
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-redeclare: "error"*/
 
@@ -38,7 +40,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-redeclare: "error"*/
@@ -60,6 +66,8 @@ class C {
 
 ```
 
+:::
+
 ## Options
 
 This rule takes one optional argument, an object with a boolean property `"builtinGlobals"`. It defaults to `true`.
@@ -71,13 +79,19 @@ The `"builtinGlobals"` option will check for redeclaration of built-in globals i
 
 Examples of **incorrect** code for the `{ "builtinGlobals": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint no-redeclare: ["error", { "builtinGlobals": true }]*/
 
 var Object = 0;
 ```
 
+:::
+
 Examples of **incorrect** code for the `{ "builtinGlobals": true }` option and the `browser` environment:
+
+::: incorrect
 
 ```js
 /*eslint no-redeclare: ["error", { "builtinGlobals": true }]*/
@@ -85,6 +99,8 @@ Examples of **incorrect** code for the `{ "builtinGlobals": true }` option and t
 
 var top = 0;
 ```
+
+:::
 
 The `browser` environment has many built-in global variables (for example, `top`). Some of built-in global variables cannot be redeclared.
 

--- a/docs/src/rules/no-regex-spaces.md
+++ b/docs/src/rules/no-regex-spaces.md
@@ -34,6 +34,8 @@ This rule disallows multiple spaces in regular expression literals.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-regex-spaces: "error"*/
 
@@ -41,7 +43,11 @@ var re = /foo   bar/;
 var re = new RegExp("foo   bar");
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-regex-spaces: "error"*/
@@ -49,6 +55,8 @@ Examples of **correct** code for this rule:
 var re = /foo {3}bar/;
 var re = new RegExp("foo {3}bar");
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-reserved-keys.md
+++ b/docs/src/rules/no-reserved-keys.md
@@ -29,6 +29,8 @@ This rule is aimed at eliminating the use of ECMAScript 3 keywords and reserved 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 var superman = {
     class: "Superhero",
@@ -40,7 +42,11 @@ var values = {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 var superman = {
@@ -52,6 +58,8 @@ var values = {
     "enum": ["red", "blue", "green"]
 };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-restricted-exports.md
+++ b/docs/src/rules/no-restricted-exports.md
@@ -23,6 +23,8 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-restricted-exports: ["error", {
     "restrictedNamedExports": ["foo", "bar", "Baz", "a", "b", "c", "d", "e", "👍"]
@@ -49,7 +51,11 @@ export { something as e } from "some_module";
 export { "👍" } from "some_module";
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-restricted-exports: ["error", {
@@ -77,11 +83,15 @@ export { something } from "some_module";
 export { "👍" as thumbsUp } from "some_module";
 ```
 
+:::
+
 ### Default exports
 
 By design, this rule doesn't disallow `export default` declarations. If you configure `"default"` as a restricted name, that restriction will apply only to named export declarations.
 
 Examples of additional **incorrect** code for this rule:
+
+::: incorrect
 
 ```js
 /*eslint no-restricted-exports: ["error", { "restrictedNamedExports": ["default"] }]*/
@@ -91,6 +101,8 @@ function foo() {}
 export { foo as default };
 ```
 
+:::
+
 ```js
 /*eslint no-restricted-exports: ["error", { "restrictedNamedExports": ["default"] }]*/
 
@@ -99,11 +111,15 @@ export { default } from "some_module";
 
 Examples of additional **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint no-restricted-exports: ["error", { "restrictedNamedExports": ["default", "foo"] }]*/
 
 export default function foo() {}
 ```
+
+:::
 
 ## Known Limitations
 

--- a/docs/src/rules/no-restricted-globals.md
+++ b/docs/src/rules/no-restricted-globals.md
@@ -55,6 +55,8 @@ Alternatively, the rule also accepts objects, where the global name and an optio
 
 Examples of **incorrect** code for sample `"event", "fdescribe"` global variable names:
 
+::: incorrect
+
 ```js
 /*global event, fdescribe*/
 /*eslint no-restricted-globals: ["error", "event", "fdescribe"]*/
@@ -67,7 +69,11 @@ fdescribe("foo", function() {
 });
 ```
 
+:::
+
 Examples of **correct** code for a sample `"event"` global variable name:
+
+::: correct
 
 ```js
 /*global event*/
@@ -75,6 +81,8 @@ Examples of **correct** code for a sample `"event"` global variable name:
 
 import event from "event-module";
 ```
+
+:::
 
 ```js
 /*global event*/
@@ -85,6 +93,8 @@ var event = 1;
 
 Examples of **incorrect** code for a sample `"event"` global variable name, along with a custom error message:
 
+::: incorrect
+
 ```js
 /*global event*/
 /* eslint no-restricted-globals: ["error", { name: "event", message: "Use local parameter instead." }] */
@@ -93,3 +103,5 @@ function onClick() {
     console.log(event);    // Unexpected global variable 'event'. Use local parameter instead.
 }
 ```
+
+:::

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -121,11 +121,15 @@ To restrict the use of all Node.js core imports (via <https://github.com/nodejs/
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
 
 import fs from 'fs';
 ```
+
+:::
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
@@ -205,12 +209,16 @@ import pick from 'fooBar';
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
 
 import crypto from 'crypto';
 export { foo } from "bar";
 ```
+
+:::
 
 ```js
 /*eslint no-restricted-imports: ["error", { "paths": ["fs"], "patterns": ["eslint/*"] }]*/

--- a/docs/src/rules/no-restricted-modules.md
+++ b/docs/src/rules/no-restricted-modules.md
@@ -78,12 +78,16 @@ To restrict the use of all Node.js core modules (via <https://github.com/nodejs/
 
 Examples of **incorrect** code for this rule  with sample `"fs", "cluster", "lodash"` restricted modules:
 
+::: incorrect
+
 ```js
 /*eslint no-restricted-modules: ["error", "fs", "cluster"]*/
 
 var fs = require('fs');
 var cluster = require('cluster');
 ```
+
+:::
 
 ```js
 /*eslint no-restricted-modules: ["error", {"paths": ["cluster"] }]*/
@@ -99,11 +103,15 @@ var pick = require('lodash/pick');
 
 Examples of **correct** code for this rule with sample `"fs", "cluster", "lodash"` restricted modules:
 
+::: correct
+
 ```js
 /*eslint no-restricted-modules: ["error", "fs", "cluster"]*/
 
 var crypto = require('crypto');
 ```
+
+:::
 
 ```js
 /*eslint no-restricted-modules: ["error", {

--- a/docs/src/rules/no-restricted-properties.md
+++ b/docs/src/rules/no-restricted-properties.md
@@ -76,6 +76,8 @@ If the property name is omitted, accessing any property of the given object is d
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /* eslint no-restricted-properties: [2, {
     "object": "disallowedObjectName",
@@ -86,6 +88,8 @@ var example = disallowedObjectName.disallowedPropertyName; /*error Disallowed ob
 
 disallowedObjectName.disallowedPropertyName(); /*error Disallowed object property: disallowedObjectName.disallowedPropertyName.*/
 ```
+
+:::
 
 ```js
 /* eslint no-restricted-properties: [2, {
@@ -105,6 +109,8 @@ require.resolve('foo');
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /* eslint no-restricted-properties: [2, {
     "object": "disallowedObjectName",
@@ -115,6 +121,8 @@ var example = disallowedObjectName.somePropertyName;
 
 allowedObjectName.disallowedPropertyName();
 ```
+
+:::
 
 ```js
 /* eslint no-restricted-properties: [2, {

--- a/docs/src/rules/no-restricted-syntax.md
+++ b/docs/src/rules/no-restricted-syntax.md
@@ -60,6 +60,8 @@ The string and object formats can be freely mixed in the configuration as needed
 
 Examples of **incorrect** code for this rule with the `"FunctionExpression", "WithStatement", BinaryExpression[operator='in']` options:
 
+::: incorrect
+
 ```js
 /* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement", "BinaryExpression[operator='in']"] */
 
@@ -72,7 +74,11 @@ var doSomething = function () {};
 foo in bar;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"FunctionExpression", "WithStatement", BinaryExpression[operator='in']` options:
+
+::: correct
 
 ```js
 /* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement", "BinaryExpression[operator='in']"] */
@@ -83,6 +89,8 @@ function doSomething() {};
 
 foo instanceof bar;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-return-assign.md
+++ b/docs/src/rules/no-return-assign.md
@@ -37,6 +37,8 @@ It disallows assignments unless they are enclosed in parentheses.
 
 Examples of **incorrect** code for the default `"except-parens"` option:
 
+::: incorrect
+
 ```js
 /*eslint no-return-assign: "error"*/
 
@@ -57,7 +59,11 @@ function doSomething() {
 }
 ```
 
+:::
+
 Examples of **correct** code for the default `"except-parens"` option:
+
+::: correct
 
 ```js
 /*eslint no-return-assign: "error"*/
@@ -83,12 +89,16 @@ function doSomething() {
 }
 ```
 
+:::
+
 ### always
 
 This option disallows all assignments in `return` statements.
 All assignments are treated as problems.
 
 Examples of **incorrect** code for the `"always"` option:
+
+::: incorrect
 
 ```js
 /*eslint no-return-assign: ["error", "always"]*/
@@ -106,7 +116,11 @@ function doSomething() {
 }
 ```
 
+:::
+
 Examples of **correct** code for the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint no-return-assign: ["error", "always"]*/
@@ -119,6 +133,8 @@ function doSomething() {
     return foo === bar + 2;
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -20,6 +20,8 @@ This rule aims to prevent a likely common performance hazard due to a lack of un
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-return-await: "error"*/
 
@@ -28,7 +30,11 @@ async function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-return-await: "error"*/
@@ -55,6 +61,8 @@ async function foo() {
     } catch (error) {}
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-script-url.md
+++ b/docs/src/rules/no-script-url.md
@@ -15,6 +15,8 @@ Using `javascript:` URLs is considered by some as a form of `eval`. Code passed 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-script-url: "error"*/
 
@@ -22,6 +24,8 @@ location.href = "javascript:void(0)";
 
 location.href = `javascript:void(0)`;
 ```
+
+:::
 
 ## Compatibility
 

--- a/docs/src/rules/no-self-assign.md
+++ b/docs/src/rules/no-self-assign.md
@@ -23,6 +23,8 @@ This rule is aimed at eliminating self assignments.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-self-assign: "error"*/
 
@@ -39,7 +41,11 @@ foo ||= foo;
 foo ??= foo;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-self-assign: "error"*/
@@ -72,6 +78,8 @@ obj[a + b] = obj[a + b];
 obj["a" + "b"] = obj["a" + "b"];
 ```
 
+:::
+
 ## Options
 
 This rule has the option to check properties as well.
@@ -88,6 +96,8 @@ This rule has the option to check properties as well.
 
 Examples of **correct** code with the `{ "props": false }` option:
 
+::: correct
+
 ```js
 /*eslint no-self-assign: ["error", {"props": false}]*/
 
@@ -97,6 +107,8 @@ obj.a.b = obj.a.b;
 obj["a"] = obj["a"];
 obj[a] = obj[a];
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-self-compare.md
+++ b/docs/src/rules/no-self-compare.md
@@ -17,6 +17,8 @@ This error is raised to highlight a potentially confusing and potentially pointl
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-self-compare: "error"*/
 
@@ -25,3 +27,5 @@ if (x === x) {
     x = 20;
 }
 ```
+
+:::

--- a/docs/src/rules/no-sequences.md
+++ b/docs/src/rules/no-sequences.md
@@ -28,6 +28,8 @@ This rule forbids the use of the comma operator, with the following exceptions:
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-sequences: "error"*/
 
@@ -48,7 +50,11 @@ while (val = foo(), val < 42);
 with (doSomething(), val) {}
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-sequences: "error"*/
@@ -70,11 +76,15 @@ while ((val = foo(), val < 42));
 with ((doSomething(), val)) {}
 ```
 
+:::
+
 ### Note about arrow function bodies
 
 If an arrow function body is a statement rather than a block, and that statement contains a sequence, you need to use double parentheses around the statement to indicate that the sequence is intentional.
 
 Examples of **incorrect** code for arrow functions:
+
+::: incorrect
 
 ```js
 /*eslint no-sequences: "error"*/
@@ -85,7 +95,11 @@ const foo = () => ((bar = 123), 10);
 const foo = () => { return (bar = 123), 10 }
 ```
 
+:::
+
 Examples of **correct** code for arrow functions:
+
+::: correct
 
 ```js
 /*eslint no-sequences: "error"*/
@@ -96,6 +110,8 @@ const foo = () => (((bar = 123), 10));
 const foo = () => { return ((bar = 123), 10) }
 ```
 
+:::
+
 ## Options
 
 This rule takes one option, an object, with the following properties:
@@ -105,6 +121,8 @@ This rule takes one option, an object, with the following properties:
 ### allowInParentheses
 
 Examples of **incorrect** code for this rule with the `{ "allowInParentheses": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-sequences: ["error", { "allowInParentheses": false }]*/
@@ -128,13 +146,19 @@ with ((doSomething(), val)) {}
 const foo = (val) => ((console.log('bar'), val));
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "allowInParentheses": false }` option:
+
+::: correct
 
 ```js
 /*eslint no-sequences: ["error", { "allowInParentheses": false }]*/
 
 for (i = 0, j = 10; i < j; i++, j--);
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-setter-return.md
+++ b/docs/src/rules/no-setter-return.md
@@ -31,6 +31,8 @@ This rule checks setters in:
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-setter-return: "error"*/
 
@@ -68,7 +70,11 @@ Object.defineProperty(foo, "bar", {
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-setter-return: "error"*/
@@ -104,3 +110,5 @@ Object.defineProperty(foo, "bar", {
     }
 });
 ```
+
+:::

--- a/docs/src/rules/no-shadow-restricted-names.md
+++ b/docs/src/rules/no-shadow-restricted-names.md
@@ -26,6 +26,8 @@ Then any code used within the same scope would not get the global `undefined`, b
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-shadow-restricted-names: "error"*/
 
@@ -38,7 +40,11 @@ var undefined = 5;
 try {} catch(eval){}
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-shadow-restricted-names: "error"*/
@@ -50,3 +56,5 @@ function f(a, b){}
 // Exception: `undefined` may be shadowed if the variable is never assigned a value.
 var undefined;
 ```
+
+:::

--- a/docs/src/rules/no-shadow.md
+++ b/docs/src/rules/no-shadow.md
@@ -28,6 +28,8 @@ This rule aims to eliminate shadowed variable declarations.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-shadow: "error"*/
 /*eslint-env es6*/
@@ -51,6 +53,8 @@ if (true) {
 }
 ```
 
+:::
+
 ## Options
 
 This rule takes one option, an object, with properties `"builtinGlobals"`, `"hoist"`, `"allow"` and `"ignoreOnInitialization"`.
@@ -68,6 +72,8 @@ If it is `true`, the rule prevents shadowing of built-in global variables: `Obje
 
 Examples of **incorrect** code for the `{ "builtinGlobals": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint no-shadow: ["error", { "builtinGlobals": true }]*/
 
@@ -75,6 +81,8 @@ function foo() {
     var Object = 0;
 }
 ```
+
+:::
 
 ### hoist
 
@@ -88,6 +96,8 @@ The `hoist` option has three settings:
 
 Examples of **incorrect** code for the default `{ "hoist": "functions" }` option:
 
+::: incorrect
+
 ```js
 /*eslint no-shadow: ["error", { "hoist": "functions" }]*/
 /*eslint-env es6*/
@@ -99,9 +109,13 @@ if (true) {
 function b() {}
 ```
 
+:::
+
 Although `let b` in the `if` statement is before the *function* declaration in the outer scope, it is incorrect.
 
 Examples of **correct** code for the default `{ "hoist": "functions" }` option:
+
+::: correct
 
 ```js
 /*eslint no-shadow: ["error", { "hoist": "functions" }]*/
@@ -114,11 +128,15 @@ if (true) {
 let a = 5;
 ```
 
+:::
+
 Because `let a` in the `if` statement is before the *variable* declaration in the outer scope, it is correct.
 
 #### hoist: all
 
 Examples of **incorrect** code for the `{ "hoist": "all" }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-shadow: ["error", { "hoist": "all" }]*/
@@ -133,9 +151,13 @@ let a = 5;
 function b() {}
 ```
 
+:::
+
 #### hoist: never
 
 Examples of **correct** code for the `{ "hoist": "never" }` option:
+
+::: correct
 
 ```js
 /*eslint no-shadow: ["error", { "hoist": "never" }]*/
@@ -150,6 +172,8 @@ let a = 5;
 function b() {}
 ```
 
+:::
+
 Because `let a` and `let b` in the `if` statement are before the declarations in the outer scope, they are correct.
 
 ### allow
@@ -157,6 +181,8 @@ Because `let a` and `let b` in the `if` statement are before the declarations in
 The `allow` option is an array of identifier names for which shadowing is allowed. For example, `"resolve"`, `"reject"`, `"done"`, `"cb"`.
 
 Examples of **correct** code for the `{ "allow": ["done"] }` option:
+
+::: correct
 
 ```js
 /*eslint no-shadow: ["error", { "allow": ["done"] }]*/
@@ -175,6 +201,8 @@ foo(function (err, result) {
 });
 ```
 
+:::
+
 ### ignoreOnInitialization
 
 The `ignoreOnInitialization` option is `false` by default. If it is `true`, it prevents reporting shadowing of variables in their initializers when the shadowed variable is presumably still uninitialized.
@@ -183,15 +211,21 @@ The shadowed variable must be on the left side. The shadowing variable must be o
 
 Examples of **incorrect** code for the `{ "ignoreOnInitialization": "true" }` option:
 
+::: incorrect
+
 ```js
 /*eslint no-shadow: ["error", { "ignoreOnInitialization": true }]*/
 
 var x = x => x;
 ```
 
+:::
+
 Because the shadowing variable `x` will shadow the already initialized shadowed variable `x`.
 
 Examples of **correct** code for the `{ "ignoreOnInitialization": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-shadow: ["error", { "ignoreOnInitialization": true }]*/
@@ -200,5 +234,7 @@ var x = foo(x => x)
 
 var y = (y => y)()
 ```
+
+:::
 
 The rationale for callback functions is the assumption that they will be called during the initialization, so that at the time when the shadowing variable will be used, the shadowed variable has not yet been initialized.

--- a/docs/src/rules/no-space-before-semi.md
+++ b/docs/src/rules/no-space-before-semi.md
@@ -28,6 +28,8 @@ This rule prevents the use of spaces before a semicolon in expressions.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 var foo = "bar" ;
 
@@ -39,10 +41,16 @@ var foo = function() {
 var foo = 1 + 2 ;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 ;(function(){}());
 
 var foo = "bar";
 ```
+
+:::

--- a/docs/src/rules/no-spaced-func.md
+++ b/docs/src/rules/no-spaced-func.md
@@ -19,6 +19,8 @@ This rule disallows spacing between function identifiers and their applications.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-spaced-func: "error"*/
 
@@ -28,10 +30,16 @@ fn
 ()
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-spaced-func: "error"*/
 
 fn()
 ```
+
+:::

--- a/docs/src/rules/no-sparse-arrays.md
+++ b/docs/src/rules/no-sparse-arrays.md
@@ -33,6 +33,8 @@ This rule disallows sparse array literals which have "holes" where commas are no
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-sparse-arrays: "error"*/
 
@@ -40,7 +42,11 @@ var items = [,];
 var colors = [ "red",, "blue" ];
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-sparse-arrays: "error"*/
@@ -51,6 +57,8 @@ var items = new Array(23);
 // trailing comma (after the last element) is not a problem
 var colors = [ "red", "blue", ];
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-sync.md
+++ b/docs/src/rules/no-sync.md
@@ -21,6 +21,8 @@ This rule has an optional object option `{ allowAtRootLevel: <boolean> }`, which
 
 Examples of **incorrect** code for this rule with the default `{ allowAtRootLevel: false }` option:
 
+::: incorrect
+
 ```js
 /*eslint no-sync: "error"*/
 
@@ -31,7 +33,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ allowAtRootLevel: false }` option:
+
+::: correct
 
 ```js
 /*eslint no-sync: "error"*/
@@ -43,7 +49,11 @@ async(function() {
 });
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ allowAtRootLevel: true }` option
+
+::: incorrect
 
 ```js
 /*eslint no-sync: ["error", { allowAtRootLevel: true }]*/
@@ -55,13 +65,19 @@ function foo() {
 var bar = baz => fs.readFileSync(qux);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ allowAtRootLevel: true }` option
+
+::: correct
 
 ```js
 /*eslint no-sync: ["error", { allowAtRootLevel: true }]*/
 
 fs.readFileSync(somePath).toString();
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-tabs.md
+++ b/docs/src/rules/no-tabs.md
@@ -15,6 +15,8 @@ This rule looks for tabs anywhere inside a file: code, comments or anything else
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 var a \t= 2;
 
@@ -26,7 +28,11 @@ function test(){}
 var x = 1; // \t test
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 var a = 2;
@@ -39,6 +45,8 @@ function test(){}
 var x = 1; // test
 ```
 
+:::
+
 ### Options
 
 This rule has an optional object option with the following properties:
@@ -49,6 +57,8 @@ This rule has an optional object option with the following properties:
 
 Examples of **correct** code for this rule with the `allowIndentationTabs: true` option:
 
+::: correct
+
 ```js
 /* eslint no-tabs: ["error", { allowIndentationTabs: true }] */
 
@@ -58,6 +68,8 @@ function test() {
 
 \t// comment with leading indentation tab
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-template-curly-in-string.md
+++ b/docs/src/rules/no-template-curly-in-string.md
@@ -17,6 +17,8 @@ This rule aims to warn when a regular string contains what looks like a template
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-template-curly-in-string: "error"*/
 "Hello ${name}!";
@@ -24,7 +26,11 @@ Examples of **incorrect** code for this rule:
 "Time: ${12 * 60 * 60 * 1000}";
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-template-curly-in-string: "error"*/
@@ -33,6 +39,8 @@ Examples of **correct** code for this rule:
 
 templateFunction`Hello ${name}`;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-ternary.md
+++ b/docs/src/rules/no-ternary.md
@@ -22,6 +22,8 @@ This rule disallows ternary operators.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-ternary: "error"*/
 
@@ -32,7 +34,11 @@ function quux() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-ternary: "error"*/
@@ -53,3 +59,5 @@ function quux() {
     }
 }
 ```
+
+:::

--- a/docs/src/rules/no-this-before-super.md
+++ b/docs/src/rules/no-this-before-super.md
@@ -21,6 +21,8 @@ This rule is aimed to flag `this`/`super` keywords before `super()` callings.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-this-before-super: "error"*/
 /*eslint-env es6*/
@@ -53,7 +55,11 @@ class A extends B {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-this-before-super: "error"*/
@@ -78,6 +84,8 @@ class A extends B {
     }
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-throw-literal.md
+++ b/docs/src/rules/no-throw-literal.md
@@ -18,6 +18,8 @@ This rule is aimed at maintaining consistency when throwing exception by disallo
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-throw-literal: "error"*/
 /*eslint-env es6*/
@@ -39,7 +41,11 @@ throw `${err}`
 
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-throw-literal: "error"*/
@@ -58,11 +64,15 @@ try {
 }
 ```
 
+:::
+
 ## Known Limitations
 
 Due to the limits of static analysis, this rule cannot guarantee that you will only throw `Error` objects.
 
 Examples of **correct** code for this rule, but which do not throw an `Error` object:
+
+::: correct
 
 ```js
 /*eslint no-throw-literal: "error"*/
@@ -82,3 +92,5 @@ var foo = {
 };
 throw foo.bar;
 ```
+
+:::

--- a/docs/src/rules/no-trailing-spaces.md
+++ b/docs/src/rules/no-trailing-spaces.md
@@ -17,6 +17,8 @@ This rule disallows trailing whitespace (spaces, tabs, and other Unicode whitesp
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-trailing-spaces: "error"*/
 
@@ -25,7 +27,11 @@ var baz = 5;//••
 //•••••
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-trailing-spaces: "error"*/
@@ -33,6 +39,8 @@ Examples of **correct** code for this rule:
 var foo = 0;
 var baz = 5;
 ```
+
+:::
 
 ## Options
 
@@ -47,6 +55,8 @@ This rule has an object option:
 
 Examples of **correct** code for this rule with the `{ "skipBlankLines": true }` option:
 
+::: correct
+
 ```js
 /*eslint no-trailing-spaces: ["error", { "skipBlankLines": true }]*/
 
@@ -55,9 +65,13 @@ var baz = 5;
 //•••••
 ```
 
+:::
+
 ### ignoreComments
 
 Examples of **correct** code for this rule with the `{ "ignoreComments": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-trailing-spaces: ["error", { "ignoreComments": true }]*/
@@ -70,3 +84,5 @@ Examples of **correct** code for this rule with the `{ "ignoreComments": true }`
  *•bar
  */
 ```
+
+:::

--- a/docs/src/rules/no-undef-init.md
+++ b/docs/src/rules/no-undef-init.md
@@ -34,6 +34,8 @@ This rule aims to eliminate `var` and `let` variable declarations that initializ
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-undef-init: "error"*/
 
@@ -41,7 +43,11 @@ var foo = undefined;
 let bar = undefined;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-undef-init: "error"*/
@@ -50,9 +56,13 @@ var foo;
 let bar;
 ```
 
+:::
+
 Please note that this rule does not check `const` declarations, destructuring patterns, function parameters, and class fields.
 
 Examples of additional **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-undef-init: "error"*/
@@ -70,11 +80,15 @@ class Foo {
 }
 ```
 
+:::
+
 ## When Not To Use It
 
 There is one situation where initializing to `undefined` behaves differently than omitting the initialization, and that's when a `var` declaration occurs inside of a loop. For example:
 
 Example of **incorrect** code for this rule:
+
+::: incorrect
 
 ```js
 for (i = 0; i < 10; i++) {
@@ -83,6 +97,8 @@ for (i = 0; i < 10; i++) {
     x = i;
 }
 ```
+
+:::
 
 In this case, the `var x` is hoisted out of the loop, effectively creating:
 
@@ -123,6 +139,8 @@ If you're using such an initialization inside of a loop, then you should disable
 
 Example of **correct** code for this rule, because it is disabled on a specific line:
 
+::: correct
+
 ```js
 /*eslint no-undef-init: "error"*/
 
@@ -132,3 +150,5 @@ for (i = 0; i < 10; i++) {
     x = i;
 }
 ```
+
+:::

--- a/docs/src/rules/no-undef.md
+++ b/docs/src/rules/no-undef.md
@@ -20,6 +20,8 @@ Any reference to an undeclared variable causes a warning, unless the variable is
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-undef: "error"*/
 
@@ -27,7 +29,11 @@ var foo = someFunction();
 var bar = a + 1;
 ```
 
+:::
+
 Examples of **correct** code for this rule with `global` declaration:
+
+::: correct
 
 ```js
 /*global someFunction, a*/
@@ -36,6 +42,8 @@ Examples of **correct** code for this rule with `global` declaration:
 var foo = someFunction();
 var bar = a + 1;
 ```
+
+:::
 
 Note that this rule does not disallow assignments to read-only global variables.
 See [no-global-assign](no-global-assign) if you also want to disallow those assignments.
@@ -51,6 +59,8 @@ See [no-redeclare](no-redeclare) if you also want to disallow those redeclaratio
 
 Examples of **correct** code for the default `{ "typeof": false }` option:
 
+::: correct
+
 ```js
 /*eslint no-undef: "error"*/
 
@@ -59,9 +69,13 @@ if (typeof UndefinedIdentifier === "undefined") {
 }
 ```
 
+:::
+
 You can use this option if you want to prevent `typeof` check on a variable which has not been declared.
 
 Examples of **incorrect** code for the `{ "typeof": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-undef: ["error", { "typeof": true }] */
@@ -69,7 +83,11 @@ Examples of **incorrect** code for the `{ "typeof": true }` option:
 if(typeof a === "string"){}
 ```
 
+:::
+
 Examples of **correct** code for the `{ "typeof": true }` option with `global` declaration:
+
+::: correct
 
 ```js
 /*global a*/
@@ -78,6 +96,8 @@ Examples of **correct** code for the `{ "typeof": true }` option with `global` d
 if(typeof a === "string"){}
 ```
 
+:::
+
 ## Environments
 
 For convenience, ESLint provides shortcuts that pre-define global variables exposed by popular libraries and runtime environments. This rule supports these environments, as listed in [Specifying Environments](../user-guide/configuring/language-options#specifying-environments).  A few examples are given below.
@@ -85,6 +105,8 @@ For convenience, ESLint provides shortcuts that pre-define global variables expo
 ### browser
 
 Examples of **correct** code for this rule with `browser` environment:
+
+::: correct
 
 ```js
 /*eslint no-undef: "error"*/
@@ -95,9 +117,13 @@ setTimeout(function() {
 });
 ```
 
+:::
+
 ### Node.js
 
 Examples of **correct** code for this rule with `node` environment:
+
+::: correct
 
 ```js
 /*eslint no-undef: "error"*/
@@ -108,6 +134,8 @@ module.exports = function() {
     console.log(fs);
 };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-undefined.md
+++ b/docs/src/rules/no-undefined.md
@@ -44,6 +44,8 @@ This rule aims to eliminate the use of `undefined`, and as such, generates a war
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-undefined: "error"*/
 
@@ -60,7 +62,11 @@ function foo(undefined) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-undefined: "error"*/
@@ -75,6 +81,8 @@ if (typeof foo === "undefined") {
 
 global.undefined = "foo";
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-underscore-dangle.md
+++ b/docs/src/rules/no-underscore-dangle.md
@@ -23,6 +23,8 @@ This rule disallows dangling underscores in identifiers.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-underscore-dangle: "error"*/
 
@@ -31,7 +33,11 @@ var __proto__ = {};
 foo._bar();
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-underscore-dangle: "error"*/
@@ -44,6 +50,8 @@ function foo(_bar) {};
 const foo = { onClick(_bar) {} };
 const foo = (_bar) => {};
 ```
+
+:::
 
 ## Options
 
@@ -61,6 +69,8 @@ This rule has an object option:
 
 Examples of additional **correct** code for this rule with the `{ "allow": ["foo_", "_bar"] }` option:
 
+::: correct
+
 ```js
 /*eslint no-underscore-dangle: ["error", { "allow": ["foo_", "_bar"] }]*/
 
@@ -68,9 +78,13 @@ var foo_;
 foo._bar();
 ```
 
+:::
+
 ### allowAfterThis
 
 Examples of **correct** code for this rule with the `{ "allowAfterThis": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-underscore-dangle: ["error", { "allowAfterThis": true }]*/
@@ -79,9 +93,13 @@ var a = this.foo_;
 this._bar();
 ```
 
+:::
+
 ### allowAfterSuper
 
 Examples of **correct** code for this rule with the `{ "allowAfterSuper": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-underscore-dangle: ["error", { "allowAfterSuper": true }]*/
@@ -90,9 +108,13 @@ var a = super.foo_;
 super._bar();
 ```
 
+:::
+
 ### allowAfterThisConstructor
 
 Examples of **correct** code for this rule with the `{ "allowAfterThisConstructor": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-underscore-dangle: ["error", { "allowAfterThisConstructor": true }]*/
@@ -101,9 +123,13 @@ var a = this.constructor.foo_;
 this.constructor._bar();
 ```
 
+:::
+
 ### enforceInMethodNames
 
 Examples of **incorrect** code for this rule with the `{ "enforceInMethodNames": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-underscore-dangle: ["error", { "enforceInMethodNames": true }]*/
@@ -125,9 +151,13 @@ const o = {
 };
 ```
 
+:::
+
 ### enforceInClassFields
 
 Examples of **incorrect** code for this rule with the `{ "enforceInClassFields": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-underscore-dangle: ["error", { "enforceInClassFields": true }]*/
@@ -153,9 +183,13 @@ class Foo {
 }
 ```
 
+:::
+
 ### allowFunctionParams
 
 Examples of **incorrect** code for this rule with the `{ "allowFunctionParams": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-underscore-dangle: ["error", { "allowFunctionParams": false }]*/
@@ -172,6 +206,8 @@ const foo = (_bar) => {};
 const foo = (_bar = 0) => {};
 const foo = (..._bar) => {};
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-unexpected-multiline.md
+++ b/docs/src/rules/no-unexpected-multiline.md
@@ -30,6 +30,8 @@ This rule disallows confusing multiline expressions where a newline looks like i
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-unexpected-multiline: "error"*/
 
@@ -50,7 +52,11 @@ let x = foo
 /regex/g.test(bar)
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-unexpected-multiline: "error"*/
@@ -73,6 +79,8 @@ let x = function() {};
 let tag = function() {}
 tag `hello`
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-unmodified-loop-condition.md
+++ b/docs/src/rules/no-unmodified-loop-condition.md
@@ -35,6 +35,8 @@ If a reference is inside of a dynamic expression (e.g. `CallExpression`,
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-unmodified-loop-condition: "error"*/
 
@@ -54,7 +56,11 @@ while (node !== root) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-unmodified-loop-condition: "error"*/
@@ -91,6 +97,8 @@ while (check(obj)) {
     doSomething(obj);
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-unneeded-ternary.md
+++ b/docs/src/rules/no-unneeded-ternary.md
@@ -46,6 +46,8 @@ This rule disallow ternary operators when simpler alternatives exist.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-unneeded-ternary: "error"*/
 
@@ -54,7 +56,11 @@ var a = x === 2 ? true : false;
 var a = x ? true : false;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-unneeded-ternary: "error"*/
@@ -70,6 +76,8 @@ var a = x ? y : x;
 f(x ? x : 1); // default assignment - would be disallowed if defaultAssignment option set to false. See option details below.
 ```
 
+:::
+
 ## Options
 
 This rule has an object option:
@@ -83,6 +91,8 @@ When set to `true`, which it is by default, The defaultAssignment option allows 
 
 Examples of additional **incorrect** code for this rule with the `{ "defaultAssignment": false }` option:
 
+::: incorrect
+
 ```js
 /*eslint no-unneeded-ternary: ["error", { "defaultAssignment": false }]*/
 
@@ -90,6 +100,8 @@ var a = x ? x : 1;
 
 f(x ? x : 1);
 ```
+
+:::
 
 Note that `defaultAssignment: false` still allows expressions of the form `x ? expr : x` (where the identifier is on the right hand side of the ternary).
 

--- a/docs/src/rules/no-unreachable-loop.md
+++ b/docs/src/rules/no-unreachable-loop.md
@@ -36,6 +36,8 @@ This rule checks `while`, `do-while`, `for`, `for-in` and `for-of` loops. You ca
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-unreachable-loop: "error"*/
 
@@ -83,7 +85,11 @@ for (foo of bar) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-unreachable-loop: "error"*/
@@ -132,9 +138,13 @@ for (foo of bar) {
 }
 ```
 
+:::
+
 Please note that this rule is not designed to check loop conditions, and will not warn in cases such as the following examples.
 
 Examples of additional **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-unreachable-loop: "error"*/
@@ -151,6 +161,8 @@ for (const a of [1]) {
     doSomething(a);
 }
 ```
+
+:::
 
 ## Options
 
@@ -170,6 +182,8 @@ You can specify up to 5 different elements in the `"ignore"` array:
 
 Examples of **correct** code for this rule with the `"ignore"` option:
 
+::: correct
+
 ```js
 /*eslint no-unreachable-loop: ["error", { "ignore": ["ForInStatement", "ForOfStatement"] }]*/
 
@@ -180,6 +194,8 @@ for (var key in obj) {
 
 for (const a of b) break;
 ```
+
+:::
 
 ## Known Limitations
 

--- a/docs/src/rules/no-unreachable.md
+++ b/docs/src/rules/no-unreachable.md
@@ -37,6 +37,8 @@ This rule disallows unreachable code after `return`, `throw`, `continue`, and `b
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-unreachable: "error"*/
 
@@ -71,7 +73,11 @@ for (;;) {}
 console.log("done");
 ```
 
+:::
+
 Examples of **correct** code for this rule, because of JavaScript function and variable hoisting:
+
+::: correct
 
 ```js
 /*eslint no-unreachable: "error"*/
@@ -95,7 +101,11 @@ switch (foo) {
 }
 ```
 
+:::
+
 Examples of additional **incorrect** code for this rule:
+
+::: incorrect
 
 ```js
 /*eslint no-unreachable: "error"*/
@@ -112,7 +122,11 @@ class C extends B {
 }
 ```
 
+:::
+
 Examples of additional **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-unreachable: "error"*/
@@ -148,3 +162,5 @@ class F extends B {
     }
 }
 ```
+
+:::

--- a/docs/src/rules/no-unsafe-finally.md
+++ b/docs/src/rules/no-unsafe-finally.md
@@ -74,6 +74,8 @@ This rule disallows `return`, `throw`, `break`, and `continue` statements inside
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-unsafe-finally: "error"*/
 let foo = function() {
@@ -86,6 +88,8 @@ let foo = function() {
     }
 };
 ```
+
+:::
 
 ```js
 /*eslint no-unsafe-finally: "error"*/
@@ -102,6 +106,8 @@ let foo = function() {
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint no-unsafe-finally: "error"*/
 let foo = function() {
@@ -114,6 +120,8 @@ let foo = function() {
     }
 };
 ```
+
+:::
 
 ```js
 /*eslint no-unsafe-finally: "error"*/

--- a/docs/src/rules/no-unsafe-negation.md
+++ b/docs/src/rules/no-unsafe-negation.md
@@ -22,6 +22,8 @@ This rule disallows negating the left operand of the following relational operat
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-unsafe-negation: "error"*/
 
@@ -36,7 +38,11 @@ if (!obj instanceof Ctor) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-unsafe-negation: "error"*/
@@ -50,12 +56,16 @@ if (!(obj instanceof Ctor)) {
 }
 ```
 
+:::
+
 ### Exception
 
 For rare situations when negating the left operand is intended, this rule allows an exception.
 If the whole negation is explicitly wrapped in parentheses, the rule will not report a problem.
 
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-unsafe-negation: "error"*/
@@ -71,7 +81,11 @@ if(("" + !foo) in object) {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule:
+
+::: incorrect
 
 ```js
 /*eslint no-unsafe-negation: "error"*/
@@ -80,6 +94,8 @@ if (!(foo) in object) {
     // this is not an allowed exception
 }
 ```
+
+:::
 
 ## Options
 
@@ -101,6 +117,8 @@ The purpose is to avoid expressions such as `! a < b` (which is equivalent to `(
 
 Examples of additional **incorrect** code for this rule with the `{ "enforceForOrderingRelations": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint no-unsafe-negation: ["error", { "enforceForOrderingRelations": true }]*/
 
@@ -112,6 +130,8 @@ foo = ! a <= b;
 
 foo = ! a >= b;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-unsafe-optional-chaining.md
+++ b/docs/src/rules/no-unsafe-optional-chaining.md
@@ -36,6 +36,8 @@ This rule aims to detect some cases where the use of optional chaining doesn't p
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-unsafe-optional-chaining: "error"*/
 
@@ -88,7 +90,11 @@ async function foo () {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-unsafe-optional-chaining: "error"*/
@@ -120,6 +126,8 @@ async function foo () {
 }
 ```
 
+:::
+
 ## Options
 
 This rule has an object option:
@@ -135,6 +143,8 @@ With this option set to `true` the rule is enforced for:
 * Assignment operators: `+=`, `-=`, `/=`, `*=`, `%=`, `**=`
 
 Examples of additional **incorrect** code for this rule with the `{ "disallowArithmeticOperators": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-unsafe-optional-chaining: ["error", { "disallowArithmeticOperators": true }]*/
@@ -162,3 +172,5 @@ async function foo () {
   baz += await obj?.foo;
 }
 ```
+
+:::

--- a/docs/src/rules/no-unused-expressions.md
+++ b/docs/src/rules/no-unused-expressions.md
@@ -44,6 +44,8 @@ These options allow unused expressions *only if all* of the code paths either di
 
 Examples of **incorrect** code for the default `{ "allowShortCircuit": false, "allowTernary": false }` options:
 
+::: incorrect
+
 ```js
 /*eslint no-unused-expressions: "error"*/
 
@@ -69,7 +71,11 @@ injectGlobal`body{ color: red; }`
 
 ```
 
+:::
+
 Examples of **correct** code for the default `{ "allowShortCircuit": false, "allowTernary": false }` options:
+
+::: correct
 
 ```js
 /*eslint no-unused-expressions: "error"*/
@@ -93,9 +99,13 @@ delete a.b
 void a
 ```
 
+:::
+
 Note that one or more string expression statements (with or without semi-colons) will only be considered as unused if they are not in the beginning of a script, module, or function (alone and uninterrupted by other statements). Otherwise, they will be treated as part of a "directive prologue", a section potentially usable by JavaScript engines. This includes "strict mode" directives.
 
 Examples of **correct** code for this rule in regard to directives:
+
+::: correct
 
 ```js
 /*eslint no-unused-expressions: "error"*/
@@ -118,7 +128,11 @@ class Foo {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule in regard to directives:
+
+::: incorrect
 
 ```js
 /*eslint no-unused-expressions: "error"*/
@@ -137,9 +151,13 @@ class Foo {
 }
 ```
 
+:::
+
 ### allowShortCircuit
 
 Examples of **incorrect** code for the `{ "allowShortCircuit": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-unused-expressions: ["error", { "allowShortCircuit": true }]*/
@@ -147,7 +165,11 @@ Examples of **incorrect** code for the `{ "allowShortCircuit": true }` option:
 a || b
 ```
 
+:::
+
 Examples of **correct** code for the `{ "allowShortCircuit": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-unused-expressions: ["error", { "allowShortCircuit": true }]*/
@@ -156,9 +178,13 @@ a && b()
 a() || (b = c)
 ```
 
+:::
+
 ### allowTernary
 
 Examples of **incorrect** code for the `{ "allowTernary": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-unused-expressions: ["error", { "allowTernary": true }]*/
@@ -167,7 +193,11 @@ a ? b : 0
 a ? b : c()
 ```
 
+:::
+
 Examples of **correct** code for the `{ "allowTernary": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-unused-expressions: ["error", { "allowTernary": true }]*/
@@ -176,9 +206,13 @@ a ? b() : c()
 a ? (b = c) : d()
 ```
 
+:::
+
 ### allowShortCircuit and allowTernary
 
 Examples of **correct** code for the `{ "allowShortCircuit": true, "allowTernary": true }` options:
+
+::: correct
 
 ```js
 /*eslint no-unused-expressions: ["error", { "allowShortCircuit": true, "allowTernary": true }]*/
@@ -186,9 +220,13 @@ Examples of **correct** code for the `{ "allowShortCircuit": true, "allowTernary
 a ? b() || (c = d) : e()
 ```
 
+:::
+
 ### allowTaggedTemplates
 
 Examples of **incorrect** code for the `{ "allowTaggedTemplates": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-unused-expressions: ["error", { "allowTaggedTemplates": true }]*/
@@ -196,7 +234,11 @@ Examples of **incorrect** code for the `{ "allowTaggedTemplates": true }` option
 `some untagged template string`;
 ```
 
+:::
+
 Examples of **correct** code for the `{ "allowTaggedTemplates": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-unused-expressions: ["error", { "allowTaggedTemplates": true }]*/
@@ -204,11 +246,15 @@ Examples of **correct** code for the `{ "allowTaggedTemplates": true }` option:
 tag`some tagged template string`;
 ```
 
+:::
+
 ### enforceForJSX
 
 JSX is most-commonly used in the React ecosystem, where it is compiled to `React.createElement` expressions. Though free from side-effects, these calls are not automatically flagged by the `no-unused-expression` rule. If you're using React, or any other side-effect-free JSX pragma, this option can be enabled to flag these expressions.
 
 Examples of **incorrect** code for the `{ "enforceForJSX": true }` option:
+
+::: incorrect
 
 ```jsx
 /*eslint no-unused-expressions: ["error", { "enforceForJSX": true }]*/
@@ -218,7 +264,11 @@ Examples of **incorrect** code for the `{ "enforceForJSX": true }` option:
 <></>;
 ```
 
+:::
+
 Examples of **correct** code for the `{ "enforceForJSX": true }` option:
+
+::: correct
 
 ```jsx
 /*eslint no-unused-expressions: ["error", { "enforceForJSX": true }]*/
@@ -227,3 +277,5 @@ var myComponentPartial = <MyComponent />;
 
 var myFragment = <></>;
 ```
+
+:::

--- a/docs/src/rules/no-unused-labels.md
+++ b/docs/src/rules/no-unused-labels.md
@@ -36,6 +36,8 @@ This rule is aimed at eliminating unused labels.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-unused-labels: "error"*/
 
@@ -51,7 +53,11 @@ for (let i = 0; i < 10; ++i) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-unused-labels: "error"*/
@@ -71,6 +77,8 @@ for (let i = 0; i < 10; ++i) {
     bar();
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-unused-private-class-members.md
+++ b/docs/src/rules/no-unused-private-class-members.md
@@ -18,6 +18,8 @@ This rule reports unused private class members.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-unused-private-class-members: "error"*/
 
@@ -49,7 +51,11 @@ class Foo {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-unused-private-class-members: "error"*/
@@ -79,6 +85,8 @@ class Foo {
     }
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-unused-vars.md
+++ b/docs/src/rules/no-unused-vars.md
@@ -26,6 +26,8 @@ A variable is *not* considered to be used if it is only ever declared (`var foo 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-unused-vars: "error"*/
 /*global some_unused_var*/
@@ -60,7 +62,11 @@ function getY([x, y]) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-unused-vars: "error"*/
@@ -89,6 +95,8 @@ function getY([, y]) {
 }
 ```
 
+:::
+
 ### exported
 
 In environments outside of CommonJS or ECMAScript modules, you may use `var` to create a global variable that may be used by other scripts. You can use the `/* exported variableName */` comment block to indicate that this variable is being exported and therefore should not be considered unused.
@@ -103,11 +111,15 @@ The line comment `// exported variableName` will not work as `exported` is not l
 
 Examples of **correct** code for `/* exported variableName */` operation:
 
+::: correct
+
 ```js
 /* exported global_var */
 
 var global_var = 42;
 ```
+
+:::
 
 ## Options
 
@@ -134,6 +146,8 @@ The `vars` option has two settings:
 
 Examples of **correct** code for the `{ "vars": "local" }` option:
 
+::: correct
+
 ```js
 /*eslint no-unused-vars: ["error", { "vars": "local" }]*/
 /*global some_unused_var */
@@ -141,11 +155,15 @@ Examples of **correct** code for the `{ "vars": "local" }` option:
 some_unused_var = 42;
 ```
 
+:::
+
 ### varsIgnorePattern
 
 The `varsIgnorePattern` option specifies exceptions not to check for usage: variables whose names match a regexp pattern. For example, variables whose names contain `ignored` or `Ignored`.
 
 Examples of **correct** code for the `{ "varsIgnorePattern": "[iI]gnored" }` option:
+
+::: correct
 
 ```js
 /*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
@@ -154,6 +172,8 @@ var firstVarIgnored = 1;
 var secondVar = 2;
 console.log(secondVar);
 ```
+
+:::
 
 ### args
 
@@ -167,6 +187,8 @@ The `args` option has three settings:
 
 Examples of **incorrect** code for the default `{ "args": "after-used" }` option:
 
+::: incorrect
+
 ```js
 /*eslint no-unused-vars: ["error", { "args": "after-used" }]*/
 
@@ -178,7 +200,11 @@ Examples of **incorrect** code for the default `{ "args": "after-used" }` option
 })();
 ```
 
+:::
+
 Examples of **correct** code for the default `{ "args": "after-used" }` option:
+
+::: correct
 
 ```js
 /*eslint no-unused-vars: ["error", {"args": "after-used"}]*/
@@ -188,9 +214,13 @@ Examples of **correct** code for the default `{ "args": "after-used" }` option:
 })();
 ```
 
+:::
+
 #### args: all
 
 Examples of **incorrect** code for the `{ "args": "all" }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-unused-vars: ["error", { "args": "all" }]*/
@@ -203,9 +233,13 @@ Examples of **incorrect** code for the `{ "args": "all" }` option:
 })();
 ```
 
+:::
+
 #### args: none
 
 Examples of **correct** code for the `{ "args": "none" }` option:
+
+::: correct
 
 ```js
 /*eslint no-unused-vars: ["error", { "args": "none" }]*/
@@ -215,11 +249,15 @@ Examples of **correct** code for the `{ "args": "none" }` option:
 })();
 ```
 
+:::
+
 ### ignoreRestSiblings
 
 The `ignoreRestSiblings` option is a boolean (default: `false`). Using a [Rest Property](https://github.com/tc39/proposal-object-rest-spread) it is possible to "omit" properties from an object, but by default the sibling properties are marked as "unused". With this option enabled the rest property's siblings are ignored.
 
 Examples of **correct** code for the `{ "ignoreRestSiblings": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-unused-vars: ["error", { "ignoreRestSiblings": true }]*/
@@ -230,11 +268,15 @@ var bar;
 ({ bar, ...coords } = data);
 ```
 
+:::
+
 ### argsIgnorePattern
 
 The `argsIgnorePattern` option specifies exceptions not to check for usage: arguments whose names match a regexp pattern. For example, variables whose names begin with an underscore.
 
 Examples of **correct** code for the `{ "argsIgnorePattern": "^_" }` option:
+
+::: correct
 
 ```js
 /*eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }]*/
@@ -245,11 +287,15 @@ function foo(x, _y) {
 foo();
 ```
 
+:::
+
 ### destructuredArrayIgnorePattern
 
 The `destructuredArrayIgnorePattern` option specifies exceptions not to check for usage: elements of array destructuring patterns whose names match a regexp pattern. For example, variables whose names begin with an underscore.
 
 Examples of **correct** code for the `{ "destructuredArrayIgnorePattern": "^_" }` option:
+
+::: correct
 
 ```js
 /*eslint no-unused-vars: ["error", { "destructuredArrayIgnorePattern": "^_" }]*/
@@ -282,6 +328,8 @@ _o = 1;
 p;
 ```
 
+:::
+
 ### caughtErrors
 
 The `caughtErrors` option is used for `catch` block arguments validation.
@@ -297,6 +345,8 @@ Not specifying this rule is equivalent of assigning it to `none`.
 
 Examples of **correct** code for the `{ "caughtErrors": "none" }` option:
 
+::: correct
+
 ```js
 /*eslint no-unused-vars: ["error", { "caughtErrors": "none" }]*/
 
@@ -307,9 +357,13 @@ try {
 }
 ```
 
+:::
+
 #### caughtErrors: all
 
 Examples of **incorrect** code for the `{ "caughtErrors": "all" }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-unused-vars: ["error", { "caughtErrors": "all" }]*/
@@ -323,11 +377,15 @@ try {
 }
 ```
 
+:::
+
 ### caughtErrorsIgnorePattern
 
 The `caughtErrorsIgnorePattern` option specifies exceptions not to check for usage: catch arguments whose names match a regexp pattern. For example, variables whose names begin with a string 'ignore'.
 
 Examples of **correct** code for the `{ "caughtErrorsIgnorePattern": "^ignore" }` option:
+
+::: correct
 
 ```js
 /*eslint no-unused-vars: ["error", { "caughtErrorsIgnorePattern": "^ignore" }]*/
@@ -338,6 +396,8 @@ try {
     console.error("errors");
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-use-before-define.md
+++ b/docs/src/rules/no-use-before-define.md
@@ -17,6 +17,8 @@ This rule will warn when it encounters a reference to an identifier that has not
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-use-before-define: "error"*/
 
@@ -65,7 +67,11 @@ export { foo };
 const foo = 1;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-use-before-define: "error"*/
@@ -117,6 +123,8 @@ const foo = 1;
 export { foo };
 ```
 
+:::
+
 ## Options
 
 ```json
@@ -159,6 +167,8 @@ This rule accepts `"nofunc"` string as an option.
 
 Examples of **correct** code for the `{ "functions": false }` option:
 
+::: correct
+
 ```js
 /*eslint no-use-before-define: ["error", { "functions": false }]*/
 
@@ -166,11 +176,15 @@ f();
 function f() {}
 ```
 
+:::
+
 This option allows references to function declarations. For function expressions and arrow functions, please see the [`variables`](#variables) option.
 
 ### classes
 
 Examples of **incorrect** code for the `{ "classes": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-use-before-define: ["error", { "classes": false }]*/
@@ -205,7 +219,11 @@ class A {
 }
 ```
 
+:::
+
 Examples of **correct** code for the `{ "classes": false }` option:
+
+::: correct
 
 ```js
 /*eslint no-use-before-define: ["error", { "classes": false }]*/
@@ -218,9 +236,13 @@ class A {
 }
 ```
 
+:::
+
 ### variables
 
 Examples of **incorrect** code for the `{ "variables": false }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-use-before-define: ["error", { "variables": false }]*/
@@ -257,7 +279,11 @@ const g = function() {};
 }
 ```
 
+:::
+
 Examples of **correct** code for the `{ "variables": false }` option:
+
+::: correct
 
 ```js
 /*eslint no-use-before-define: ["error", { "variables": false }]*/
@@ -283,9 +309,13 @@ const g = function() {}
 }
 ```
 
+:::
+
 ### allowNamedExports
 
 Examples of **correct** code for the `{ "allowNamedExports": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-use-before-define: ["error", { "allowNamedExports": true }]*/
@@ -301,7 +331,11 @@ function f () {}
 class C {}
 ```
 
+:::
+
 Examples of **incorrect** code for the `{ "allowNamedExports": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-use-before-define: ["error", { "allowNamedExports": true }]*/
@@ -317,3 +351,5 @@ export function foo() {
 }
 const d = 1;
 ```
+
+:::

--- a/docs/src/rules/no-useless-backreference.md
+++ b/docs/src/rules/no-useless-backreference.md
@@ -56,6 +56,8 @@ This might be surprising to developers coming from other languages where some of
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-useless-backreference: "error"*/
 
@@ -88,7 +90,11 @@ new RegExp('(\\1)'); // nested reference to (\1)
 /(?<!(a))b\1/; // reference to (a) into a negative lookbehind
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-useless-backreference: "error"*/
@@ -120,9 +126,13 @@ new RegExp('(.)\\1'); // reference to (.)
 /(?<!\1(a))b/; // reference to (a), correct as it's from within the same negative lookbehind
 ```
 
+:::
+
 Please note that this rule does not aim to detect and disallow a potentially erroneous use of backreference syntax in regular expressions, like the use in character classes or an attempt to reference a group that doesn't exist. Depending on the context, a `\1`...`\9` sequence that is not a syntactically valid backreference may produce syntax error, or be parsed as something else (e.g., as a legacy octal escape sequence).
 
 Examples of additional **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-useless-backreference: "error"*/
@@ -133,3 +143,5 @@ Examples of additional **correct** code for this rule:
 /^\1$/.test("\x01"); // true. Since the group 1 doesn't exist, \1 is treated as an octal escape sequence.
 /^(a)\1\2$/.test("aa\x02"); // true. In this case, \1 is a backreference, \2 is an octal escape sequence.
 ```
+
+:::

--- a/docs/src/rules/no-useless-call.md
+++ b/docs/src/rules/no-useless-call.md
@@ -18,6 +18,8 @@ This rule is aimed to flag usage of `Function.prototype.call()` and `Function.pr
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-useless-call: "error"*/
 
@@ -32,7 +34,11 @@ obj.foo.call(obj, 1, 2, 3);
 obj.foo.apply(obj, [1, 2, 3]);
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-useless-call: "error"*/
@@ -52,6 +58,8 @@ foo.apply(null, args);
 obj.foo.apply(obj, args);
 ```
 
+:::
+
 ## Known Limitations
 
 This rule compares code statically to check whether or not `thisArg` is changed.
@@ -59,19 +67,27 @@ So if the code about `thisArg` is a dynamic expression, this rule cannot judge c
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-useless-call: "error"*/
 
 a[i++].foo.call(a[i++], 1, 2, 3);
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-useless-call: "error"*/
 
 a[++i].foo.call(a[i], 1, 2, 3);
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-useless-catch.md
+++ b/docs/src/rules/no-useless-catch.md
@@ -17,6 +17,8 @@ This rule reports `catch` clauses that only `throw` the caught error.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-useless-catch: "error"*/
 
@@ -35,7 +37,11 @@ try {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-useless-catch: "error"*/
@@ -59,6 +65,8 @@ try {
   cleanUp();
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-useless-computed-key.md
+++ b/docs/src/rules/no-useless-computed-key.md
@@ -27,6 +27,8 @@ This rule disallows unnecessary usage of computed property keys.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-useless-computed-key: "error"*/
 
@@ -37,7 +39,11 @@ var a = { ['x']: 0 };
 var a = { ['x']() {} };
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-useless-computed-key: "error"*/
@@ -49,7 +55,11 @@ var c = { a: 0 };
 var c = { '0+1,234': 0 };
 ```
 
+:::
+
 Examples of additional **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-useless-computed-key: "error"*/
@@ -60,6 +70,8 @@ var c = {
     ["__proto__"]: bar // defines a property named "__proto__"
 };
 ```
+
+:::
 
 ## Options
 
@@ -75,6 +87,8 @@ as the default value for `enforceForClassMembers` is `false`.
 When `enforceForClassMembers` is set to `true`, the rule will also disallow unnecessary computed keys inside of class fields, class methods, class getters, and class setters.
 
 Examples of **incorrect** code for this rule with the `{ "enforceForClassMembers": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": true }]*/
@@ -93,7 +107,11 @@ class Foo {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "enforceForClassMembers": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": true }]*/
@@ -112,7 +130,11 @@ class Foo {
 }
 ```
 
+:::
+
 Examples of additional **correct** code for this rule with the `{ "enforceForClassMembers": true }` option:
+
+::: correct
 
 ```js
 /*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": true }]*/
@@ -129,6 +151,8 @@ class Foo {
     static ["prototype"]; // runtime error, it would be a parsing error without `[]`
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-useless-concat.md
+++ b/docs/src/rules/no-useless-concat.md
@@ -25,6 +25,8 @@ This rule aims to flag the concatenation of 2 literals when they could be combin
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-useless-concat: "error"*/
 /*eslint-env es6*/
@@ -38,7 +40,11 @@ var a = `1` + '0';
 var a = `1` + `0`;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-useless-concat: "error"*/
@@ -52,6 +58,8 @@ var c = 1 - 2;
 var c = "foo" +
     "bar";
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-useless-constructor.md
+++ b/docs/src/rules/no-useless-constructor.md
@@ -30,6 +30,8 @@ This rule flags class constructors that can be safely removed without changing h
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-useless-constructor: "error"*/
 /*eslint-env es6*/
@@ -46,7 +48,11 @@ class B extends A {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-useless-constructor: "error"*/
@@ -72,6 +78,8 @@ class B extends A {
     }
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-useless-escape.md
+++ b/docs/src/rules/no-useless-escape.md
@@ -25,6 +25,8 @@ This rule flags escapes that can be safely removed without changing behavior.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-useless-escape: "error"*/
 
@@ -41,7 +43,11 @@ Examples of **incorrect** code for this rule:
 /[a-z\-]/;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-useless-escape: "error"*/
@@ -62,6 +68,8 @@ Examples of **correct** code for this rule:
 /[\]]/;
 /[a-z-]/;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-useless-rename.md
+++ b/docs/src/rules/no-useless-rename.md
@@ -59,6 +59,8 @@ By default, all options are set to `false`:
 
 Examples of **incorrect** code for this rule by default:
 
+::: incorrect
+
 ```js
 /*eslint no-useless-rename: "error"*/
 
@@ -74,7 +76,11 @@ function foo({ bar: bar }) {}
 ({ foo: foo }) => {}
 ```
 
+:::
+
 Examples of **correct** code for this rule by default:
+
+::: correct
 
 ```js
 /*eslint no-useless-rename: "error"*/
@@ -101,7 +107,11 @@ function foo({ bar: baz }) {}
 ({ foo: bar }) => {}
 ```
 
+:::
+
 Examples of **correct** code for this rule with `{ ignoreImport: true }`:
+
+::: correct
 
 ```js
 /*eslint no-useless-rename: ["error", { ignoreImport: true }]*/
@@ -109,7 +119,11 @@ Examples of **correct** code for this rule with `{ ignoreImport: true }`:
 import { foo as foo } from "bar";
 ```
 
+:::
+
 Examples of **correct** code for this rule with `{ ignoreExport: true }`:
+
+::: correct
 
 ```js
 /*eslint no-useless-rename: ["error", { ignoreExport: true }]*/
@@ -118,7 +132,11 @@ export { foo as foo };
 export { foo as foo } from "bar";
 ```
 
+:::
+
 Examples of **correct** code for this rule with `{ ignoreDestructuring: true }`:
+
+::: correct
 
 ```js
 /*eslint no-useless-rename: ["error", { ignoreDestructuring: true }]*/
@@ -127,6 +145,8 @@ let { foo: foo } = bar;
 function foo({ bar: bar }) {}
 ({ foo: foo }) => {}
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-useless-return.md
+++ b/docs/src/rules/no-useless-return.md
@@ -17,6 +17,8 @@ This rule aims to report redundant `return` statements.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /* eslint no-useless-return: "error" */
 
@@ -48,7 +50,11 @@ function foo() {
 
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /* eslint no-useless-return: "error" */
@@ -86,6 +92,8 @@ function foo() {
 }
 
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-var.md
+++ b/docs/src/rules/no-var.md
@@ -34,6 +34,8 @@ This rule is aimed at discouraging the use of `var` and encouraging the use of `
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-var: "error"*/
 
@@ -41,7 +43,11 @@ var x = "y";
 var CONFIG = {};
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-var: "error"*/
@@ -50,6 +56,8 @@ Examples of **correct** code for this rule:
 let x = "y";
 const CONFIG = {};
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-void.md
+++ b/docs/src/rules/no-void.md
@@ -63,6 +63,8 @@ This rule aims to eliminate use of void operator.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-void: "error"*/
 
@@ -74,6 +76,8 @@ function baz() {
     return void 0;
 }
 ```
+
+:::
 
 ## Options
 
@@ -87,6 +91,8 @@ When `allowAsStatement` is set to true, the rule will not error on cases that th
 
 Examples of **incorrect** code for `{ "allowAsStatement": true }`:
 
+::: incorrect
+
 ```js
 /*eslint no-void: ["error", { "allowAsStatement": true }]*/
 
@@ -96,7 +102,11 @@ function baz() {
 }
 ```
 
+:::
+
 Examples of **correct** code for `{ "allowAsStatement": true }`:
+
+::: correct
 
 ```js
 /*eslint no-void: ["error", { "allowAsStatement": true }]*/
@@ -104,6 +114,8 @@ Examples of **correct** code for `{ "allowAsStatement": true }`:
 void foo;
 void someFunction();
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-warning-comments.md
+++ b/docs/src/rules/no-warning-comments.md
@@ -27,6 +27,8 @@ This rule has an options object literal:
 
 Example of **incorrect** code for the default `{ "terms": ["todo", "fixme", "xxx"], "location": "start" }` options:
 
+::: incorrect
+
 ```js
 /*eslint no-warning-comments: "error"*/
 
@@ -39,7 +41,11 @@ function callback(err, results) {
 }
 ```
 
+:::
+
 Example of **correct** code for the default `{ "terms": ["todo", "fixme", "xxx"], "location": "start" }` options:
+
+::: correct
 
 ```js
 /*eslint no-warning-comments: "error"*/
@@ -54,9 +60,13 @@ function callback(err, results) {
 }
 ```
 
+:::
+
 ### terms and location
 
 Examples of **incorrect** code for the `{ "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }` options:
+
+::: incorrect
 
 ```js
 /*eslint no-warning-comments: ["error", { "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }]*/
@@ -71,7 +81,11 @@ Examples of **incorrect** code for the `{ "terms": ["todo", "fixme", "any other 
  */
 ```
 
+:::
+
 Examples of **correct** code for the `{ "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }` options:
+
+::: correct
 
 ```js
 /*eslint no-warning-comments: ["error", { "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }]*/
@@ -85,6 +99,8 @@ Examples of **correct** code for the `{ "terms": ["todo", "fixme", "any other te
  * or fix me this
  */
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-whitespace-before-property.md
+++ b/docs/src/rules/no-whitespace-before-property.md
@@ -28,6 +28,8 @@ foo
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-whitespace-before-property: "error"*/
 
@@ -46,7 +48,11 @@ foo
   .bar(). baz()
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-whitespace-before-property: "error"*/
@@ -70,6 +76,8 @@ foo.
   bar().
   baz()
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-with.md
+++ b/docs/src/rules/no-with.md
@@ -21,6 +21,8 @@ If ESLint parses code in strict mode, the parser (instead of this rule) reports 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint no-with: "error"*/
 
@@ -29,7 +31,11 @@ with (point) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint no-with: "error"*/
@@ -37,6 +43,8 @@ Examples of **correct** code for this rule:
 
 const r = ({x, y}) => Math.sqrt(x * x + y * y);
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-wrap-func.md
+++ b/docs/src/rules/no-wrap-func.md
@@ -27,14 +27,22 @@ This rule will raise a warning when it encounters a function expression wrapped 
 
 Example of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 var a = (function() {/*...*/});
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 var a = function() {/*...*/};
 
 (function() {/*...*/})();
 ```
+
+:::

--- a/docs/src/rules/nonblock-statement-body-position.md
+++ b/docs/src/rules/nonblock-statement-body-position.md
@@ -55,6 +55,8 @@ Additionally, the rule accepts an optional object option with an `"overrides"` k
 
 Examples of **incorrect** code for this rule with the default `"beside"` option:
 
+::: incorrect
+
 ```js
 /* eslint nonblock-statement-body-position: ["error", "beside"] */
 
@@ -75,7 +77,11 @@ while (foo)
 
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"beside"` option:
+
+::: correct
 
 ```js
 /* eslint nonblock-statement-body-position: ["error", "beside"] */
@@ -96,7 +102,11 @@ if (foo) { // block statements are always allowed with this rule
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"below"` option:
+
+::: incorrect
 
 ```js
 /* eslint nonblock-statement-body-position: ["error", "below"] */
@@ -111,7 +121,11 @@ for (let i = 1; i < foo; i++) bar();
 do bar(); while (foo)
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"below"` option:
+
+::: correct
 
 ```js
 /* eslint nonblock-statement-body-position: ["error", "below"] */
@@ -138,7 +152,11 @@ if (foo) {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"beside", { "overrides": { "while": "below" } }` rule:
+
+::: incorrect
 
 ```js
 /* eslint nonblock-statement-body-position: ["error", "beside", { "overrides": { "while": "below" } }] */
@@ -149,7 +167,11 @@ if (foo)
 while (foo) bar();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"beside", { "overrides": { "while": "below" } }` rule:
+
+::: correct
 
 ```js
 /* eslint nonblock-statement-body-position: ["error", "beside", { "overrides": { "while": "below" } }] */
@@ -159,6 +181,8 @@ if (foo) bar();
 while (foo)
   bar();
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/object-curly-newline.md
+++ b/docs/src/rules/object-curly-newline.md
@@ -55,6 +55,8 @@ You can specify different options for object literals, destructuring assignments
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint object-curly-newline: ["error", "always"]*/
 /*eslint-env es6*/
@@ -78,7 +80,11 @@ let {k = function() {
 }} = obj;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint object-curly-newline: ["error", "always"]*/
@@ -121,9 +127,13 @@ let {
 } = obj;
 ```
 
+:::
+
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint object-curly-newline: ["error", "never"]*/
@@ -166,7 +176,11 @@ let {
 } = obj;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint object-curly-newline: ["error", "never"]*/
@@ -190,11 +204,15 @@ let {k = function() {
     dosomething();
 }} = obj;
 ```
+
+:::
 
 ### multiline
 
 Examples of **incorrect** code for this rule with the `{ "multiline": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint object-curly-newline: ["error", { "multiline": true }]*/
 /*eslint-env es6*/
@@ -228,7 +246,11 @@ let {k = function() {
 }} = obj;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "multiline": true }` option:
+
+::: correct
 
 ```js
 /*eslint object-curly-newline: ["error", { "multiline": true }]*/
@@ -260,11 +282,15 @@ let {
     }
 } = obj;
 ```
+
+:::
 
 ### minProperties
 
 Examples of **incorrect** code for this rule with the `{ "minProperties": 2 }` option:
 
+::: incorrect
+
 ```js
 /*eslint object-curly-newline: ["error", { "minProperties": 2 }]*/
 /*eslint-env es6*/
@@ -298,7 +324,11 @@ let {
 } = obj;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "minProperties": 2 }` option:
+
+::: correct
 
 ```js
 /*eslint object-curly-newline: ["error", { "minProperties": 2 }]*/
@@ -331,9 +361,13 @@ let {k = function() {
 }} = obj;
 ```
 
+:::
+
 ### consistent
 
 Examples of **incorrect** code for this rule with the default `{ "consistent": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint object-curly-newline: ["error", { "consistent": true }]*/
@@ -377,7 +411,11 @@ let {
     }} = obj;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `{ "consistent": true }` option:
+
+::: correct
 
 ```js
 /*eslint object-curly-newline: ["error", { "consistent": true }]*/
@@ -429,9 +467,13 @@ let {
 } = obj;
 ```
 
+:::
+
 ### ObjectExpression and ObjectPattern
 
 Examples of **incorrect** code for this rule with the `{ "ObjectExpression": "always", "ObjectPattern": "never" }` options:
+
+::: incorrect
 
 ```js
 /*eslint object-curly-newline: ["error", { "ObjectExpression": "always", "ObjectPattern": "never" }]*/
@@ -465,7 +507,11 @@ let {
 } = obj;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "ObjectExpression": "always", "ObjectPattern": "never" }` options:
+
+::: correct
 
 ```js
 /*eslint object-curly-newline: ["error", { "ObjectExpression": "always", "ObjectPattern": "never" }]*/
@@ -499,9 +545,13 @@ let {k = function() {
 }} = obj;
 ```
 
+:::
+
 ### ImportDeclaration and ExportDeclaration
 
 Examples of **incorrect** code for this rule with the `{ "ImportDeclaration": "always", "ExportDeclaration": "never" }` options:
+
+::: incorrect
 
 ```js
 /*eslint object-curly-newline: ["error", { "ImportDeclaration": "always", "ExportDeclaration": "never" }]*/
@@ -522,7 +572,11 @@ export {
 } from 'foo-bar';
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "ImportDeclaration": "always", "ExportDeclaration": "never" }` options:
+
+::: correct
 
 ```js
 /*eslint object-curly-newline: ["error", { "ImportDeclaration": "always", "ExportDeclaration": "never" }]*/
@@ -543,6 +597,8 @@ import {
 export { foo, bar } from 'foo-bar';
 export { foo as f, bar } from 'foo-bar';
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/object-curly-spacing.md
+++ b/docs/src/rules/object-curly-spacing.md
@@ -56,6 +56,8 @@ Object option:
 
 Examples of **incorrect** code for this rule with the default `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint object-curly-spacing: ["error", "never"]*/
 
@@ -67,7 +69,11 @@ var {x } = y;
 import { foo } from 'bar';
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"never"` option:
+
+::: correct
 
 ```js
 /*eslint object-curly-spacing: ["error", "never"]*/
@@ -86,9 +92,13 @@ var {x} = y;
 import {foo} from 'bar';
 ```
 
+:::
+
 ### always
 
 Examples of **incorrect** code for this rule with the `"always"` option:
+
+::: incorrect
 
 ```js
 /*eslint object-curly-spacing: ["error", "always"]*/
@@ -105,7 +115,11 @@ var {x} = y;
 import {foo } from 'bar';
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint object-curly-spacing: ["error", "always"]*/
@@ -120,9 +134,13 @@ var { x } = y;
 import { foo } from 'bar';
 ```
 
+:::
+
 #### arraysInObjects
 
 Examples of additional **correct** code for this rule with the `"never", { "arraysInObjects": true }` options:
+
+::: correct
 
 ```js
 /*eslint object-curly-spacing: ["error", "never", { "arraysInObjects": true }]*/
@@ -131,7 +149,11 @@ var obj = {"foo": [ 1, 2 ] };
 var obj = {"foo": [ "baz", "bar" ] };
 ```
 
+:::
+
 Examples of additional **correct** code for this rule with the `"always", { "arraysInObjects": false }` options:
+
+::: correct
 
 ```js
 /*eslint object-curly-spacing: ["error", "always", { "arraysInObjects": false }]*/
@@ -140,9 +162,13 @@ var obj = { "foo": [ 1, 2 ]};
 var obj = { "foo": [ "baz", "bar" ]};
 ```
 
+:::
+
 #### objectsInObjects
 
 Examples of additional **correct** code for this rule with the `"never", { "objectsInObjects": true }` options:
+
+::: correct
 
 ```js
 /*eslint object-curly-spacing: ["error", "never", { "objectsInObjects": true }]*/
@@ -150,13 +176,19 @@ Examples of additional **correct** code for this rule with the `"never", { "obje
 var obj = {"foo": {"baz": 1, "bar": 2} };
 ```
 
+:::
+
 Examples of additional **correct** code for this rule with the `"always", { "objectsInObjects": false }` options:
+
+::: correct
 
 ```js
 /*eslint object-curly-spacing: ["error", "always", { "objectsInObjects": false }]*/
 
 var obj = { "foo": { "baz": 1, "bar": 2 }};
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/object-property-newline.md
+++ b/docs/src/rules/object-property-newline.md
@@ -188,6 +188,8 @@ As illustrated above, the `--fix` option, applied to this rule, does not comply 
 
 Examples of **incorrect** code for this rule, with no object option or with `allowAllPropertiesOnSameLine` set to `false`:
 
+::: incorrect
+
 ```js
 /*eslint object-property-newline: "error"*/
 
@@ -222,7 +224,11 @@ const obj5 = {
 ]: true};
 ```
 
+:::
+
 Examples of **correct** code for this rule, with no object option or with `allowAllPropertiesOnSameLine` set to `false`:
+
+::: correct
 
 ```js
 /*eslint object-property-newline: "error"*/
@@ -252,7 +258,11 @@ const obj3 = {
 };
 ```
 
+:::
+
 Examples of additional **correct** code for this rule with the `{ "allowAllPropertiesOnSameLine": true }` option:
+
+::: correct
 
 ```js
 /*eslint object-property-newline: ["error", { "allowAllPropertiesOnSameLine": true }]*/
@@ -267,6 +277,8 @@ const obj3 = {
     user, [process.argv[3] ? "foo" : "bar"]: 0, baz: [1, 2, 4, 8]
 };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/object-shorthand.md
+++ b/docs/src/rules/object-shorthand.md
@@ -129,6 +129,8 @@ Additionally, the rule takes an optional object configuration:
 
 Example of **incorrect** code for this rule with the `"always", { "avoidQuotes": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidQuotes": true }]*/
 /*eslint-env es6*/
@@ -138,7 +140,11 @@ var foo = {
 };
 ```
 
+:::
+
 Example of **correct** code for this rule with the `"always", { "avoidQuotes": true }` option:
+
+::: correct
 
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidQuotes": true }]*/
@@ -150,6 +156,8 @@ var foo = {
 };
 ```
 
+:::
+
 ### `ignoreConstructors`
 
 ```json
@@ -160,6 +168,8 @@ var foo = {
 
 Example of **correct** code for this rule with the `"always", { "ignoreConstructors": true }` option:
 
+::: correct
+
 ```js
 /*eslint object-shorthand: ["error", "always", { "ignoreConstructors": true }]*/
 /*eslint-env es6*/
@@ -168,6 +178,8 @@ var foo = {
     ConstructorFunction: function() {}
 };
 ```
+
+:::
 
 ### `avoidExplicitReturnArrows`
 
@@ -178,6 +190,8 @@ var foo = {
 ```
 
 Example of **incorrect** code for this rule with the `"always", { "avoidExplicitReturnArrows": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidExplicitReturnArrows": true }]*/
@@ -194,7 +208,11 @@ var foo = {
 };
 ```
 
+:::
+
 Example of **correct** code for this rule with the `"always", { "avoidExplicitReturnArrows": true }` option:
+
+::: correct
 
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidExplicitReturnArrows": true }]*/
@@ -209,7 +227,11 @@ var foo = {
 };
 ```
 
+:::
+
 Example of **incorrect** code for this rule with the `"consistent"` option:
+
+::: incorrect
 
 ```js
 /*eslint object-shorthand: [2, "consistent"]*/
@@ -221,7 +243,11 @@ var foo = {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"consistent"` option:
+
+::: correct
 
 ```js
 /*eslint object-shorthand: [2, "consistent"]*/
@@ -238,7 +264,11 @@ var bar = {
 };
 ```
 
+:::
+
 Example of **incorrect** code with the `"consistent-as-needed"` option, which is very similar to `"consistent"`:
+
+::: incorrect
 
 ```js
 /*eslint object-shorthand: [2, "consistent-as-needed"]*/
@@ -249,6 +279,8 @@ var foo = {
     b: b,
 };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/one-var-declaration-per-line.md
+++ b/docs/src/rules/one-var-declaration-per-line.md
@@ -42,6 +42,8 @@ This rule has a single string option:
 
 Examples of **incorrect** code for this rule with the default `"initializations"` option:
 
+::: incorrect
+
 ```js
 /*eslint one-var-declaration-per-line: ["error", "initializations"]*/
 /*eslint-env es6*/
@@ -52,7 +54,11 @@ let a,
     b = 0, c;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"initializations"` option:
+
+::: correct
 
 ```js
 /*eslint one-var-declaration-per-line: ["error", "initializations"]*/
@@ -67,9 +73,13 @@ let a,
     b = 0;
 ```
 
+:::
+
 ### always
 
 Examples of **incorrect** code for this rule with the `"always"` option:
+
+::: incorrect
 
 ```js
 /*eslint one-var-declaration-per-line: ["error", "always"]*/
@@ -82,7 +92,11 @@ let a, b = 0;
 const a = 0, b = 0;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint one-var-declaration-per-line: ["error", "always"]*/
@@ -94,3 +108,5 @@ var a,
 let a,
     b = 0;
 ```
+
+:::

--- a/docs/src/rules/one-var.md
+++ b/docs/src/rules/one-var.md
@@ -73,6 +73,8 @@ Alternate object option:
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint one-var: ["error", "always"]*/
 
@@ -118,7 +120,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint one-var: ["error", "always"]*/
@@ -179,9 +185,13 @@ class C {
 }
 ```
 
+:::
+
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", "never"]*/
@@ -215,7 +225,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint one-var: ["error", "never"]*/
@@ -256,9 +270,13 @@ for (var i = 0, len = arr.length; i < len; i++) {
 }
 ```
 
+:::
+
 ### consecutive
 
 Examples of **incorrect** code for this rule with the `"consecutive"` option:
+
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", "consecutive"]*/
@@ -288,7 +306,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"consecutive"` option:
+
+::: correct
 
 ```js
 /*eslint one-var: ["error", "consecutive"]*/
@@ -319,9 +341,13 @@ class C {
 }
 ```
 
+:::
+
 ### var, let, and const
 
 Examples of **incorrect** code for this rule with the `{ var: "always", let: "never", const: "never" }` option:
+
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", { var: "always", let: "never", const: "never" }]*/
@@ -342,7 +368,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ var: "always", let: "never", const: "never" }` option:
+
+::: correct
 
 ```js
 /*eslint one-var: ["error", { var: "always", let: "never", const: "never" }]*/
@@ -363,7 +393,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ var: "never" }` option:
+
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", { var: "never" }]*/
@@ -375,7 +409,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ var: "never" }` option:
+
+::: correct
 
 ```js
 /*eslint one-var: ["error", { var: "never" }]*/
@@ -391,7 +429,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ separateRequires: true }` option:
+
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", { separateRequires: true, var: "always" }]*/
@@ -401,7 +443,11 @@ var foo = require("foo"),
     bar = "bar";
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ separateRequires: true }` option:
+
+::: correct
 
 ```js
 /*eslint one-var: ["error", { separateRequires: true, var: "always" }]*/
@@ -411,12 +457,16 @@ var foo = require("foo");
 var bar = "bar";
 ```
 
+:::
+
 ```js
 var foo = require("foo"),
     bar = require("bar");
 ```
 
 Examples of **incorrect** code for this rule with the `{ var: "never", let: "consecutive", const: "consecutive" }` option:
+
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", { var: "never", let: "consecutive", const: "consecutive" }]*/
@@ -441,7 +491,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ var: "never", let: "consecutive", const: "consecutive" }` option:
+
+::: correct
 
 ```js
 /*eslint one-var: ["error", { var: "never", let: "consecutive", const: "consecutive" }]*/
@@ -468,7 +522,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ var: "consecutive" }` option:
+
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", { var: "consecutive" }]*/
@@ -480,7 +538,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ var: "consecutive" }` option:
+
+::: correct
 
 ```js
 /*eslint one-var: ["error", { var: "consecutive" }]*/
@@ -496,9 +558,13 @@ function foo() {
 }
 ```
 
+:::
+
 ### initialized and uninitialized
 
 Examples of **incorrect** code for this rule with the `{ "initialized": "always", "uninitialized": "never" }` option:
+
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", { "initialized": "always", "uninitialized": "never" }]*/
@@ -511,7 +577,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "initialized": "always", "uninitialized": "never" }` option:
+
+::: correct
 
 ```js
 /*eslint one-var: ["error", { "initialized": "always", "uninitialized": "never" }]*/
@@ -534,7 +604,11 @@ for (z of foo) {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "initialized": "never" }` option:
+
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", { "initialized": "never" }]*/
@@ -546,7 +620,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "initialized": "never" }` option:
+
+::: correct
 
 ```js
 /*eslint one-var: ["error", { "initialized": "never" }]*/
@@ -558,7 +636,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "initialized": "consecutive", "uninitialized": "never" }` option:
+
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", { "initialized": "consecutive", "uninitialized": "never" }]*/
@@ -573,7 +655,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "initialized": "consecutive", "uninitialized": "never" }` option:
+
+::: correct
 
 ```js
 /*eslint one-var: ["error", { "initialized": "consecutive", "uninitialized": "never" }]*/
@@ -588,7 +674,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "initialized": "consecutive" }` option:
+
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", { "initialized": "consecutive" }]*/
@@ -604,7 +694,11 @@ function foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "initialized": "consecutive" }` option:
+
+::: correct
 
 ```js
 /*eslint one-var: ["error", { "initialized": "consecutive" }]*/
@@ -619,6 +713,8 @@ function foo() {
         d = 4;
 }
 ```
+
+:::
 
 ## Compatibility
 

--- a/docs/src/rules/operator-assignment.md
+++ b/docs/src/rules/operator-assignment.md
@@ -45,6 +45,8 @@ This rule has a single string option:
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint operator-assignment: ["error", "always"]*/
 
@@ -54,7 +56,11 @@ x[0] = x[0] / y;
 x.y = x.y << z;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint operator-assignment: ["error", "always"]*/
@@ -68,9 +74,13 @@ x[foo()] = x[foo()] % 2;
 x = y + x; // `+` is not always commutative (e.g. x = "abc")
 ```
 
+:::
+
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint operator-assignment: ["error", "never"]*/
@@ -79,7 +89,11 @@ x *= y;
 x ^= (y + z) / foo();
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint operator-assignment: ["error", "never"]*/
@@ -87,6 +101,8 @@ Examples of **correct** code for this rule with the `"never"` option:
 x = x + y;
 x.y = x.y / a.b;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/operator-linebreak.md
+++ b/docs/src/rules/operator-linebreak.md
@@ -51,6 +51,8 @@ The default configuration is `"after", { "overrides": { "?": "before", ":": "bef
 
 Examples of **incorrect** code for this rule with the `"after"` option:
 
+::: incorrect
+
 ```js
 /*eslint operator-linebreak: ["error", "after"]*/
 
@@ -83,7 +85,11 @@ class Foo {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"after"` option:
+
+::: correct
 
 ```js
 /*eslint operator-linebreak: ["error", "after"]*/
@@ -116,9 +122,13 @@ class Foo {
 }
 ```
 
+:::
+
 ### before
 
 Examples of **incorrect** code for this rule with the `"before"` option:
+
+::: incorrect
 
 ```js
 /*eslint operator-linebreak: ["error", "before"]*/
@@ -148,7 +158,11 @@ class Foo {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"before"` option:
+
+::: correct
 
 ```js
 /*eslint operator-linebreak: ["error", "before"]*/
@@ -181,9 +195,13 @@ class Foo {
 }
 ```
 
+:::
+
 ### none
 
 Examples of **incorrect** code for this rule with the `"none"` option:
+
+::: incorrect
 
 ```js
 /*eslint operator-linebreak: ["error", "none"]*/
@@ -228,7 +246,11 @@ class Foo {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"none"` option:
+
+::: correct
 
 ```js
 /*eslint operator-linebreak: ["error", "none"]*/
@@ -254,9 +276,13 @@ class Foo {
 }
 ```
 
+:::
+
 ### overrides
 
 Examples of additional **incorrect** code for this rule with the `{ "overrides": { "+=": "before" } }` option:
+
+::: incorrect
 
 ```js
 /*eslint operator-linebreak: ["error", "after", { "overrides": { "+=": "before" } }]*/
@@ -266,7 +292,11 @@ thing +=
   's';
 ```
 
+:::
+
 Examples of additional **correct** code for this rule with the `{ "overrides": { "+=": "before" } }` option:
+
+::: correct
 
 ```js
 /*eslint operator-linebreak: ["error", "after", { "overrides": { "+=": "before" } }]*/
@@ -276,7 +306,11 @@ thing
   += 's';
 ```
 
+:::
+
 Examples of additional **correct** code for this rule with the `{ "overrides": { "?": "ignore", ":": "ignore" } }` option:
+
+::: correct
 
 ```js
 /*eslint operator-linebreak: ["error", "after", { "overrides": { "?": "ignore", ":": "ignore" } }]*/
@@ -292,7 +326,11 @@ answer = everything
   foo;
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the default `"after", { "overrides": { "?": "before", ":": "before" } }` option:
+
+::: incorrect
 
 ```js
 /*eslint operator-linebreak: ["error", "after", { "overrides": { "?": "before", ":": "before" } }]*/
@@ -316,7 +354,11 @@ answer = everything ?
   foo;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"after", { "overrides": { "?": "before", ":": "before" } }` option:
+
+::: correct
 
 ```js
 /*eslint operator-linebreak: ["error", "after", { "overrides": { "?": "before", ":": "before" } }]*/
@@ -337,6 +379,8 @@ answer = everything
   ? 42
   : foo;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/padded-blocks.md
+++ b/docs/src/rules/padded-blocks.md
@@ -56,6 +56,8 @@ Object option:
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint padded-blocks: ["error", "always"]*/
 
@@ -88,7 +90,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint padded-blocks: ["error", "always"]*/
@@ -123,11 +129,15 @@ class C {
 
 }
 ```
+
+:::
 
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint padded-blocks: ["error", "never"]*/
 
@@ -164,9 +174,13 @@ class C {
 
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"never"` option:
 
+::: correct
+
 ```js
 /*eslint padded-blocks: ["error", "never"]*/
 
@@ -185,11 +199,15 @@ class C {
     }
 }
 ```
+
+:::
 
 ### blocks
 
 Examples of **incorrect** code for this rule with the `{ "blocks": "always" }` option:
 
+::: incorrect
+
 ```js
 /*eslint padded-blocks: ["error", { "blocks": "always" }]*/
 
@@ -229,7 +247,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "blocks": "always" }` option:
+
+::: correct
 
 ```js
 /*eslint padded-blocks: ["error", { "blocks": "always" }]*/
@@ -274,7 +296,11 @@ class D {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "blocks": "never" }` option:
+
+::: incorrect
 
 ```js
 /*eslint padded-blocks: ["error", { "blocks": "never" }]*/
@@ -311,7 +337,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "blocks": "never" }` option:
+
+::: correct
 
 ```js
 /*eslint padded-blocks: ["error", { "blocks": "never" }]*/
@@ -339,11 +369,15 @@ class D {
 
 }
 ```
+
+:::
 
 ### classes
 
 Examples of **incorrect** code for this rule with the `{ "classes": "always" }` option:
 
+::: incorrect
+
 ```js
 /*eslint padded-blocks: ["error", { "classes": "always" }]*/
 
@@ -352,9 +386,13 @@ class  A {
     }
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{ "classes": "always" }` option:
 
+::: correct
+
 ```js
 /*eslint padded-blocks: ["error", { "classes": "always" }]*/
 
@@ -366,7 +404,11 @@ class  A {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "classes": "never" }` option:
+
+::: incorrect
 
 ```js
 /*eslint padded-blocks: ["error", { "classes": "never" }]*/
@@ -378,9 +420,13 @@ class  A {
 
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{ "classes": "never" }` option:
 
+::: correct
+
 ```js
 /*eslint padded-blocks: ["error", { "classes": "never" }]*/
 
@@ -389,11 +435,15 @@ class  A {
     }
 }
 ```
+
+:::
 
 ### switches
 
 Examples of **incorrect** code for this rule with the `{ "switches": "always" }` option:
 
+::: incorrect
+
 ```js
 /*eslint padded-blocks: ["error", { "switches": "always" }]*/
 
@@ -401,9 +451,13 @@ switch (a) {
     case 0: foo();
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{ "switches": "always" }` option:
 
+::: correct
+
 ```js
 /*eslint padded-blocks: ["error", { "switches": "always" }]*/
 
@@ -418,7 +472,11 @@ if (a) {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{ "switches": "never" }` option:
+
+::: incorrect
 
 ```js
 /*eslint padded-blocks: ["error", { "switches": "never" }]*/
@@ -430,7 +488,11 @@ switch (a) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "switches": "never" }` option:
+
+::: correct
 
 ```js
 /*eslint padded-blocks: ["error", { "switches": "never" }]*/
@@ -445,10 +507,14 @@ if (a) {
 
 }
 ```
+
+:::
 
 ### always + allowSingleLineBlocks
 
 Examples of **incorrect** code for this rule with the `"always", {"allowSingleLineBlocks": true}` options:
+
+::: incorrect
 
 ```js
 /*eslint padded-blocks: ["error", "always", { allowSingleLineBlocks: true }]*/
@@ -468,7 +534,11 @@ if (a) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always", {"allowSingleLineBlocks": true}` options:
+
+::: correct
 
 ```js
 /*eslint padded-blocks: ["error", "always", { allowSingleLineBlocks: true }]*/
@@ -481,6 +551,8 @@ if (a) {
 
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/padding-line-between-statements.md
+++ b/docs/src/rules/padding-line-between-statements.md
@@ -98,6 +98,8 @@ This configuration would require blank lines before all `return` statements, lik
 
 Examples of **incorrect** code for the `[{ blankLine: "always", prev: "*", next: "return" }]` configuration:
 
+::: incorrect
+
 ```js
 /*eslint padding-line-between-statements: [
     "error",
@@ -109,9 +111,13 @@ function foo() {
     return;
 }
 ```
+
+:::
 
 Examples of **correct** code for the `[{ blankLine: "always", prev: "*", next: "return" }]` configuration:
 
+::: correct
+
 ```js
 /*eslint padding-line-between-statements: [
     "error",
@@ -128,12 +134,16 @@ function foo() {
     return;
 }
 ```
+
+:::
 
 ----
 
 This configuration would require blank lines after every sequence of variable declarations, like the [newline-after-var](newline-after-var) rule.
 
 Examples of **incorrect** code for the `[{ blankLine: "always", prev: ["const", "let", "var"], next: "*"}, { blankLine: "any", prev: ["const", "let", "var"], next: ["const", "let", "var"]}]` configuration:
+
+::: incorrect
 
 ```js
 /*eslint padding-line-between-statements: [
@@ -165,7 +175,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for the `[{ blankLine: "always", prev: ["const", "let", "var"], next: "*"}, { blankLine: "any", prev: ["const", "let", "var"], next: ["const", "let", "var"]}]` configuration:
+
+::: correct
 
 ```js
 /*eslint padding-line-between-statements: [
@@ -205,11 +219,15 @@ class C {
 }
 ```
 
+:::
+
 ----
 
 This configuration would require blank lines after all directive prologues, like the [lines-around-directive](lines-around-directive) rule.
 
 Examples of **incorrect** code for the `[{ blankLine: "always", prev: "directive", next: "*" }, { blankLine: "any", prev: "directive", next: "directive" }]` configuration:
+
+::: incorrect
 
 ```js
 /*eslint padding-line-between-statements: [
@@ -222,7 +240,11 @@ Examples of **incorrect** code for the `[{ blankLine: "always", prev: "directive
 foo();
 ```
 
+:::
+
 Examples of **correct** code for the `[{ blankLine: "always", prev: "directive", next: "*" }, { blankLine: "any", prev: "directive", next: "directive" }]` configuration:
+
+::: correct
 
 ```js
 /*eslint padding-line-between-statements: [
@@ -237,12 +259,16 @@ Examples of **correct** code for the `[{ blankLine: "always", prev: "directive",
 foo();
 ```
 
+:::
+
 ----
 
 This configuration would require blank lines between clauses in `switch` statements.
 
 Examples of **incorrect** code for the `[{ blankLine: "always", prev: ["case", "default"], next: "*" }]` configuration:
 
+::: incorrect
+
 ```js
 /*eslint padding-line-between-statements: [
     "error",
@@ -261,9 +287,13 @@ switch (foo) {
         quux();
 }
 ```
+
+:::
 
 Examples of **correct** code for the `[{ blankLine: "always", prev: ["case", "default"], next: "*" }]` configuration:
 
+::: correct
+
 ```js
 /*eslint padding-line-between-statements: [
     "error",
@@ -285,6 +315,8 @@ switch (foo) {
         quux();
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/prefer-const.md
+++ b/docs/src/rules/prefer-const.md
@@ -22,6 +22,8 @@ This rule is aimed at flagging variables that are declared using `let` keyword, 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint prefer-const: "error"*/
 
@@ -52,7 +54,11 @@ for (let a of [1, 2, 3]) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint prefer-const: "error"*/
@@ -120,6 +126,8 @@ var b = 3;
 console.log(b);
 ```
 
+:::
+
 ## Options
 
 ```json
@@ -141,6 +149,8 @@ There are 2 values:
 
 Examples of **incorrect** code for the default `{"destructuring": "any"}` option:
 
+::: incorrect
+
 ```js
 /*eslint prefer-const: "error"*/
 /*eslint-env es6*/
@@ -149,7 +159,11 @@ let {a, b} = obj;    /*error 'b' is never reassigned, use 'const' instead.*/
 a = a + 1;
 ```
 
+:::
+
 Examples of **correct** code for the default `{"destructuring": "any"}` option:
+
+::: correct
 
 ```js
 /*eslint prefer-const: "error"*/
@@ -165,7 +179,11 @@ a = a + 1;
 b = b + 1;
 ```
 
+:::
+
 Examples of **incorrect** code for the `{"destructuring": "all"}` option:
+
+::: incorrect
 
 ```js
 /*eslint prefer-const: ["error", {"destructuring": "all"}]*/
@@ -176,7 +194,11 @@ let {a, b} = obj;    /*error 'a' is never reassigned, use 'const' instead.
                              'b' is never reassigned, use 'const' instead.*/
 ```
 
+:::
+
 Examples of **correct** code for the `{"destructuring": "all"}` option:
+
+::: correct
 
 ```js
 /*eslint prefer-const: ["error", {"destructuring": "all"}]*/
@@ -187,6 +209,8 @@ let {a, b} = obj;
 a = a + 1;
 ```
 
+:::
+
 ### ignoreReadBeforeAssign
 
 This is an option to avoid conflicting with `no-use-before-define` rule (without `"nofunc"` option).
@@ -194,6 +218,8 @@ If `true` is specified, this rule will ignore variables that are read between th
 Default is `false`.
 
 Examples of **correct** code for the `{"ignoreReadBeforeAssign": true}` option:
+
+::: correct
 
 ```js
 /*eslint prefer-const: ["error", {"ignoreReadBeforeAssign": true}]*/
@@ -208,7 +234,11 @@ function initialize() {
 timer = setInterval(initialize, 100);
 ```
 
+:::
+
 Examples of **correct** code for the default `{"ignoreReadBeforeAssign": false}` option:
+
+::: correct
 
 ```js
 /*eslint prefer-const: ["error", {"ignoreReadBeforeAssign": false}]*/
@@ -221,6 +251,8 @@ function initialize() {
     }
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/prefer-destructuring.md
+++ b/docs/src/rules/prefer-destructuring.md
@@ -37,6 +37,8 @@ The `--fix` option on the command line fixes only problems reported in variable 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```javascript
 // With `array` enabled
 var foo = array[0];
@@ -46,7 +48,11 @@ var foo = object.foo;
 var foo = object['foo'];
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```javascript
 // With `array` enabled
@@ -62,19 +68,31 @@ let foo;
 ({ foo } = object);
 ```
 
+:::
+
 Examples of **incorrect** code when `enforceForRenamedProperties` is enabled:
+
+::: incorrect
 
 ```javascript
 var foo = object.bar;
 ```
 
+:::
+
 Examples of **correct** code when `enforceForRenamedProperties` is enabled:
+
+::: correct
 
 ```javascript
 var { bar: foo } = object;
 ```
 
+:::
+
 Examples of additional **correct** code when `enforceForRenamedProperties` is enabled:
+
+::: correct
 
 ```javascript
 class C {
@@ -84,6 +102,8 @@ class C {
     }
 }
 ```
+
+:::
 
 An example configuration, with the defaults `array` and `object` filled in, looks like this:
 
@@ -159,17 +179,25 @@ For example, the following configuration enforces object destructuring in variab
 
 Examples of **correct** code when object destructuring in `VariableDeclarator` is enforced:
 
+::: correct
+
 ```javascript
 /* eslint prefer-destructuring: ["error", {VariableDeclarator: {object: true}}] */
 var {bar: foo} = object;
 ```
 
+:::
+
 Examples of **correct** code when array destructuring in `AssignmentExpression` is enforced:
+
+::: correct
 
 ```javascript
 /* eslint prefer-destructuring: ["error", {AssignmentExpression: {array: true}}] */
 [bar] = array;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/prefer-exponentiation-operator.md
+++ b/docs/src/rules/prefer-exponentiation-operator.md
@@ -22,6 +22,8 @@ This rule disallows calls to `Math.pow` and suggests using the `**` operator ins
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint prefer-exponentiation-operator: "error"*/
 
@@ -34,7 +36,11 @@ let baz = Math.pow(a + b, c + d);
 let quux = Math.pow(-1, n);
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint prefer-exponentiation-operator: "error"*/
@@ -47,6 +53,8 @@ let baz = (a + b) ** (c + d);
 
 let quux = (-1) ** n;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/prefer-named-capture-group.md
+++ b/docs/src/rules/prefer-named-capture-group.md
@@ -26,6 +26,8 @@ const regex = /(?:cauli|sun)flower/;
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint prefer-named-capture-group: "error"*/
 
@@ -36,7 +38,11 @@ const baz = RegExp('(ba[rz])');
 foo.exec('bar')[1]; // Retrieve the group result.
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint prefer-named-capture-group: "error"*/
@@ -48,6 +54,8 @@ const xyz = /xyz(?:zy|abc)/;
 
 foo.exec('bar').groups.id; // Retrieve the group result.
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/prefer-numeric-literals.md
+++ b/docs/src/rules/prefer-numeric-literals.md
@@ -22,6 +22,8 @@ This rule disallows calls to `parseInt()` or `Number.parseInt()` if called with 
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint prefer-numeric-literals: "error"*/
 
@@ -34,7 +36,11 @@ Number.parseInt("767", 8) === 503;
 Number.parseInt("1F7", 16) === 503;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint prefer-numeric-literals: "error"*/
@@ -56,6 +62,8 @@ parseInt(foo, 2);
 Number.parseInt(foo);
 Number.parseInt(foo, 2);
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/prefer-object-has-own.md
+++ b/docs/src/rules/prefer-object-has-own.md
@@ -33,6 +33,8 @@ if (Object.hasOwn(object, "foo")) {
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint prefer-object-has-own: "error"*/
 
@@ -45,7 +47,11 @@ Object.hasOwnProperty.call(obj, "a");
 const hasProperty = Object.prototype.hasOwnProperty.call(object, property);
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint prefer-object-has-own: "error"*/
@@ -54,6 +60,8 @@ Object.hasOwn(obj, "a");
 
 const hasProperty = Object.hasOwn(object, property);
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/prefer-object-spread.md
+++ b/docs/src/rules/prefer-object-spread.md
@@ -17,6 +17,8 @@ Introduced in ES2018, object spread is a declarative alternative which may perfo
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint prefer-object-spread: "error"*/
 
@@ -36,7 +38,11 @@ Object.assign({});
 Object.assign({ foo: bar });
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint prefer-object-spread: "error"*/
@@ -54,6 +60,8 @@ Object.assign(foo, { bar, baz });
 
 Object.assign(foo, { ...baz });
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/prefer-promise-reject-errors.md
+++ b/docs/src/rules/prefer-promise-reject-errors.md
@@ -25,6 +25,8 @@ This rule takes one optional object argument:
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint prefer-promise-reject-errors: "error"*/
 
@@ -44,7 +46,11 @@ new Promise(function(resolve, reject) {
 
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint prefer-promise-reject-errors: "error"*/
@@ -61,7 +67,11 @@ var foo = getUnknownValue();
 Promise.reject(foo);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `allowEmptyReject: true` option:
+
+::: correct
 
 ```js
 /*eslint prefer-promise-reject-errors: ["error", {"allowEmptyReject": true}]*/
@@ -72,6 +82,8 @@ new Promise(function(resolve, reject) {
   reject();
 });
 ```
+
+:::
 
 ## Known Limitations
 

--- a/docs/src/rules/prefer-reflect.md
+++ b/docs/src/rules/prefer-reflect.md
@@ -48,6 +48,8 @@ Deprecates `Function.prototype.apply()` and `Function.prototype.call()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
 
+::: incorrect
+
 ```js
 /*eslint prefer-reflect: "error"*/
 
@@ -62,7 +64,11 @@ obj.myMethod.call(obj, arg);
 obj.myMethod.call(other, arg);
 ```
 
+:::
+
 Examples of **correct** code for this rule when used without exceptions:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -77,7 +83,11 @@ Reflect.apply(obj.myMethod, obj, [arg]);
 Reflect.apply(obj.myMethod, other, [arg]);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "exceptions": ["apply"] }` option:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: ["error", { "exceptions": ["apply"] }]*/
@@ -89,7 +99,11 @@ obj.myMethod.apply(obj, args);
 obj.myMethod.apply(other, args);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "exceptions": ["call"] }` option:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: ["error", { "exceptions": ["call"] }]*/
@@ -101,11 +115,15 @@ obj.myMethod.call(obj, arg);
 obj.myMethod.call(other, arg);
 ```
 
+:::
+
 ### Reflect.defineProperty
 
 Deprecates `Object.defineProperty()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
+
+::: incorrect
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -113,7 +131,11 @@ Examples of **incorrect** code for this rule when used without exceptions:
 Object.defineProperty({}, 'foo', {value: 1})
 ```
 
+:::
+
 Examples of **correct** code for this rule when used without exceptions:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -121,7 +143,11 @@ Examples of **correct** code for this rule when used without exceptions:
 Reflect.defineProperty({}, 'foo', {value: 1})
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "exceptions": ["defineProperty"] }` option:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: ["error", { "exceptions": ["defineProperty"] }]*/
@@ -130,11 +156,15 @@ Object.defineProperty({}, 'foo', {value: 1})
 Reflect.defineProperty({}, 'foo', {value: 1})
 ```
 
+:::
+
 ### Reflect.getOwnPropertyDescriptor
 
 Deprecates `Object.getOwnPropertyDescriptor()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
+
+::: incorrect
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -142,7 +172,11 @@ Examples of **incorrect** code for this rule when used without exceptions:
 Object.getOwnPropertyDescriptor({}, 'foo')
 ```
 
+:::
+
 Examples of **correct** code for this rule when used without exceptions:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -150,7 +184,11 @@ Examples of **correct** code for this rule when used without exceptions:
 Reflect.getOwnPropertyDescriptor({}, 'foo')
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "exceptions": ["getOwnPropertyDescriptor"] }` option:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: ["error", { "exceptions": ["getOwnPropertyDescriptor"] }]*/
@@ -159,11 +197,15 @@ Object.getOwnPropertyDescriptor({}, 'foo')
 Reflect.getOwnPropertyDescriptor({}, 'foo')
 ```
 
+:::
+
 ### Reflect.getPrototypeOf
 
 Deprecates `Object.getPrototypeOf()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
+
+::: incorrect
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -171,7 +213,11 @@ Examples of **incorrect** code for this rule when used without exceptions:
 Object.getPrototypeOf({}, 'foo')
 ```
 
+:::
+
 Examples of **correct** code for this rule when used without exceptions:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -179,7 +225,11 @@ Examples of **correct** code for this rule when used without exceptions:
 Reflect.getPrototypeOf({}, 'foo')
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "exceptions": ["getPrototypeOf"] }` option:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: ["error", { "exceptions": ["getPrototypeOf"] }]*/
@@ -188,11 +238,15 @@ Object.getPrototypeOf({}, 'foo')
 Reflect.getPrototypeOf({}, 'foo')
 ```
 
+:::
+
 ### Reflect.setPrototypeOf
 
 Deprecates `Object.setPrototypeOf()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
+
+::: incorrect
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -200,7 +254,11 @@ Examples of **incorrect** code for this rule when used without exceptions:
 Object.setPrototypeOf({}, Object.prototype)
 ```
 
+:::
+
 Examples of **correct** code for this rule when used without exceptions:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -208,7 +266,11 @@ Examples of **correct** code for this rule when used without exceptions:
 Reflect.setPrototypeOf({}, Object.prototype)
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "exceptions": ["setPrototypeOf"] }` option:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: ["error", { "exceptions": ["setPrototypeOf"] }]*/
@@ -217,11 +279,15 @@ Object.setPrototypeOf({}, Object.prototype)
 Reflect.setPrototypeOf({}, Object.prototype)
 ```
 
+:::
+
 ### Reflect.isExtensible
 
 Deprecates `Object.isExtensible`
 
 Examples of **incorrect** code for this rule when used without exceptions:
+
+::: incorrect
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -229,7 +295,11 @@ Examples of **incorrect** code for this rule when used without exceptions:
 Object.isExtensible({})
 ```
 
+:::
+
 Examples of **correct** code for this rule when used without exceptions:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -237,7 +307,11 @@ Examples of **correct** code for this rule when used without exceptions:
 Reflect.isExtensible({})
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "exceptions": ["isExtensible"] }` option:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: ["error", { "exceptions": ["isExtensible"] }]*/
@@ -246,11 +320,15 @@ Object.isExtensible({})
 Reflect.isExtensible({})
 ```
 
+:::
+
 ### Reflect.getOwnPropertyNames
 
 Deprecates `Object.getOwnPropertyNames()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
+
+::: incorrect
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -258,7 +336,11 @@ Examples of **incorrect** code for this rule when used without exceptions:
 Object.getOwnPropertyNames({})
 ```
 
+:::
+
 Examples of **correct** code for this rule when used without exceptions:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -266,7 +348,11 @@ Examples of **correct** code for this rule when used without exceptions:
 Reflect.getOwnPropertyNames({})
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "exceptions": ["getOwnPropertyNames"] }` option:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: ["error", { "exceptions": ["getOwnPropertyNames"] }]*/
@@ -275,11 +361,15 @@ Object.getOwnPropertyNames({})
 Reflect.getOwnPropertyNames({})
 ```
 
+:::
+
 ### Reflect.preventExtensions
 
 Deprecates `Object.preventExtensions()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
+
+::: incorrect
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -287,7 +377,11 @@ Examples of **incorrect** code for this rule when used without exceptions:
 Object.preventExtensions({})
 ```
 
+:::
+
 Examples of **correct** code for this rule when used without exceptions:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -295,7 +389,11 @@ Examples of **correct** code for this rule when used without exceptions:
 Reflect.preventExtensions({})
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "exceptions": ["preventExtensions"] }` option:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: ["error", { "exceptions": ["preventExtensions"] }]*/
@@ -304,11 +402,15 @@ Object.preventExtensions({})
 Reflect.preventExtensions({})
 ```
 
+:::
+
 ### Reflect.deleteProperty
 
 Deprecates the `delete` keyword
 
 Examples of **incorrect** code for this rule when used without exceptions:
+
+::: incorrect
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -316,7 +418,11 @@ Examples of **incorrect** code for this rule when used without exceptions:
 delete foo.bar; // deleting object property
 ```
 
+:::
+
 Examples of **correct** code for this rule when used without exceptions:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -325,9 +431,13 @@ delete bar; // deleting variable
 Reflect.deleteProperty(foo, 'bar');
 ```
 
+:::
+
 Note: For a rule preventing deletion of variables, see [no-delete-var instead](no-delete-var)
 
 Examples of **correct** code for this rule with the `{ "exceptions": ["delete"] }` option:
+
+::: correct
 
 ```js
 /*eslint prefer-reflect: ["error", { "exceptions": ["delete"] }]*/
@@ -336,6 +446,8 @@ delete bar
 delete foo.bar
 Reflect.deleteProperty(foo, 'bar');
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/prefer-regex-literals.md
+++ b/docs/src/rules/prefer-regex-literals.md
@@ -56,6 +56,8 @@ dynamically generated regular expressions.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint prefer-regex-literals: "error"*/
 
@@ -74,7 +76,11 @@ RegExp(`^\\d\\.$`);
 new RegExp(String.raw`^\d\.$`);
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint prefer-regex-literals: "error"*/
@@ -99,6 +105,8 @@ RegExp(`${prefix}abc`);
 
 new RegExp(String.raw`^\d\. ${suffix}`);
 ```
+
+:::
 
 ## Options
 

--- a/docs/src/rules/prefer-rest-params.md
+++ b/docs/src/rules/prefer-rest-params.md
@@ -22,6 +22,8 @@ This rule is aimed to flag usage of `arguments` variables.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint prefer-rest-params: "error"*/
 
@@ -40,7 +42,11 @@ function foo(action) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint prefer-rest-params: "error"*/
@@ -62,6 +68,8 @@ function foo() {
     console.log(arguments); // This is a local variable.
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/prefer-spread.md
+++ b/docs/src/rules/prefer-spread.md
@@ -33,6 +33,8 @@ This rule is aimed to flag usage of `Function.prototype.apply()` in situations w
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint prefer-spread: "error"*/
 
@@ -41,7 +43,11 @@ foo.apply(null, args);
 obj.foo.apply(obj, args);
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint prefer-spread: "error"*/
@@ -61,6 +67,8 @@ foo.apply(undefined, [1, 2, 3]);
 foo.apply(null, [1, 2, 3]);
 obj.foo.apply(obj, [1, 2, 3]);
 ```
+
+:::
 
 Known limitations:
 

--- a/docs/src/rules/prefer-template.md
+++ b/docs/src/rules/prefer-template.md
@@ -32,6 +32,8 @@ This rule is aimed to flag usage of `+` operators with strings.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint prefer-template: "error"*/
 
@@ -39,7 +41,11 @@ var str = "Hello, " + name + "!";
 var str = "Time: " + (12 * 60 * 60 * 1000);
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint prefer-template: "error"*/
@@ -52,6 +58,8 @@ var str = `Time: ${12 * 60 * 60 * 1000}`;
 // This is reported by `no-useless-concat`.
 var str = "Hello, " + "World!";
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/quote-props.md
+++ b/docs/src/rules/quote-props.md
@@ -68,6 +68,8 @@ Object option:
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint quote-props: ["error", "always"]*/
 
@@ -77,7 +79,11 @@ var object = {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint quote-props: ["error", "always"]*/
@@ -102,9 +108,13 @@ var object3 = {
 };
 ```
 
+:::
+
 ### as-needed
 
 Examples of **incorrect** code for this rule with the `"as-needed"` option:
+
+::: incorrect
 
 ```js
 /*eslint quote-props: ["error", "as-needed"]*/
@@ -117,7 +127,11 @@ var object = {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"as-needed"` option:
+
+::: correct
 
 ```js
 /*eslint quote-props: ["error", "as-needed"]*/
@@ -144,9 +158,13 @@ var object3 = {
 };
 ```
 
+:::
+
 ### consistent
 
 Examples of **incorrect** code for this rule with the `"consistent"` option:
+
+::: incorrect
 
 ```js
 /*eslint quote-props: ["error", "consistent"]*/
@@ -163,7 +181,11 @@ var object2 = {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"consistent"` option:
+
+::: correct
 
 ```js
 /*eslint quote-props: ["error", "consistent"]*/
@@ -185,9 +207,13 @@ var object3 = {
 };
 ```
 
+:::
+
 ### consistent-as-needed
 
 Examples of **incorrect** code for this rule with the `"consistent-as-needed"` option:
+
+::: incorrect
 
 ```js
 /*eslint quote-props: ["error", "consistent-as-needed"]*/
@@ -204,7 +230,11 @@ var object2 = {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"consistent-as-needed"` option:
+
+::: correct
 
 ```js
 /*eslint quote-props: ["error", "consistent-as-needed"]*/
@@ -221,9 +251,13 @@ var object2 = {
 };
 ```
 
+:::
+
 ### keywords
 
 Examples of additional **incorrect** code for this rule with the `"as-needed", { "keywords": true }` options:
+
+::: incorrect
 
 ```js
 /*eslint quote-props: ["error", "as-needed", { "keywords": true }]*/
@@ -234,7 +268,11 @@ var x = {
 };
 ```
 
+:::
+
 Examples of additional **incorrect** code for this rule with the `"consistent-as-needed", { "keywords": true }` options:
+
+::: incorrect
 
 ```js
 /*eslint quote-props: ["error", "consistent-as-needed", { "keywords": true }]*/
@@ -245,9 +283,13 @@ var x = {
 };
 ```
 
+:::
+
 ### unnecessary
 
 Examples of additional **correct** code for this rule with the `"as-needed", { "unnecessary": false }` options:
+
+::: correct
 
 ```js
 /*eslint quote-props: ["error", "as-needed", { "keywords": true, "unnecessary": false }]*/
@@ -258,9 +300,13 @@ var x = {
 };
 ```
 
+:::
+
 ### numbers
 
 Examples of additional **incorrect** code for this rule with the `"as-needed", { "numbers": true }` options:
+
+::: incorrect
 
 ```js
 /*eslint quote-props: ["error", "as-needed", { "numbers": true }]*/
@@ -269,6 +315,8 @@ var x = {
     100: 1
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/quotes.md
+++ b/docs/src/rules/quotes.md
@@ -48,6 +48,8 @@ Object option:
 
 Examples of **incorrect** code for this rule with the default `"double"` option:
 
+::: incorrect
+
 ```js
 /*eslint quotes: ["error", "double"]*/
 
@@ -56,7 +58,11 @@ var unescaped = 'a string containing "double" quotes';
 var backtick = `back\ntick`; // you can use \n in single or double quoted strings
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"double"` option:
+
+::: correct
 
 ```js
 /*eslint quotes: ["error", "double"]*/
@@ -68,9 +74,13 @@ tick`;  // backticks are allowed due to newline
 var backtick = tag`backtick`; // backticks are allowed due to tag
 ```
 
+:::
+
 ### single
 
 Examples of **incorrect** code for this rule with the `"single"` option:
+
+::: incorrect
 
 ```js
 /*eslint quotes: ["error", "single"]*/
@@ -79,7 +89,11 @@ var double = "double";
 var unescaped = "a string containing 'single' quotes";
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"single"` option:
+
+::: correct
 
 ```js
 /*eslint quotes: ["error", "single"]*/
@@ -89,9 +103,13 @@ var single = 'single';
 var backtick = `back${x}tick`; // backticks are allowed due to substitution
 ```
 
+:::
+
 ### backticks
 
 Examples of **incorrect** code for this rule with the `"backtick"` option:
+
+::: incorrect
 
 ```js
 /*eslint quotes: ["error", "backtick"]*/
@@ -101,7 +119,11 @@ var double = "double";
 var unescaped = 'a string containing `backticks`';
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"backtick"` option:
+
+::: correct
 
 ```js
 /*eslint quotes: ["error", "backtick"]*/
@@ -110,9 +132,13 @@ Examples of **correct** code for this rule with the `"backtick"` option:
 var backtick = `backtick`;
 ```
 
+:::
+
 ### avoidEscape
 
 Examples of additional **correct** code for this rule with the `"double", { "avoidEscape": true }` options:
+
+::: correct
 
 ```js
 /*eslint quotes: ["error", "double", { "avoidEscape": true }]*/
@@ -120,7 +146,11 @@ Examples of additional **correct** code for this rule with the `"double", { "avo
 var single = 'a string containing "double" quotes';
 ```
 
+:::
+
 Examples of additional **correct** code for this rule with the `"single", { "avoidEscape": true }` options:
+
+::: correct
 
 ```js
 /*eslint quotes: ["error", "single", { "avoidEscape": true }]*/
@@ -128,7 +158,11 @@ Examples of additional **correct** code for this rule with the `"single", { "avo
 var double = "a string containing 'single' quotes";
 ```
 
+:::
+
 Examples of additional **correct** code for this rule with the `"backtick", { "avoidEscape": true }` options:
+
+::: correct
 
 ```js
 /*eslint quotes: ["error", "backtick", { "avoidEscape": true }]*/
@@ -136,9 +170,13 @@ Examples of additional **correct** code for this rule with the `"backtick", { "a
 var double = "a string containing `backtick` quotes"
 ```
 
+:::
+
 ### allowTemplateLiterals
 
 Examples of additional **correct** code for this rule with the `"double", { "allowTemplateLiterals": true }` options:
+
+::: correct
 
 ```js
 /*eslint quotes: ["error", "double", { "allowTemplateLiterals": true }]*/
@@ -147,7 +185,11 @@ var double = "double";
 var double = `double`;
 ```
 
+:::
+
 Examples of additional **correct** code for this rule with the `"single", { "allowTemplateLiterals": true }` options:
+
+::: correct
 
 ```js
 /*eslint quotes: ["error", "single", { "allowTemplateLiterals": true }]*/
@@ -155,6 +197,8 @@ Examples of additional **correct** code for this rule with the `"single", { "all
 var single = 'single';
 var single = `single`;
 ```
+
+:::
 
 `{ "allowTemplateLiterals": false }` will not disallow the usage of all template literals. If you want to forbid any instance of template literals, use [no-restricted-syntax](no-restricted-syntax) and target the `TemplateLiteral` selector.
 

--- a/docs/src/rules/radix.md
+++ b/docs/src/rules/radix.md
@@ -44,6 +44,8 @@ There are two options for this rule:
 
 Examples of **incorrect** code for the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint radix: "error"*/
 
@@ -58,7 +60,11 @@ var num = parseInt("071", 37);
 var num = parseInt();
 ```
 
+:::
+
 Examples of **correct** code for the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint radix: "error"*/
@@ -70,9 +76,13 @@ var num = parseInt("071", 8);
 var num = parseFloat(someValue);
 ```
 
+:::
+
 ### as-needed
 
 Examples of **incorrect** code for the `"as-needed"` option:
+
+::: incorrect
 
 ```js
 /*eslint radix: ["error", "as-needed"]*/
@@ -84,7 +94,11 @@ var num = parseInt("071", "abc");
 var num = parseInt();
 ```
 
+:::
+
 Examples of **correct** code for the `"as-needed"` option:
+
+::: correct
 
 ```js
 /*eslint radix: ["error", "as-needed"]*/
@@ -95,6 +109,8 @@ var num = parseInt("071", 8);
 
 var num = parseFloat(someValue);
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/require-atomic-updates.md
+++ b/docs/src/rules/require-atomic-updates.md
@@ -64,6 +64,8 @@ Note that the rule does not report the assignment in step 3 in any of the follow
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /* eslint require-atomic-updates: error */
 
@@ -92,7 +94,11 @@ function* generator() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /* eslint require-atomic-updates: error */
@@ -127,6 +133,8 @@ function* generator() {
 }
 ```
 
+:::
+
 ### Properties
 
 This rule reports an assignment to a property through a variable when it detects the following execution flow in a generator or async function:
@@ -139,6 +147,8 @@ This logic is similar to the logic for variables, but stricter because the prope
 
 Example of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /* eslint require-atomic-updates: error */
 
@@ -149,7 +159,11 @@ async function foo(obj) {
 }
 ```
 
+:::
+
 Example of **correct** code for this rule:
+
+::: correct
 
 ```js
 /* eslint require-atomic-updates: error */
@@ -164,6 +178,8 @@ async function foo(obj) {
 }
 ```
 
+:::
+
 ## Options
 
 This rule has an object option:
@@ -174,6 +190,8 @@ This rule has an object option:
 
 Example of **correct** code for this rule with the `{ "allowProperties": true }` option:
 
+::: correct
+
 ```js
 /* eslint require-atomic-updates: ["error", { "allowProperties": true }] */
 
@@ -183,6 +201,8 @@ async function foo(obj) {
     }
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/require-await.md
+++ b/docs/src/rules/require-await.md
@@ -35,6 +35,8 @@ This rule warns async functions which have no `await` expression.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint require-await: "error"*/
 
@@ -47,7 +49,11 @@ bar(async () => {
 });
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint require-await: "error"*/
@@ -71,6 +77,8 @@ bar(() => {
 // Allow empty functions.
 async function noop() {}
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/require-jsdoc.md
+++ b/docs/src/rules/require-jsdoc.md
@@ -63,6 +63,8 @@ Default option settings are:
 
 Examples of **incorrect** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": true, "FunctionExpression": true } }` option:
 
+::: incorrect
+
 ```js
 /*eslint "require-jsdoc": ["error", {
     "require": {
@@ -103,7 +105,11 @@ var foo = {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": true, "FunctionExpression": true } }` option:
+
+::: correct
 
 ```js
 /*eslint "require-jsdoc": ["error", {
@@ -188,6 +194,8 @@ var foo = {
 
 setTimeout(() => {}, 10); // since it's an anonymous arrow function
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/require-unicode-regexp.md
+++ b/docs/src/rules/require-unicode-regexp.md
@@ -32,6 +32,8 @@ This rule aims to enforce the use of `u` flag on regular expressions.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint require-unicode-regexp: error */
 
@@ -41,7 +43,11 @@ const c = new RegExp("ccc")
 const d = new RegExp("ddd", "gi")
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint require-unicode-regexp: error */
@@ -56,6 +62,8 @@ function f(flags) {
     return new RegExp("eee", flags)
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/require-yield.md
+++ b/docs/src/rules/require-yield.md
@@ -19,6 +19,8 @@ This rule generates warnings for generator functions that do not have the `yield
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint require-yield: "error"*/
 /*eslint-env es6*/
@@ -28,7 +30,11 @@ function* foo() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint require-yield: "error"*/
@@ -46,6 +52,8 @@ function foo() {
 // This rule does not warn on empty generator functions.
 function* foo() { }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/rest-spread-spacing.md
+++ b/docs/src/rules/rest-spread-spacing.md
@@ -84,6 +84,8 @@ rest-spread-spacing: ["error", "never"]
 
 Examples of **incorrect** code for this rule with `"never"`:
 
+::: incorrect
+
 ```js
 /*eslint rest-spread-spacing: ["error", "never"]*/
 
@@ -95,7 +97,11 @@ let { x, y, ... z } = { x: 1, y: 2, a: 3, b: 4 };
 let n = { x, y, ... z };
 ```
 
+:::
+
 Examples of **correct** code for this rule with `"never"`:
+
+::: correct
 
 ```js
 /*eslint rest-spread-spacing: ["error", "never"]*/
@@ -108,6 +114,8 @@ let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };
 let n = { x, y, ...z };
 ```
 
+:::
+
 ### "always"
 
 When using the `"always"` option, whitespace is required between spread operators and their expressions.
@@ -117,6 +125,8 @@ rest-spread-spacing: ["error", "always"]
 ```
 
 Examples of **incorrect** code for this rule with `"always"`:
+
+::: incorrect
 
 ```js
 /*eslint rest-spread-spacing:["error", "always"]*/
@@ -129,7 +139,11 @@ let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };
 let n = { x, y, ...z };
 ```
 
+:::
+
 Examples of **correct** code for this rule with `"always"`:
+
+::: correct
 
 ```js
 /*eslint rest-spread-spacing: ["error", "always"]*/
@@ -141,6 +155,8 @@ function fn(... args) { console.log(args); }
 let { x, y, ... z } = { x: 1, y: 2, a: 3, b: 4 };
 let n = { x, y, ... z };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/semi-spacing.md
+++ b/docs/src/rules/semi-spacing.md
@@ -56,6 +56,8 @@ This is the default option. It enforces spacing after semicolons and disallows s
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint semi-spacing: "error"*/
 
@@ -67,7 +69,11 @@ for (i = 0 ; i < 10 ; i++) {}
 for (i = 0;i < 10;i++) {}
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint semi-spacing: "error"*/
@@ -82,11 +88,15 @@ if (true) {;}
 ;foo();
 ```
 
+:::
+
 ### `{"before": true, "after": false}`
 
 This option enforces spacing before semicolons and disallows spacing after semicolons.
 
 Examples of **incorrect** code for this rule with the `{"before": true, "after": false}` option:
+
+::: incorrect
 
 ```js
 /*eslint semi-spacing: ["error", { "before": true, "after": false }]*/
@@ -99,7 +109,11 @@ for (i = 0;i < 10;i++) {}
 for (i = 0; i < 10; i++) {}
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{"before": true, "after": false}` option:
+
+::: correct
 
 ```js
 /*eslint semi-spacing: ["error", { "before": true, "after": false }]*/
@@ -110,6 +124,8 @@ throw new Error("error") ;
 while (a) {break ;}
 for (i = 0 ;i < 10 ;i++) {}
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/semi-style.md
+++ b/docs/src/rules/semi-style.md
@@ -32,6 +32,8 @@ This rule has an option.
 
 Examples of **incorrect** code for this rule with `"last"` option:
 
+::: incorrect
+
 ```js
 /*eslint semi-style: ["error", "last"]*/
 
@@ -53,9 +55,13 @@ class C {
     }
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with `"last"` option:
 
+::: correct
+
 ```js
 /*eslint semi-style: ["error", "last"]*/
 
@@ -78,7 +84,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with `"first"` option:
+
+::: incorrect
 
 ```js
 /*eslint semi-style: ["error", "first"]*/
@@ -102,7 +112,11 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with `"first"` option:
+
+::: correct
 
 ```js
 /*eslint semi-style: ["error", "first"]*/
@@ -125,6 +139,8 @@ class C {
     }
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/sort-imports.md
+++ b/docs/src/rules/sort-imports.md
@@ -75,6 +75,8 @@ Default option settings are:
 
 Examples of **correct** code for this rule when using default options:
 
+::: correct
+
 ```js
 /*eslint sort-imports: "error"*/
 import 'module-without-export.js';
@@ -101,7 +103,11 @@ import {d} from 'quux.js';
 import {a, b, c} from 'foo.js'
 ```
 
+:::
+
 Examples of **incorrect** code for this rule when using default options:
+
+::: incorrect
 
 ```js
 /*eslint sort-imports: "error"*/
@@ -132,11 +138,15 @@ import * as b from 'bar.js';
 import {b, a, c} from 'foo.js'
 ```
 
+:::
+
 ### `ignoreCase`
 
 When `true` the rule ignores the case-sensitivity of the imports local name.
 
 Examples of **incorrect** code for this rule with the `{ "ignoreCase": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint sort-imports: ["error", { "ignoreCase": true }]*/
@@ -145,7 +155,11 @@ import B from 'foo.js';
 import a from 'bar.js';
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "ignoreCase": true }` option:
+
+::: correct
 
 ```js
 /*eslint sort-imports: ["error", { "ignoreCase": true }]*/
@@ -155,6 +169,8 @@ import B from 'bar.js';
 import c from 'baz.js';
 ```
 
+:::
+
 Default is `false`.
 
 ### `ignoreDeclarationSort`
@@ -163,19 +179,27 @@ Ignores the sorting of import declaration statements.
 
 Examples of **incorrect** code for this rule with the default `{ "ignoreDeclarationSort": false }` option:
 
+::: incorrect
+
 ```js
 /*eslint sort-imports: ["error", { "ignoreDeclarationSort": false }]*/
 import b from 'foo.js'
 import a from 'bar.js'
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "ignoreDeclarationSort": true }` option:
+
+::: correct
 
 ```js
 /*eslint sort-imports: ["error", { "ignoreDeclarationSort": true }]*/
 import a from 'foo.js'
 import b from 'bar.js'
 ```
+
+:::
 
 ```js
 /*eslint sort-imports: ["error", { "ignoreDeclarationSort": true }]*/
@@ -191,17 +215,25 @@ Ignores the member sorting within a `multiple` member import declaration.
 
 Examples of **incorrect** code for this rule with the default `{ "ignoreMemberSort": false }` option:
 
+::: incorrect
+
 ```js
 /*eslint sort-imports: ["error", { "ignoreMemberSort": false }]*/
 import {b, a, c} from 'foo.js'
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "ignoreMemberSort": true }` option:
+
+::: correct
 
 ```js
 /*eslint sort-imports: ["error", { "ignoreMemberSort": true }]*/
 import {b, a, c} from 'foo.js'
 ```
+
+:::
 
 Default is `false`.
 
@@ -218,13 +250,19 @@ All four options must be specified in the array, but you can customize their ord
 
 Examples of **incorrect** code for this rule with the default `{ "memberSyntaxSortOrder": ["none", "all", "multiple", "single"] }` option:
 
+::: incorrect
+
 ```js
 /*eslint sort-imports: "error"*/
 import a from 'foo.js';
 import * as b from 'bar.js';
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "memberSyntaxSortOrder": ['single', 'all', 'multiple', 'none'] }` option:
+
+::: correct
 
 ```js
 /*eslint sort-imports: ["error", { "memberSyntaxSortOrder": ['single', 'all', 'multiple', 'none'] }]*/
@@ -233,7 +271,11 @@ import a from 'foo.js';
 import * as b from 'bar.js';
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{ "memberSyntaxSortOrder": ['all', 'single', 'multiple', 'none'] }` option:
+
+::: correct
 
 ```js
 /*eslint sort-imports: ["error", { "memberSyntaxSortOrder": ['all', 'single', 'multiple', 'none'] }]*/
@@ -242,6 +284,8 @@ import * as foo from 'foo.js';
 import z from 'zoo.js';
 import {a, b} from 'foo.js';
 ```
+
+:::
 
 Default is `["none", "all", "multiple", "single"]`.
 
@@ -253,6 +297,8 @@ In other words, a blank line or a comment line or line with any other statement 
 
 Examples of **incorrect** code for this rule with the `{ "allowSeparatedGroups": true }` option:
 
+::: incorrect
+
 ```js
 /*eslint sort-imports: ["error", { "allowSeparatedGroups": true }]*/
 
@@ -260,9 +306,13 @@ import b from 'foo.js';
 import c from 'bar.js';
 import a from 'baz.js';
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{ "allowSeparatedGroups": true }` option:
 
+::: correct
+
 ```js
 /*eslint sort-imports: ["error", { "allowSeparatedGroups": true }]*/
 
@@ -271,6 +321,8 @@ import c from 'bar.js';
 
 import a from 'baz.js';
 ```
+
+:::
 
 ```js
 /*eslint sort-imports: ["error", { "allowSeparatedGroups": true }]*/

--- a/docs/src/rules/sort-keys.md
+++ b/docs/src/rules/sort-keys.md
@@ -18,6 +18,8 @@ This rule checks all property definitions of object expressions and verifies tha
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint sort-keys: "error"*/
 /*eslint-env es6*/
@@ -38,7 +40,11 @@ let obj = {a: 1, ["c"]: 3, b: 2};
 let obj = {a: 1, [S]: 3, b: 2};
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint sort-keys: "error"*/
@@ -66,6 +72,8 @@ let obj = {a: 1, [tag`c`]: 3, b: 2};
 // This rule does not report unsorted properties that are separated by a spread property.
 let obj = {b: 1, ...c, a: 2};
 ```
+
+:::
 
 ## Options
 
@@ -106,6 +114,8 @@ With `natural` as false, the ordering would be
 
 Examples of **incorrect** code for the `"desc"` option:
 
+::: incorrect
+
 ```js
 /*eslint sort-keys: ["error", "desc"]*/
 /*eslint-env es6*/
@@ -120,7 +130,11 @@ let obj = {C: 1, b: 3, a: 2};
 let obj = {10: b, 2: c, 1: a};
 ```
 
+:::
+
 Examples of **correct** code for the `"desc"` option:
+
+::: correct
 
 ```js
 /*eslint sort-keys: ["error", "desc"]*/
@@ -136,9 +150,13 @@ let obj = {b: 3, a: 2, C: 1};
 let obj = {2: c, 10: b, 1: a};
 ```
 
+:::
+
 ### insensitive
 
 Examples of **incorrect** code for the `{caseSensitive: false}` option:
+
+::: incorrect
 
 ```js
 /*eslint sort-keys: ["error", "asc", {caseSensitive: false}]*/
@@ -148,7 +166,11 @@ let obj = {a: 1, c: 3, C: 4, b: 2};
 let obj = {a: 1, C: 3, c: 4, b: 2};
 ```
 
+:::
+
 Examples of **correct** code for the `{caseSensitive: false}` option:
+
+::: correct
 
 ```js
 /*eslint sort-keys: ["error", "asc", {caseSensitive: false}]*/
@@ -158,9 +180,13 @@ let obj = {a: 1, b: 2, c: 3, C: 4};
 let obj = {a: 1, b: 2, C: 3, c: 4};
 ```
 
+:::
+
 ### natural
 
 Examples of **incorrect** code for the `{natural: true}` option:
+
+::: incorrect
 
 ```js
 /*eslint sort-keys: ["error", "asc", {natural: true}]*/
@@ -169,7 +195,11 @@ Examples of **incorrect** code for the `{natural: true}` option:
 let obj = {1: a, 10: c, 2: b};
 ```
 
+:::
+
 Examples of **correct** code for the `{natural: true}` option:
+
+::: correct
 
 ```js
 /*eslint sort-keys: ["error", "asc", {natural: true}]*/
@@ -178,9 +208,13 @@ Examples of **correct** code for the `{natural: true}` option:
 let obj = {1: a, 2: b, 10: c};
 ```
 
+:::
+
 ### minKeys
 
 Examples of **incorrect** code for the `{minKeys: 4}` option:
+
+::: incorrect
 
 ```js
 /*eslint sort-keys: ["error", "asc", {minKeys: 4}]*/
@@ -204,7 +238,11 @@ let obj = {
 };
 ```
 
+:::
+
 Examples of **correct** code for the `{minKeys: 4}` option:
+
+::: correct
 
 ```js
 /*eslint sort-keys: ["error", "asc", {minKeys: 4}]*/
@@ -223,6 +261,8 @@ let obj = {
     1: 'a',
 };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/sort-vars.md
+++ b/docs/src/rules/sort-vars.md
@@ -21,6 +21,8 @@ The default configuration of the rule is case-sensitive.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint sort-vars: "error"*/
 
@@ -31,7 +33,11 @@ var a, B, c;
 var a, A;
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint sort-vars: "error"*/
@@ -45,6 +51,8 @@ var A, a;
 
 var B, a, c;
 ```
+
+:::
 
 Alphabetical list is maintained starting from the first variable and excluding any that are considered problems. So the following code will produce two problems:
 
@@ -72,6 +80,8 @@ This rule has an object option:
 
 Examples of **correct** code for this rule with the `{ "ignoreCase": true }` option:
 
+::: correct
+
 ```js
 /*eslint sort-vars: ["error", { "ignoreCase": true }]*/
 
@@ -79,6 +89,8 @@ var a, A;
 
 var a, B, c;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/space-after-function-name.md
+++ b/docs/src/rules/space-after-function-name.md
@@ -29,6 +29,8 @@ This rule aims to enforce a consistent spacing after function names. It takes on
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 function foo (x) {
     // ...
@@ -42,7 +44,11 @@ function bar(x) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 function foo(x) {
@@ -56,3 +62,5 @@ function bar (x) {
     // ...
 }
 ```
+
+:::

--- a/docs/src/rules/space-after-keywords.md
+++ b/docs/src/rules/space-after-keywords.md
@@ -36,6 +36,8 @@ then there should be no spaces following. The default is `"always"`.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint space-after-keywords: "error"*/
 
@@ -46,6 +48,8 @@ if (a) {} else{}
 do{} while (a);
 ```
 
+:::
+
 ```js
 /*eslint space-after-keywords: ["error", "never"]*/
 
@@ -54,6 +58,8 @@ if (a) {}
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint space-after-keywords: "error"*/
 
@@ -61,6 +67,8 @@ if (a) {}
 
 if (a) {} else {}
 ```
+
+:::
 
 ```js
 /*eslint space-after-keywords: ["error", "never"]*/

--- a/docs/src/rules/space-before-blocks.md
+++ b/docs/src/rules/space-before-blocks.md
@@ -43,6 +43,8 @@ The default is `"always"`.
 
 Examples of **incorrect** code for this rule with the "always" option:
 
+::: incorrect
+
 ```js
 /*eslint space-before-blocks: "error"*/
 
@@ -63,7 +65,11 @@ class Foo{
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint space-before-blocks: "error"*/
@@ -91,9 +97,13 @@ for (;;) {
 try {} catch(a) {}
 ```
 
+:::
+
 ### "never"
 
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint space-before-blocks: ["error", "never"]*/
@@ -111,7 +121,11 @@ for (;;) {
 try {} catch(a) {}
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint space-before-blocks: ["error", "never"]*/
@@ -133,7 +147,11 @@ class Foo{
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule when configured `{ "functions": "never", "keywords": "always", "classes": "never" }`:
+
+::: incorrect
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "always", "classes": "never" }]*/
@@ -148,7 +166,11 @@ class Foo{
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule when configured `{ "functions": "never", "keywords": "always", "classes": "never" }`:
+
+::: correct
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "always", "classes": "never" }]*/
@@ -167,7 +189,11 @@ class Foo{
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule when configured `{ "functions": "always", "keywords": "never", "classes": "never" }`:
+
+::: incorrect
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", "classes": "never" }]*/
@@ -182,7 +208,11 @@ class Foo {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule when configured `{ "functions": "always", "keywords": "never", "classes": "never" }`:
+
+::: correct
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", "classes": "never" }]*/
@@ -199,7 +229,11 @@ class Foo{
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule when configured `{ "functions": "never", "keywords": "never", "classes": "always" }`:
+
+::: incorrect
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "never", "classes": "always" }]*/
@@ -210,7 +244,11 @@ class Foo{
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule when configured `{ "functions": "never", "keywords": "never", "classes": "always" }`:
+
+::: correct
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "never", "classes": "always" }]*/
@@ -220,6 +258,8 @@ class Foo {
   constructor(){}
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/space-before-function-paren.md
+++ b/docs/src/rules/space-before-function-paren.md
@@ -66,6 +66,8 @@ Each of the following options can be set to `"always"`, `"never"`, or `"ignore"`
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint space-before-function-paren: "error"*/
 /*eslint-env es6*/
@@ -97,7 +99,11 @@ var foo = {
 var foo = async() => 1
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint space-before-function-paren: "error"*/
@@ -129,11 +135,15 @@ var foo = {
 
 var foo = async () => 1
 ```
+
+:::
 
 ### "never"
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint space-before-function-paren: ["error", "never"]*/
 /*eslint-env es6*/
@@ -165,7 +175,11 @@ var foo = {
 var foo = async () => 1
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint space-before-function-paren: ["error", "never"]*/
@@ -198,9 +212,13 @@ var foo = {
 var foo = async() => 1
 ```
 
+:::
+
 ### `{"anonymous": "always", "named": "never", "asyncArrow": "always"}`
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "always", "named": "never", "asyncArrow": "always"}` option:
+
+::: incorrect
 
 ```js
 /*eslint space-before-function-paren: ["error", {"anonymous": "always", "named": "never", "asyncArrow": "always"}]*/
@@ -229,7 +247,11 @@ var foo = {
 var foo = async(a) => await a
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{"anonymous": "always", "named": "never", "asyncArrow": "always"}` option:
+
+::: correct
 
 ```js
 /*eslint space-before-function-paren: ["error", {"anonymous": "always", "named": "never", "asyncArrow": "always"}]*/
@@ -258,9 +280,13 @@ var foo = {
 var foo = async (a) => await a
 ```
 
+:::
+
 ### `{"anonymous": "never", "named": "always"}`
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
+
+::: incorrect
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
@@ -287,7 +313,11 @@ var foo = {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
+
+::: correct
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
@@ -313,11 +343,15 @@ var foo = {
     }
 };
 ```
+
+:::
 
 ### `{"anonymous": "ignore", "named": "always"}`
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "ignore", "named": "always"}` option:
 
+::: incorrect
+
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/
 /*eslint-env es6*/
@@ -339,7 +373,11 @@ var foo = {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{"anonymous": "ignore", "named": "always"}` option:
+
+::: correct
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/
@@ -369,6 +407,8 @@ var foo = {
     }
 };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/space-before-function-parentheses.md
+++ b/docs/src/rules/space-before-function-parentheses.md
@@ -38,6 +38,8 @@ This rule takes one argument. If it is `"always"`, which is the default option, 
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint-env es6*/
 
@@ -65,9 +67,13 @@ var foo = {
     }
 };
 ```
+
+:::
 
 Examples of **correct** code for this rule with the default `"always"` option:
 
+::: correct
+
 ```js
 /*eslint-env es6*/
 
@@ -95,9 +101,13 @@ var foo = {
     }
 };
 ```
+
+:::
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint-env es6*/
 
@@ -126,7 +136,11 @@ var foo = {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint-env es6*/
@@ -156,7 +170,11 @@ var foo = {
 };
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `{"anonymous": "always", "named": "never"}` option:
+
+::: incorrect
 
 ```js
 /*eslint-env es6*/
@@ -181,9 +199,13 @@ var foo = {
     }
 };
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{"anonymous": "always", "named": "never"}` option:
 
+::: correct
+
 ```js
 /*eslint-env es6*/
 
@@ -207,9 +229,13 @@ var foo = {
     }
 };
 ```
+
+:::
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
+::: incorrect
+
 ```js
 /*eslint-env es6*/
 
@@ -234,7 +260,11 @@ var foo = {
 };
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
+
+::: correct
 
 ```js
 /*eslint-env es6*/
@@ -259,6 +289,8 @@ var foo = {
     }
 };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/space-before-keywords.md
+++ b/docs/src/rules/space-before-keywords.md
@@ -45,6 +45,8 @@ this behavior, consider using the [block-spacing](block-spacing) rule.
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint space-before-keywords: ["error", "always"]*/
 /*eslint-env es6*/
@@ -62,7 +64,11 @@ function bar() {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"always"` option:
+
+::: correct
 
 ```js
 /*eslint space-before-keywords: ["error", "always"]*/
@@ -79,7 +85,11 @@ if (foo) {
 for (let foo of ['bar', 'baz', 'qux']) {}
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint space-before-keywords: ["error", "never"]*/
@@ -98,7 +108,11 @@ try {} finally {}
 try {} catch(e) {}
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never"` option:
+
+::: correct
 
 ```js
 /*eslint space-before-keywords: ["error", "never"]*/
@@ -113,6 +127,8 @@ try {}finally {}
 
 try{}catch(e) {}
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/space-in-brackets.md
+++ b/docs/src/rules/space-in-brackets.md
@@ -47,6 +47,8 @@ Depending on your coding conventions, you can choose either option by specifying
 
 Examples of **incorrect** code for this rule with the default `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint-env es6*/
 
@@ -67,7 +69,11 @@ var obj = { baz: {'foo': 'qux'}, bar};
 var obj = {baz: { 'foo': 'qux' }, bar};
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"never"` option:
+
+::: correct
 
 ```js
 // When options are ["error", "never"]
@@ -107,9 +113,13 @@ var obj = {
 var obj = {};
 ```
 
+:::
+
 ### "always"
 
 Examples of **incorrect** code for this rule with the `"always"` option:
+
+::: incorrect
 
 ```js
 /*eslint-env es6*/
@@ -140,7 +150,11 @@ var obj = {
   'foo':'bar'};
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 foo[ 'bar' ];
@@ -165,6 +179,8 @@ var obj = {
   'foo': 'bar'
 };
 ```
+
+:::
 
 Note that `"always"` has a special case where `{}` and `[]` are not considered problems.
 
@@ -213,6 +229,8 @@ In each of the following examples, the `"always"` option is assumed.
 
 Examples of **incorrect** code for this rule when `"singleValue"` is set to `false`:
 
+::: incorrect
+
 ```js
 var foo = [ 'foo' ];
 var foo = [ 'foo'];
@@ -224,7 +242,11 @@ var foo = [ [ 1, 2 ] ];
 var foo = [ { 'foo': 'bar' } ];
 ```
 
+:::
+
 Examples of **correct** code for this rule when `"singleValue"` is set to `false`:
+
+::: correct
 
 ```js
 var foo = ['foo'];
@@ -233,7 +255,11 @@ var foo = [[ 1, 1 ]];
 var foo = [{ 'foo': 'bar' }];
 ```
 
+:::
+
 Examples of **incorrect** code when `"objectsInArrays"` is set to `false`:
+
+::: incorrect
 
 ```js
 var arr = [ { 'foo': 'bar' } ];
@@ -242,7 +268,11 @@ var arr = [ {
 } ]
 ```
 
+:::
+
 Examples of **correct** code when `"objectsInArrays"` is set to `false`:
+
+::: correct
 
 ```js
 var arr = [{ 'foo': 'bar' }];
@@ -251,61 +281,95 @@ var arr = [{
 }];
 ```
 
+:::
+
 Examples of **incorrect** code when `"arraysInArrays"` is set to `false`:
+
+::: incorrect
 
 ```js
 var arr = [ [ 1, 2 ], 2, 3, 4 ];
 var arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];
 ```
 
+:::
+
 Examples of **correct** code when `"arraysInArrays"` is set to `false`:
+
+::: correct
 
 ```js
 var arr = [[ 1, 2 ], 2, 3, 4 ];
 var arr = [[ 1, 2 ], 2, [ 3, 4 ]];
 ```
 
+:::
+
 Examples of **incorrect** code when `"arraysInObjects"` is set to `false`:
+
+::: incorrect
 
 ```js
 var obj = { "foo": [ 1, 2 ] };
 var obj = { "foo": [ "baz", "bar" ] };
 ```
 
+:::
+
 Examples of **correct** code when `"arraysInObjects"` is set to `false`:
+
+::: correct
 
 ```js
 var obj = { "foo": [ 1, 2 ]};
 var obj = { "foo": [ "baz", "bar" ]};
 ```
 
+:::
+
 Examples of **incorrect** code when `"objectsInObjects"` is set to `false`:
+
+::: incorrect
 
 ```js
 var obj = { "foo": { "baz": 1, "bar": 2 } };
 var obj = { "foo": [ "baz", "bar" ], "qux": { "baz": 1, "bar": 2 } };
 ```
 
+:::
+
 Examples of **correct** code when `"objectsInObjects"` is set to `false`:
+
+::: correct
 
 ```js
 var obj = { "foo": { "baz": 1, "bar": 2 }};
 var obj = { "foo": [ "baz", "bar" ], "qux": { "baz": 1, "bar": 2 }};
 ```
 
+:::
+
 Examples of **incorrect** code when `"propertyName"` is set to `false`:
+
+::: incorrect
 
 ```js
 var foo = obj[ 1 ];
 var foo = obj[ bar ];
 ```
 
+:::
+
 Examples of **correct** code when `"propertyName"` is set to `false`:
+
+::: correct
 
 ```js
 var foo = obj[bar];
 var foo = obj[0, 1];
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/space-in-parens.md
+++ b/docs/src/rules/space-in-parens.md
@@ -46,6 +46,8 @@ Depending on your coding conventions, you can choose either option by specifying
 
 Examples of **incorrect** code for this rule with the default `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint space-in-parens: ["error", "never"]*/
 
@@ -61,7 +63,11 @@ var foo = ( 1 + 2 ) * 3;
 ( function () { return 'bar'; }() );
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"never"` option:
+
+::: correct
 
 ```js
 /*eslint space-in-parens: ["error", "never"]*/
@@ -75,11 +81,15 @@ foo(/* bar */);
 var foo = (1 + 2) * 3;
 (function () { return 'bar'; }());
 ```
+
+:::
 
 ### "always"
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint space-in-parens: ["error", "always"]*/
 
@@ -93,7 +103,11 @@ var foo = (1 + 2) * 3;
 (function () { return 'bar'; }());
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint space-in-parens: ["error", "always"]*/
@@ -108,6 +122,8 @@ foo( /* bar */ );
 var foo = ( 1 + 2 ) * 3;
 ( function () { return 'bar'; }() );
 ```
+
+:::
 
 ### Exceptions
 
@@ -130,6 +146,8 @@ Empty parens exception and behavior:
 
 Examples of **incorrect** code for this rule with the `"never", { "exceptions": ["{}"] }` option:
 
+::: incorrect
+
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["{}"] }]*/
 
@@ -137,7 +155,11 @@ foo({bar: 'baz'});
 foo(1, {bar: 'baz'});
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never", { "exceptions": ["{}"] }` option:
+
+::: correct
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["{}"] }]*/
@@ -146,7 +168,11 @@ foo( {bar: 'baz'} );
 foo(1, {bar: 'baz'} );
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"always", { "exceptions": ["{}"] }` option:
+
+::: incorrect
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["{}"] }]*/
@@ -155,7 +181,11 @@ foo( {bar: 'baz'} );
 foo( 1, {bar: 'baz'} );
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always", { "exceptions": ["{}"] }` option:
+
+::: correct
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["{}"] }]*/
@@ -164,7 +194,11 @@ foo({bar: 'baz'});
 foo( 1, {bar: 'baz'});
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"never", { "exceptions": ["[]"] }` option:
+
+::: incorrect
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["[]"] }]*/
@@ -173,7 +207,11 @@ foo([bar, baz]);
 foo([bar, baz], 1);
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never", { "exceptions": ["[]"] }` option:
+
+::: correct
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["[]"] }]*/
@@ -182,7 +220,11 @@ foo( [bar, baz] );
 foo( [bar, baz], 1);
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"always", { "exceptions": ["[]"] }` option:
+
+::: incorrect
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["[]"] }]*/
@@ -191,7 +233,11 @@ foo( [bar, baz] );
 foo( [bar, baz], 1 );
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always", { "exceptions": ["[]"] }` option:
+
+::: correct
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["[]"] }]*/
@@ -200,7 +246,11 @@ foo([bar, baz]);
 foo([bar, baz], 1 );
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"never", { "exceptions": ["()"] }]` option:
+
+::: incorrect
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["()"] }]*/
@@ -210,7 +260,11 @@ foo((1 + 2), 1);
 foo(bar());
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"never", { "exceptions": ["()"] }]` option:
+
+::: correct
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["()"] }]*/
@@ -220,7 +274,11 @@ foo( (1 + 2), 1);
 foo(bar() );
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with the `"always", { "exceptions": ["()"] }]` option:
+
+::: incorrect
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["()"] }]*/
@@ -229,7 +287,11 @@ foo( ( 1 + 2 ) );
 foo( ( 1 + 2 ), 1 );
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always", { "exceptions": ["()"] }]` option:
+
+::: correct
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["()"] }]*/
@@ -238,25 +300,37 @@ foo(( 1 + 2 ));
 foo(( 1 + 2 ), 1 );
 ```
 
+:::
+
 The `"empty"` exception concerns empty parentheses, and works the same way as the other exceptions, inverting the first option.
 
 Example of **incorrect** code for this rule with the `"never", { "exceptions": ["empty"] }]` option:
 
+::: incorrect
+
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["empty"] }]*/
 
 foo();
 ```
+
+:::
 
 Example of **correct** code for this rule with the `"never", { "exceptions": ["empty"] }]` option:
 
+::: correct
+
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["empty"] }]*/
 
 foo( );
 ```
 
+:::
+
 Example of **incorrect** code for this rule with the `"always", { "exceptions": ["empty"] }]` option:
+
+::: incorrect
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["empty"] }]*/
@@ -264,17 +338,25 @@ Example of **incorrect** code for this rule with the `"always", { "exceptions": 
 foo( );
 ```
 
+:::
+
 Example of **correct** code for this rule with the `"always", { "exceptions": ["empty"] }]` option:
+
+::: correct
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["empty"] }]*/
 
 foo();
 ```
+
+:::
 
 You can include multiple entries in the `"exceptions"` array.
 
 Examples of **incorrect** code for this rule with the `"always", { "exceptions": ["{}", "[]"] }]` option:
+
+::: incorrect
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["{}", "[]"] }]*/
@@ -284,7 +366,11 @@ baz( 1, [1,2] );
 foo( {bar: 'baz'}, [1, 2] );
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always", { "exceptions": ["{}", "[]"] }]` option:
+
+::: correct
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["{}", "[]"] }]*/
@@ -293,6 +379,8 @@ bar({bar:'baz'});
 baz( 1, [1,2]);
 foo({bar: 'baz'}, [1, 2]);
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/space-infix-ops.md
+++ b/docs/src/rules/space-infix-ops.md
@@ -45,6 +45,8 @@ var foo = bar|0; // `foo` is forced to be signed 32 bit integer
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint space-infix-ops: "error"*/
 /*eslint-env es6*/
@@ -64,7 +66,11 @@ var {a=0}=bar;
 function foo(a=0) { }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint space-infix-ops: "error"*/
@@ -82,6 +88,8 @@ var {a = 0} = bar;
 
 function foo(a = 0) { }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/space-return-throw-case.md
+++ b/docs/src/rules/space-return-throw-case.md
@@ -17,6 +17,8 @@ Require spaces following `return`, `throw`, and `case`.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint space-return-throw-case: "error"*/
 
@@ -27,7 +29,11 @@ function f(){ return-a; }
 switch(a){ case'a': break; }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint space-return-throw-case: "error"*/
@@ -38,3 +44,5 @@ function f(){ return -a; }
 
 switch(a){ case 'a': break; }
 ```
+
+:::

--- a/docs/src/rules/space-unary-ops.md
+++ b/docs/src/rules/space-unary-ops.md
@@ -72,6 +72,8 @@ In this case, spacing will be disallowed after a `new` operator and required bef
 
 Examples of **incorrect** code for this rule with the default `{"words": true, "nonwords": false}` option:
 
+::: incorrect
+
 ```js
 /*eslint space-unary-ops: "error"*/
 
@@ -92,6 +94,8 @@ foo --;
 + "3";
 ```
 
+:::
+
 ```js
 /*eslint space-unary-ops: "error"*/
 /*eslint-env es6*/
@@ -110,6 +114,8 @@ async function foo() {
 ```
 
 Examples of **correct** code for this rule with the `{"words": true, "nonwords": false}` option:
+
+::: correct
 
 ```js
 /*eslint space-unary-ops: "error"*/
@@ -138,6 +144,8 @@ foo--;
 // Unary operator "+" is not followed by whitespace.
 +"3";
 ```
+
+:::
 
 ```js
 /*eslint space-unary-ops: "error"*/

--- a/docs/src/rules/space-unary-word-ops.md
+++ b/docs/src/rules/space-unary-word-ops.md
@@ -15,9 +15,13 @@ Require spaces following unary word operators.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 typeof!a
 ```
+
+:::
 
 ```js
 void{a:0}
@@ -33,9 +37,13 @@ delete(a.b)
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 delete a.b
 ```
+
+:::
 
 ```js
 new C

--- a/docs/src/rules/spaced-comment.md
+++ b/docs/src/rules/spaced-comment.md
@@ -76,6 +76,8 @@ You can also define separate exceptions and markers for block and line comments.
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint spaced-comment: ["error", "always"]*/
 
@@ -84,12 +86,16 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 /*This is a comment with no whitespace at the beginning */
 ```
 
+:::
+
 ```js
 /* eslint spaced-comment: ["error", "always", { "block": { "balanced": true } }] */
 /* This is a comment with whitespace at the beginning but not the end*/
 ```
 
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /* eslint spaced-comment: ["error", "always"] */
@@ -107,6 +113,8 @@ This comment has a newline
 */
 ```
 
+:::
+
 ```js
 /* eslint spaced-comment: ["error", "always"] */
 
@@ -119,6 +127,8 @@ This comment has a newline
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint spaced-comment: ["error", "never"]*/
 
@@ -129,6 +139,8 @@ Examples of **incorrect** code for this rule with the `"never"` option:
 /* \nThis is a comment with a whitespace at the beginning */
 ```
 
+:::
+
 ```js
 /*eslint spaced-comment: ["error", "never", { "block": { "balanced": true } }]*/
 /*This is a comment with whitespace at the end */
@@ -136,11 +148,15 @@ Examples of **incorrect** code for this rule with the `"never"` option:
 
 Examples of **correct** code for this rule with the `"never"` option:
 
+::: correct
+
 ```js
 /*eslint spaced-comment: ["error", "never"]*/
 
 /*This is a comment with no whitespace at the beginning */
 ```
+
+:::
 
 ```js
 /*eslint spaced-comment: ["error", "never"]*/
@@ -154,6 +170,8 @@ Examples of **correct** code for this rule with the `"never"` option:
 
 Examples of **incorrect** code for this rule with the `"always"` option combined with `"exceptions"`:
 
+::: incorrect
+
 ```js
 /* eslint spaced-comment: ["error", "always", { "block": { "exceptions": ["-"] } }] */
 
@@ -161,6 +179,8 @@ Examples of **incorrect** code for this rule with the `"always"` option combined
 // Comment block
 //--------------
 ```
+
+:::
 
 ```js
 /* eslint spaced-comment: ["error", "always", { "exceptions": ["-", "+"] }] */
@@ -194,6 +214,8 @@ Examples of **incorrect** code for this rule with the `"always"` option combined
 
 Examples of **correct** code for this rule with the `"always"` option combined with `"exceptions"`:
 
+::: correct
+
 ```js
 /* eslint spaced-comment: ["error", "always", { "exceptions": ["-"] }] */
 
@@ -201,6 +223,8 @@ Examples of **correct** code for this rule with the `"always"` option combined w
 // Comment block
 //--------------
 ```
+
+:::
 
 ```js
 /* eslint spaced-comment: ["error", "always", { "line": { "exceptions": ["-"] } }] */
@@ -252,11 +276,15 @@ COMMENT
 
 Examples of **incorrect** code for this rule with the `"always"` option combined with `"markers"`:
 
+::: incorrect
+
 ```js
 /* eslint spaced-comment: ["error", "always", { "markers": ["/"] }] */
 
 ///This is a comment with a marker but without whitespace
 ```
+
+:::
 
 ```js
 /*eslint spaced-comment: ["error", "always", { "block": { "markers": ["!"], "balanced": true } }]*/
@@ -270,11 +298,15 @@ Examples of **incorrect** code for this rule with the `"always"` option combined
 
 Examples of **correct** code for this rule with the `"always"` option combined with `"markers"`:
 
+::: correct
+
 ```js
 /* eslint spaced-comment: ["error", "always", { "markers": ["/"] }] */
 
 /// This is a comment with a marker
 ```
+
+:::
 
 ```js
 /*eslint spaced-comment: ["error", "never", { "markers": ["!<"] }]*/

--- a/docs/src/rules/spaced-line-comment.md
+++ b/docs/src/rules/spaced-line-comment.md
@@ -30,10 +30,14 @@ Exceptions cannot be mixed.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 // When ["never"]
 // This is a comment with a whitespace at the beginning
 ```
+
+:::
 
 ```js
 //When ["always"]
@@ -50,11 +54,15 @@ var foo = 5;
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 // When ["always"]
 // This is a comment with a whitespace at the beginning
 var foo = 5;
 ```
+
+:::
 
 ```js
 //When ["never"]

--- a/docs/src/rules/strict.md
+++ b/docs/src/rules/strict.md
@@ -86,12 +86,16 @@ Otherwise the `"safe"` option corresponds to the `"function"` option. Note that 
 
 Examples of **incorrect** code for this rule with the `"global"` option:
 
+::: incorrect
+
 ```js
 /*eslint strict: ["error", "global"]*/
 
 function foo() {
 }
 ```
+
+:::
 
 ```js
 /*eslint strict: ["error", "global"]*/
@@ -113,6 +117,8 @@ function foo() {
 
 Examples of **correct** code for this rule with the `"global"` option:
 
+::: correct
+
 ```js
 /*eslint strict: ["error", "global"]*/
 
@@ -122,11 +128,15 @@ function foo() {
 }
 ```
 
+:::
+
 ### function
 
 This option ensures that all function bodies are strict mode code, while global code is not. Particularly if a build step concatenates multiple scripts, a strict mode directive in global code of one script could unintentionally enable strict mode in another script that was not intended to be strict code.
 
 Examples of **incorrect** code for this rule with the `"function"` option:
+
+::: incorrect
 
 ```js
 /*eslint strict: ["error", "function"]*/
@@ -136,6 +146,8 @@ Examples of **incorrect** code for this rule with the `"function"` option:
 function foo() {
 }
 ```
+
+:::
 
 ```js
 /*eslint strict: ["error", "function"]*/
@@ -168,6 +180,8 @@ function foo(a = 1) {
 
 Examples of **correct** code for this rule with the `"function"` option:
 
+::: correct
+
 ```js
 /*eslint strict: ["error", "function"]*/
 
@@ -193,9 +207,13 @@ var foo = (function() {
 }());
 ```
 
+:::
+
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint strict: ["error", "never"]*/
@@ -205,6 +223,8 @@ Examples of **incorrect** code for this rule with the `"never"` option:
 function foo() {
 }
 ```
+
+:::
 
 ```js
 /*eslint strict: ["error", "never"]*/
@@ -216,12 +236,16 @@ function foo() {
 
 Examples of **correct** code for this rule with the `"never"` option:
 
+::: correct
+
 ```js
 /*eslint strict: ["error", "never"]*/
 
 function foo() {
 }
 ```
+
+:::
 
 ### earlier default (removed)
 
@@ -231,12 +255,16 @@ This option ensures that all functions are executed in strict mode. A strict mod
 
 Examples of **incorrect** code for this rule with the earlier default option which has been removed:
 
+::: incorrect
+
 ```js
 // "strict": "error"
 
 function foo() {
 }
 ```
+
+:::
 
 ```js
 // "strict": "error"
@@ -250,6 +278,8 @@ function foo() {
 
 Examples of **correct** code for this rule with the earlier default option which has been removed:
 
+::: correct
+
 ```js
 // "strict": "error"
 
@@ -258,6 +288,8 @@ Examples of **correct** code for this rule with the earlier default option which
 function foo() {
 }
 ```
+
+:::
 
 ```js
 // "strict": "error"

--- a/docs/src/rules/switch-colon-spacing.md
+++ b/docs/src/rules/switch-colon-spacing.md
@@ -31,6 +31,8 @@ This rule has 2 options that are boolean value.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint switch-colon-spacing: "error"*/
 
@@ -40,7 +42,11 @@ switch (a) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint switch-colon-spacing: "error"*/
@@ -56,7 +62,11 @@ switch (a) {
 }
 ```
 
+:::
+
 Examples of **incorrect** code for this rule with `{"after": false, "before": true}` option:
+
+::: incorrect
 
 ```js
 /*eslint switch-colon-spacing: ["error", {"after": false, "before": true}]*/
@@ -67,7 +77,11 @@ switch (a) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with `{"after": false, "before": true}` option:
+
+::: correct
 
 ```js
 /*eslint switch-colon-spacing: ["error", {"after": false, "before": true}]*/
@@ -82,6 +96,8 @@ switch (a) {
         break;
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/symbol-description.md
+++ b/docs/src/rules/symbol-description.md
@@ -37,6 +37,8 @@ This rules requires a description when creating symbols.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint symbol-description: "error"*/
 /*eslint-env es6*/
@@ -44,7 +46,11 @@ Examples of **incorrect** code for this rule:
 var foo = Symbol();
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint symbol-description: "error"*/
@@ -55,6 +61,8 @@ var foo = Symbol("some description");
 var someString = "some description";
 var bar = Symbol(someString);
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/template-curly-spacing.md
+++ b/docs/src/rules/template-curly-spacing.md
@@ -40,6 +40,8 @@ This rule has one option which has either `"never"` or `"always"` as value.
 
 Examples of **incorrect** code for this rule with the default `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint template-curly-spacing: "error"*/
 
@@ -49,7 +51,11 @@ Examples of **incorrect** code for this rule with the default `"never"` option:
 `hello, ${ people.name }!`;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"never"` option:
+
+::: correct
 
 ```js
 /*eslint template-curly-spacing: "error"*/
@@ -60,11 +66,15 @@ Examples of **correct** code for this rule with the default `"never"` option:
     people.name
 }!`;
 ```
+
+:::
 
 ### always
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint template-curly-spacing: ["error", "always"]*/
 
@@ -74,7 +84,11 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 `hello, ${people.name}!`;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint template-curly-spacing: ["error", "always"]*/
@@ -85,6 +99,8 @@ Examples of **correct** code for this rule with the `"always"` option:
     people.name
 }!`;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/template-tag-spacing.md
+++ b/docs/src/rules/template-tag-spacing.md
@@ -44,37 +44,53 @@ This rule has one option whose value can be set to `"never"` or `"always"`
 
 Examples of **incorrect** code for this rule with the default `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint template-tag-spacing: "error"*/
 
 func `Hello world`;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the default `"never"` option:
+
+::: correct
 
 ```js
 /*eslint template-tag-spacing: "error"*/
 
 func`Hello world`;
 ```
+
+:::
 
 ### always
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
+::: incorrect
+
 ```js
 /*eslint template-tag-spacing: ["error", "always"]*/
 
 func`Hello world`;
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint template-tag-spacing: ["error", "always"]*/
 
 func `Hello world`;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/unicode-bom.md
+++ b/docs/src/rules/unicode-bom.md
@@ -32,6 +32,8 @@ This rule has a string option:
 
 Example of **correct** code for this rule with the `"always"` option:
 
+::: correct
+
 ```js
 /*eslint unicode-bom: ["error", "always"]*/
 
@@ -39,25 +41,37 @@ U+FEFF
 var abc;
 ```
 
+:::
+
 Example of **incorrect** code for this rule with the `"always"` option:
+
+::: incorrect
 
 ```js
 /*eslint unicode-bom: ["error", "always"]*/
 
 var abc;
 ```
+
+:::
 
 ### never
 
 Example of **correct** code for this rule with the default `"never"` option:
 
+::: correct
+
 ```js
 /*eslint unicode-bom: ["error", "never"]*/
 
 var abc;
 ```
 
+:::
+
 Example of **incorrect** code for this rule with the `"never"` option:
+
+::: incorrect
 
 ```js
 /*eslint unicode-bom: ["error", "never"]*/
@@ -65,6 +79,8 @@ Example of **incorrect** code for this rule with the `"never"` option:
 U+FEFF
 var abc;
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/use-isnan.md
+++ b/docs/src/rules/use-isnan.md
@@ -24,6 +24,8 @@ This rule disallows comparisons to 'NaN'.
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint use-isnan: "error"*/
 
@@ -44,7 +46,11 @@ if (foo != Number.NaN) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint use-isnan: "error"*/
@@ -57,6 +63,8 @@ if (!isNaN(foo)) {
     // ...
 }
 ```
+
+:::
 
 ## Options
 
@@ -71,6 +79,8 @@ The `switch` statement internally uses the `===` comparison to match the express
 Therefore, it can never match `case NaN`. Also, `switch(NaN)` can never match a case clause.
 
 Examples of **incorrect** code for this rule with `"enforceForSwitchCase"` option set to `true` (default):
+
+::: incorrect
 
 ```js
 /*eslint use-isnan: ["error", {"enforceForSwitchCase": true}]*/
@@ -116,7 +126,11 @@ switch (Number.NaN) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule with `"enforceForSwitchCase"` option set to `true` (default):
+
+::: correct
 
 ```js
 /*eslint use-isnan: ["error", {"enforceForSwitchCase": true}]*/
@@ -139,7 +153,11 @@ if (Number.isNaN(a)) {
 } // ...
 ```
 
+:::
+
 Examples of **correct** code for this rule with `"enforceForSwitchCase"` option set to `false`:
+
+::: correct
 
 ```js
 /*eslint use-isnan: ["error", {"enforceForSwitchCase": false}]*/
@@ -185,6 +203,8 @@ switch (Number.NaN) {
 }
 ```
 
+:::
+
 ### enforceForIndexOf
 
 The following methods internally use the `===` comparison to match the given value with an array element:
@@ -198,6 +218,8 @@ Set `"enforceForIndexOf"` to `true` if you want this rule to report `indexOf(NaN
 
 Examples of **incorrect** code for this rule with `"enforceForIndexOf"` option set to `true`:
 
+::: incorrect
+
 ```js
 /*eslint use-isnan: ["error", {"enforceForIndexOf": true}]*/
 
@@ -208,7 +230,11 @@ var firstIndex = myArray.indexOf(NaN);
 var lastIndex = myArray.lastIndexOf(NaN);
 ```
 
+:::
+
 Examples of **correct** code for this rule with `"enforceForIndexOf"` option set to `true`:
+
+::: correct
 
 ```js
 /*eslint use-isnan: ["error", {"enforceForIndexOf": true}]*/
@@ -252,6 +278,8 @@ var firstIndex = myArray.findIndex(Number.isNaN);
 // ES2016
 var hasNaN = myArray.includes(NaN);
 ```
+
+:::
 
 #### Known Limitations
 

--- a/docs/src/rules/valid-jsdoc.md
+++ b/docs/src/rules/valid-jsdoc.md
@@ -50,6 +50,8 @@ This rule does not report missing JSDoc comments for classes, functions, or meth
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint valid-jsdoc: "error"*/
 
@@ -88,7 +90,11 @@ function sum(num1, num2) {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint valid-jsdoc: "error"*/
@@ -165,6 +171,8 @@ class WonderfulWidget extends Widget {
 }
 ```
 
+:::
+
 ## Options
 
 This rule has an object option:
@@ -183,6 +191,8 @@ This rule has an object option:
 ### prefer
 
 Examples of additional **incorrect** code for this rule with sample `"prefer": { "arg": "param", "argument": "param", "class": "constructor", "return": "returns", "virtual": "abstract" }` options:
+
+::: incorrect
 
 ```js
 /*eslint valid-jsdoc: ["error", { "prefer": { "arg": "param", "argument": "param", "class": "constructor", "return": "returns", "virtual": "abstract" } }]*/
@@ -222,9 +232,13 @@ class Widget {
 }
 ```
 
+:::
+
 ### preferType
 
 Examples of additional **incorrect** code for this rule with sample `"preferType": { "Boolean": "boolean", "Number": "number", "object": "Object", "String": "string" }` options:
+
+::: incorrect
 
 ```js
 /*eslint valid-jsdoc: ["error", { "preferType": { "Boolean": "boolean", "Number": "number", "object": "Object", "String": "string" } }]*/
@@ -262,9 +276,13 @@ class Widget {
 }
 ```
 
+:::
+
 ### requireReturn
 
 Examples of additional **incorrect** code for this rule with the `"requireReturn": false` option:
+
+::: incorrect
 
 ```js
 /*eslint valid-jsdoc: ["error", { "requireReturn": false }]*/
@@ -291,7 +309,11 @@ class Widget {
 }
 ```
 
+:::
+
 Example of additional **correct** code for this rule with the `"requireReturn": false` option:
+
+::: correct
 
 ```js
 /*eslint valid-jsdoc: ["error", { "requireReturn": false }]*/
@@ -304,9 +326,13 @@ function greet(name) {
 }
 ```
 
+:::
+
 ### requireReturnType
 
 Example of additional **correct** code for this rule with the `"requireReturnType": false` option:
+
+::: correct
 
 ```js
 /*eslint valid-jsdoc: ["error", { "requireReturnType": false }]*/
@@ -322,9 +348,13 @@ function add(num1, num2) {
 }
 ```
 
+:::
+
 ### requireParamType
 
 Example of additional **correct** code for this rule with the `"requireParamType": false` option:
+
+::: correct
 
 ```js
 /*eslint valid-jsdoc: ["error", { "requireParamType": false }]*/
@@ -340,9 +370,13 @@ function add(num1, num2) {
 }
 ```
 
+:::
+
 ### matchDescription
 
 Example of additional **incorrect** code for this rule with a sample `"matchDescription": ".+"` option:
+
+::: incorrect
 
 ```js
 /*eslint valid-jsdoc: ["error", { "matchDescription": ".+" }]*/
@@ -357,9 +391,13 @@ function greet(name) {
 }
 ```
 
+:::
+
 ### requireParamDescription
 
 Example of additional **correct** code for this rule with the `"requireParamDescription": false` option:
+
+::: correct
 
 ```js
 /*eslint valid-jsdoc: ["error", { "requireParamDescription": false }]*/
@@ -375,9 +413,13 @@ function add(num1, num2) {
 }
 ```
 
+:::
+
 ### requireReturnDescription
 
 Example of additional **correct** code for this rule with the `"requireReturnDescription": false` option:
+
+::: correct
 
 ```js
 /*eslint valid-jsdoc: ["error", { "requireReturnDescription": false }]*/
@@ -392,6 +434,8 @@ function add(num1, num2) {
     return num1 + num2;
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/valid-typeof.md
+++ b/docs/src/rules/valid-typeof.md
@@ -27,6 +27,8 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint valid-typeof: "error"*/
 
@@ -36,7 +38,11 @@ typeof bar != "nunber"
 typeof bar !== "fucntion"
 ```
 
+:::
+
 Examples of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint valid-typeof: "error"*/
@@ -47,7 +53,11 @@ typeof foo === baz
 typeof bar === typeof qux
 ```
 
+:::
+
 Examples of **incorrect** code with the `{ "requireStringLiterals": true }` option:
+
+::: incorrect
 
 ```js
 /*eslint valid-typeof: ["error", { "requireStringLiterals": true }]*/
@@ -60,7 +70,11 @@ typeof baz === anotherVariable
 typeof foo == 5
 ```
 
+:::
+
 Examples of **correct** code with the `{ "requireStringLiterals": true }` option:
+
+::: correct
 
 ```js
 /*eslint valid-typeof: ["error", { "requireStringLiterals": true }]*/
@@ -70,6 +84,8 @@ typeof bar == "object"
 typeof baz === "string"
 typeof bar === typeof qux
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/vars-on-top.md
+++ b/docs/src/rules/vars-on-top.md
@@ -23,6 +23,8 @@ Allowing multiple declarations helps promote maintainability and is thus allowed
 
 Examples of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint vars-on-top: "error"*/
 
@@ -39,6 +41,8 @@ function doSomething() {
     for (var i=0; i<10; i++) {}
 }
 ```
+
+:::
 
 ```js
 /*eslint vars-on-top: "error"*/
@@ -73,6 +77,8 @@ class C {
 
 Examples of **correct** code for this rule:
 
+::: correct
+
 ```js
 /*eslint vars-on-top: "error"*/
 
@@ -89,6 +95,8 @@ function doSomething() {
     for (i=0; i<10; i++) {}
 }
 ```
+
+:::
 
 ```js
 /*eslint vars-on-top: "error"*/

--- a/docs/src/rules/wrap-iife.md
+++ b/docs/src/rules/wrap-iife.md
@@ -41,6 +41,8 @@ Object option:
 
 Examples of **incorrect** code for the default `"outside"` option:
 
+::: incorrect
+
 ```js
 /*eslint wrap-iife: ["error", "outside"]*/
 
@@ -48,18 +50,26 @@ var x = function () { return { y: 1 };}(); // unwrapped
 var x = (function () { return { y: 1 };})(); // wrapped function expression
 ```
 
+:::
+
 Examples of **correct** code for the default `"outside"` option:
+
+::: correct
 
 ```js
 /*eslint wrap-iife: ["error", "outside"]*/
 
 var x = (function () { return { y: 1 };}()); // wrapped call expression
 ```
+
+:::
 
 ### inside
 
 Examples of **incorrect** code for the `"inside"` option:
 
+::: incorrect
+
 ```js
 /*eslint wrap-iife: ["error", "inside"]*/
 
@@ -67,25 +77,37 @@ var x = function () { return { y: 1 };}(); // unwrapped
 var x = (function () { return { y: 1 };}()); // wrapped call expression
 ```
 
+:::
+
 Examples of **correct** code for the `"inside"` option:
+
+::: correct
 
 ```js
 /*eslint wrap-iife: ["error", "inside"]*/
 
 var x = (function () { return { y: 1 };})(); // wrapped function expression
 ```
+
+:::
 
 ### any
 
 Examples of **incorrect** code for the `"any"` option:
 
+::: incorrect
+
 ```js
 /*eslint wrap-iife: ["error", "any"]*/
 
 var x = function () { return { y: 1 };}(); // unwrapped
 ```
 
+:::
+
 Examples of **correct** code for the `"any"` option:
+
+::: correct
 
 ```js
 /*eslint wrap-iife: ["error", "any"]*/
@@ -94,9 +116,13 @@ var x = (function () { return { y: 1 };}()); // wrapped call expression
 var x = (function () { return { y: 1 };})(); // wrapped function expression
 ```
 
+:::
+
 ### functionPrototypeMethods
 
 Examples of **incorrect** code for this rule with the `"inside", { "functionPrototypeMethods": true }` options:
+
+::: incorrect
 
 ```js
 /* eslint wrap-iife: [2, "inside", { functionPrototypeMethods: true }] */
@@ -107,7 +133,11 @@ var x = function(){ foo(); }.call(bar)
 var x = (function(){ foo(); }.call(bar))
 ```
 
+:::
+
 Examples of **correct** code for this rule with the `"inside", { "functionPrototypeMethods": true }` options:
+
+::: correct
 
 ```js
 /* eslint wrap-iife: [2, "inside", { functionPrototypeMethods: true }] */
@@ -115,3 +145,5 @@ Examples of **correct** code for this rule with the `"inside", { "functionProtot
 var x = (function(){ foo(); })()
 var x = (function(){ foo(); }).call(bar)
 ```
+
+:::

--- a/docs/src/rules/wrap-regex.md
+++ b/docs/src/rules/wrap-regex.md
@@ -23,6 +23,8 @@ This is used to disambiguate the slash operator and facilitates more readable co
 
 Example of **incorrect** code for this rule:
 
+::: incorrect
+
 ```js
 /*eslint wrap-regex: "error"*/
 
@@ -31,7 +33,11 @@ function a() {
 }
 ```
 
+:::
+
 Example of **correct** code for this rule:
+
+::: correct
 
 ```js
 /*eslint wrap-regex: "error"*/
@@ -40,3 +46,5 @@ function a() {
     return (/foo/).test("bar");
 }
 ```
+
+:::

--- a/docs/src/rules/yield-star-spacing.md
+++ b/docs/src/rules/yield-star-spacing.md
@@ -48,6 +48,8 @@ The option also has a string shorthand:
 
 Examples of **correct** code for this rule with the default `"after"` option:
 
+::: correct
+
 ```js
 /*eslint yield-star-spacing: ["error", "after"]*/
 /*eslint-env es6*/
@@ -57,9 +59,13 @@ function* generator() {
 }
 ```
 
+:::
+
 ### before
 
 Examples of **correct** code for this rule with the `"before"` option:
+
+::: correct
 
 ```js
 /*eslint yield-star-spacing: ["error", "before"]*/
@@ -70,9 +76,13 @@ function *generator() {
 }
 ```
 
+:::
+
 ### both
 
 Examples of **correct** code for this rule with the `"both"` option:
+
+::: correct
 
 ```js
 /*eslint yield-star-spacing: ["error", "both"]*/
@@ -83,9 +93,13 @@ function * generator() {
 }
 ```
 
+:::
+
 ### neither
 
 Examples of **correct** code for this rule with the `"neither"` option:
+
+::: correct
 
 ```js
 /*eslint yield-star-spacing: ["error", "neither"]*/
@@ -95,6 +109,8 @@ function*generator() {
   yield*other();
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/yoda.md
+++ b/docs/src/rules/yoda.md
@@ -56,6 +56,8 @@ The `onlyEquality` option allows a superset of the exceptions which `exceptRange
 
 Examples of **incorrect** code for the default `"never"` option:
 
+::: incorrect
+
 ```js
 /*eslint yoda: "error"*/
 
@@ -88,7 +90,11 @@ if (0 <= x && x < 1) {
 }
 ```
 
+:::
+
 Examples of **correct** code for the default `"never"` option:
+
+::: correct
 
 ```js
 /*eslint yoda: "error"*/
@@ -110,9 +116,13 @@ if (`${value}` === `red`) {
 }
 ```
 
+:::
+
 ### exceptRange
 
 Examples of **correct** code for the `"never", { "exceptRange": true }` options:
+
+::: correct
 
 ```js
 /*eslint yoda: ["error", "never", { "exceptRange": true }]*/
@@ -138,9 +148,13 @@ function howLong(arr) {
 }
 ```
 
+:::
+
 ### onlyEquality
 
 Examples of **correct** code for the `"never", { "onlyEquality": true }` options:
+
+::: correct
 
 ```js
 /*eslint yoda: ["error", "never", { "onlyEquality": true }]*/
@@ -155,9 +169,13 @@ if (x !== `foo` && `bar` != x) {
 }
 ```
 
+:::
+
 ### always
 
 Examples of **incorrect** code for the `"always"` option:
+
+::: incorrect
 
 ```js
 /*eslint yoda: ["error", "always"]*/
@@ -171,7 +189,11 @@ if (color == `blue`) {
 }
 ```
 
+:::
+
 Examples of **correct** code for the `"always"` option:
+
+::: correct
 
 ```js
 /*eslint yoda: ["error", "always"]*/
@@ -192,3 +214,5 @@ if (-1 < str.indexOf(substr)) {
     // ...
 }
 ```
+
+:::


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

Add correct and incorrect to all code snippets 

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)


Ran `regex` to add `correct` and `incorrect` to all files at once

find 
```js
\*\*correct\*\*(.*)\n*(```.*(\n|.)*?```)
```
replace with
```js
**correct**$1

::: correct
$2 
:::
```
we basically group the text after the `**correct**` until the line end `\n` and that is `$1`. The `$2` is the code snippet wrapped within ***```***. Same works well with the text in correct as well



If you see one empty line after the ``` closing it is because of the new line addition after ::: correct or ::: incorrect but in file it is not going to be there


In case if you were wondering what would happen to the markdowns already with correct and incorrect values. The regex wouldn't match it so no adding correct and incorrect wrapper for those snippets :)
