### PR TITLE
docs: use shorthand property name in example

### DIFF
--- a/docs/src/user-guide/configuring/configuration-files-new.md
+++ b/docs/src/user-guide/configuring/configuration-files-new.md
@@ -360,7 +360,7 @@ export default [
     {
         files: ["**/*.js"],
         plugins: {
-            jsdoc: jsdoc
+            jsdoc
         }
         rules: {
             "jsdoc/require-description": "error",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The text that introduces the relevant config example says "you can also shorten the configuration to this", but in the config example that follows nothing is shorter than in the previous config example. This PR fixes the config example by using a shorthand property name for `jsdoc` (which I'm assuming was the intention).

#### Is there anything you'd like reviewers to focus on?

No.

<!-- markdownlint-disable-file MD004 -->
