### PR TITLE
fix: allow multiple custom messages for `no-restricted-imports`

### DIFF
--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -156,12 +156,18 @@ module.exports = {
         const restrictedPaths = (isPathAndPatternsObject ? options[0].paths : context.options) || [];
         const restrictedPathMessages = restrictedPaths.reduce((memo, importSource) => {
             if (typeof importSource === "string") {
-                memo[importSource] = { message: null };
+                if (!Object.prototype.hasOwnProperty.call(memo, importSource)) {
+                    memo[importSource] = [];
+                }
+                memo[importSource].push({ message: null });
             } else {
-                memo[importSource.name] = {
+                if (!Object.prototype.hasOwnProperty.call(memo, importSource.name)) {
+                    memo[importSource.name] = [];
+                }
+                memo[importSource.name].push({
                     message: importSource.message,
                     importNames: importSource.importNames
-                };
+                });
             }
             return memo;
         }, {});
@@ -199,52 +205,51 @@ module.exports = {
                 return;
             }
 
-            const customMessage = restrictedPathMessages[importSource].message;
-            const restrictedImportNames = restrictedPathMessages[importSource].importNames;
+            for (const { message: customMessage, importNames: restrictedImportNames } of restrictedPathMessages[importSource]) {
+                if (restrictedImportNames) {
+                    if (importNames.has("*")) {
+                        const specifierData = importNames.get("*")[0];
 
-            if (restrictedImportNames) {
-                if (importNames.has("*")) {
-                    const specifierData = importNames.get("*")[0];
+                        context.report({
+                            node,
+                            messageId: customMessage ? "everythingWithCustomMessage" : "everything",
+                            loc: specifierData.loc,
+                            data: {
+                                importSource,
+                                importNames: restrictedImportNames,
+                                customMessage
+                            }
+                        });
+                    }
 
+                    restrictedImportNames.forEach(importName => {
+                        if (importNames.has(importName)) {
+                            const specifiers = importNames.get(importName);
+
+                            specifiers.forEach(specifier => {
+                                context.report({
+                                    node,
+                                    messageId: customMessage ? "importNameWithCustomMessage" : "importName",
+                                    loc: specifier.loc,
+                                    data: {
+                                        importSource,
+                                        customMessage,
+                                        importName
+                                    }
+                                });
+                            });
+                        }
+                    });
+                } else {
                     context.report({
                         node,
-                        messageId: customMessage ? "everythingWithCustomMessage" : "everything",
-                        loc: specifierData.loc,
+                        messageId: customMessage ? "pathWithCustomMessage" : "path",
                         data: {
                             importSource,
-                            importNames: restrictedImportNames,
                             customMessage
                         }
                     });
                 }
-
-                restrictedImportNames.forEach(importName => {
-                    if (importNames.has(importName)) {
-                        const specifiers = importNames.get(importName);
-
-                        specifiers.forEach(specifier => {
-                            context.report({
-                                node,
-                                messageId: customMessage ? "importNameWithCustomMessage" : "importName",
-                                loc: specifier.loc,
-                                data: {
-                                    importSource,
-                                    customMessage,
-                                    importName
-                                }
-                            });
-                        });
-                    }
-                });
-            } else {
-                context.report({
-                    node,
-                    messageId: customMessage ? "pathWithCustomMessage" : "path",
-                    data: {
-                        importSource,
-                        customMessage
-                    }
-                });
             }
         }
 

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -817,6 +817,29 @@ ruleTester.run("no-restricted-imports", rule, {
         }]
     },
     {
+        code: "import { DisallowedObject1 } from \"foo\";",
+        options: [{
+            paths: [{
+                name: "foo",
+                importNames: ["DisallowedObject1"],
+                message: "Please import DisallowedObject1 of 'foo' from /bar/DisallowedObject1 instead."
+            },
+            {
+                name: "foo",
+                importNames: ["DisallowedObject2"],
+                message: "Please import DisallowedObject2 of 'foo' from /bar/DisallowedObject2 instead."
+            }
+            ]
+        }],
+        errors: [{
+            message: "'DisallowedObject1' import from 'foo' is restricted. Please import DisallowedObject1 of 'foo' from /bar/DisallowedObject1 instead.",
+            type: "ImportDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 27
+        }]
+    },
+    {
         code: "import AllowedObject, * as AllowedObjectTwo from \"foo\";",
         options: [{
             paths: [{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Before, if you provided multiple custom messages for different import paths in `no-restricted-imports`, the rule would only check for the last set of import paths. This PR fixes it so that the custom error will be thrown for all import paths. It adds a test that is broken before my change but passing after this change.

#### Is there anything you'd like reviewers to focus on?
It's a pretty simple fix (looping through an array) so hopefully not too tricky to review.
<!-- markdownlint-disable-file MD004 -->
