### PR TITLE
feat: do not group properties in `key-spacing` if value starts on a new line

### DIFF
--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -278,7 +278,9 @@ ruleTester.run("key-spacing", rule, {
             "    method() {",
             "        return 42;",
             "    },",
-            "    baz: 456",
+            "    baz: 456,",
+            "    10:     ",
+            "    10",
             "};"
         ].join("\n"),
         options: [{ align: "value" }],
@@ -360,6 +362,10 @@ ruleTester.run("key-spacing", rule, {
             "    bat:      function() {",
             "        return this.a;",
             "    },",
+            "    barfoo:",
+            "    [",
+            "        1",
+            "    ],",
             "    baz: 42",
             "};"
         ].join("\n"),
@@ -633,6 +639,10 @@ ruleTester.run("key-spacing", rule, {
             "    internalGroup: {",
             "        internal : true,",
             "        ext      : false",
+            "    },",
+            "    func3:",
+            "    function () {",
+            "        var test3 = true;",
             "    }",
             "})"
         ].join("\n"),
@@ -969,6 +979,80 @@ ruleTester.run("key-spacing", rule, {
             align: {
                 on: "value"
             }
+        }],
+        parserOptions: { ecmaVersion: 6 }
+    },
+
+    // https://github.com/eslint/eslint/issues/16490
+    {
+        code: `
+            var foo =
+            {
+                id:   1,
+                code: 2,
+                [n]:  3,
+                message:
+                "some value on the next line",
+            };
+        `,
+        options: [{
+            align: "value"
+        }],
+        parserOptions: { ecmaVersion: 6 }
+    },
+    {
+        code: `
+            var foo =
+            {
+                id   : 1,
+                code : 2,
+                message :
+                "some value on the next line",
+            };
+        `,
+        options: [{
+            align: "colon",
+            beforeColon: true
+        }]
+    },
+    {
+        code: `
+            ({
+                a: 1,
+                // different group
+                bcd:
+                2
+            })
+        `,
+        options: [{
+            align: "value"
+        }]
+    },
+    {
+        code: `
+            ({
+                foo  :  1,
+                bar  :  2,
+                foobar :
+                3
+            })
+        `,
+        options: [{
+            align: "value",
+            beforeColon: true,
+            mode: "minimum"
+        }]
+    },
+    {
+        code: `
+            ({
+                oneLine: 1,
+                ["some key " +
+                "spanning multiple lines"]: 2
+            })
+        `,
+        options: [{
+            align: "value"
         }],
         parserOptions: { ecmaVersion: 6 }
     }],
@@ -1464,7 +1548,9 @@ ruleTester.run("key-spacing", rule, {
             "    method() {",
             "        return 42;",
             "    },",
-            "    baz:    456",
+            "    baz:    456,",
+            "    10:     ",
+            "    10",
             "};"
         ].join("\n"),
         output: [
@@ -1473,7 +1559,9 @@ ruleTester.run("key-spacing", rule, {
             "    method() {",
             "        return 42;",
             "    },",
-            "    baz: 456",
+            "    baz: 456,",
+            "    10:     ",
+            "    10",
             "};"
         ].join("\n"),
         options: [{ align: "value" }],
@@ -2374,6 +2462,123 @@ ruleTester.run("key-spacing", rule, {
             { messageId: "extraValue", data: { computed: "", key: "🎁" }, line: 4, column: 21, type: "Literal" },
             { messageId: "extraValue", data: { computed: "", key: "🇮🇳" }, line: 5, column: 23, type: "Literal" }
         ]
-    }
-    ]
+    },
+
+    // https://github.com/eslint/eslint/issues/16490
+    {
+        code: `
+            var foo =
+            {
+                id:      1,
+                code:    2,
+                [n]:     3,
+                message:
+                "some value on the next line",
+            };
+        `,
+        output: `
+            var foo =
+            {
+                id:   1,
+                code: 2,
+                [n]:  3,
+                message:
+                "some value on the next line",
+            };
+        `,
+        options: [{
+            align: "value"
+        }],
+        parserOptions: { ecmaVersion: 6 },
+        errors: [
+            { messageId: "extraValue", data: { computed: "", key: "id" }, line: 4, column: 19, type: "Literal" },
+            { messageId: "extraValue", data: { computed: "", key: "code" }, line: 5, column: 21, type: "Literal" },
+            { messageId: "extraValue", data: { computed: "computed ", key: "n" }, line: 6, column: 20, type: "Literal" }
+        ]
+    },
+    {
+        code: `
+            var foo =
+            {
+                id      : 1,
+                code    : 2,
+                message :
+                "some value on the next line",
+            };
+        `,
+        output: `
+            var foo =
+            {
+                id   : 1,
+                code : 2,
+                message :
+                "some value on the next line",
+            };
+        `,
+        options: [{
+            align: "colon",
+            beforeColon: true
+        }],
+        errors: [
+            { messageId: "extraKey", data: { computed: "", key: "id" }, line: 4, column: 19, type: "Identifier" },
+            { messageId: "extraKey", data: { computed: "", key: "code" }, line: 5, column: 21, type: "Identifier" }
+        ]
+    },
+    {
+        code: `
+            ({
+                a:   1,
+                // different group
+                bcd:
+                2
+            })
+        `,
+        output: `
+            ({
+                a: 1,
+                // different group
+                bcd:
+                2
+            })
+        `,
+        options: [{
+            align: "value"
+        }],
+        errors: [
+            { messageId: "extraValue", data: { computed: "", key: "a" }, line: 3, column: 18, type: "Literal" }
+        ]
+    },
+    {
+        code: [
+            "({",
+            "    singleLine : 10,",
+            "    newGroup :",
+            "    function() {",
+            "        var test3 = true;",
+            "    }",
+            "})"
+        ].join("\n"),
+        output: [
+            "({",
+            "    singleLine: 10,",
+            "    newGroup:",
+            "    function() {",
+            "        var test3 = true;",
+            "    }",
+            "})"
+        ].join("\n"),
+        options: [{
+            multiLine: {
+                beforeColon: false
+            },
+            align: {
+                on: "colon",
+                beforeColon: true
+            }
+        }],
+        errors: [
+            { messageId: "extraKey", data: { computed: "", key: "singleLine" }, line: 2, column: 15, type: "Identifier" },
+            { messageId: "extraKey", data: { computed: "", key: "newGroup" }, line: 3, column: 13, type: "Identifier" }
+        ]
+    }]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #16490

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Changed the logic in rule `key-spacing` to ensure that properties whose value starts on a new line are not grouped with any previously defined properties.
* Moved around function `isKeyValueProperty` in key-spacing.js to comply with lint settings.
* Added unit tests to rule `key-spacing`.
* Extended some existing unit tests for rule `key-spacing` to check that properties whose value starts on a new line are allowed regardless of spacing after the colon (for default `afterColon` settings) and not grouped with any successively defined properties. This is the current behavior, but it was missing unit tests.

<!-- markdownlint-disable-file MD004 -->
