### PR TITLE
perf: switch from object spread to `Object.assign` when merging globals

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1601,12 +1601,18 @@ class Linter {
             languageOptions.ecmaVersion
         );
 
-        // add configured globals and language globals
-        const configuredGlobals = {
-            ...(getGlobalsForEcmaVersion(languageOptions.ecmaVersion)),
-            ...(languageOptions.sourceType === "commonjs" ? globals.commonjs : void 0),
-            ...languageOptions.globals
-        };
+        /*
+         * add configured globals and language globals
+         *
+         * using Object.assign instead of object spread for performance reasons
+         * https://github.com/eslint/eslint/issues/16302
+         */
+        const configuredGlobals = Object.assign(
+            {},
+            getGlobalsForEcmaVersion(languageOptions.ecmaVersion),
+            languageOptions.sourceType === "commonjs" ? globals.commonjs : void 0,
+            languageOptions.globals
+        );
 
         // double check that there is a parser to avoid mysterious error messages
         if (!languageOptions.parser) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Refs #16302, improves performance of the new config system.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Replaced object spread with `Object.assign` when merging globals in Linter.

Performance before the change:

```
Loading:
  Load performance Run #1:  243.3295ms
  Load performance Run #2:  241.7577ms
  Load performance Run #3:  235.5167ms
  Load performance Run #4:  235.3724ms
  Load performance Run #5:  237.996ms

  Load Performance median:  237.996ms


Single File:
  CPU Speed is 2695 with multiplier 13000000
  Performance Run #1:  4841.3415ms
  Performance Run #2:  4890.8617ms
  Performance Run #3:  4893.3863ms
  Performance Run #4:  4876.1869ms
  Performance Run #5:  4874.6275000000005ms

  Performance budget exceeded: 4876.1869ms (limit: 4823.747680890538ms)


Multi Files (450 files):
  CPU Speed is 2695 with multiplier 39000000
  Performance Run #1:  21488.7766ms
  Performance Run #2:  21504.3844ms
  Performance Run #3:  21209.8782ms
  Performance Run #4:  21661.8554ms
  Performance Run #5:  21306.0702ms

  Performance budget exceeded: 21488.7766ms (limit: 14471.243042671615ms)
```

Performance after the change:

```
Loading:
  Load performance Run #1:  253.1144ms
  Load performance Run #2:  240.3637ms
  Load performance Run #3:  236.3409ms
  Load performance Run #4:  246.4793ms
  Load performance Run #5:  240.9472ms

  Load Performance median:  240.9472ms


Single File:
  CPU Speed is 2695 with multiplier 13000000
  Performance Run #1:  4928.4451ms
  Performance Run #2:  4910.2437ms
  Performance Run #3:  4891.29ms
  Performance Run #4:  4920.5213ms
  Performance Run #5:  4845.6497ms

  Performance budget exceeded: 4910.2437ms (limit: 4823.747680890538ms)


Multi Files (450 files):
  CPU Speed is 2695 with multiplier 39000000
  Performance Run #1:  13381.7765ms
  Performance Run #2:  13581.8668ms
  Performance Run #3:  13452.5753ms
  Performance Run #4:  13381.2314ms
  Performance Run #5:  13594.2325ms

  Performance budget ok:  13452.5753ms (limit: 14471.243042671615ms)
```

Note: Before running performance tests, I added browser globals in the [config](https://github.com/eslint/eslint/blob/8cc0bbe440dc5e6af6ef02f00d0514a40ca07c24/Makefile.js#L934):

 
```diff
-"languageOptions": {sourceType: "commonjs"},
+"languageOptions": {sourceType: "commonjs", globals: { ...require("globals").browser } },
```

#### Is there anything you'd like reviewers to focus on?



<!-- markdownlint-disable-file MD004 -->
