### PR TITLE
rules use ecmaVersion from languageOptions

### DIFF
--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -134,7 +134,7 @@ module.exports = {
     },
 
     create(context) {
-        const options = normalizeOptions(context.options[0], context.parserOptions.ecmaVersion);
+        const options = normalizeOptions(context.options[0], context.languageOptions.ecmaVersion);
 
         const sourceCode = context.getSourceCode();
 

--- a/lib/rules/func-name-matching.js
+++ b/lib/rules/func-name-matching.js
@@ -104,7 +104,7 @@ module.exports = {
         const nameMatches = typeof context.options[0] === "string" ? context.options[0] : "always";
         const considerPropertyDescriptor = options.considerPropertyDescriptor;
         const includeModuleExports = options.includeCommonJSModuleExports;
-        const ecmaVersion = context.parserOptions && context.parserOptions.ecmaVersion ? context.parserOptions.ecmaVersion : 5;
+        const ecmaVersion = context.languageOptions && context.languageOptions.ecmaVersion ? context.languageOptions.ecmaVersion : 5;
 
         /**
          * Check whether node is a certain CallExpression.

--- a/lib/rules/no-misleading-character-class.js
+++ b/lib/rules/no-misleading-character-class.js
@@ -193,7 +193,7 @@ module.exports = {
          * ecmaVersion doesn't support the `u` flag.
          */
         function isValidWithUnicodeFlag(pattern) {
-            const { ecmaVersion } = context.parserOptions;
+            const { ecmaVersion } = context.languageOptions;
 
             // ecmaVersion is unknown or it doesn't support the 'u' flag
             if (typeof ecmaVersion !== "number" || ecmaVersion <= 5) {

--- a/lib/rules/prefer-regex-literals.js
+++ b/lib/rules/prefer-regex-literals.js
@@ -320,7 +320,7 @@ module.exports = {
                             flags = getStringValue(node.arguments[1]);
                         }
 
-                        const regexppEcmaVersion = getRegexppEcmaVersion(context.parserOptions.ecmaVersion);
+                        const regexppEcmaVersion = getRegexppEcmaVersion(context.languageOptions.ecmaVersion);
                         const RegExpValidatorInstance = new RegExpValidator({ ecmaVersion: regexppEcmaVersion });
 
                         try {


### PR DESCRIPTION
vs parserOptions; in support of "flat config" paradigm

see #16442

----

I won't be signing the CLA, feel free to take or leave these changes.  `no-lone-blocks` is precedent for this semantic: https://github.com/eslint/eslint/blob/main/lib/rules/no-lone-blocks.js#L94