### PR TITLE
feat: add exception options to no-tabs

### DIFF
--- a/docs/src/rules/no-tabs.md
+++ b/docs/src/rules/no-tabs.md
@@ -16,14 +16,14 @@ Examples of **incorrect** code for this rule:
 ::: incorrect
 
 ```js
-var a \t= 2;
+var a⇥ = 2;
 
 /**
-* \t\t it's a test function
+* ⇥ ⇥ it's a test function
 */
 function test(){}
 
-var x = 1; // \t test
+var x = 1; //⇥ test
 ```
 
 :::
@@ -50,6 +50,10 @@ var x = 1; // test
 This rule has an optional object option with the following properties:
 
 * `allowIndentationTabs` (default: false): If this is set to true, then the rule will not report tabs used for indentation.
+* `allowInComments` (default: false): If this is set to true, then the rule will not report tabs in comments.
+* `allowInStrings` (default: false): If this is set to true, then the rule will not report tabs in string .
+* `allowInTemplates` (default: false): If this is set to true, then the rule will not report tabs in template literals.
+* `allowInRegExps` (default: false): If this is set to true, then the rule will not report tabs used in RegExp literals.
 
 #### allowIndentationTabs
 
@@ -61,10 +65,70 @@ Examples of **correct** code for this rule with the `allowIndentationTabs: true`
 /* eslint no-tabs: ["error", { allowIndentationTabs: true }] */
 
 function test() {
-\tdoSomething();
+⇥ doSomething();
 }
 
