### PR TITLE
docs: use only fenced code blocks

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -15,4 +15,5 @@ MD029: false     # Ordered list item prefix
 MD030: false     # Spaces after list markers
 MD033: false     # Allow inline HTML
 MD041: false     # First line in file should be a top level header
-MD046: false     # Code block style
+MD046:           # Code block style
+    style: fenced

--- a/docs/src/developer-guide/development-environment.md
+++ b/docs/src/developer-guide/development-environment.md
@@ -47,11 +47,15 @@ Now, the remote `upstream` points to the upstream source.
 
 [Yeoman](http://yeoman.io) is a scaffold generator that ESLint uses to help streamline development of new rules. If you don't already have Yeoman installed, you can install it via npm:
 
-    npm install -g yo
+```shell
+npm install -g yo
+```
 
 Then, you can install the ESLint Yeoman generator:
 
-    npm install -g generator-eslint
+```shell
+npm install -g generator-eslint
+```
 
 Please see the [generator documentation](https://github.com/eslint/generator-eslint) for instructions on how to use it.
 

--- a/docs/src/developer-guide/source-code.md
+++ b/docs/src/developer-guide/source-code.md
@@ -14,7 +14,9 @@ ESLint is hosted at [GitHub](https://github.com/eslint/eslint) and uses [Git](ht
 
 If you simply want to create a local copy of the source to play with, you can clone the main repository using this command:
 
-    git clone git://github.com/eslint/eslint.git
+```shell
+git clone git://github.com/eslint/eslint.git
+```
 
 If you're planning on contributing to ESLint, then it's a good idea to fork the repository. You can find instructions for forking a repository at [https://help.github.com/articles/fork-a-repo/](https://help.github.com/articles/fork-a-repo/). After forking the ESLint repository, you'll want to create a local copy of your fork.
 
@@ -27,8 +29,10 @@ Before you can get started developing, you'll need to have a couple of things in
 
 Once you have a local copy and have Node.JS and npm installed, you'll need to install the ESLint dependencies:
 
-    cd eslint
-    npm install
+```shell
+cd eslint
+npm install
+```
 
 Now when you run `eslint`, it will be running your local copy and showing your changes.
 

--- a/docs/src/developer-guide/unit-tests.md
+++ b/docs/src/developer-guide/unit-tests.md
@@ -14,7 +14,9 @@ Most parts of ESLint have unit tests associated with them. Unit tests are writte
 
 When you first get the source code, you need to run `npm install` once initially to set ESLint for development. Once you've done that, you can run the tests via:
 
-    npm test
+```shell
+npm test
+```
 
 This automatically starts Mocha and runs all tests in the `tests` directory. You need only add yours and it will automatically be picked up when running tests.
 
@@ -22,7 +24,9 @@ This automatically starts Mocha and runs all tests in the `tests` directory. You
 
 If you want to quickly run just one test file, you can do so by running Mocha directly and passing in the filename. For example:
 
-    npm run test:cli tests/lib/rules/no-undef.js
+```shell
+npm run test:cli tests/lib/rules/no-undef.js
+```
 
 If you want to run just one or a subset of `RuleTester` test cases, add `only: true` to each test case or wrap the test case in `RuleTester.only(...)` to add it automatically:
 
@@ -50,4 +54,6 @@ Running individual tests is useful when you're working on a specific bug and ite
 
 The default timeout for tests in `npm test` is 10000ms. You may change the timeout by providing `ESLINT_MOCHA_TIMEOUT` environment variable, for example:
 
-    ESLINT_MOCHA_TIMEOUT=20000 npm test
+```shell
+ESLINT_MOCHA_TIMEOUT=20000 npm test
+```

--- a/docs/src/pages/rules.md
+++ b/docs/src/pages/rules.md
@@ -84,3 +84,5 @@ Rules in ESLint are grouped by type to help you understand their purpose. Each r
     }) }}
 {%- endfor -%}
 {%- endif -%}
