### PR TITLE
docs: auto-generation edit link

### DIFF
--- a/docs/src/_data/sites/en.yml
+++ b/docs/src/_data/sites/en.yml
@@ -113,5 +113,5 @@ footer:
 #------------------------------------------------------------------------------
 
 edit_link:
-  start_with: https://github.com/eslint/eslint/blob/main/docs/
+  start_with: https://github.com/eslint/eslint/edit/main/docs/
   text: Edit this page

--- a/docs/src/_data/sites/en.yml
+++ b/docs/src/_data/sites/en.yml
@@ -107,3 +107,11 @@ footer:
   actions:
     back_to_home: Back to homepage
     browse_docs: Browse the docs
+
+#------------------------------------------------------------------------------
+# Edit link
+#------------------------------------------------------------------------------
+
+edit_link:
+  start_with: https://github.com/eslint/eslint/blob/main/docs/
+  text: Edit this page

--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -81,7 +81,14 @@ layout: base.html
             </div>
 
             <div class="docs-edit-link">
-                <a href="{{ edit_link }}" class="c-btn c-btn--secondary">Edit this page</a>
+                <a href="
+                {% if edit_link %}
+                    {{ edit_link }}
+                {% else %}
+                    {{ site.edit_link.start_with }}{{ page.inputPath }}
+                {% endif %}
+                "
+                class="c-btn c-btn--secondary">{{ site.edit_link.text }}</a>
             </div>
         </main>
 

--- a/docs/src/about/index.md
+++ b/docs/src/about/index.md
@@ -1,7 +1,6 @@
 ---
 title: About
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/about/index.md
 
 ---
 

--- a/docs/src/developer-guide/architecture/index.md
+++ b/docs/src/developer-guide/architecture/index.md
@@ -1,7 +1,6 @@
 ---
 title: Architecture
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/architecture/index.md
 eleventyNavigation:
     key: architecture
     parent: developer guide

--- a/docs/src/developer-guide/code-conventions.md
+++ b/docs/src/developer-guide/code-conventions.md
@@ -1,7 +1,6 @@
 ---
 title: Code Conventions
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/code-conventions.md
 
 ---
 

--- a/docs/src/developer-guide/code-path-analysis.md
+++ b/docs/src/developer-guide/code-path-analysis.md
@@ -1,7 +1,6 @@
 ---
 title: Code Path Analysis Details
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/code-path-analysis.md
 
 ---
 

--- a/docs/src/developer-guide/contributing/changes.md
+++ b/docs/src/developer-guide/contributing/changes.md
@@ -1,15 +1,14 @@
 ---
 title: Change Requests
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/contributing/changes.md
 
 ---
 
 If you'd like to request a change to ESLint, please [create a new issue](https://github.com/eslint/eslint/issues/new/choose) on GitHub. Be sure to include the following information:
 
 1. The version of ESLint you are using.
-1. The problem you want to solve.
-1. Your take on the correct solution to problem.
+2. The problem you want to solve.
+3. Your take on the correct solution to problem.
 
 If you're requesting a change to a rule, it's helpful to include this information as well:
 

--- a/docs/src/developer-guide/contributing/index.md
+++ b/docs/src/developer-guide/contributing/index.md
@@ -1,7 +1,6 @@
 ---
 title: Contributing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/contributing/index.md
 eleventyNavigation:
     key: contributing
     parent: developer guide

--- a/docs/src/developer-guide/contributing/new-rules.md
+++ b/docs/src/developer-guide/contributing/new-rules.md
@@ -1,7 +1,6 @@
 ---
 title: New Rules
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/contributing/new-rules.md
 
 ---
 

--- a/docs/src/developer-guide/contributing/pull-requests.md
+++ b/docs/src/developer-guide/contributing/pull-requests.md
@@ -1,7 +1,6 @@
 ---
 title: Pull Requests
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/contributing/pull-requests.md
 
 ---
 

--- a/docs/src/developer-guide/contributing/reporting-bugs.md
+++ b/docs/src/developer-guide/contributing/reporting-bugs.md
@@ -1,7 +1,6 @@
 ---
 title: Reporting Bugs
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/contributing/reporting-bugs.md
 
 ---
 

--- a/docs/src/developer-guide/contributing/rule-changes.md
+++ b/docs/src/developer-guide/contributing/rule-changes.md
@@ -1,7 +1,6 @@
 ---
 title: Rule Changes
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/contributing/rule-changes.md
 
 ---
 

--- a/docs/src/developer-guide/contributing/working-on-issues.md
+++ b/docs/src/developer-guide/contributing/working-on-issues.md
@@ -1,7 +1,6 @@
 ---
 title: Working on Issues
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/contributing/working-on-issues.md
 
 ---
 

--- a/docs/src/developer-guide/development-environment.md
+++ b/docs/src/developer-guide/development-environment.md
@@ -1,7 +1,6 @@
 ---
 title: Development Environment
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/development-environment.md
 eleventyNavigation:
     key: set up a development environment
     parent: developer guide

--- a/docs/src/developer-guide/index.md
+++ b/docs/src/developer-guide/index.md
@@ -1,7 +1,6 @@
 ---
 title: Developer Guide
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/index.md
 eleventyNavigation:
     key: developer guide 
     title: Developer Guide 

--- a/docs/src/developer-guide/nodejs-api.md
+++ b/docs/src/developer-guide/nodejs-api.md
@@ -1,7 +1,6 @@
 ---
 title: Node.js API
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/nodejs-api.md
 eleventyNavigation:
     key: node.js api
     parent: developer guide

--- a/docs/src/developer-guide/scope-manager-interface.md
+++ b/docs/src/developer-guide/scope-manager-interface.md
@@ -1,7 +1,6 @@
 ---
 title: ScopeManager
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/scope-manager-interface.md
 
 ---
 

--- a/docs/src/developer-guide/selectors.md
+++ b/docs/src/developer-guide/selectors.md
@@ -1,15 +1,14 @@
 ---
 title: Selectors
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/selectors.md
 
 ---
 
 Some rules and APIs allow the use of selectors to query an AST. This page is intended to:
 
 1. Explain what selectors are
-1. Describe the syntax for creating selectors
-1. Describe what selectors can be used for
+2. Describe the syntax for creating selectors
+3. Describe what selectors can be used for
 
 ## What is a selector?
 

--- a/docs/src/developer-guide/shareable-configs.md
+++ b/docs/src/developer-guide/shareable-configs.md
@@ -1,7 +1,6 @@
 ---
 title: Shareable Configs
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/shareable-configs.md
 eleventyNavigation:
     key: shareable configs
     parent: developer guide

--- a/docs/src/developer-guide/source-code.md
+++ b/docs/src/developer-guide/source-code.md
@@ -1,7 +1,6 @@
 ---
 title: Source Code
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/source-code.md
 eleventyNavigation:
     key: getting the source code
     parent: developer guide

--- a/docs/src/developer-guide/unit-tests.md
+++ b/docs/src/developer-guide/unit-tests.md
@@ -1,7 +1,6 @@
 ---
 title: Unit Tests
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/unit-tests.md
 eleventyNavigation:
     key: run the tests
     parent: developer guide

--- a/docs/src/developer-guide/working-with-custom-formatters.md
+++ b/docs/src/developer-guide/working-with-custom-formatters.md
@@ -1,7 +1,6 @@
 ---
 title: Working with Custom Formatters
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/working-with-custom-formatters.md
 eleventyNavigation:
     key: working with custom formatters
     parent: developer guide

--- a/docs/src/developer-guide/working-with-custom-parsers.md
+++ b/docs/src/developer-guide/working-with-custom-parsers.md
@@ -1,7 +1,6 @@
 ---
 title: Working with Custom Parsers
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/working-with-custom-parsers.md
 eleventyNavigation:
     key: working with custom parsers
     parent: developer guide

--- a/docs/src/developer-guide/working-with-plugins.md
+++ b/docs/src/developer-guide/working-with-plugins.md
@@ -1,7 +1,6 @@
 ---
 title: Working with Plugins
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/working-with-plugins.md
 eleventyNavigation:
     key: working with plugings
     parent: developer guide

--- a/docs/src/developer-guide/working-with-rules-deprecated.md
+++ b/docs/src/developer-guide/working-with-rules-deprecated.md
@@ -1,7 +1,6 @@
 ---
 title: Working with Rules (Deprecated)
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/working-with-rules-deprecated.md
 
 ---
 

--- a/docs/src/developer-guide/working-with-rules.md
+++ b/docs/src/developer-guide/working-with-rules.md
@@ -1,7 +1,6 @@
 ---
 title: Working with Rules
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/developer-guide/working-with-rules.md
 eleventyNavigation:
     key: working with rules
     parent: developer guide

--- a/docs/src/maintainer-guide/governance.md
+++ b/docs/src/maintainer-guide/governance.md
@@ -1,7 +1,6 @@
 ---
 title: Governance
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/maintainer-guide/governance.md
 eleventyNavigation:
     key: governance
     parent: maintainer guide

--- a/docs/src/maintainer-guide/index.md
+++ b/docs/src/maintainer-guide/index.md
@@ -1,7 +1,6 @@
 ---
 title: Maintainer Guide
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/maintainer-guide/index.md
 eleventyNavigation:
     key: maintainer guide 
     title: Maintainer Guide 

--- a/docs/src/maintainer-guide/issues.md
+++ b/docs/src/maintainer-guide/issues.md
@@ -1,7 +1,6 @@
 ---
 title: Managing Issues
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/maintainer-guide/issues.md
 eleventyNavigation:
     key: managing issues
     parent: maintainer guide 

--- a/docs/src/maintainer-guide/pullrequests.md
+++ b/docs/src/maintainer-guide/pullrequests.md
@@ -1,7 +1,6 @@
 ---
 title: Reviewing Pull Requests
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/maintainer-guide/pullrequests.md
 eleventyNavigation:
     key: reviewing pull requests
     parent: maintainer guide 

--- a/docs/src/maintainer-guide/releases.md
+++ b/docs/src/maintainer-guide/releases.md
@@ -1,7 +1,6 @@
 ---
 title: Managing Releases
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/maintainer-guide/releases.md
 eleventyNavigation:
     key: managing releases
     parent: maintainer guide 

--- a/docs/src/maintainer-guide/working-groups.md
+++ b/docs/src/maintainer-guide/working-groups.md
@@ -1,7 +1,6 @@
 ---
 title: Working Groups
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/maintainer-guide/working-groups.md
 
 ---
 

--- a/docs/src/pages/index.md
+++ b/docs/src/pages/index.md
@@ -2,7 +2,6 @@
 title: Documentation
 layout: doc
 permalink: /index.html
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/pages/index.md
 ---
 
 Welcome to our documentation pages! What would you like to view?

--- a/docs/src/rules/accessor-pairs.md
+++ b/docs/src/rules/accessor-pairs.md
@@ -1,7 +1,6 @@
 ---
 title: accessor-pairs
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/accessor-pairs.md
 rule_type: suggestion
 related_rules:
 - no-dupe-keys

