### PR TITLE
fix: handle files with unspecified path in `getRulesMetaForResults`

### DIFF
--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -161,6 +161,16 @@ function createRulesMeta(rules) {
     }, {});
 }
 
+/**
+ * Return the absolute path of a file named `"__placeholder__.js"` in a given directory.
+ * This is used as a replacement for a missing file path.
+ * @param {string} cwd An absolute directory path.
+ * @returns {string} The absolute path of a file named `"__placeholder__.js"` in the given directory.
+ */
+function getPlaceholderPath(cwd) {
+    return path.join(cwd, "__placeholder__.js");
+}
+
 /** @type {WeakMap<ExtractedConfig, DeprecatedRuleInfo[]>} */
 const usedDeprecatedRulesCache = new WeakMap();
 
@@ -177,7 +187,7 @@ function getOrFindUsedDeprecatedRules(eslint, maybeFilePath) {
     } = privateMembers.get(eslint);
     const filePath = path.isAbsolute(maybeFilePath)
         ? maybeFilePath
-        : path.join(cwd, "__placeholder__.js");
+        : getPlaceholderPath(cwd);
     const config = configs.getConfig(filePath);
 
     // Most files use the same config, so cache it.
@@ -427,7 +437,7 @@ function verifyText({
      * `config.extractConfig(filePath)` requires an absolute path, but `linter`
      * doesn't know CWD, so it gives `linter` an absolute path always.
      */
-    const filePathToVerify = filePath === "<text>" ? path.join(cwd, "__placeholder__.js") : filePath;
+    const filePathToVerify = filePath === "<text>" ? getPlaceholderPath(cwd) : filePath;
     const { fixed, messages, output } = linter.verifyAndFix(
         text,
         configs,
@@ -522,6 +532,14 @@ function *iterateRuleDeprecationWarnings(configs) {
             };
         }
     }
+}
+
+/**
+ * Creates an error to be thrown when an array of results passed to `getRulesMetaForResults` was not created by the current engine.
+ * @returns {TypeError} An error object.
+ */
+function createExtraneousResultsError() {
+    return new TypeError("Results object was not created from this ESLint instance.");
 }
 
 //-----------------------------------------------------------------------------
@@ -660,7 +678,10 @@ class FlatESLint {
         }
 
         const resultRules = new Map();
