### PR TITLE
Breaking: not ignore files beginning with a dot

### DIFF
--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -32,7 +32,7 @@ const DEFAULT_IGNORE_DIRS = [
     "/bower_components/*"
 ];
 const DEFAULT_OPTIONS = {
-    dotfiles: false,
+    dotfiles: true,
     cwd: process.cwd()
 };
 


### PR DESCRIPTION
 From f6aa08ac4c72e977afe343ba49ff0fb480012670 Mon Sep 17 00:00:00 2001
From: "dependabot[bot]" <49699333+dependabot[bot]@users.noreply.github.com>
Date: Mon, 17 Jan 2022 06:21:34 +0000
Subject: [PATCH] build(deps-dev): bump eslint from 7.32.0 to 8.7.0

Bumps [eslint](https://github.com/eslint/eslint) from 7.32.0 to 8.7.0.
- [Release notes](https://github.com/eslint/eslint/releases)
- [Changelog](https://github.com/eslint/eslint/blob/main/CHANGELOG.md)
- [Commits](https://github.com/eslint/eslint/compare/v7.32.0...v8.7.0)

---
updated-dependencies:
- dependency-name: eslint
  dependency-type: direct:development
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>
---
 package.json | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/package.json b/package.json
index 6fa07f6c8..1567ac6b5 100644
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "cross-env": "^7.0.2",
     "dayjs": "^1.10.4",
     "dayjs-plugin-utc": "^0.1.2",
-    "eslint": "^7.8.1",
+    "eslint": "^8.7.0",
     "eslint-config-prettier": "^7.0.0",
     "glob": "^7.0.0",
     "husky": "^7.0.1",