### PR TITLE
chore: use `github-slugger` for markdown anchors

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -162,11 +162,7 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.setLibrary("md",
         markdownIt({ html: true, linkify: true, typographer: true })
             .use(markdownItAnchor, {
-                slugify(text) {
-
-                    // need to replace all the characters GitHub replaces
-                    return slugify(text);
-                }
+                slugify
             })
             .use(markdownItContainer, "correct", {})
             .use(markdownItContainer, "incorrect", {})

--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -4,7 +4,6 @@ const eleventyNavigationPlugin = require("@11ty/eleventy-navigation");
 const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const pluginRss = require("@11ty/eleventy-plugin-rss");
 const pluginTOC = require("eleventy-plugin-nesting-toc");
-const slugify = require("slugify");
 const markdownItAnchor = require("markdown-it-anchor");
 const markdownItContainer = require("markdown-it-container");
 const Image = require("@11ty/eleventy-img");
@@ -61,16 +60,23 @@ module.exports = function(eleventyConfig) {
 
     eleventyConfig.addFilter("jsonify", variable => JSON.stringify(variable));
 
+    /**
+     * Takes in a string and converts to a slug
+     * @param {string} text text to be converted into slug
+     * @returns {string} slug to be used as anchors
+     */
+    function slugify(text) {
+        return slug(text.replace(/[<>()[\]{}]/gu, ""))
+        // eslint-disable-next-line no-control-regex -- used regex from https://github.com/eslint/archive-website/blob/master/_11ty/plugins/markdown-plugins.js#L37
+            .replace(/[^\u{00}-\u{FF}]/gu, "");
+    }
+
     eleventyConfig.addFilter("slugify", str => {
         if (!str) {
             return "";
         }
 
-        return slugify(str, {
-            lower: true,
-            strict: true,
-            remove: /["]/gu
-        });
+        return slugify(str);
     });
 
     eleventyConfig.addFilter("URIencode", str => {
@@ -159,11 +165,7 @@ module.exports = function(eleventyConfig) {
                 slugify(text) {
 
                     // need to replace all the characters GitHub replaces
-                    return slug(text.replace(/[<>()[\]{}]/gu, ""))
-
-                        // remove non-ASCII characters
-                        // eslint-disable-next-line no-control-regex -- used regex from https://github.com/eslint/archive-website/blob/master/_11ty/plugins/markdown-plugins.js#L37
-                        .replace(/[^\u{00}-\u{FF}]/gu, "");
+                    return slugify(text);
                 }
             })
             .use(markdownItContainer, "correct", {})

--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -9,6 +9,7 @@ const markdownItAnchor = require("markdown-it-anchor");
 const markdownItContainer = require("markdown-it-container");
 const Image = require("@11ty/eleventy-img");
 const path = require("path");
+const { slug } = require("github-slugger");
 const yaml = require("js-yaml");
 
 const {
@@ -154,7 +155,17 @@ module.exports = function(eleventyConfig) {
 
     eleventyConfig.setLibrary("md",
         markdownIt({ html: true, linkify: true, typographer: true })
-            .use(markdownItAnchor, {})
+            .use(markdownItAnchor, {
+                slugify(text) {
+
+                    // need to replace all the characters GitHub replaces
+                    return slug(text.replace(/[<>()[\]{}]/gu, ""))
+
+                        // remove non-ASCII characters
+                        // eslint-disable-next-line no-control-regex -- used regex from https://github.com/eslint/archive-website/blob/master/_11ty/plugins/markdown-plugins.js#L37
+                        .replace(/[^\u{00}-\u{FF}]/gu, "");
+                }
+            })
             .use(markdownItContainer, "correct", {})
             .use(markdownItContainer, "incorrect", {})
             .disable("code"));

--- a/docs/package.json
+++ b/docs/package.json
@@ -39,8 +39,7 @@
         "netlify-cli": "^10.3.1",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",
-        "sass": "^1.52.1",
-        "slugify": "^1.6.3"
+        "sass": "^1.52.1"
     },
     "engines": {
         "node": ">=14.0.0"

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,6 +28,7 @@
         "eleventy-plugin-nesting-toc": "^1.3.0",
         "eleventy-plugin-page-assets": "^0.3.0",
         "eleventy-plugin-reading-time": "^0.0.1",
+        "github-slugger": "^1.4.0",
         "imagemin": "^8.0.1",
         "imagemin-cli": "^7.0.0",
         "js-yaml": "^3.14.1",


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)


Making use of slugify function from old site

reference:
- https://github.com/eslint/eslint/pull/16066#issuecomment-1168689803

#### Is there anything you'd like reviewers to focus on?

There is one another slugger library 

- https://github.com/eslint/eslint/blob/b6aee9591ecc2e2f5738ab8bef20faac1e05b5c3/docs/package.json#L42

that we add as filter in eleventy and have used it inside only one file 
- https://github.com/eslint/eslint/blob/b6aee9591ecc2e2f5738ab8bef20faac1e05b5c3/docs/src/pages/rules.md?plain=1#L26

The problem here is that this library `Coerces foreign symbols to their English equivalent` [link](https://github.com/simov/slugify/blob/master/config/charmap.json) for more details. so the `problems & statements` is turned into `problems-and-statements` and added inside id. How ever I don't see this id being referenced anywhere. If it is not referenced anywhere (please help confirm this) we can go ahead and remove `slugify` library. 😄 
