### PR TITLE
docs: Configuring Plugins page intro, page tweaks, and rename

### DIFF
--- a/docs/src/developer-guide/working-with-plugins.md
+++ b/docs/src/developer-guide/working-with-plugins.md
@@ -144,7 +144,7 @@ overrides:
     processor: a-plugin/markdown
 ```
 
-See [Specifying Processor](../user-guide/configuring/plugins#specifying-processor) for details.
+See [Specifying Processor](../user-guide/configuring/plugins#specify-a-processor) for details.
 
 #### File Extension-named Processor
 
@@ -205,7 +205,7 @@ If the example plugin above were called `eslint-plugin-myPlugin`, the `myConfig`
 
 ```
 
-**Note:** Please note that configuration will not enable any of the plugin's rules by default, and instead should be treated as a standalone config. This means that you must specify your plugin name in the `plugins` array as well as any rules you want to enable that are part of the plugin. Any plugin rules must be prefixed with the short or long plugin name. See [Configuring Plugins](../user-guide/configuring/plugins#configuring-plugins) for more information.
+**Note:** Please note that configuration will not enable any of the plugin's rules by default, and instead should be treated as a standalone config. This means that you must specify your plugin name in the `plugins` array as well as any rules you want to enable that are part of the plugin. Any plugin rules must be prefixed with the short or long plugin name. See [Configuring Plugins](../user-guide/configuring/plugins#configure-plugins) for more information.
 
 ### Peer Dependency
 

