### PR TITLE
fix: throw helpful exception when rule has wrong return type

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1119,7 +1119,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
             };
         }
 
-        if (typeof ruleListeners !== "object" || Array.isArray(ruleListeners) || ruleListeners === null) {
+        if (typeof ruleListeners !== "object" || ruleListeners === null) {
             throw new Error(`The create() function for rule ${ruleId} did not return an object.`);
         }
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1119,6 +1119,10 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
             };
         }
 
+        if (typeof ruleListeners !== "object" || Array.isArray(ruleListeners) || ruleListeners === null) {
+            throw new Error(`The create() function for rule ${ruleId} did not return an object.`);
+        }
+
         // add all the selectors from the rule as listeners
         Object.keys(ruleListeners).forEach(selector => {
             const ruleListener = timing.enabled

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1119,7 +1119,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
             };
         }
 
-        if (typeof ruleListeners !== "object" || ruleListeners === null) {
+        if (typeof ruleListeners === "undefined" || ruleListeners === null) {
             throw new Error(`The create() function for rule ${ruleId} did not return an object.`);
         }
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1120,7 +1120,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
         }
 
         if (typeof ruleListeners === "undefined" || ruleListeners === null) {
-            throw new Error(`The create() function for rule ${ruleId} did not return an object.`);
+            throw new Error(`The create() function for rule '${ruleId}' did not return an object.`);
         }
 
         // add all the selectors from the rule as listeners

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7000,6 +7000,28 @@ var a = "test2";
 
             assert(ok);
         });
+
+        it("should throw when rule's create() function does not return an object", () => {
+            const config = { rules: { checker: "error" } };
+
+            linter.defineRule("checker", () => null); // returns null
+
+            assert.throws(() => {
+                linter.verify("abc", config, filename);
+            }, "The create() function for rule checker did not return an object.");
+
+            linter.defineRule("checker", () => {}); // returns undefined
+
+            assert.throws(() => {
+                linter.verify("abc", config, filename);
+            }, "The create() function for rule checker did not return an object.");
+
+            linter.defineRule("checker", () => []); // returns an array
+
+            assert.throws(() => {
+                linter.verify("abc", config, filename);
+            }, "The create() function for rule checker did not return an object.");
+        });
     });
 
     describe("Custom parser", () => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7018,9 +7018,8 @@ var a = "test2";
 
             linter.defineRule("checker", () => []); // returns an array
 
-            assert.throws(() => {
-                linter.verify("abc", config, filename);
-            }, "The create() function for rule checker did not return an object.");
+            // array should not throw
+            linter.verify("abc", config, filename);
         });
     });
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7008,18 +7008,13 @@ var a = "test2";
 
             assert.throws(() => {
                 linter.verify("abc", config, filename);
-            }, "The create() function for rule checker did not return an object.");
+            }, "The create() function for rule 'checker' did not return an object.");
 
             linter.defineRule("checker", () => {}); // returns undefined
 
             assert.throws(() => {
                 linter.verify("abc", config, filename);
-            }, "The create() function for rule checker did not return an object.");
-
-            linter.defineRule("checker", () => []); // returns an array
-
-            // array should not throw
-            linter.verify("abc", config, filename);
+            }, "The create() function for rule 'checker' did not return an object.");
         });
     });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Especially when developing a custom rule, it's possible to return the wrong data type in the rule's `create(context)` function. In particular, this often happens when attempting to bail out of a rule early, as shown below. The user needs to use `return {};` to bail out instead of null/undefined. 

```js
module.exports = {
    meta: {
        // ...
    },

    create(context) {
        if (foo) {
            // bail out since rule doesn't apply
            return null; // wrong, should actually be return {};
        }
        return {
            BlockStatement(node) {},
        };
    }
};
```

Before (unhelpful error message):

```
~/Development/repo * yarn eslint file.js
yarn run v1.22.19

Oops! Something went wrong! :(

ESLint: 8.18.0

TypeError: Cannot convert undefined or null to object
Occurred while linting file.js
    at Function.keys (<anonymous>)
    at /Users/username/Development/eslint/lib/linter/linter.js:1129:16
    at Array.forEach (<anonymous>)

```

After (helpful error message):

```
~/Development/repo * yarn eslint file.js
yarn run v1.22.19

Oops! Something went wrong! :(

ESLint: 8.18.0

Error: The create() function for rule my-rule did not return an object.
Occurred while linting file.js
    at /Users/user/Development/eslint/lib/linter/linter.js:1123:19
    at Array.forEach (<anonymous>)
```

This is not a breaking change because this scenario already resulted in a crash and should only be hit during development.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
This could also be considered a chore/documentation improvement but it does have a public (dev-facing) impact. 