### PR TITLE
docs: add missing correct/incorrect containers

### DIFF
--- a/docs/src/rules/camelcase.md
+++ b/docs/src/rules/camelcase.md
@@ -319,6 +319,8 @@ function UNSAFE_componentWillMount() {
 
 :::
 
+::: correct
+
 ```js
 /*eslint camelcase: ["error", {allow: ["^UNSAFE_"]}]*/
 
@@ -330,6 +332,8 @@ function UNSAFE_componentWillMount() {
     // ...
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/func-name-matching.md
+++ b/docs/src/rules/func-name-matching.md
@@ -31,6 +31,8 @@ class C {
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint func-name-matching: ["error", "never"] */
 
@@ -45,6 +47,8 @@ class C {
     foo = function foo() {};
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
@@ -95,6 +99,8 @@ module['exports'] = function foo(name) {};
 
 :::
 
+::: correct
+
 ```js
 /*eslint func-name-matching: ["error", "never"] */
 /*eslint-env es6*/
@@ -136,6 +142,8 @@ class D {
 module.exports = function foo(name) {};
 module['exports'] = function foo(name) {};
 ```
+
+:::
 
 ## Options
 

--- a/docs/src/rules/key-spacing.md
+++ b/docs/src/rules/key-spacing.md
@@ -290,6 +290,8 @@ var obj = {
 
 :::
 
+::: correct
+
 ```js
 /*eslint key-spacing: ["error", {
     "align": {
@@ -304,6 +306,8 @@ var obj = {
     "seven":7
 }
 ```
+
+:::
 
 ### align and multiLine
 

--- a/docs/src/rules/max-lines-per-function.md
+++ b/docs/src/rules/max-lines-per-function.md
@@ -87,6 +87,8 @@ function foo() {
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint max-lines-per-function: ["error", 2]*/
 function foo() {
@@ -94,6 +96,10 @@ function foo() {
     var x = 0;
 }
 ```
+
+:::
+
+::: incorrect
 
 ```js
 /*eslint max-lines-per-function: ["error", 2]*/
@@ -103,6 +109,8 @@ function foo() {
     var x = 0;
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with a max value of `3`:
 
@@ -117,6 +125,8 @@ function foo() {
 
 :::
 
+::: correct
+
 ```js
 /*eslint max-lines-per-function: ["error", 3]*/
 function foo() {
@@ -124,6 +134,10 @@ function foo() {
     var x = 0;
 }
 ```
+
+:::
+
+::: correct
 
 ```js
 /*eslint max-lines-per-function: ["error", 3]*/
@@ -133,6 +147,8 @@ function foo() {
     var x = 0;
 }
 ```
+
+:::
 
 ### skipBlankLines
 

--- a/docs/src/rules/max-lines.md
+++ b/docs/src/rules/max-lines.md
@@ -48,12 +48,18 @@ var a,
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint max-lines: ["error", 2]*/
 
 var a,
     b,c;
 ```
+
+:::
+
+::: incorrect
 
 ```js
 /*eslint max-lines: ["error", 2]*/
@@ -61,6 +67,8 @@ var a,
 var a,
     b,c;
 ```
+
+:::
 
 Examples of **correct** code for this rule with a max value of `2`:
 
@@ -74,17 +82,25 @@ var a,
 
 :::
 
+::: correct
+
 ```js
 /*eslint max-lines: ["error", 2]*/
 
 var a, b, c;
 ```
+
+:::
+
+::: correct
 
 ```js
 /*eslint max-lines: ["error", 2]*/
 // a comment
 var a, b, c;
 ```
+
+:::
 
 ### skipBlankLines
 

--- a/docs/src/rules/no-class-assign.md
+++ b/docs/src/rules/no-class-assign.md
@@ -36,6 +36,8 @@ A = 0;
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint no-class-assign: "error"*/
 /*eslint-env es6*/
@@ -43,6 +45,10 @@ A = 0;
 A = 0;
 class A { }
 ```
+
+:::
+
+::: incorrect
 
 ```js
 /*eslint no-class-assign: "error"*/
@@ -55,6 +61,10 @@ class A {
 }
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /*eslint no-class-assign: "error"*/
 /*eslint-env es6*/
@@ -66,6 +76,8 @@ let A = class A {
     }
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
@@ -81,6 +93,8 @@ A = 0; // A is a variable.
 
 :::
 
+::: correct
+
 ```js
 /*eslint no-class-assign: "error"*/
 /*eslint-env es6*/
@@ -92,6 +106,10 @@ let A = class {
 }
 ```
 
+:::
+
+::: correct
+
 ```js
 /*eslint no-class-assign: 2*/
 /*eslint-env es6*/
@@ -102,6 +120,8 @@ class A {
     }
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-compare-neg-zero.md
+++ b/docs/src/rules/no-compare-neg-zero.md
@@ -39,6 +39,8 @@ if (x === 0) {
 
 :::
 
+::: correct
+
 ```js
 /* eslint no-compare-neg-zero: "error" */
 
@@ -46,3 +48,5 @@ if (Object.is(x, -0)) {
     // doSomething()...
 }
 ```
+
+:::

--- a/docs/src/rules/no-const-assign.md
+++ b/docs/src/rules/no-const-assign.md
@@ -30,6 +30,8 @@ a = 1;
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint no-const-assign: "error"*/
 /*eslint-env es6*/
@@ -38,6 +40,10 @@ const a = 0;
 a += 1;
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /*eslint no-const-assign: "error"*/
 /*eslint-env es6*/
@@ -45,6 +51,8 @@ a += 1;
 const a = 0;
 ++a;
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
@@ -60,6 +68,8 @@ console.log(a);
 
 :::
 
+::: correct
+
 ```js
 /*eslint no-const-assign: "error"*/
 /*eslint-env es6*/
@@ -69,6 +79,10 @@ for (const a in [1, 2, 3]) { // `a` is re-defined (not modified) on each loop st
 }
 ```
 
+:::
+
+::: correct
+
 ```js
 /*eslint no-const-assign: "error"*/
 /*eslint-env es6*/
@@ -77,6 +91,8 @@ for (const a of [1, 2, 3]) { // `a` is re-defined (not modified) on each loop st
     console.log(a);
 }
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-continue.md
+++ b/docs/src/rules/no-continue.md
@@ -46,6 +46,8 @@ for(i = 0; i < 10; i++) {
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint no-continue: "error"*/
 
@@ -60,6 +62,8 @@ labeledLoop: for(i = 0; i < 10; i++) {
     a += i;
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 

--- a/docs/src/rules/no-eval.md
+++ b/docs/src/rules/no-eval.md
@@ -146,6 +146,8 @@ this.eval("var a = 0");
 
 :::
 
+::: correct
+
 ```js
 /*eslint no-eval: "error"*/
 /*eslint-env browser*/
@@ -153,12 +155,18 @@ this.eval("var a = 0");
 window.eval("var a = 0");
 ```
 
+:::
+
+::: correct
+
 ```js
 /*eslint no-eval: "error"*/
 /*eslint-env node*/
 
 global.eval("var a = 0");
 ```
+
+:::
 
 ## Known Limitations
 

--- a/docs/src/rules/no-extra-strict.md
+++ b/docs/src/rules/no-extra-strict.md
@@ -55,9 +55,13 @@ Examples of **correct** code for this rule:
 
 :::
 
+::: correct
+
 ```js
 (function () {
     "use strict";
     var foo = true;
 }());
 ```
+
+:::

--- a/docs/src/rules/no-global-assign.md
+++ b/docs/src/rules/no-global-assign.md
@@ -41,6 +41,8 @@ undefined = 1
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint no-global-assign: "error"*/
 /*eslint-env browser*/
@@ -50,12 +52,18 @@ length = 1
 top = 1
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /*eslint no-global-assign: "error"*/
 /*global a:readonly*/
 
 a = 1
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
@@ -71,6 +79,8 @@ b = 2
 
 :::
 
+::: correct
+
 ```js
 /*eslint no-global-assign: "error"*/
 /*eslint-env browser*/
@@ -78,12 +88,18 @@ b = 2
 onload = function() {}
 ```
 
+:::
+
+::: correct
+
 ```js
 /*eslint no-global-assign: "error"*/
 /*global a:writable*/
 
 a = 1
 ```
+
+:::
 
 ## Options
 

--- a/docs/src/rules/no-magic-numbers.md
+++ b/docs/src/rules/no-magic-numbers.md
@@ -32,6 +32,8 @@ var dutyFreePrice = 100,
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint no-magic-numbers: "error"*/
 
@@ -40,6 +42,10 @@ var data = ['foo', 'bar', 'baz'];
 var dataLast = data[2];
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /*eslint no-magic-numbers: "error"*/
 
@@ -47,6 +53,8 @@ var SECONDS;
 
 SECONDS = 60;
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
@@ -176,12 +184,16 @@ function mapParallel(concurrency = 3) { /***/ }
 
 :::
 
+::: correct
+
 ```js
 /*eslint no-magic-numbers: ["error", { "ignoreDefaultValues": true }]*/
 
 let head;
 [head = 100] = []
 ```
+
+:::
 
 ### enforceConst
 

--- a/docs/src/rules/no-mixed-operators.md
+++ b/docs/src/rules/no-mixed-operators.md
@@ -124,6 +124,8 @@ var foo = a & b | c;
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint no-mixed-operators: ["error", {"groups": [["&&", "||", "?:"]]}]*/
 
@@ -133,6 +135,8 @@ var bar = a ? b || c : d;
 
 var baz = a ? b : c || d;
 ```
+
+:::
 
 Examples of **correct** code for this rule with `{"groups": [["&", "|", "^", "~", "<<", ">>", ">>>"], ["&&", "||"]]}` option:
 
@@ -154,6 +158,8 @@ var foo = (a + b) * c;
 
 :::
 
+::: correct
+
 ```js
 /*eslint no-mixed-operators: ["error", {"groups": [["&&", "||", "?:"]]}]*/
 
@@ -165,6 +171,8 @@ var bar = a ? (b || c) : d;
 var baz = a ? b : (c || d);
 var baz = (a ? b : c) || d;
 ```
+
+:::
 
 ### allowSamePrecedence
 

--- a/docs/src/rules/no-native-reassign.md
+++ b/docs/src/rules/no-native-reassign.md
@@ -42,6 +42,8 @@ undefined = 1
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint no-native-reassign: "error"*/
 /*eslint-env browser*/
@@ -51,12 +53,18 @@ length = 1
 top = 1
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /*eslint no-native-reassign: "error"*/
 /*global a:readonly*/
 
 a = 1
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
@@ -72,6 +80,8 @@ b = 2
 
 :::
 
+::: correct
+
 ```js
 /*eslint no-native-reassign: "error"*/
 /*eslint-env browser*/
@@ -79,12 +89,18 @@ b = 2
 onload = function() {}
 ```
 
+:::
+
+::: correct
+
 ```js
 /*eslint no-native-reassign: "error"*/
 /*global a:writable*/
 
 a = 1
 ```
+
+:::
 
 ## Options
 

--- a/docs/src/rules/no-restricted-exports.md
+++ b/docs/src/rules/no-restricted-exports.md
@@ -102,11 +102,15 @@ export { foo as default };
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint no-restricted-exports: ["error", { "restrictedNamedExports": ["default"] }]*/
 
 export { default } from "some_module";
 ```
+
+:::
 
 Examples of additional **correct** code for this rule:
 

--- a/docs/src/rules/no-restricted-globals.md
+++ b/docs/src/rules/no-restricted-globals.md
@@ -83,12 +83,16 @@ import event from "event-module";
 
 :::
 
+::: correct
+
 ```js
 /*global event*/
 /*eslint no-restricted-globals: ["error", "event"]*/
 
 var event = 1;
 ```
+
+:::
 
 Examples of **incorrect** code for a sample `"event"` global variable name, along with a custom error message:
 

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -142,11 +142,17 @@ import fs from 'fs';
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
 
 export { fs } from 'fs';
 ```
+
+:::
+
+::: incorrect
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
@@ -154,17 +160,29 @@ export { fs } from 'fs';
 export * from 'fs';
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /*eslint no-restricted-imports: ["error", { "paths": ["cluster"] }]*/
 
 import cluster from 'cluster';
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /*eslint no-restricted-imports: ["error", { "patterns": ["lodash/*"] }]*/
 
 import pick from 'lodash/pick';
 ```
+
+:::
+
+::: incorrect
 
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{
@@ -175,6 +193,10 @@ import pick from 'lodash/pick';
 
 import DisallowedObject from "foo";
 ```
+
+:::
+
+::: incorrect
 
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{
@@ -190,6 +212,10 @@ import { DisallowedObject as AllowedObject } from "foo";
 import { "DisallowedObject" as AllowedObject } from "foo";
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{
     name: "foo",
@@ -200,6 +226,10 @@ import { "DisallowedObject" as AllowedObject } from "foo";
 import * as Foo from "foo";
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
     group: ["lodash/*"],
@@ -208,6 +238,10 @@ import * as Foo from "foo";
 
 import pick from 'lodash/pick';
 ```
+
+:::
+
+::: incorrect
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
@@ -218,6 +252,10 @@ import pick from 'lodash/pick';
 import pick from 'fooBar';
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
     group: ["utils/*"],
@@ -227,6 +265,8 @@ import pick from 'fooBar';
 
 import { isEmpty } from 'utils/collection-utils';
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
@@ -241,6 +281,8 @@ export { foo } from "bar";
 
 :::
 
+::: correct
+
 ```js
 /*eslint no-restricted-imports: ["error", { "paths": ["fs"], "patterns": ["eslint/*"] }]*/
 
@@ -249,11 +291,19 @@ import eslint from 'eslint';
 export * from "path";
 ```
 
+:::
+
+::: correct
+
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{ name: "foo", importNames: ["DisallowedObject"] }] }]*/
 
 import DisallowedObject from "foo"
 ```
+
+:::
+
+::: correct
 
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{
@@ -265,6 +315,10 @@ import DisallowedObject from "foo"
 import { AllowedObject as DisallowedObject } from "foo";
 ```
 
+:::
+
+::: correct
+
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
     group: ["lodash/*"],
@@ -273,6 +327,10 @@ import { AllowedObject as DisallowedObject } from "foo";
 
 import lodash from 'lodash';
 ```
+
+:::
+
+::: correct
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
@@ -283,6 +341,10 @@ import lodash from 'lodash';
 import pick from 'food';
 ```
 
+:::
+
+::: correct
+
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
     group: ["utils/*"],
@@ -292,6 +354,8 @@ import pick from 'food';
 
 import { hasValues } from 'utils/collection-utils';
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-restricted-modules.md
+++ b/docs/src/rules/no-restricted-modules.md
@@ -88,17 +88,25 @@ var cluster = require('cluster');
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint no-restricted-modules: ["error", {"paths": ["cluster"] }]*/
 
 var cluster = require('cluster');
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /*eslint no-restricted-modules: ["error", { "patterns": ["lodash/*"] }]*/
 
 var pick = require('lodash/pick');
 ```
+
+:::
 
 Examples of **correct** code for this rule with sample `"fs", "cluster", "lodash"` restricted modules:
 
@@ -112,6 +120,8 @@ var crypto = require('crypto');
 
 :::
 
+::: correct
+
 ```js
 /*eslint no-restricted-modules: ["error", {
     "paths": ["fs", "cluster"],
@@ -121,3 +131,5 @@ var crypto = require('crypto');
 var crypto = require('crypto');
 var pick = require('lodash/pick');
 ```
+
+:::

--- a/docs/src/rules/no-restricted-properties.md
+++ b/docs/src/rules/no-restricted-properties.md
@@ -90,6 +90,8 @@ disallowedObjectName.disallowedPropertyName(); /*error Disallowed object propert
 
 :::
 
+::: incorrect
+
 ```js
 /* eslint no-restricted-properties: [2, {
     "property": "__defineGetter__"
@@ -98,6 +100,10 @@ disallowedObjectName.disallowedPropertyName(); /*error Disallowed object propert
 foo.__defineGetter__(bar, baz);
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /* eslint no-restricted-properties: [2, {
     "object": "require"
@@ -105,6 +111,8 @@ foo.__defineGetter__(bar, baz);
 
 require.resolve('foo');
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
@@ -123,6 +131,8 @@ allowedObjectName.disallowedPropertyName();
 
 :::
 
+::: correct
+
 ```js
 /* eslint no-restricted-properties: [2, {
     "object": "require"
@@ -130,6 +140,8 @@ allowedObjectName.disallowedPropertyName();
 
 require('foo');
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/no-unsafe-finally.md
+++ b/docs/src/rules/no-unsafe-finally.md
@@ -89,6 +89,8 @@ let foo = function() {
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint no-unsafe-finally: "error"*/
 let foo = function() {
@@ -101,6 +103,8 @@ let foo = function() {
     }
 };
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
@@ -121,6 +125,8 @@ let foo = function() {
 
 :::
 
+::: correct
+
 ```js
 /*eslint no-unsafe-finally: "error"*/
 let foo = function() {
@@ -135,6 +141,10 @@ let foo = function() {
     }
 };
 ```
+
+:::
+
+::: correct
 
 ```js
 /*eslint no-unsafe-finally: "error"*/
@@ -153,6 +163,8 @@ let foo = function(a) {
     }
 };
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/one-var.md
+++ b/docs/src/rules/one-var.md
@@ -457,10 +457,14 @@ var bar = "bar";
 
 :::
 
+::: correct
+
 ```js
 var foo = require("foo"),
     bar = require("bar");
 ```
+
+:::
 
 Examples of **incorrect** code for this rule with the `{ var: "never", let: "consecutive", const: "consecutive" }` option:
 

--- a/docs/src/rules/sort-imports.md
+++ b/docs/src/rules/sort-imports.md
@@ -199,11 +199,15 @@ import b from 'bar.js'
 
 :::
 
+::: correct
+
 ```js
 /*eslint sort-imports: ["error", { "ignoreDeclarationSort": true }]*/
 import b from 'foo.js'
 import a from 'bar.js'
 ```
+
+:::
 
 Default is `false`.
 
@@ -322,6 +326,8 @@ import a from 'baz.js';
 
 :::
 
+::: correct
+
 ```js
 /*eslint sort-imports: ["error", { "allowSeparatedGroups": true }]*/
 
@@ -331,6 +337,10 @@ import c from 'bar.js';
 import a from 'baz.js';
 ```
 
+:::
+
+::: correct
+
 ```js
 /*eslint sort-imports: ["error", { "allowSeparatedGroups": true }]*/
 
@@ -339,6 +349,8 @@ import c from 'bar.js';
 quux();
 import a from 'baz.js';
 ```
+
+:::
 
 Default is `false`.
 

--- a/docs/src/rules/space-after-keywords.md
+++ b/docs/src/rules/space-after-keywords.md
@@ -50,11 +50,15 @@ do{} while (a);
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint space-after-keywords: ["error", "never"]*/
 
 if (a) {}
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
@@ -70,8 +74,12 @@ if (a) {} else {}
 
 :::
 
+::: correct
+
 ```js
 /*eslint space-after-keywords: ["error", "never"]*/
 
 if(a) {}
 ```
+
+:::

--- a/docs/src/rules/space-unary-ops.md
+++ b/docs/src/rules/space-unary-ops.md
@@ -94,6 +94,8 @@ foo --;
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint space-unary-ops: "error"*/
 /*eslint-env es6*/
@@ -103,6 +105,10 @@ function *foo() {
 }
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /*eslint space-unary-ops: "error"*/
 
@@ -110,6 +116,8 @@ async function foo() {
     await(bar);
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `{"words": true, "nonwords": false}` option:
 
@@ -145,6 +153,8 @@ foo--;
 
 :::
 
+::: correct
+
 ```js
 /*eslint space-unary-ops: "error"*/
 /*eslint-env es6*/
@@ -154,6 +164,10 @@ function *foo() {
 }
 ```
 
+:::
+
+::: correct
+
 ```js
 /*eslint space-unary-ops: "error"*/
 
@@ -161,3 +175,5 @@ async function foo() {
     await (bar);
 }
 ```
+
+:::

--- a/docs/src/rules/space-unary-word-ops.md
+++ b/docs/src/rules/space-unary-word-ops.md
@@ -23,17 +23,29 @@ typeof!a
 
 :::
 
+::: incorrect
+
 ```js
 void{a:0}
 ```
+
+:::
+
+::: incorrect
 
 ```js
 new[a][0]
 ```
 
+:::
+
+::: incorrect
+
 ```js
 delete(a.b)
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
@@ -45,10 +57,18 @@ delete a.b
 
 :::
 
+::: correct
+
 ```js
 new C
 ```
 
+:::
+
+::: correct
+
 ```js
 void 0
 ```
+
+:::

--- a/docs/src/rules/spaced-comment.md
+++ b/docs/src/rules/spaced-comment.md
@@ -86,10 +86,14 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 
 :::
 
+::: incorrect
+
 ```js
 /* eslint spaced-comment: ["error", "always", { "block": { "balanced": true } }] */
 /* This is a comment with whitespace at the beginning but not the end*/
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"always"` option:
 
@@ -113,6 +117,8 @@ This comment has a newline
 
 :::
 
+::: correct
+
 ```js
 /* eslint spaced-comment: ["error", "always"] */
 
@@ -120,6 +126,8 @@ This comment has a newline
 * I am jsdoc
 */
 ```
+
+:::
 
 ### never
 
@@ -139,10 +147,14 @@ Examples of **incorrect** code for this rule with the `"never"` option:
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint spaced-comment: ["error", "never", { "block": { "balanced": true } }]*/
 /*This is a comment with whitespace at the end */
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"never"` option:
 
@@ -156,6 +168,8 @@ Examples of **correct** code for this rule with the `"never"` option:
 
 :::
 
+::: correct
+
 ```js
 /*eslint spaced-comment: ["error", "never"]*/
 
@@ -163,6 +177,8 @@ Examples of **correct** code for this rule with the `"never"` option:
 * I am jsdoc
 */
 ```
+
+:::
 
 ### exceptions
 
@@ -180,6 +196,8 @@ Examples of **incorrect** code for this rule with the `"always"` option combined
 
 :::
 
+::: incorrect
+
 ```js
 /* eslint spaced-comment: ["error", "always", { "exceptions": ["-", "+"] }] */
 
@@ -187,6 +205,10 @@ Examples of **incorrect** code for this rule with the `"always"` option combined
 // Comment block
 //------++++++++
 ```
+
+:::
+
+::: incorrect
 
 ```js
 /* eslint spaced-comment: ["error", "always", { "exceptions": ["-", "+"] }] */
@@ -196,6 +218,10 @@ Examples of **incorrect** code for this rule with the `"always"` option combined
 /*------++++++++*/
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /* eslint spaced-comment: ["error", "always", { "line": { "exceptions": ["-+"] } }] */
 
@@ -204,11 +230,17 @@ Examples of **incorrect** code for this rule with the `"always"` option combined
 /*-+-+-+-+-+-+-+*/
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /* eslint spaced-comment: ["error", "always", { "block": { "exceptions": ["*"] } }] */
 
 /******** COMMENT *******/
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"always"` option combined with `"exceptions"`:
 
@@ -224,6 +256,8 @@ Examples of **correct** code for this rule with the `"always"` option combined w
 
 :::
 
+::: correct
+
 ```js
 /* eslint spaced-comment: ["error", "always", { "line": { "exceptions": ["-"] } }] */
 
@@ -232,6 +266,10 @@ Examples of **correct** code for this rule with the `"always"` option combined w
 //--------------
 ```
 
+:::
+
+::: correct
+
 ```js
 /* eslint spaced-comment: ["error", "always", { "exceptions": ["*"] }] */
 
@@ -239,6 +277,10 @@ Examples of **correct** code for this rule with the `"always"` option combined w
  * Comment block
  ****************/
 ```
+
+:::
+
+::: correct
 
 ```js
 /* eslint spaced-comment: ["error", "always", { "exceptions": ["-+"] }] */
@@ -252,6 +294,10 @@ Examples of **correct** code for this rule with the `"always"` option combined w
 /*-+-+-+-+-+-+-+*/
 ```
 
+:::
+
+::: correct
+
 ```js
 /* eslint spaced-comment: ["error", "always", { "block": { "exceptions": ["-+"] } }] */
 
@@ -259,6 +305,10 @@ Examples of **correct** code for this rule with the `"always"` option combined w
 // Comment block
 /*-+-+-+-+-+-+-+*/
 ```
+
+:::
+
+::: correct
 
 ```js
 /* eslint spaced-comment: ["error", "always", { "block": { "exceptions": ["*"] } }] */
@@ -269,6 +319,8 @@ Examples of **correct** code for this rule with the `"always"` option combined w
 COMMENT
 *******/
 ```
+
+:::
 
 ### markers
 
@@ -284,15 +336,23 @@ Examples of **incorrect** code for this rule with the `"always"` option combined
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint spaced-comment: ["error", "always", { "block": { "markers": ["!"], "balanced": true } }]*/
 /*! This is a comment with a marker but without whitespace at the end*/
 ```
 
+:::
+
+::: incorrect
+
 ```js
 /*eslint spaced-comment: ["error", "never", { "block": { "markers": ["!"], "balanced": true } }]*/
 /*!This is a comment with a marker but with whitespace at the end */
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"always"` option combined with `"markers"`:
 
@@ -306,6 +366,8 @@ Examples of **correct** code for this rule with the `"always"` option combined w
 
 :::
 
+::: correct
+
 ```js
 /*eslint spaced-comment: ["error", "never", { "markers": ["!<"] }]*/
 
@@ -316,8 +378,14 @@ subsequent lines are ignored
 */
 ```
 
+:::
+
+::: correct
+
 ```js
 /* eslint spaced-comment: ["error", "always", { "markers": ["global"] }] */
 
 /*global ABC*/
 ```
+
+:::

--- a/docs/src/rules/spaced-line-comment.md
+++ b/docs/src/rules/spaced-line-comment.md
@@ -39,11 +39,17 @@ Examples of **incorrect** code for this rule:
 
 :::
 
+::: incorrect
+
 ```js
 //When ["always"]
 //This is a comment with no whitespace at the beginning
 var foo = 5;
 ```
+
+:::
+
+::: incorrect
 
 ```js
 // When ["always",{"exceptions":["-","+"]}]
@@ -51,6 +57,8 @@ var foo = 5;
 // Comment block
 //------++++++++
 ```
+
+:::
 
 Examples of **correct** code for this rule:
 
@@ -64,11 +72,17 @@ var foo = 5;
 
 :::
 
+::: correct
+
 ```js
 //When ["never"]
 //This is a comment with no whitespace at the beginning
 var foo = 5;
 ```
+
+:::
+
+::: correct
 
 ```js
 // When ["always",{"exceptions":["-"]}]
@@ -77,9 +91,15 @@ var foo = 5;
 //--------------
 ```
 
+:::
+
+::: correct
+
 ```js
 // When ["always",{"exceptions":["-+"]}]
 //-+-+-+-+-+-+-+
 // Comment block
 //-+-+-+-+-+-+-+
 ```
+
+:::

--- a/docs/src/rules/strict.md
+++ b/docs/src/rules/strict.md
@@ -95,6 +95,8 @@ function foo() {
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint strict: ["error", "global"]*/
 
@@ -102,6 +104,10 @@ function foo() {
     "use strict";
 }
 ```
+
+:::
+
+::: incorrect
 
 ```js
 /*eslint strict: ["error", "global"]*/
@@ -112,6 +118,8 @@ function foo() {
     "use strict";
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"global"` option:
 
@@ -147,6 +155,8 @@ function foo() {
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint strict: ["error", "function"]*/
 
@@ -159,6 +169,10 @@ function foo() {
     }
 }());
 ```
+
+:::
+
+::: incorrect
 
 ```js
 /*eslint strict: ["error", "function"]*/
@@ -175,6 +189,8 @@ function foo(a = 1) {
 function foo(a = 1) {
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"function"` option:
 
@@ -224,6 +240,8 @@ function foo() {
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint strict: ["error", "never"]*/
 
@@ -231,6 +249,8 @@ function foo() {
     "use strict";
 }
 ```
+
+:::
 
 Examples of **correct** code for this rule with the `"never"` option:
 
@@ -264,6 +284,8 @@ function foo() {
 
 :::
 
+::: incorrect
+
 ```js
 // "strict": "error"
 
@@ -273,6 +295,8 @@ function foo() {
     }
 }());
 ```
+
+:::
 
 Examples of **correct** code for this rule with the earlier default option which has been removed:
 
@@ -289,6 +313,8 @@ function foo() {
 
 :::
 
+::: correct
+
 ```js
 // "strict": "error"
 
@@ -296,6 +322,10 @@ function foo() {
     "use strict";
 }
 ```
+
+:::
+
+::: correct
 
 ```js
 // "strict": "error"
@@ -307,6 +337,8 @@ function foo() {
     }
 }());
 ```
+
+:::
 
 ## When Not To Use It
 

--- a/docs/src/rules/vars-on-top.md
+++ b/docs/src/rules/vars-on-top.md
@@ -43,6 +43,8 @@ function doSomething() {
 
 :::
 
+::: incorrect
+
 ```js
 /*eslint vars-on-top: "error"*/
 
@@ -50,6 +52,10 @@ function doSomething() {
 f();
 var a;
 ```
+
+:::
+
+::: incorrect
 
 ```js
 /*eslint vars-on-top: "error"*/
@@ -74,6 +80,8 @@ class C {
 }
 ```
 
+:::
+
 Examples of **correct** code for this rule:
 
 ::: correct
@@ -97,12 +105,18 @@ function doSomething() {
 
 :::
 
+::: correct
+
 ```js
 /*eslint vars-on-top: "error"*/
 
 var a;
 f();
 ```
+
+:::
+
+::: correct
 
 ```js
 /*eslint vars-on-top: "error"*/
@@ -124,6 +138,10 @@ class C {
 }
 ```
 
+:::
+
+::: correct
+
 ```js
 /*eslint vars-on-top: "error"*/
 
@@ -140,3 +158,5 @@ function doSomething() {
     var second
 }
 ```
+
+:::


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

I noticed when we have multiple examples of correct/incorrect code as separate code blocks, only the first code block has ✓/ x.

For example https://eslint.org/docs/latest/rules/no-restricted-imports#examples

![image](https://user-images.githubusercontent.com/44349756/177008943-a71eadec-39d5-4627-833c-0c93a657f0f3.png)


#### What changes did you make? (Give an overview)

Wrapped each of the remaining code blocks in a `::: correct` / `::: incorrect` container, so that consecutive examples now look like this:

![image](https://user-images.githubusercontent.com/44349756/177009135-d567d136-41af-44f7-90ca-5d3265a31593.png)

#### Is there anything you'd like reviewers to focus on?

Was it intended that ✓/ x appear for each code block?

<!-- markdownlint-disable-file MD004 -->
