### PR TITLE
feat: Pass --max-warnings value to formatters

### DIFF
--- a/docs/src/developer-guide/nodejs-api.md
+++ b/docs/src/developer-guide/nodejs-api.md
@@ -410,8 +410,8 @@ This edit information means replacing the range of the `range` property by the `
 
 The `LoadedFormatter` value is the object to convert the [LintResult] objects to text. The [eslint.loadFormatter()][eslint-loadformatter] method returns it. It has the following method:
 
-* `format` (`(results: LintResult[]) => string | Promise<string>`)<br>
-  The method to convert the [LintResult] objects to text.
+* `format` (`(results: LintResult[], resultsMeta: ResultsMeta) => string | Promise<string>`)<br>
+  The method to convert the [LintResult] objects to text. `resultsMeta` is an object that will contain a `maxWarningsExceeded` object if `--max-warnings` was set and the number of warnings exceeded the limit. The `maxWarningsExceeded` object will contain two properties: `maxWarnings`, the value of the `--max-warnings` option, and `foundWarnings`, the number of lint warnings.
 
 ---
 

--- a/docs/src/developer-guide/working-with-custom-formatters.md
+++ b/docs/src/developer-guide/working-with-custom-formatters.md
@@ -129,7 +129,7 @@ Each `message` object contains information about the ESLint rule that was trigge
 
 ## The `context` Argument
 
-The formatter function receives an object as the second argument. The object has two properties:
+The formatter function receives an object as the second argument. The object has the following properties:
 
 * `cwd` ... The current working directory. This value comes from the `cwd` constructor option of the [ESLint](nodejs-api#-new-eslintoptions) class.
 * `maxWarningsExceeded` (optional): If `--max-warnings` was set and the number of warnings exceeded the limit, this property's value will be an object containing two properties: `maxWarnings`, the value of the `--max-warnings` option, and `foundWarnings`, the number of lint warnings.

--- a/docs/src/developer-guide/working-with-custom-formatters.md
+++ b/docs/src/developer-guide/working-with-custom-formatters.md
@@ -132,6 +132,7 @@ Each `message` object contains information about the ESLint rule that was trigge
 The formatter function receives an object as the second argument. The object has two properties:
 
 * `cwd` ... The current working directory. This value comes from the `cwd` constructor option of the [ESLint](nodejs-api#-new-eslintoptions) class.
+* `maxWarningsExceeded` (optional): If `--max-warnings` was set and the number of warnings exceeded the limit, this property's value will be an object containing two properties: `maxWarnings`, the value of the `--max-warnings` option, and `foundWarnings`, the number of lint warnings.
 * `rulesMeta` ... The `meta` property values of rules. See the [Working with Rules](working-with-rules) page for more information about rules.
 
 For example, here's what the object would look like if one rule, `no-extra-semi`, had been run:
@@ -139,6 +140,10 @@ For example, here's what the object would look like if one rule, `no-extra-semi`
 ```js
 {
     cwd: "/path/to/cwd",
+    maxWarningsExceeded: {
+        maxWarnings: 5,
+        foundWarnings: 6
+    },
     rulesMeta: {
         "no-extra-semi": {
             type: "suggestion",
@@ -153,7 +158,7 @@ For example, here's what the object would look like if one rule, `no-extra-semi`
                 unexpected: "Unnecessary semicolon."
             }
         }
-    }
+    },
 }
 ```
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -38,6 +38,7 @@ const debug = require("debug")("eslint:cli");
 /** @typedef {import("./eslint/eslint").LintMessage} LintMessage */
 /** @typedef {import("./eslint/eslint").LintResult} LintResult */
 /** @typedef {import("./options").ParsedCLIOptions} ParsedCLIOptions */
+/** @typedef {import("./shared/types").ResultsMeta} ResultsMeta */
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -239,7 +240,7 @@ async function isDirectory(filePath) {
  * @param {LintResult[]} results The results to print.
  * @param {string} format The name of the formatter to use or the path to the formatter.
  * @param {string} outputFile The path for the output file.
- * @param {Object} resultsMeta Warning count and max threshold.
+ * @param {ResultsMeta} resultsMeta Warning count and max threshold.
  * @returns {Promise<boolean>} True if the printing succeeds, false if not.
  * @private
  */

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -201,7 +201,7 @@ async function translateOptions({
 /**
  * Count error messages.
  * @param {LintResult[]} results The lint results.
- * @returns {{errorCount:number;warningCount:number}} The number of error messages.
+ * @returns {{errorCount:number;fatalErrorCount:number,warningCount:number}} The number of error messages.
  */
 function countErrors(results) {
     let errorCount = 0;
@@ -239,10 +239,11 @@ async function isDirectory(filePath) {
  * @param {LintResult[]} results The results to print.
  * @param {string} format The name of the formatter to use or the path to the formatter.
  * @param {string} outputFile The path for the output file.
+ * @param {Object} resultsMeta Warning count and max threshold.
  * @returns {Promise<boolean>} True if the printing succeeds, false if not.
  * @private
  */
-async function printResults(engine, results, format, outputFile) {
+async function printResults(engine, results, format, outputFile, resultsMeta) {
     let formatter;
 
     try {
@@ -252,7 +253,7 @@ async function printResults(engine, results, format, outputFile) {
         return false;
     }
 
-    const output = await formatter.format(results);
+    const output = await formatter.format(results, resultsMeta);
 
     if (output) {
         if (outputFile) {
@@ -407,17 +408,24 @@ const cli = {
             resultsToPrint = ActiveESLint.getErrorResults(resultsToPrint);
         }
 
-        if (await printResults(engine, resultsToPrint, options.format, options.outputFile)) {
+        const resultCounts = countErrors(results);
+        const tooManyWarnings = options.maxWarnings >= 0 && resultCounts.warningCount > options.maxWarnings;
+        const resultsMeta = tooManyWarnings
+            ? {
+                maxWarningsExceeded: {
+                    maxWarnings: options.maxWarnings,
+                    foundWarnings: resultCounts.warningCount
+                }
+            }
+            : {};
+
+        if (await printResults(engine, resultsToPrint, options.format, options.outputFile, resultsMeta)) {
 
             // Errors and warnings from the original unfiltered results should determine the exit code
-            const { errorCount, fatalErrorCount, warningCount } = countErrors(results);
-
-            const tooManyWarnings =
-                options.maxWarnings >= 0 && warningCount > options.maxWarnings;
             const shouldExitForFatalErrors =
-                options.exitOnFatalError && fatalErrorCount > 0;
+                options.exitOnFatalError && resultCounts.fatalErrorCount > 0;
 
-            if (!errorCount && tooManyWarnings) {
+            if (!resultCounts.errorCount && tooManyWarnings) {
                 log.error(
                     "ESLint found too many warnings (maximum: %s).",
                     options.maxWarnings
@@ -428,7 +436,7 @@ const cli = {
                 return 2;
             }
 
-            return (errorCount || tooManyWarnings) ? 1 : 0;
+            return (resultCounts.errorCount || tooManyWarnings) ? 1 : 0;
         }
 
         return 2;

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -625,14 +625,16 @@ class ESLint {
             /**
              * The main formatter method.
              * @param {LintResult[]} results The lint results to format.
+             * @param {Object} resultsMeta Warning count and max threshold.
              * @returns {string | Promise<string>} The formatted lint results.
              */
-            format(results) {
+            format(results, resultsMeta) {
                 let rulesMeta = null;
 
                 results.sort(compareResultsByFilePath);
 
                 return formatter(results, {
+                    ...resultsMeta,
                     get cwd() {
                         return options.cwd;
                     },

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -36,11 +36,12 @@ const { version } = require("../../package.json");
 /** @typedef {import("../shared/types").Plugin} Plugin */
 /** @typedef {import("../shared/types").Rule} Rule */
 /** @typedef {import("../shared/types").LintResult} LintResult */
+/** @typedef {import("../shared/types").ResultsMeta} ResultsMeta */
 
 /**
  * The main formatter object.
  * @typedef LoadedFormatter
- * @property {function(LintResult[]): string | Promise<string>} format format function.
+ * @property {(results: LintResult[], resultsMeta: ResultsMeta) => string | Promise<string>} format format function.
  */
 
 /**
@@ -625,7 +626,7 @@ class ESLint {
             /**
              * The main formatter method.
              * @param {LintResult[]} results The lint results to format.
-             * @param {Object} resultsMeta Warning count and max threshold.
+             * @param {ResultsMeta} resultsMeta Warning count and max threshold.
              * @returns {string | Promise<string>} The formatted lint results.
              */
             format(results, resultsMeta) {

--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -59,6 +59,7 @@ const LintResultCache = require("../cli-engine/lint-result-cache");
 /** @typedef {import("../shared/types").LintMessage} LintMessage */
 /** @typedef {import("../shared/types").ParserOptions} ParserOptions */
 /** @typedef {import("../shared/types").Plugin} Plugin */
+/** @typedef {import("../shared/types").ResultsMeta} ResultsMeta */
 /** @typedef {import("../shared/types").RuleConf} RuleConf */
 /** @typedef {import("../shared/types").Rule} Rule */
 /** @typedef {ReturnType<ConfigArray.extractConfig>} ExtractedConfig */
@@ -1114,7 +1115,7 @@ class FlatESLint {
             /**
              * The main formatter method.
              * @param {LintResults[]} results The lint results to format.
-             * @param {Object} resultsMeta Warning count and max threshold.
+             * @param {ResultsMeta} resultsMeta Warning count and max threshold.
              * @returns {string} The formatted lint results.
              */
             format(results, resultsMeta) {

--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -1114,14 +1114,16 @@ class FlatESLint {
             /**
              * The main formatter method.
              * @param {LintResults[]} results The lint results to format.
+             * @param {Object} resultsMeta Warning count and max threshold.
              * @returns {string} The formatted lint results.
              */
-            format(results) {
+            format(results, resultsMeta) {
                 let rulesMeta = null;
 
                 results.sort(compareResultsByFilePath);
 
                 return formatter(results, {
+                    ...resultsMeta,
                     cwd,
                     get rulesMeta() {
                         if (!rulesMeta) {

--- a/lib/shared/types.js
+++ b/lib/shared/types.js
@@ -191,9 +191,22 @@ module.exports = {};
  */
 
 /**
+ * Information provided when the maximum warning threshold is exceeded.
+ * @typedef {Object} MaxWarningsExceeded
+ * @property {number} maxWarnings Number of warnings to trigger nonzero exit code.
+ * @property {number} foundWarnings Number of warnings found while linting.
+ */
+
+/**
+ * Metadata about results for formatters.
+ * @typedef {Object} ResultsMeta
+ * @property {MaxWarningsExceeded} [maxWarningsExceeded] Present if the maxWarnings threshold was exceeded.
+ */
+
+/**
  * A formatter function.
  * @callback FormatterFunction
  * @param {LintResult[]} results The list of linting results.
- * @param {{cwd: string, rulesMeta: Record<string, RuleMeta>}} [context] A context object.
+ * @param {{cwd: string, maxWarningsExceeded?: MaxWarningsExceeded, rulesMeta: Record<string, RuleMeta>}} [context] A context object.
  * @returns {string | Promise<string>} Formatted text.
  */


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This fixes #14881 by giving formatters access to the `--max-warnings` threshold when it is exceeded. The `maxWarningsExceeded` property matches [what `stylelint` uses](https://stylelint.io/developer-guide/formatters/).

I had hoped to disable ESLint's own output message if the formatter provides its own message, but that would require even more API, so that's left as a future possibility if we get a request for it.

#### Is there anything you'd like reviewers to focus on?

1. The logic lives in the CLI's `execute()` method because that's where we're already doing the `tooManyWarnings` exit code calculation. We could instead pass the `maxWarnings` threshold through to `ESLint`/`FlatESLint` and have them replicate that calculation to create the `maxWarningsExceeded` object, but that seemed worse. I tested this logic as part of the CLI's formatter tests rather than the `--max-warnings` tests, though the logic is adjacent.
2. Rather than adding a `maxWarningsExceeded` arg and piping that through, I put it in a `resultsMeta` object in case we want to add something else to it in the future.
3. `stylelint`'s `maxWarningsExceeded` property only exists if the threshold was exceeded. We could set it to `null` or `false` instead of omitting it, but I matched `stylelint`'s behavior.
4. I enabled this for both `ESLint` as well as `FlatESLint` because I only had to pass through the `resultsMeta` object. If we feel like we need more carrots to encourage switching to `FlatESLint` and that this would be a good one, I could remove it.

<!-- markdownlint-disable-file MD004 -->
