### PR TITLE
Rule Change: Treat class / instance fields as named constants in no-magic-numbers

### DIFF
--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -201,7 +201,9 @@ module.exports = {
                     return;
                 }
 
-                if (parent.type === "VariableDeclarator") {
+                if (parent.type === "VariableDeclarator" ||
+                  (parent.type === "PropertyDefinition" && parent.parent.type === "ClassBody")
+                ) {
                     if (enforceConst && parent.parent.kind !== "const") {
                         context.report({
                             node: fullNumberNode,

--- a/tests/lib/rules/no-magic-numbers.js
+++ b/tests/lib/rules/no-magic-numbers.js
@@ -257,6 +257,12 @@ ruleTester.run("no-magic-numbers", rule, {
             code: "foo?.[777]",
             options: [{ ignoreArrayIndexes: true }],
             parserOptions: { ecmaVersion: 2020 }
+        },
+
+        // Class / instance fields
+        {
+            code: "class Foo { static bar = 1; baz = 2; }",
+            parserOptions: { ecmaVersion: 2022 }
         }
     ],
     invalid: [


### PR DESCRIPTION


#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Solves #16228 by extending the non-error case to `PropertyDefinition` if `parent.parent`'s type is a `ClassBody`. Note that the inner `enforceConst` check isn't relevant in that case, but I didn't want to create an extra empty if-clause, nor would that be accepted by ESlint's linting rules for its own code.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
