### PR TITLE
docs: fix mobile Safari double tap issue

### DIFF
--- a/docs/src/assets/scss/docs.scss
+++ b/docs/src/assets/scss/docs.scss
@@ -147,3 +147,9 @@ pre[class*="language-"] {
         display: none;
     }
 }
+
+@media (hover: none) {
+    .anchorjs-link {
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Just happened to see this [annoying double tap issue on mobile Safari](https://css-tricks.com/annoying-mobile-double-tap-link-issue/) when I was using my cellphone to check eslint docs.


https://user-images.githubusercontent.com/1091472/189482786-5fee5813-326c-402c-97d1-bb2c6b9fc71f.MP4

As you can see, the first tap won't open the link, and I believe it's related to anchorjs https://github.com/bryanbraun/anchorjs/blob/5090a963ceb8c51d8f9c4213ebdc154e54feae61/anchor.js#L320-L323 where introduces this css rules:

```css
:hover>.anchorjs-link {
  opacity: 1;
}
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Always show anchor link on mobile with [hover media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover) which is supported by most browsers, and it's how GitHub deals with their readme pages' anchors on mobile phone.

#### Is there anything you'd like reviewers to focus on?

