### PR TITLE
chore: enable linting `.eleventy.js` again

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -538,7 +538,7 @@ target.lintDocsJS = function([fix = false] = []) {
     let errors = 0;
 
     echo("Validating JavaScript files in the docs directory");
-    const lastReturn = exec(`${ESLINT}${fix ? "--fix" : ""} docs`);
+    const lastReturn = exec(`${ESLINT}${fix ? "--fix" : ""} docs/.eleventy.js`);
 
     if (lastReturn.code !== 0) {
         errors++;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,10 +77,11 @@ function createInternalFilesPatterns(pattern = null) {
 }
 
 module.exports = [
-    ...compat.extends("eslint", "plugin:eslint-plugin/recommended"),
+    ...compat.extends("eslint"),
     {
         plugins: {
-            "internal-rules": internalPlugin
+            "internal-rules": internalPlugin,
+            "eslint-plugin": eslintPlugin
         },
         languageOptions: {
             ecmaVersion: "latest"
@@ -96,20 +97,6 @@ module.exports = [
             }
         },
         rules: {
-            "eslint-plugin/consistent-output": "error",
-            "eslint-plugin/no-deprecated-context-methods": "error",
-            "eslint-plugin/no-only-tests": "error",
-            "eslint-plugin/prefer-message-ids": "error",
-            "eslint-plugin/prefer-output-null": "error",
-            "eslint-plugin/prefer-placeholders": "error",
-            "eslint-plugin/prefer-replace-text": "error",
-            "eslint-plugin/report-message-format": ["error", "[^a-z].*\\.$"],
-            "eslint-plugin/require-meta-docs-description": "error",
-            "eslint-plugin/require-meta-has-suggestions": "error",
-            "eslint-plugin/require-meta-schema": "error",
-            "eslint-plugin/require-meta-type": "error",
-            "eslint-plugin/test-case-property-ordering": "error",
-            "eslint-plugin/test-case-shorthand-strings": "error",
             "internal-rules/multiline-comment-style": "error"
         }
     },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

`lint:docsjs` script is intended to lint `docs/.eleventy.js` file. Currently, after switching to `eslint.config.js`, it doesn't lint that file. This went unnoticed because of https://github.com/eslint/eslint/issues/16260 (the script runs `eslint docs` command; the command doesn't really lint any files in `docs`, but it mistakenly lints files outside `docs`, so it doesn't trigger the "no files matching the pattern" error).

The `eslint docs` command skips `docs/.eleventy.js` because:

* It's a dotfile (https://github.com/eslint/eslint/issues/16265)
* Even if it wasn't a dotfile, it would be skipped because `globby`/`fast-glob` doesn't support negated patterns in `ignore` (https://github.com/mrmlnc/fast-glob/issues/356), and we have `/docs/**` & `!/docs/.eleventy.js` patterns in [`.eslintignore`](https://github.com/eslint/eslint/blob/42bfbd7b7b91106e5f279a05f40c20769e3cd29f/.eslintignore#L3-L4).

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Update the command to lint `docs/.eleventy.js` directly. This works because it doesn't go through `globby` so there are no dotfile and unignore issues.
* Synced `eslint.config.js` with `.eslintrc.js` in regard to `eslint-plugin-eslint-plugin` rules. In particular, the rules are removed from the top level because they are detecting `docs/.eleventy.js` as an eslint rule file so there are false positives.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
