### PR TITLE
fix: throw error for first unmatched pattern

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -76,7 +76,7 @@ class UnmatchedSearchPatternsError extends Error {
     constructor({ basePath, unmatchedPatterns, patterns, rawPatterns }) {
         super(`No files matching '${rawPatterns}' in '${basePath}' were found.`);
         this.basePath = basePath;
-        this.patternsToCheck = unmatchedPatterns;
+        this.unmatchedPatterns = unmatchedPatterns;
         this.patterns = patterns;
         this.rawPatterns = rawPatterns;
     }
@@ -337,49 +337,43 @@ async function globSearch({
 }
 
 /**
- * Checks to see if there are any ignored results for a given search. This
- * happens either when there are unmatched patterns during a search or if
- * a search returns no results.
+ * Throws an error for unmatched patterns. The error will only contain information about the first one.
+ * Checks to see if there are any ignored results for a given search.
  * @param {Object} options The options for this function.
  * @param {string} options.basePath The directory to search.
  * @param {Array<string>} options.patterns An array of glob patterns
  *      that were used in the original search.
  * @param {Array<string>} options.rawPatterns An array of glob patterns
  *      as the user inputted them. Used for errors.
- * @param {Array<string>} options.patternsToCheck An array of glob patterns
- *      to use for this check.
- * @returns {void}
- * @throws {NoFilesFoundError} If there is a pattern that doesn't match
- *      any files and `errorOnUnmatchedPattern` is true.
- * @throws {AllFilesIgnoredError} If there is a pattern that matches files
- *      when there are no ignores.
+ * @param {Array<string>} options.unmatchedPatterns A non-empty array of glob patterns
+ *      that were unmatched in the original search.
+ * @returns {void} Always throws an error.
+ * @throws {NoFilesFoundError} If the first unmatched pattern
+ *      doesn't match any files even when there are no ignores.
+ * @throws {AllFilesIgnoredError} If the first unmatched pattern
+ *      matches some files when there are no ignores.
  */
-async function checkForIgnoredResults({
+async function throwErrorForUnmatchedPatterns({
     basePath,
     patterns,
     rawPatterns,
-    patternsToCheck = patterns
+    unmatchedPatterns
 }) {
 
-    for (const pattern of patternsToCheck) {
+    const [pattern] = unmatchedPatterns;
+    const rawPattern = rawPatterns[patterns.indexOf(pattern)];
 
-        const patternHasMatch = await globMatch({
-            basePath,
-            pattern
-        });
+    const patternHasMatch = await globMatch({
+        basePath,
+        pattern
+    });
 
-        if (patternHasMatch) {
-            throw new AllFilesIgnoredError(
-                rawPatterns[patterns.indexOf(pattern)]
-            );
-        }
+    if (patternHasMatch) {
+        throw new AllFilesIgnoredError(rawPattern);
     }
 
     // if we get here there are truly no matches
-    throw new NoFilesFoundError(
-        rawPatterns[patterns.indexOf(patternsToCheck[0])],
-        true
-    );
+    throw new NoFilesFoundError(rawPattern, true);
 }
 
 /**
@@ -446,9 +440,9 @@ async function globMultiSearch({ searches, configs, errorOnUnmatchedPattern }) {
 
         if (errorOnUnmatchedPattern) {
 
-            await checkForIgnoredResults({
+            await throwErrorForUnmatchedPatterns({
                 ...currentSearch,
-                patternsToCheck: error.patternsToCheck
+                unmatchedPatterns: error.unmatchedPatterns
             });
 
         }

--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -360,7 +360,7 @@ async function throwErrorForUnmatchedPatterns({
     unmatchedPatterns
 }) {
 
-    const [pattern] = unmatchedPatterns;
+    const pattern = unmatchedPatterns[0];
     const rawPattern = rawPatterns[patterns.indexOf(pattern)];
 
     const patternHasMatch = await globMatch({

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -848,6 +848,31 @@ describe("FlatESLint", () => {
                 }, /All files matched by 'subdir2\/\*\.js' are ignored/u);
             });
 
+            it("should always throw an error for the first unmatched file pattern", async () => {
+                eslint = new FlatESLint({
+                    cwd: getFixturePath("example-app2"),
+                    overrideConfig: {
+                        ignores: ["subdir1/*.js", "subdir2/*.js"]
+                    }
+                });
+
+                await assert.rejects(async () => {
+                    await eslint.lintFiles(["doesnotexist1/*.js", "doesnotexist2/*.js"]);
+                }, /No files matching 'doesnotexist1\/\*\.js' were found/u);
+
+                await assert.rejects(async () => {
+                    await eslint.lintFiles(["doesnotexist1/*.js", "subdir1/*.js"]);
+                }, /No files matching 'doesnotexist1\/\*\.js' were found/u);
+
+                await assert.rejects(async () => {
+                    await eslint.lintFiles(["subdir1/*.js", "doesnotexist1/*.js"]);
+                }, /All files matched by 'subdir1\/\*\.js' are ignored/u);
+
+                await assert.rejects(async () => {
+                    await eslint.lintFiles(["subdir1/*.js", "subdir2/*.js"]);
+                }, /All files matched by 'subdir1\/\*\.js' are ignored/u);
+            });
+
             it("should not throw an error for an ignored file pattern when errorOnUnmatchedPattern is false", async () => {
                 eslint = new FlatESLint({
                     cwd: getFixturePath("example-app2"),


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Addresses https://github.com/eslint/eslint/pull/16462#pullrequestreview-1168561292.

When there are multiple unmatched patterns, both ESLint and FlatESLint throw an error containing information about only one pattern. The error can be either that the pattern doesn't match any files or that it matches only ignored files.

The difference is that ESLint always throws an error for the very first unmatched pattern, while FlatESLint first checks if there are patterns that match ignored files.

To reproduce, run `eslint "doesnotexist/*.js" "tests/fixtures/*.js"`.

ESLint:

```
Oops! Something went wrong! :(

ESLint: 8.27.0

No files matching the pattern "doesnotexist/*.js" were found.
Please check for typing mistakes in the pattern.
```

FlatESLint:

```
Oops! Something went wrong! :(

ESLint: 8.27.0

You are linting "tests/fixtures/*.js", but all of the files matching the glob pattern "tests/fixtures/*.js" are ignored.

If you don't want to lint these files, remove the pattern "tests/fixtures/*.js" from the list of arguments passed to ESLint.

If you do want to lint these files, try the following solutions:

* Check your .eslintignore file, or the eslintIgnore property in package.json, to ensure that the files are not configured to be ignored.
* Explicitly list the files from this glob that you'd like to lint on the command-line, rather than providing a glob as an argument.
```

It's an error either way, but I think ESLint behavior is preferable as it would be surprising for users that after fixing or removing the reported pattern, eslint in the next run reports an error for a preceding pattern. Checking only the first pattern also simplifies the code a bit, and is better for performance in this, albeit exceptional, scenario.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I changed the code in `eslint-helpers` to always check only the first unmatched pattern.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
