### PR TITLE
fix: Ensure that dot files are found with globs.

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -26,6 +26,7 @@ const isPathInside = require("is-path-inside");
 
 const doFsWalk = util.promisify(fswalk.walk);
 const Minimatch = minimatch.Minimatch;
+const MINIMATCH_OPTIONS = { dot: true };
 
 //-----------------------------------------------------------------------------
 // Types
@@ -158,7 +159,7 @@ function globMatch({ basePath, pattern }) {
         ? normalizeToPosix(path.relative(basePath, pattern))
         : pattern;
 
-    const matcher = new Minimatch(patternToUse);
+    const matcher = new Minimatch(patternToUse, MINIMATCH_OPTIONS);
 
     const fsWalkSettings = {
 
@@ -257,7 +258,7 @@ async function globSearch({
 
         relativeToPatterns.set(patternToUse, patterns[i]);
 
-        return new minimatch.Minimatch(patternToUse);
+        return new Minimatch(patternToUse, MINIMATCH_OPTIONS);
     });
 
     /*

--- a/tests/fixtures/dot-files/.a.js
+++ b/tests/fixtures/dot-files/.a.js
@@ -1,0 +1,1 @@
+console.log("Running");

--- a/tests/fixtures/dot-files/.c.js
+++ b/tests/fixtures/dot-files/.c.js
@@ -1,0 +1,1 @@
+console.log("Running");

--- a/tests/fixtures/dot-files/b.js
+++ b/tests/fixtures/dot-files/b.js
@@ -1,0 +1,1 @@
+console.log("Running");

--- a/tests/fixtures/dot-files/eslint.config.js
+++ b/tests/fixtures/dot-files/eslint.config.js
@@ -1,0 +1,8 @@
+module.exports = [
+    {
+        files: ["*.js"]
+    },
+    {
+        ignores: ["eslint.config.js"]
+    }
+];

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -25,6 +25,23 @@ const { unIndent, createCustomTeardown } = require("../../_utils");
 const coreRules = require("../../../lib/rules");
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Creates a directory if it doesn't already exist.
+ * @param {string} dirPath The path to the directory that should exist.
+ * @returns {void}
+ */
+function ensureDirectoryExists(dirPath) {
+    try {
+        fs.statSync(dirPath);
+    } catch {
+        fs.mkdirSync(dirPath);
+    }
+}
+
+//------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
@@ -773,7 +790,7 @@ describe("FlatESLint", () => {
             });
             const results = await eslint.lintFiles(["fixtures/files/"]);
 
-            assert.strictEqual(results.length, 2);
+            assert.strictEqual(results.length, 3);
             assert.strictEqual(results[0].messages.length, 0);
             assert.strictEqual(results[1].messages.length, 0);
             assert.strictEqual(results[0].suppressedMessages.length, 0);
@@ -821,6 +838,58 @@ describe("FlatESLint", () => {
             assert.strictEqual(results[0].messages.length, 0);
             assert.strictEqual(results[0].filePath, getFixturePath("example-app2/subdir1/a.js"));
             assert.strictEqual(results[0].suppressedMessages.length, 0);
+        });
+
+        // https://github.com/eslint/eslint/issues/16265
+        describe("Dot files in searches", () => {
+
+            it("should find dot files in current directory when a . pattern is used", async () => {
+                eslint = new FlatESLint({
+                    cwd: getFixturePath("dot-files")
+                });
+                const results = await eslint.lintFiles(["."]);
+
+                assert.strictEqual(results.length, 3);
+                assert.strictEqual(results[0].messages.length, 0);
+                assert.strictEqual(results[0].filePath, getFixturePath("dot-files/.a.js"));
+                assert.strictEqual(results[0].suppressedMessages.length, 0);
+                assert.strictEqual(results[1].messages.length, 0);
+                assert.strictEqual(results[1].filePath, getFixturePath("dot-files/.c.js"));
+                assert.strictEqual(results[1].suppressedMessages.length, 0);
+                assert.strictEqual(results[2].messages.length, 0);
+                assert.strictEqual(results[2].filePath, getFixturePath("dot-files/b.js"));
+                assert.strictEqual(results[2].suppressedMessages.length, 0);
+            });
+
+            it("should find dot files in current directory when a *.js pattern is used", async () => {
+                eslint = new FlatESLint({
+                    cwd: getFixturePath("dot-files")
+                });
+                const results = await eslint.lintFiles(["*.js"]);
+
+                assert.strictEqual(results.length, 3);
+                assert.strictEqual(results[0].messages.length, 0);
+                assert.strictEqual(results[0].filePath, getFixturePath("dot-files/.a.js"));
+                assert.strictEqual(results[0].suppressedMessages.length, 0);
+                assert.strictEqual(results[1].messages.length, 0);
+                assert.strictEqual(results[1].filePath, getFixturePath("dot-files/.c.js"));
+                assert.strictEqual(results[1].suppressedMessages.length, 0);
+                assert.strictEqual(results[2].messages.length, 0);
+                assert.strictEqual(results[2].filePath, getFixturePath("dot-files/b.js"));
+                assert.strictEqual(results[2].suppressedMessages.length, 0);
+            });
+
+            it("should find dot files in current directory when a .a.js pattern is used", async () => {
+                eslint = new FlatESLint({
+                    cwd: getFixturePath("dot-files")
+                });
+                const results = await eslint.lintFiles([".a.js"]);
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].messages.length, 0);
+                assert.strictEqual(results[0].filePath, getFixturePath("dot-files/.a.js"));
+                assert.strictEqual(results[0].suppressedMessages.length, 0);
+            });
         });
 
         // https://github.com/eslint/eslint/issues/16275
