### PR TITLE
feat: func-style: optionally allow arrow functions with let

### DIFF
--- a/docs/src/rules/func-style.md
+++ b/docs/src/rules/func-style.md
@@ -61,9 +61,10 @@ This rule has a string option:
 * `"expression"` (default) requires the use of function expressions instead of function declarations
 * `"declaration"` requires the use of function declarations instead of function expressions
 
-This rule has an object option for an exception:
+This rule has two object options for exceptions:
 
 * `"allowArrowFunctions"`: `true` (default `false`) allows the use of arrow functions. This option applies only when the string option is set to `"declaration"` (arrow functions are always allowed when the string option is set to `"expression"`, regardless of this option)
+* `"allowLetArrowFunctions"`: `true` (default `false`) allows the use of arrow functions in `let` expressions. This option applies only when the string option is set to `"declaration"` (arrow functions are always allowed when the string option is set to `"expression"`, regardless of this option)
 
 ### expression
 
@@ -146,6 +147,32 @@ Examples of additional **correct** code for this rule with the `"declaration", {
 /*eslint func-style: ["error", "declaration", { "allowArrowFunctions": true }]*/
 
 var foo = () => {};
+```
+
+:::
+
+### allowLetArrowFunctions
+
+Examples of additional **correct** code for this rule with the `"declaration", { "allowLetArrowFunctions": true }` options:
+
+::: correct
+
+```js
+/*eslint func-style: ["error", "declaration", { "allowLetArrowFunctions": true }]*/
+
+let foo = () => {};
+```
+
+:::
+
+Examples of **incorrect** code for this rule with the `"declaration", { "allowLetArrowFunctions": true }` options:
+
+::: incorrect
+
+```js
+/*eslint func-style: ["error", "declaration", { "allowLetArrowFunctions": true }]*/
+
+const foo = () => {};
 ```
 
 :::

--- a/lib/rules/func-style.js
+++ b/lib/rules/func-style.js
@@ -29,6 +29,10 @@ module.exports = {
                     allowArrowFunctions: {
                         type: "boolean",
                         default: false
+                    },
+                    allowLetArrowFunctions: {
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -45,6 +49,7 @@ module.exports = {
 
         const style = context.options[0],
             allowArrowFunctions = context.options[1] && context.options[1].allowArrowFunctions,
+            allowLetArrowFunctions = context.options[1] && context.options[1].allowLetArrowFunctions,
             enforceDeclarations = (style === "declaration"),
             stack = [];
 
@@ -86,7 +91,8 @@ module.exports = {
             nodesToCheck["ArrowFunctionExpression:exit"] = function(node) {
                 const hasThisExpr = stack.pop();
 
-                if (enforceDeclarations && !hasThisExpr && node.parent.type === "VariableDeclarator") {
+                if (enforceDeclarations && !hasThisExpr && node.parent.type === "VariableDeclarator" &&
+                    (!allowLetArrowFunctions || node.parent.parent.kind !== "let")) {
                     context.report({ node: node.parent, messageId: "declaration" });
                 }
             };

--- a/tests/lib/rules/func-style.js
+++ b/tests/lib/rules/func-style.js
@@ -81,6 +81,11 @@ ruleTester.run("func-style", rule, {
             code: "var foo = () => { function foo() { this; } };",
             options: ["declaration", { allowArrowFunctions: true }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "let foo = () => {};",
+            options: ["declaration", { allowLetArrowFunctions: true }],
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
 
@@ -109,6 +114,17 @@ ruleTester.run("func-style", rule, {
         {
             code: "var foo = () => { function foo() { this; } };",
             options: ["declaration"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "declaration",
+                    type: "VariableDeclarator"
+                }
+            ]
+        },
+        {
+            code: "const foo = () => {};",
+            options: ["declaration", { allowLetArrowFunctions: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {


### PR DESCRIPTION
Add a new option for func-style when used with the "declaration" style.

The rationale is that in code styles that prefer function declarations and generally don't allow code like `const foo = () => {};`, there needs to be an exception when using `let` - variables that will be reassigned. Currently, the `func-style` rule either disallows both or allows both.

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

`func-style`

**Does this change cause the rule to produce more or fewer warnings?**

fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**

a new option called `allowLetArrowFunctions`

**Please provide some example code that this change will affect:**

```js
// foo is intended as a variable (it can be reassigned later)
// and we do not want to use a function declaration and reassign that.
let foo = () => {};
```

**What does the rule currently do for this code?**

With the `"declaration"` option, this code will be considered incorrect.

**What will the rule do after it's changed?**

With the `"declaration", { allowLetArrowFunctions: true }` options, the code will be allowed.


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I added the new option, tests for incorrect and correct code, and updated the documentation.

#### Is there anything you'd like reviewers to focus on?

If this is forbidden by the freeze of stylistic rules, can you please add guidance on best practices for these types of changes?

<!-- markdownlint-disable-file MD004 -->
