### PR TITLE
feat: account for `sourceType: "commonjs"` in the strict rule

### DIFF
--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -105,7 +105,7 @@ module.exports = {
         if (ecmaFeatures.impliedStrict) {
             mode = "implied";
         } else if (mode === "safe") {
-            mode = ecmaFeatures.globalReturn ? "global" : "function";
+            mode = ecmaFeatures.globalReturn || context.languageOptions.sourceType === "commonjs" ? "global" : "function";
         }
 
         /**

--- a/tests/lib/rules/strict.js
+++ b/tests/lib/rules/strict.js
@@ -10,7 +10,8 @@
 //------------------------------------------------------------------------------
 
 const rule = require("../../../lib/rules/strict"),
-    { RuleTester } = require("../../../lib/rule-tester");
+    { RuleTester } = require("../../../lib/rule-tester"),
+    FlatRuleTester = require("../../../lib/rule-tester/flat-rule-tester");
 
 //------------------------------------------------------------------------------
 // Tests
@@ -655,6 +656,49 @@ ruleTester.run("strict", rule, {
             errors: [
                 { messageId: "unnecessaryInClasses", line: 2 },
                 { messageId: "multiple", line: 3 }
+            ]
+        }
+    ]
+});
+
+const flatRuleTester = new FlatRuleTester();
+
+// TODO: merge these tests into `ruleTester.run` once we switch to FlatRuleTester (when FlatRuleTester becomes RuleTester).
+flatRuleTester.run("strict", rule, {
+    valid: [
+        {
+            code: "'use strict'; module.exports = function identity (value) { return value; }",
+            languageOptions: {
+                sourceType: "commonjs"
+            }
+        },
+        {
+            code: "'use strict'; module.exports = function identity (value) { return value; }",
+            options: ["safe"],
+            languageOptions: {
+                sourceType: "commonjs"
+            }
+        }
+    ],
+
+    invalid: [
+        {
+            code: "module.exports = function identity (value) { return value; }",
+            options: ["safe"],
+            languageOptions: {
+                sourceType: "commonjs"
+            },
+            errors: [
+                { messageId: "global", line: 1 }
+            ]
+        },
+        {
+            code: "module.exports = function identity (value) { return value; }",
+            languageOptions: {
+                sourceType: "commonjs"
+            },
+            errors: [
+                { messageId: "global", line: 1 }
             ]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #16304

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In the `strict` rule, I added `context.languageOptions.sourceType === "commonjs"` as another condition to determine whether a file is a CommonJS module.

#### Is there anything you'd like reviewers to focus on?

Marked as `feat` because it changes the behavior of this rule and can produce more warnings in the flat config mode.

I wasn't sure if we should update the docs for this rule a this point, because mentioning `languageOptions` might be confusing as it doesn't exist in the current eslintrc config format. 

<!-- markdownlint-disable-file MD004 -->
