### PR TITLE
fix: use `baseConfig` constructor option in FlatESLint

### DIFF
--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -262,24 +262,16 @@ function findFlatConfigFile(cwd) {
 /**
  * Load the config array from the given filename.
  * @param {string} filePath The filename to load from.
- * @param {Object} options Options to help load the config file.
- * @param {string} options.basePath The base path for the config array.
- * @param {boolean} options.shouldIgnore Whether to honor ignore patterns.
- * @returns {Promise<FlatConfigArray>} The config array loaded from the config file.
+ * @returns {Promise<any>} The config loaded from the config file.
  */
-async function loadFlatConfigFile(filePath, { basePath, shouldIgnore }) {
+async function loadFlatConfigFile(filePath) {
     debug(`Loading config from ${filePath}`);
 
     const fileURL = pathToFileURL(filePath);
 
     debug(`Config file URL is ${fileURL}`);
 
-    const module = await import(fileURL);
-
-    return new FlatConfigArray(module.default, {
-        basePath,
-        shouldIgnore
-    });
+    return (await import(fileURL)).default;
 }
 
 /**
@@ -290,6 +282,7 @@ async function loadFlatConfigFile(filePath, { basePath, shouldIgnore }) {
  */
 async function calculateConfigArray(eslint, {
     cwd,
+    baseConfig,
     overrideConfig,
     configFile,
     ignore: shouldIgnore,
@@ -321,16 +314,18 @@ async function calculateConfigArray(eslint, {
         basePath = path.resolve(path.dirname(configFilePath));
     }
 
-    // load config array
-    let configs;
 
+    const configs = new FlatConfigArray(baseConfig || [], { basePath, shouldIgnore });
+
+    // load config file
     if (configFilePath) {
-        configs = await loadFlatConfigFile(configFilePath, {
-            basePath,
-            shouldIgnore
-        });
-    } else {
-        configs = new FlatConfigArray([], { basePath, shouldIgnore });
+        const fileConfig = await loadFlatConfigFile(configFilePath);
+
+        if (Array.isArray(fileConfig)) {
+            configs.push(...fileConfig);
+        } else {
+            configs.push(fileConfig);
+        }
     }
 
     // add in any configured defaults

--- a/tests/fixtures/eslint.config_with_rules.js
+++ b/tests/fixtures/eslint.config_with_rules.js
@@ -1,0 +1,5 @@
+module.exports = [{
+    rules: {
+        quotes: ["error", "single"]
+    }
+}];


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes https://github.com/eslint/eslint/issues/16341

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed `FlatESLint` class to use `baseConfig`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