+
+{# <!-- markdownlint-disable-file MD046 --> #}

--- a/docs/src/rules/no-irregular-whitespace.md
+++ b/docs/src/rules/no-irregular-whitespace.md
@@ -32,30 +32,32 @@ This rule is aimed at catching invalid whitespace that is not a normal tab and s
 
 This rule disallows the following characters except where the options allow:
 
-    \u000B - Line Tabulation (\v) - <VT>
-    \u000C - Form Feed (\f) - <FF>
-    \u00A0 - No-Break Space - <NBSP>
-    \u0085 - Next Line
-    \u1680 - Ogham Space Mark
-    \u180E - Mongolian Vowel Separator - <MVS>
-    \ufeff - Zero Width No-Break Space - <BOM>
-    \u2000 - En Quad
-    \u2001 - Em Quad
-    \u2002 - En Space - <ENSP>
-    \u2003 - Em Space - <EMSP>
-    \u2004 - Three-Per-Em
-    \u2005 - Four-Per-Em
-    \u2006 - Six-Per-Em
-    \u2007 - Figure Space
-    \u2008 - Punctuation Space - <PUNCSP>
-    \u2009 - Thin Space
-    \u200A - Hair Space
-    \u200B - Zero Width Space - <ZWSP>
-    \u2028 - Line Separator
-    \u2029 - Paragraph Separator
-    \u202F - Narrow No-Break Space
-    \u205f - Medium Mathematical Space
-    \u3000 - Ideographic Space
+```text
+\u000B - Line Tabulation (\v) - <VT>
+\u000C - Form Feed (\f) - <FF>
+\u00A0 - No-Break Space - <NBSP>
+\u0085 - Next Line
+\u1680 - Ogham Space Mark
+\u180E - Mongolian Vowel Separator - <MVS>
+\ufeff - Zero Width No-Break Space - <BOM>
+\u2000 - En Quad
+\u2001 - Em Quad
+\u2002 - En Space - <ENSP>
+\u2003 - Em Space - <EMSP>
+\u2004 - Three-Per-Em
+\u2005 - Four-Per-Em
+\u2006 - Six-Per-Em
+\u2007 - Figure Space
+\u2008 - Punctuation Space - <PUNCSP>
+\u2009 - Thin Space
+\u200A - Hair Space
+\u200B - Zero Width Space - <ZWSP>
+\u2028 - Line Separator
+\u2029 - Paragraph Separator
+\u202F - Narrow No-Break Space
+\u205f - Medium Mathematical Space
+\u3000 - Ideographic Space
+```
 
 ## Options
 

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -106,9 +106,11 @@ Options that accept array values can be specified by repeating the option or wit
 
 Example:
 
-    npx eslint --ext .jsx --ext .js lib/
+```shell
+npx eslint --ext .jsx --ext .js lib/
 
-    npx eslint --ext .jsx,.js lib/
+npx eslint --ext .jsx,.js lib/
+```
 
 ### Basic configuration
 
@@ -118,7 +120,9 @@ Disables use of configuration from `.eslintrc.*` and `package.json` files.
 
 Example:
 
-    npx eslint --no-eslintrc file.js
+```shell
+npx eslint --no-eslintrc file.js
+```
 
 #### `-c`, `--config`
 
@@ -126,7 +130,9 @@ This option allows you to specify an additional configuration file for ESLint (s
 
 Example:
 
-    npx eslint -c ~/my-eslint.json file.js
+```shell
+npx eslint -c ~/my-eslint.json file.js
+```
 
 This example uses the configuration file at `~/my-eslint.json`.
 
@@ -138,8 +144,10 @@ This option enables specific environments. Details about the global variables de
 
 Examples:
 
-    npx eslint --env browser,node file.js
-    npx eslint --env browser --env node file.js
+```shell
+npx eslint --env browser,node file.js
+npx eslint --env browser --env node file.js
+```
 
 #### `--ext`
 
@@ -148,14 +156,16 @@ By default, ESLint lints `*.js` files and the files that match the `overrides` e
 
 Examples:
 
-    # Use only .ts extension
-    npx eslint . --ext .ts
+```shell
+# Use only .ts extension
+npx eslint . --ext .ts
 
-    # Use both .js and .ts
-    npx eslint . --ext .js --ext .ts
+# Use both .js and .ts
+npx eslint . --ext .js --ext .ts
 
-    # Also use both .js and .ts
-    npx eslint . --ext .js,.ts
+# Also use both .js and .ts
+npx eslint . --ext .js,.ts
+```
 
 **Note:** `--ext` is only used when the arguments are directories. If you use glob patterns or file names, then `--ext` is ignored.
 
@@ -167,8 +177,10 @@ This option defines global variables so that they will not be flagged as undefin
 
 Examples:
 
-    npx eslint --global require,exports:true file.js
-    npx eslint --global require --global exports:true
+```shell
+npx eslint --global require,exports:true file.js
+npx eslint --global require --global exports:true
+```
 
 #### `--parser`
 
@@ -180,8 +192,10 @@ This option allows you to specify parser options to be used by ESLint. Note that
 
 Examples:
 
-    echo '3 ** 4' | npx eslint --stdin --parser-options=ecmaVersion:6 # will fail with a parsing error
-    echo '3 ** 4' | npx eslint --stdin --parser-options=ecmaVersion:7 # succeeds, yay!
+```shell
+echo '3 ** 4' | npx eslint --stdin --parser-options=ecmaVersion:6 # will fail with a parsing error
+echo '3 ** 4' | npx eslint --stdin --parser-options=ecmaVersion:7 # succeeds, yay!
+```
 
 #### `--resolve-plugins-relative-to`
 
@@ -200,8 +214,10 @@ Before using the plugin, you have to install it using npm.
 
 Examples:
 
-    npx eslint --plugin jquery file.js
-    npx eslint --plugin eslint-plugin-mocha file.js
+```shell
+npx eslint --plugin jquery file.js
+npx eslint --plugin eslint-plugin-mocha file.js
+```
 
 #### `--rule`
 
@@ -211,9 +227,11 @@ If the rule is defined within a plugin, you have to prefix the rule ID with the 
 
 Examples:
 
-    npx eslint --rule 'quotes: [error, double]'
-    npx eslint --rule 'guard-for-in: error' --rule 'brace-style: [error, 1tbs]'
-    npx eslint --rule 'jquery/dollar-sign: error'
+```shell
+npx eslint --rule 'quotes: [error, double]'
+npx eslint --rule 'guard-for-in: error' --rule 'brace-style: [error, 1tbs]'
+npx eslint --rule 'jquery/dollar-sign: error'
+```
 
 #### `--rulesdir`
 
@@ -223,11 +241,15 @@ This option allows you to specify another directory from which to load rules fil
 
 Example:
 
-    npx eslint --rulesdir my-rules/ file.js
+```shell
+npx eslint --rulesdir my-rules/ file.js
+```
 
 The rules in your custom rules directory must follow the same format as bundled rules to work properly. You can also specify multiple locations for custom rules by including multiple `--rulesdir` options:
 
-    npx eslint --rulesdir my-rules/ --rulesdir my-other-rules/ file.js
+```shell
+npx eslint --rulesdir my-rules/ --rulesdir my-other-rules/ file.js
+```
 
 Note that, as with core rules and plugin rules, you still need to enable the rules in configuration or via the `--rule` CLI option in order to actually run those rules during linting. Specifying a rules directory with `--rulesdir` does not automatically enable the rules within that directory.
 
@@ -281,8 +303,10 @@ This option allows you to specify the file to use as your `.eslintignore`. By de
 
 Example:
 
-    npx eslint --ignore-path tmp/.eslintignore file.js
-    npx eslint --ignore-path .gitignore file.js
+```shell
+npx eslint --ignore-path tmp/.eslintignore file.js
+npx eslint --ignore-path .gitignore file.js
+```
 
 #### `--no-ignore`
 
@@ -290,7 +314,9 @@ Disables excluding of files from `.eslintignore`, `--ignore-path`, `--ignore-pat
 
 Example:
 
-    npx eslint --no-ignore file.js
+```shell
+npx eslint --no-ignore file.js
+```
 
 #### `--ignore-pattern`
 
@@ -298,7 +324,9 @@ This option allows you to specify patterns of files to ignore (in addition to th
 
 Example:
 
-    npx eslint --ignore-pattern '/lib/' --ignore-pattern '/src/vendor/*' .
+```shell
+npx eslint --ignore-pattern '/lib/' --ignore-pattern '/src/vendor/*' .
+```
 
 ### Using stdin
 
@@ -308,7 +336,9 @@ This option tells ESLint to read and lint source code from STDIN instead of from
 
 Example:
 
-    cat myfile.js | npx eslint --stdin
+```shell
+cat myfile.js | npx eslint --stdin
+```
 
 #### `--stdin-filename`
 
@@ -316,7 +346,9 @@ This option allows you to specify a filename to process STDIN as. This is useful
 
 Example
 
-    cat myfile.js | npx eslint --stdin --stdin-filename=myfile.js
+```shell
+cat myfile.js | npx eslint --stdin --stdin-filename=myfile.js
+```
 
 ### Handling warnings
 
@@ -326,7 +358,9 @@ This option allows you to disable reporting on warnings. If you enable this opti
 
 Example:
 
-    npx eslint --quiet file.js
+```shell
+npx eslint --quiet file.js
+```
 
 #### `--max-warnings`
 
@@ -336,7 +370,9 @@ Normally, if ESLint runs and finds no errors (only warnings), it will exit with 
 
 Example:
 
-    npx eslint --max-warnings 10 file.js
+```shell
+npx eslint --max-warnings 10 file.js
+```
 
 ### Output
 
@@ -346,7 +382,9 @@ Enable report to be written to a file.
 
 Example:
 
-    npx eslint -o ./test/test.html
+```shell
+npx eslint -o ./test/test.html
+```
 
 When specified, the given format is output into the provided file name.
 
@@ -367,28 +405,36 @@ This option specifies the output format for the console. Possible formats are:
 
 Example:
 
-    npx eslint -f compact file.js
+```shell
+npx eslint -f compact file.js
+```
 
 You can also use a custom formatter from the command line by specifying a path to the custom formatter file.
 
 Example:
 
-    npx eslint -f ./customformat.js file.js
+```shell
+npx eslint -f ./customformat.js file.js
+```
 
 An npm-installed formatter is resolved with or without `eslint-formatter-` prefix.
 
 Example:
 
-    npm install eslint-formatter-pretty
+```shell
+npm install eslint-formatter-pretty
 
-    npx eslint -f pretty file.js
+npx eslint -f pretty file.js
 
-    // equivalent:
-    npx eslint -f eslint-formatter-pretty file.js
+// equivalent:
+npx eslint -f eslint-formatter-pretty file.js
+```
 
 When specified, the given format is output to the console. If you'd like to save that output into a file, you can do so on the command line like so:
 
-    npx eslint -f compact file.js > results.txt
+```shell
+npx eslint -f compact file.js > results.txt
+```
 
 This saves the output into the `results.txt` file.
 
@@ -398,8 +444,10 @@ This option forces the enabling/disabling of colorized output. You can use this 
 
 Examples:
 
-    npx eslint --color file.js | cat
-    npx eslint --no-color file.js
+```shell
+npx eslint --color file.js | cat
+npx eslint --no-color file.js
+```
 
 ### Inline configuration comments
 
@@ -419,7 +467,9 @@ config without files modifying it. All inline config comments are ignored, e.g.:
 
 Example:
 
-    npx eslint --no-inline-config file.js
+```shell
+npx eslint --no-inline-config file.js
+```
 
 #### `--report-unused-disable-directives`
 
@@ -429,7 +479,9 @@ This option causes ESLint to report directive comments like `// eslint-disable-l
 
 Example:
 
-    npx eslint --report-unused-disable-directives file.js
+```shell
+npx eslint --report-unused-disable-directives file.js
+```
 
 ### Caching
 
@@ -455,7 +507,9 @@ If a directory is specified, a cache file will be created inside the specified f
 
 Example:
 
-    npx eslint "src/**/*.js" --cache --cache-location "/Users/user/.eslintcache/"
+```shell
+npx eslint "src/**/*.js" --cache --cache-location "/Users/user/.eslintcache/"
+```
 
 #### `--cache-strategy`
 
@@ -465,7 +519,9 @@ The `content` strategy can be useful in cases where the modification time of you
 
 Example:
 
-    npx eslint "src/**/*.js" --cache --cache-strategy content
+```shell
+npx eslint "src/**/*.js" --cache --cache-strategy content
+```
 
 ### Miscellaneous
 
@@ -506,14 +562,18 @@ This option outputs the configuration to be used for the file passed. When prese
 
 Example:
 
-    npx eslint --print-config file.js
+```shell
+npx eslint --print-config file.js
+```
 
 ## Ignoring files from linting
 
 ESLint supports `.eslintignore` files to exclude files from the linting process when ESLint operates on a directory. Files given as individual CLI arguments will be exempt from exclusion. The `.eslintignore` file is a plain text file containing one pattern per line. It can be located in any of the target directory's ancestors; it will affect files in its containing directory as well as all sub-directories. Here's a simple example of a `.eslintignore` file:
 
-    temp.js
-    **/vendor/*.js
+```text
+temp.js
+**/vendor/*.js
+```
 
 A more detailed breakdown of supported patterns and directories ESLint ignores by default can be found in [Ignoring Code](configuring/ignoring-code).
 

--- a/docs/src/user-guide/configuring/configuration-files.md
+++ b/docs/src/user-guide/configuring/configuration-files.md
@@ -37,7 +37,9 @@ The first way to use configuration files is via `.eslintrc.*` and `package.json`
 
 The second way to use configuration files is to save the file wherever you would like and pass its location to the CLI using the `--config` option, such as:
 
-    eslint -c myconfig.json myfiletotest.js
+```shell
+eslint -c myconfig.json myfiletotest.js
+```
 
 If you are using one configuration file and want ESLint to ignore any `.eslintrc.*` files, make sure to use [`--no-eslintrc`](https://eslint.org/docs/user-guide/command-line-interface#--no-eslintrc) along with the [`-c`](https://eslint.org/docs/user-guide/command-line-interface#-c---config) flag.
 

--- a/docs/src/user-guide/configuring/ignoring-code.md
+++ b/docs/src/user-guide/configuring/ignoring-code.md
@@ -89,17 +89,23 @@ There are also some exceptions to these rules:
 
   The following `--ignore-pattern` is also equivalent:
 
-      eslint --ignore-pattern '!.build' --ignore-pattern '.build/*' --ignore-pattern '!.build/test.js' parent-folder/
+  ```shell
+  eslint --ignore-pattern '!.build' --ignore-pattern '.build/*' --ignore-pattern '!.build/test.js' parent-folder/
+  ```
 
 ## Using an Alternate File
 
 If you'd prefer to use a different file than the `.eslintignore` in the current working directory, you can specify it on the command line using the `--ignore-path` option. For example, you can use `.jshintignore` file because it has the same format:
 
-    eslint --ignore-path .jshintignore file.js
+```shell
+eslint --ignore-path .jshintignore file.js
+```
 
 You can also use your `.gitignore` file:
 
-    eslint --ignore-path .gitignore file.js
+```shell
+eslint --ignore-path .gitignore file.js
+```
 
 Any file that follows the standard ignore file format can be used. Keep in mind that specifying `--ignore-path` means that any existing `.eslintignore` file will not be used. Note that globbing rules in `.eslintignore` follow those of `.gitignore`.
 
@@ -107,17 +113,19 @@ Any file that follows the standard ignore file format can be used. Keep in mind 
 
 If an `.eslintignore` file is not found and an alternate file is not specified, ESLint will look in package.json for an `eslintIgnore` key to check for files to ignore.
 
-    {
-      "name": "mypackage",
-      "version": "0.0.1",
-      "eslintConfig": {
-          "env": {
-              "browser": true,
-              "node": true
-          }
-      },
-      "eslintIgnore": ["hello.js", "world.js"]
-    }
+```json
+{
+    "name": "mypackage",
+    "version": "0.0.1",
+    "eslintConfig": {
+        "env": {
+            "browser": true,
+            "node": true
+        }
+    },
+    "eslintIgnore": ["hello.js", "world.js"]
+}
+```
 
 ## Ignored File Warnings
 
@@ -129,7 +137,9 @@ foo.js
 
 And then you run:
 
-    eslint foo.js
+```shell
+eslint foo.js
+```
 
 You'll see this warning:
 
@@ -144,7 +154,9 @@ This message occurs because ESLint is unsure if you wanted to actually lint the 
 
 Consider another scenario where you may want to run ESLint on a specific dot-file or dot-folder, but have forgotten to specifically allow those files in your `.eslintignore` file. You would run something like this:
 
-    eslint .config/foo.js
+```shell
+eslint .config/foo.js
+```
 
 You would see this warning:
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Build setup for the new docs site does not treat indented text as code blocks.

This is observable in most examples on https://new.eslint.org/docs/head/user-guide/command-line-interface

and most notably here: https://new.eslint.org/docs/head/rules/no-irregular-whitespace#rule-details

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I'm not sure where exactly is this configured, but it seemed better to just consistently use fenced code blocks, so I enabled [MD046 - Code block style](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md046) rule with `style: "fenced"` and changed all indented code blocks to fenced code blocks.

#### Is there anything you'd like reviewers to focus on?

I disabled this rule in `pages/rules.md` because it was interpreting indentation as code blocks.

<!-- markdownlint-disable-file MD004 -->
