### PR TITLE
Docs: nodejs-api: typo: false -> true

### DIFF
--- a/docs/src/developer-guide/nodejs-api.md
+++ b/docs/src/developer-guide/nodejs-api.md
@@ -101,7 +101,7 @@ The `ESLint` constructor takes an `options` object. If you omit the `options` ob
 ##### Linting
 
 * `options.allowInlineConfig` (`boolean`)<br>
-  Default is `true`. If `false` is present, ESLint suppresses directive comments in source code. If this option is `false`, it overrides the `noInlineConfig` setting in your configurations.
+  Default is `true`. If `false` is present, ESLint suppresses directive comments in source code. If this option is `true`, it overrides the `noInlineConfig` setting in your configurations.
 * `options.baseConfig` (`ConfigData | null`)<br>
   Default is `null`. [Configuration object], extended by all configurations used with this instance. You can use this option to define the default settings that will be used if your configuration files don't configure it.
 * `options.overrideConfig` (`ConfigData | null`)<br>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`options.allowInlineConfig` (`boolean`)<br>
  Default is `true`. If `false` is present, ESLint suppresses directive comments in source code. If this option is **`false`**, it overrides the `noInlineConfig` setting in your configurations.

Looks like there is a typo, and `true` should be used instead, so `allowInlineConfig=true` it overrides `noInlineConfig`, in other way there is nothing to override, both options disables inline config.


#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
