### PR TITLE
fix: apply `allowBlockStart` for switch statements too

### DIFF
--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -264,7 +264,8 @@ module.exports = {
                 isCommentAtParentStart(token, "ClassBody") ||
                 isCommentAtParentStart(token, "BlockStatement") ||
                 isCommentAtParentStart(token, "StaticBlock") ||
-                isCommentAtParentStart(token, "SwitchCase")
+                isCommentAtParentStart(token, "SwitchCase") ||
+                isCommentAtParentStart(token, "SwitchStatement")
             );
         }
 

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -364,6 +364,27 @@ ruleTester.run("lines-around-comment", rule, {
             parserOptions: { ecmaVersion: 2022 }
         },
 
+        // https://github.com/eslint/eslint/issues/16131
+        {
+            code: `
+            switch (foo) {
+            // this comment is allowed by allowBlockStart: true 
+                
+            case 1:    
+                bar();
+                break;
+                
+            // this comment is allowed by allowBlockEnd: true
+            }
+            `,
+            options: [{
+                allowBlockStart: true,
+                beforeLineComment: true,
+                afterLineComment: true,
+                allowBlockEnd: true
+            }]
+        },
+
         // check for block end comments
         {
             code: "var a,\n// line\n\nb;",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fix https://github.com/eslint/eslint/issues/16131

```js
/* eslint lines-around-comment: ["error", {
  beforeLineComment: true,
  afterLineComment: true,
  allowBlockStart: true,
  allowBlockEnd: true
}]*/

switch (foo) {
  // this comment is allowed by allowBlockStart: true 
    
  case 1:    
    bar();
    break;
    
  // this comment is allowed by allowBlockEnd: true
}

```
#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