-\t// comment with leading indentation tab
+⇥ // comment with leading indentation tab
+```
+
+:::
+
+#### allowInComments
+
+Examples of **correct** code for this rule with the `allowInComments: true` option:
+
+::: correct
+
+```js
+/* eslint no-tabs: ["error", { allowInComments: true }] */
+
+// function test() {
+// ⇥ doSomething();
+// }
+
+/*⇥ block⇥ comment⇥ with⇥ tabs⇥ */
+```
+
+:::
+
+#### allowInStrings
+
+Examples of **correct** code for this rule with the `allowInStrings: true` option:
+
+::: correct
+
+```js
+/* eslint no-tabs: ["error", { allowInStrings: true }] */
+
+const test = "string⇥ literal⇥ with⇥ tabs";
+```
+
+:::
+
+#### allowInTemplates
+
+Examples of **correct** code for this rule with the `allowInTemplates: true` option:
+
+::: correct
+
+```js
+/* eslint no-tabs: ["error", { allowInTemplates: true }] */
+
+const test = `template⇥ literal⇥ with⇥ tabs`;
+```
+
+:::
+
+#### allowInRegExps
+
+Examples of **correct** code for this rule with the `allowInRegExps: true` option:
+
+::: correct
+
+```js
+/* eslint no-tabs: ["error", { allowInRegExps: true }] */
+
+const test = /RegExps⇥ literal⇥ with⇥ tabs/;
 ```
 
 :::

--- a/lib/rules/no-tabs.js
+++ b/lib/rules/no-tabs.js
@@ -32,6 +32,22 @@ module.exports = {
                 allowIndentationTabs: {
                     type: "boolean",
                     default: false
+                },
+                allowInComments: {
+                    type: "boolean",
+                    default: false
+                },
+                allowInStrings: {
+                    type: "boolean",
+                    default: false
+                },
+                allowInTemplates: {
+                    type: "boolean",
+                    default: false
+                },
+                allowInRegExps: {
+                    type: "boolean",
+                    default: false
                 }
             },
             additionalProperties: false
@@ -43,12 +59,93 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
-        const allowIndentationTabs = context.options && context.options[0] && context.options[0].allowIndentationTabs;
+        const options = context.options[0] || {};
+        const allowIndentationTabs = options.allowIndentationTabs || false;
+        const allowInComments = options.allowInComments || false;
+        const allowInStrings = options.allowInStrings || false;
+        const allowInTemplates = options.allowInTemplates || false;
+        const allowInRegExps = options.allowInRegExps || false;
 
-        return {
+        const sourceCode = context.getSourceCode();
+        const sourceLines = sourceCode.getLines();
+        const commentNodes = sourceCode.getAllComments();
+
+        let errors = [];
+
+        /**
+         * A no-op function to act as placeholder.
+         * @returns {void}
+         * @private
+         */
+        function noop() {}
+
+        /**
+         * Checks if an error intersects with the given node
+         * @param {{loc:{start: Location, end: Location}}} error The error
+         * @param {ASTNode} node The program node
+         * @returns {boolean} true if they intersect, false otherwise
+         * @private
+         */
+        function intersects(error, node) {
+            const locStart = node.loc.start;
+            const locEnd = node.loc.end;
+
+            return (
+                error.loc.start.line < locStart.line ||
+                error.loc.start.line === locStart.line && error.loc.start.column < locStart.column ||
+                error.loc.start.line === locEnd.line && error.loc.start.column >= locEnd.column ||
+                error.loc.start.line > locEnd.line
+            );
+        }
+
+        /**
+         * Removes errors from node if it is a string or regexp node
+         * @param {ASTNode} node The program node
+         * @returns {void}
+         * @private
+         */
+        function removeNodeErrorsIfStringOrRegExp(node) {
+            if (
+                allowInStrings && typeof node.value === "string" && node.raw.includes("\t") ||
+                allowInRegExps && Boolean(node.regex) && node.raw.includes("\t")
+            ) {
+                errors = errors.filter(error => intersects(error, node));
+            }
+        }
+
+        /**
+         * Removes errors from template node
+         * @param {ASTNode} node The program node
+         * @returns {void}
+         * @private
+         */
+        function removeNodeErrorsInTemplate(node) {
+            if (typeof node.value.raw === "string" && node.value.raw.includes("\t")) {
+                errors = errors.filter(error => intersects(error, node));
+            }
+        }
+
+        /**
+         * Removes errors from comment node
+         * @param {ASTNode} node The comment node
+         * @returns {void}
+         * @private
+         */
+        function removeNodeErrorsInComment(node) {
+            if (typeof node.value === "string" && node.value.includes("\t") !== -1) {
+                errors = errors.filter(error => intersects(error, node));
+            }
+        }
+
+        const handleLiteral = allowInStrings || allowInRegExps ? removeNodeErrorsIfStringOrRegExp : noop;
+
+        const handleTemplate = allowInTemplates ? removeNodeErrorsInTemplate : noop;
+
+        const handleComment = allowInComments ? removeNodeErrorsInComment : noop;
+
+        const nodes = {
             Program(node) {
-                sourceCode.getLines().forEach((line, index) => {
+                sourceLines.forEach((line, index) => {
                     let match;
 
                     while ((match = tabRegex.exec(line)) !== null) {
@@ -56,7 +153,7 @@ module.exports = {
                             continue;
                         }
 
-                        context.report({
+                        errors.push({
                             node,
                             loc: {
                                 start: {
@@ -74,5 +171,16 @@ module.exports = {
                 });
             }
         };
+
+        nodes.Literal = handleLiteral;
+
+        nodes.TemplateElement = handleTemplate;
+
+        nodes["Program:exit"] = function() {
+            commentNodes.forEach(handleComment);
+            errors.forEach(error => context.report(error));
+        };
+
+        return nodes;
     }
 };

--- a/tests/lib/rules/no-tabs.js
+++ b/tests/lib/rules/no-tabs.js
@@ -31,6 +31,27 @@ ruleTester.run("no-tabs", rule, {
         {
             code: "\t// comment",
             options: [{ allowIndentationTabs: true }]
+        },
+        {
+            code: "//\t\tcomment\t\t",
+            options: [{ allowInComments: true }]
+        },
+        {
+            code: "doSomething(); /* \tcomment\t */",
+            options: [{ allowInComments: true }]
+        },
+        {
+            code: "doSomething('a\t\tb');",
+            options: [{ allowInStrings: true }]
+        },
+        {
+            code: "`\tabc\t`",
+            options: [{ allowInTemplates: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var r = /^\t$/",
+            options: [{ allowInRegExps: true }]
         }
     ],
     invalid: [
@@ -150,6 +171,93 @@ ruleTester.run("no-tabs", rule, {
                     column: 17,
                     endLine: 1,
                     endColumn: 19
+                }
+            ]
+        },
+        {
+            code: "//\t\tcomment\t\t",
+            options: [{ allowInComments: false }],
+            errors: [
+                {
+                    messageId: "unexpectedTab",
+                    line: 1,
+                    column: 3,
+                    endLine: 1,
+                    endColumn: 5
+                },
+                {
+                    messageId: "unexpectedTab",
+                    line: 1,
+                    column: 12,
+                    endLine: 1,
+                    endColumn: 14
+                }
+            ]
+        },
+        {
+            code: "doSomething(); /* \tcomment\t */",
+            options: [{ allowInComments: false }],
+            errors: [
+                {
+                    messageId: "unexpectedTab",
+                    line: 1,
+                    column: 19,
+                    endLine: 1,
+                    endColumn: 20
+                },
+                {
+                    messageId: "unexpectedTab",
+                    line: 1,
+                    column: 27,
+                    endLine: 1,
+                    endColumn: 28
+                }
+            ]
+        },
+        {
+            code: "doSomething('a\t\tb');",
+            options: [{ allowInStrings: false }],
+            errors: [
+                {
+                    messageId: "unexpectedTab",
+                    line: 1,
+                    column: 15,
+                    endLine: 1,
+                    endColumn: 17
+                }
+            ]
+        },
+        {
+            code: "`\tabc\t`",
+            options: [{ allowInTemplates: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedTab",
+                    line: 1,
+                    column: 2,
+                    endLine: 1,
+                    endColumn: 3
+                },
+                {
+                    messageId: "unexpectedTab",
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 7
+                }
+            ]
+        },
+        {
+            code: "var r = /^\t$/",
+            options: [{ allowInRegExps: false }],
+            errors: [
+                {
+                    messageId: "unexpectedTab",
+                    line: 1,
+                    column: 11,
+                    endLine: 1,
+                    endColumn: 12
                 }
             ]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Issue: https://github.com/eslint/eslint/issues/12438

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

`no-tabs`

**Does this change cause the rule to produce more or fewer warnings?**

The rule will produce fewer warnings if the new options are enabled

**How will the change be implemented? (New option, new default behavior, etc.)?**

Adding four new boolean options, `allowInComments`, `allowInStrings`, `allowInTemplates`, `allowInRegExps`

**Please provide some example code that this change will affect:**

```js

// comments with tabs

// if (condition) {
// ⇥	console.log("!!!");
// }

/*
 * ⇥	block
 * ⇥	comment
 */

const str = "⇥	string⇥	with⇥	tabs";

const template = `
⇥	template⇥	${with}⇥	tabs
`;

const regex = /⇥	regex⇥	with⇥	tabs⇥	/u;

```

**What does the rule currently do for this code?**

The rule currently warns in all above cases

**What will the rule do after it's changed?**

If `allowInComments` is set to true, the rule will not warn for tabs in both line comments and block comments

If `allowInStrings` is set to true, the rule will not warn for tabs in string literals

If `allowInTemplates` is set to true, the rule will not warn for tabs in template literals

If `allowInRegExps` is set to true, the rule will not warn for tabs in RegExp literals

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!-- markdownlint-disable-file MD004 -->
