### PR TITLE
docs: clarify esquery issue workaround

### DIFF
--- a/docs/src/developer-guide/selectors.md
+++ b/docs/src/developer-guide/selectors.md
@@ -137,4 +137,16 @@ Using selectors in the `no-restricted-syntax` rule can give you a lot of control
 
 ### Known issues
 
-Due to a [bug](https://github.com/estools/esquery/issues/68) in [esquery](https://github.com/estools/esquery), regular expressions that contain a forward-slash character `/` aren't properly parsed, so `[value=/some\/path/]` will be a syntax error. As a [workaround](https://github.com/estools/esquery/issues/68), you can replace the `/` character with its unicode counterpart, like so: `[value=/some\\u002Fpath/]`.
+Due to a [bug](https://github.com/estools/esquery/issues/68) in [esquery](https://github.com/estools/esquery), regular expressions that contain a forward-slash character `/` aren't properly parsed, so `[value=/some\/path/]` will be a syntax error. As a [workaround](https://github.com/estools/esquery/issues/68), you can replace the `/` character with its unicode counterpart, like so: `[value=/some\u002Fpath/]`.
+
+For example, the following configuration disallows importing from `some/path`:
+
+```json
+{
+  "rules": {
+    "no-restricted-syntax": ["error", "ImportDeclaration[source.value=/^some\\u002Fpath$/]"]
+  }
+}
+```
+
+Note that the `\` character needs to be escaped (`\\`) in JSON and string literals.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

This is a follow-up to https://github.com/eslint/eslint/pull/14675#discussion_r650371457.

Updates https://eslint.org/docs/latest/developer-guide/selectors#known-issues section.

The current version is a bit confusing because `[value=/some\/path/]` contains an unescaped backslash character while the suggested workaround `[value=/some\\u002Fpath/]` contains an escaped backslash character.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the workaround to not escape the backslash character, representing the selector as a list of characters, and added a JSON example where it needs to be escaped.

#### Is there anything you'd like reviewers to focus on?



<!-- markdownlint-disable-file MD004 -->
