### PR TITLE
docs: reduce cumulative layout shift

### DIFF
--- a/docs/src/_includes/components/docs-index.html
+++ b/docs/src/_includes/components/docs-index.html
@@ -11,7 +11,7 @@
 {%- endmacro %}
 
 <nav class="docs-index" id="docs-index">
-    <button class="docs-index-toggle" id="js-docs-index-toggle" hidden>
+    <button class="docs-index-toggle" id="js-docs-index-toggle">
         Index
         <svg width="20" height="20" viewBox="20 20 60 60" aria-hidden="true" focusable="false">
             <path id="ham-top" d="M30,37 L70,37 Z" stroke="currentColor"></path>

--- a/docs/src/_includes/components/nav-version-switcher.html
+++ b/docs/src/_includes/components/nav-version-switcher.html
@@ -2,7 +2,7 @@
 <div class="version-switcher">
     <a href="{{ '/versions/' | url }}" class="switcher-fallback">Versions</a>
 
-    <div hidden role="region" class="switcher switcher--version" aria-labelledby="nav-version-switcher-label" id="nav-version-switcher">
+    <div role="region" class="switcher switcher--version" aria-labelledby="nav-version-switcher-label" id="nav-version-switcher">
         <span id="nav-version-switcher-label" hidden>Version Switcher</span>
         <div class="infobox visually-hidden" id="nav-version-infobox">
             Selecting a version will take you to the chosen version of the ESLint docs.

--- a/docs/src/_includes/components/navigation.html
+++ b/docs/src/_includes/components/navigation.html
@@ -1,7 +1,7 @@
 <nav class="docs-site-nav" aria-label="Main">
     <div class="flexer">
         <a href="{{ links.donate }}" class="c-btn c-btn--primary donate-link">{{ site.shared.donate}}</a>
-        <button class="docs-site-nav-toggle" aria-label="Menu" id="nav-toggle" hidden>
+        <button class="docs-site-nav-toggle" aria-label="Menu" id="nav-toggle">
             <svg width="20" height="20" viewBox="20 20 60 60">
                 <path id="ham-top"    d="M30,37 L70,37 Z" stroke="currentColor"></path>
                 <path id="ham-middle" d="M30,50 L70,50 Z" stroke="currentColor"></path>

--- a/docs/src/_includes/components/version-switcher.html
+++ b/docs/src/_includes/components/version-switcher.html
@@ -2,7 +2,7 @@
 <div class="version-switcher">
     <a href="{{ '/versions/' | url }}" class="switcher-fallback">Versions</a>
 
-    <div hidden role="region" class="switcher switcher--version" aria-labelledby="version-switcher-label" id="version-switcher">
+    <div role="region" class="switcher switcher--version" aria-labelledby="version-switcher-label" id="version-switcher">
         <span id="version-switcher-label" hidden>Version Switcher</span>
         <div class="infobox visually-hidden" id="version-infobox">
             Selecting a version will take you to the chosen version of the ESLint docs.

--- a/docs/src/_includes/layouts/base.html
+++ b/docs/src/_includes/layouts/base.html
@@ -50,7 +50,7 @@
     <meta name="twitter:creator" content="@geteslint">
 
 
-    <script type="module">
+    <script>
         // This is a capable browser, let's improve the UI further!
         document.documentElement.classList.add("enhanced");
         document.documentElement.classList.remove('no-js');

--- a/docs/src/assets/scss/carbon-ads.scss
+++ b/docs/src/assets/scss/carbon-ads.scss
@@ -4,6 +4,10 @@
      }
 }
 
+.docs-ad {
+    height: 335px;
+}
+
 #carbonads * {
     margin: initial;
     padding: initial;
@@ -13,7 +17,6 @@
     display: inline-block;
     margin: 2rem 0;;
     padding: .6em;
-
     font-size: 16px;
     line-height: 1.35;
     overflow: hidden;

--- a/docs/src/assets/scss/components/docs-index.scss
+++ b/docs/src/assets/scss/components/docs-index.scss
@@ -73,6 +73,11 @@
 }
 
 .docs__index__panel {
+
+    @media all and (max-width: 1023px){
+        display: none;
+    }
+
     &[data-open="false"] {
         display: none;
 
@@ -151,4 +156,34 @@
             transform: rotate(-41deg);
         }
     }
+}
+
+.enhanced .switcher-fallback {
+    display: none !important 
+}
+
+.no-js #js-docs-index-toggle, .no-js #nav-toggle, .no-js #version-switcher, .no-js #nav-version-switcher {
+    display: none;
+}
+
+.no-js #js-docs-index-list {
+    display: block !important
+}
+
+.no-js #nav-panel {
+    @media all and (max-width: 1023px) {
+        display: block !important;
+    } 
+}
+
+.no-js #js-docs-index-panel {
+    @media all and (max-width: 1023px) {
+        display: block !important;
+    } 
+}
+
+.no-js #js-toc-panel {
+    @media all and (max-width: 1023px) {
+        display: block !important;
+    } 
 }

--- a/docs/src/assets/scss/components/docs-navigation.scss
+++ b/docs/src/assets/scss/components/docs-navigation.scss
@@ -48,6 +48,13 @@
         text-decoration: none;
         font-weight: 500;
     }
+
+    a.switcher-fallback{
+        color: var(--link-color);
+        transition: color 0.1s linear;
+        text-decoration: underline;
+    }
+
 }
 
 
@@ -71,8 +78,32 @@
     }
 }
 
-.docs-nav-panel .mobile-only {
-    @media all and (min-width: 1023px) {
+#nav-panel{
+    @media all and (max-width: 1023px) {
+        display: none;
+    }
+}
+
+#nav-panel[data-open="true"]{
+    @media all and (max-width: 1023px) {
+    display: block;
+    }
+}
+
+#js-docs-index-list {
+    @media all and (max-width: 1023px) {
+        display: none;
+    }
+}
+
+#js-docs-index-list[data-open="true"]{
+    @media all and (max-width: 1023px) {
+    display: block;
+    }
+}
+
+#nav-toggle{
+    @media all and (min-width: 1024px) {
         display: none;
     }
 }

--- a/docs/src/assets/scss/components/toc.scss
+++ b/docs/src/assets/scss/components/toc.scss
@@ -108,6 +108,10 @@
 
 
 .c-toc__panel {
+    @media all and (max-width: 1023px){
+        display: none;
+    }
+
     &[data-open="false"] {
         display: none;
     }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
     Reduced cumulative layout shift.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
 Reduced cumulative layout shift.
     

|   | Before | After  |
| ------------- | ------------- | -------------|
| Desktop | <img width="600" alt="Screenshot 2022-06-24 at 1 12 42 AM" src="https://user-images.githubusercontent.com/30730124/175384194-1f6dce9d-ee2d-4264-bcf1-f3d9dab00849.png"> | <img width="600" alt="Screenshot 2022-06-24 at 1 06 57 AM" src="https://user-images.githubusercontent.com/30730124/175384349-a69074c3-f133-47fc-a094-84e37a0802d3.png"> |
|  Mobile | <img width="600" alt="Screenshot 2022-06-24 at 1 09 35 AM" src="https://user-images.githubusercontent.com/30730124/175384251-199f8634-a9a4-40ba-8eeb-5e4604bdece8.png"> | <img width="600" alt="Screenshot 2022-06-24 at 1 07 38 AM" src="https://user-images.githubusercontent.com/30730124/175384397-093f1367-af39-47b7-83c2-acbc241e741a.png"> |






 
 
