### PR TITLE
fix: `--ignore-pattern` in flat config mode should be relative to `cwd`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -92,7 +92,7 @@ module.exports = [
             "tmp/**",
             "tools/internal-rules/node_modules/**",
             "**/test.js",
-            "!**/.eslintrc.js"
+            "!.eslintrc.js"
         ]
     },
     {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -143,12 +143,6 @@ async function translateOptions({
             overrideConfig[0].plugins = plugins;
         }
 
-        if (ignorePattern) {
-            overrideConfig.push({
-                ignores: ignorePattern
-            });
-        }
-
     } else {
         overrideConfigFile = config;
 
@@ -193,6 +187,10 @@ async function translateOptions({
         options.useEslintrc = eslintrc;
         options.extensions = ext;
         options.ignorePath = ignorePath;
+    } else {
+        if (ignorePattern) {
+            options.ignorePatterns = ignorePattern;
+        }
     }
 
     return options;

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -181,16 +181,14 @@ async function translateOptions({
         reportUnusedDisableDirectives: reportUnusedDisableDirectives ? "error" : void 0
     };
 
-    if (configType !== "flat") {
+    if (configType === "flat") {
+        options.ignorePatterns = ignorePattern;
+    } else {
         options.resolvePluginsRelativeTo = resolvePluginsRelativeTo;
         options.rulePaths = rulesdir;
         options.useEslintrc = eslintrc;
         options.extensions = ext;
         options.ignorePath = ignorePath;
-    } else {
-        if (ignorePattern) {
-            options.ignorePatterns = ignorePattern;
-        }
     }
 
     return options;

--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -362,17 +362,6 @@ async function calculateConfigArray(eslint, {
             const negated = pattern.startsWith("!");
             const basePattern = negated ? pattern.slice(1) : pattern;
 
-            /*
-             * Ignore patterns are considered relative to a directory
-             * when the pattern contains a slash in a position other
-             * than the last character. If that's the case, we need to
-             * add the relative ignore path to the current pattern to
-             * get the correct behavior. Otherwise, no change is needed.
-             */
-            if (!basePattern.includes("/") || basePattern.endsWith("/")) {
-                return pattern;
-            }
-
             return (negated ? "!" : "") +
                 path.posix.join(relativeIgnorePath, basePattern);
         });

--- a/tests/fixtures/cli/ignore-pattern-relative/.eslintrc.js
+++ b/tests/fixtures/cli/ignore-pattern-relative/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+    root: true
+};

--- a/tests/fixtures/cli/ignore-pattern-relative/eslint.config.js
+++ b/tests/fixtures/cli/ignore-pattern-relative/eslint.config.js
@@ -1,0 +1,1 @@
+module.exports = [];

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -798,6 +798,32 @@ describe("cli", () => {
                         assert.strictEqual(exit, 0);
                     });
 
+                    it(`should interpret pattern that contains a slash as relative to cwd with configType:${configType}`, async () => {
+                        process.cwd = () => getFixturePath("cli/ignore-pattern-relative/subdir");
+
+                        /*
+                         * The config file is in `cli/ignore-pattern-relative`, so this would fail
+                         * if `subdir/**` ignore pattern is interpreted as relative to the config base path.
+                         */
+                        const exit = await cli.execute("**/*.js --ignore-pattern subdir/**", null, useFlatConfig);
+
+                        assert.strictEqual(exit, 0);
+
+                        await stdAssert.rejects(
+                            async () => await cli.execute("**/*.js --ignore-pattern subsubdir/*.js", null, useFlatConfig),
+                            /All files matched by '\*\*\/\*\.js' are ignored/u
+                        );
+                    });
+
+                    it(`should interpret pattern that doesn't contain a slash as relative to cwd with configType:${configType}`, async () => {
+                        process.cwd = () => getFixturePath("cli/ignore-pattern-relative/subdir/subsubdir");
+
+                        await stdAssert.rejects(
+                            async () => await cli.execute("**/*.js --ignore-pattern *.js", null, useFlatConfig),
+                            /All files matched by '\*\*\/\*\.js' are ignored/u
+                        );
+                    });
+
                     if (useFlatConfig) {
                         it("should ignore files if the pattern is a path to a directory (with trailing slash)", async () => {
                             const filePath = getFixturePath("cli/syntax-error.js");


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Closes https://github.com/eslint/eslint/issues/16264

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

After fixing https://github.com/eslint/eslint/issues/16300, `--ignore-pattern` became relative to `configs.basePath`, because they were mapped to `overrideConfig.ignores`. I updated `cli.js` to map them to the `ignorePatterns` constructor option instead, so now they will be again relative to `cwd`.

#### Is there anything you'd like reviewers to focus on?

The removed conditional in `flat-eslint.js`.
