### PR TITLE
docs: Stylelint declaration-block-no-shorthand-property-overrides

### DIFF
--- a/docs/.stylelintrc.json
+++ b/docs/.stylelintrc.json
@@ -11,7 +11,6 @@
             "ignore": ["consecutive-duplicates-with-different-values"]
         }],
         "declaration-block-no-redundant-longhand-properties": null,
-        "declaration-block-no-shorthand-property-overrides": null,
         "hue-degree-notation": "number",
         "indentation": 4,
         "max-line-length": null,

--- a/docs/src/assets/scss/components/theme-switcher.scss
+++ b/docs/src/assets/scss/components/theme-switcher.scss
@@ -6,7 +6,6 @@
 }
 
 .theme-switcher-label.theme-switcher-label {
-    font-size: inherit;
     color: inherit;
     font: inherit;
     font-family: var(--text-font);

--- a/docs/src/assets/scss/utilities.scss
+++ b/docs/src/assets/scss/utilities.scss
@@ -34,7 +34,6 @@
 }
 
 .text.text {
-    font-size: inherit;
     color: inherit;
     font: inherit;
     font-family: var(--text-font);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? 

Enabled the rule and manually cleaned up the duplicate `font-size: inherit` since the `font: inherit` is shadowing this

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
