### PR TITLE
docs: don't show toc when toc content empty

### DIFF
--- a/docs/src/_includes/components/docs-toc.html
+++ b/docs/src/_includes/components/docs-toc.html
@@ -1,5 +1,5 @@
 <nav class="docs-toc c-toc" aria-labelledby="js-toc-label">
-    {%- if all_content | toc | safe -%}
+    {%- if all_content | toc | safe | length -%}
     <h2 class="c-toc__label" id="js-toc-label">Table of Contents</h2>
     <div class="c-toc__panel" id="js-toc-panel">
         {{ all_content | toc | safe }}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
Hide the `Table of Contents` section when it is content empty.
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Hide the `Table of Contents` section when it is content empty.


| Before  | After  |
| ------------- | ------------- |
| <img width="600" alt="image" src="https://user-images.githubusercontent.com/30730124/177206073-fade53f1-9c9e-4da9-a2af-896b5d03352c.png">  |  <img width="600" alt="image" src="https://user-images.githubusercontent.com/30730124/177206615-28c7aa0c-cd49-43c1-8fab-b0e4585fb052.png"> |
|  <img width="350" alt="image" src="https://user-images.githubusercontent.com/30730124/177206795-dce73a75-d09d-42fd-98b5-94889ee6c97a.png"> |  <img width="360" alt="image" src="https://user-images.githubusercontent.com/30730124/177206705-4d7ca6d3-b466-44c2-a8cc-ca608aff531b.png">
  |


