### PR TITLE
docs: switch to wrench emoji for auto-fixable rules

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -247,7 +247,7 @@ module.exports = function(eleventyConfig) {
 
     eleventyConfig.addShortcode("fixable", () => `
         <div class="rule-category">
-            <span class="rule-category__icon">🛠 <span class="visually-hidden">Fixable</span></span>
+            <span class="rule-category__icon">🔧 <span class="visually-hidden">Fixable</span></span>
             <p class="rule-category__description">
                 if some problems reported by the rule are automatically fixable by the <code>--fix</code> command line option
             </p>

--- a/docs/src/_includes/components/rule-categories.macro.html
+++ b/docs/src/_includes/components/rule-categories.macro.html
@@ -11,7 +11,7 @@
     {%- endif -%}
     {%- if params.fixable -%}
     <div class="rule-category">
-        <span class="rule-category__icon">🛠 <span class="visually-hidden">Fixable</span></span>
+        <span class="rule-category__icon">🔧 <span class="visually-hidden">Fixable</span></span>
         <p class="rule-category__description">
             Some problems reported by this rule are automatically fixable by the <code>--fix</code> <a href="../user-guide/command-line-interface#--fix">command line</a> option
         </p>
@@ -39,7 +39,7 @@
 
 {%- macro fixable() -%}
 <div class="rule-category">
-    <span class="rule-category__icon">🛠 <span class="visually-hidden">Fixable</span></span>
+    <span class="rule-category__icon">🔧 <span class="visually-hidden">Fixable</span></span>
     <p class="rule-category__description">
         if some problems reported by the rule are automatically fixable by the <code>--fix</code> command line option
     </p>

--- a/docs/src/_includes/components/rule.macro.html
+++ b/docs/src/_includes/components/rule.macro.html
@@ -37,7 +37,7 @@
         {%- endif -%}
 
         <p class="rule__categories__type" {% if params.categories.fixable == false %}aria-hidden="true" {%- endif -%}>
-            🛠 <span class="visually-hidden">Fix</span>
+            🔧 <span class="visually-hidden">Fix</span>
         </p>
         <p class="rule__categories__type" {% if params.categories.hasSuggestions == false %}aria-hidden="true" {%- endif -%}>
             💡 <span class="visually-hidden">Suggestions</span>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

- [X] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Switch from the 🛠 (hammer and wrench) to 🔧 (wrench) emoji to represent auto-fixable rules.

Why?

- The wrench could be considered simpler, "less busy", and a "more straightforward" emoji to indicate the desired meaning
- I used [eslint-ecosystem-analyzer](https://github.com/bmish/eslint-ecosystem-analyzer) to count usages of each emoji across the top 1,000 ESLint plugins, and found the wrench to be vastly more popular:

| Emoji | Number of Files in Top 1,000 ESLint Plugins | 
| --- | --- | 
| 🔧 | 607 |
| 🛠 | 15 | 

As a result of the greater popularity of the wrench emoji, I have also adopted it in [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator) which is used in the top 15+ ESLint plugins ([example output](https://github.com/jest-community/eslint-plugin-jest#rules)).

This is a great opportunity to finish standardizing the entire ESLint ecosystem on the wrench emoji by adopting it inside ESLint core as well.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
