### PR TITLE
feat: add ability to import FlatESLint

### DIFF
--- a/lib/unsupported-api.mjs
+++ b/lib/unsupported-api.mjs
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview APIs that are not officially supported by ESLint.
+ *      These APIs may change or be removed at any time. Use at your
+ *      own risk.
+ * @author Nicholas C. Zakas
+ */
+
+//-----------------------------------------------------------------------------
+// Requirements
+//-----------------------------------------------------------------------------
+
+import unsupportedAPI from './unsupported-api.js';
+
+const {
+    builtinRules,
+    FlatESLint,
+    FlatRuleTester,
+    FileEnumerator
+} = unsupportedAPI;
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+export {
+    builtinRules,
+    FlatESLint,
+    FlatRuleTester,
+    FileEnumerator
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": "./lib/api.js",
-    "./use-at-your-own-risk": "./lib/unsupported-api.js"
+    "./use-at-your-own-risk": {
+        "require": "./lib/unsupported-api.js",
+        "import": "./lib/unsupported-api.mjs"
+    }
   },
   "scripts": {
     "test": "node Makefile.js test",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Hi folks!

I'm trying a new configuration system `FLatESLint` and see some missing feature, that is planned as I understand.

#### What changes did you make? (Give an overview)

As I see in a blog page [ESLint's new config system, Part 3: Developer preview](https://eslint.org/blog/2022/08/new-config-system-part-3/#using-flat-config-with-the-eslint-class) there should be a way to `import {FlatESLint}` from `ESM`:

![image](https://user-images.githubusercontent.com/1573141/187043661-229e9cdb-f0a3-4aa0-b676-51f41e942e94.png)

But that doesn't works and what I see is:

```js
import { FlatESLint } from "eslint/use-at-your-own-risk";
         ^^^^^^^^^^
SyntaxError: Named export 'FlatESLint' not found. The requested module 'eslint/use-at-your-own-risk' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'eslint/use-at-your-own-risk';
const { FlatESLint } = pkg;
```

#### Is there anything you'd like reviewers to focus on?

Would be nice to have ability to import `FlatESLint` in the way described in a blog post :).
I added the ability to use such import using [conditional exports](https://nodejs.org/api/packages.html#conditional-exports).

<!-- markdownlint-disable-file MD004 -->