--- a/docs/src/rules/array-bracket-newline.md
+++ b/docs/src/rules/array-bracket-newline.md
@@ -1,7 +1,6 @@
 ---
 title: array-bracket-newline
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/array-bracket-newline.md
 rule_type: layout
 related_rules:
 - array-bracket-spacing

--- a/docs/src/rules/array-bracket-spacing.md
+++ b/docs/src/rules/array-bracket-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: array-bracket-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/array-bracket-spacing.md
 rule_type: layout
 related_rules:
 - space-in-parens

--- a/docs/src/rules/array-callback-return.md
+++ b/docs/src/rules/array-callback-return.md
@@ -1,7 +1,6 @@
 ---
 title: array-callback-return
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/array-callback-return.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/array-element-newline.md
+++ b/docs/src/rules/array-element-newline.md
@@ -1,7 +1,6 @@
 ---
 title: array-element-newline
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/array-element-newline.md
 rule_type: layout
 related_rules:
 - array-bracket-spacing

--- a/docs/src/rules/arrow-body-style.md
+++ b/docs/src/rules/arrow-body-style.md
@@ -1,7 +1,6 @@
 ---
 title: arrow-body-style
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/arrow-body-style.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/arrow-parens.md
+++ b/docs/src/rules/arrow-parens.md
@@ -1,7 +1,6 @@
 ---
 title: arrow-parens
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/arrow-parens.md
 rule_type: layout
 further_reading:
 - https://github.com/airbnb/javascript#arrows--one-arg-parens

--- a/docs/src/rules/arrow-spacing.md
+++ b/docs/src/rules/arrow-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: arrow-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/arrow-spacing.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/block-scoped-var.md
+++ b/docs/src/rules/block-scoped-var.md
@@ -1,7 +1,6 @@
 ---
 title: block-scoped-var
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/block-scoped-var.md
 rule_type: suggestion
 further_reading:
 - https://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html

--- a/docs/src/rules/block-spacing.md
+++ b/docs/src/rules/block-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: block-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/block-spacing.md
 rule_type: layout
 related_rules:
 - space-before-blocks

--- a/docs/src/rules/brace-style.md
+++ b/docs/src/rules/brace-style.md
@@ -1,7 +1,6 @@
 ---
 title: brace-style
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/brace-style.md
 rule_type: layout
 related_rules:
 - block-spacing

--- a/docs/src/rules/callback-return.md
+++ b/docs/src/rules/callback-return.md
@@ -1,7 +1,6 @@
 ---
 title: callback-return
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/callback-return.md
 rule_type: suggestion
 related_rules:
 - handle-callback-err

--- a/docs/src/rules/camelcase.md
+++ b/docs/src/rules/camelcase.md
@@ -1,7 +1,6 @@
 ---
 title: camelcase
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/camelcase.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/capitalized-comments.md
+++ b/docs/src/rules/capitalized-comments.md
@@ -1,7 +1,6 @@
 ---
 title: capitalized-comments
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/capitalized-comments.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/class-methods-use-this.md
+++ b/docs/src/rules/class-methods-use-this.md
@@ -1,7 +1,6 @@
 ---
 title: class-methods-use-this
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/class-methods-use-this.md
 rule_type: suggestion
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes

--- a/docs/src/rules/comma-dangle.md
+++ b/docs/src/rules/comma-dangle.md
@@ -1,7 +1,6 @@
 ---
 title: comma-dangle
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/comma-dangle.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/comma-spacing.md
+++ b/docs/src/rules/comma-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: comma-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/comma-spacing.md
 rule_type: layout
 related_rules:
 - array-bracket-spacing

--- a/docs/src/rules/comma-style.md
+++ b/docs/src/rules/comma-style.md
@@ -1,7 +1,6 @@
 ---
 title: comma-style
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/comma-style.md
 rule_type: layout
 related_rules:
 - operator-linebreak

--- a/docs/src/rules/complexity.md
+++ b/docs/src/rules/complexity.md
@@ -1,7 +1,6 @@
 ---
 title: complexity
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/complexity.md
 rule_type: suggestion
 related_rules:
 - max-depth

--- a/docs/src/rules/computed-property-spacing.md
+++ b/docs/src/rules/computed-property-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: computed-property-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/computed-property-spacing.md
 rule_type: layout
 related_rules:
 - array-bracket-spacing

--- a/docs/src/rules/consistent-return.md
+++ b/docs/src/rules/consistent-return.md
@@ -1,7 +1,6 @@
 ---
 title: consistent-return
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/consistent-return.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/consistent-this.md
+++ b/docs/src/rules/consistent-this.md
@@ -1,7 +1,6 @@
 ---
 title: consistent-this
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/consistent-this.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/constructor-super.md
+++ b/docs/src/rules/constructor-super.md
@@ -1,7 +1,6 @@
 ---
 title: constructor-super
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/constructor-super.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/curly.md
+++ b/docs/src/rules/curly.md
@@ -1,7 +1,6 @@
 ---
 title: curly
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/curly.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/default-case-last.md
+++ b/docs/src/rules/default-case-last.md
@@ -1,7 +1,6 @@
 ---
 title: default-case-last
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/default-case-last.md
 rule_type: suggestion
 related_rules:
 - default-case

--- a/docs/src/rules/default-case.md
+++ b/docs/src/rules/default-case.md
@@ -1,7 +1,6 @@
 ---
 title: default-case
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/default-case.md
 rule_type: suggestion
 related_rules:
 - no-fallthrough

--- a/docs/src/rules/default-param-last.md
+++ b/docs/src/rules/default-param-last.md
@@ -1,7 +1,6 @@
 ---
 title: default-param-last
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/default-param-last.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/dot-location.md
+++ b/docs/src/rules/dot-location.md
@@ -1,7 +1,6 @@
 ---
 title: dot-location
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/dot-location.md
 rule_type: layout
 related_rules:
 - newline-after-var

--- a/docs/src/rules/dot-notation.md
+++ b/docs/src/rules/dot-notation.md
@@ -1,7 +1,6 @@
 ---
 title: dot-notation
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/dot-notation.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/eol-last.md
+++ b/docs/src/rules/eol-last.md
@@ -1,7 +1,6 @@
 ---
 title: eol-last
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/eol-last.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/eqeqeq.md
+++ b/docs/src/rules/eqeqeq.md
@@ -1,7 +1,6 @@
 ---
 title: eqeqeq
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/eqeqeq.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/for-direction.md
+++ b/docs/src/rules/for-direction.md
@@ -1,7 +1,6 @@
 ---
 title: for-direction
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/for-direction.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/func-call-spacing.md
+++ b/docs/src/rules/func-call-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: func-call-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/func-call-spacing.md
 rule_type: layout
 related_rules:
 - no-spaced-func

--- a/docs/src/rules/func-name-matching.md
+++ b/docs/src/rules/func-name-matching.md
@@ -1,7 +1,6 @@
 ---
 title: func-name-matching
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/func-name-matching.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/func-names.md
+++ b/docs/src/rules/func-names.md
@@ -1,7 +1,6 @@
 ---
 title: func-names
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/func-names.md
 rule_type: suggestion
 further_reading:
 - https://web.archive.org/web/20201112040809/http://markdaggett.com/blog/2013/02/15/functions-explained/

--- a/docs/src/rules/func-style.md
+++ b/docs/src/rules/func-style.md
@@ -1,7 +1,6 @@
 ---
 title: func-style
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/func-style.md
 rule_type: suggestion
 further_reading:
 - https://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html

--- a/docs/src/rules/function-call-argument-newline.md
+++ b/docs/src/rules/function-call-argument-newline.md
@@ -1,7 +1,6 @@
 ---
 title: function-call-argument-newline
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/function-call-argument-newline.md
 rule_type: layout
 related_rules:
 - function-paren-newline

--- a/docs/src/rules/function-paren-newline.md
+++ b/docs/src/rules/function-paren-newline.md
@@ -1,7 +1,6 @@
 ---
 title: function-paren-newline
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/function-paren-newline.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/generator-star-spacing.md
+++ b/docs/src/rules/generator-star-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: generator-star-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/generator-star-spacing.md
 rule_type: layout
 further_reading:
 - https://leanpub.com/understandinges6/read/#leanpub-auto-generators

--- a/docs/src/rules/generator-star.md
+++ b/docs/src/rules/generator-star.md
@@ -1,7 +1,6 @@
 ---
 title: generator-star
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/generator-star.md
 further_reading:
 - https://leanpub.com/understandinges6/read/#leanpub-auto-generators
 ---

--- a/docs/src/rules/getter-return.md
+++ b/docs/src/rules/getter-return.md
@@ -1,7 +1,6 @@
 ---
 title: getter-return
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/getter-return.md
 rule_type: problem
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get

--- a/docs/src/rules/global-require.md
+++ b/docs/src/rules/global-require.md
@@ -1,7 +1,6 @@
 ---
 title: global-require
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/global-require.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/global-strict.md
+++ b/docs/src/rules/global-strict.md
@@ -1,7 +1,6 @@
 ---
 title: global-strict
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/global-strict.md
 
 ---
 

--- a/docs/src/rules/grouped-accessor-pairs.md
+++ b/docs/src/rules/grouped-accessor-pairs.md
@@ -1,7 +1,6 @@
 ---
 title: grouped-accessor-pairs
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/grouped-accessor-pairs.md
 rule_type: suggestion
 related_rules:
 - accessor-pairs

--- a/docs/src/rules/guard-for-in.md
+++ b/docs/src/rules/guard-for-in.md
@@ -1,7 +1,6 @@
 ---
 title: guard-for-in
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/guard-for-in.md
 rule_type: suggestion
 related_rules:
 - no-prototype-builtins

--- a/docs/src/rules/handle-callback-err.md
+++ b/docs/src/rules/handle-callback-err.md
@@ -1,7 +1,6 @@
 ---
 title: handle-callback-err
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/handle-callback-err.md
 rule_type: suggestion
 further_reading:
 - https://github.com/maxogden/art-of-node#callbacks

--- a/docs/src/rules/id-blacklist.md
+++ b/docs/src/rules/id-blacklist.md
@@ -1,7 +1,6 @@
 ---
 title: id-blacklist
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/id-blacklist.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/id-denylist.md
+++ b/docs/src/rules/id-denylist.md
@@ -1,7 +1,6 @@
 ---
 title: id-denylist
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/id-denylist.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/id-length.md
+++ b/docs/src/rules/id-length.md
@@ -1,7 +1,6 @@
 ---
 title: id-length
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/id-length.md
 rule_type: suggestion
 related_rules:
 - max-len

--- a/docs/src/rules/id-match.md
+++ b/docs/src/rules/id-match.md
@@ -1,7 +1,6 @@
 ---
 title: id-match
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/id-match.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/implicit-arrow-linebreak.md
+++ b/docs/src/rules/implicit-arrow-linebreak.md
@@ -1,7 +1,6 @@
 ---
 title: implicit-arrow-linebreak
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/implicit-arrow-linebreak.md
 rule_type: layout
 related_rules:
 - brace-style

