### PR TITLE
feat: allow RGBA arrays for no-magic-numbers

### DIFF
--- a/docs/src/rules/no-magic-numbers.md
+++ b/docs/src/rules/no-magic-numbers.md
@@ -253,3 +253,25 @@ var dutyFreePrice = 100,
 ```
 
 :::
+
+### allowRGBa
+
+A boolean to specify if we should detect numbers in arrays representing rgba colors. `false` by default.
+
+Examples of **incorrect** code for the `{ "allowRGBa": true }` option:
+
+```js
+/*eslint no-magic-numbers: ["error", { "allowRGBa": true }]*/
+
+const rgbaColor = [255, 255, 300, 1.8] // each channel cannot be more than 255, alpha cannot be more than 1;
+const rgbColor = [-5, 255, 300] // channels cannot be negative
+```
+
+Examples of **correct** code for the `{ "allowRGBa": true }` option:
+
+```js
+/*eslint no-magic-numbers: ["error", { "allowRGBa": true }]*/
+
+const rgbaColor = [255, 255, 255, 0.6]
+const rgbColr = [0, 0, 125]
+```

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -177,13 +177,12 @@ module.exports = {
         /**
          *
          * Returns whether or not given node is a valid RGBA single channel value
-         * @param {ASTNode} literal a literal node
-         * @param {number} ceil a maximum allowed number
+         * @param {ASTNode} fullNumberNode a node which has the literal number
          * @returns {boolean} true if the node is a valid channel value
          */
-        function isColorRepresentation(literal, ceil) {
-            return typeof literal.value === "number" &&
-                literal.value >= 0 && literal.value <= ceil;
+        function isColorRepresentation(fullNumberNode) {
+            return Number.isInteger(fullNumberNode.value) &&
+                fullNumberNode.value >= 0 && fullNumberNode.value <= 255;
         }
 
         /**
@@ -214,8 +213,9 @@ module.exports = {
             }
 
             const colors = array.slice(0, 3);
-            const validAlpha = array[3] ? isColorRepresentation(array[3], 1) : true;
-            const validArray = validAlpha && colors.every(literal => isColorRepresentation(literal, 255));
+
+            const validAlpha = array[3] ? array[3].value >= 0 && array[3].value <= 1 : true;
+            const validArray = validAlpha && colors.every(isColorRepresentation);
 
             if (validArray) {
                 validArrays.add(array);

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -198,6 +198,7 @@ module.exports = {
             if (!parent) {
                 return false;
             }
+
             const array = parent.elements;
 
             if (!Array.isArray(array)) {
@@ -257,7 +258,7 @@ module.exports = {
                     return;
                 }
 
-                if (allowRGBa && isInRGBaArray(value)) {
+                if (allowRGBa && isInRGBaArray(fullNumberNode)) {
                     return;
                 }
 

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -9,6 +9,12 @@ const astUtils = require("./utils/ast-utils");
 
 // Maximum array length by the ECMAScript Specification.
 const MAX_ARRAY_LENGTH = 2 ** 32 - 1;
+const RGB_LENGTH = 3;
+const RGBA_LENGTH = 4;
+const MAX_CHANNEL_VALUE = 255;
+const MIN_CHANNEL_VALUE = 0;
+const MAX_ALPHA_VALUE = 1;
+const ALPHA_IDX = 3;
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -186,7 +192,7 @@ module.exports = {
             }
 
             return Number.isInteger(fullNumberNode.value) &&
-                fullNumberNode.value >= 0 && fullNumberNode.value <= 255;
+                fullNumberNode.value >= MIN_CHANNEL_VALUE && fullNumberNode.value <= MAX_CHANNEL_VALUE;
         }
 
         /**
@@ -212,13 +218,13 @@ module.exports = {
                 return true;
             }
 
-            if (array.length !== 4 && array.length !== 3) {
+            if (array.length !== RGB_LENGTH && array.length !== RGBA_LENGTH) {
                 return false;
             }
 
-            const colors = array.slice(0, 3);
+            const colors = array.slice(0, ALPHA_IDX);
 
-            const validAlpha = array[3] ? array[3].value >= 0 && array[3].value <= 1 : true;
+            const validAlpha = array[ALPHA_IDX] ? array[ALPHA_IDX].value >= MIN_CHANNEL_VALUE && array[ALPHA_IDX].value <= MAX_ALPHA_VALUE : true;
             const validArray = validAlpha && colors.every(isColorRepresentation);
 
             if (validArray) {

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -181,6 +181,10 @@ module.exports = {
          * @returns {boolean} true if the node is a valid channel value
          */
         function isColorRepresentation(fullNumberNode) {
+            if (!fullNumberNode) {
+                return false;
+            }
+
             return Number.isInteger(fullNumberNode.value) &&
                 fullNumberNode.value >= 0 && fullNumberNode.value <= 255;
         }

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -65,6 +65,10 @@ module.exports = {
                 ignoreDefaultValues: {
                     type: "boolean",
                     default: false
+                },
+                allowRGBa: {
+                    type: "boolean",
+                    default: false
                 }
             },
             additionalProperties: false
@@ -82,7 +86,10 @@ module.exports = {
             enforceConst = !!config.enforceConst,
             ignore = new Set((config.ignore || []).map(normalizeIgnoreValue)),
             ignoreArrayIndexes = !!config.ignoreArrayIndexes,
-            ignoreDefaultValues = !!config.ignoreDefaultValues;
+            ignoreDefaultValues = !!config.ignoreDefaultValues,
+            allowRGBa = !!config.allowRGBa;
+
+        const validArrays = new Set();
 
         const okTypes = detectObjects ? [] : ["ObjectExpression", "Property", "AssignmentExpression"];
 
@@ -167,6 +174,55 @@ module.exports = {
                 value >= 0 && value < MAX_ARRAY_LENGTH;
         }
 
+        /**
+         *
+         * Returns whether or not given node is a valid RGBA single channel value
+         * @param {ASTNode} literal a literal node
+         * @param {number} ceil a maximum allowed number
+         * @returns {boolean} true if the node is a valid channel value
+         */
+        function isColorRepresentation(literal, ceil) {
+            return typeof literal.value === "number" &&
+                literal.value >= 0 && literal.value <= ceil;
+        }
+
+        /**
+         *
+         * Returns whether the given node is used in an array specifying an RGB(A) set
+         * @param {ASTNode} fullNumberNode `Literal` or `UnaryExpression` full number node
+         * @returns {boolean} true if the node is a valid RGB(A) array
+         */
+        function isInRGBaArray(fullNumberNode) {
+            const parent = fullNumberNode.parent;
+
+            if (!parent) {
+                return false;
+            }
+            const array = parent.elements;
+
+            if (!Array.isArray(array)) {
+                return false;
+            }
+
+            if (validArrays.has(array)) {
+                return true;
+            }
+
+            if (array.length !== 4 && array.length !== 3) {
+                return false;
+            }
+
+            const colors = array.slice(0, 3);
+            const validAlpha = array[3] ? isColorRepresentation(array[3], 1) : true;
+            const validArray = validAlpha && colors.every(literal => isColorRepresentation(literal, 255));
+
+            if (validArray) {
+                validArrays.add(array);
+            }
+
+            return validArray;
+        }
+
         return {
             Literal(node) {
                 if (!astUtils.isNumericLiteral(node)) {
@@ -198,6 +254,10 @@ module.exports = {
                     isJSXNumber(fullNumberNode) ||
                     (ignoreArrayIndexes && isArrayIndex(fullNumberNode, value))
                 ) {
+                    return;
+                }
+
+                if (allowRGBa && isInRGBaArray(value)) {
                     return;
                 }
 

--- a/tests/lib/rules/no-magic-numbers.js
+++ b/tests/lib/rules/no-magic-numbers.js
@@ -902,13 +902,10 @@ ruleTester.run("no-magic-numbers", rule, {
             ]
         },
         {
-
-            // @TODO invalid array
             code: "var x = [255, 255, 1.2];",
             options: [{ allowRGBa: true }],
             env: { es6: true },
             errors: [
-                { messageId: "noMagic", data: { raw: "-5" }, line: 1 },
                 { messageId: "noMagic", data: { raw: "255" }, line: 1 },
                 { messageId: "noMagic", data: { raw: "255" }, line: 1 },
                 { messageId: "noMagic", data: { raw: "1.2" }, line: 1 }

--- a/tests/lib/rules/no-magic-numbers.js
+++ b/tests/lib/rules/no-magic-numbers.js
@@ -812,6 +812,11 @@ ruleTester.run("no-magic-numbers", rule, {
                 { messageId: "noMagic", data: { raw: "1" }, line: 1 },
                 { messageId: "noMagic", data: { raw: "2" }, line: 1 }
             ]
+        },
+        {
+            code: "const color = [0, 155, 255]",
+            options: [{ allowRGBa: true }],
+            env: { es6: true }
         }
     ]
 });

--- a/tests/lib/rules/no-magic-numbers.js
+++ b/tests/lib/rules/no-magic-numbers.js
@@ -257,6 +257,40 @@ ruleTester.run("no-magic-numbers", rule, {
             code: "foo?.[777]",
             options: [{ ignoreArrayIndexes: true }],
             parserOptions: { ecmaVersion: 2020 }
+        },
+
+        // RGBa arrays
+        {
+            code: "var x = [0, 23, 125, 0.5];",
+            options: [{ allowRGBa: true }]
+        },
+        {
+            code: "var x = [14, 0, 255];",
+            options: [{ allowRGBa: true }]
+        },
+        {
+            code: "var x = [0, 0, 0, 1.0];",
+            options: [{ allowRGBa: true }]
+        },
+        {
+            code: "var x = [0, 0, 0, 1];",
+            options: [{ allowRGBa: true }]
+        },
+        {
+            code: "var x = [0, 0, 0, 0];",
+            options: [{ allowRGBa: true }]
+        },
+        {
+            code: "var x = [255, 255, 255, 1.0];",
+            options: [{ allowRGBa: true }]
+        },
+        {
+            code: "var foo = { color: [123, 134, 255, 0.4] }",
+            options: [{ allowRGBa: true }]
+        },
+        {
+            code: "var foo = { color: [123, 134, 255] }",
+            options: [{ allowRGBa: true }]
         }
     ],
     invalid: [
@@ -814,9 +848,71 @@ ruleTester.run("no-magic-numbers", rule, {
             ]
         },
         {
-            code: "const color = [0, 155, 255]",
+            code: "var x = [2, 123, 256];",
             options: [{ allowRGBa: true }],
-            env: { es6: true }
+            env: { es6: true },
+            errors: [
+                { messageId: "noMagic", data: { raw: "2" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "123" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "256" }, line: 1 }
+            ]
+        },
+        {
+            code: "var x = [0, 0, 0, 1.2];",
+            options: [{ allowRGBa: true }],
+            env: { es6: true },
+            errors: [
+                { messageId: "noMagic", data: { raw: "0" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "0" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "0" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "1.2" }, line: 1 }
+            ]
+        },
+        {
+            code: "var x = [255, 255, 255, 1.2];",
+            options: [{ allowRGBa: true }],
+            env: { es6: true },
+            errors: [
+                { messageId: "noMagic", data: { raw: "255" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "255" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "255" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "1.2" }, line: 1 }
+            ]
+        },
+        {
+            code: "var x = [255, 255, 255, -0.1];",
+            options: [{ allowRGBa: true }],
+            env: { es6: true },
+            errors: [
+                { messageId: "noMagic", data: { raw: "255" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "255" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "255" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "-0.1" }, line: 1 }
+            ]
+        },
+        {
+            code: "var x = [-5, 255, 255, 1.2];",
+            options: [{ allowRGBa: true }],
+            env: { es6: true },
+            errors: [
+                { messageId: "noMagic", data: { raw: "-5" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "255" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "255" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "1.2" }, line: 1 }
+            ]
+        },
+        {
+
+            // @TODO invalid array
+            code: "var x = [255, 255, 1.2];",
+            options: [{ allowRGBa: true }],
+            env: { es6: true },
+            errors: [
+                { messageId: "noMagic", data: { raw: "-5" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "255" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "255" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "1.2" }, line: 1 }
+            ]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

It is quite common in working with data visualization libraries to assign default color values as rgba arrays. [deck.gl](https://deck.gl/docs/api-reference/layers/column-layer) is a good example. Working with such a library would require a lot of  disables for the `no-magic-numbers` rule if keeping it on. On the other hand, an array representing a color is quite self-explanatory and moving each channel representation would bloat the codebase with constants declarations or disables.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
I have added `isInRGBaArray` function to the rule to check contents of an array. Also, I have added `allowRGBa` option to the rule configuration and some tests.

#### Is there anything you'd like reviewers to focus on?

**What rule do you want to change?**
This is the change of the `no-magic-numbers` rule

**Does this change cause the rule to produce more or fewer warnings?**
It causes to produce less warnings

**How will the change be implemented? (New option, new default behavior, etc.)?**
There will be a new option in the rule configuration

**Please provide some example code that this change will affect:**

```js
const layer = new ColumnLayer({
    id: 'column-layer',
    getLineColor: [0, 0, 0],
    getFillColor: [255, 255, 255, 0.8]
  });
```

**What does the rule currently do for this code?**
It marks it as invalid

**What will the rule do after it's changed?**
It will treat it as valid

<!-- markdownlint-disable-file MD004 -->
