### PR TITLE
feat: `id-length` counts graphemes instead of code units

### DIFF
--- a/docs/src/rules/id-length.md
+++ b/docs/src/rules/id-length.md
@@ -20,6 +20,8 @@ var x = 5; // too short; difficult to understand its purpose without context
 
 This rule enforces a minimum and/or maximum identifier length convention.
 
+This rule counts [graphemes](http://unicode.org/reports/tr29/#Default_Grapheme_Cluster_Table) instead of using [`String length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length).
+
 ## Options
 
 Examples of **incorrect** code for this rule with the default options:

--- a/docs/src/rules/id-length.md
+++ b/docs/src/rules/id-length.md
@@ -20,7 +20,7 @@ var x = 5; // too short; difficult to understand its purpose without context
 
 This rule enforces a minimum and/or maximum identifier length convention.
 
-This rule counts [graphemes](http://unicode.org/reports/tr29/#Default_Grapheme_Cluster_Table) instead of using [`String length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length).
+This rule counts [graphemes](https://unicode.org/reports/tr29/#Default_Grapheme_Cluster_Table) instead of using [`String length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length).
 
 ## Options
 

--- a/lib/rules/id-length.js
+++ b/lib/rules/id-length.js
@@ -7,6 +7,13 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+const GraphemeSplitter = require("grapheme-splitter");
+
+const splitter = new GraphemeSplitter();
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -130,8 +137,10 @@ module.exports = {
                 const name = node.name;
                 const parent = node.parent;
 
-                const isShort = name.length < minLength;
-                const isLong = name.length > maxLength;
+                const nameLength = splitter.countGraphemes(name);
+
+                const isShort = nameLength < minLength;
+                const isLong = nameLength > maxLength;
 
                 if (!(isShort || isLong) || exceptions.has(name) || matchesExceptionPattern(name)) {
                     return; // Nothing to report

--- a/lib/rules/id-length.js
+++ b/lib/rules/id-length.js
@@ -24,12 +24,7 @@ function isASCII(value) {
     if (typeof value !== "string") {
         return false;
     }
-    for (let i = 0; i < value.length; i++) {
-        if (value.charCodeAt(i) > 127) {
-            return false;
-        }
-    }
-    return true;
+    return /^[\u0020-\u007f]*$/u.test(value);
 }
 
 /** @type {GraphemeSplitter | undefined} */

--- a/lib/rules/id-length.js
+++ b/lib/rules/id-length.js
@@ -11,7 +11,44 @@
 //------------------------------------------------------------------------------
 const GraphemeSplitter = require("grapheme-splitter");
 
-const splitter = new GraphemeSplitter();
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks if the string given as argument is ASCII or not.
+ * @param {string} value A string that you want to know if it is ASCII or not.
+ * @returns {boolean} `true` if `value` is ASCII string.
+ */
+function isASCII(value) {
+    if (typeof value !== "string") {
+        return false;
+    }
+    for (let i = 0; i < value.length; i++) {
+        if (value.charCodeAt(i) > 127) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/** @type {GraphemeSplitter | undefined} */
+let splitter;
+
+/**
+ * Gets the length of the string. If the string is not in ASCII, counts graphemes.
+ * @param {string} value A string that you want to get the length.
+ * @returns {number} The length of `value`.
+ */
+function getStringLength(value) {
+    if (isASCII(value)) {
+        return value.length;
+    }
+    if (!splitter) {
+        splitter = new GraphemeSplitter();
+    }
+    return splitter.countGraphemes(value);
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -137,7 +174,7 @@ module.exports = {
                 const name = node.name;
                 const parent = node.parent;
 
-                const nameLength = splitter.countGraphemes(name);
+                const nameLength = getStringLength(name);
 
                 const isShort = nameLength < minLength;
                 const isLong = nameLength > maxLength;

--- a/tests/lib/rules/id-length.js
+++ b/tests/lib/rules/id-length.js
@@ -122,6 +122,11 @@ ruleTester.run("id-length", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
+            code: "var 葛󠄀 = 2",
+            options: [{ min: 1, max: 1 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "var a = { 𐌘: 1 };",
             options: [{ min: 1, max: 1 }],
             parserOptions: {
@@ -681,6 +686,13 @@ ruleTester.run("id-length", rule, {
         // Identifier consisting of two code units
         {
             code: "var 𠮟 = 2",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "var 葛󠄀 = 2",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 tooShortError

--- a/tests/lib/rules/id-length.js
+++ b/tests/lib/rules/id-length.js
@@ -122,7 +122,7 @@ ruleTester.run("id-length", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "var 葛󠄀 = 2",
+            code: "var 葛󠄀 = 2", // 2 code points but only 1 grapheme
             options: [{ min: 1, max: 1 }],
             parserOptions: { ecmaVersion: 6 }
         },

--- a/tests/lib/rules/id-length.js
+++ b/tests/lib/rules/id-length.js
@@ -113,6 +113,13 @@ ruleTester.run("id-length", rule, {
             code: "class Foo { #abc = 1 }",
             options: [{ max: 3 }],
             parserOptions: { ecmaVersion: 2022 }
+        },
+
+        // Identifier consisting of two code units
+        {
+            code: "var 𠮟 = 2",
+            options: [{ min: 1 }],
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
     invalid: [
@@ -563,6 +570,13 @@ ruleTester.run("id-length", rule, {
             parserOptions: { ecmaVersion: 2022 },
             errors: [
                 tooLongErrorPrivate
+            ]
+        },
+        {
+            code: "var 𠮟 = 2",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                tooShortError
             ]
         }
     ]

--- a/tests/lib/rules/id-length.js
+++ b/tests/lib/rules/id-length.js
@@ -118,110 +118,110 @@ ruleTester.run("id-length", rule, {
         // Identifier consisting of two code units
         {
             code: "var 𠮟 = 2",
-            options: [{ min: 1 }],
+            options: [{ min: 1, max: 1 }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "var myObj = { 𐌘: 1 };",
-            options: [{ min: 1 }],
+            code: "var a = { 𐌘: 1 };",
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "(𐌘) => { 𐌘 * 𐌘 };",
-            options: [{ min: 1 }],
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "class 𠮟 { }",
-            options: [{ min: 1 }],
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
-            code: "class Foo { 𐌘() {} }",
-            options: [{ min: 1 }],
+            code: "class F { 𐌘() {} }",
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
-            code: "class Foo1 { #𐌘() {} }",
-            options: [{ min: 1 }],
+            code: "class F { #𐌘() {} }",
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 2022
             }
         },
         {
-            code: "class Foo2 { 𐌘 = 1 }",
-            options: [{ min: 1 }],
+            code: "class F { 𐌘 = 1 }",
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 2022
             }
         },
         {
-            code: "class Foo3 { #𐌘 = 1 }",
-            options: [{ min: 1 }],
+            code: "class F { #𐌘 = 1 }",
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 2022
             }
         },
         {
-            code: "function foo1(...𐌘) { }",
-            options: [{ min: 1 }],
+            code: "function f(...𐌘) { }",
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
-            code: "function foo([𐌘]) { }",
-            options: [{ min: 1 }],
+            code: "function f([𐌘]) { }",
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
-            code: "var [ 𐌘 ] = arr;",
-            options: [{ min: 1 }],
+            code: "var [ 𐌘 ] = a;",
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
-            code: "var { prop: [𐌘]} = {};",
-            options: [{ min: 1 }],
+            code: "var { p: [𐌘]} = {};",
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
-            code: "function foo({𐌘}) { }",
-            options: [{ min: 1 }],
+            code: "function f({𐌘}) { }",
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code: "var { 𐌘 } = {};",
-            options: [{ min: 1 }],
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
-            code: "var { prop: 𐌘} = {};",
-            options: [{ min: 1 }],
+            code: "var { p: 𐌘} = {};",
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
-            code: "({ prop: obj.𐌘 } = {});",
-            options: [{ min: 1 }],
+            code: "({ prop: o.𐌘 } = {});",
+            options: [{ min: 1, max: 1 }],
             parserOptions: {
                 ecmaVersion: 6
             }

--- a/tests/lib/rules/id-length.js
+++ b/tests/lib/rules/id-length.js
@@ -572,9 +572,146 @@ ruleTester.run("id-length", rule, {
                 tooLongErrorPrivate
             ]
         },
+
+        // Identifier consisting of two code units
         {
             code: "var 𠮟 = 2",
             parserOptions: { ecmaVersion: 6 },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "var myObj = { 𐌘: 1 };",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "(𐌘) => { 𐌘 * 𐌘 };",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "class 𠮟 { }",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "class Foo { 𐌘() {} }",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "class Foo1 { #𐌘() {} }",
+            parserOptions: {
+                ecmaVersion: 2022
+            },
+            errors: [
+                tooShortErrorPrivate
+            ]
+        },
+        {
+            code: "class Foo2 { 𐌘 = 1 }",
+            parserOptions: {
+                ecmaVersion: 2022
+            },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "class Foo3 { #𐌘 = 1 }",
+            parserOptions: {
+                ecmaVersion: 2022
+            },
+            errors: [
+                tooShortErrorPrivate
+            ]
+        },
+        {
+            code: "function foo1(...𐌘) { }",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "function foo([𐌘]) { }",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "var [ 𐌘 ] = arr;",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "var { prop: [𐌘]} = {};",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "function foo({𐌘}) { }",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "var { 𐌘 } = {};",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "var { prop: 𐌘} = {};",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [
+                tooShortError
+            ]
+        },
+        {
+            code: "({ prop: obj.𐌘 } = {});",
+            parserOptions: {
+                ecmaVersion: 6
+            },
             errors: [
                 tooShortError
             ]

--- a/tests/lib/rules/id-length.js
+++ b/tests/lib/rules/id-length.js
@@ -120,6 +120,111 @@ ruleTester.run("id-length", rule, {
             code: "var 𠮟 = 2",
             options: [{ min: 1 }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var myObj = { 𐌘: 1 };",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "(𐌘) => { 𐌘 * 𐌘 };",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "class 𠮟 { }",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "class Foo { 𐌘() {} }",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "class Foo1 { #𐌘() {} }",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
+        {
+            code: "class Foo2 { 𐌘 = 1 }",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
+        {
+            code: "class Foo3 { #𐌘 = 1 }",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 2022
+            }
+        },
+        {
+            code: "function foo1(...𐌘) { }",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "function foo([𐌘]) { }",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "var [ 𐌘 ] = arr;",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "var { prop: [𐌘]} = {};",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "function foo({𐌘}) { }",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "var { 𐌘 } = {};",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "var { prop: 𐌘} = {};",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "({ prop: obj.𐌘 } = {});",
+            options: [{ min: 1 }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
         }
     ],
     invalid: [

--- a/tests/lib/rules/id-length.js
+++ b/tests/lib/rules/id-length.js
@@ -692,7 +692,7 @@ ruleTester.run("id-length", rule, {
             ]
         },
         {
-            code: "var 葛󠄀 = 2",
+            code: "var 葛󠄀 = 2", // 2 code points but only 1 grapheme
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 tooShortError


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixes #16316

Counts graphemes instead of code units with [grapheme-splitter](https://github.com/orling/grapheme-splitter)

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