--- a/docs/src/rules/indent-legacy.md
+++ b/docs/src/rules/indent-legacy.md
@@ -1,7 +1,6 @@
 ---
 title: indent-legacy
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/indent-legacy.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/indent.md
+++ b/docs/src/rules/indent.md
@@ -1,7 +1,6 @@
 ---
 title: indent
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/indent.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/init-declarations.md
+++ b/docs/src/rules/init-declarations.md
@@ -1,7 +1,6 @@
 ---
 title: init-declarations
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/init-declarations.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/jsx-quotes.md
+++ b/docs/src/rules/jsx-quotes.md
@@ -1,7 +1,6 @@
 ---
 title: jsx-quotes
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/jsx-quotes.md
 rule_type: layout
 related_rules:
 - quotes

--- a/docs/src/rules/key-spacing.md
+++ b/docs/src/rules/key-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: key-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/key-spacing.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/keyword-spacing.md
+++ b/docs/src/rules/keyword-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: keyword-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/keyword-spacing.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/line-comment-position.md
+++ b/docs/src/rules/line-comment-position.md
@@ -1,7 +1,6 @@
 ---
 title: line-comment-position
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/line-comment-position.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/linebreak-style.md
+++ b/docs/src/rules/linebreak-style.md
@@ -1,7 +1,6 @@
 ---
 title: linebreak-style
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/linebreak-style.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/lines-around-comment.md
+++ b/docs/src/rules/lines-around-comment.md
@@ -1,7 +1,6 @@
 ---
 title: lines-around-comment
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/lines-around-comment.md
 rule_type: layout
 related_rules:
 - space-before-blocks

--- a/docs/src/rules/lines-around-directive.md
+++ b/docs/src/rules/lines-around-directive.md
@@ -1,7 +1,6 @@
 ---
 title: lines-around-directive
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/lines-around-directive.md
 rule_type: layout
 related_rules:
 - lines-around-comment

--- a/docs/src/rules/lines-between-class-members.md
+++ b/docs/src/rules/lines-between-class-members.md
@@ -1,7 +1,6 @@
 ---
 title: lines-between-class-members
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/lines-between-class-members.md
 rule_type: layout
 related_rules:
 - padded-blocks

--- a/docs/src/rules/max-classes-per-file.md
+++ b/docs/src/rules/max-classes-per-file.md
@@ -1,7 +1,6 @@
 ---
 title: max-classes-per-file
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/max-classes-per-file.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/max-depth.md
+++ b/docs/src/rules/max-depth.md
@@ -1,7 +1,6 @@
 ---
 title: max-depth
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/max-depth.md
 rule_type: suggestion
 related_rules:
 - complexity

--- a/docs/src/rules/max-len.md
+++ b/docs/src/rules/max-len.md
@@ -1,7 +1,6 @@
 ---
 title: max-len
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/max-len.md
 rule_type: layout
 related_rules:
 - complexity

--- a/docs/src/rules/max-lines-per-function.md
+++ b/docs/src/rules/max-lines-per-function.md
@@ -1,7 +1,6 @@
 ---
 title: max-lines-per-function
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/max-lines-per-function.md
 rule_type: suggestion
 related_rules:
 - complexity

--- a/docs/src/rules/max-lines.md
+++ b/docs/src/rules/max-lines.md
@@ -1,7 +1,6 @@
 ---
 title: max-lines
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/max-lines.md
 rule_type: suggestion
 related_rules:
 - complexity

--- a/docs/src/rules/max-nested-callbacks.md
+++ b/docs/src/rules/max-nested-callbacks.md
@@ -1,7 +1,6 @@
 ---
 title: max-nested-callbacks
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/max-nested-callbacks.md
 rule_type: suggestion
 related_rules:
 - complexity

--- a/docs/src/rules/max-params.md
+++ b/docs/src/rules/max-params.md
@@ -1,7 +1,6 @@
 ---
 title: max-params
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/max-params.md
 rule_type: suggestion
 related_rules:
 - complexity

--- a/docs/src/rules/max-statements-per-line.md
+++ b/docs/src/rules/max-statements-per-line.md
@@ -1,7 +1,6 @@
 ---
 title: max-statements-per-line
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/max-statements-per-line.md
 rule_type: layout
 related_rules:
 - max-depth

--- a/docs/src/rules/max-statements.md
+++ b/docs/src/rules/max-statements.md
@@ -1,7 +1,6 @@
 ---
 title: max-statements
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/max-statements.md
 rule_type: suggestion
 related_rules:
 - complexity

--- a/docs/src/rules/multiline-comment-style.md
+++ b/docs/src/rules/multiline-comment-style.md
@@ -1,7 +1,6 @@
 ---
 title: multiline-comment-style
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/multiline-comment-style.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/multiline-ternary.md
+++ b/docs/src/rules/multiline-ternary.md
@@ -1,7 +1,6 @@
 ---
 title: multiline-ternary
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/multiline-ternary.md
 rule_type: layout
 related_rules:
 - operator-linebreak

--- a/docs/src/rules/new-cap.md
+++ b/docs/src/rules/new-cap.md
@@ -1,7 +1,6 @@
 ---
 title: new-cap
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/new-cap.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/new-parens.md
+++ b/docs/src/rules/new-parens.md
@@ -1,7 +1,6 @@
 ---
 title: new-parens
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/new-parens.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/newline-after-var.md
+++ b/docs/src/rules/newline-after-var.md
@@ -1,7 +1,6 @@
 ---
 title: newline-after-var
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/newline-after-var.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/newline-before-return.md
+++ b/docs/src/rules/newline-before-return.md
@@ -1,7 +1,6 @@
 ---
 title: newline-before-return
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/newline-before-return.md
 rule_type: layout
 related_rules:
 - newline-after-var

--- a/docs/src/rules/newline-per-chained-call.md
+++ b/docs/src/rules/newline-per-chained-call.md
@@ -1,7 +1,6 @@
 ---
 title: newline-per-chained-call
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/newline-per-chained-call.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/no-alert.md
+++ b/docs/src/rules/no-alert.md
@@ -1,7 +1,6 @@
 ---
 title: no-alert
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-alert.md
 rule_type: suggestion
 related_rules:
 - no-console

--- a/docs/src/rules/no-array-constructor.md
+++ b/docs/src/rules/no-array-constructor.md
@@ -1,7 +1,6 @@
 ---
 title: no-array-constructor
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-array-constructor.md
 rule_type: suggestion
 related_rules:
 - no-new-object

--- a/docs/src/rules/no-arrow-condition.md
+++ b/docs/src/rules/no-arrow-condition.md
@@ -1,7 +1,6 @@
 ---
 title: no-arrow-condition
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-arrow-condition.md
 
 related_rules:
 - arrow-parens

--- a/docs/src/rules/no-async-promise-executor.md
+++ b/docs/src/rules/no-async-promise-executor.md
@@ -1,7 +1,6 @@
 ---
 title: no-async-promise-executor
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-async-promise-executor.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-await-in-loop.md
+++ b/docs/src/rules/no-await-in-loop.md
@@ -1,7 +1,6 @@
 ---
 title: no-await-in-loop
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-await-in-loop.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-bitwise.md
+++ b/docs/src/rules/no-bitwise.md
@@ -1,7 +1,6 @@
 ---
 title: no-bitwise
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-bitwise.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-buffer-constructor.md
+++ b/docs/src/rules/no-buffer-constructor.md
@@ -1,7 +1,6 @@
 ---
 title: no-buffer-constructor
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-buffer-constructor.md
 rule_type: problem
 further_reading:
 - https://nodejs.org/api/buffer.html

--- a/docs/src/rules/no-caller.md
+++ b/docs/src/rules/no-caller.md
@@ -1,7 +1,6 @@
 ---
 title: no-caller
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-caller.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-case-declarations.md
+++ b/docs/src/rules/no-case-declarations.md
@@ -1,7 +1,6 @@
 ---
 title: no-case-declarations
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-case-declarations.md
 rule_type: suggestion
 related_rules:
 - no-fallthrough

--- a/docs/src/rules/no-catch-shadow.md
+++ b/docs/src/rules/no-catch-shadow.md
@@ -1,7 +1,6 @@
 ---
 title: no-catch-shadow
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-catch-shadow.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-class-assign.md
+++ b/docs/src/rules/no-class-assign.md
@@ -1,7 +1,6 @@
 ---
 title: no-class-assign
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-class-assign.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-comma-dangle.md
+++ b/docs/src/rules/no-comma-dangle.md
@@ -1,7 +1,6 @@
 ---
 title: no-comma-dangle
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-comma-dangle.md
 
 ---
 

--- a/docs/src/rules/no-compare-neg-zero.md
+++ b/docs/src/rules/no-compare-neg-zero.md
@@ -1,7 +1,6 @@
 ---
 title: no-compare-neg-zero
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-compare-neg-zero.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-cond-assign.md
+++ b/docs/src/rules/no-cond-assign.md
@@ -1,7 +1,6 @@
 ---
 title: no-cond-assign
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-cond-assign.md
 rule_type: problem
 related_rules:
 - no-extra-parens

--- a/docs/src/rules/no-confusing-arrow.md
+++ b/docs/src/rules/no-confusing-arrow.md
@@ -1,7 +1,6 @@
 ---
 title: no-confusing-arrow
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-confusing-arrow.md
 rule_type: suggestion
 related_rules:
 - no-constant-condition

--- a/docs/src/rules/no-console.md
+++ b/docs/src/rules/no-console.md
@@ -1,7 +1,6 @@
 ---
 title: no-console
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-console.md
 rule_type: suggestion
 related_rules:
 - no-alert

--- a/docs/src/rules/no-const-assign.md
+++ b/docs/src/rules/no-const-assign.md
@@ -1,7 +1,6 @@
 ---
 title: no-const-assign
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-const-assign.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-constant-binary-expression.md
+++ b/docs/src/rules/no-constant-binary-expression.md
@@ -1,7 +1,6 @@
 ---
 title: no-constant-binary-expression
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-constant-binary-expression.md
 rule_type: problem
 related_rules:
 - no-constant-condition

--- a/docs/src/rules/no-constant-condition.md
+++ b/docs/src/rules/no-constant-condition.md
@@ -1,7 +1,6 @@
 ---
 title: no-constant-condition
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-constant-condition.md
 rule_type: problem
 related_rules:
 - no-constant-binary-expression

--- a/docs/src/rules/no-constructor-return.md
+++ b/docs/src/rules/no-constructor-return.md
@@ -1,7 +1,6 @@
 ---
 title: no-constructor-return
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-constructor-return.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-continue.md
+++ b/docs/src/rules/no-continue.md
@@ -1,7 +1,6 @@
 ---
 title: no-continue
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-continue.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-control-regex.md
+++ b/docs/src/rules/no-control-regex.md
@@ -1,7 +1,6 @@
 ---
 title: no-control-regex
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-control-regex.md
 rule_type: problem
 related_rules:
 - no-div-regex

