### PR TITLE
feat: improve the key width calculation in `key-spacing` rule

### DIFF
--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -9,6 +9,7 @@
 //------------------------------------------------------------------------------
 
 const astUtils = require("./utils/ast-utils");
+const GraphemeSplitter = require("grapheme-splitter");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -505,10 +506,22 @@ module.exports = {
          * @returns {int} Width of the key.
          */
         function getKeyWidth(property) {
-            const startToken = sourceCode.getFirstToken(property);
-            const endToken = getLastTokenBeforeColon(property.key);
+            const splitter = new GraphemeSplitter();
 
-            return endToken.range[1] - startToken.range[0];
+            if (property.computed) {
+                const startToken = sourceCode.getFirstToken(property);
+                const endToken = getLastTokenBeforeColon(property.key);
+                const allTokens = sourceCode.getTokensBetween(startToken, endToken);
+
+                const keyWidth = allTokens.reduce(
+                    (width, token) => width + splitter.countGraphemes(token.value),
+                    splitter.countGraphemes(startToken.value) + splitter.countGraphemes(endToken.value)
+                );
+
+                return keyWidth;
+            }
+
+            return splitter.countGraphemes(property.key.name || property.key.raw);
         }
 
         /**

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -507,21 +507,10 @@ module.exports = {
          */
         function getKeyWidth(property) {
             const splitter = new GraphemeSplitter();
+            const startToken = sourceCode.getFirstToken(property);
+            const endToken = getLastTokenBeforeColon(property.key);
 
-            if (property.computed) {
-                const startToken = sourceCode.getFirstToken(property);
-                const endToken = getLastTokenBeforeColon(property.key);
-                const allTokens = sourceCode.getTokensBetween(startToken, endToken);
-
-                const keyWidth = allTokens.reduce(
-                    (width, token) => width + splitter.countGraphemes(token.value),
-                    splitter.countGraphemes(startToken.value) + splitter.countGraphemes(endToken.value)
-                );
-
-                return keyWidth;
-            }
-
-            return splitter.countGraphemes(property.key.name || property.key.raw);
+            return splitter.countGraphemes(sourceCode.getText().slice(startToken.range[0], endToken.range[1]));
         }
 
         /**

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -11,6 +11,8 @@
 const astUtils = require("./utils/ast-utils");
 const GraphemeSplitter = require("grapheme-splitter");
 
+const splitter = new GraphemeSplitter();
+
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -506,7 +508,6 @@ module.exports = {
          * @returns {int} Width of the key.
          */
         function getKeyWidth(property) {
-            const splitter = new GraphemeSplitter();
             const startToken = sourceCode.getFirstToken(property);
             const endToken = getLastTokenBeforeColon(property.key);
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "functional-red-black-tree": "^1.0.1",
     "glob-parent": "^6.0.1",
     "globals": "^13.15.0",
+    "grapheme-splitter": "^1.0.4",
     "ignore": "^5.2.0",
     "import-fresh": "^3.0.0",
     "imurmurhash": "^0.1.4",

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -2346,5 +2346,34 @@ ruleTester.run("key-spacing", rule, {
         errors: [
             { messageId: "extraValue", data: { computed: "", key: "a" }, line: 3, column: 20, type: "Literal" }
         ]
-    }]
+    },
+    {
+        code: `
+            var foo = {
+                "🌷":     "bar", // 2 code points
+                "🎁":     "baz", // 2 code points
+                "🇮🇳":   "qux", // 4 code points
+                "🏳️‍🌈": "xyz", // 6 code points
+            };
+        `,
+        output: `
+            var foo = {
+                "🌷": "bar", // 2 code points
+                "🎁": "baz", // 2 code points
+                "🇮🇳": "qux", // 4 code points
+                "🏳️‍🌈": "xyz", // 6 code points
+            };
+        `,
+        options: [{
+            align: {
+                on: "value"
+            }
+        }],
+        errors: [
+            { messageId: "extraValue", data: { computed: "", key: "🌷" }, line: 3, column: 21, type: "Literal" },
+            { messageId: "extraValue", data: { computed: "", key: "🎁" }, line: 4, column: 21, type: "Literal" },
+            { messageId: "extraValue", data: { computed: "", key: "🇮🇳" }, line: 5, column: 23, type: "Literal" }
+        ]
+    }
+    ]
 });

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -914,6 +914,38 @@ ruleTester.run("key-spacing", rule, {
     },
     {
         code: `
+            var foo = {
+                "a": "bar",
+                "Á": "baz",
+                "o͂": "qux",
+                "m̅": "xyz",
+                "ř": "abc"
+
+            };
+        `,
+        options: [{
+            align: {
+                on: "value"
+            }
+        }]
+    },
+    {
+        code: `
+            var foo = {
+                "🌷": "bar", // 2 code points
+                "🎁": "baz", // 2 code points
+                "🇮🇳": "qux", // 4 code points
+                "🏳️‍🌈": "xyz", // 6 code points
+            };
+        `,
+        options: [{
+            align: {
+                on: "value"
+            }
+        }]
+    },
+    {
+        code: `
             const foo = {
                 "a": "bar",
                 [𐌘]: "baz"

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -925,8 +925,21 @@ ruleTester.run("key-spacing", rule, {
             }
         }],
         parserOptions: { ecmaVersion: 6 }
-    }
-    ],
+    },
+    {
+        code: `
+            const foo = {
+                "abc": "bar",
+                [ 𐌘 ]: "baz"
+            };
+        `,
+        options: [{
+            align: {
+                on: "value"
+            }
+        }],
+        parserOptions: { ecmaVersion: 6 }
+    }],
     invalid: [{
         code: "var a ={'key' : value };",
         output: "var a ={'key':value };",
@@ -2231,6 +2244,75 @@ ruleTester.run("key-spacing", rule, {
             { messageId: "missingValue", data: { computed: "", key: "foo" }, line: 2, column: 10, type: "Literal" },
             { messageId: "missingValue", data: { computed: "", key: "bar" }, line: 3, column: 12, type: "Literal" },
             { messageId: "missingValue", data: { computed: "", key: "baz" }, line: 3, column: 20, type: "Literal" }
+        ]
+    },
+    {
+        code: `
+            const foo = {
+                "a": "bar",
+                [ 𐌘 ]: "baz"
+            };
+        `,
+        output: `
+            const foo = {
+                "a":   "bar",
+                [ 𐌘 ]: "baz"
+            };
+        `,
+        options: [{
+            align: {
+                on: "value"
+            }
+        }],
+        parserOptions: { ecmaVersion: 6 },
+        errors: [
+            { messageId: "missingValue", data: { computed: "", key: "a" }, line: 3, column: 22, type: "Literal" }
+        ]
+    },
+    {
+        code: `
+            const foo = {
+                "a": "bar",
+                [ 𐌘 ]: "baz"
+            };
+        `,
+        output: `
+            const foo = {
+                "a"  : "bar",
+                [ 𐌘 ]: "baz"
+            };
+        `,
+        options: [{
+            align: {
+                on: "colon"
+            }
+        }],
+        parserOptions: { ecmaVersion: 6 },
+        errors: [
+            { messageId: "missingKey", data: { computed: "", key: "a" }, line: 3, column: 17, type: "Literal" }
+        ]
+    },
+    {
+        code: `
+            const foo = {
+                "a":  "bar",
+                "𐌘": "baz"
+            };
+        `,
+        output: `
+            const foo = {
+                "a": "bar",
+                "𐌘": "baz"
+            };
+        `,
+        options: [{
+            align: {
+                on: "value"
+            }
+        }],
+        parserOptions: { ecmaVersion: 6 },
+        errors: [
+            { messageId: "extraValue", data: { computed: "", key: "a" }, line: 3, column: 20, type: "Literal" }
         ]
     }]
 });

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -896,6 +896,35 @@ ruleTester.run("key-spacing", rule, {
                 on: "value"
             }
         }]
+    },
+
+    // https://github.com/eslint/eslint/issues/15914
+    {
+        code: `
+            var foo = {
+                "a": "bar",
+                "𐌘": "baz"
+            };
+        `,
+        options: [{
+            align: {
+                on: "value"
+            }
+        }]
+    },
+    {
+        code: `
+            const foo = {
+                "a": "bar",
+                [𐌘]: "baz"
+            };
+        `,
+        options: [{
+            align: {
+                on: "value"
+            }
+        }],
+        parserOptions: { ecmaVersion: 6 }
     }
     ],
     invalid: [{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fix https://github.com/eslint/eslint/issues/15914

The following code doesn't report any error anymore.

```js
/* eslint "key-spacing": [2, { "align": "value" }] */

const foo = {
    "a": "bar",
    "𐌘": "baz",
    [𐌘]: "foo"
};
```
#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
