### PR TITLE
feat: `prefer-named-capture-group` add suggestions

### DIFF
--- a/lib/rules/prefer-named-capture-group.js
+++ b/lib/rules/prefer-named-capture-group.js
@@ -23,6 +23,50 @@ const regexpp = require("regexpp");
 
 const parser = new regexpp.RegExpParser();
 
+/**
+ * Creates fixer suggestions for the regex, if statically determinable.
+ * @param {number} groupStart Starting index of the regex group.
+ * @param {string} pattern The regular expression pattern to be checked.
+ * @param {string} rawText Source text of the regexNode.
+ * @param {ASTNode} regexNode AST node which contains the regular expression.
+ * @returns {Array<SuggestionResult>} Fixer suggestions for the regex, if statically determinable.
+ */
+function suggestIfPossible(groupStart, pattern, rawText, regexNode) {
+    if (regexNode.type === "Literal") {
+        if (typeof regexNode.value === "string" && rawText.includes("\\")) {
+            return null;
+        }
+    } else if (
+        regexNode.type === "TemplateLiteral" &&
+        (regexNode.expressions.length || rawText.slice(1, -1) !== pattern)
+    ) {
+        return null;
+    }
+
+    const start = regexNode.range[0] + rawText.indexOf("(", groupStart) + 1;
+
+    return [
+        {
+            fix(fixer) {
+                return fixer.insertTextBeforeRange(
+                    [start, start],
+                    `?<temp${((pattern.match(/temp\d+/gu) || []).length || 0) + 1}>`
+                );
+            },
+            messageId: "addGroupName"
+        },
+        {
+            fix(fixer) {
+                return fixer.insertTextBeforeRange(
+                    [start, start],
+                    "?:"
+                );
+            },
+            messageId: "addNonCapture"
+        }
+    ];
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -38,8 +82,6 @@ module.exports = {
             url: "https://eslint.org/docs/rules/prefer-named-capture-group"
         },
 
-        // https://github.com/eslint-community/eslint-plugin-eslint-plugin/issues/281
-        // eslint-disable-next-line eslint-plugin/require-meta-has-suggestions -- 👆
         hasSuggestions: true,
 
         schema: [],
@@ -56,9 +98,9 @@ module.exports = {
 
         /**
          * Function to check regular expression.
-         * @param {string} pattern The regular expression pattern to be check.
-         * @param {ASTNode} node AST node which contains regular expression or a call/new expression.
-         * @param {ASTNode} regexNode AST node which contains regular expression.
+         * @param {string} pattern The regular expression pattern to be checked.
+         * @param {ASTNode} node AST node which contains the regular expression or a call/new expression.
+         * @param {ASTNode} regexNode AST node which contains the regular expression.
          * @param {boolean} uFlag Flag indicates whether unicode mode is enabled or not.
          * @returns {void}
          */
@@ -77,7 +119,7 @@ module.exports = {
                 onCapturingGroupEnter(group) {
                     if (!group.name) {
                         const rawText = sourceCode.getText(regexNode);
-                        const start = regexNode.range[0] + rawText.indexOf("(", group.start) + 1;
+                        const suggest = suggestIfPossible(group.start, pattern, rawText, regexNode);
 
                         context.report({
                             node,
@@ -85,28 +127,7 @@ module.exports = {
                             data: {
                                 group: group.raw
                             },
-                            ...(!rawText.includes("\\") && ({
-                                suggest: [
-                                    {
-                                        fix(fixer) {
-                                            return fixer.insertTextBeforeRange(
-                                                [start, start],
-                                                `?<temp${((pattern.match(/temp\d+/gu) || []).length || 0) + 1}>`
-                                            );
-                                        },
-                                        messageId: "addGroupName"
-                                    },
-                                    {
-                                        fix(fixer) {
-                                            return fixer.insertTextBeforeRange(
-                                                [start, start],
-                                                "?:"
-                                            );
-                                        },
-                                        messageId: "addNonCapture"
-                                    }
-                                ]
-                            }))
+                            suggest
                         });
                     }
                 }

--- a/lib/rules/prefer-named-capture-group.js
+++ b/lib/rules/prefer-named-capture-group.js
@@ -38,6 +38,8 @@ module.exports = {
             url: "https://eslint.org/docs/rules/prefer-named-capture-group"
         },
 
+        // https://github.com/eslint-community/eslint-plugin-eslint-plugin/issues/281
+        // eslint-disable-next-line eslint-plugin/require-meta-has-suggestions -- 👆
         hasSuggestions: true,
 
         schema: [],
@@ -83,26 +85,28 @@ module.exports = {
                             data: {
                                 group: group.raw
                             },
-                            suggest: [
-                                {
-                                    fix(fixer) {
-                                        return fixer.insertTextBeforeRange(
-                                            [start, start],
-                                            `?<temp${((pattern.match(/temp\d+/gu) || []).length || 0) + 1}>`
-                                        );
+                            ...(!rawText.includes("\\") && ({
+                                suggest: [
+                                    {
+                                        fix(fixer) {
+                                            return fixer.insertTextBeforeRange(
+                                                [start, start],
+                                                `?<temp${((pattern.match(/temp\d+/gu) || []).length || 0) + 1}>`
+                                            );
+                                        },
+                                        messageId: "addGroupName"
                                     },
-                                    messageId: "addGroupName"
-                                },
-                                {
-                                    fix(fixer) {
-                                        return fixer.insertTextBeforeRange(
-                                            [start, start],
-                                            "?:"
-                                        );
-                                    },
-                                    messageId: "addNonCapture"
-                                }
-                            ]
+                                    {
+                                        fix(fixer) {
+                                            return fixer.insertTextBeforeRange(
+                                                [start, start],
+                                                "?:"
+                                            );
+                                        },
+                                        messageId: "addNonCapture"
+                                    }
+                                ]
+                            }))
                         });
                     }
                 }

--- a/lib/rules/prefer-named-capture-group.js
+++ b/lib/rules/prefer-named-capture-group.js
@@ -38,23 +38,29 @@ module.exports = {
             url: "https://eslint.org/docs/rules/prefer-named-capture-group"
         },
 
+        hasSuggestions: true,
+
         schema: [],
 
         messages: {
+            addGroupName: "Add name to capture group.",
+            addNonCapture: "Convert group to non-capturing.",
             required: "Capture group '{{group}}' should be converted to a named or non-capturing group."
         }
     },
 
     create(context) {
+        const sourceCode = context.getSourceCode();
 
         /**
          * Function to check regular expression.
          * @param {string} pattern The regular expression pattern to be check.
-         * @param {ASTNode} node AST node which contains regular expression.
+         * @param {ASTNode} node AST node which contains regular expression or a call/new expression.
+         * @param {ASTNode} regexNode AST node which contains regular expression.
          * @param {boolean} uFlag Flag indicates whether unicode mode is enabled or not.
          * @returns {void}
          */
-        function checkRegex(pattern, node, uFlag) {
+        function checkRegex(pattern, node, regexNode, uFlag) {
             let ast;
 
             try {
@@ -68,12 +74,35 @@ module.exports = {
             regexpp.visitRegExpAST(ast, {
                 onCapturingGroupEnter(group) {
                     if (!group.name) {
+                        const rawText = sourceCode.getText(regexNode);
+                        const start = regexNode.range[0] + rawText.indexOf("(", group.start) + 1;
+
                         context.report({
                             node,
                             messageId: "required",
                             data: {
                                 group: group.raw
-                            }
+                            },
+                            suggest: [
+                                {
+                                    fix(fixer) {
+                                        return fixer.insertTextBeforeRange(
+                                            [start, start],
+                                            `?<temp${((pattern.match(/temp\d+/gu) || []).length || 0) + 1}>`
+                                        );
+                                    },
+                                    messageId: "addGroupName"
+                                },
+                                {
+                                    fix(fixer) {
+                                        return fixer.insertTextBeforeRange(
+                                            [start, start],
+                                            "?:"
+                                        );
+                                    },
+                                    messageId: "addNonCapture"
+                                }
+                            ]
                         });
                     }
                 }
@@ -83,7 +112,7 @@ module.exports = {
         return {
             Literal(node) {
                 if (node.regex) {
-                    checkRegex(node.regex.pattern, node, node.regex.flags.includes("u"));
+                    checkRegex(node.regex.pattern, node, node, node.regex.flags.includes("u"));
                 }
             },
             Program() {
@@ -101,7 +130,7 @@ module.exports = {
                     const flags = getStringIfConstant(node.arguments[1]);
 
                     if (regex) {
-                        checkRegex(regex, node, flags && flags.includes("u"));
+                        checkRegex(regex, node, node.arguments[0], flags && flags.includes("u"));
                     }
                 }
             }

--- a/lib/rules/prefer-named-capture-group.js
+++ b/lib/rules/prefer-named-capture-group.js
@@ -32,18 +32,22 @@ const parser = new regexpp.RegExpParser();
  * @returns {Array<SuggestionResult>} Fixer suggestions for the regex, if statically determinable.
  */
 function suggestIfPossible(groupStart, pattern, rawText, regexNode) {
-    if (regexNode.type === "Literal") {
-        if (typeof regexNode.value === "string" && rawText.includes("\\")) {
+    switch (regexNode.type) {
+        case "Literal":
+            if (typeof regexNode.value === "string" && rawText.includes("\\")) {
+                return null;
+            }
+            break;
+        case "TemplateLiteral":
+            if (regexNode.expressions.length || rawText.slice(1, -1) !== pattern) {
+                return null;
+            }
+            break;
+        default:
             return null;
-        }
-    } else if (
-        regexNode.type === "TemplateLiteral" &&
-        (regexNode.expressions.length || rawText.slice(1, -1) !== pattern)
-    ) {
-        return null;
     }
 
-    const start = regexNode.range[0] + rawText.indexOf("(", groupStart) + 1;
+    const start = regexNode.range[0] + groupStart + 2;
 
     return [
         {

--- a/lib/rules/prefer-named-capture-group.js
+++ b/lib/rules/prefer-named-capture-group.js
@@ -52,9 +52,16 @@ function suggestIfPossible(groupStart, pattern, rawText, regexNode) {
     return [
         {
             fix(fixer) {
+                const existingTemps = pattern.match(/temp\d+/gu) || [];
+                const highestTempCount = existingTemps.reduce(
+                    (previous, next) =>
+                        Math.max(previous, Number(next.slice("temp".length))),
+                    0
+                );
+
                 return fixer.insertTextBeforeRange(
                     [start, start],
-                    `?<temp${((pattern.match(/temp\d+/gu) || []).length || 0) + 1}>`
+                    `?<temp${highestTempCount + 1}>`
                 );
             },
             messageId: "addGroupName"

--- a/tests/lib/rules/prefer-named-capture-group.js
+++ b/tests/lib/rules/prefer-named-capture-group.js
@@ -174,6 +174,14 @@ ruleTester.run("prefer-named-capture-group", rule, {
             }]
         },
         {
+            code: "new RegExp('\\u1234\\u5678(?:a)(b)');",
+            errors: [{
+                messageId: "required",
+                type: "NewExpression",
+                data: { group: "(b)" }
+            }]
+        },
+        {
             code: "/([0-9]{4})-(\\w{5})/",
             errors: [
                 {
@@ -182,17 +190,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
                     data: { group: "([0-9]{4})" },
                     line: 1,
                     column: 1,
-                    endColumn: 21,
-                    suggestions: [
-                        {
-                            messageId: "addGroupName",
-                            output: "/(?<temp1>[0-9]{4})-(\\w{5})/"
-                        },
-                        {
-                            messageId: "addNonCapture",
-                            output: "/(?:[0-9]{4})-(\\w{5})/"
-                        }
-                    ]
+                    endColumn: 21
                 },
                 {
                     messageId: "required",
@@ -200,15 +198,46 @@ ruleTester.run("prefer-named-capture-group", rule, {
                     data: { group: "(\\w{5})" },
                     line: 1,
                     column: 1,
-                    endColumn: 21,
+                    endColumn: 21
+                }
+            ]
+        },
+        {
+            code: "/([0-9]{4})-(5)/",
+            errors: [
+                {
+                    messageId: "required",
+                    type: "Literal",
+                    data: { group: "([0-9]{4})" },
+                    line: 1,
+                    column: 1,
+                    endColumn: 17,
                     suggestions: [
                         {
                             messageId: "addGroupName",
-                            output: "/([0-9]{4})-(?<temp1>\\w{5})/"
+                            output: "/(?<temp1>[0-9]{4})-(5)/"
                         },
                         {
                             messageId: "addNonCapture",
-                            output: "/([0-9]{4})-(?:\\w{5})/"
+                            output: "/(?:[0-9]{4})-(5)/"
+                        }
+                    ]
+                },
+                {
+                    messageId: "required",
+                    type: "Literal",
+                    data: { group: "(5)" },
+                    line: 1,
+                    column: 1,
+                    endColumn: 17,
+                    suggestions: [
+                        {
+                            messageId: "addGroupName",
+                            output: "/([0-9]{4})-(?<temp1>5)/"
+                        },
+                        {
+                            messageId: "addNonCapture",
+                            output: "/([0-9]{4})-(?:5)/"
                         }
                     ]
                 }
@@ -223,15 +252,28 @@ ruleTester.run("prefer-named-capture-group", rule, {
                     data: { group: "(\\w{5})" },
                     line: 1,
                     column: 1,
-                    endColumn: 29,
+                    endColumn: 29
+                }
+            ]
+        },
+        {
+            code: "/(?<temp1>[0-9]{4})-(5)/",
+            errors: [
+                {
+                    messageId: "required",
+                    type: "Literal",
+                    data: { group: "(5)" },
+                    line: 1,
+                    column: 1,
+                    endColumn: 25,
                     suggestions: [
                         {
                             messageId: "addGroupName",
-                            output: "/(?<temp1>[0-9]{4})-(?<temp2>\\w{5})/"
+                            output: "/(?<temp1>[0-9]{4})-(?<temp2>5)/"
                         },
                         {
                             messageId: "addNonCapture",
-                            output: "/(?<temp1>[0-9]{4})-(?:\\w{5})/"
+                            output: "/(?<temp1>[0-9]{4})-(?:5)/"
                         }
                     ]
                 }
@@ -395,17 +437,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(b)" },
-                suggestions: [
-                    {
-                        messageId: "addGroupName",
-                        output: "new RegExp('a(?<temp1>b)\\'')"
-                    },
-                    {
-                        messageId: "addNonCapture",
-                        output: "new RegExp('a(?:b)\\'')"
-                    }
-                ]
+                data: { group: "(b)" }
             }]
         },
         {
@@ -413,17 +445,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(a)" },
-                suggestions: [
-                    {
-                        messageId: "addGroupName",
-                        output: "RegExp('(?<temp1>a)\\\\d')"
-                    },
-                    {
-                        messageId: "addNonCapture",
-                        output: "RegExp('(?:a)\\\\d')"
-                    }
-                ]
+                data: { group: "(a)" }
             }]
         },
         {
@@ -431,17 +453,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(b)" },
-                suggestions: [
-                    {
-                        messageId: "addGroupName",
-                        output: "RegExp(`\\a(?<temp1>b)`)"
-                    },
-                    {
-                        messageId: "addNonCapture",
-                        output: "RegExp(`\\a(?:b)`)"
-                    }
-                ]
+                data: { group: "(b)" }
             }]
         },
         {

--- a/tests/lib/rules/prefer-named-capture-group.js
+++ b/tests/lib/rules/prefer-named-capture-group.js
@@ -82,7 +82,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
                 data: { group: "([0-9]{4})" },
                 line: 1,
                 column: 1,
-                endColumn: 13
+                endColumn: 13,
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "/(?<temp1>[0-9]{4})/"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "/(?:[0-9]{4})/"
+                    }
+                ]
             }]
         },
         {
@@ -93,7 +103,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
                 data: { group: "([0-9]{4})" },
                 line: 1,
                 column: 1,
-                endColumn: 25
+                endColumn: 25,
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "new RegExp('(?<temp1>[0-9]{4})')"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "new RegExp('(?:[0-9]{4})')"
+                    }
+                ]
             }]
         },
         {
@@ -104,7 +124,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
                 data: { group: "([0-9]{4})" },
                 line: 1,
                 column: 1,
-                endColumn: 21
+                endColumn: 21,
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "RegExp('(?<temp1>[0-9]{4})')"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "RegExp('(?:[0-9]{4})')"
+                    }
+                ]
             }]
         },
         {
@@ -112,7 +142,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(bc)" }
+                data: { group: "(bc)" },
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "new RegExp(`a(?<temp1>bc)d`)"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "new RegExp(`a(?:bc)d`)"
+                    }
+                ]
             }]
         },
         {
@@ -124,7 +164,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
                     data: { group: "([0-9]{4})" },
                     line: 1,
                     column: 1,
-                    endColumn: 21
+                    endColumn: 21,
+                    suggestions: [
+                        {
+                            messageId: "addGroupName",
+                            output: "/(?<temp1>[0-9]{4})-(\\w{5})/"
+                        },
+                        {
+                            messageId: "addNonCapture",
+                            output: "/(?:[0-9]{4})-(\\w{5})/"
+                        }
+                    ]
                 },
                 {
                     messageId: "required",
@@ -132,7 +182,63 @@ ruleTester.run("prefer-named-capture-group", rule, {
                     data: { group: "(\\w{5})" },
                     line: 1,
                     column: 1,
-                    endColumn: 21
+                    endColumn: 21,
+                    suggestions: [
+                        {
+                            messageId: "addGroupName",
+                            output: "/([0-9]{4})-(?<temp1>\\w{5})/"
+                        },
+                        {
+                            messageId: "addNonCapture",
+                            output: "/([0-9]{4})-(?:\\w{5})/"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "/(?<temp1>[0-9]{4})-(\\w{5})/",
+            errors: [
+                {
+                    messageId: "required",
+                    type: "Literal",
+                    data: { group: "(\\w{5})" },
+                    line: 1,
+                    column: 1,
+                    endColumn: 29,
+                    suggestions: [
+                        {
+                            messageId: "addGroupName",
+                            output: "/(?<temp1>[0-9]{4})-(?<temp2>\\w{5})/"
+                        },
+                        {
+                            messageId: "addNonCapture",
+                            output: "/(?<temp1>[0-9]{4})-(?:\\w{5})/"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "/(?<temp1>a)(?<temp2>a)(a)(?<temp3>a)/",
+            errors: [
+                {
+                    messageId: "required",
+                    type: "Literal",
+                    data: { group: "(a)" },
+                    line: 1,
+                    column: 1,
+                    endColumn: 39,
+                    suggestions: [
+                        {
+                            messageId: "addGroupName",
+                            output: "/(?<temp1>a)(?<temp2>a)(?<temp4>a)(?<temp3>a)/"
+                        },
+                        {
+                            messageId: "addNonCapture",
+                            output: "/(?<temp1>a)(?<temp2>a)(?:a)(?<temp3>a)/"
+                        }
+                    ]
                 }
             ]
         },
@@ -141,7 +247,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(a)" }
+                data: { group: "(a)" },
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "new RegExp('(?<temp1>' + 'a)')"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "new RegExp('(?:' + 'a)')"
+                    }
+                ]
             }]
         },
         {
@@ -149,7 +265,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(bc)" }
+                data: { group: "(bc)" },
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "new RegExp('a(?<temp1>bc)d' + 'e')"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "new RegExp('a(?:bc)d' + 'e')"
+                    }
+                ]
             }]
         },
         {
@@ -157,7 +283,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(a)" }
+                data: { group: "(a)" },
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "RegExp('(?<temp1>a)'+'')"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "RegExp('(?:a)'+'')"
+                    }
+                ]
             }]
         },
         {
@@ -165,7 +301,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(ab)" }
+                data: { group: "(ab)" },
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "RegExp( '' + '(?<temp1>ab)')"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "RegExp( '' + '(?:ab)')"
+                    }
+                ]
             }]
         },
         {
@@ -173,7 +319,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(ab)" }
+                data: { group: "(ab)" },
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "new RegExp(`(?<temp1>ab)${''}`)"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "new RegExp(`(?:ab)${''}`)"
+                    }
+                ]
             }]
         },
         {
@@ -185,7 +341,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
                 line: 1,
                 column: 1,
                 endLine: 2,
-                endColumn: 3
+                endColumn: 3,
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "new RegExp(`(?<temp1>a)\n`)"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "new RegExp(`(?:a)\n`)"
+                    }
+                ]
             }]
         },
         {
@@ -193,7 +359,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(b\nc)" }
+                data: { group: "(b\nc)" },
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "RegExp(`a(?<temp1>b\nc)d`)"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "RegExp(`a(?:b\nc)d`)"
+                    }
+                ]
             }]
         },
         {
@@ -201,7 +377,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(b)" }
+                data: { group: "(b)" },
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "new RegExp('a(?<temp1>b)\\'')"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "new RegExp('a(?:b)\\'')"
+                    }
+                ]
             }]
         },
         {
@@ -209,7 +395,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(a)" }
+                data: { group: "(a)" },
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "RegExp('(?<temp1>a)\\\\d')"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "RegExp('(?:a)\\\\d')"
+                    }
+                ]
             }]
         },
         {
@@ -217,7 +413,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(b)" }
+                data: { group: "(b)" },
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "RegExp(`\\a(?<temp1>b)`)"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "RegExp(`\\a(?:b)`)"
+                    }
+                ]
             }]
         },
         {
@@ -229,7 +435,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
                 data: { group: "([0-9]{4})" },
                 line: 1,
                 column: 1,
-                endColumn: 36
+                endColumn: 36,
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "new globalThis.RegExp('(?<temp1>[0-9]{4})')"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "new globalThis.RegExp('(?:[0-9]{4})')"
+                    }
+                ]
             }]
         },
         {
@@ -241,7 +457,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
                 data: { group: "([0-9]{4})" },
                 line: 1,
                 column: 1,
-                endColumn: 32
+                endColumn: 32,
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "globalThis.RegExp('(?<temp1>[0-9]{4})')"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "globalThis.RegExp('(?:[0-9]{4})')"
+                    }
+                ]
             }]
         },
         {
@@ -256,7 +482,23 @@ ruleTester.run("prefer-named-capture-group", rule, {
                 data: { group: "([0-9]{4})" },
                 line: 3,
                 column: 17,
-                endColumn: 52
+                endColumn: 52,
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: `
+                function foo() { var globalThis = bar; }
+                new globalThis.RegExp('(?<temp1>[0-9]{4})');
+            `
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: `
+                function foo() { var globalThis = bar; }
+                new globalThis.RegExp('(?:[0-9]{4})');
+            `
+                    }
+                ]
             }]
         }
     ]