--- a/docs/src/rules/no-debugger.md
+++ b/docs/src/rules/no-debugger.md
@@ -1,7 +1,6 @@
 ---
 title: no-debugger
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-debugger.md
 rule_type: problem
 related_rules:
 - no-alert

--- a/docs/src/rules/no-delete-var.md
+++ b/docs/src/rules/no-delete-var.md
@@ -1,7 +1,6 @@
 ---
 title: no-delete-var
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-delete-var.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-div-regex.md
+++ b/docs/src/rules/no-div-regex.md
@@ -1,7 +1,6 @@
 ---
 title: no-div-regex
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-div-regex.md
 rule_type: suggestion
 related_rules:
 - no-control-regex

--- a/docs/src/rules/no-dupe-args.md
+++ b/docs/src/rules/no-dupe-args.md
@@ -1,7 +1,6 @@
 ---
 title: no-dupe-args
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-dupe-args.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -1,7 +1,6 @@
 ---
 title: no-dupe-class-members
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-dupe-class-members.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-dupe-else-if.md
+++ b/docs/src/rules/no-dupe-else-if.md
@@ -1,7 +1,6 @@
 ---
 title: no-dupe-else-if
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-dupe-else-if.md
 rule_type: problem
 related_rules:
 - no-duplicate-case

--- a/docs/src/rules/no-dupe-keys.md
+++ b/docs/src/rules/no-dupe-keys.md
@@ -1,7 +1,6 @@
 ---
 title: no-dupe-keys
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-dupe-keys.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-duplicate-case.md
+++ b/docs/src/rules/no-duplicate-case.md
@@ -1,7 +1,6 @@
 ---
 title: no-duplicate-case
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-duplicate-case.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-duplicate-imports.md
+++ b/docs/src/rules/no-duplicate-imports.md
@@ -1,7 +1,6 @@
 ---
 title: no-duplicate-imports
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-duplicate-imports.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-else-return.md
+++ b/docs/src/rules/no-else-return.md
@@ -1,7 +1,6 @@
 ---
 title: no-else-return
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-else-return.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-empty-character-class.md
+++ b/docs/src/rules/no-empty-character-class.md
@@ -1,7 +1,6 @@
 ---
 title: no-empty-character-class
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-empty-character-class.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-empty-class.md
+++ b/docs/src/rules/no-empty-class.md
@@ -1,7 +1,6 @@
 ---
 title: no-empty-class
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-empty-class.md
 
 ---
 

--- a/docs/src/rules/no-empty-function.md
+++ b/docs/src/rules/no-empty-function.md
@@ -1,7 +1,6 @@
 ---
 title: no-empty-function
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-empty-function.md
 rule_type: suggestion
 related_rules:
 - no-empty

--- a/docs/src/rules/no-empty-label.md
+++ b/docs/src/rules/no-empty-label.md
@@ -1,7 +1,6 @@
 ---
 title: no-empty-label
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-empty-label.md
 
 related_rules:
 - no-labels

--- a/docs/src/rules/no-empty-pattern.md
+++ b/docs/src/rules/no-empty-pattern.md
@@ -1,7 +1,6 @@
 ---
 title: no-empty-pattern
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-empty-pattern.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-empty.md
+++ b/docs/src/rules/no-empty.md
@@ -1,7 +1,6 @@
 ---
 title: no-empty
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-empty.md
 rule_type: suggestion
 related_rules:
 - no-empty-function

--- a/docs/src/rules/no-eq-null.md
+++ b/docs/src/rules/no-eq-null.md
@@ -1,7 +1,6 @@
 ---
 title: no-eq-null
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-eq-null.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-eval.md
+++ b/docs/src/rules/no-eval.md
@@ -1,7 +1,6 @@
 ---
 title: no-eval
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-eval.md
 rule_type: suggestion
 related_rules:
 - no-implied-eval

--- a/docs/src/rules/no-ex-assign.md
+++ b/docs/src/rules/no-ex-assign.md
@@ -1,7 +1,6 @@
 ---
 title: no-ex-assign
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-ex-assign.md
 rule_type: problem
 further_reading:
 - https://bocoup.com/blog/the-catch-with-try-catch

--- a/docs/src/rules/no-extend-native.md
+++ b/docs/src/rules/no-extend-native.md
@@ -1,7 +1,6 @@
 ---
 title: no-extend-native
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-extend-native.md
 rule_type: suggestion
 related_rules:
 - no-global-assign

--- a/docs/src/rules/no-extra-bind.md
+++ b/docs/src/rules/no-extra-bind.md
@@ -1,7 +1,6 @@
 ---
 title: no-extra-bind
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-extra-bind.md
 rule_type: suggestion
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind

--- a/docs/src/rules/no-extra-boolean-cast.md
+++ b/docs/src/rules/no-extra-boolean-cast.md
@@ -1,7 +1,6 @@
 ---
 title: no-extra-boolean-cast
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-extra-boolean-cast.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-extra-label.md
+++ b/docs/src/rules/no-extra-label.md
@@ -1,7 +1,6 @@
 ---
 title: no-extra-label
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-extra-label.md
 rule_type: suggestion
 related_rules:
 - no-labels

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -1,7 +1,6 @@
 ---
 title: no-extra-parens
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-extra-parens.md
 rule_type: layout
 related_rules:
 - arrow-parens

--- a/docs/src/rules/no-extra-semi.md
+++ b/docs/src/rules/no-extra-semi.md
@@ -1,7 +1,6 @@
 ---
 title: no-extra-semi
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-extra-semi.md
 rule_type: suggestion
 related_rules:
 - semi

--- a/docs/src/rules/no-extra-strict.md
+++ b/docs/src/rules/no-extra-strict.md
@@ -1,7 +1,6 @@
 ---
 title: no-extra-strict
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-extra-strict.md
 
 further_reading:
 - https://es5.github.io/#C

--- a/docs/src/rules/no-fallthrough.md
+++ b/docs/src/rules/no-fallthrough.md
@@ -1,7 +1,6 @@
 ---
 title: no-fallthrough
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-fallthrough.md
 rule_type: problem
 related_rules:
 - default-case

--- a/docs/src/rules/no-floating-decimal.md
+++ b/docs/src/rules/no-floating-decimal.md
@@ -1,7 +1,6 @@
 ---
 title: no-floating-decimal
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-floating-decimal.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-func-assign.md
+++ b/docs/src/rules/no-func-assign.md
@@ -1,7 +1,6 @@
 ---
 title: no-func-assign
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-func-assign.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-global-assign.md
+++ b/docs/src/rules/no-global-assign.md
@@ -1,7 +1,6 @@
 ---
 title: no-global-assign
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-global-assign.md
 rule_type: suggestion
 related_rules:
 - no-extend-native

--- a/docs/src/rules/no-implicit-coercion.md
+++ b/docs/src/rules/no-implicit-coercion.md
@@ -1,7 +1,6 @@
 ---
 title: no-implicit-coercion
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-implicit-coercion.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-implicit-globals.md
+++ b/docs/src/rules/no-implicit-globals.md
@@ -1,7 +1,6 @@
 ---
 title: no-implicit-globals
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-implicit-globals.md
 rule_type: suggestion
 related_rules:
 - no-undef

--- a/docs/src/rules/no-implied-eval.md
+++ b/docs/src/rules/no-implied-eval.md
@@ -1,7 +1,6 @@
 ---
 title: no-implied-eval
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-implied-eval.md
 rule_type: suggestion
 related_rules:
 - no-eval

--- a/docs/src/rules/no-import-assign.md
+++ b/docs/src/rules/no-import-assign.md
@@ -1,7 +1,6 @@
 ---
 title: no-import-assign
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-import-assign.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-inline-comments.md
+++ b/docs/src/rules/no-inline-comments.md
@@ -1,7 +1,6 @@
 ---
 title: no-inline-comments
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-inline-comments.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-inner-declarations.md
+++ b/docs/src/rules/no-inner-declarations.md
@@ -1,7 +1,6 @@
 ---
 title: no-inner-declarations
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-inner-declarations.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-invalid-regexp.md
+++ b/docs/src/rules/no-invalid-regexp.md
@@ -1,7 +1,6 @@
 ---
 title: no-invalid-regexp
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-invalid-regexp.md
 rule_type: problem
 further_reading:
 - https://es5.github.io/#x7.8.5

--- a/docs/src/rules/no-invalid-this.md
+++ b/docs/src/rules/no-invalid-this.md
@@ -1,7 +1,6 @@
 ---
 title: no-invalid-this
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-invalid-this.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-irregular-whitespace.md
+++ b/docs/src/rules/no-irregular-whitespace.md
@@ -1,7 +1,6 @@
 ---
 title: no-irregular-whitespace
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-irregular-whitespace.md
 rule_type: problem
 further_reading:
 - https://es5.github.io/#x7.2

--- a/docs/src/rules/no-iterator.md
+++ b/docs/src/rules/no-iterator.md
@@ -1,7 +1,6 @@
 ---
 title: no-iterator
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-iterator.md
 rule_type: suggestion
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators

--- a/docs/src/rules/no-label-var.md
+++ b/docs/src/rules/no-label-var.md
@@ -1,7 +1,6 @@
 ---
 title: no-label-var
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-label-var.md
 rule_type: suggestion
 related_rules:
 - no-extra-label

--- a/docs/src/rules/no-labels.md
+++ b/docs/src/rules/no-labels.md
@@ -1,7 +1,6 @@
 ---
 title: no-labels
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-labels.md
 rule_type: suggestion
 related_rules:
 - no-extra-label

--- a/docs/src/rules/no-lone-blocks.md
+++ b/docs/src/rules/no-lone-blocks.md
@@ -1,7 +1,6 @@
 ---
 title: no-lone-blocks
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-lone-blocks.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-lonely-if.md
+++ b/docs/src/rules/no-lonely-if.md
@@ -1,7 +1,6 @@
 ---
 title: no-lonely-if
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-lonely-if.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-loop-func.md
+++ b/docs/src/rules/no-loop-func.md
@@ -1,7 +1,6 @@
 ---
 title: no-loop-func
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-loop-func.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-loss-of-precision.md
+++ b/docs/src/rules/no-loss-of-precision.md
@@ -1,7 +1,6 @@
 ---
 title: no-loss-of-precision
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-loss-of-precision.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-magic-numbers.md
+++ b/docs/src/rules/no-magic-numbers.md
@@ -1,7 +1,6 @@
 ---
 title: no-magic-numbers
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-magic-numbers.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-misleading-character-class.md
+++ b/docs/src/rules/no-misleading-character-class.md
@@ -1,7 +1,6 @@
 ---
 title: no-misleading-character-class
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-misleading-character-class.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-mixed-operators.md
+++ b/docs/src/rules/no-mixed-operators.md
@@ -1,7 +1,6 @@
 ---
 title: no-mixed-operators
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-mixed-operators.md
 rule_type: suggestion
 related_rules:
 - no-extra-parens

