### PR TITLE
build: add node v19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18.x, 17.x, 16.x, 14.x, 12.x, "12.22.0"]
+        node: [19.x, 18.x, 17.x, 16.x, 14.x, 12.x, "12.22.0"]
         include:
         - os: windows-latest
           node: "16.x"

--- a/tests/lib/shared/runtime-info.js
+++ b/tests/lib/shared/runtime-info.js
@@ -206,7 +206,7 @@ describe("RuntimeInfo", () => {
             spawnSyncStubArgs[2] = "This is not JSON";
             setupSpawnSyncStubReturnVals(spawnSyncStub, spawnSyncStubArgs);
 
-            assert.throws(RuntimeInfo.environment, "Unexpected token T in JSON at position 0");
+            assert.throws(RuntimeInfo.environment, /^Unexpected token .*T.* JSON/u);
             assert.strictEqual(logErrorStub.args[0][0], "Error finding eslint version running the command `npm ls --depth=0 --json eslint`");
         });
 
@@ -214,7 +214,7 @@ describe("RuntimeInfo", () => {
             spawnSyncStubArgs[4] = "This is not JSON";
             setupSpawnSyncStubReturnVals(spawnSyncStub, spawnSyncStubArgs);
 
-            assert.throws(RuntimeInfo.environment, "Unexpected token T in JSON at position 0");
+            assert.throws(RuntimeInfo.environment, /^Unexpected token .*T.* JSON/u);
             assert.strictEqual(logErrorStub.args[0][0], "Error finding eslint version running the command `npm ls --depth=0 --json eslint -g`");
         });
     });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Node v19.0.0 has been released.
https://nodejs.org/en/blog/release/v19.0.0/

This PR adds the v19 matrix.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

This PR also fixes the following tests failure when using v19.0.0.

```console
% node -v
v19.0.0
% npx mocha tests/lib/shared/runtime-info.js
(snip)

1) RuntimeInfo
     environment()
       log and throw an error when checking for local ESLint version when returned output of command is malformed:

    AssertionError: expected [Function environment] to throw error including 'Unexpected token T in JSON at positio…' but got 'Unexpected token \'T\', "This is not …'
    + expected - actual

    -Unexpected token 'T', "This is not JSON" is not valid JSON
    +Unexpected token T in JSON at position 0

    at Context.<anonymous> (tests/lib/shared/runtime-info.js:209:20)
    at process.processImmediate (node:internal/timers:471:21)

2) RuntimeInfo
     environment()
       log and throw an error when checking for global ESLint version when returned output of command is malformed:

    AssertionError: expected [Function environment] to throw error including 'Unexpected token T in JSON at positio…' but got 'Unexpected token \'T\', "This is not …'
    + expected - actual

    -Unexpected token 'T', "This is not JSON" is not valid JSON
    +Unexpected token T in JSON at position 0

    at Context.<anonymous> (tests/lib/shared/runtime-info.js:217:20)
    at process.processImmediate (node:internal/timers:471:21)
```

This patch uses regexp to match both messages because the message has changed in v19.0.0.
