### PR TITLE
feat: no-warning-comments support comments with decoration

### DIFF
--- a/docs/src/rules/no-warning-comments.md
+++ b/docs/src/rules/no-warning-comments.md
@@ -23,7 +23,7 @@ This rule has an options object literal:
 
 * `"terms"`: optional array of terms to match. Defaults to `["todo", "fixme", "xxx"]`. Terms are matched case-insensitively and as whole words: `fix` would match `FIX` but not `fixing`. Terms can consist of multiple words: `really bad idea`.
 * `"location"`: optional string that configures where in your comments to check for matches. Defaults to `"start"`. The start is from the first non-decorative character, ignoring whitespace, new lines and characters specified in `decoration`. The other value is match `anywhere` in comments.
-* `"decoration"`: optional character, or array of characters that specify decorative characters that are ignored at the start of a comment, when location is `"start"`. Defaults to `""`. Any sequence of whitespace or the characters from this property are ignored. This option is ignored when location is `"anywhere"`.
+* `"decoration"`: optional array of characters that are ignored at the start of a comment, when location is `"start"`. Defaults to `[]`. Any sequence of whitespace or the characters from this property are ignored. This option is ignored when location is `"anywhere"`.
 
 Example of **incorrect** code for the default `{ "terms": ["todo", "fixme", "xxx"], "location": "start" }` options:
 
@@ -145,11 +145,9 @@ Examples of **correct** code for the `{ "decoration": ["/", "*"] }` options:
 ```js
 /*eslint no-warning-comments: ["error", { "decoration": ["/", "*"] }]*/
 
-// This is to do
+//!TODO preceded by non-decoration character
 /**
- * The same goes for block comments
- * with any other interesting term
- * or fix me this
+ *!TODO preceded by non-decoration character in a block comment
  */
 ```
 

--- a/docs/src/rules/no-warning-comments.md
+++ b/docs/src/rules/no-warning-comments.md
@@ -23,7 +23,7 @@ This rule has an options object literal:
 
 * `"terms"`: optional array of terms to match. Defaults to `["todo", "fixme", "xxx"]`. Terms are matched case-insensitively and as whole words: `fix` would match `FIX` but not `fixing`. Terms can consist of multiple words: `really bad idea`.
 * `"location"`: optional string that configures where in your comments to check for matches. Defaults to `"start"`. For multi-line comments, the start is from the first non-decorative character, ignoring whitespace, new lines or characters specified in `decoration`. The other value is match `anywhere` in comments.
-* `"decoration"`: optional string or array of strings that specifies decorative characters that are ignored at the start of a comment, when location is `"start"`. Defaults to `""`. Any sequence of whitespace or the characters from this string are ignored. Note that the string `"/-*"` is equivalent to the array of strings `["/", "-", "*"]`. This option is ignored when location is `"anywhere"`.
+* `"decoration"`: optional character, or array of characters that specify decorative characters that are ignored at the start of a comment, when location is `"start"`. Defaults to `""`. Any sequence of whitespace or the characters from this property are ignored. This option is ignored when location is `"anywhere"`.
 
 Example of **incorrect** code for the default `{ "terms": ["todo", "fixme", "xxx"], "location": "start" }` options:
 
