### PR TITLE
chore: suppress a Node.js deprecation warning

### DIFF
--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -2607,7 +2607,17 @@ describe("FlatESLint", () => {
             let id;
 
             beforeEach(() => (id = Date.now().toString()));
-            afterEach(async () => fsp.rmdir(root, { recursive: true, force: true }));
+
+            /*
+             * `fs.rmdir(path, { recursive: true })` is deprecated and will be removed.
+             * Use `fs.rm(path, { recursive: true })` instead.
+             * When supporting Node.js 14.14.0+, the compatibility condition can be removed for `fs.rmdir`.
+             */
+            if (typeof fsp.rm === "function") {
+                afterEach(async () => fsp.rm(root, { recursive: true, force: true }));
+            } else {
+                afterEach(async () => fsp.rmdir(root, { recursive: true, force: true }));
+            }
 
             it("should lint only JavaScript blocks.", async () => {
                 const teardown = createCustomTeardown({


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Follow up https://github.com/nodejs/node/pull/37302.

This PR suppress the following Node.js warning.

```console
% node -v
v18.10.0
% cd path/to/eslint
% node Makefile mocha
Running unit tests
(snip)

(node:63796) [DEP0147] DeprecationWarning: In future versions of Node.js,
fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

This PR adds compatibility condition to prevent the following error when using Node.js 14.13.1 or lower.

```console
% node -v
v14.13.1
% npx mocha tests/lib/eslint/flat-eslint.js
(snip)

1) FlatESLint
     lintFiles()
       multiple processors
         "after each" hook for "should lint only JavaScript blocks.":
     TypeError: fsp.rm is not a function
```