### PR TITLE
docs: update header

### DIFF
--- a/docs/src/_includes/layouts/base.html
+++ b/docs/src/_includes/layouts/base.html
@@ -24,7 +24,7 @@
     <title>{{ page_title }}</title>
     <meta name="description" content="{{ page_desc }}">
     <link rel="canonical" href="{{ page_url }}">
-    
+
     <!-- https://github.com/eslint/eslint/issues/15844 -->
     <base href="{{ relative_page_url }}">
 
@@ -76,7 +76,7 @@
 
 
     <style>
-    
+
         /* Overrides for funky punctuators */
         @font-face {
             font-family: "Mono Punctuators";
@@ -85,7 +85,7 @@
             unicode-range: U+40, U+7B, U+7D, U+28, U+29;
             font-display: swap;
         }
-        
+
         /* Space Grotesk for headings */
         @font-face {
             font-family: "Space Grotesk";
@@ -136,7 +136,7 @@
     <script src="https://unpkg.com/anchor-js@4.3.1/anchor.min.js"></script>
 </head>
 
-<body class="{{ hook }} docs">
+<body class="{{ hook }}">
     <a href="#main" class="c-btn c-btn--primary" id="skip-link">Skip to main content</a>
 
     {{ content | safe }}

--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -5,7 +5,7 @@ layout: base.html
 {% include "partials/docs-header.html" %}
 {% from 'components/rule-categories.macro.html' import ruleCategories %}
 
-<div class="docs-wrapper">
+<div class="docs-wrapper docs">
     <div class="docs-nav">
         <div class="desktop-only">
             {% include 'components/version-switcher.html' %}
@@ -48,7 +48,7 @@ layout: base.html
 
         {% set all_content = [all_content, further_reading_content] | join %}
     {% endif %}
-        
+
     {% if rule_meta %}
         {% set resources_content %}
             <h2 id="resources">Resources</h2>
@@ -76,7 +76,7 @@ layout: base.html
                 {% endif %}
 
                 {% include 'components/docs-toc.html' %}
-                
+
                 {{ all_content | safe }}
             </div>
 

--- a/docs/src/_includes/partials/docs-header.html
+++ b/docs/src/_includes/partials/docs-header.html
@@ -1,5 +1,5 @@
 <header class="site-header">
-    <div class="docs-wrapper">
+    <div class="docs-wrapper docs">
         <a href="https://eslint.org" aria-label="ESLint Homepage" class="logo-link">
             {% include "components/logo.html" %}
         </a>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update

To keep the top border of header consistent with other pages like Team/Blog which would take up the full width of viewport.

<img width="2467" alt="CleanShot 2022-10-10 at 18 27 43@2x" src="https://user-images.githubusercontent.com/1091472/194846619-d3260276-94f0-4f3c-9f6c-6fd3e9ac1df1.png">

[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

1. Move `.docs` class to `.docs-wrapper` element

##### Before

<img width="2465" alt="CleanShot 2022-10-10 at 18 30 17@2x" src="https://user-images.githubusercontent.com/1091472/194846673-bc8d81ce-6e03-475f-a03b-30b781b1f06e.png">

##### After

<img width="2467" alt="CleanShot 2022-10-10 at 18 30 38@2x" src="https://user-images.githubusercontent.com/1091472/194846719-467add52-b1d9-46c3-b292-f56275c851c5.png">

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
