### PR TITLE
feat: Implement caching for FlatESLint

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -436,9 +436,6 @@ function processOptions({
     if (typeof cache !== "boolean") {
         errors.push("'cache' must be a boolean.");
     }
-    if (cache) {
-        errors.push("'cache' option is not yet supported.");
-    }
     if (!isNonEmptyString(cacheLocation)) {
         errors.push("'cacheLocation' must be a non-empty string.");
     }


### PR DESCRIPTION
Refs #13481

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR implements caching for `FlatESLint` by making the following changes:

1. Enabling `cache: true` as an option for `FlatESLint`
2. Adding back all of the caching functionality that was removed for the first developer preview
3. Creating a `toJSON()` method on each config object that will normalize it into a form that is more appropriate for storing in the cache

#### Is there anything you'd like reviewers to focus on?

For now, I throw an error when trying to serialize a config object where either the `parser` or the `processor` are objects instead of strings because it's not clear how best to serialize these. I see the following possible paths forward from here:

1. We ask that parsers and processors publish a `name` property that we can use for caching purposes and otherwise throw an error. This seems like the simplest approach.
2. We disallow objects for `processor` (same as eslintrc) and `parser` (different from eslintrc -- problematic for back compat reasons)
3. We figure out some way to hash a value for objects. Maybe for `parser` we could hash to `toString()` of the `parse()` method, and maybe for processor we could hash the `toString()` of both `preprocess()` and `postprocess()`?



<!-- markdownlint-disable-file MD004 -->