--- a/tests/lib/rules/prefer-named-capture-group.js
+++ b/tests/lib/rules/prefer-named-capture-group.js
@@ -191,7 +191,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
                     data: { group: "([0-9]{4})" },
                     line: 1,
                     column: 1,
-                    endColumn: 21
+                    endColumn: 21,
+                    suggestions: [
+                        {
+                            messageId: "addGroupName",
+                            output: "/(?<temp1>[0-9]{4})-(\\w{5})/"
+                        },
+                        {
+                            messageId: "addNonCapture",
+                            output: "/(?:[0-9]{4})-(\\w{5})/"
+                        }
+                    ]
                 },
                 {
                     messageId: "required",
@@ -199,7 +209,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
                     data: { group: "(\\w{5})" },
                     line: 1,
                     column: 1,
-                    endColumn: 21
+                    endColumn: 21,
+                    suggestions: [
+                        {
+                            messageId: "addGroupName",
+                            output: "/([0-9]{4})-(?<temp1>\\w{5})/"
+                        },
+                        {
+                            messageId: "addNonCapture",
+                            output: "/([0-9]{4})-(?:\\w{5})/"
+                        }
+                    ]
                 }
             ]
         },
@@ -239,6 +259,52 @@ ruleTester.run("prefer-named-capture-group", rule, {
                         {
                             messageId: "addNonCapture",
                             output: "/([0-9]{4})-(?:5)/"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "/(?<temp2>(a))/",
+            errors: [
+                {
+                    messageId: "required",
+                    type: "Literal",
+                    data: { group: "(a)" },
+                    line: 1,
+                    column: 1,
+                    endColumn: 16,
+                    suggestions: [
+                        {
+                            messageId: "addGroupName",
+                            output: "/(?<temp2>(?<temp3>a))/"
+                        },
+                        {
+                            messageId: "addNonCapture",
+                            output: "/(?<temp2>(?:a))/"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "/(?<temp2>(a)(?<temp5>b))/",
+            errors: [
+                {
+                    messageId: "required",
+                    type: "Literal",
+                    data: { group: "(a)" },
+                    line: 1,
+                    column: 1,
+                    endColumn: 27,
+                    suggestions: [
+                        {
+                            messageId: "addGroupName",
+                            output: "/(?<temp2>(?<temp6>a)(?<temp5>b))/"
+                        },
+                        {
+                            messageId: "addNonCapture",
+                            output: "/(?<temp2>(?:a)(?<temp5>b))/"
                         }
                     ]
                 }

--- a/tests/lib/rules/prefer-named-capture-group.js
+++ b/tests/lib/rules/prefer-named-capture-group.js
@@ -307,17 +307,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(a)" },
-                suggestions: [
-                    {
-                        messageId: "addGroupName",
-                        output: "new RegExp('(?<temp1>' + 'a)')"
-                    },
-                    {
-                        messageId: "addNonCapture",
-                        output: "new RegExp('(?:' + 'a)')"
-                    }
-                ]
+                data: { group: "(a)" }
             }]
         },
         {
@@ -325,17 +315,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(bc)" },
-                suggestions: [
-                    {
-                        messageId: "addGroupName",
-                        output: "new RegExp('a(?<temp1>bc)d' + 'e')"
-                    },
-                    {
-                        messageId: "addNonCapture",
-                        output: "new RegExp('a(?:bc)d' + 'e')"
-                    }
-                ]
+                data: { group: "(bc)" }
             }]
         },
         {
@@ -343,17 +323,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(a)" },
-                suggestions: [
-                    {
-                        messageId: "addGroupName",
-                        output: "RegExp('(?<temp1>a)'+'')"
-                    },
-                    {
-                        messageId: "addNonCapture",
-                        output: "RegExp('(?:a)'+'')"
-                    }
-                ]
+                data: { group: "(a)" }
             }]
         },
         {
@@ -361,17 +331,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(ab)" },
-                suggestions: [
-                    {
-                        messageId: "addGroupName",
-                        output: "RegExp( '' + '(?<temp1>ab)')"
-                    },
-                    {
-                        messageId: "addNonCapture",
-                        output: "RegExp( '' + '(?:ab)')"
-                    }
-                ]
+                data: { group: "(ab)" }
             }]
         },
         {
@@ -379,17 +339,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(ab)" },
-                suggestions: [
-                    {
-                        messageId: "addGroupName",
-                        output: "new RegExp(`(?<temp1>ab)${''}`)"
-                    },
-                    {
-                        messageId: "addNonCapture",
-                        output: "new RegExp(`(?:ab)${''}`)"
-                    }
-                ]
+                data: { group: "(ab)" }
             }]
         },
         {

--- a/tests/lib/rules/prefer-named-capture-group.js
+++ b/tests/lib/rules/prefer-named-capture-group.js
@@ -178,7 +178,8 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(b)" }
+                data: { group: "(b)" },
+                suggestions: null
             }]
         },
         {
@@ -252,7 +253,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
                     data: { group: "(\\w{5})" },
                     line: 1,
                     column: 1,
-                    endColumn: 29
+                    endColumn: 29,
+                    suggestions: [
+                        {
+                            messageId: "addGroupName",
+                            output: "/(?<temp1>[0-9]{4})-(?<temp2>\\w{5})/"
+                        },
+                        {
+                            messageId: "addNonCapture",
+                            output: "/(?<temp1>[0-9]{4})-(?:\\w{5})/"
+                        }
+                    ]
                 }
             ]
         },
