### PR TITLE
fix: make `getRulesMetaForResults` return a plain object in trivial case

### DIFF
--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -665,13 +665,12 @@ class FlatESLint {
      */
     getRulesMetaForResults(results) {
 
-        const resultRules = new Map();
-
         // short-circuit simple case
         if (results.length === 0) {
-            return resultRules;
+            return {};
         }
 
+        const resultRules = new Map();
         const { configs } = privateMembers.get(this);
 
         /*

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -4971,7 +4971,7 @@ describe("ESLint", () => {
 
             const rulesMeta = engine.getRulesMetaForResults([]);
 
-            assert.strictEqual(Object.keys(rulesMeta).length, 0);
+            assert.deepStrictEqual(rulesMeta, {});
         });
 
         it("should return one rule meta when there is a linting error", async () => {

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -3726,7 +3726,7 @@ describe("FlatESLint", () => {
 
             const rulesMeta = engine.getRulesMetaForResults([]);
 
-            assert.strictEqual(Object.keys(rulesMeta).length, 0);
+            assert.deepStrictEqual(rulesMeta, {});
         });
 
         it("should return one rule meta when there is a linting error", async () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

This fixes an edge case where `FlatESLint.prototype.getRulesMetaForResults([])` would return an empty `Map` instead of a plain object.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment:**

Node version: v18.11.0
npm version: v8.19.2
Local ESLint version: v8.25.0 (Currently used)
Global ESLint version: Not found
Operating System: darwin 21.6.0

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**What did you do? Please include the actual source code causing the issue.**

```js
const { default: { FlatESLint } } = await import('eslint/use-at-your-own-risk');
const engine = new FlatESLint();
const rulesMeta = engine.getRulesMetaForResults([]);
console.log(rulesMeta);
```

**What did you expect to happen?**

`getRulesMetaForResults` should return an empty plain object when called with an empty array.

**What actually happened? Please include the actual, raw output from ESLint.**

`getRulesMetaForResults` returns an empty `Map`.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the logic in `FlatESLint` and updated a unit test.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
