### PR TITLE
chore: Add tests to verify #16038 is fixed

### DIFF
--- a/tests/fixtures/dots-in-files/a..b.js
+++ b/tests/fixtures/dots-in-files/a..b.js
@@ -1,0 +1,1 @@
+console.log("Running");

--- a/tests/fixtures/dots-in-files/eslint.config.js
+++ b/tests/fixtures/dots-in-files/eslint.config.js
@@ -1,0 +1,8 @@
+module.exports = [
+    {
+        files: ["a..b.js"]
+    },
+    {
+        ignores: ["eslint.config.js"]
+    }
+];

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -794,6 +794,21 @@ describe("FlatESLint", () => {
             assert.strictEqual(results[1].suppressedMessages.length, 0);
         });
 
+        // https://github.com/eslint/eslint/issues/16038
+        it("should allow files patterns with '..' inside", async () => {
+            eslint = new FlatESLint({
+                ignore: false,
+                cwd: getFixturePath("dots-in-files")
+            });
+            const results = await eslint.lintFiles(["."]);
+
+            assert.strictEqual(results.length, 2);
+            assert.strictEqual(results[0].messages.length, 0);
+            assert.strictEqual(results[0].filePath, getFixturePath("dots-in-files/a..b.js"));
+            assert.strictEqual(results[0].suppressedMessages.length, 0);
+        });
+
+
         // https://github.com/eslint/eslint/issues/16299
         it("should only find files in the subdir1 directory when given a directory name", async () => {
             eslint = new FlatESLint({


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:


Added a test

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This test just verifies that we can have `files` pattern that include two dots in a row like "a..b.js" when using flat config.

Closes #16038

#### Is there anything you'd like reviewers to focus on?

Nope.

<!-- markdownlint-disable-file MD004 -->