@@ -307,7 +318,8 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(a)" }
+                data: { group: "(a)" },
+                suggestions: null
             }]
         },
         {
@@ -315,7 +327,34 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(bc)" }
+                data: { group: "(bc)" },
+                suggestions: null
+            }]
+        },
+        {
+            code: "new RegExp(\"foo\" + \"(a)\" + \"(b)\");",
+            errors: [
+                {
+                    messageId: "required",
+                    type: "NewExpression",
+                    data: { group: "(a)" },
+                    suggestions: null
+                },
+                {
+                    messageId: "required",
+                    type: "NewExpression",
+                    data: { group: "(b)" },
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "new RegExp(\"foo\" + \"(?:a)\" + \"(b)\");",
+            errors: [{
+                messageId: "required",
+                type: "NewExpression",
+                data: { group: "(b)" },
+                suggestions: null
             }]
         },
         {
@@ -323,7 +362,8 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(a)" }
+                data: { group: "(a)" },
+                suggestions: null
             }]
         },
         {
@@ -331,7 +371,8 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(ab)" }
+                data: { group: "(ab)" },
+                suggestions: null
             }]
         },
         {
@@ -339,7 +380,8 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(ab)" }
+                data: { group: "(ab)" },
+                suggestions: null
             }]
         },
         {
@@ -387,7 +429,8 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(b)" }
+                data: { group: "(b)" },
+                suggestions: null
             }]
         },
         {
@@ -395,7 +438,8 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(a)" }
+                data: { group: "(a)" },
+                suggestions: null
             }]
         },
         {
@@ -403,7 +447,8 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(b)" }
+                data: { group: "(b)" },
+                suggestions: null
             }]
         },
         {

--- a/tests/lib/rules/prefer-named-capture-group.js
+++ b/tests/lib/rules/prefer-named-capture-group.js
@@ -156,6 +156,24 @@ ruleTester.run("prefer-named-capture-group", rule, {
             }]
         },
         {
+            code: "new RegExp('\u1234\u5678(?:a)(b)');",
+            errors: [{
+                messageId: "required",
+                type: "NewExpression",
+                data: { group: "(b)" },
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "new RegExp('\u1234\u5678(?:a)(?<temp1>b)');"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "new RegExp('\u1234\u5678(?:a)(?:b)');"
+                    }
+                ]
+            }]
+        },
+        {
             code: "/([0-9]{4})-(\\w{5})/",
             errors: [
                 {


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[x] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #16530

#### What changes did you make? (Give an overview)

Adds `meta.hasSuggestions` to `prefer-named-capture-group` for two suggestions:

* Changing a capture group to named: e.g. `(?<temp1>a)`
* Changing a capture group to non-named: e.g. `(?:a)`

#### Is there anything you'd like reviewers to focus on?

I don't work with named capture groups much in regular expressions, so I'm not highly confident there aren't edge cases I didn't think of.