### PR TITLE
feat: add importNames support for patterns in no-restricted-imports

### DIFF
--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -109,6 +109,18 @@ Pattern matches can also be configured to be case-sensitive:
 }]
 ```
 
+Pattern matches can restrict specific import names only, similar to the `paths` option:
+
+```json
+"no-restricted-imports": ["error", {
+    "patterns": [{
+      "group": ["utils/*"],
+      "importNames": ["isEmpty"],
+      "message": "Use 'isEmpty' from lodash instead."
+    }]
+}]
+```
+
 To restrict the use of all Node.js core imports (via <https://github.com/nodejs/node/tree/master/lib>):
 
 ```json

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -219,6 +219,16 @@ import pick from 'lodash/pick';
 import pick from 'fooBar';
 ```
 
+```js
+/*eslint no-restricted-imports: ["error", { patterns: [{
+    group: ["utils/*"],
+    importNames: ['isEmpty'],
+    message: "Use 'isEmpty' from lodash instead."
+}]}]*/
+
+import { isEmpty } from 'utils/collection-utils';
+```
+
 Examples of **correct** code for this rule:
 
 ::: correct
@@ -272,6 +282,16 @@ import lodash from 'lodash';
 }]}]*/
 
 import pick from 'food';
+```
+
+```js
+/*eslint no-restricted-imports: ["error", { patterns: [{
+    group: ["utils/*"],
+    importNames: ['isEmpty'],
+    message: "Use 'isEmpty' from lodash instead."
+}]}]*/
+
+import { hasValues } from 'utils/collection-utils';
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -108,6 +108,10 @@ module.exports = {
             // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
             patternWithCustomMessage: "'{{importSource}}' import is restricted from being used by a pattern. {{customMessage}}",
 
+            patternAndImportName: "'{{importName}}' import from '{{importSource}}' is restricted from being used by a pattern.",
+            // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
+            patternAndImportNameWithCustomMessage: "'{{importName}}' import from '{{importSource}}' is restricted from being used by a pattern. {{customMessage}}",
+
             everything: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted.",
             // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
             everythingWithCustomMessage: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted. {{customMessage}}",
@@ -257,7 +261,7 @@ module.exports = {
              * If we are not restricting to any specific import names and just the pattern itself,
              * report the error and move on
              */
-            if (restrictedImportNames.length < 1) {
+            if (restrictedImportNames.length < 1 || importNames.has("*")) {
                 context.report({
                     node,
                     messageId: customMessage ? "patternWithCustomMessage" : "patterns",
@@ -279,7 +283,7 @@ module.exports = {
                 specifiers.forEach(specifier => {
                     context.report({
                         node,
-                        messageId: customMessage ? "importNameWithCustomMessage" : "importName",
+                        messageId: customMessage ? "patternAndImportNameWithCustomMessage" : "patternAndImportName",
                         loc: specifier.loc,
                         data: {
                             importSource,

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -62,7 +62,9 @@ const arrayOfStringsOrObjectPatterns = {
                         type: "array",
                         items: {
                             type: "string"
-                        }
+                        },
+                        minItems: 1,
+                        uniqueItems: true
                     },
                     group: {
                         type: "array",
@@ -259,13 +261,13 @@ module.exports = {
             const importSource = node.source.value.trim();
 
             const customMessage = group.customMessage;
-            const restrictedImportNames = group.importNames || [];
+            const restrictedImportNames = group.importNames;
 
             /*
              * If we are not restricting to any specific import names and just the pattern itself,
              * report the error and move on
              */
-            if (restrictedImportNames.length < 1) {
+            if (!restrictedImportNames) {
                 context.report({
                     node,
                     messageId: customMessage ? "patternWithCustomMessage" : "patterns",

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -112,6 +112,10 @@ module.exports = {
             // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
             patternAndImportNameWithCustomMessage: "'{{importName}}' import from '{{importSource}}' is restricted from being used by a pattern. {{customMessage}}",
 
+            patternAndEverything: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted from being used by a pattern.",
+            // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
+            patternAndEverythingWithCustomMessage: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted from being used by a pattern. {{customMessage}}",
+
             everything: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted.",
             // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
             everythingWithCustomMessage: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted. {{customMessage}}",
@@ -261,7 +265,7 @@ module.exports = {
              * If we are not restricting to any specific import names and just the pattern itself,
              * report the error and move on
              */
-            if (restrictedImportNames.length < 1 || importNames.has("*")) {
+            if (restrictedImportNames.length < 1) {
                 context.report({
                     node,
                     messageId: customMessage ? "patternWithCustomMessage" : "patterns",
@@ -270,6 +274,23 @@ module.exports = {
                         customMessage
                     }
                 });
+                return;
+            }
+
+            if (importNames.has("*")) {
+                const specifierData = importNames.get("*")[0];
+
+                context.report({
+                    node,
+                    messageId: customMessage ? "patternAndEverythingWithCustomMessage" : "patternAndEverything",
+                    loc: specifierData.loc,
+                    data: {
+                        importSource,
+                        importNames: restrictedImportNames,
+                        customMessage
+                    }
+                });
+
                 return;
             }
 

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -58,6 +58,12 @@ const arrayOfStringsOrObjectPatterns = {
             items: {
                 type: "object",
                 properties: {
+                    importNames: {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        }
+                    },
                     group: {
                         type: "array",
                         items: {
@@ -159,9 +165,10 @@ module.exports = {
         }
 
         // relative paths are supported for this rule
-        const restrictedPatternGroups = restrictedPatterns.map(({ group, message, caseSensitive }) => ({
+        const restrictedPatternGroups = restrictedPatterns.map(({ group, message, caseSensitive, importNames }) => ({
             matcher: ignore({ allowRelativePaths: true, ignorecase: !caseSensitive }).add(group),
-            customMessage: message
+            customMessage: message,
+            importNames
         }));
 
         // if no imports are restricted we don't need to check
@@ -234,20 +241,53 @@ module.exports = {
         /**
          * Report a restricted path specifically for patterns.
          * @param {node} node representing the restricted path reference
-         * @param {Object} group contains a Ignore instance for paths, and the customMessage to show if it fails
+         * @param {Object} group contains an Ignore instance for paths, the customMessage to show on failure,
+         * and any restricted import names that have been specified in the config
+         * @param {Map<string,Object[]>} importNames Map of import names that are being imported
          * @returns {void}
          * @private
          */
-        function reportPathForPatterns(node, group) {
+        function reportPathForPatterns(node, group, importNames) {
             const importSource = node.source.value.trim();
 
-            context.report({
-                node,
-                messageId: group.customMessage ? "patternWithCustomMessage" : "patterns",
-                data: {
-                    importSource,
-                    customMessage: group.customMessage
+            const customMessage = group.customMessage;
+            const restrictedImportNames = group.importNames || [];
+
+            /*
+             * If we are not restricting to any specific import names and just the pattern itself,
+             * report the error and move on
+             */
+            if (restrictedImportNames.length < 1) {
+                context.report({
+                    node,
+                    messageId: customMessage ? "patternWithCustomMessage" : "patterns",
+                    data: {
+                        importSource,
+                        customMessage
+                    }
+                });
+                return;
+            }
+
+            restrictedImportNames.forEach(importName => {
+                if (!importNames.has(importName)) {
+                    return;
                 }
+
+                const specifiers = importNames.get(importName);
+
+                specifiers.forEach(specifier => {
+                    context.report({
+                        node,
+                        messageId: customMessage ? "importNameWithCustomMessage" : "importName",
+                        loc: specifier.loc,
+                        data: {
+                            importSource,
+                            customMessage,
+                            importName
+                        }
+                    });
+                });
             });
         }
 
@@ -304,7 +344,7 @@ module.exports = {
             checkRestrictedPathAndReport(importSource, importNames, node);
             restrictedPatternGroups.forEach(group => {
                 if (isRestrictedPattern(importSource, group)) {
-                    reportPathForPatterns(node, group);
+                    reportPathForPatterns(node, group, importNames);
                 }
             });
         }

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -290,8 +290,6 @@ module.exports = {
                         customMessage
                     }
                 });
-
-                return;
             }
 
             restrictedImportNames.forEach(importName => {

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -1155,8 +1155,11 @@ ruleTester.run("no-restricted-imports", rule, {
     },
     {
 
-        // Star import should be reported for consistency with `paths` option (see: https://github.com/eslint/eslint/pull/16059#discussion_r908749964)
-        code: "import * as Foo from '../../my/relative-module';",
+        /*
+         * Star import should be reported for consistency with `paths` option (see: https://github.com/eslint/eslint/pull/16059#discussion_r908749964)
+         * For example, import * as All allows for calling/referencing the restricted import All.Foo
+         */
+        code: "import * as All from '../../my/relative-module';",
         options: [{
             patterns: [{
                 group: ["**/my/relative-module"],
@@ -1164,10 +1167,11 @@ ruleTester.run("no-restricted-imports", rule, {
             }]
         }],
         errors: [{
+            message: "* import is invalid because 'Foo' from '../../my/relative-module' is restricted from being used by a pattern.",
             type: "ImportDeclaration",
             line: 1,
-            column: 1,
-            endColumn: 49
+            column: 8,
+            endColumn: 16
         }]
     }
     ]

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -262,6 +262,37 @@ ruleTester.run("no-restricted-imports", rule, {
                     importNames: ["DisallowedObject"]
                 }]
             }]
+        },
+        {
+            code: "import { Bar } from '../../my/relative-module';",
+            options: [{
+                patterns: [{
+                    group: ["**/my/relative-module"],
+                    importNames: ["Foo"]
+                }]
+            }]
+        },
+        {
+
+            // Default import should not be reported - just drop the importNames option for this behavior
+            code: "import Foo from '../../my/relative-module';",
+            options: [{
+                patterns: [{
+                    group: ["**/my/relative-module"],
+                    importNames: ["Foo"]
+                }]
+            }]
+        },
+        {
+
+            // Star import should not be reported - just drop the importNames option for this behavior
+            code: "import * as Foo from '../../my/relative-module';",
+            options: [{
+                patterns: [{
+                    group: ["**/my/relative-module"],
+                    importNames: ["Foo"]
+                }]
+            }]
         }
     ],
     invalid: [{
@@ -1093,6 +1124,41 @@ ruleTester.run("no-restricted-imports", rule, {
             line: 1,
             column: 1,
             endColumn: 45
+        }]
+    },
+    {
+        code: "import { Foo } from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                group: ["**/my/relative-module"],
+                importNames: ["Foo"]
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 13
+        }]
+    },
+    {
+        code: "import { Foo, Bar } from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                group: ["**/my/relative-module"],
+                importNames: ["Foo", "Bar"]
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 13
+        }, {
+            type: "ImportDeclaration",
+            line: 1,
+            column: 15,
+            endColumn: 18
         }]
     }
     ]

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -282,17 +282,6 @@ ruleTester.run("no-restricted-imports", rule, {
                     importNames: ["Foo"]
                 }]
             }]
-        },
-        {
-
-            // Star import should not be reported - just drop the importNames option for this behavior
-            code: "import * as Foo from '../../my/relative-module';",
-            options: [{
-                patterns: [{
-                    group: ["**/my/relative-module"],
-                    importNames: ["Foo"]
-                }]
-            }]
         }
     ],
     invalid: [{
@@ -1146,19 +1135,39 @@ ruleTester.run("no-restricted-imports", rule, {
         options: [{
             patterns: [{
                 group: ["**/my/relative-module"],
-                importNames: ["Foo", "Bar"]
+                importNames: ["Foo", "Bar"],
+                message: "Import from @/utils instead."
             }]
         }],
         errors: [{
             type: "ImportDeclaration",
             line: 1,
             column: 10,
-            endColumn: 13
+            endColumn: 13,
+            message: "'Foo' import from '../../my/relative-module' is restricted from being used by a pattern. Import from @/utils instead."
         }, {
             type: "ImportDeclaration",
             line: 1,
             column: 15,
-            endColumn: 18
+            endColumn: 18,
+            message: "'Bar' import from '../../my/relative-module' is restricted from being used by a pattern. Import from @/utils instead."
+        }]
+    },
+    {
+
+        // Star import should be reported for consistency with `paths` option (see: https://github.com/eslint/eslint/pull/16059#discussion_r908749964)
+        code: "import * as Foo from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                group: ["**/my/relative-module"],
+                importNames: ["Foo"]
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 1,
+            endColumn: 49
         }]
     }
     ]

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -274,7 +274,7 @@ ruleTester.run("no-restricted-imports", rule, {
         },
         {
 
-            // Default import should not be reported - just drop the importNames option for this behavior
+            // Default import should not be reported unless importNames includes 'default'
             code: "import Foo from '../../my/relative-module';",
             options: [{
                 patterns: [{
@@ -1127,7 +1127,8 @@ ruleTester.run("no-restricted-imports", rule, {
             type: "ImportDeclaration",
             line: 1,
             column: 10,
-            endColumn: 13
+            endColumn: 13,
+            message: "'Foo' import from '../../my/relative-module' is restricted from being used by a pattern."
         }]
     },
     {
@@ -1172,6 +1173,67 @@ ruleTester.run("no-restricted-imports", rule, {
             line: 1,
             column: 8,
             endColumn: 16
+        }]
+    },
+    {
+
+        /*
+         * Star import should be reported for consistency with `paths` option (see: https://github.com/eslint/eslint/pull/16059#discussion_r908749964)
+         * For example, import * as All allows for calling/referencing the restricted import All.Foo
+         */
+        code: "import * as AllWithCustomMessage from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                group: ["**/my/relative-module"],
+                importNames: ["Foo"],
+                message: "Import from @/utils instead."
+            }]
+        }],
+        errors: [{
+            message: "* import is invalid because 'Foo' from '../../my/relative-module' is restricted from being used by a pattern. Import from @/utils instead.",
+            type: "ImportDeclaration",
+            line: 1,
+            column: 8,
+            endColumn: 33
+        }]
+    },
+    {
+        code: "import def, * as ns from 'mod';",
+        options: [{
+            patterns: [{
+                group: ["mod"],
+                importNames: ["default"]
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 8,
+            endColumn: 11,
+            message: "'default' import from 'mod' is restricted from being used by a pattern."
+        },
+        {
+            type: "ImportDeclaration",
+            line: 1,
+            column: 13,
+            endColumn: 20,
+            message: "* import is invalid because 'default' from 'mod' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "import Foo from 'mod';",
+        options: [{
+            patterns: [{
+                group: ["mod"],
+                importNames: ["default"]
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 8,
+            endColumn: 11,
+            message: "'default' import from 'mod' is restricted from being used by a pattern."
         }]
     }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Resolves #14274 

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This change expands the functionality of `no-restricted-imports` to allow restricting only specific named imports from an import pattern ban. For example, if I wanted to ban importing `Foo` from `'../../../my/relative/module'`, but importing `Bar` from the matched pattern is OK, I can now do that:

```
"no-restricted-imports": ["error", {            
    "patterns": [{
        "group": ["**/my/relative-module"],
        "importNames": ["Foo"],
        "message": "Don't import Foo from my/relative-module. Instead import from @repo/foo"
    }]
}]
```

```
import { Foo } from '../../../my/relative-module' // error
import { Foo, Bar } from '../../../my/relative-module' // error
import { Bar } from '../../../my/relative-module' // ok
```

#### Is there anything you'd like reviewers to focus on?

Nope - this is my first time contributing here, so please forgive me if I've missed anything - happy to update as needed!

<!-- markdownlint-disable-file MD004 -->
