### PR TITLE
fix: allow `* 1` when followed by `/` in no-implicit-coercion

### DIFF
--- a/docs/src/rules/no-implicit-coercion.md
+++ b/docs/src/rules/no-implicit-coercion.md
@@ -103,6 +103,8 @@ Examples of **correct** code for the default `{ "number": true }` option:
 var n = Number(foo);
 var n = parseFloat(foo);
 var n = parseInt(foo, 10);
+
+var n = foo * 1/4; // `* 1` is allowed when followed by the `/` operator
 ```
 
 :::

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -72,6 +72,24 @@ function isMultiplyByOne(node) {
 }
 
 /**
+ * Checks whether the given node logically represents multiplication by a fraction of `1`.
+ * For example, `a * 1` in `a * 1 / b` is technically multiplication by `1`, but the
+ * whole expression can be logically interpreted as `a * (1 / b)` rather than `(a * 1) / b`.
+ * @param {BinaryExpression} node A BinaryExpression node to check.
+ * @param {SourceCode} sourceCode The source code object
+ * @returns {boolean} Whether or not the node is a multiplying by a fraction of `1`.
+ */
+function isMultiplyByFractionOfOne(node, sourceCode) {
+    return node.type === "BinaryExpression" &&
+        node.operator === "*" &&
+        (node.right.type === "Literal" && node.right.value === 1) &&
+        node.parent.type === "BinaryExpression" &&
+        node.parent.operator === "/" &&
+        node.parent.left === node &&
+        !astUtils.isParenthesised(sourceCode, node);
+}
+
+/**
  * Checks whether the result of a node is numeric or not
  * @param {ASTNode} node The node to test
  * @returns {boolean} true if the node is a number literal or a `Number()`, `parseInt` or `parseFloat` call
@@ -290,7 +308,8 @@ module.exports = {
 
                 // 1 * foo
                 operatorAllowed = options.allow.includes("*");
-                const nonNumericOperand = !operatorAllowed && options.number && isMultiplyByOne(node) && getNonNumericOperand(node);
+                const nonNumericOperand = !operatorAllowed && options.number && isMultiplyByOne(node) && !isMultiplyByFractionOfOne(node, sourceCode) &&
+                    getNonNumericOperand(node);
 
                 if (nonNumericOperand) {
                     const recommendation = `Number(${sourceCode.getText(nonNumericOperand)})`;

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -76,7 +76,7 @@ function isMultiplyByOne(node) {
  * For example, `a * 1` in `a * 1 / b` is technically multiplication by `1`, but the
  * whole expression can be logically interpreted as `a * (1 / b)` rather than `(a * 1) / b`.
  * @param {BinaryExpression} node A BinaryExpression node to check.
- * @param {SourceCode} sourceCode The source code object
+ * @param {SourceCode} sourceCode The source code object.
  * @returns {boolean} Whether or not the node is a multiplying by a fraction of `1`.
  */
 function isMultiplyByFractionOfOne(node, sourceCode) {

--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -433,7 +433,7 @@ ruleTester.run("no-implicit-coercion", rule, {
             }]
         },
 
-        // https://github.com/eslint/eslint/issues/16373
+        // https://github.com/eslint/eslint/issues/16373 regression tests
         {
             code: "1 * a / 2",
             output: "Number(a) / 2",
@@ -458,6 +458,15 @@ ruleTester.run("no-implicit-coercion", rule, {
             errors: [{
                 messageId: "useRecommendation",
                 data: { recommendation: "Number(b)" },
+                type: "BinaryExpression"
+            }]
+        },
+        {
+            code: "a * 1 + 2",
+            output: "Number(a) + 2",
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Number(a)" },
                 type: "BinaryExpression"
             }]
         }

--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -104,7 +104,12 @@ ruleTester.run("no-implicit-coercion", rule, {
         { code: "String(foo) + ``", parserOptions: { ecmaVersion: 6 } },
         { code: "`${'foo'}`", options: [{ disallowTemplateShorthand: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "`${`foo`}`", options: [{ disallowTemplateShorthand: true }], parserOptions: { ecmaVersion: 6 } },
-        { code: "`${String(foo)}`", options: [{ disallowTemplateShorthand: true }], parserOptions: { ecmaVersion: 6 } }
+        { code: "`${String(foo)}`", options: [{ disallowTemplateShorthand: true }], parserOptions: { ecmaVersion: 6 } },
+
+        // https://github.com/eslint/eslint/issues/16373
+        "console.log(Math.PI * 1/4)",
+        "a * 1 / 2",
+        "a * 1 / b"
     ],
     invalid: [
         {
@@ -425,6 +430,35 @@ ruleTester.run("no-implicit-coercion", rule, {
                 messageId: "useRecommendation",
                 data: { recommendation: "(foo?.indexOf)(1) !== -1" },
                 type: "UnaryExpression"
+            }]
+        },
+
+        // https://github.com/eslint/eslint/issues/16373
+        {
+            code: "1 * a / 2",
+            output: "Number(a) / 2",
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Number(a)" },
+                type: "BinaryExpression"
+            }]
+        },
+        {
+            code: "(a * 1) / 2",
+            output: "(Number(a)) / 2",
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Number(a)" },
+                type: "BinaryExpression"
+            }]
+        },
+        {
+            code: "a * 1 / (b * 1)",
+            output: "a * 1 / (Number(b))",
+            errors: [{
+                messageId: "useRecommendation",
+                data: { recommendation: "Number(b)" },
+                type: "BinaryExpression"
             }]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #16373

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

A minimal change in `no-implicit-coercion` behavior to allow special case described in #16373:

> I'd like a special case/exception made to the rule's checks that if the * 1 is immediately followed by a / then it is not an error.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
