### PR TITLE
fix: remove redundant spaces when auto-fixing `prefer-template` rule

### DIFF
--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -195,11 +195,8 @@ module.exports = {
                 const plusSign = sourceCode.getFirstTokenBetween(currentNode.left, currentNode.right, token => token.value === "+");
                 const textBeforePlus = getTextBetween(currentNode.left, plusSign);
                 const textAfterPlus = getTextBetween(plusSign, currentNode.right);
-                const cleanTextAroundPlus = `${
-                    textBeforePlus.replace(/ +$/u, "")
-                }${
-                    textAfterPlus.replace(/^ +/u, "")
-                }`;
+                const cleanTextAroundPlus = textBeforePlus.replace(/ +$/u, "") +
+                  textAfterPlus.replace(/^ +/u, "");
 
                 const leftEndsWithCurly = endsWithTemplateCurly(currentNode.left);
                 const rightStartsWithCurly = startsWithTemplateCurly(currentNode.right);

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -166,6 +166,9 @@ module.exports = {
          * @returns {string} A string form of this node, represented as a template literal
          */
         function getTemplateLiteral(currentNode, textBeforeNode, textAfterNode) {
+            const cleanTextBeforeNode = (textBeforeNode || "").replace(/^ +?/u, "");
+            const cleanTextAfterNode = (textAfterNode || "").replace(/ +$/u, "");
+
             if (currentNode.type === "Literal" && typeof currentNode.value === "string") {
 
                 /*
@@ -192,6 +195,12 @@ module.exports = {
                 const plusSign = sourceCode.getFirstTokenBetween(currentNode.left, currentNode.right, token => token.value === "+");
                 const textBeforePlus = getTextBetween(currentNode.left, plusSign);
                 const textAfterPlus = getTextBetween(plusSign, currentNode.right);
+                const cleanTextAroundPlus = `${
+                    textBeforePlus.replace(/ +$/u, "")
+                }${
+                    textAfterPlus.replace(/^ +/u, "")
+                }`;
+
                 const leftEndsWithCurly = endsWithTemplateCurly(currentNode.left);
                 const rightStartsWithCurly = startsWithTemplateCurly(currentNode.right);
 
@@ -199,7 +208,7 @@ module.exports = {
 
                     // If the left side of the expression ends with a template curly, add the extra text to the end of the curly bracket.
                     // `foo${bar}` /* comment */ + 'baz' --> `foo${bar /* comment */  }${baz}`
-                    return getTemplateLiteral(currentNode.left, textBeforeNode, textBeforePlus + textAfterPlus).slice(0, -1) +
+                    return getTemplateLiteral(currentNode.left, textBeforeNode, cleanTextAroundPlus).slice(0, -1) +
                         getTemplateLiteral(currentNode.right, null, textAfterNode).slice(1);
                 }
                 if (rightStartsWithCurly) {
@@ -207,17 +216,17 @@ module.exports = {
                     // Otherwise, if the right side of the expression starts with a template curly, add the text there.
                     // 'foo' /* comment */ + `${bar}baz` --> `foo${ /* comment */  bar}baz`
                     return getTemplateLiteral(currentNode.left, textBeforeNode, null).slice(0, -1) +
-                        getTemplateLiteral(currentNode.right, textBeforePlus + textAfterPlus, textAfterNode).slice(1);
+                        getTemplateLiteral(currentNode.right, cleanTextAroundPlus, textAfterNode).slice(1);
                 }
 
                 /*
                  * Otherwise, these nodes should not be combined into a template curly, since there is nowhere to put
                  * the text between them.
                  */
-                return `${getTemplateLiteral(currentNode.left, textBeforeNode, null)}${textBeforePlus}+${textAfterPlus}${getTemplateLiteral(currentNode.right, textAfterNode, null)}`;
+                return `${getTemplateLiteral(currentNode.left, cleanTextBeforeNode, null)}${textBeforePlus}+${textAfterPlus}${getTemplateLiteral(currentNode.right, cleanTextAfterNode, null)}`;
             }
 
-            return `\`\${${textBeforeNode || ""}${sourceCode.getText(currentNode)}${textAfterNode || ""}}\``;
+            return `\`\${${cleanTextBeforeNode}${sourceCode.getText(currentNode)}${cleanTextAfterNode}}\``;
         }
 
         /**

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -220,7 +220,7 @@ module.exports = {
                  * Otherwise, these nodes should not be combined into a template curly, since there is nowhere to put
                  * the text between them.
                  */
-                return `${getTemplateLiteral(currentNode.left, cleanTextBeforeNode, null)}${textBeforePlus}+${textAfterPlus}${getTemplateLiteral(currentNode.right, cleanTextAfterNode, null)}`;
+                return `${getTemplateLiteral(currentNode.left, textBeforeNode, null)}${textBeforePlus}+${textAfterPlus}${getTemplateLiteral(currentNode.right, textAfterNode, null)}`;
             }
 
             return `\`\${${cleanTextBeforeNode}${sourceCode.getText(currentNode)}${cleanTextAfterNode}}\``;

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -90,7 +90,7 @@ function hasNonStringLiteral(node) {
 
 /**
  * Determines whether a given node will start with a template curly expression (`${}`) when being converted to a template literal.
- * @param {ASTNode} node The node that will be fixed to a template literal
+ * @param {ASTNode} node The node that will be fixed to a template literal.
  * @returns {boolean} `true` if the node will start with a template curly.
  */
 function startsWithTemplateCurly(node) {
@@ -105,7 +105,7 @@ function startsWithTemplateCurly(node) {
 
 /**
  * Determines whether a given node end with a template curly expression (`${}`) when being converted to a template literal.
- * @param {ASTNode} node The node that will be fixed to a template literal
+ * @param {ASTNode} node The node that will be fixed to a template literal.
  * @returns {boolean} `true` if the node will end with a template curly.
  */
 function endsWithTemplateCurly(node) {
@@ -116,6 +116,24 @@ function endsWithTemplateCurly(node) {
         return node.expressions.length && node.quasis.length && node.quasis[node.quasis.length - 1].range[0] === node.quasis[node.quasis.length - 1].range[1];
     }
     return node.type !== "Literal" || typeof node.value !== "string";
+}
+
+/**
+ * Removes spaces from the beginning of a string.
+ * @param {string | undefined} text The text that will be trimmed of leading spaces.
+ * @returns {string} The trimmed text, or an empty string.
+ */
+function trimLeadingSpaces(text) {
+    return (text || "").replace(/^ +/u, "");
+}
+
+/**
+ * Removes spaces from the end of a string.
+ * @param {string | undefined} text The text that will be trimmed of trailing spaces.
+ * @returns {string} The trimmed text, or an empty string.
+ */
+function trimTrailingSpaces(text) {
+    return (text || "").replace(/ +$/u, "");
 }
 
 //------------------------------------------------------------------------------
@@ -166,9 +184,6 @@ module.exports = {
          * @returns {string} A string form of this node, represented as a template literal
          */
         function getTemplateLiteral(currentNode, textBeforeNode, textAfterNode) {
-            const cleanTextBeforeNode = (textBeforeNode || "").replace(/^ +?/u, "");
-            const cleanTextAfterNode = (textAfterNode || "").replace(/ +$/u, "");
-
             if (currentNode.type === "Literal" && typeof currentNode.value === "string") {
 
                 /*
@@ -195,8 +210,7 @@ module.exports = {
                 const plusSign = sourceCode.getFirstTokenBetween(currentNode.left, currentNode.right, token => token.value === "+");
                 const textBeforePlus = getTextBetween(currentNode.left, plusSign);
                 const textAfterPlus = getTextBetween(plusSign, currentNode.right);
-                const cleanTextAroundPlus = textBeforePlus.replace(/ +$/u, "") +
-                  textAfterPlus.replace(/^ +/u, "");
+                const cleanTextAroundPlus = trimTrailingSpaces(textBeforePlus) + trimLeadingSpaces(textAfterPlus);
 
                 const leftEndsWithCurly = endsWithTemplateCurly(currentNode.left);
                 const rightStartsWithCurly = startsWithTemplateCurly(currentNode.right);
@@ -222,6 +236,9 @@ module.exports = {
                  */
                 return `${getTemplateLiteral(currentNode.left, textBeforeNode, null)}${textBeforePlus}+${textAfterPlus}${getTemplateLiteral(currentNode.right, textAfterNode, null)}`;
             }
+
+            const cleanTextBeforeNode = trimLeadingSpaces(textBeforeNode);
+            const cleanTextAfterNode = trimTrailingSpaces(textAfterNode);
 
             return `\`\${${cleanTextBeforeNode}${sourceCode.getText(currentNode)}${cleanTextAfterNode}}\``;
         }

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -40,87 +40,87 @@ ruleTester.run("prefer-template", rule, {
     invalid: [
         {
             code: "var foo = 'hello, ' + name + '!';",
-            output: "var foo = `hello, ${  name  }!`;",
+            output: "var foo = `hello, ${name}!`;",
             errors
         },
         {
             code: "var foo = bar + 'baz';",
-            output: "var foo = `${bar  }baz`;",
+            output: "var foo = `${bar}baz`;",
             errors
         },
         {
             code: "var foo = bar + `baz`;",
-            output: "var foo = `${bar  }baz`;",
+            output: "var foo = `${bar}baz`;",
             errors
         },
         {
             code: "var foo = +100 + 'yen';",
-            output: "var foo = `${+100  }yen`;",
+            output: "var foo = `${+100}yen`;",
             errors
         },
         {
             code: "var foo = 'bar' + baz;",
-            output: "var foo = `bar${  baz}`;",
+            output: "var foo = `bar${baz}`;",
             errors
         },
         {
             code: "var foo = '￥' + (n * 1000) + '-'",
-            output: "var foo = `￥${  n * 1000  }-`",
+            output: "var foo = `￥${n * 1000}-`",
             errors
         },
         {
             code: "var foo = 'aaa' + aaa; var bar = 'bbb' + bbb;",
-            output: "var foo = `aaa${  aaa}`; var bar = `bbb${  bbb}`;",
+            output: "var foo = `aaa${aaa}`; var bar = `bbb${bbb}`;",
             errors: [errors[0], errors[0]]
         },
         {
             code: "var string = (number + 1) + 'px';",
-            output: "var string = `${number + 1  }px`;",
+            output: "var string = `${number + 1}px`;",
             errors
         },
         {
             code: "var foo = 'bar' + baz + 'qux';",
-            output: "var foo = `bar${  baz  }qux`;",
+            output: "var foo = `bar${baz}qux`;",
             errors
         },
         {
             code: "var foo = '0 backslashes: ${bar}' + baz;",
-            output: "var foo = `0 backslashes: \\${bar}${  baz}`;",
+            output: "var foo = `0 backslashes: \\${bar}${baz}`;",
             errors
         },
         {
             code: "var foo = '1 backslash: \\${bar}' + baz;",
-            output: "var foo = `1 backslash: \\${bar}${  baz}`;",
+            output: "var foo = `1 backslash: \\${bar}${baz}`;",
             errors
         },
         {
             code: "var foo = '2 backslashes: \\\\${bar}' + baz;",
-            output: "var foo = `2 backslashes: \\\\\\${bar}${  baz}`;",
+            output: "var foo = `2 backslashes: \\\\\\${bar}${baz}`;",
             errors
         },
         {
             code: "var foo = '3 backslashes: \\\\\\${bar}' + baz;",
-            output: "var foo = `3 backslashes: \\\\\\${bar}${  baz}`;",
+            output: "var foo = `3 backslashes: \\\\\\${bar}${baz}`;",
             errors
         },
         {
             code: "var foo = bar + 'this is a backtick: `' + baz;",
-            output: "var foo = `${bar  }this is a backtick: \\`${  baz}`;",
+            output: "var foo = `${bar}this is a backtick: \\`${baz}`;",
             errors
         },
         {
             code: "var foo = bar + 'this is a backtick preceded by a backslash: \\`' + baz;",
-            output: "var foo = `${bar  }this is a backtick preceded by a backslash: \\`${  baz}`;",
+            output: "var foo = `${bar}this is a backtick preceded by a backslash: \\`${baz}`;",
             errors
         },
         {
             code: "var foo = bar + 'this is a backtick preceded by two backslashes: \\\\`' + baz;",
-            output: "var foo = `${bar  }this is a backtick preceded by two backslashes: \\\\\\`${  baz}`;",
+            output: "var foo = `${bar}this is a backtick preceded by two backslashes: \\\\\\`${baz}`;",
             errors
         },
         {
             code: "var foo = bar + `${baz}foo`;",
-            output: "var foo = `${bar  }${baz}foo`;",
+            output: "var foo = `${bar}${baz}foo`;",
             errors
         },
         {
@@ -129,14 +129,14 @@ ruleTester.run("prefer-template", rule, {
             "    return f.name;\n" +
             "}) + ';';",
             output:
-            "var foo = `favorites: ${  favorites.map(f => {\n" +
+            "var foo = `favorites: ${favorites.map(f => {\n" +
             "    return f.name;\n" +
-            "})  };`;",
+            "})};`;",
             errors
         },
         {
             code: "var foo = bar + baz + 'qux';",
-            output: "var foo = `${bar + baz  }qux`;",
+            output: "var foo = `${bar + baz}qux`;",
             errors
         },
         {
@@ -147,46 +147,46 @@ ruleTester.run("prefer-template", rule, {
             "    }) +\n" +
             "';';",
             output:
-            "var foo = `favorites: ${ \n" +
+            "var foo = `favorites: ${\n" +
             "    favorites.map(f => {\n" +
             "        return f.name;\n" +
-            "    }) \n" +
+            "    })\n" +
             "};`;",
             errors
         },
         {
             code: "var foo = /* a */ 'bar' /* b */ + /* c */ baz /* d */ + 'qux' /* e */ ;",
-            output: "var foo = /* a */ `bar${ /* b */  /* c */ baz /* d */  }qux` /* e */ ;",
+            output: "var foo = /* a */ `bar${/* b *//* c */ baz /* d */}qux` /* e */ ;",
             errors
         },
         {
             code: "var foo = bar + ('baz') + 'qux' + (boop);",
-            output: "var foo = `${bar  }baz` + `qux${  boop}`;",
+            output: "var foo = `${bar}baz` + `qux${boop}`;",
             errors
         },
         {
             code: "foo + 'unescapes an escaped single quote in a single-quoted string: \\''",
-            output: "`${foo  }unescapes an escaped single quote in a single-quoted string: '`",
+            output: "`${foo}unescapes an escaped single quote in a single-quoted string: '`",
             errors
         },
         {
             code: "foo + \"unescapes an escaped double quote in a double-quoted string: \\\"\"",
-            output: "`${foo  }unescapes an escaped double quote in a double-quoted string: \"`",
+            output: "`${foo}unescapes an escaped double quote in a double-quoted string: \"`",
             errors
         },
         {
             code: "foo + 'does not unescape an escaped double quote in a single-quoted string: \\\"'",
-            output: "`${foo  }does not unescape an escaped double quote in a single-quoted string: \\\"`",
+            output: "`${foo}does not unescape an escaped double quote in a single-quoted string: \\\"`",
             errors
         },
         {
             code: "foo + \"does not unescape an escaped single quote in a double-quoted string: \\'\"",
-            output: "`${foo  }does not unescape an escaped single quote in a double-quoted string: \\'`",
+            output: "`${foo}does not unescape an escaped single quote in a double-quoted string: \\'`",
             errors
         },
         {
             code: "foo + 'handles unicode escapes correctly: \\x27'", // "\x27" === "'"
-            output: "`${foo  }handles unicode escapes correctly: \\x27`",
+            output: "`${foo}handles unicode escapes correctly: \\x27`",
             errors
         },
         {
@@ -216,12 +216,12 @@ ruleTester.run("prefer-template", rule, {
         },
         {
             code: "foo + '\\\\033'",
-            output: "`${foo  }\\\\033`",
+            output: "`${foo}\\\\033`",
             errors
         },
         {
             code: "foo + '\\0'",
-            output: "`${foo  }\\0`",
+            output: "`${foo}\\0`",
             errors
         },
 
@@ -232,177 +232,177 @@ ruleTester.run("prefer-template", rule, {
             + "report-to " + foo + ";"`,
             output: `\`default-src 'self' https://*.google.com;\`
             + \`frame-ancestors 'none';\`
-            + \`report-to \${  foo  };\``,
+            + \`report-to \${foo};\``,
             errors
         },
         {
             code: "'a' + 'b' + foo",
-            output: "`a` + `b${  foo}`",
+            output: "`a` + `b${foo}`",
             errors
         },
         {
             code: "'a' + 'b' + foo + 'c' + 'd'",
-            output: "`a` + `b${  foo  }c` + `d`",
+            output: "`a` + `b${foo}c` + `d`",
             errors
         },
         {
             code: "'a' + 'b + c' + foo + 'd' + 'e'",
-            output: "`a` + `b + c${  foo  }d` + `e`",
+            output: "`a` + `b + c${foo}d` + `e`",
             errors
         },
         {
             code: "'a' + 'b' + foo + ('c' + 'd')",
-            output: "`a` + `b${  foo  }c` + `d`",
+            output: "`a` + `b${foo}c` + `d`",
             errors
         },
         {
             code: "'a' + 'b' + foo + ('a' + 'b')",
-            output: "`a` + `b${  foo  }a` + `b`",
+            output: "`a` + `b${foo}a` + `b`",
             errors
         },
         {
             code: "'a' + 'b' + foo + ('c' + 'd') + ('e' + 'f')",
-            output: "`a` + `b${  foo  }c` + `d` + `e` + `f`",
+            output: "`a` + `b${foo}c` + `d` + `e` + `f`",
             errors
         },
         {
             code: "foo + ('a' + 'b') + ('c' + 'd')",
-            output: "`${foo  }a` + `b` + `c` + `d`",
+            output: "`${foo}a` + `b` + `c` + `d`",
             errors
         },
         {
             code: "'a' + foo + ('b' + 'c') + ('d' + bar + 'e')",
-            output: "`a${  foo  }b` + `c` + `d${  bar  }e`",
+            output: "`a${foo}b` + `c` + `d${bar}e`",
             errors
         },
         {
             code: "foo + ('b' + 'c') + ('d' + bar + 'e')",
-            output: "`${foo  }b` + `c` + `d${  bar  }e`",
+            output: "`${foo}b` + `c` + `d${bar}e`",
             errors
         },
         {
             code: "'a' + 'b' + foo + ('c' + 'd' + 'e')",
-            output: "`a` + `b${  foo  }c` + `d` + `e`",
+            output: "`a` + `b${foo}c` + `d` + `e`",
             errors
         },
         {
             code: "'a' + 'b' + foo + ('c' + bar + 'd')",
-            output: "`a` + `b${  foo  }c${  bar  }d`",
+            output: "`a` + `b${foo}c${bar}d`",
             errors
         },
         {
             code: "'a' + 'b' + foo + ('c' + bar + ('d' + 'e') + 'f')",
-            output: "`a` + `b${  foo  }c${  bar  }d` + `e` + `f`",
+            output: "`a` + `b${foo}c${bar}d` + `e` + `f`",
             errors
         },
         {
             code: "'a' + 'b' + foo + ('c' + bar + 'e') + 'f' + test",
-            output: "`a` + `b${  foo  }c${  bar  }e` + `f${  test}`",
+            output: "`a` + `b${foo}c${bar}e` + `f${test}`",
             errors
         },
         {
             code: "'a' + foo + ('b' + bar + 'c') + ('d' + test)",
-            output: "`a${  foo  }b${  bar  }c` + `d${  test}`",
+            output: "`a${foo}b${bar}c` + `d${test}`",
             errors
         },
         {
             code: "'a' + foo + ('b' + 'c') + ('d' + bar)",
-            output: "`a${  foo  }b` + `c` + `d${  bar}`",
+            output: "`a${foo}b` + `c` + `d${bar}`",
             errors
         },
         {
             code: "foo + ('a' + bar + 'b') + 'c' + test",
-            output: "`${foo  }a${  bar  }b` + `c${  test}`",
+            output: "`${foo}a${bar}b` + `c${test}`",
             errors
         },
         {
             code: "'a' + '`b`' + c",
-            output: "`a` + `\\`b\\`${  c}`",
+            output: "`a` + `\\`b\\`${c}`",
             errors
         },
         {
             code: "'a' + '`b` + `c`' + d",
-            output: "`a` + `\\`b\\` + \\`c\\`${  d}`",
+            output: "`a` + `\\`b\\` + \\`c\\`${d}`",
             errors
         },
         {
             code: "'a' + b + ('`c`' + '`d`')",
-            output: "`a${  b  }\\`c\\`` + `\\`d\\``",
+            output: "`a${b}\\`c\\`` + `\\`d\\``",
             errors
         },
         {
             code: "'`a`' + b + ('`c`' + '`d`')",
-            output: "`\\`a\\`${  b  }\\`c\\`` + `\\`d\\``",
+            output: "`\\`a\\`${b}\\`c\\`` + `\\`d\\``",
             errors
         },
         {
             code: "foo + ('`a`' + bar + '`b`') + '`c`' + test",
-            output: "`${foo  }\\`a\\`${  bar  }\\`b\\`` + `\\`c\\`${  test}`",
+            output: "`${foo}\\`a\\`${bar}\\`b\\`` + `\\`c\\`${test}`",
             errors
         },
         {
             code: "'a' + ('b' + 'c') + d",
-            output: "`a` + `b` + `c${  d}`",
+            output: "`a` + `b` + `c${d}`",
             errors
         },
         {
             code: "'a' + ('`b`' + '`c`') + d",
-            output: "`a` + `\\`b\\`` + `\\`c\\`${  d}`",
+            output: "`a` + `\\`b\\`` + `\\`c\\`${d}`",
             errors
         },
         {
             code: "a + ('b' + 'c') + d",
-            output: "`${a  }b` + `c${  d}`",
+            output: "`${a}b` + `c${d}`",
             errors
         },
         {
             code: "a + ('b' + 'c') + (d + 'e')",
-            output: "`${a  }b` + `c${  d  }e`",
+            output: "`${a}b` + `c${d}e`",
             errors
         },
         {
             code: "a + ('`b`' + '`c`') + d",
-            output: "`${a  }\\`b\\`` + `\\`c\\`${  d}`",
+            output: "`${a}\\`b\\`` + `\\`c\\`${d}`",
             errors
         },
         {
             code: "a + ('`b` + `c`' + '`d`') + e",
-            output: "`${a  }\\`b\\` + \\`c\\`` + `\\`d\\`${  e}`",
+            output: "`${a}\\`b\\` + \\`c\\`` + `\\`d\\`${e}`",
             errors
         },
         {
             code: "'a' + ('b' + 'c' + 'd') + e",
-            output: "`a` + `b` + `c` + `d${  e}`",
+            output: "`a` + `b` + `c` + `d${e}`",
             errors
         },
         {
             code: "'a' + ('b' + 'c' + 'd' + (e + 'f') + 'g' +'h' + 'i') + j",
-            output: "`a` + `b` + `c` + `d${  e  }fg` +`h` + `i${  j}`",
+            output: "`a` + `b` + `c` + `d${e}fg` +`h` + `i${j}`",
             errors
         },
         {
             code: "a + (('b' + 'c') + 'd')",
-            output: "`${a  }b` + `c` + `d`",
+            output: "`${a}b` + `c` + `d`",
             errors
         },
         {
             code: "(a + 'b') + ('c' + 'd') + e",
-            output: "`${a  }b` + `c` + `d${  e}`",
+            output: "`${a}b` + `c` + `d${e}`",
             errors
         },
         {
             code: "var foo = \"Hello \" + \"world \" + \"another \" + test",
-            output: "var foo = `Hello ` + `world ` + `another ${  test}`",
+            output: "var foo = `Hello ` + `world ` + `another ${test}`",
             errors
         },
         {
             code: "'Hello ' + '\"world\" ' + test",
-            output: "`Hello ` + `\"world\" ${  test}`",
+            output: "`Hello ` + `\"world\" ${test}`",
             errors
         },
         {
             code: "\"Hello \" + \"'world' \" + test",
-            output: "`Hello ` + `'world' ${  test}`",
+            output: "`Hello ` + `'world' ${test}`",
             errors
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Following issue [https://github.com/eslint/eslint/issues/8520](https://github.com/eslint/eslint/issues/8520) (one of multiple issues that describe of the same topic), I added a logic to ignore redundant spaces when auto-fixing the [`prefer-template`](https://eslint.org/docs/latest/rules/prefer-template) rule.
The change affects pretty much all of the invalid case tests, hence it's self-explanatory.

#### Is there anything you'd like reviewers to focus on?

I wasn't sure how much of the code should be inline, as opposed to helper functions.

<!-- markdownlint-disable-file MD004 -->