@@ -106,6 +106,21 @@ Examples of **correct** code for the `{ "terms": ["todo", "fixme", "any other te
 :::
 
 ### Decoration Characters
+
+Examples of **incorrect** code for the `{ "decoration": "*" }` options:
+
+::: incorrect
+
+```js
+/*eslint no-warning-comments: ["error", { "decoration": "*" }]*/
+
+//***** todo decorative asterisks are ignored *****//
+/**
+ * TODO new lines and asterisks are also ignored in block comments.
+ */
+```
+
+:::
 
 Examples of **incorrect** code for the `{ "decoration": ["/", "*"] }` options:
 

--- a/docs/src/rules/no-warning-comments.md
+++ b/docs/src/rules/no-warning-comments.md
@@ -21,8 +21,9 @@ This rule reports comments that include any of the predefined terms specified in
 
 This rule has an options object literal:
 
-* `"terms"`: optional array of terms to match. Defaults to `["todo", "fixme", "xxx"]`. Terms are matched case-insensitive and as whole words: `fix` would match `FIX` but not `fixing`. Terms can consist of multiple words: `really bad idea`.
-* `"location"`: optional string that configures where in your comments to check for matches. Defaults to `"start"`. The other value is match `anywhere` in comments.
+* `"terms"`: optional array of terms to match. Defaults to `["todo", "fixme", "xxx"]`. Terms are matched case-insensitively and as whole words: `fix` would match `FIX` but not `fixing`. Terms can consist of multiple words: `really bad idea`.
+* `"location"`: optional string that configures where in your comments to check for matches. Defaults to `"start"`. For multi-line comments, the start is from the first non-decorative character, ignoring whitespace, new lines or characters specified in `decoration`. The other value is match `anywhere` in comments.
+* `"decoration"`: optional string that specifies decorative characters that are ignored at the start of a comment, when location is `"start"`. Defaults to `""`. Any sequence of whitespace or the characters from this string are ignored. This option is ignored when location is `"anywhere"`.
 
 Example of **incorrect** code for the default `{ "terms": ["todo", "fixme", "xxx"], "location": "start" }` options:
 
@@ -31,6 +32,9 @@ Example of **incorrect** code for the default `{ "terms": ["todo", "fixme", "xxx
 ```js
 /*eslint no-warning-comments: "error"*/
 
+/*
+FIXME
+*/
 function callback(err, results) {
   if (err) {
     console.error(err);
@@ -73,7 +77,7 @@ Examples of **incorrect** code for the `{ "terms": ["todo", "fixme", "any other 
 // TODO: this
 // todo: this too
 // Even this: TODO
-/* /*
+/*
  * The same goes for this TODO comment
  * Or a fixme
  * as well as any other term
@@ -93,6 +97,43 @@ Examples of **correct** code for the `{ "terms": ["todo", "fixme", "any other te
 // even not any other    term
 // any other terminal
 /*
+ * The same goes for block comments
+ * with any other interesting term
+ * or fix me this
+ */
+```
+
+:::
+
+### Decoration Characters
+
+Examples of **incorrect** code for the `{ "terms": ["todo"], "location": "start", "decoration": "/*" }` options:
+
+::: incorrect
+
+```js
+/*eslint no-warning-comments: ["error", { "terms": ["todo"], "location": "start", "decoration": "/*" }]*/
+
+////// TODO decorative slashes and whitespace are ignored //////
+//***** todo decorative asterisks are also ignored *****//
+/**
+ * TODO new lines are also ignored in block comments.
+ */
+```
+
+:::
+
+Examples of **correct** code for the `{ "terms": ["todo"], "location": "start", "decoration": "/*" }` options:
+
+::: correct
+
+```js
+/*eslint no-warning-comments: ["error", { "terms": ["todo"], "location": "start", "decoration": "/*" }]*/
+
+// This is to do
+// even not any other    term
+// any other terminal
+/**
  * The same goes for block comments
  * with any other interesting term
  * or fix me this

--- a/docs/src/rules/no-warning-comments.md
+++ b/docs/src/rules/no-warning-comments.md
@@ -107,12 +107,12 @@ Examples of **correct** code for the `{ "terms": ["todo", "fixme", "any other te
 
 ### Decoration Characters
 
-Examples of **incorrect** code for the `{ "decoration": "*" }` options:
+Examples of **incorrect** code for the `{ "decoration": ["*"] }` options:
 
 ::: incorrect
 
 ```js
-/*eslint no-warning-comments: ["error", { "decoration": "*" }]*/
+/*eslint no-warning-comments: ["error", { "decoration": ["*"] }]*/
 
 //***** todo decorative asterisks are ignored *****//
 /**

--- a/docs/src/rules/no-warning-comments.md
+++ b/docs/src/rules/no-warning-comments.md
@@ -23,7 +23,7 @@ This rule has an options object literal:
 
 * `"terms"`: optional array of terms to match. Defaults to `["todo", "fixme", "xxx"]`. Terms are matched case-insensitively and as whole words: `fix` would match `FIX` but not `fixing`. Terms can consist of multiple words: `really bad idea`.
 * `"location"`: optional string that configures where in your comments to check for matches. Defaults to `"start"`. For multi-line comments, the start is from the first non-decorative character, ignoring whitespace, new lines or characters specified in `decoration`. The other value is match `anywhere` in comments.
-* `"decoration"`: optional string that specifies decorative characters that are ignored at the start of a comment, when location is `"start"`. Defaults to `""`. Any sequence of whitespace or the characters from this string are ignored. This option is ignored when location is `"anywhere"`.
+* `"decoration"`: optional string or array of strings that specifies decorative characters that are ignored at the start of a comment, when location is `"start"`. Defaults to `""`. Any sequence of whitespace or the characters from this string are ignored. Note that the string `"/-*"` is equivalent to the array of strings `["/", "-", "*"]`. This option is ignored when location is `"anywhere"`.
 
 Example of **incorrect** code for the default `{ "terms": ["todo", "fixme", "xxx"], "location": "start" }` options:
 
@@ -107,12 +107,12 @@ Examples of **correct** code for the `{ "terms": ["todo", "fixme", "any other te
 
 ### Decoration Characters
 
-Examples of **incorrect** code for the `{ "terms": ["todo"], "location": "start", "decoration": "/*" }` options:
+Examples of **incorrect** code for the `{ "decoration": ["/", "*"] }` options:
 
 ::: incorrect
 
 ```js
-/*eslint no-warning-comments: ["error", { "terms": ["todo"], "location": "start", "decoration": "/*" }]*/
+/*eslint no-warning-comments: ["error", { "decoration": ["/", "*"] }]*/
 
 ////// TODO decorative slashes and whitespace are ignored //////
 //***** todo decorative asterisks are also ignored *****//
@@ -123,16 +123,14 @@ Examples of **incorrect** code for the `{ "terms": ["todo"], "location": "start"
 
 :::
 
-Examples of **correct** code for the `{ "terms": ["todo"], "location": "start", "decoration": "/*" }` options:
+Examples of **correct** code for the `{ "decoration": ["/", "*"] }` options:
 
 ::: correct
 
 ```js
-/*eslint no-warning-comments: ["error", { "terms": ["todo"], "location": "start", "decoration": "/*" }]*/
+/*eslint no-warning-comments: ["error", { "decoration": ["/", "*"] }]*/
 
 // This is to do
-// even not any other    term
-// any other terminal
 /**
  * The same goes for block comments
  * with any other interesting term

--- a/docs/src/rules/no-warning-comments.md
+++ b/docs/src/rules/no-warning-comments.md
@@ -22,7 +22,7 @@ This rule reports comments that include any of the predefined terms specified in
 This rule has an options object literal:
 
 * `"terms"`: optional array of terms to match. Defaults to `["todo", "fixme", "xxx"]`. Terms are matched case-insensitively and as whole words: `fix` would match `FIX` but not `fixing`. Terms can consist of multiple words: `really bad idea`.
-* `"location"`: optional string that configures where in your comments to check for matches. Defaults to `"start"`. For multi-line comments, the start is from the first non-decorative character, ignoring whitespace, new lines or characters specified in `decoration`. The other value is match `anywhere` in comments.
+* `"location"`: optional string that configures where in your comments to check for matches. Defaults to `"start"`. The start is from the first non-decorative character, ignoring whitespace, new lines and characters specified in `decoration`. The other value is match `anywhere` in comments.
 * `"decoration"`: optional character, or array of characters that specify decorative characters that are ignored at the start of a comment, when location is `"start"`. Defaults to `""`. Any sequence of whitespace or the characters from this property are ignored. This option is ignored when location is `"anywhere"`.
 
 Example of **incorrect** code for the default `{ "terms": ["todo", "fixme", "xxx"], "location": "start" }` options:

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -92,7 +92,7 @@ module.exports = {
              * For location start:
              * [\s]* handles optional leading spaces
              *     e.g. terms ["TODO"] matches `//    TODO something`
-             * [\s\*] (where "\*" is the escaped string of decoration) handles
+             * [\s\*]* (where "\*" is the escaped string of decoration)
              *     handles optional leading spaces or decoration characters (for "start" location only)
              *     e.g. terms ["TODO"] matches `/**** TODO something ... `
              */

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -37,6 +37,9 @@ module.exports = {
                     },
                     location: {
                         enum: ["start", "anywhere"]
+                    },
+                    decoration: {
+                        type: "string"
                     }
                 },
                 additionalProperties: false
@@ -53,6 +56,7 @@ module.exports = {
             configuration = context.options[0] || {},
             warningTerms = configuration.terms || ["todo", "fixme", "xxx"],
             location = configuration.location || "start",
+            decoration = configuration.decoration || "",
             selfConfigRegEx = /\bno-warning-comments\b/u;
 
         /**
@@ -64,6 +68,7 @@ module.exports = {
          */
         function convertToRegExp(term) {
             const escaped = escapeRegExp(term);
+            const escapedDecoration = escapeRegExp(decoration);
 
             /*
              * When matching at the start, ignore leading whitespace, and
@@ -74,18 +79,23 @@ module.exports = {
              *     e.g. terms ["TODO"] matches `//TODO something`
              * $   handles any terms at the end of a comment
              *     e.g. terms ["TODO"] matches `// something TODO`
-             * \s* handles optional leading spaces (for "start" location only)
-             *     e.g. terms ["TODO"] matches `//    TODO something`
              * \b  handles terms preceded/followed by word boundary
              *     e.g. terms: ["!FIX", "FIX!"] matches `// FIX!something` or `// something!FIX`
              *          terms: ["FIX"] matches `// FIX!` or `// !FIX`, but not `// fixed or affix`
+             *
+             * For location start:
+             * [\s]* handles optional leading spaces
+             *     e.g. terms ["TODO"] matches `//    TODO something`
+             * [\s\*] (where "\*" is the escaped string of decoration) handles
+             *     handles optional leading spaces or decoration characters (for "start" location only)
+             *     e.g. terms ["TODO"] matches `/**** TODO something ... `
              */
             const wordBoundary = "\\b";
 
             let prefix = "";
 
             if (location === "start") {
-                prefix = "^\\s*";
+                prefix = `^[\\s${escapedDecoration}]*`;
             } else if (/^\w/u.test(term)) {
                 prefix = wordBoundary;
             }
@@ -95,12 +105,15 @@ module.exports = {
 
             /*
              * For location "start", the typical regex is:
-             *   /^\s*ESCAPED_TERM\b/iu.
+             *   /^[\s]*ESCAPED_TERM\b/iu.
+             * Or if decoration characters are specified (e.g. "*"), then any of
+             * those characters may appear in any order at the start:
+             *   /^[\s\*]*ESCAPED_TERM\b/iu.
              *
              * For location "anywhere" the typical regex is
              *   /\bESCAPED_TERM\b/iu
              *
-             * If it starts or ends with non-word character, the prefix and suffix empty, respectively.
+             * If it starts or ends with non-word character, the prefix and suffix are empty, respectively.
              */
             return new RegExp(`${prefix}${escaped}${suffix}`, flags);
         }

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -44,7 +44,9 @@ module.exports = {
                             type: "string",
                             pattern: "^\\S$"
                         },
-                        pattern: "^\\S$"
+                        pattern: "^\\S$",
+                        minItems: 1,
+                        uniqueItems: true
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -39,7 +39,10 @@ module.exports = {
                         enum: ["start", "anywhere"]
                     },
                     decoration: {
-                        type: "string"
+                        type: ["string", "array"],
+                        items: {
+                            type: "string"
+                        }
                     }
                 },
                 additionalProperties: false
@@ -56,7 +59,7 @@ module.exports = {
             configuration = context.options[0] || {},
             warningTerms = configuration.terms || ["todo", "fixme", "xxx"],
             location = configuration.location || "start",
-            decoration = configuration.decoration || "",
+            decoration = [...configuration.decoration || ""].join(""),
             selfConfigRegEx = /\bno-warning-comments\b/u;
 
         /**

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -41,8 +41,10 @@ module.exports = {
                     decoration: {
                         type: ["string", "array"],
                         items: {
-                            type: "string"
-                        }
+                            type: "string",
+                            pattern: "^\\S$"
+                        },
+                        pattern: "^\\S$"
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -39,12 +39,11 @@ module.exports = {
                         enum: ["start", "anywhere"]
                     },
                     decoration: {
-                        type: ["string", "array"],
+                        type: "array",
                         items: {
                             type: "string",
                             pattern: "^\\S$"
                         },
-                        pattern: "^\\S$",
                         minItems: 1,
                         uniqueItems: true
                     }
@@ -63,7 +62,7 @@ module.exports = {
             configuration = context.options[0] || {},
             warningTerms = configuration.terms || ["todo", "fixme", "xxx"],
             location = configuration.location || "start",
-            decoration = [...configuration.decoration || ""].join(""),
+            decoration = [...configuration.decoration || []].join(""),
             selfConfigRegEx = /\bno-warning-comments\b/u;
 
         /**

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -429,8 +429,21 @@ ruleTester.run("no-warning-comments", rule, {
             ]
         },
         {
-            code: "///// TODO decorated single-line comment (start) \n /////",
+            code: "///// TODO decorated single-line comment with decoration string \n /////",
             options: [{ terms: ["todo"], location: "start", decoration: "*/" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "todo",
+                        comment: "/// TODO decorated single-line comment..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "///// TODO decorated single-line comment with decoration array \n /////",
+            options: [{ terms: ["todo"], location: "start", decoration: ["*", "/"] }],
             errors: [
                 {
                     messageId: "unexpectedComment",

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -38,7 +38,8 @@ ruleTester.run("no-warning-comments", rule, {
         "/*eslint no-warning-comments: [2, { \"terms\": [\"todo\", \"fixme\", \"any other term\"], \"location\": \"anywhere\" }]*/\n\nvar x = 10;\n",
         { code: "/*eslint no-warning-comments: [2, { \"terms\": [\"todo\", \"fixme\", \"any other term\"], \"location\": \"anywhere\" }]*/\n\nvar x = 10;\n", options: [{ location: "anywhere" }] },
         { code: "// foo", options: [{ terms: ["foo-bar"] }] },
-        "/** multi-line block comment with lines starting with\nTODO\nFIXME or\nXXX\n*/"
+        "/** multi-line block comment with lines starting with\nTODO\nFIXME or\nXXX\n*/",
+        { code: "//!TODO ", options: [{ decoration: ["*"] }] }
     ],
     invalid: [
         {
@@ -398,32 +399,6 @@ ruleTester.run("no-warning-comments", rule, {
                     data: {
                         matchedTerm: "todo",
                         comment: "TODO undecorated multi-line block..."
-                    }
-                }
-            ]
-        },
-        {
-            code: "/** TODO decorated single line block comment (start) */",
-            options: [{ terms: ["todo"], location: "start", decoration: "*" }],
-            errors: [
-                {
-                    messageId: "unexpectedComment",
-                    data: {
-                        matchedTerm: "todo",
-                        comment: "* TODO decorated single line block..."
-                    }
-                }
-            ]
-        },
-        {
-            code: "/**\n * TODO decorated multi-line block comment (start) \n */",
-            options: [{ terms: ["todo"], location: "start", decoration: "*" }],
-            errors: [
-                {
-                    messageId: "unexpectedComment",
-                    data: {
-                        matchedTerm: "todo",
-                        comment: "* * TODO decorated multi-line block..."
                     }
                 }
             ]

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -37,7 +37,8 @@ ruleTester.run("no-warning-comments", rule, {
         { code: "// special regex characters don't cause a problem", options: [{ terms: ["[aeiou]"], location: "anywhere" }] },
         "/*eslint no-warning-comments: [2, { \"terms\": [\"todo\", \"fixme\", \"any other term\"], \"location\": \"anywhere\" }]*/\n\nvar x = 10;\n",
         { code: "/*eslint no-warning-comments: [2, { \"terms\": [\"todo\", \"fixme\", \"any other term\"], \"location\": \"anywhere\" }]*/\n\nvar x = 10;\n", options: [{ location: "anywhere" }] },
-        { code: "// foo", options: [{ terms: ["foo-bar"] }] }
+        { code: "// foo", options: [{ terms: ["foo-bar"] }] },
+        "/** multi-line block comment with lines starting with\nTODO\nFIXME or\nXXX\n*/"
     ],
     invalid: [
         {
@@ -384,6 +385,71 @@ ruleTester.run("no-warning-comments", rule, {
                     data: {
                         matchedTerm: "!xxx",
                         comment: "!XXX comment starting with no spaces..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "/*\nTODO undecorated multi-line block comment (start)\n*/",
+            options: [{ terms: ["todo"], location: "start" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "todo",
+                        comment: "TODO undecorated multi-line block..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "/** TODO decorated single line block comment (start) */",
+            options: [{ terms: ["todo"], location: "start", decoration: "*" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "todo",
+                        comment: "* TODO decorated single line block..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "/**\n * TODO decorated multi-line block comment (start) \n */",
+            options: [{ terms: ["todo"], location: "start", decoration: "*" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "todo",
+                        comment: "* * TODO decorated multi-line block..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "///// TODO decorated single-line comment (start) \n /////",
+            options: [{ terms: ["todo"], location: "start", decoration: "*/" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "todo",
+                        comment: "/// TODO decorated single-line comment..."
+                    }
+                }
+            ]
+        },
+        {
+            code: "///*/*/ TODO decorated single-line comment with multiple decoration characters (start) \n /////",
+            options: [{ terms: ["todo"], location: "start", decoration: "*/" }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "todo",
+                        comment: "/*/*/ TODO decorated single-line comment..."
                     }
                 }
             ]

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -429,19 +429,6 @@ ruleTester.run("no-warning-comments", rule, {
             ]
         },
         {
-            code: "///// TODO decorated single-line comment with decoration string \n /////",
-            options: [{ terms: ["todo"], location: "start", decoration: "*/" }],
-            errors: [
-                {
-                    messageId: "unexpectedComment",
-                    data: {
-                        matchedTerm: "todo",
-                        comment: "/// TODO decorated single-line comment..."
-                    }
-                }
-            ]
-        },
-        {
             code: "///// TODO decorated single-line comment with decoration array \n /////",
             options: [{ terms: ["todo"], location: "start", decoration: ["*", "/"] }],
             errors: [
@@ -456,7 +443,7 @@ ruleTester.run("no-warning-comments", rule, {
         },
         {
             code: "///*/*/ TODO decorated single-line comment with multiple decoration characters (start) \n /////",
-            options: [{ terms: ["todo"], location: "start", decoration: "*/" }],
+            options: [{ terms: ["todo"], location: "start", decoration: ["*", "/"] }],
             errors: [
                 {
                     messageId: "unexpectedComment",

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -428,6 +428,19 @@ ruleTester.run("no-warning-comments", rule, {
                     }
                 }
             ]
+        },
+        {
+            code: "//**TODO term starts with a decoration character",
+            options: [{ terms: ["*todo"], location: "start", decoration: ["*"] }],
+            errors: [
+                {
+                    messageId: "unexpectedComment",
+                    data: {
+                        matchedTerm: "*todo",
+                        comment: "**TODO term starts with a decoration..."
+                    }
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fix: #16103 

Regular Expression generated for terms in function `convertToRegExp` needed the multi-line flag, and a new function in AST-utils to extract the meaningful comment text from comments by stripping decorative punctuation.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