--- a/docs/src/user-guide/configuring/configuration-files.md
+++ b/docs/src/user-guide/configuring/configuration-files.md
@@ -279,7 +279,7 @@ module.exports = {
 
 A [plugin](https://eslint.org/docs/developer-guide/working-with-plugins) is an npm package that can add various extensions to ESLint. A plugin can perform numerous functions, including but not limited to adding new rules and exporting [shareable configurations](https://eslint.org/docs/developer-guide/working-with-plugins#configs-in-plugins). Make sure the package has been installed in a directory where ESLint can require it.
 
-The `plugins` [property value](./plugins#configuring-plugins) can omit the `eslint-plugin-` prefix of the package name.
+The `plugins` [property value](./plugins#configure-plugins) can omit the `eslint-plugin-` prefix of the package name.
 
 The `extends` property value can consist of:
 

--- a/docs/src/user-guide/configuring/index.md
+++ b/docs/src/user-guide/configuring/index.md
@@ -47,9 +47,9 @@ All of these options give you fine-grained control over how ESLint treats your c
 
 [**Plugins**](plugins)
 
-* [Configuring Plugins](./plugins#configuring-plugins)
-* [Specifying Processor](./plugins#specifying-processor)
-* [Configuring Parsers](./plugins#configuring-parsers)
+* [Configuring Plugins](./plugins#configure-plugins)
+* [Specifying Processors](./plugins#specify-a-processor)
+* [Configuring Parsers](./plugins#configure-a-parser)
 
 [**Ignoring Code**](ignoring-code)
 

--- a/docs/src/user-guide/configuring/index.md
+++ b/docs/src/user-guide/configuring/index.md
@@ -47,9 +47,9 @@ All of these options give you fine-grained control over how ESLint treats your c
 
 [**Plugins**](plugins)
 
-* [Specifying Parser](./plugins#specifying-parser)
-* [Specifying Processor](./plugins#specifying-processor)
 * [Configuring Plugins](./plugins#configuring-plugins)
+* [Specifying Processor](./plugins#specifying-processor)
+* [Configuring Parsers](./plugins#configuring-parsers)
 
 [**Ignoring Code**](ignoring-code)
 

--- a/docs/src/user-guide/configuring/plugins.md
+++ b/docs/src/user-guide/configuring/plugins.md
@@ -3,19 +3,27 @@ title: Plugins
 eleventyNavigation:
     key: configuring plugins
     parent: configuring
-    title: Configuring Plugins
+    title: Configuring Extensions
     order: 4
 
 ---
 
+You can extend ESLint in a variety of different ways.
+
+* Add a custom parser to convert JavaScript code into an abstract syntax tree for ESLint to evaluate. You might want to add a custom parser if the code you're writing isn't compatible with the ESLint default parser, Espree.
+* Add a custom processor to extract JavaScript code from other kinds of files or preprocess code before linting.
+* Add plugins to include custom rules, configurations, processors, and environments in your ESLint project.
+
+You can include and customize all these different extension types in your ESLint configuration file.
+
 ## Specifying Parser
 
-By default, ESLint uses [Espree](https://github.com/eslint/espree) as its parser. You can optionally specify that a different parser should be used in your configuration file so long as the parser meets the following requirements:
+By default, ESLint uses [Espree](https://github.com/eslint/espree) as its parser. You can optionally specify that a different parser should be used in your configuration file if the parser meets the following requirements:
 
 1. It must be a Node module loadable from the config file where the parser is used. Usually, this means you should install the parser package separately using npm.
 1. It must conform to the [parser interface](../../developer-guide/working-with-custom-parsers).
 
-Note that even with these compatibilities, there are no guarantees that an external parser will work correctly with ESLint and ESLint will not fix bugs related to incompatibilities with other parsers.
+Note that even with these compatibilities, there are no guarantees that an external parser works correctly with ESLint. ESLint does not fix bugs related to incompatibilities with other parsers.
 
 To indicate the npm module to use as your parser, specify it using the `parser` option in your `.eslintrc` file. For example, the following specifies to use Esprima instead of Espree:
 
@@ -34,7 +42,7 @@ The following parsers are compatible with ESLint:
 * [@babel/eslint-parser](https://www.npmjs.com/package/@babel/eslint-parser) - A wrapper around the [Babel](https://babeljs.io) parser that makes it compatible with ESLint.
 * [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser) - A parser that converts TypeScript into an ESTree-compatible form so it can be used in ESLint.
 
-Note when using a custom parser, the `parserOptions` configuration property is still required for ESLint to work properly with features not in ECMAScript 5 by default. Parsers are all passed `parserOptions` and may or may not use them to determine which features to enable.
+Note that when using a custom parser, the `parserOptions` configuration property is still required for ESLint to work properly with features not in ECMAScript 5 by default. Parsers are all passed `parserOptions` and may or may not use them to determine which features to enable.
 
 ## Specifying Processor
 
@@ -87,7 +95,7 @@ ESLint checks the file path of named code blocks then ignores those if any `over
 
 ## Configuring Plugins
 
-ESLint supports the use of third-party plugins. Before using the plugin, you have to install it using npm.
+ESLint supports the use of third-party plugins. Before using a plugin, you have to install it using npm.
 
 To configure plugins inside of a configuration file, use the `plugins` key, which contains a list of plugin names. The `eslint-plugin-` prefix can be omitted from the plugin name.
 
@@ -111,14 +119,16 @@ And in YAML:
 
 **Notes:**
 
-1. Plugins are resolved relative to the config file. In other words, ESLint will load the plugin as a user would obtain by running `require('eslint-plugin-pluginname')` in the config file.
+1. Plugins are resolved relative to the config file. In other words, ESLint loads the plugin as a user would obtain by running `require('eslint-plugin-pluginname')` in the config file.
 2. Plugins in the base configuration (loaded by `extends` setting) are relative to the derived config file. For example, if `./.eslintrc` has `extends: ["foo"]` and the `eslint-config-foo` has `plugins: ["bar"]`, ESLint finds the `eslint-plugin-bar` from `./node_modules/` (rather than `./node_modules/eslint-config-foo/node_modules/`) or ancestor directories. Thus every plugin in the config file and base configurations is resolved uniquely.
 
 ### Naming convention
 
 #### Include a plugin
 
-The `eslint-plugin-` prefix can be omitted for non-scoped packages
+The `eslint-plugin-` prefix can be omitted for both non-scoped and scoped packages.
+
+A non-scoped package:
 
 ```js
 {
@@ -130,7 +140,7 @@ The `eslint-plugin-` prefix can be omitted for non-scoped packages
 }
 ```
 
-The same rule does apply to scoped packages:
+A scoped packages:
 
 ```js
 {
@@ -145,7 +155,7 @@ The same rule does apply to scoped packages:
 
 #### Use a plugin
 
-When using rules, environments or configs defined by plugins, they must be referenced following the convention:
+Rules, environments and configs defined in plugins must be referenced with the following convention:
 
 * `eslint-plugin-foo` → `foo/a-rule`
 * `@foo/eslint-plugin` → `@foo/a-config`

--- a/docs/src/user-guide/configuring/plugins.md
+++ b/docs/src/user-guide/configuring/plugins.md
@@ -1,96 +1,21 @@
 ---
-title: Plugins
+title: Plugins & Parsers
+layout: doc
 eleventyNavigation:
     key: configuring plugins
     parent: configuring
-    title: Configuring Plugins
+    title: Configuring Plugins & Parsers
     order: 4
 
 ---
 
 You can extend ESLint with plugins in a variety of different ways. Plugins can include:
 
-* Custom parsers to convert JavaScript code into an abstract syntax tree for ESLint to evaluate. You might want to add a custom parser if the code you're writing isn't compatible with the ESLint default parser, Espree.
 * Custom processors to extract JavaScript code from other kinds of files or preprocess code before linting.
 * Custom rules to validates if your code meets a certain expectation, and what to do if it does not meet that expectation.
 * Other custom configuration using ESLint's built in features.
 
-## Specifying Parser
-
-By default, ESLint uses [Espree](https://github.com/eslint/espree) as its parser. You can optionally specify that a different parser should be used in your configuration file if the parser meets the following requirements:
-
-1. It must be a Node module loadable from the config file where the parser is used. Usually, this means you should install the parser package separately using npm.
-1. It must conform to the [parser interface](../../developer-guide/working-with-custom-parsers).
-
-Note that even with these compatibilities, there are no guarantees that an external parser works correctly with ESLint. ESLint does not fix bugs related to incompatibilities with other parsers.
-
-To indicate the npm module to use as your parser, specify it using the `parser` option in your `.eslintrc` file. For example, the following specifies to use Esprima instead of Espree:
-
-```json
-{
-    "parser": "esprima",
-    "rules": {
-        "semi": "error"
-    }
-}
-```
-
-The following parsers are compatible with ESLint:
-
-* [Esprima](https://www.npmjs.com/package/esprima)
-* [@babel/eslint-parser](https://www.npmjs.com/package/@babel/eslint-parser) - A wrapper around the [Babel](https://babeljs.io) parser that makes it compatible with ESLint.
-* [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser) - A parser that converts TypeScript into an ESTree-compatible form so it can be used in ESLint.
-
-Note that when using a custom parser, the `parserOptions` configuration property is still required for ESLint to work properly with features not in ECMAScript 5 by default. Parsers are all passed `parserOptions` and may or may not use them to determine which features to enable.
-
-## Specifying Processor
-
-Plugins may provide processors. Processors can extract JavaScript code from other kinds of files, then let ESLint lint the JavaScript code or processors can convert JavaScript code in preprocessing for some purpose.
-
-To specify processors in a configuration file, use the `processor` key with the concatenated string of a plugin name and a processor name by a slash. For example, the following enables the processor `a-processor` that the plugin `a-plugin` provided:
-
-```json
-{
-    "plugins": ["a-plugin"],
-    "processor": "a-plugin/a-processor"
-}
-```
-
-To specify processors for specific kinds of files, use the combination of the `overrides` key and the `processor` key. For example, the following uses the processor `a-plugin/markdown` for `*.md` files.
-
-```json
-{
-    "plugins": ["a-plugin"],
-    "overrides": [
-        {
-            "files": ["*.md"],
-            "processor": "a-plugin/markdown"
-        }
-    ]
-}
-```
-
-Processors may make named code blocks such as `0.js` and `1.js`. ESLint handles such a named code block as a child file of the original file. You can specify additional configurations for named code blocks in the `overrides` section of the config. For example, the following disables the `strict` rule for the named code blocks which end with `.js` in markdown files.
-
-```json
-{
-    "plugins": ["a-plugin"],
-    "overrides": [
-        {
-            "files": ["*.md"],
-            "processor": "a-plugin/markdown"
-        },
-        {
-            "files": ["**/*.md/*.js"],
-            "rules": {
-                "strict": "off"
-            }
-        }
-    ]
-}
-```
-
-ESLint checks the file path of named code blocks then ignores those if any `overrides` entry didn't match the file path. Be sure to add an `overrides` entry if you want to lint named code blocks other than `*.js`.
+You can also use custom parsers to convert JavaScript code into an abstract syntax tree for ESLint to evaluate. You might want to add a custom parser if the code you're writing isn't compatible with the ESLint default parser, Espree.
 
 ## Configuring Plugins
 
@@ -187,3 +112,80 @@ For example:
     // ...
 }
 ```
+
+### Specifying Processor
+
+Plugins may provide processors. Processors can extract JavaScript code from other kinds of files, then let ESLint lint the JavaScript code or processors can convert JavaScript code in preprocessing for some purpose.
+
+To specify processors in a configuration file, use the `processor` key with the concatenated string of a plugin name and a processor name by a slash. For example, the following enables the processor `a-processor` that the plugin `a-plugin` provided:
+
+```json
+{
+    "plugins": ["a-plugin"],
+    "processor": "a-plugin/a-processor"
+}
+```
+
+To specify processors for specific kinds of files, use the combination of the `overrides` key and the `processor` key. For example, the following uses the processor `a-plugin/markdown` for `*.md` files.
+
+```json
+{
+    "plugins": ["a-plugin"],
+    "overrides": [
+        {
+            "files": ["*.md"],
+            "processor": "a-plugin/markdown"
+        }
+    ]
+}
+```
+
+Processors may make named code blocks such as `0.js` and `1.js`. ESLint handles such a named code block as a child file of the original file. You can specify additional configurations for named code blocks in the `overrides` section of the config. For example, the following disables the `strict` rule for the named code blocks which end with `.js` in markdown files.
+
+```json
+{
+    "plugins": ["a-plugin"],
+    "overrides": [
+        {
+            "files": ["*.md"],
+            "processor": "a-plugin/markdown"
+        },
+        {
+            "files": ["**/*.md/*.js"],
+            "rules": {
+                "strict": "off"
+            }
+        }
+    ]
+}
+```
+
+ESLint checks the file path of named code blocks then ignores those if any `overrides` entry didn't match the file path. Be sure to add an `overrides` entry if you want to lint named code blocks other than `*.js`.
+
+## Configuring Parsers
+
+By default, ESLint uses [Espree](https://github.com/eslint/espree) as its parser. You can optionally specify that a different parser should be used in your configuration file if the parser meets the following requirements:
+
+1. It must be a Node module loadable from the config file where the parser is used. Usually, this means you should install the parser package separately using npm.
+1. It must conform to the [parser interface](../../developer-guide/working-with-custom-parsers).
+
+Note that even with these compatibilities, there are no guarantees that an external parser works correctly with ESLint. ESLint does not fix bugs related to incompatibilities with other parsers.
+
+To indicate the npm module to use as your parser, specify it using the `parser` option in your `.eslintrc` file. For example, the following specifies to use Esprima instead of Espree:
+
+```json
+{
+    "parser": "esprima",
+    "rules": {
+        "semi": "error"
+    }
+}
+```
+
+The following parsers are compatible with ESLint:
+
+* [Esprima](https://www.npmjs.com/package/esprima)
+* [@babel/eslint-parser](https://www.npmjs.com/package/@babel/eslint-parser) - A wrapper around the [Babel](https://babeljs.io) parser that makes it compatible with ESLint.
+* [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser) - A parser that converts TypeScript into an ESTree-compatible form so it can be used in ESLint.
+
+Note that when using a custom parser, the `parserOptions` configuration property is still required for ESLint to work properly with features not in ECMAScript 5 by default. Parsers are all passed `parserOptions` and may or may not use them to determine which features to enable.

--- a/docs/src/user-guide/configuring/plugins.md
+++ b/docs/src/user-guide/configuring/plugins.md
@@ -15,7 +15,7 @@ You can extend ESLint with plugins in a variety of different ways. Plugins can i
 * Custom rules to validate if your code meets a certain expectation, and what to do if it does not meet that expectation.
 * Custom configurations.
 
-You can also use custom parsers to convert JavaScript code into an abstract syntax tree for ESLint to evaluate. You might want to add a custom parser if the code you're writing isn't compatible with the ESLint default parser, Espree.
+You can also use custom parsers to convert JavaScript code into an abstract syntax tree for ESLint to evaluate. You might want to add a custom parser if your code isn't compatible with ESLint's default parser, Espree.
 
 ## Configuring Plugins
 

--- a/docs/src/user-guide/configuring/plugins.md
+++ b/docs/src/user-guide/configuring/plugins.md
@@ -17,7 +17,7 @@ You can extend ESLint with plugins in a variety of different ways. Plugins can i
 
 You can also use custom parsers to convert JavaScript code into an abstract syntax tree for ESLint to evaluate. You might want to add a custom parser if your code isn't compatible with ESLint's default parser, Espree.
 
-## Configuring Plugins
+## Configure Plugins
 
 ESLint supports the use of third-party plugins. Before using a plugin, you have to install it using npm.
 
@@ -113,7 +113,7 @@ For example:
 }
 ```
 
-### Specifying Processor
+### Specify a Processor
 
 Plugins may provide processors. Processors can extract JavaScript code from other kinds of files, then let ESLint lint the JavaScript code. Alternatively, processors can convert JavaScript code during preprocessing.
 
@@ -162,7 +162,7 @@ Processors may make named code blocks such as `0.js` and `1.js`. ESLint handles 
 
 ESLint checks the file path of named code blocks then ignores those if any `overrides` entry didn't match the file path. Be sure to add an `overrides` entry if you want to lint named code blocks other than `*.js`.
 
-## Configuring Parsers
+## Configure a Parser
 
 By default, ESLint uses [Espree](https://github.com/eslint/espree) as its parser. You can optionally specify that a different parser should be used in your configuration file if the parser meets the following requirements:
 

--- a/docs/src/user-guide/configuring/plugins.md
+++ b/docs/src/user-guide/configuring/plugins.md
@@ -12,8 +12,8 @@ eleventyNavigation:
 You can extend ESLint with plugins in a variety of different ways. Plugins can include:
 
 * Custom processors to extract JavaScript code from other kinds of files or preprocess code before linting.
-* Custom rules to validates if your code meets a certain expectation, and what to do if it does not meet that expectation.
-* Other custom configuration using ESLint's built-in features.
+* Custom rules to validate if your code meets a certain expectation, and what to do if it does not meet that expectation.
+* Other custom configurations using ESLint's built-in features.
 
 You can also use custom parsers to convert JavaScript code into an abstract syntax tree for ESLint to evaluate. You might want to add a custom parser if the code you're writing isn't compatible with the ESLint default parser, Espree.
 
@@ -64,7 +64,7 @@ A non-scoped package:
 }
 ```
 
-A scoped packages:
+A scoped package:
 
 ```js
 {

--- a/docs/src/user-guide/configuring/plugins.md
+++ b/docs/src/user-guide/configuring/plugins.md
@@ -13,7 +13,7 @@ You can extend ESLint with plugins in a variety of different ways. Plugins can i
 
 * Custom processors to extract JavaScript code from other kinds of files or preprocess code before linting.
 * Custom rules to validates if your code meets a certain expectation, and what to do if it does not meet that expectation.
-* Other custom configuration using ESLint's built in features.
+* Other custom configuration using ESLint's built-in features.
 
 You can also use custom parsers to convert JavaScript code into an abstract syntax tree for ESLint to evaluate. You might want to add a custom parser if the code you're writing isn't compatible with the ESLint default parser, Espree.
 
@@ -79,7 +79,7 @@ A scoped packages:
 
 #### Use a plugin
 
-Rules, environments and configs defined in plugins must be referenced with the following convention:
+Rules, environments, and configurations defined in plugins must be referenced with the following convention:
 
 * `eslint-plugin-foo` → `foo/a-rule`
 * `@foo/eslint-plugin` → `@foo/a-config`
@@ -115,7 +115,7 @@ For example:
 
 ### Specifying Processor
 
-Plugins may provide processors. Processors can extract JavaScript code from other kinds of files, then let ESLint lint the JavaScript code or processors can convert JavaScript code in preprocessing for some purpose.
+Plugins may provide processors. Processors can extract JavaScript code from other kinds of files, then let ESLint lint the JavaScript code. Alternatively, processors can convert JavaScript code during preprocessing.
 
 To specify processors in a configuration file, use the `processor` key with the concatenated string of a plugin name and a processor name by a slash. For example, the following enables the processor `a-processor` that the plugin `a-plugin` provided:
 

--- a/docs/src/user-guide/configuring/plugins.md
+++ b/docs/src/user-guide/configuring/plugins.md
@@ -13,7 +13,7 @@ You can extend ESLint with plugins in a variety of different ways. Plugins can i
 
 * Custom processors to extract JavaScript code from other kinds of files or preprocess code before linting.
 * Custom rules to validate if your code meets a certain expectation, and what to do if it does not meet that expectation.
-* Other custom configurations using ESLint's built-in features.
+* Custom configurations.
 
 You can also use custom parsers to convert JavaScript code into an abstract syntax tree for ESLint to evaluate. You might want to add a custom parser if the code you're writing isn't compatible with the ESLint default parser, Espree.
 

--- a/docs/src/user-guide/configuring/plugins.md
+++ b/docs/src/user-guide/configuring/plugins.md
@@ -1,6 +1,5 @@
 ---
 title: Plugins & Parsers
-layout: doc
 eleventyNavigation:
     key: configuring plugins
     parent: configuring
@@ -11,10 +10,10 @@ eleventyNavigation:
 
 You can extend ESLint with plugins in a variety of different ways. Plugins can include:
 
-* Custom processors to extract JavaScript code from other kinds of files or preprocess code before linting.
 * Custom rules to validate if your code meets a certain expectation, and what to do if it does not meet that expectation.
 * Custom configurations.
 * Custom environments.
+* Custom processors to extract JavaScript code from other kinds of files or preprocess code before linting.
 
 You can also use custom parsers to convert JavaScript code into an abstract syntax tree for ESLint to evaluate. You might want to add a custom parser if your code isn't compatible with ESLint's default parser, Espree.
 

--- a/docs/src/user-guide/configuring/plugins.md
+++ b/docs/src/user-guide/configuring/plugins.md
@@ -3,18 +3,17 @@ title: Plugins
 eleventyNavigation:
     key: configuring plugins
     parent: configuring
-    title: Configuring Extensions
+    title: Configuring Plugins
     order: 4
 
 ---
 
-You can extend ESLint in a variety of different ways.
+You can extend ESLint with plugins in a variety of different ways. Plugins can include:
 
-* Add a custom parser to convert JavaScript code into an abstract syntax tree for ESLint to evaluate. You might want to add a custom parser if the code you're writing isn't compatible with the ESLint default parser, Espree.
-* Add a custom processor to extract JavaScript code from other kinds of files or preprocess code before linting.
-* Add plugins to include custom rules, configurations, processors, and environments in your ESLint project.
-
-You can include and customize all these different extension types in your ESLint configuration file.
+* Custom parsers to convert JavaScript code into an abstract syntax tree for ESLint to evaluate. You might want to add a custom parser if the code you're writing isn't compatible with the ESLint default parser, Espree.
+* Custom processors to extract JavaScript code from other kinds of files or preprocess code before linting.
+* Custom rules to validates if your code meets a certain expectation, and what to do if it does not meet that expectation.
+* Other custom configuration using ESLint's built in features.
 
 ## Specifying Parser
 

--- a/docs/src/user-guide/configuring/plugins.md
+++ b/docs/src/user-guide/configuring/plugins.md
@@ -14,6 +14,7 @@ You can extend ESLint with plugins in a variety of different ways. Plugins can i
 * Custom processors to extract JavaScript code from other kinds of files or preprocess code before linting.
 * Custom rules to validate if your code meets a certain expectation, and what to do if it does not meet that expectation.
 * Custom configurations.
+* Custom environments.
 
 You can also use custom parsers to convert JavaScript code into an abstract syntax tree for ESLint to evaluate. You might want to add a custom parser if your code isn't compatible with ESLint's default parser, Espree.
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- renamed 'Configuring Plugins' page to 'Configuring Plugins & Parsers' b/c plugins separate from parsers
  - note: didn't change page name b/c didn't want to break the existing URL path before we have redirects set up
- added intro section to page
- small copy edits throughout page
- move section order to make clear that processors are part of plugins, whereas parsers are separate. 
- also moved up the docs on configuring plugins b/c that is the more commonly used feature.

Part of https://github.com/eslint/eslint/issues/16473

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
