### PR TITLE
feat: Single-line and multi-line imports for `padding-line-between-statements` rule

### DIFF
--- a/docs/src/rules/padding-line-between-statements.md
+++ b/docs/src/rules/padding-line-between-statements.md
@@ -79,10 +79,12 @@ You can supply any number of configurations. If a statement pair matches multipl
     * `"multiline-expression"` is expression statements. This is the same as `expression` type, but only if the statement is multiline.
     * `"multiline-let"` is multiline `let` variable declarations.
     * `"multiline-var"` is multiline `var` variable declarations.
+    * `"multiline-import"` is multiline `import` declarations.
     * `"return"` is `return` statements.
     * `"singleline-const"` is single-line `const` variable declarations.
     * `"singleline-let"` is single-line `let` variable declarations.
     * `"singleline-var"` is single-line `var` variable declarations.
+    * `"singleline-import"` is single-line `import` declarations.
     * `"switch"` is `switch` statements.
     * `"throw"` is `throw` statements.
     * `"try"` is `try` statements.

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -391,9 +391,11 @@ const StatementTypes = {
     "multiline-const": newMultilineKeywordTester("const"),
     "multiline-let": newMultilineKeywordTester("let"),
     "multiline-var": newMultilineKeywordTester("var"),
+    "multiline-import": newMultilineKeywordTester("import"),
     "singleline-const": newSinglelineKeywordTester("const"),
     "singleline-let": newSinglelineKeywordTester("let"),
     "singleline-var": newSinglelineKeywordTester("var"),
+    "singleline-import": newSinglelineKeywordTester("import"),
 
     block: newNodeTypeTester("BlockStatement"),
     empty: newNodeTypeTester("EmptyStatement"),

--- a/tests/lib/rules/padding-line-between-statements.js
+++ b/tests/lib/rules/padding-line-between-statements.js
@@ -1168,6 +1168,43 @@ ruleTester.run("padding-line-between-statements", rule, {
         },
 
         //----------------------------------------------------------------------
+        // multiline-import
+        //----------------------------------------------------------------------
+
+        {
+            code: "import {\na,\nb\n} from 'c'\n\nimport d from 'e'",
+            options: [
+                { blankLine: "never", prev: "*", next: "*" },
+                { blankLine: "always", prev: "multiline-import", next: "*" }
+            ],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code: "import a from 'b'\n\nimport{\nc,\nd\n} from 'e'",
+            options: [
+                { blankLine: "never", prev: "*", next: "*" },
+                { blankLine: "always", prev: "*", next: "multiline-import" }
+            ],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code: "import a from 'b'\nimport c from 'd'",
+            options: [
+                { blankLine: "never", prev: "*", next: "*" },
+                { blankLine: "always", prev: "multiline-import", next: "*" }
+            ],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code: "import a from 'b'\nimport c from 'd'",
+            options: [
+                { blankLine: "never", prev: "*", next: "*" },
+                { blankLine: "always", prev: "*", next: "multiline-import" }
+            ],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+
+        //----------------------------------------------------------------------
         // singleline-const
         //----------------------------------------------------------------------
 
@@ -1264,6 +1301,43 @@ ruleTester.run("padding-line-between-statements", rule, {
                 { blankLine: "never", prev: "*", next: "*" },
                 { blankLine: "always", prev: "*", next: "singleline-var" }
             ]
+        },
+
+        //----------------------------------------------------------------------
+        // singleline-import
+        //----------------------------------------------------------------------
+
+        {
+            code: "import a from 'b'\n\nimport b from 'c'",
+            options: [
+                { blankLine: "never", prev: "*", next: "*" },
+                { blankLine: "always", prev: "singleline-import", next: "*" }
+            ],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code: "import a from 'b'\n\nimport b from 'c'",
+            options: [
+                { blankLine: "never", prev: "*", next: "*" },
+                { blankLine: "always", prev: "*", next: "singleline-import" }
+            ],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code: "import {\na,\nb\n} from 'c'\nimport {\nd,\ne\n} from 'f'",
+            options: [
+                { blankLine: "never", prev: "*", next: "*" },
+                { blankLine: "always", prev: "singleline-import", next: "*" }
+            ],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code: "import {\na,\nb\n} from 'c'\nimport {\nd,\ne\n} from 'f'",
+            options: [
+                { blankLine: "never", prev: "*", next: "*" },
+                { blankLine: "always", prev: "*", next: "singleline-import" }
+            ],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
         },
 
         //----------------------------------------------------------------------


### PR DESCRIPTION
Added `singleline-import` and `multiline-import` options for `padding-line-between-statements` rule.

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

`padding-line-between-statements`

**Does this change cause the rule to produce more or fewer warnings?**

More warnings.

**How will the change be implemented? (New option, new default behavior, etc.)?**

Two new options are to be added: `singleline-import` and `multiline-import`

**Please provide some example code that this change will affect:**

Options will handle two additional cases, similar to `singleline-{const,var,let}` and `multiline-{const,var,let}` but for `import` declarations.

```js
// single-line imports
import woof from 'woof';
import { bark } from 'bark';

// multi-line import
import {
  woof,
  bark
} from 'pooque';
```

**What does the rule currently do for this code?**

These new options will add more granularity to `import` declarations. Pretty similar to `singleline-{const,var,let}` and `multiline-{const,var,let}`.

**What will the rule do after it's changed?**

Using options `singleline-import` and `multiline-import` will allow us to handle cases when imports should/n't have a padded line depending on the preference.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I've just added the `import` keyword to multi-line and single-line keyword testers.

<!-- markdownlint-disable-file MD004 -->
