### PR TITLE
chore: switch to eslint-plugin-node's maintained fork

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,7 +122,7 @@ module.exports = {
             files: ["lib/*"],
             excludedFiles: ["lib/unsupported-api.js"],
             rules: {
-                "node/no-restricted-require": ["error", [
+                "n/no-restricted-require": ["error", [
                     ...createInternalFilesPatterns()
                 ]]
             }
@@ -130,7 +130,7 @@ module.exports = {
         {
             files: [INTERNAL_FILES.CLI_ENGINE_PATTERN],
             rules: {
-                "node/no-restricted-require": ["error", [
+                "n/no-restricted-require": ["error", [
                     ...createInternalFilesPatterns(INTERNAL_FILES.CLI_ENGINE_PATTERN)
                 ]]
             }
@@ -138,7 +138,7 @@ module.exports = {
         {
             files: [INTERNAL_FILES.LINTER_PATTERN],
             rules: {
-                "node/no-restricted-require": ["error", [
+                "n/no-restricted-require": ["error", [
                     ...createInternalFilesPatterns(INTERNAL_FILES.LINTER_PATTERN),
                     "fs",
                     resolveAbsolutePath("lib/cli-engine/index.js"),
@@ -149,7 +149,7 @@ module.exports = {
         {
             files: [INTERNAL_FILES.RULES_PATTERN],
             rules: {
-                "node/no-restricted-require": ["error", [
+                "n/no-restricted-require": ["error", [
                     ...createInternalFilesPatterns(INTERNAL_FILES.RULES_PATTERN),
                     "fs",
                     resolveAbsolutePath("lib/cli-engine/index.js"),
@@ -162,7 +162,7 @@ module.exports = {
         {
             files: ["lib/shared/**/*"],
             rules: {
-                "node/no-restricted-require": ["error", [
+                "n/no-restricted-require": ["error", [
                     ...createInternalFilesPatterns(),
                     resolveAbsolutePath("lib/cli-engine/index.js"),
                     resolveAbsolutePath("lib/linter/index.js"),
@@ -174,7 +174,7 @@ module.exports = {
         {
             files: [INTERNAL_FILES.SOURCE_CODE_PATTERN],
             rules: {
-                "node/no-restricted-require": ["error", [
+                "n/no-restricted-require": ["error", [
                     ...createInternalFilesPatterns(INTERNAL_FILES.SOURCE_CODE_PATTERN),
                     "fs",
                     resolveAbsolutePath("lib/cli-engine/index.js"),
@@ -187,7 +187,7 @@ module.exports = {
         {
             files: [INTERNAL_FILES.RULE_TESTER_PATTERN],
             rules: {
-                "node/no-restricted-require": ["error", [
+                "n/no-restricted-require": ["error", [
                     ...createInternalFilesPatterns(INTERNAL_FILES.RULE_TESTER_PATTERN),
                     resolveAbsolutePath("lib/cli-engine/index.js")
                 ]]

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "eslint-plugin-eslint-plugin": "^4.4.0",
     "eslint-plugin-internal-rules": "file:tools/internal-rules",
     "eslint-plugin-jsdoc": "^38.1.6",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^15.2.4",
     "eslint-plugin-unicorn": "^42.0.0",
     "eslint-release": "^3.2.0",
     "eslump": "^3.0.0",

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -1,7 +1,7 @@
 reportUnusedDisableDirectives: true
 extends:
     - "eslint:recommended"
-    - "plugin:node/recommended"
+    - "plugin:n/recommended"
     - "plugin:jsdoc/recommended"
     - "plugin:eslint-comments/recommended"
 plugins:
@@ -14,11 +14,11 @@ settings:
             class: "constructor"
         preferredTypes:
             "*":
-              message: "Use a more precise type or if necessary use `any` or `ArbitraryCallbackResult`"
-              replacement: "any"
+                message: "Use a more precise type or if necessary use `any` or `ArbitraryCallbackResult`"
+                replacement: "any"
             Any:
-              message: "Use a more precise type or if necessary use `any` or `ArbitraryCallbackResult`"
-              replacement: "any"
+                message: "Use a more precise type or if necessary use `any` or `ArbitraryCallbackResult`"
+                replacement: "any"
             # Function:
             #   message: "Point to a `@callback` namepath or `GenericCallback` if truly arbitrary in form"
             #   replacement: "GenericCallback"
@@ -26,13 +26,13 @@ settings:
             #   message: "Point to a `@callback` namepath or `GenericCallback` if truly arbitrary in form"
             #   replacement: "GenericCallback"
             function:
-              message: "Point to a `@callback` namepath or `Function` if truly arbitrary in form"
-              replacement: "Function"
+                message: "Point to a `@callback` namepath or `Function` if truly arbitrary in form"
+                replacement: "Function"
             Promise:
-              message: "Specify the specific Promise type, including, if necessary, the type `any`"
+                message: "Specify the specific Promise type, including, if necessary, the type `any`"
             ".<>":
-              message: "Prefer type form without dot"
-              replacement: "<>"
+                message: "Prefer type form without dot"
+                replacement: "<>"
             # Object:
             #   message: "Use the specific object type or `PlainObject` if truly arbitrary"
             #   replacement: "PlainObject"
@@ -40,8 +40,8 @@ settings:
             #   message: "Use the specific object type or `PlainObject` if truly arbitrary"
             #   replacement: "PlainObject"
             object:
-               message: "Use the specific object type or `Object` if truly arbitrary"
-               replacement: "Object"
+                message: "Use the specific object type or `Object` if truly arbitrary"
+                replacement: "Object"
             # Array:
             #   message: "Use the specific array type or `GenericArray` if it is truly arbitrary."
             #   replacement: "GenericArray"
@@ -56,7 +56,7 @@ rules:
     arrow-body-style: ["error", "as-needed"]
     arrow-parens: ["error", "as-needed"]
     arrow-spacing: "error"
-    indent: ["error", 4, {SwitchCase: 1}]
+    indent: ["error", 4, { SwitchCase: 1 }]
     block-spacing: "error"
     brace-style: ["error", "1tbs"]
     camelcase: "error"
@@ -101,9 +101,21 @@ rules:
     jsdoc/require-description: ["error", { checkConstructors: false }]
     # jsdoc/require-file-overview: "error"
     jsdoc/require-hyphen-before-param-description: ["error", "never"]
-    jsdoc/require-returns: ["error", { forceRequireReturn: true, forceReturnsWithAsync: true }]
+    jsdoc/require-returns:
+        ["error", { forceRequireReturn: true, forceReturnsWithAsync: true }]
     jsdoc/require-throws: "error"
-    jsdoc/tag-lines: ["error", "never", { tags: { example: { lines: "always" }, fileoverview: { lines: "any" } } }]
+    jsdoc/tag-lines:
+        [
+            "error",
+            "never",
+            {
+                tags:
+                    {
+                        example: { lines: "always" },
+                        fileoverview: { lines: "any" },
+                    },
+            },
+        ]
 
     # jsdoc: disable recommended rules
     jsdoc/no-undefined-types: "off"
@@ -120,7 +132,7 @@ rules:
     jsdoc/implements-on-classes: "error"
     jsdoc/multiline-blocks: "error"
     jsdoc/no-multi-asterisks: "error"
-    jsdoc/require-jsdoc: ["error", { require: {ClassDeclaration: true} }]
+    jsdoc/require-jsdoc: ["error", { require: { ClassDeclaration: true } }]
     jsdoc/require-param: "error"
     jsdoc/require-param-description: "error"
     jsdoc/require-param-name: "error"
@@ -137,19 +149,28 @@ rules:
 
     key-spacing: ["error", { beforeColon: false, afterColon: true }]
     keyword-spacing: "error"
-    lines-around-comment: ["error", {
-        beforeBlockComment: true,
-        afterBlockComment: false,
-        beforeLineComment: true,
-        afterLineComment: false
-    }]
-    max-len: ["error", 160, {
-        "ignoreComments": true,
-        "ignoreUrls": true,
-        "ignoreStrings": true,
-        "ignoreTemplateLiterals": true,
-        "ignoreRegExpLiterals": true
-    }]
+    lines-around-comment:
+        [
+            "error",
+            {
+                beforeBlockComment: true,
+                afterBlockComment: false,
+                beforeLineComment: true,
+                afterLineComment: false,
+            },
+        ]
+    max-len:
+        [
+            "error",
+            160,
+            {
+                "ignoreComments": true,
+                "ignoreUrls": true,
+                "ignoreStrings": true,
+                "ignoreTemplateLiterals": true,
+                "ignoreRegExpLiterals": true,
+            },
+        ]
     max-statements-per-line: "error"
     new-cap: "error"
     new-parens: "error"
@@ -175,7 +196,7 @@ rules:
     no-mixed-spaces-and-tabs: ["error", false] # Modified from recommended
     no-multi-spaces: "error"
     no-multi-str: "error"
-    no-multiple-empty-lines: ["error", {max: 2, maxBOF: 0, maxEOF: 0}]
+    no-multiple-empty-lines: ["error", { max: 2, maxBOF: 0, maxEOF: 0 }]
     no-nested-ternary: "error"
     no-new: "error"
     no-new-func: "error"
@@ -185,15 +206,35 @@ rules:
     no-param-reassign: "error"
     no-proto: "error"
     no-process-exit: "off"
-    no-restricted-properties: [
-        "error",
-        { property: "substring", message: "Use .slice instead of .substring." },
-        { property: "substr", message: "Use .slice instead of .substr." },
-        { object: "assert", property: "equal", message: "Use assert.strictEqual instead of assert.equal." },
-        { object: "assert", property: "notEqual", message: "Use assert.notStrictEqual instead of assert.notEqual." },
-        { object: "assert", property: "deepEqual", message: "Use assert.deepStrictEqual instead of assert.deepEqual." },
-        { object: "assert", property: "notDeepEqual", message: "Use assert.notDeepStrictEqual instead of assert.notDeepEqual." }
-    ]
+    no-restricted-properties:
+        [
+            "error",
+            {
+                property: "substring",
+                message: "Use .slice instead of .substring.",
+            },
+            { property: "substr", message: "Use .slice instead of .substr." },
+            {
+                object: "assert",
+                property: "equal",
+                message: "Use assert.strictEqual instead of assert.equal.",
+            },
+            {
+                object: "assert",
+                property: "notEqual",
+                message: "Use assert.notStrictEqual instead of assert.notEqual.",
+            },
+            {
+                object: "assert",
+                property: "deepEqual",
+                message: "Use assert.deepStrictEqual instead of assert.deepEqual.",
+            },
+            {
+                object: "assert",
+                property: "notDeepEqual",
+                message: "Use assert.notDeepStrictEqual instead of assert.notDeepEqual.",
+            },
+        ]
     no-return-assign: "error"
     no-script-url: "error"
     no-self-compare: "error"
@@ -202,15 +243,18 @@ rules:
     no-tabs: "error"
     no-throw-literal: "error"
     no-trailing-spaces: "error"
-    no-undef: ["error", {typeof: true}] # Modified from recommended
+    no-undef: ["error", { typeof: true }] # Modified from recommended
     no-undef-init: "error"
     no-undefined: "error"
-    no-underscore-dangle: ["error", {allowAfterThis: true}]
+    no-underscore-dangle: ["error", { allowAfterThis: true }]
     no-unmodified-loop-condition: "error"
     no-unneeded-ternary: "error"
     no-unreachable-loop: "error"
     no-unused-expressions: "error"
-    no-unused-vars: ["error", {vars: "all", args: "after-used", caughtErrors: "all"}] # Modified from recommended
+    no-unused-vars: [
+            "error",
+            { vars: "all", args: "after-used", caughtErrors: "all" },
+        ] # Modified from recommended
     no-use-before-define: "error"
     no-useless-call: "error"
     no-useless-computed-key: "error"
@@ -221,12 +265,12 @@ rules:
     no-whitespace-before-property: "error"
     no-var: "error"
 
-    node/callback-return: ["error", ["cb", "callback", "next"]]
-    node/handle-callback-err: ["error", "err"]
-    node/no-deprecated-api: "error"
-    node/no-mixed-requires: "error"
-    node/no-new-require: "error"
-    node/no-path-concat: "error"
+    n/callback-return: ["error", ["cb", "callback", "next"]]
+    n/handle-callback-err: ["error", "err"]
+    n/no-deprecated-api: "error"
+    n/no-mixed-requires: "error"
+    n/no-new-require: "error"
+    n/no-path-concat: "error"
 
     object-curly-newline: ["error", { "consistent": true, "multiline": true }]
     object-curly-spacing: ["error", "always"]
@@ -235,19 +279,16 @@ rules:
     one-var-declaration-per-line: "error"
     operator-assignment: "error"
     operator-linebreak: "error"
-    padding-line-between-statements: [
-        "error",
-        {
-            blankLine: "always",
-            prev: ["const", "let", "var"],
-            next: "*"
-        },
-        {
-            blankLine: "any",
-            prev: ["const", "let", "var"],
-            next: ["const", "let", "var"]
-        }
-    ]
+    padding-line-between-statements:
+        [
+            "error",
+            { blankLine: "always", prev: ["const", "let", "var"], next: "*" },
+            {
+                blankLine: "any",
+                prev: ["const", "let", "var"],
+                next: ["const", "let", "var"],
+            },
+        ]
     prefer-arrow-callback: "error"
     prefer-const: "error"
     prefer-exponentiation-operator: "error"
@@ -257,24 +298,24 @@ rules:
     prefer-rest-params: "error"
     prefer-spread: "error"
     prefer-template: "error"
-    quotes: ["error", "double", {avoidEscape: true}]
+    quotes: ["error", "double", { avoidEscape: true }]
     quote-props: ["error", "as-needed"]
     radix: "error"
     require-unicode-regexp: "error"
     rest-spread-spacing: "error"
     semi: "error"
-    semi-spacing: ["error", {before: false, after: true}]
+    semi-spacing: ["error", { before: false, after: true }]
     semi-style: "error"
     space-before-blocks: "error"
-    space-before-function-paren: ["error", {
-        "anonymous": "never",
-        "named": "never",
-        "asyncArrow": "always"
-    }]
+    space-before-function-paren:
+        [
+            "error",
+            { "anonymous": "never", "named": "never", "asyncArrow": "always" },
+        ]
     space-in-parens: "error"
     space-infix-ops: "error"
-    space-unary-ops: ["error", {words: true, nonwords: false}]
-    spaced-comment: ["error", "always", { exceptions: ["-"]}]
+    space-unary-ops: ["error", { words: true, nonwords: false }]
+    spaced-comment: ["error", "always", { exceptions: ["-"] }]
     strict: ["error", "global"]
     switch-colon-spacing: "error"
     symbol-description: "error"

--- a/packages/eslint-config-eslint/package.json
+++ b/packages/eslint-config-eslint/package.json
@@ -22,7 +22,7 @@
   "peerDependencies": {
     "eslint-plugin-eslint-comments": ">=3.2.0",
     "eslint-plugin-jsdoc": ">=38.1.6",
-    "eslint-plugin-node": ">=11.1.0",
+    "eslint-plugin-n": ">=15.2.4",
     "eslint-plugin-unicorn": ">=42.0.0"
   },
   "keywords": [

--- a/tests/_utils/test-lazy-loading-rules.js
+++ b/tests/_utils/test-lazy-loading-rules.js
@@ -62,5 +62,5 @@ addHook(
     await eslint.lintFiles([pattern]);
 })().catch(({ message, stack }) => {
     process.send({ message, stack });
-    process.exit(1);
+    process.exit(1); // eslint-disable-line n/no-process-exit -- this is a child process
 });

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -5089,9 +5089,9 @@ describe("CLIEngine", () => {
         });
 
         it("should expose the list of plugin rules", () => {
-            const engine = new CLIEngine({ plugins: ["node"] });
+            const engine = new CLIEngine({ plugins: ["n"] });
 
-            assert(engine.getRules().has("node/no-deprecated-api"), "node/no-deprecated-api is present");
+            assert(engine.getRules().has("n/no-deprecated-api"), "n/no-deprecated-api is present");
         });
 
         it("should expose the list of rules from a preloaded plugin", () => {
@@ -5099,7 +5099,7 @@ describe("CLIEngine", () => {
                 plugins: ["foo"]
             }, {
                 preloadedPlugins: {
-                    foo: require("eslint-plugin-node")
+                    foo: require("eslint-plugin-n")
                 }
             });
 

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -5025,16 +5025,16 @@ describe("ESLint", () => {
         });
 
         it("should return multiple rule meta when there are multiple linting errors from a plugin", async () => {
-            const nodePlugin = require("eslint-plugin-node");
+            const nodePlugin = require("eslint-plugin-n");
             const engine = new ESLint({
                 useEslintrc: false,
                 plugins: {
                     node: nodePlugin
                 },
                 overrideConfig: {
-                    plugins: ["node"],
+                    plugins: ["n"],
                     rules: {
-                        "node/no-new-require": 2,
+                        "n/no-new-require": 2,
                         semi: 2,
                         quotes: [2, "double"]
                     }
@@ -5047,7 +5047,7 @@ describe("ESLint", () => {
             assert.strictEqual(rulesMeta.semi, coreRules.get("semi").meta);
             assert.strictEqual(rulesMeta.quotes, coreRules.get("quotes").meta);
             assert.strictEqual(
-                rulesMeta["node/no-new-require"],
+                rulesMeta["n/no-new-require"],
                 nodePlugin.rules["no-new-require"].meta
             );
         });

--- a/tests/lib/linter/code-path-analysis/code-path.js
+++ b/tests/lib/linter/code-path-analysis/code-path.js
@@ -54,7 +54,7 @@ function getOrderOfTraversing(codePath, options, callback) {
     codePath.traverseSegments(options, (segment, controller) => {
         retv.push(segment.id);
         if (callback) {
-            callback(segment, controller); // eslint-disable-line node/callback-return -- At end of inner function
+            callback(segment, controller); // eslint-disable-line n/callback-return -- At end of inner function
         }
     });
 

--- a/tools/fetch-docs-links.js
+++ b/tools/fetch-docs-links.js
@@ -28,7 +28,7 @@ const metascraper = require("metascraper")([
 ]);
 const got = require("got");
 const path = require("path");
-const fs = require("fs/promises");
+const fs = require("fs").promises;
 const glob = require("fast-glob");
 
 //-----------------------------------------------------------------------------
@@ -99,7 +99,7 @@ async function fetchLinkMeta(url) {
                         console.error("Could not fetch data for", url);
                         console.error(ex.message);
                         console.error(ex.stack);
-                        process.exit(1);
+                        process.exit(1); // eslint-disable-line n/no-process-exit -- used in tools
                     }
                 }
             }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ x] Other, please explain: 

`eslint-plugin-node` is no longer actively maintained. this one is just a maintained fork.
it's main improvement is better esm supports. you can see the latest releases: https://github.com/weiran-zsd/eslint-plugin-node/releases

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

#### Is there anything you'd like reviewers to focus on?

we may transfer the fork to the new org `@eslint-community`, and rename it to `@eslint-community/eslint-plugin-node` later. will update when it happens. related: https://github.com/eslint/rfcs/pull/91

<!-- markdownlint-disable-file MD004 -->