-        const { configs } = privateMembers.get(this);
+        const {
+            configs,
+            options: { cwd }
+        } = privateMembers.get(this);
 
         /*
          * We can only accurately return rules meta information for linting results if the
@@ -669,7 +690,7 @@ class FlatESLint {
          * to let the user know we can't do anything here.
          */
         if (!configs) {
-            throw new TypeError("Results object was not created from this ESLint instance.");
+            throw createExtraneousResultsError();
         }
 
         for (const result of results) {
@@ -678,13 +699,7 @@ class FlatESLint {
              * Normalize filename for <text>.
              */
             const filePath = result.filePath === "<text>"
-                ? "__placeholder__.js" : result.filePath;
-
-            /*
-             * All of the plugin and rule information is contained within the
-             * calculated config for the given file.
-             */
-            const config = configs.getConfig(filePath);
+                ? getPlaceholderPath(cwd) : result.filePath;
             const allMessages = result.messages.concat(result.suppressedMessages);
 
             for (const { ruleId } of allMessages) {
@@ -692,6 +707,15 @@ class FlatESLint {
                     continue;
                 }
 
+                /*
+                 * All of the plugin and rule information is contained within the
+                 * calculated config for the given file.
+                 */
+                const config = configs.getConfig(filePath);
+
+                if (!config) {
+                    throw createExtraneousResultsError();
+                }
                 const rule = getRuleFromConfig(ruleId, config);
 
                 // ensure the rule exists
@@ -1029,7 +1053,7 @@ class FlatESLint {
                 const npmFormat = naming.normalizePackageName(normalizedFormatName, "eslint-formatter");
 
                 // TODO: This is pretty dirty...would be nice to clean up at some point.
-                formatterPath = ModuleResolver.resolve(npmFormat, path.join(cwd, "__placeholder__.js"));
+                formatterPath = ModuleResolver.resolve(npmFormat, getPlaceholderPath(cwd));
             } catch {
                 formatterPath = path.resolve(__dirname, "../", "cli-engine", "formatters", `${normalizedFormatName}.js`);
             }

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -3813,6 +3813,26 @@ describe("FlatESLint", () => {
             assert.deepStrictEqual(rulesMeta, {});
         });
 
+        it("should not throw an error if results contain linted files and one ignored file", async () => {
+            const engine = new FlatESLint({
+                overrideConfigFile: true,
+                cwd: getFixturePath(),
+                ignorePatterns: "passing*",
+                overrideConfig: {
+                    rules: {
+                        "no-undef": 2,
+                        semi: 1
+                    }
+                }
+            });
+
+            const results = await engine.lintFiles(["missing-semicolon.js", "passing.js", "undef.js"]);
+            const rulesMeta = engine.getRulesMetaForResults(results);
+
+            assert.deepStrictEqual(rulesMeta["no-undef"], coreRules.get("no-undef").meta);
+            assert.deepStrictEqual(rulesMeta.semi, coreRules.get("semi").meta);
+        });
+
         it("should return empty object when there are no linting errors", async () => {
             const engine = new FlatESLint({
                 overrideConfigFile: true

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -3782,6 +3782,37 @@ describe("FlatESLint", () => {
             });
         });
 
+        it("should treat a result without `filePath` as if the file was located in `cwd`", async () => {
+            const engine = new FlatESLint({
+                overrideConfigFile: true,
+                cwd: path.join(fixtureDir, "foo", "bar"),
+                ignorePatterns: "*/**", // ignore all subdirectories of `cwd`
+                overrideConfig: {
+                    rules: {
+                        eqeqeq: "warn"
+                    }
+                }
+            });
+
+            const results = await engine.lintText("a==b");
+            const rulesMeta = engine.getRulesMetaForResults(results);
+
+            assert.deepStrictEqual(rulesMeta.eqeqeq, coreRules.get("eqeqeq").meta);
+        });
+
+        it("should not throw an error if a result without `filePath` contains an ignored file warning", async () => {
+            const engine = new FlatESLint({
+                overrideConfigFile: true,
+                cwd: path.join(fixtureDir, "foo", "bar"),
+                ignorePatterns: "**"
+            });
+
+            const results = await engine.lintText("", { warnIgnored: true });
+            const rulesMeta = engine.getRulesMetaForResults(results);
+
+            assert.deepStrictEqual(rulesMeta, {});
+        });
+
         it("should return empty object when there are no linting errors", async () => {
             const engine = new FlatESLint({
                 overrideConfigFile: true
@@ -3914,24 +3945,6 @@ describe("FlatESLint", () => {
             const rulesMeta = engine.getRulesMetaForResults(results);
 
             assert.deepStrictEqual(rulesMeta, { "no-var": coreRules.get("no-var").meta });
-        });
-
-        it("should treat a result without `filePath` as if the file was located in `cwd`", async () => {
-            const engine = new FlatESLint({
-                overrideConfigFile: true,
-                cwd: path.join(fixtureDir, "foo", "bar"),
-                ignorePatterns: "*/**", // ignore all subdirectories of `cwd`
-                overrideConfig: {
-                    rules: {
-                        eqeqeq: "warn"
-                    }
-                }
-            });
-
-            const results = await engine.lintText("a==b");
-            const rulesMeta = engine.getRulesMetaForResults(results);
-
-            assert.deepStrictEqual(rulesMeta.eqeqeq, coreRules.get("eqeqeq").meta);
         });
     });
 

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -3827,6 +3827,12 @@ describe("FlatESLint", () => {
             });
 
             const results = await engine.lintFiles(["missing-semicolon.js", "passing.js", "undef.js"]);
+
+            assert(
+                results.some(({ messages }) => messages.some(({ message, ruleId }) => !ruleId && message.startsWith("File ignored"))),
+                "At least one file should be ignored but none is."
+            );
+
             const rulesMeta = engine.getRulesMetaForResults(results);
 
             assert.deepStrictEqual(rulesMeta["no-undef"], coreRules.get("no-undef").meta);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #16410

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* In `getRulesMetaForResults`, files with an unspecified path are now treated as if they were located inside `cwd`.
* In `getRulesMetaForResults`, when a result referencing a rule has no config, we will explicitly throw an error with a descriptive message.
* Added top-level, internal functions `getPlaceholderPath` and `createExtraneousResultsError` to avoid code repetition.
* Added two new unit tests.
* Renamed an existing unit test to better disambiguate it from a new one. Also changed the assertion to check both error message and constructor.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
