### PR TITLE
fix: no-warning-comments rule escapes special RegEx characters in terms

### DIFF
--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -64,59 +64,36 @@ module.exports = {
          */
         function convertToRegExp(term) {
             const escaped = escapeRegExp(term);
-            const wordBoundary = "\\b";
-            const eitherOrWordBoundary = `|${wordBoundary}`;
-            let prefix;
 
             /*
-             * If the term ends in a word character (a-z0-9_), ensure a word
-             * boundary at the end, so that substrings do not get falsely
-             * matched. eg "todo" in a string such as "mastodon".
-             * If the term ends in a non-word character, then \b won't match on
-             * the boundary to the next non-word character, which would likely
-             * be a space. For example `/\bFIX!\b/.test('FIX! blah') === false`.
-             * In these cases, use no bounding match. Same applies for the
-             * prefix, handled below.
+             * When matching at the start, ignore leading whitespace, and
+             * there's no need to worry about word boundaries.
+             *
+             * These expressions for the prefix and suffix are designed as follows:
+             * ^   handles any terms at the beginning of a line
+             *     e.g. terms ["TODO"] matches `//TODO something`
+             * $   handles any terms at the end of a line
+             *     e.g. terms ["TODO"] matches `// something TODO`
+             * \s* handles optional leading spaces (for "start" location only)
+             *     e.g. terms ["TODO"] matches `//    TODO something`
+             * \W  handles terms preceded/followed by non-word characters, especially where there's no word boundary.
+             *     e.g. terms: ["!TODO", "TODO!"] matches `// !!!TODO blah` or `// TODO!!! blah`
+             * \b  handles terms preceded/followed by word boundary
+             *     e.g. terms: ["!FIX", "FIX!"] matches `// FIX!something` or `// something!FIX`
+             *          terms: ["FIX"] matches `// FIX!` or `// !FIX`, but not `// fixed or affix`
              */
-            const suffix = /\w$/u.test(term) ? "\\b" : "";
-
-            if (location === "start") {
-
-                /*
-                 * When matching at the start, ignore leading whitespace, and
-                 * there's no need to worry about word boundaries.
-                 */
-                prefix = "^\\s*";
-            } else if (/^\w/u.test(term)) {
-                prefix = wordBoundary;
-            } else {
-                prefix = "";
-            }
-
-            if (location === "start") {
-
-                /*
-                 * For location "start" the regex should be
-                 * ^\s*TERM\b.  This checks the word boundary
-                 * at the beginning of the comment.
-                 */
-                return new RegExp(prefix + escaped + suffix, "iu");
-            }
+            const prefix = location === "start" ? "^\\s*" : "(?:^|\\b|\\W)";
+            const suffix = "(?:\\b|\\W|$)";
+            const flags = "iu"; // Case-insensitive with Unicode case folding.
 
             /*
-             * For location "anywhere" the regex should be
-             * \bTERM\b|\bTERM\b, this checks the entire comment
-             * for the term.
+             * For location "start" the regex should be
+             *   /^\s*ESCAPED_TERM(?:\b|\W|$)/iu.
+             *
+             * For location "anywhere" the regex should be:
+             *   /(?:^|\b|\W)ESCAPED_TERM(?:\b|\W|$)/iu
              */
-            return new RegExp(
-                prefix +
-                    escaped +
-                    suffix +
-                    eitherOrWordBoundary +
-                    term +
-                    wordBoundary,
-                "iu"
-            );
+            return new RegExp(`${prefix}${escaped}${suffix}`, flags);
         }
 
         const warningRegExps = warningTerms.map(convertToRegExp);

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -70,7 +70,7 @@ module.exports = {
              * there's no need to worry about word boundaries.
              *
              * These expressions for the prefix and suffix are designed as follows:
-             * ^   handles any terms at the beginning of a line
+             * ^   handles any terms at the beginning of a comment.
              *     e.g. terms ["TODO"] matches `//TODO something`
              * $   handles any terms at the end of a line
              *     e.g. terms ["TODO"] matches `// something TODO`

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -76,22 +76,39 @@ module.exports = {
              *     e.g. terms ["TODO"] matches `// something TODO`
              * \s* handles optional leading spaces (for "start" location only)
              *     e.g. terms ["TODO"] matches `//    TODO something`
-             * \W  handles terms preceded/followed by non-word characters, especially where there's no word boundary.
-             *     e.g. terms: ["!TODO", "TODO!"] matches `// !!!TODO blah` or `// TODO!!! blah`
+             * !|[^!] handles terms preceded/followed by non-word characters (e.g. punctuation).
+             *     In this case, the term can be followed by anything.
+             *     This is equivalent to ".", but performance testing with eslint shows this is orders of magnitude faster.
+             *     e.g. terms: ["!TODO", "TODO!"] matches `// !!!TODO something` or `// TODO!!! something`
+             *          terms: ["TODO:"] matches `// TODO:something"
              * \b  handles terms preceded/followed by word boundary
              *     e.g. terms: ["!FIX", "FIX!"] matches `// FIX!something` or `// something!FIX`
              *          terms: ["FIX"] matches `// FIX!` or `// !FIX`, but not `// fixed or affix`
              */
-            const prefix = location === "start" ? "^\\s*" : `(?:^|\\b${/^\W/u.test(escaped) ? "|\\W" : ""})`;
-            const suffix = `(?:\\b${/\W$/u.test(escaped) ? "|\\W" : ""}|$)`;
+            const wordBoundary = "\\b";
+            const anyChar = "!|[^!]";
+            let prefix;
+
+            if (location === "start") {
+                prefix = "^\\s*";
+            } else if (/^\w/u.test(term)) {
+                prefix = wordBoundary;
+            } else {
+                prefix = `(?:^|${anyChar})`;
+            }
+
+            const suffix = /\w$/u.test(term) ? wordBoundary : `(?:${anyChar}|$)`;
             const flags = "iu"; // Case-insensitive with Unicode case folding.
 
             /*
-             * For location "start" the regex should be
-             *   /^\s*ESCAPED_TERM(?:\b|\W|$)/iu.
+             * For location "start", the typical regex is:
+             *   /^\s*ESCAPED_TERM\b/iu.
              *
-             * For location "anywhere" the regex should be:
-             *   /(?:^|\b|\W)ESCAPED_TERM(?:\b|\W|$)/iu
+             * For location "anywhere" the typical regex is
+             *   /\bESCAPED_TERM\b/iu
+             *
+             * If it starts or ends with non-word character, the prefix and suffix are modified
+             * to match the start or end of the comment, or any other character.
              */
             return new RegExp(`${prefix}${escaped}${suffix}`, flags);
         }

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -22,7 +22,7 @@ module.exports = {
         docs: {
             description: "Disallow specified warning terms in comments",
             recommended: false,
-            url: "https://eslint.org/docs/rules/no-warning-comments",
+            url: "https://eslint.org/docs/rules/no-warning-comments"
         },
 
         schema: [
@@ -32,21 +32,20 @@ module.exports = {
                     terms: {
                         type: "array",
                         items: {
-                            type: "string",
-                        },
+                            type: "string"
+                        }
                     },
                     location: {
-                        enum: ["start", "anywhere"],
-                    },
+                        enum: ["start", "anywhere"]
+                    }
                 },
-                additionalProperties: false,
-            },
+                additionalProperties: false
+            }
         ],
 
         messages: {
-            unexpectedComment:
-                "Unexpected '{{matchedTerm}}' comment: '{{comment}}'.",
-        },
+            unexpectedComment: "Unexpected '{{matchedTerm}}' comment: '{{comment}}'."
+        }
     },
 
     create(context) {
@@ -133,14 +132,12 @@ module.exports = {
 
             const matches = commentContainsWarningTerm(comment);
 
-            matches.forEach((matchedTerm) => {
+            matches.forEach(matchedTerm => {
                 let commentToDisplay = "";
                 let truncated = false;
 
                 for (const c of comment.trim().split(/\s+/u)) {
-                    const tmp = commentToDisplay
-                        ? `${commentToDisplay} ${c}`
-                        : c;
+                    const tmp = commentToDisplay ? `${commentToDisplay} ${c}` : c;
 
                     if (tmp.length <= CHAR_LIMIT) {
                         commentToDisplay = tmp;
@@ -155,8 +152,10 @@ module.exports = {
                     messageId: "unexpectedComment",
                     data: {
                         matchedTerm,
-                        comment: `${commentToDisplay}${truncated ? "..." : ""}`,
-                    },
+                        comment: `${commentToDisplay}${
+                            truncated ? "..." : ""
+                        }`
+                    }
                 });
             });
         }
@@ -166,9 +165,9 @@ module.exports = {
                 const comments = sourceCode.getAllComments();
 
                 comments
-                    .filter((token) => token.type !== "Shebang")
+                    .filter(token => token.type !== "Shebang")
                     .forEach(checkComment);
-            },
+            }
         };
-    },
+    }
 };

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -22,7 +22,7 @@ module.exports = {
         docs: {
             description: "Disallow specified warning terms in comments",
             recommended: false,
-            url: "https://eslint.org/docs/rules/no-warning-comments"
+            url: "https://eslint.org/docs/rules/no-warning-comments",
         },
 
         schema: [
@@ -32,20 +32,21 @@ module.exports = {
                     terms: {
                         type: "array",
                         items: {
-                            type: "string"
-                        }
+                            type: "string",
+                        },
                     },
                     location: {
-                        enum: ["start", "anywhere"]
-                    }
+                        enum: ["start", "anywhere"],
+                    },
                 },
