### PR TITLE
Use emoji instead of svg for deprecated rule symbol

### DIFF
--- a/docs/src/_includes/components/rule.macro.html
+++ b/docs/src/_includes/components/rule.macro.html
@@ -29,11 +29,7 @@
     <div class="rule__categories">
         <span class="visually-hidden">Categories:</span>
         {%- if (params.deprecated) or (params.removed) -%}
-            <p class="rule__categories__type">
-                <svg width="24" height="24" viewBox="12 12 20 20" fill="none" aria-hidden="true" focusable="false" style="position: relative; right: -1px;">
-                    <path d="M28.5 16L16.5 28M16.5 16L28.5 28" stroke="#F63D68" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-            </p>
+            <p class="rule__categories__type">❌</p>
             {%- else -%}
             <p class="rule__categories__type" {% if params.categories.recommended == false %}aria-hidden="true" {%- endif -%}>
             ✅ <span class="visually-hidden">Extends</span>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

- [X] Documentation update


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Use the ❌ emoji to symbolize deprecated rules. This is the emoji-version of the former SVG. Emojis are preferred as they can be selected/copy-pasted, and are more consistent with the other fixable/recommended/suggestions emojis used in the [rules](https://eslint.org/docs/latest/rules/) list/index/table.

This emoji also matches the emoji for "deprecated rule" used by many top plugins ([example](https://github.com/jest-community/eslint-plugin-jest#rules)), and it's the same emoji used by [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator) which I wrote.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->