--- a/docs/src/rules/no-mixed-requires.md
+++ b/docs/src/rules/no-mixed-requires.md
@@ -1,7 +1,6 @@
 ---
 title: no-mixed-requires
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-mixed-requires.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-mixed-spaces-and-tabs.md
+++ b/docs/src/rules/no-mixed-spaces-and-tabs.md
@@ -1,7 +1,6 @@
 ---
 title: no-mixed-spaces-and-tabs
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-mixed-spaces-and-tabs.md
 rule_type: layout
 further_reading:
 - https://www.emacswiki.org/emacs/SmartTabs

--- a/docs/src/rules/no-multi-assign.md
+++ b/docs/src/rules/no-multi-assign.md
@@ -1,7 +1,6 @@
 ---
 title: no-multi-assign
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-multi-assign.md
 rule_type: suggestion
 related_rules:
 - max-statements-per-line

--- a/docs/src/rules/no-multi-spaces.md
+++ b/docs/src/rules/no-multi-spaces.md
@@ -1,7 +1,6 @@
 ---
 title: no-multi-spaces
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-multi-spaces.md
 rule_type: layout
 related_rules:
 - key-spacing

--- a/docs/src/rules/no-multi-str.md
+++ b/docs/src/rules/no-multi-str.md
@@ -1,7 +1,6 @@
 ---
 title: no-multi-str
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-multi-str.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-multiple-empty-lines.md
+++ b/docs/src/rules/no-multiple-empty-lines.md
@@ -1,7 +1,6 @@
 ---
 title: no-multiple-empty-lines
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-multiple-empty-lines.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/no-native-reassign.md
+++ b/docs/src/rules/no-native-reassign.md
@@ -1,7 +1,6 @@
 ---
 title: no-native-reassign
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-native-reassign.md
 rule_type: suggestion
 related_rules:
 - no-extend-native

--- a/docs/src/rules/no-negated-condition.md
+++ b/docs/src/rules/no-negated-condition.md
@@ -1,7 +1,6 @@
 ---
 title: no-negated-condition
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-negated-condition.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-negated-in-lhs.md
+++ b/docs/src/rules/no-negated-in-lhs.md
@@ -1,7 +1,6 @@
 ---
 title: no-negated-in-lhs
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-negated-in-lhs.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-nested-ternary.md
+++ b/docs/src/rules/no-nested-ternary.md
@@ -1,7 +1,6 @@
 ---
 title: no-nested-ternary
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-nested-ternary.md
 rule_type: suggestion
 related_rules:
 - no-ternary

--- a/docs/src/rules/no-new-func.md
+++ b/docs/src/rules/no-new-func.md
@@ -1,7 +1,6 @@
 ---
 title: no-new-func
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-new-func.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-new-object.md
+++ b/docs/src/rules/no-new-object.md
@@ -1,7 +1,6 @@
 ---
 title: no-new-object
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-new-object.md
 rule_type: suggestion
 related_rules:
 - no-array-constructor

--- a/docs/src/rules/no-new-require.md
+++ b/docs/src/rules/no-new-require.md
@@ -1,7 +1,6 @@
 ---
 title: no-new-require
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-new-require.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-new-symbol.md
+++ b/docs/src/rules/no-new-symbol.md
@@ -1,7 +1,6 @@
 ---
 title: no-new-symbol
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-new-symbol.md
 rule_type: problem
 further_reading:
 - https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects

--- a/docs/src/rules/no-new-wrappers.md
+++ b/docs/src/rules/no-new-wrappers.md
@@ -1,7 +1,6 @@
 ---
 title: no-new-wrappers
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-new-wrappers.md
 rule_type: suggestion
 related_rules:
 - no-array-constructor

--- a/docs/src/rules/no-new.md
+++ b/docs/src/rules/no-new.md
@@ -1,7 +1,6 @@
 ---
 title: no-new
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-new.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-nonoctal-decimal-escape.md
+++ b/docs/src/rules/no-nonoctal-decimal-escape.md
@@ -1,7 +1,6 @@
 ---
 title: no-nonoctal-decimal-escape
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-nonoctal-decimal-escape.md
 rule_type: suggestion
 related_rules:
 - no-octal-escape

--- a/docs/src/rules/no-obj-calls.md
+++ b/docs/src/rules/no-obj-calls.md
@@ -1,7 +1,6 @@
 ---
 title: no-obj-calls
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-obj-calls.md
 rule_type: problem
 further_reading:
 - https://es5.github.io/#x15.8

--- a/docs/src/rules/no-octal-escape.md
+++ b/docs/src/rules/no-octal-escape.md
@@ -1,7 +1,6 @@
 ---
 title: no-octal-escape
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-octal-escape.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-octal.md
+++ b/docs/src/rules/no-octal.md
@@ -1,7 +1,6 @@
 ---
 title: no-octal
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-octal.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-param-reassign.md
+++ b/docs/src/rules/no-param-reassign.md
@@ -1,7 +1,6 @@
 ---
 title: no-param-reassign
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-param-reassign.md
 rule_type: suggestion
 further_reading:
 - https://spin.atomicobject.com/2011/04/10/javascript-don-t-reassign-your-function-arguments/

--- a/docs/src/rules/no-path-concat.md
+++ b/docs/src/rules/no-path-concat.md
@@ -1,7 +1,6 @@
 ---
 title: no-path-concat
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-path-concat.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-plusplus.md
+++ b/docs/src/rules/no-plusplus.md
@@ -1,7 +1,6 @@
 ---
 title: no-plusplus
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-plusplus.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-process-env.md
+++ b/docs/src/rules/no-process-env.md
@@ -1,7 +1,6 @@
 ---
 title: no-process-env
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-process-env.md
 rule_type: suggestion
 further_reading:
 - https://stackoverflow.com/questions/5869216/how-to-store-node-js-deployment-settings-configuration-files

--- a/docs/src/rules/no-process-exit.md
+++ b/docs/src/rules/no-process-exit.md
@@ -1,7 +1,6 @@
 ---
 title: no-process-exit
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-process-exit.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-promise-executor-return.md
+++ b/docs/src/rules/no-promise-executor-return.md
@@ -1,7 +1,6 @@
 ---
 title: no-promise-executor-return
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-promise-executor-return.md
 rule_type: problem
 related_rules:
 - no-async-promise-executor

--- a/docs/src/rules/no-proto.md
+++ b/docs/src/rules/no-proto.md
@@ -1,7 +1,6 @@
 ---
 title: no-proto
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-proto.md
 rule_type: suggestion
 further_reading:
 - https://johnresig.com/blog/objectgetprototypeof/

--- a/docs/src/rules/no-prototype-builtins.md
+++ b/docs/src/rules/no-prototype-builtins.md
@@ -1,7 +1,6 @@
 ---
 title: no-prototype-builtins
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-prototype-builtins.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-redeclare.md
+++ b/docs/src/rules/no-redeclare.md
@@ -1,7 +1,6 @@
 ---
 title: no-redeclare
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-redeclare.md
 rule_type: suggestion
 related_rules:
 - no-shadow

--- a/docs/src/rules/no-regex-spaces.md
+++ b/docs/src/rules/no-regex-spaces.md
@@ -1,7 +1,6 @@
 ---
 title: no-regex-spaces
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-regex-spaces.md
 rule_type: suggestion
 related_rules:
 - no-div-regex

--- a/docs/src/rules/no-reserved-keys.md
+++ b/docs/src/rules/no-reserved-keys.md
@@ -1,7 +1,6 @@
 ---
 title: no-reserved-keys
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-reserved-keys.md
 
 further_reading:
 - https://kangax.github.io/compat-table/es5/#Reserved_words_as_property_names

--- a/docs/src/rules/no-restricted-exports.md
+++ b/docs/src/rules/no-restricted-exports.md
@@ -1,7 +1,6 @@
 ---
 title: no-restricted-exports
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-restricted-exports.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-restricted-globals.md
+++ b/docs/src/rules/no-restricted-globals.md
@@ -1,7 +1,6 @@
 ---
 title: no-restricted-globals
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-restricted-globals.md
 rule_type: suggestion
 related_rules:
 - no-restricted-properties

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -1,7 +1,6 @@
 ---
 title: no-restricted-imports
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-restricted-imports.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-restricted-modules.md
+++ b/docs/src/rules/no-restricted-modules.md
@@ -1,7 +1,6 @@
 ---
 title: no-restricted-modules
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-restricted-modules.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-restricted-properties.md
+++ b/docs/src/rules/no-restricted-properties.md
@@ -1,7 +1,6 @@
 ---
 title: no-restricted-properties
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-restricted-properties.md
 rule_type: suggestion
 related_rules:
 - no-restricted-globals

--- a/docs/src/rules/no-restricted-syntax.md
+++ b/docs/src/rules/no-restricted-syntax.md
@@ -1,7 +1,6 @@
 ---
 title: no-restricted-syntax
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-restricted-syntax.md
 rule_type: suggestion
 related_rules:
 - no-alert

--- a/docs/src/rules/no-return-assign.md
+++ b/docs/src/rules/no-return-assign.md
@@ -1,7 +1,6 @@
 ---
 title: no-return-assign
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-return-assign.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -1,7 +1,6 @@
 ---
 title: no-return-await
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-return-await.md
 rule_type: suggestion
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function

--- a/docs/src/rules/no-script-url.md
+++ b/docs/src/rules/no-script-url.md
@@ -1,7 +1,6 @@
 ---
 title: no-script-url
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-script-url.md
 rule_type: suggestion
 further_reading:
 - https://stackoverflow.com/questions/13497971/what-is-the-matter-with-script-targeted-urls

--- a/docs/src/rules/no-self-assign.md
+++ b/docs/src/rules/no-self-assign.md
@@ -1,7 +1,6 @@
 ---
 title: no-self-assign
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-self-assign.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-self-compare.md
+++ b/docs/src/rules/no-self-compare.md
@@ -1,7 +1,6 @@
 ---
 title: no-self-compare
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-self-compare.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-sequences.md
+++ b/docs/src/rules/no-sequences.md
@@ -1,7 +1,6 @@
 ---
 title: no-sequences
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-sequences.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-setter-return.md
+++ b/docs/src/rules/no-setter-return.md
@@ -1,7 +1,6 @@
 ---
 title: no-setter-return
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-setter-return.md
 rule_type: problem
 related_rules:
 - getter-return

--- a/docs/src/rules/no-shadow-restricted-names.md
+++ b/docs/src/rules/no-shadow-restricted-names.md
@@ -1,7 +1,6 @@
 ---
 title: no-shadow-restricted-names
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-shadow-restricted-names.md
 rule_type: suggestion
 related_rules:
 - no-shadow

--- a/docs/src/rules/no-shadow.md
+++ b/docs/src/rules/no-shadow.md
@@ -1,7 +1,6 @@
 ---
 title: no-shadow
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-shadow.md
 rule_type: suggestion
 related_rules:
 - no-shadow-restricted-names

