### PR TITLE
chore: correctly use .markdownlintignore in Makefile

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -22,6 +22,7 @@ const checker = require("npm-license"),
     ejs = require("ejs"),
     loadPerf = require("load-perf"),
     yaml = require("js-yaml"),
+    ignore = require("ignore"),
     { CLIEngine } = require("./lib/cli-engine"),
     builtinRules = require("./lib/rules/index");
 
@@ -72,8 +73,8 @@ const NODE = "node ", // intentional extra space
     // Files
     RULE_FILES = glob.sync("lib/rules/*.js").filter(filePath => path.basename(filePath) !== "index.js"),
     JSON_FILES = find("conf/").filter(fileType("json")),
-    MARKDOWNLINT_IGNORED_FILES = fs.readFileSync(path.join(__dirname, ".markdownlintignore"), "utf-8").split("\n"),
-    MARKDOWN_FILES_ARRAY = find("docs/").concat(ls(".")).filter(fileType("md")).filter(file => !MARKDOWNLINT_IGNORED_FILES.includes(file)),
+    MARKDOWNLINT_IGNORE_INSTANCE = ignore().add(fs.readFileSync(path.join(__dirname, ".markdownlintignore"), "utf-8")),
+    MARKDOWN_FILES_ARRAY = MARKDOWNLINT_IGNORE_INSTANCE.filter(find("docs/").concat(ls(".")).filter(fileType("md"))),
     TEST_FILES = "\"tests/{bin,conf,lib,tools}/**/*.js\"",
     PERF_ESLINTRC = path.join(PERF_TMP_DIR, "eslintrc.yml"),
     PERF_MULTIFILES_TARGET_DIR = path.join(PERF_TMP_DIR, "eslint"),


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

- [x] Other, please explain:

Improve robustness of internal `npm run lint` command.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In the Makefile, we run markdownlint on all of our documentation files.

We previously had a naive check to ignore files that are mentioned in `.markdownlintignore`. But this didn't handle nested `node_modules` which will be created after running `npm install` in folders like `docs/`.

In this PR, I have updated the check to use the existing [ignore](https://www.npmjs.com/package/ignore) library to correctly [filter](https://github.com/kaelzhang/node-ignore#addpatterns-arraystring--ignore-this) out the gitignore-style ignore patterns in `.markdownlintignore`.

Note that the reason we have to manually do this ignore-filtering is because [markdownlint](https://github.com/DavidAnson/markdownlint/markdownlint) does [not support](https://github.com/DavidAnson/markdownlint/issues/287) `.markdownlintignore` yet whereas [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) and editor extensions do. In the Makefile, we have to use markdownlint because it has a Node API whereas markdownlint-cli doesn't.

Thank you to @amareshsm for finding this issue.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