@@ -992,11 +1061,13 @@ describe("FlatESLint", () => {
             });
             const results = await eslint.lintFiles(["fixtures/files/*"]);
 
-            assert.strictEqual(results.length, 2);
+            assert.strictEqual(results.length, 3);
             assert.strictEqual(results[0].messages.length, 0);
             assert.strictEqual(results[1].messages.length, 0);
+            assert.strictEqual(results[2].messages.length, 0);
             assert.strictEqual(results[0].suppressedMessages.length, 0);
             assert.strictEqual(results[1].suppressedMessages.length, 0);
+            assert.strictEqual(results[2].suppressedMessages.length, 0);
         });
 
         it("should resolve globs when 'globInputPaths' option is true", async () => {
@@ -1009,11 +1080,13 @@ describe("FlatESLint", () => {
             });
             const results = await eslint.lintFiles(["fixtures/files/*"]);
 
-            assert.strictEqual(results.length, 2);
+            assert.strictEqual(results.length, 3);
             assert.strictEqual(results[0].messages.length, 0);
             assert.strictEqual(results[1].messages.length, 0);
+            assert.strictEqual(results[2].messages.length, 0);
             assert.strictEqual(results[0].suppressedMessages.length, 0);
             assert.strictEqual(results[1].suppressedMessages.length, 0);
+            assert.strictEqual(results[2].suppressedMessages.length, 0);
         });
 
         // only works on a Windows machine
@@ -1029,11 +1102,13 @@ describe("FlatESLint", () => {
                 });
                 const results = await eslint.lintFiles(["fixtures\\files\\*"]);
 
-                assert.strictEqual(results.length, 2);
+                assert.strictEqual(results.length, 3);
                 assert.strictEqual(results[0].messages.length, 0);
                 assert.strictEqual(results[1].messages.length, 0);
+                assert.strictEqual(results[2].messages.length, 0);
                 assert.strictEqual(results[0].suppressedMessages.length, 0);
                 assert.strictEqual(results[1].suppressedMessages.length, 0);
+                assert.strictEqual(results[2].suppressedMessages.length, 0);
             });
 
         }
@@ -1358,11 +1433,13 @@ describe("FlatESLint", () => {
             });
             const results = await eslint.lintFiles(["fixtures/files/*.?s*"]);
 
-            assert.strictEqual(results.length, 2);
+            assert.strictEqual(results.length, 3);
             assert.strictEqual(results[0].messages.length, 0);
             assert.strictEqual(results[0].suppressedMessages.length, 0);
             assert.strictEqual(results[1].messages.length, 0);
             assert.strictEqual(results[1].suppressedMessages.length, 0);
+            assert.strictEqual(results[2].messages.length, 0);
+            assert.strictEqual(results[2].suppressedMessages.length, 0);
         });
 
         it("should return one error message when given a config with rules with options and severity level set to error", async () => {
@@ -2785,6 +2862,7 @@ describe("FlatESLint", () => {
             });
 
             it("should throw if the directory exists and is empty", async () => {
+                ensureDirectoryExists(getFixturePath("cli-engine/empty"));
                 await assert.rejects(async () => {
                     await eslint.lintFiles(["empty"]);
                 }, /No files matching 'empty' were found\./u);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Previously, glob patterns didn't match dot files and couldn't be changed while we were using globby for flat config. Because we moved to our own glob search, we can now include dot files in our searches automatically.

Note that `ConfigArray` was [already matching](https://github.com/humanwhocodes/config-array/blob/main/src/config-array.js#L26) patterns against dot files. This change brings our glob search into alignment with how `ConfigArray` works.

Fixes #16265

#### Is there anything you'd like reviewers to focus on?

I had to adjust some existing tests because they had dot files in the directories they were running in. Please double-check those changes.

<!-- markdownlint-disable-file MD004 -->