--- a/docs/src/rules/no-space-before-semi.md
+++ b/docs/src/rules/no-space-before-semi.md
@@ -1,7 +1,6 @@
 ---
 title: no-space-before-semi
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-space-before-semi.md
 
 related_rules:
 - semi

--- a/docs/src/rules/no-spaced-func.md
+++ b/docs/src/rules/no-spaced-func.md
@@ -1,7 +1,6 @@
 ---
 title: no-spaced-func
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-spaced-func.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/no-sparse-arrays.md
+++ b/docs/src/rules/no-sparse-arrays.md
@@ -1,7 +1,6 @@
 ---
 title: no-sparse-arrays
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-sparse-arrays.md
 rule_type: problem
 further_reading:
 - https://www.nczonline.net/blog/2007/09/09/inconsistent-array-literals/

--- a/docs/src/rules/no-sync.md
+++ b/docs/src/rules/no-sync.md
@@ -1,7 +1,6 @@
 ---
 title: no-sync
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-sync.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-tabs.md
+++ b/docs/src/rules/no-tabs.md
@@ -1,7 +1,6 @@
 ---
 title: no-tabs
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-tabs.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/no-template-curly-in-string.md
+++ b/docs/src/rules/no-template-curly-in-string.md
@@ -1,7 +1,6 @@
 ---
 title: no-template-curly-in-string
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-template-curly-in-string.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-ternary.md
+++ b/docs/src/rules/no-ternary.md
@@ -1,7 +1,6 @@
 ---
 title: no-ternary
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-ternary.md
 rule_type: suggestion
 related_rules:
 - no-nested-ternary

--- a/docs/src/rules/no-this-before-super.md
+++ b/docs/src/rules/no-this-before-super.md
@@ -1,7 +1,6 @@
 ---
 title: no-this-before-super
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-this-before-super.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-throw-literal.md
+++ b/docs/src/rules/no-throw-literal.md
@@ -1,7 +1,6 @@
 ---
 title: no-throw-literal
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-throw-literal.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-trailing-spaces.md
+++ b/docs/src/rules/no-trailing-spaces.md
@@ -1,7 +1,6 @@
 ---
 title: no-trailing-spaces
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-trailing-spaces.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/no-undef-init.md
+++ b/docs/src/rules/no-undef-init.md
@@ -1,7 +1,6 @@
 ---
 title: no-undef-init
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-undef-init.md
 rule_type: suggestion
 related_rules:
 - no-undefined

--- a/docs/src/rules/no-undef.md
+++ b/docs/src/rules/no-undef.md
@@ -1,7 +1,6 @@
 ---
 title: no-undef
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-undef.md
 rule_type: problem
 related_rules:
 - no-global-assign

--- a/docs/src/rules/no-undefined.md
+++ b/docs/src/rules/no-undefined.md
@@ -1,7 +1,6 @@
 ---
 title: no-undefined
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-undefined.md
 rule_type: suggestion
 related_rules:
 - no-undef-init

--- a/docs/src/rules/no-underscore-dangle.md
+++ b/docs/src/rules/no-underscore-dangle.md
@@ -1,7 +1,6 @@
 ---
 title: no-underscore-dangle
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-underscore-dangle.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-unexpected-multiline.md
+++ b/docs/src/rules/no-unexpected-multiline.md
@@ -1,7 +1,6 @@
 ---
 title: no-unexpected-multiline
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-unexpected-multiline.md
 rule_type: problem
 related_rules:
 - func-call-spacing

--- a/docs/src/rules/no-unmodified-loop-condition.md
+++ b/docs/src/rules/no-unmodified-loop-condition.md
@@ -1,7 +1,6 @@
 ---
 title: no-unmodified-loop-condition
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-unmodified-loop-condition.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-unneeded-ternary.md
+++ b/docs/src/rules/no-unneeded-ternary.md
@@ -1,7 +1,6 @@
 ---
 title: no-unneeded-ternary
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-unneeded-ternary.md
 rule_type: suggestion
 related_rules:
 - no-ternary

--- a/docs/src/rules/no-unreachable-loop.md
+++ b/docs/src/rules/no-unreachable-loop.md
@@ -1,7 +1,6 @@
 ---
 title: no-unreachable-loop
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-unreachable-loop.md
 rule_type: problem
 related_rules:
 - no-unreachable

--- a/docs/src/rules/no-unreachable.md
+++ b/docs/src/rules/no-unreachable.md
@@ -1,7 +1,6 @@
 ---
 title: no-unreachable
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-unreachable.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-unsafe-finally.md
+++ b/docs/src/rules/no-unsafe-finally.md
@@ -1,7 +1,6 @@
 ---
 title: no-unsafe-finally
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-unsafe-finally.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-unsafe-negation.md
+++ b/docs/src/rules/no-unsafe-negation.md
@@ -1,7 +1,6 @@
 ---
 title: no-unsafe-negation
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-unsafe-negation.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-unsafe-optional-chaining.md
+++ b/docs/src/rules/no-unsafe-optional-chaining.md
@@ -1,7 +1,6 @@
 ---
 title: no-unsafe-optional-chaining
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-unsafe-optional-chaining.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-unused-expressions.md
+++ b/docs/src/rules/no-unused-expressions.md
@@ -1,7 +1,6 @@
 ---
 title: no-unused-expressions
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-unused-expressions.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-unused-labels.md
+++ b/docs/src/rules/no-unused-labels.md
@@ -1,7 +1,6 @@
 ---
 title: no-unused-labels
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-unused-labels.md
 rule_type: suggestion
 related_rules:
 - no-extra-label

--- a/docs/src/rules/no-unused-private-class-members.md
+++ b/docs/src/rules/no-unused-private-class-members.md
@@ -1,7 +1,6 @@
 ---
 title: no-unused-private-class-members
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-unused-private-class-members.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-unused-vars.md
+++ b/docs/src/rules/no-unused-vars.md
@@ -1,7 +1,6 @@
 ---
 title: no-unused-vars
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-unused-vars.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-use-before-define.md
+++ b/docs/src/rules/no-use-before-define.md
@@ -1,7 +1,6 @@
 ---
 title: no-use-before-define
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-use-before-define.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/no-useless-backreference.md
+++ b/docs/src/rules/no-useless-backreference.md
@@ -1,7 +1,6 @@
 ---
 title: no-useless-backreference
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-useless-backreference.md
 rule_type: problem
 related_rules:
 - no-control-regex

--- a/docs/src/rules/no-useless-call.md
+++ b/docs/src/rules/no-useless-call.md
@@ -1,7 +1,6 @@
 ---
 title: no-useless-call
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-useless-call.md
 rule_type: suggestion
 related_rules:
 - prefer-spread

--- a/docs/src/rules/no-useless-catch.md
+++ b/docs/src/rules/no-useless-catch.md
@@ -1,7 +1,6 @@
 ---
 title: no-useless-catch
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-useless-catch.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-useless-computed-key.md
+++ b/docs/src/rules/no-useless-computed-key.md
@@ -1,7 +1,6 @@
 ---
 title: no-useless-computed-key
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-useless-computed-key.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-useless-concat.md
+++ b/docs/src/rules/no-useless-concat.md
@@ -1,7 +1,6 @@
 ---
 title: no-useless-concat
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-useless-concat.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-useless-constructor.md
+++ b/docs/src/rules/no-useless-constructor.md
@@ -1,7 +1,6 @@
 ---
 title: no-useless-constructor
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-useless-constructor.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-useless-escape.md
+++ b/docs/src/rules/no-useless-escape.md
@@ -1,7 +1,6 @@
 ---
 title: no-useless-escape
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-useless-escape.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-useless-rename.md
+++ b/docs/src/rules/no-useless-rename.md
@@ -1,7 +1,6 @@
 ---
 title: no-useless-rename
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-useless-rename.md
 rule_type: suggestion
 related_rules:
 - object-shorthand

--- a/docs/src/rules/no-useless-return.md
+++ b/docs/src/rules/no-useless-return.md
@@ -1,7 +1,6 @@
 ---
 title: no-useless-return
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-useless-return.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-var.md
+++ b/docs/src/rules/no-var.md
@@ -1,7 +1,6 @@
 ---
 title: no-var
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-var.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-void.md
+++ b/docs/src/rules/no-void.md
@@ -1,7 +1,6 @@
 ---
 title: no-void
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-void.md
 rule_type: suggestion
 related_rules:
 - no-undef-init

--- a/docs/src/rules/no-warning-comments.md
+++ b/docs/src/rules/no-warning-comments.md
@@ -1,7 +1,6 @@
 ---
 title: no-warning-comments
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-warning-comments.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/no-whitespace-before-property.md
+++ b/docs/src/rules/no-whitespace-before-property.md
@@ -1,7 +1,6 @@
 ---
 title: no-whitespace-before-property
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-whitespace-before-property.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/no-with.md
+++ b/docs/src/rules/no-with.md
@@ -1,7 +1,6 @@
 ---
 title: no-with
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-with.md
 rule_type: suggestion
 further_reading:
 - https://web.archive.org/web/20200717110117/https://yuiblog.com/blog/2006/04/11/with-statement-considered-harmful/

--- a/docs/src/rules/no-wrap-func.md
+++ b/docs/src/rules/no-wrap-func.md
@@ -1,7 +1,6 @@
 ---
 title: no-wrap-func
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/no-wrap-func.md
 
 ---
 

--- a/docs/src/rules/nonblock-statement-body-position.md
+++ b/docs/src/rules/nonblock-statement-body-position.md
@@ -1,7 +1,6 @@
 ---
 title: nonblock-statement-body-position
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/nonblock-statement-body-position.md
 rule_type: layout
 further_reading:
 - https://jscs-dev.github.io/rule/requireNewlineBeforeSingleStatementsInIf

--- a/docs/src/rules/object-curly-newline.md
+++ b/docs/src/rules/object-curly-newline.md
@@ -1,7 +1,6 @@
 ---
 title: object-curly-newline
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/object-curly-newline.md
 rule_type: layout
 related_rules:
 - comma-spacing

--- a/docs/src/rules/object-curly-spacing.md
+++ b/docs/src/rules/object-curly-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: object-curly-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/object-curly-spacing.md
 rule_type: layout
 related_rules:
 - array-bracket-spacing

--- a/docs/src/rules/object-property-newline.md
+++ b/docs/src/rules/object-property-newline.md
@@ -1,7 +1,6 @@
 ---
 title: object-property-newline
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/object-property-newline.md
 rule_type: layout
 related_rules:
 - brace-style

--- a/docs/src/rules/object-shorthand.md
+++ b/docs/src/rules/object-shorthand.md
@@ -1,7 +1,6 @@
 ---
 title: object-shorthand
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/object-shorthand.md
 rule_type: suggestion
 related_rules:
 - no-useless-rename

