### PR TITLE
feat: fix handling of blockless `with` statements in indent rule

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1211,7 +1211,7 @@ module.exports = {
                 }
             },
 
-            "DoWhileStatement, WhileStatement, ForInStatement, ForOfStatement": node => addBlocklessNodeIndent(node.body),
+            "DoWhileStatement, WhileStatement, ForInStatement, ForOfStatement, WithStatement": node => addBlocklessNodeIndent(node.body),
 
             ExportNamedDeclaration(node) {
                 if (node.declaration === null) {
@@ -1268,7 +1268,7 @@ module.exports = {
              *
              * Traversal into the node sets indentation of the semicolon, so we need to override it on exit.
              */
-            ":matches(DoWhileStatement, ForStatement, ForInStatement, ForOfStatement, IfStatement, WhileStatement):exit"(node) {
+            ":matches(DoWhileStatement, ForStatement, ForInStatement, ForOfStatement, IfStatement, WhileStatement, WithStatement):exit"(node) {
                 let nodesToCheck;
 
                 if (node.type === "IfStatement") {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -778,6 +778,21 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                with (a)
+                    b();
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                with (a)
+                    b();
+                c();
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
                 if(true)
                   if (true)
                     if (true)
@@ -6324,6 +6339,14 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                with (a)
+                    console.log(b)
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
                 label: for (a of b)
                     console.log('a')
                 ;[1, 2, 3].forEach(x=>console.log(x))
@@ -6949,6 +6972,20 @@ ruleTester.run("indent", rule, {
                 do
                     b();
                 while(true)
+            `,
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 0, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                with(a)
+                b();
+            `,
+            output: unIndent`
+                with(a)
+                    b();
             `,
             options: [4],
             errors: expectedErrors([
@@ -13296,6 +13333,20 @@ ruleTester.run("indent", rule, {
             output: unIndent`
                 for (a of b)
                     console.log('a')
+                ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            options: [4],
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                with (a)
+                    console.log(b)
+                    ;[1, 2, 3].forEach(x=>console.log(x))
+            `,
+            output: unIndent`
+                with (a)
+                    console.log(b)
                 ;[1, 2, 3].forEach(x=>console.log(x))
             `,
             options: [4],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

This bug fix can produce more warnings.

I noticed this bug while working on https://github.com/eslint/eslint/pull/15951.

**Tell us about your environment:**

* **ESLint Version:** v8.18.0
* **Node Version:** 16.14.0
* **npm Version:** 8.3.1

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Playground link](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IGluZGVudDogW1wiZXJyb3JcIiwgNF0gKi9cblxud2l0aCAoYSlcbiAgICBiKCk7XG4iLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOiJsYXRlc3QiLCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7fSwiZW52Ijp7ImVzNiI6dHJ1ZX19fQ==)

```js
/* eslint indent: ["error", 4] */

with (a)
    b();
```

**What did you expect to happen?**

No errors

**What actually happened? Please include the actual, raw output from ESLint.**

1 error

```
  4:1  error  Expected indentation of 0 spaces but found 4  indent
```

Autofix:

```js
/* eslint indent: ["error", 4] */

with (a)
b();

```

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added `WithStatement` to selectors that handle blockless body nodes.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
