### PR TITLE
fix: ignore messages without a `ruleId` in `getRulesMetaForResults`

### DIFF
--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -700,6 +700,10 @@ class FlatESLint {
             const allMessages = result.messages.concat(result.suppressedMessages);
 
             for (const { ruleId } of allMessages) {
+                if (!ruleId) {
+                    continue;
+                }
+
                 const rule = getRuleFromConfig(ruleId, config);
 
                 // ensure the rule exists

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -4987,6 +4987,7 @@ describe("ESLint", () => {
             const results = await engine.lintText("a");
             const rulesMeta = engine.getRulesMetaForResults(results);
 
+            assert.strictEqual(Object.keys(rulesMeta).length, 1);
             assert.strictEqual(rulesMeta.semi, coreRules.get("semi").meta);
         });
 
@@ -5003,6 +5004,7 @@ describe("ESLint", () => {
             const results = await engine.lintText("a // eslint-disable-line semi");
             const rulesMeta = engine.getRulesMetaForResults(results);
 
+            assert.strictEqual(Object.keys(rulesMeta).length, 1);
             assert.strictEqual(rulesMeta.semi, coreRules.get("semi").meta);
         });
 
@@ -5059,14 +5061,24 @@ describe("ESLint", () => {
                 reportUnusedDisableDirectives: "warn"
             });
 
-            const results = [
-                ...await engine.lintText("syntax error"),
-                ...await engine.lintText("// eslint-disable-line no-var"),
-                ...await engine.lintText("", { filePath: "/.ignored.js", warnIgnored: true })
-            ];
-            const rulesMeta = engine.getRulesMetaForResults(results);
+            {
+                const results = await engine.lintText("syntax error");
+                const rulesMeta = engine.getRulesMetaForResults(results);
 
-            assert.deepStrictEqual(rulesMeta, {});
+                assert.deepStrictEqual(rulesMeta, {});
+            }
+            {
+                const results = await engine.lintText("// eslint-disable-line no-var");
+                const rulesMeta = engine.getRulesMetaForResults(results);
+
+                assert.deepStrictEqual(rulesMeta, {});
+            }
+            {
+                const results = await engine.lintText("", { filePath: "/.ignored.js", warnIgnored: true });
+                const rulesMeta = engine.getRulesMetaForResults(results);
+
+                assert.deepStrictEqual(rulesMeta, {});
+            }
         });
 
         it("should return a non-empty value if some of the messages are related to a rule", async () => {

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -5057,7 +5057,12 @@ describe("ESLint", () => {
         it("should ignore messages not related to a rule", async () => {
             const engine = new ESLint({
                 useEslintrc: false,
-                overrideConfig: { rules: { "no-var": "warn" } },
+                overrideConfig: {
+                    ignorePatterns: "ignored.js",
+                    rules: {
+                        "no-var": "warn"
+                    }
+                },
                 reportUnusedDisableDirectives: "warn"
             });
 
@@ -5074,7 +5079,7 @@ describe("ESLint", () => {
                 assert.deepStrictEqual(rulesMeta, {});
             }
             {
-                const results = await engine.lintText("", { filePath: "/.ignored.js", warnIgnored: true });
+                const results = await engine.lintText("", { filePath: "ignored.js", warnIgnored: true });
                 const rulesMeta = engine.getRulesMetaForResults(results);
 
                 assert.deepStrictEqual(rulesMeta, {});

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -3729,7 +3729,12 @@ describe("FlatESLint", () => {
         it("should ignore messages not related to a rule", async () => {
             const engine = new FlatESLint({
                 overrideConfigFile: true,
-                overrideConfig: { rules: { "no-var": "warn" } },
+                ignorePatterns: "ignored.js",
+                overrideConfig: {
+                    rules: {
+                        "no-var": "warn"
+                    }
+                },
                 reportUnusedDisableDirectives: "warn"
             });
 
@@ -3746,7 +3751,7 @@ describe("FlatESLint", () => {
                 assert.deepStrictEqual(rulesMeta, {});
             }
             {
-                const results = await engine.lintText("", { filePath: "/.ignored.js", warnIgnored: true });
+                const results = await engine.lintText("", { filePath: "ignored.js", warnIgnored: true });
                 const rulesMeta = engine.getRulesMetaForResults(results);
 
                 assert.deepStrictEqual(rulesMeta, {});

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -3660,6 +3660,7 @@ describe("FlatESLint", () => {
             const results = await engine.lintText("a", { filePath: "foo.js" });
             const rulesMeta = engine.getRulesMetaForResults(results);
 
+            assert.strictEqual(Object.keys(rulesMeta).length, 1);
             assert.strictEqual(rulesMeta.semi, coreRules.get("semi").meta);
         });
 
@@ -3676,6 +3677,7 @@ describe("FlatESLint", () => {
             const results = await engine.lintText("a // eslint-disable-line semi");
             const rulesMeta = engine.getRulesMetaForResults(results);
 
+            assert.strictEqual(Object.keys(rulesMeta).length, 1);
             assert.strictEqual(rulesMeta.semi, coreRules.get("semi").meta);
         });
 
@@ -3731,14 +3733,24 @@ describe("FlatESLint", () => {
                 reportUnusedDisableDirectives: "warn"
             });
 
-            const results = [
-                ...await engine.lintText("syntax error"),
-                ...await engine.lintText("// eslint-disable-line no-var"),
-                ...await engine.lintText("", { filePath: "/.ignored.js", warnIgnored: true })
-            ];
-            const rulesMeta = engine.getRulesMetaForResults(results);
+            {
+                const results = await engine.lintText("syntax error");
+                const rulesMeta = engine.getRulesMetaForResults(results);
 
-            assert.deepStrictEqual(rulesMeta, {});
+                assert.deepStrictEqual(rulesMeta, {});
+            }
+            {
+                const results = await engine.lintText("// eslint-disable-line no-var");
+                const rulesMeta = engine.getRulesMetaForResults(results);
+
+                assert.deepStrictEqual(rulesMeta, {});
+            }
+            {
+                const results = await engine.lintText("", { filePath: "/.ignored.js", warnIgnored: true });
+                const rulesMeta = engine.getRulesMetaForResults(results);
+
+                assert.deepStrictEqual(rulesMeta, {});
+            }
         });
 
         it("should return a non-empty value if some of the messages are related to a rule", async () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #16402

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* `FlatESLint.prototype.getRulesMetaForResults` will now ignore messages without a `ruleId` instead of crashing with a `TypeError`.
* Unit tests for `getRulesMetaForResults` added for both `FlatESLint` and `ESLint`.
* The unit test "should return one rule meta when there is a suppressed linting error" was ported to `FlatESLint`. This was originally introduced for `ESLint` in #15459.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