--- a/docs/src/rules/one-var-declaration-per-line.md
+++ b/docs/src/rules/one-var-declaration-per-line.md
@@ -1,7 +1,6 @@
 ---
 title: one-var-declaration-per-line
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/one-var-declaration-per-line.md
 rule_type: suggestion
 related_rules:
 - one-var

--- a/docs/src/rules/one-var.md
+++ b/docs/src/rules/one-var.md
@@ -1,7 +1,6 @@
 ---
 title: one-var
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/one-var.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/operator-assignment.md
+++ b/docs/src/rules/operator-assignment.md
@@ -1,7 +1,6 @@
 ---
 title: operator-assignment
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/operator-assignment.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/operator-linebreak.md
+++ b/docs/src/rules/operator-linebreak.md
@@ -1,7 +1,6 @@
 ---
 title: operator-linebreak
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/operator-linebreak.md
 rule_type: layout
 related_rules:
 - comma-style

--- a/docs/src/rules/padded-blocks.md
+++ b/docs/src/rules/padded-blocks.md
@@ -1,7 +1,6 @@
 ---
 title: padded-blocks
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/padded-blocks.md
 rule_type: layout
 related_rules:
 - lines-between-class-members

--- a/docs/src/rules/padding-line-between-statements.md
+++ b/docs/src/rules/padding-line-between-statements.md
@@ -1,7 +1,6 @@
 ---
 title: padding-line-between-statements
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/padding-line-between-statements.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/prefer-arrow-callback.md
+++ b/docs/src/rules/prefer-arrow-callback.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-arrow-callback
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-arrow-callback.md
 rule_type: suggestion
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions

--- a/docs/src/rules/prefer-const.md
+++ b/docs/src/rules/prefer-const.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-const
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-const.md
 rule_type: suggestion
 related_rules:
 - no-var

--- a/docs/src/rules/prefer-destructuring.md
+++ b/docs/src/rules/prefer-destructuring.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-destructuring
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-destructuring.md
 rule_type: suggestion
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment

--- a/docs/src/rules/prefer-exponentiation-operator.md
+++ b/docs/src/rules/prefer-exponentiation-operator.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-exponentiation-operator
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-exponentiation-operator.md
 rule_type: suggestion
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation

--- a/docs/src/rules/prefer-named-capture-group.md
+++ b/docs/src/rules/prefer-named-capture-group.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-named-capture-group
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-named-capture-group.md
 rule_type: suggestion
 related_rules:
 - no-invalid-regexp

--- a/docs/src/rules/prefer-numeric-literals.md
+++ b/docs/src/rules/prefer-numeric-literals.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-numeric-literals
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-numeric-literals.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/prefer-object-has-own.md
+++ b/docs/src/rules/prefer-object-has-own.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-object-has-own
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-object-has-own.md
 rule_type: suggestion
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn

--- a/docs/src/rules/prefer-object-spread.md
+++ b/docs/src/rules/prefer-object-spread.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-object-spread
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-object-spread.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/prefer-promise-reject-errors.md
+++ b/docs/src/rules/prefer-promise-reject-errors.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-promise-reject-errors
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-promise-reject-errors.md
 rule_type: suggestion
 related_rules:
 - no-throw-literal

--- a/docs/src/rules/prefer-reflect.md
+++ b/docs/src/rules/prefer-reflect.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-reflect
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-reflect.md
 rule_type: suggestion
 related_rules:
 - no-useless-call

--- a/docs/src/rules/prefer-regex-literals.md
+++ b/docs/src/rules/prefer-regex-literals.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-regex-literals
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-regex-literals.md
 rule_type: suggestion
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions

--- a/docs/src/rules/prefer-rest-params.md
+++ b/docs/src/rules/prefer-rest-params.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-rest-params
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-rest-params.md
 rule_type: suggestion
 related_rules:
 - prefer-spread

--- a/docs/src/rules/prefer-spread.md
+++ b/docs/src/rules/prefer-spread.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-spread
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-spread.md
 rule_type: suggestion
 related_rules:
 - no-useless-call

--- a/docs/src/rules/prefer-template.md
+++ b/docs/src/rules/prefer-template.md
@@ -1,7 +1,6 @@
 ---
 title: prefer-template
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/prefer-template.md
 rule_type: suggestion
 related_rules:
 - no-useless-concat

--- a/docs/src/rules/quote-props.md
+++ b/docs/src/rules/quote-props.md
@@ -1,7 +1,6 @@
 ---
 title: quote-props
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/quote-props.md
 rule_type: suggestion
 further_reading:
 - https://kangax.github.io/compat-table/es5/#Reserved_words_as_property_names

--- a/docs/src/rules/quotes.md
+++ b/docs/src/rules/quotes.md
@@ -1,7 +1,6 @@
 ---
 title: quotes
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/quotes.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/radix.md
+++ b/docs/src/rules/radix.md
@@ -1,7 +1,6 @@
 ---
 title: radix
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/radix.md
 rule_type: suggestion
 further_reading:
 - https://davidwalsh.name/parseint-radix

--- a/docs/src/rules/require-atomic-updates.md
+++ b/docs/src/rules/require-atomic-updates.md
@@ -1,7 +1,6 @@
 ---
 title: require-atomic-updates
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/require-atomic-updates.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/require-await.md
+++ b/docs/src/rules/require-await.md
@@ -1,7 +1,6 @@
 ---
 title: require-await
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/require-await.md
 rule_type: suggestion
 related_rules:
 - require-yield

--- a/docs/src/rules/require-jsdoc.md
+++ b/docs/src/rules/require-jsdoc.md
@@ -1,7 +1,6 @@
 ---
 title: require-jsdoc
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/require-jsdoc.md
 rule_type: suggestion
 related_rules:
 - valid-jsdoc

--- a/docs/src/rules/require-unicode-regexp.md
+++ b/docs/src/rules/require-unicode-regexp.md
@@ -1,7 +1,6 @@
 ---
 title: require-unicode-regexp
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/require-unicode-regexp.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/require-yield.md
+++ b/docs/src/rules/require-yield.md
@@ -1,7 +1,6 @@
 ---
 title: require-yield
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/require-yield.md
 rule_type: suggestion
 related_rules:
 - require-await

--- a/docs/src/rules/rest-spread-spacing.md
+++ b/docs/src/rules/rest-spread-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: rest-spread-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/rest-spread-spacing.md
 rule_type: layout
 further_reading:
 - https://github.com/tc39/proposal-object-rest-spread

--- a/docs/src/rules/semi-spacing.md
+++ b/docs/src/rules/semi-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: semi-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/semi-spacing.md
 rule_type: layout
 related_rules:
 - semi

--- a/docs/src/rules/semi-style.md
+++ b/docs/src/rules/semi-style.md
@@ -1,7 +1,6 @@
 ---
 title: semi-style
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/semi-style.md
 rule_type: layout
 related_rules:
 - no-extra-semi

--- a/docs/src/rules/semi.md
+++ b/docs/src/rules/semi.md
@@ -1,7 +1,6 @@
 ---
 title: semi
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/semi.md
 rule_type: layout
 related_rules:
 - no-extra-semi

--- a/docs/src/rules/sort-imports.md
+++ b/docs/src/rules/sort-imports.md
@@ -1,7 +1,6 @@
 ---
 title: sort-imports
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/sort-imports.md
 rule_type: suggestion
 related_rules:
 - sort-keys

--- a/docs/src/rules/sort-keys.md
+++ b/docs/src/rules/sort-keys.md
@@ -1,7 +1,6 @@
 ---
 title: sort-keys
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/sort-keys.md
 rule_type: suggestion
 related_rules:
 - sort-imports

--- a/docs/src/rules/sort-vars.md
+++ b/docs/src/rules/sort-vars.md
@@ -1,7 +1,6 @@
 ---
 title: sort-vars
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/sort-vars.md
 rule_type: suggestion
 related_rules:
 - sort-keys

--- a/docs/src/rules/space-after-function-name.md
+++ b/docs/src/rules/space-after-function-name.md
@@ -1,7 +1,6 @@
 ---
 title: space-after-function-name
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/space-after-function-name.md
 
 ---
 

--- a/docs/src/rules/space-after-keywords.md
+++ b/docs/src/rules/space-after-keywords.md
@@ -1,7 +1,6 @@
 ---
 title: space-after-keywords
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/space-after-keywords.md
 
 ---
 

--- a/docs/src/rules/space-before-blocks.md
+++ b/docs/src/rules/space-before-blocks.md
@@ -1,7 +1,6 @@
 ---
 title: space-before-blocks
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/space-before-blocks.md
 rule_type: layout
 related_rules:
 - keyword-spacing

--- a/docs/src/rules/space-before-function-paren.md
+++ b/docs/src/rules/space-before-function-paren.md
@@ -1,7 +1,6 @@
 ---
 title: space-before-function-paren
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/space-before-function-paren.md
 rule_type: layout
 related_rules:
 - space-after-keywords

--- a/docs/src/rules/space-before-function-parentheses.md
+++ b/docs/src/rules/space-before-function-parentheses.md
@@ -1,7 +1,6 @@
 ---
 title: space-before-function-parentheses
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/space-before-function-parentheses.md
 
 related_rules:
 - space-after-keywords

--- a/docs/src/rules/space-before-keywords.md
+++ b/docs/src/rules/space-before-keywords.md
@@ -1,7 +1,6 @@
 ---
 title: space-before-keywords
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/space-before-keywords.md
 
 related_rules:
 - space-after-keywords

--- a/docs/src/rules/space-in-brackets.md
+++ b/docs/src/rules/space-in-brackets.md
@@ -1,7 +1,6 @@
 ---
 title: space-in-brackets
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/space-in-brackets.md
 
 related_rules:
 - array-bracket-spacing

--- a/docs/src/rules/space-in-parens.md
+++ b/docs/src/rules/space-in-parens.md
@@ -1,7 +1,6 @@
 ---
 title: space-in-parens
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/space-in-parens.md
 rule_type: layout
 related_rules:
 - array-bracket-spacing

--- a/docs/src/rules/space-infix-ops.md
+++ b/docs/src/rules/space-infix-ops.md
@@ -1,7 +1,6 @@
 ---
 title: space-infix-ops
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/space-infix-ops.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/space-return-throw-case.md
+++ b/docs/src/rules/space-return-throw-case.md
@@ -1,7 +1,6 @@
 ---
 title: space-return-throw-case
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/space-return-throw-case.md
 
 ---
 

--- a/docs/src/rules/space-unary-ops.md
+++ b/docs/src/rules/space-unary-ops.md
@@ -1,7 +1,6 @@
 ---
 title: space-unary-ops
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/space-unary-ops.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/space-unary-word-ops.md
+++ b/docs/src/rules/space-unary-word-ops.md
@@ -1,7 +1,6 @@
 ---
 title: space-unary-word-ops
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/space-unary-word-ops.md
 
 ---
 

--- a/docs/src/rules/spaced-comment.md
+++ b/docs/src/rules/spaced-comment.md
@@ -1,7 +1,6 @@
 ---
 title: spaced-comment
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/spaced-comment.md
 rule_type: suggestion
 related_rules:
 - spaced-line-comment

