### PR TITLE
docs: fix route of japanese translation site

### DIFF
--- a/docs/src/_data/languages.json
+++ b/docs/src/_data/languages.json
@@ -9,7 +9,7 @@
             "flag": "🇯🇵",
             "code": "jp",
             "name": "Japanese - 日本語",
-            "url": "https://jp.eslint.org"
+            "url": "https://ja.eslint.org"
         },
         {
             "flag": "🇫🇷",

--- a/docs/src/_data/languages.json
+++ b/docs/src/_data/languages.json
@@ -7,7 +7,7 @@
         },
         {
             "flag": "🇯🇵",
-            "code": "jp",
+            "code": "ja",
             "name": "Japanese - 日本語",
             "url": "https://ja.eslint.org"
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In the language page https://eslint.org/docs/latest/languages.html the link that is rendering the users to the japanese translation page of ESlint, is not working.
So as a fix i did change the language code from **jp** to **ja** in data.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