-                additionalProperties: false
-            }
+                additionalProperties: false,
+            },
         ],
 
         messages: {
-            unexpectedComment: "Unexpected '{{matchedTerm}}' comment: '{{comment}}'."
-        }
+            unexpectedComment:
+                "Unexpected '{{matchedTerm}}' comment: '{{comment}}'.",
+        },
     },
 
     create(context) {
@@ -72,7 +73,7 @@ module.exports = {
              * These expressions for the prefix and suffix are designed as follows:
              * ^   handles any terms at the beginning of a comment.
              *     e.g. terms ["TODO"] matches `//TODO something`
-             * $   handles any terms at the end of a line
+             * $   handles any terms at the end of a comment
              *     e.g. terms ["TODO"] matches `// something TODO`
              * \s* handles optional leading spaces (for "start" location only)
              *     e.g. terms ["TODO"] matches `//    TODO something`
@@ -132,12 +133,14 @@ module.exports = {
 
             const matches = commentContainsWarningTerm(comment);
 
-            matches.forEach(matchedTerm => {
+            matches.forEach((matchedTerm) => {
                 let commentToDisplay = "";
                 let truncated = false;
 
                 for (const c of comment.trim().split(/\s+/u)) {
-                    const tmp = commentToDisplay ? `${commentToDisplay} ${c}` : c;
+                    const tmp = commentToDisplay
+                        ? `${commentToDisplay} ${c}`
+                        : c;
 
                     if (tmp.length <= CHAR_LIMIT) {
                         commentToDisplay = tmp;
@@ -152,10 +155,8 @@ module.exports = {
                     messageId: "unexpectedComment",
                     data: {
                         matchedTerm,
-                        comment: `${commentToDisplay}${
-                            truncated ? "..." : ""
-                        }`
-                    }
+                        comment: `${commentToDisplay}${truncated ? "..." : ""}`,
+                    },
                 });
             });
         }
@@ -165,9 +166,9 @@ module.exports = {
                 const comments = sourceCode.getAllComments();
 
                 comments
-                    .filter(token => token.type !== "Shebang")
+                    .filter((token) => token.type !== "Shebang")
                     .forEach(checkComment);
-            }
+            },
         };
-    }
+    },
 };

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -82,8 +82,8 @@ module.exports = {
              *     e.g. terms: ["!FIX", "FIX!"] matches `// FIX!something` or `// something!FIX`
              *          terms: ["FIX"] matches `// FIX!` or `// !FIX`, but not `// fixed or affix`
              */
-            const prefix = location === "start" ? "^\\s*" : "(?:^|\\b|\\W)";
-            const suffix = "(?:\\b|\\W|$)";
+            const prefix = location === "start" ? "^\\s*" : `(?:^|\\b${/^\W/u.test(escaped) ? "|\\W" : ""})`;
+            const suffix = `(?:\\b${/\W$/u.test(escaped) ? "|\\W" : ""}|$)`;
             const flags = "iu"; // Case-insensitive with Unicode case folding.
 
             /*

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -76,28 +76,21 @@ module.exports = {
              *     e.g. terms ["TODO"] matches `// something TODO`
              * \s* handles optional leading spaces (for "start" location only)
              *     e.g. terms ["TODO"] matches `//    TODO something`
-             * !|[^!] handles terms preceded/followed by non-word characters (e.g. punctuation).
-             *     In this case, the term can be followed by anything.
-             *     This is equivalent to ".", but performance testing with eslint shows this is orders of magnitude faster.
-             *     e.g. terms: ["!TODO", "TODO!"] matches `// !!!TODO something` or `// TODO!!! something`
-             *          terms: ["TODO:"] matches `// TODO:something"
              * \b  handles terms preceded/followed by word boundary
              *     e.g. terms: ["!FIX", "FIX!"] matches `// FIX!something` or `// something!FIX`
              *          terms: ["FIX"] matches `// FIX!` or `// !FIX`, but not `// fixed or affix`
              */
             const wordBoundary = "\\b";
-            const anyChar = "!|[^!]";
-            let prefix;
+
+            let prefix = "";
 
             if (location === "start") {
                 prefix = "^\\s*";
             } else if (/^\w/u.test(term)) {
                 prefix = wordBoundary;
-            } else {
-                prefix = `(?:^|${anyChar})`;
             }
 
-            const suffix = /\w$/u.test(term) ? wordBoundary : `(?:${anyChar}|$)`;
+            const suffix = /\w$/u.test(term) ? wordBoundary : "";
             const flags = "iu"; // Case-insensitive with Unicode case folding.
 
             /*
@@ -107,8 +100,7 @@ module.exports = {
              * For location "anywhere" the typical regex is
              *   /\bESCAPED_TERM\b/iu
              *
-             * If it starts or ends with non-word character, the prefix and suffix are modified
-             * to match the start or end of the comment, or any other character.
+             * If it starts or ends with non-word character, the prefix and suffix empty, respectively.
              */
             return new RegExp(`${prefix}${escaped}${suffix}`, flags);
         }

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -298,14 +298,14 @@ ruleTester.run("no-warning-comments", rule, {
             ]
         },
         {
-            code: "// !TODO comment starting with term",
+            code: "// !TODO comment starting with term preceded by punctuation",
             options: [{ terms: ["todo"], location: "anywhere" }],
             errors: [
                 {
                     messageId: "unexpectedComment",
                     data: {
                         matchedTerm: "todo",
-                        comment: "!TODO comment starting with term"
+                        comment: "!TODO comment starting with term..."
                     }
                 }
             ]

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -34,10 +34,10 @@ ruleTester.run("no-warning-comments", rule, {
         "/* any block comment with TODO, FIXME or XXX */",
         "/* any block comment with (TODO, FIXME's or XXX!) */",
         { code: "// comments containing terms as substrings like TodoMVC", options: [{ terms: ["todo"], location: "anywhere" }] },
-        { code: "// special regex characters don't cause problems", options: [{ terms: ["[aeiou]"], location: "anywhere" }] },
+        { code: "// special regex characters don't cause a problem", options: [{ terms: ["[aeiou]"], location: "anywhere" }] },
         "/*eslint no-warning-comments: [2, { \"terms\": [\"todo\", \"fixme\", \"any other term\"], \"location\": \"anywhere\" }]*/\n\nvar x = 10;\n",
         { code: "/*eslint no-warning-comments: [2, { \"terms\": [\"todo\", \"fixme\", \"any other term\"], \"location\": \"anywhere\" }]*/\n\nvar x = 10;\n", options: [{ location: "anywhere" }] },
-        { code: "foo", options: [{ terms: ["foo-bar"] }] }
+        { code: "// foo", options: [{ terms: ["foo-bar"] }] }
     ],
     invalid: [
         {
@@ -254,6 +254,136 @@ ruleTester.run("no-warning-comments", rule, {
                     data: {
                         matchedTerm: "todo",
                         comment: "..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "// Comment ending with term followed by punctuation TODO!",
+            options: [{ terms: ["todo"], location: "anywhere" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "todo",
+                        comment: "Comment ending with term followed by..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "// Comment ending with term including punctuation TODO!",
+            options: [{ terms: ["todo!"], location: "anywhere" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "todo!",
+                        comment: "Comment ending with term including..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "// Comment ending with term including punctuation followed by more TODO!!!",
+            options: [{ terms: ["todo!"], location: "anywhere" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "todo!",
+                        comment: "Comment ending with term including..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "// !TODO comment starting with term",
+            options: [{ terms: ["todo"], location: "anywhere" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "todo",
+                        comment: "!TODO comment starting with term"
+                    }
+                }
+            ]
+        },
+        {
+            code: "// !TODO comment starting with term including punctuation",
+            options: [{ terms: ["!todo"], location: "anywhere" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "!todo",
+                        comment: "!TODO comment starting with term..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "// !!!TODO comment starting with term including punctuation preceded by more",
+            options: [{ terms: ["!todo"], location: "anywhere" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "!todo",
+                        comment: "!!!TODO comment starting with term..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "// FIX!term ending with punctuation followed word character",
+            options: [{ terms: ["FIX!"], location: "anywhere" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "FIX!",
+                        comment: "FIX!term ending with punctuation..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "// Term starting with punctuation preceded word character!FIX",
+            options: [{ terms: ["!FIX"], location: "anywhere" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "!FIX",
+                        comment: "Term starting with punctuation preceded..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "//!XXX comment starting with no spaces (anywhere)",
+            options: [{ terms: ["!xxx"], location: "anywhere" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "!xxx",
+                        comment: "!XXX comment starting with no spaces..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "//!XXX comment starting with no spaces (start)",
+            options: [{ terms: ["!xxx"], location: "start" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "!xxx",
+                        comment: "!XXX comment starting with no spaces..."
                     }
                 }
             ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment:**

* **ESLint Version:** 8.19.0
* **Node Version:** v16.15.1
* **npm Version:** 8.11.0

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
    rules: {
        "no-warning-comments": ["error", {
            terms: ["[TODO]"],
            location: "anywhere"
        }]
    },
```
</details>

**What did you do? Please include the actual source code causing the issue.**

Regular expression characters in the `terms` property are inadvertently being treated as actual regular expression symbols when the `location` is `"anywhere"`.

```
// Any comment containing a lone letter like T, O or D will match that regex.
```

**What did you expect to happen?**

The terms property is intended to be treated as a string literal.

**What actually happened? Please include the actual, raw output from ESLint.**

```
Unexpected '[TODO]' comment: 'Any comment containing a lone letter...'.eslint no-warning-comments
```

This bug appears to have been inadvertently introduced by pull request #10381 where they were attempting to fix a different bug related to location "anywhere", and accidentally allowed the unescaped `term` to be injected into the RegExp.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* I simplified and optimised the conversion of terms to regular expressions based on the specified location.
* I fixed a test case that appears to have been written to check correct regex escaping of the terms, but which missed the actual bug.
* I added new tests to ensure edge cases weren't missed by my changes.

#### Is there anything you'd like reviewers to focus on?

N/A

<!-- markdownlint-disable-file MD004 -->