--- a/docs/src/rules/spaced-line-comment.md
+++ b/docs/src/rules/spaced-line-comment.md
@@ -1,7 +1,6 @@
 ---
 title: spaced-line-comment
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/spaced-line-comment.md
 
 related_rules:
 - spaced-comment

--- a/docs/src/rules/strict.md
+++ b/docs/src/rules/strict.md
@@ -1,7 +1,6 @@
 ---
 title: strict
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/strict.md
 rule_type: suggestion
 ---
 

--- a/docs/src/rules/switch-colon-spacing.md
+++ b/docs/src/rules/switch-colon-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: switch-colon-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/switch-colon-spacing.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/symbol-description.md
+++ b/docs/src/rules/symbol-description.md
@@ -1,7 +1,6 @@
 ---
 title: symbol-description
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/symbol-description.md
 rule_type: suggestion
 further_reading:
 - https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-description

--- a/docs/src/rules/template-curly-spacing.md
+++ b/docs/src/rules/template-curly-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: template-curly-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/template-curly-spacing.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/template-tag-spacing.md
+++ b/docs/src/rules/template-tag-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: template-tag-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/template-tag-spacing.md
 rule_type: layout
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals

--- a/docs/src/rules/unicode-bom.md
+++ b/docs/src/rules/unicode-bom.md
@@ -1,7 +1,6 @@
 ---
 title: unicode-bom
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/unicode-bom.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/use-isnan.md
+++ b/docs/src/rules/use-isnan.md
@@ -1,7 +1,6 @@
 ---
 title: use-isnan
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/use-isnan.md
 rule_type: problem
 ---
 

--- a/docs/src/rules/valid-jsdoc.md
+++ b/docs/src/rules/valid-jsdoc.md
@@ -1,7 +1,6 @@
 ---
 title: valid-jsdoc
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/valid-jsdoc.md
 rule_type: suggestion
 related_rules:
 - require-jsdoc

--- a/docs/src/rules/valid-typeof.md
+++ b/docs/src/rules/valid-typeof.md
@@ -1,7 +1,6 @@
 ---
 title: valid-typeof
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/valid-typeof.md
 rule_type: problem
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof

--- a/docs/src/rules/vars-on-top.md
+++ b/docs/src/rules/vars-on-top.md
@@ -1,7 +1,6 @@
 ---
 title: vars-on-top
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/vars-on-top.md
 rule_type: suggestion
 further_reading:
 - https://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html

--- a/docs/src/rules/wrap-iife.md
+++ b/docs/src/rules/wrap-iife.md
@@ -1,7 +1,6 @@
 ---
 title: wrap-iife
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/wrap-iife.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/wrap-regex.md
+++ b/docs/src/rules/wrap-regex.md
@@ -1,7 +1,6 @@
 ---
 title: wrap-regex
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/wrap-regex.md
 rule_type: layout
 ---
 

--- a/docs/src/rules/yield-star-spacing.md
+++ b/docs/src/rules/yield-star-spacing.md
@@ -1,7 +1,6 @@
 ---
 title: yield-star-spacing
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/yield-star-spacing.md
 rule_type: layout
 further_reading:
 - https://leanpub.com/understandinges6/read/#leanpub-auto-generators

--- a/docs/src/rules/yoda.md
+++ b/docs/src/rules/yoda.md
@@ -1,7 +1,6 @@
 ---
 title: yoda
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/rules/yoda.md
 rule_type: suggestion
 further_reading:
 - https://en.wikipedia.org/wiki/Yoda_conditions

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -1,7 +1,6 @@
 ---
 title: Command Line Interface
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/command-line-interface.md
 eleventyNavigation:
     key: command line interface
     parent: user guide

--- a/docs/src/user-guide/configuring/configuration-files-new.md
+++ b/docs/src/user-guide/configuring/configuration-files-new.md
@@ -1,7 +1,6 @@
 ---
 title: Configuration Files (New)
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/configuring/configuration-files-new.md
 eleventyNavigation:
     key: configuration files
     parent: configuring

--- a/docs/src/user-guide/configuring/configuration-files.md
+++ b/docs/src/user-guide/configuring/configuration-files.md
@@ -1,7 +1,6 @@
 ---
 title: Configuration Files
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/configuring/configuration-files.md
 eleventyNavigation:
     key: configuration files
     parent: configuring

--- a/docs/src/user-guide/configuring/ignoring-code.md
+++ b/docs/src/user-guide/configuring/ignoring-code.md
@@ -1,7 +1,6 @@
 ---
 title: Ignoring Code
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/configuring/ignoring-code.md
 eleventyNavigation:
     key: ignoring code
     parent: configuring

--- a/docs/src/user-guide/configuring/index.md
+++ b/docs/src/user-guide/configuring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Configuring ESLint
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/configuring/index.md
 eleventyNavigation:
     key: configuring
     parent: user guide
@@ -13,7 +12,7 @@ eleventyNavigation:
 ESLint is designed to be flexible and configurable for your use case. You can turn off every rule and run only with basic syntax validation or mix and match the bundled rules and your custom rules to fit the needs of your project. There are two primary ways to configure ESLint:
 
 1. **Configuration Comments** - use JavaScript comments to embed configuration information directly into a file.
-1. **Configuration Files** - use a JavaScript, JSON, or YAML file to specify configuration information for an entire directory and all of its subdirectories. This can be in the form of a [`.eslintrc.*`](./configuration-files#configuration-file-formats) file or an `eslintConfig` field in a [`package.json`](https://docs.npmjs.com/files/package.json) file, both of which ESLint will look for and read automatically, or you can specify a configuration file on the [command line](../command-line-interface).
+2. **Configuration Files** - use a JavaScript, JSON, or YAML file to specify configuration information for an entire directory and all of its subdirectories. This can be in the form of a [`.eslintrc.*`](./configuration-files#configuration-file-formats) file or an `eslintConfig` field in a [`package.json`](https://docs.npmjs.com/files/package.json) file, both of which ESLint will look for and read automatically, or you can specify a configuration file on the [command line](../command-line-interface).
 
 Here are some of the options that you can configure in ESLint:
 

--- a/docs/src/user-guide/configuring/language-options.md
+++ b/docs/src/user-guide/configuring/language-options.md
@@ -1,7 +1,6 @@
 ---
 title: Language Options
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/configuring/language-options.md
 eleventyNavigation:
     key: configuring language options
     parent: configuring

--- a/docs/src/user-guide/configuring/plugins.md
+++ b/docs/src/user-guide/configuring/plugins.md
@@ -1,7 +1,6 @@
 ---
 title: Plugins
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/configuring/plugins.md
 eleventyNavigation:
     key: configuring plugins
     parent: configuring

--- a/docs/src/user-guide/configuring/rules.md
+++ b/docs/src/user-guide/configuring/rules.md
@@ -1,7 +1,6 @@
 ---
 title: Rules
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/configuring/rules.md
 eleventyNavigation:
     key: configuring rules
     parent: configuring

--- a/docs/src/user-guide/getting-started.md
+++ b/docs/src/user-guide/getting-started.md
@@ -1,7 +1,6 @@
 ---
 title: Getting Started with ESLint
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/getting-started.md
 eleventyNavigation:
     key: getting started 
     parent: user guide

--- a/docs/src/user-guide/index.md
+++ b/docs/src/user-guide/index.md
@@ -1,7 +1,6 @@
 ---
 title: User Guide
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/index.md
 eleventyNavigation:
     key: user guide
     title: User Guide

--- a/docs/src/user-guide/integrations.md
+++ b/docs/src/user-guide/integrations.md
@@ -1,7 +1,6 @@
 ---
 title: Integrations
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/integrations.md
 eleventyNavigation:
     key: integrations
     parent: user guide

--- a/docs/src/user-guide/migrating-from-jscs.md
+++ b/docs/src/user-guide/migrating-from-jscs.md
@@ -1,7 +1,6 @@
 ---
 title: Migrating from JSCS
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/migrating-from-jscs.md
 
 ---
 

--- a/docs/src/user-guide/migrating-to-1.0.0.md
+++ b/docs/src/user-guide/migrating-to-1.0.0.md
@@ -1,7 +1,6 @@
 ---
 title: Migrating to v1.0.0
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/migrating-to-1.0.0.md
 
 ---
 

--- a/docs/src/user-guide/migrating-to-2.0.0.md
+++ b/docs/src/user-guide/migrating-to-2.0.0.md
@@ -1,7 +1,6 @@
 ---
 title: Migrating to v2.0.0
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/migrating-to-2.0.0.md
 
 ---
 

--- a/docs/src/user-guide/migrating-to-3.0.0.md
+++ b/docs/src/user-guide/migrating-to-3.0.0.md
@@ -1,7 +1,6 @@
 ---
 title: Migrating to v3.0.0
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/migrating-to-3.0.0.md
 
 ---
 

--- a/docs/src/user-guide/migrating-to-4.0.0.md
+++ b/docs/src/user-guide/migrating-to-4.0.0.md
@@ -1,7 +1,6 @@
 ---
 title: Migrating to v4.0.0
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/migrating-to-4.0.0.md
 
 ---
 

--- a/docs/src/user-guide/migrating-to-5.0.0.md
+++ b/docs/src/user-guide/migrating-to-5.0.0.md
@@ -1,7 +1,6 @@
 ---
 title: Migrating to v5.0.0
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/migrating-to-5.0.0.md
 
 ---
 

--- a/docs/src/user-guide/migrating-to-6.0.0.md
+++ b/docs/src/user-guide/migrating-to-6.0.0.md
@@ -1,7 +1,6 @@
 ---
 title: Migrating to v6.0.0
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/migrating-to-6.0.0.md
 
 ---
 

--- a/docs/src/user-guide/migrating-to-7.0.0.md
+++ b/docs/src/user-guide/migrating-to-7.0.0.md
@@ -1,7 +1,6 @@
 ---
 title: Migrating to v7.0.0
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/migrating-to-7.0.0.md
 
 ---
 

--- a/docs/src/user-guide/migrating-to-8.0.0.md
+++ b/docs/src/user-guide/migrating-to-8.0.0.md
@@ -1,7 +1,6 @@
 ---
 title: Migrating to v8.0.0
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/migrating-to-8.0.0.md
 eleventyNavigation:
     key: migrating to v8
     parent: user guide

--- a/docs/src/user-guide/rule-deprecation.md
+++ b/docs/src/user-guide/rule-deprecation.md
@@ -1,7 +1,6 @@
 ---
 title: Rule Deprecation
 layout: doc
-edit_link: https://github.com/eslint/eslint/edit/main/docs/src/user-guide/rule-deprecation.md
 
 ---
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

If `edit_link` is not specified in the md file, the corresponding edit link is generated based on the path by default.

#### Is there anything you'd like reviewers to focus on?

The second commit is mainly a cleanup of unnecessary `edit_link`

<!-- markdownlint-disable-file MD004 -->
