### PR TITLE
feat: add `allowParensAfterCommentPattern` option to no-extra-parens

### DIFF
--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -330,7 +330,7 @@ Examples of **correct** code for this rule with the `"all"` and `{ "allowParensA
 ::: correct
 
 ```js
-/* eslint no-extra-parens: ["error", "all", { "enforceForFunctionPrototypeMethods": false }] */
+/* eslint no-extra-parens: ["error", "all", { "allowParensAfterCommentPattern": "@type" }] */
 
 const span = /**@type {HTMLSpanElement}*/(event.currentTarget);
 

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -38,6 +38,7 @@ This rule has an object option for exceptions to the `"all"` option:
 * `"enforceForSequenceExpressions": false` allows extra parentheses around sequence expressions
 * `"enforceForNewInMemberExpressions": false` allows extra parentheses around `new` expressions in member expressions
 * `"enforceForFunctionPrototypeMethods": false` allows extra parentheses around immediate `.call` and `.apply` method calls on function expressions and around function expressions in the same context.
+* `"allowParensAfterComment": true` allows extra parentheses preceded by a comment that matches a regular expression
 
 ### all
 

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -38,7 +38,7 @@ This rule has an object option for exceptions to the `"all"` option:
 * `"enforceForSequenceExpressions": false` allows extra parentheses around sequence expressions
 * `"enforceForNewInMemberExpressions": false` allows extra parentheses around `new` expressions in member expressions
 * `"enforceForFunctionPrototypeMethods": false` allows extra parentheses around immediate `.call` and `.apply` method calls on function expressions and around function expressions in the same context.
-* `"allowParensAfterCommentPattern": true` allows extra parentheses preceded by a comment that matches a regular expression.
+* `"allowParensAfterCommentPattern": "any-string-pattern"` allows extra parentheses preceded by a comment that matches a regular expression.
 
 ### all
 
@@ -324,6 +324,8 @@ const quux = (function () {}.apply());
 :::
 
 ### allowParensAfterCommentPattern
+
+To make this rule allow extra parentheses preceded by specific comments, set this option to a string pattern that will be passed to the [`RegExp` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp).
 
 Examples of **correct** code for this rule with the `"all"` and `{ "allowParensAfterCommentPattern": "@type" }` options:
 

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -38,7 +38,7 @@ This rule has an object option for exceptions to the `"all"` option:
 * `"enforceForSequenceExpressions": false` allows extra parentheses around sequence expressions
 * `"enforceForNewInMemberExpressions": false` allows extra parentheses around `new` expressions in member expressions
 * `"enforceForFunctionPrototypeMethods": false` allows extra parentheses around immediate `.call` and `.apply` method calls on function expressions and around function expressions in the same context.
-* `"allowParensAfterComment": true` allows extra parentheses preceded by a comment that matches a regular expression
+* `"allowParensAfterCommentPattern": true` allows extra parentheses preceded by a comment that matches a regular expression.
 
 ### all
 
@@ -319,6 +319,32 @@ const bar = (function () {}).apply();
 const baz = (function () {}.call());
 
 const quux = (function () {}.apply());
+```
+
+:::
+
+### allowParensAfterCommentPattern
+
+Examples of **correct** code for this rule with the `"all"` and `{ "allowParensAfterCommentPattern": "@type" }` options:
+
+::: correct
+
+```js
+/* eslint no-extra-parens: ["error", "all", { "enforceForFunctionPrototypeMethods": false }] */
+
+const span = /**@type {HTMLSpanElement}*/(event.currentTarget);
+
+if (/** @type {Foo | Bar} */(options).baz) console.log('Lint free');
+
+foo(/** @type {Bar} */ (bar), options, {
+    name: "name",
+    path: "path",
+});
+
+if (foo) {
+    /** @type {Bar} */
+    (bar).prop = false;
+}
 ```
 
 :::

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -53,7 +53,7 @@ module.exports = {
                                 enforceForSequenceExpressions: { type: "boolean" },
                                 enforceForNewInMemberExpressions: { type: "boolean" },
                                 enforceForFunctionPrototypeMethods: { type: "boolean" },
-                                allowParensAfterComment: { type: "boolean" }
+                                allowParensAfterCommentPattern: { type: "string" }
                             },
                             additionalProperties: false
                         }
@@ -87,7 +87,7 @@ module.exports = {
             context.options[1].enforceForNewInMemberExpressions === false;
         const IGNORE_FUNCTION_PROTOTYPE_METHODS = ALL_NODES && context.options[1] &&
             context.options[1].enforceForFunctionPrototypeMethods === false;
-        const ALLOW_PARENS_AFTER_COMMENT = ALL_NODES && context.options[1] && context.options[1].allowParensAfterComment === true;
+        const ALLOW_PARENS_AFTER_COMMENT_PATTERN = ALL_NODES && context.options[1] && context.options[1].allowParensAfterCommentPattern;
 
         const PRECEDENCE_OF_ASSIGNMENT_EXPR = precedence({ type: "AssignmentExpression" });
         const PRECEDENCE_OF_UPDATE_EXPR = precedence({ type: "UpdateExpression" });
@@ -405,8 +405,17 @@ module.exports = {
                     return;
                 }
 
-                if (ALLOW_PARENS_AFTER_COMMENT && isParenthesised(node) && sourceCode.getCommentsBefore(leftParenToken).length > 0) {
-                    return;
+                if (ALLOW_PARENS_AFTER_COMMENT_PATTERN && isParenthesised(node)) {
+                    const commentsBeforeLeftParenToken = sourceCode.getCommentsBefore(leftParenToken);
+                    const totalCommentsBeforeLeftParenTokenCount = commentsBeforeLeftParenToken.length;
+                    const ignorePattern = new RegExp(ALLOW_PARENS_AFTER_COMMENT_PATTERN, "u");
+
+                    if (
+                        totalCommentsBeforeLeftParenTokenCount > 0 &&
+                        ignorePattern.test(commentsBeforeLeftParenToken[totalCommentsBeforeLeftParenTokenCount - 1].value)
+                    ) {
+                        return;
+                    }
                 }
             }
 

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -405,7 +405,7 @@ module.exports = {
                     return;
                 }
 
-                if (ALLOW_PARENS_AFTER_COMMENT_PATTERN && isParenthesised(node)) {
+                if (ALLOW_PARENS_AFTER_COMMENT_PATTERN) {
                     const commentsBeforeLeftParenToken = sourceCode.getCommentsBefore(leftParenToken);
                     const totalCommentsBeforeLeftParenTokenCount = commentsBeforeLeftParenToken.length;
                     const ignorePattern = new RegExp(ALLOW_PARENS_AFTER_COMMENT_PATTERN, "u");

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -52,7 +52,8 @@ module.exports = {
                                 enforceForArrowConditionals: { type: "boolean" },
                                 enforceForSequenceExpressions: { type: "boolean" },
                                 enforceForNewInMemberExpressions: { type: "boolean" },
-                                enforceForFunctionPrototypeMethods: { type: "boolean" }
+                                enforceForFunctionPrototypeMethods: { type: "boolean" },
+                                allowParensAfterComment: { type: "boolean" }
                             },
                             additionalProperties: false
                         }
@@ -86,6 +87,7 @@ module.exports = {
             context.options[1].enforceForNewInMemberExpressions === false;
         const IGNORE_FUNCTION_PROTOTYPE_METHODS = ALL_NODES && context.options[1] &&
             context.options[1].enforceForFunctionPrototypeMethods === false;
+        const ALLOW_PARENS_AFTER_COMMENT = ALL_NODES && context.options[1] && context.options[1].allowParensAfterComment === true;
 
         const PRECEDENCE_OF_ASSIGNMENT_EXPR = precedence({ type: "AssignmentExpression" });
         const PRECEDENCE_OF_UPDATE_EXPR = precedence({ type: "UpdateExpression" });
@@ -400,6 +402,10 @@ module.exports = {
                 }
 
                 if (isIIFE(node) && !isParenthesised(node.callee)) {
+                    return;
+                }
+
+                if (ALLOW_PARENS_AFTER_COMMENT && isParenthesised(node) && sourceCode.getCommentsBefore(leftParenToken).length > 0) {
                     return;
                 }
             }

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -3333,6 +3333,25 @@ ruleTester.run("no-extra-parens", rule, {
             errors: [{ messageId: "unexpected" }]
         },
         {
+            code: `
+                if (condition) {
+                    /** @type {ServerOptions} */
+                    /** extra coment */
+                    (options.server.options).requestCert = false;
+                }
+            `,
+            output: `
+                if (condition) {
+                    /** @type {ServerOptions} */
+                    /** extra coment */
+                    options.server.options.requestCert = false;
+                }
+            `,
+            options: ["all", { allowParensAfterCommentPattern: "@type" }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
             code: "const net = ipaddr.parseCIDR(/** @type {string} */ (cidr));",
             output: "const net = ipaddr.parseCIDR(/** @type {string} */ cidr);",
             options: ["all", { allowParensAfterCommentPattern: "invalid" }],

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -738,18 +738,18 @@ ruleTester.run("no-extra-parens", rule, {
         },
         {
             code: "(Object.prototype.toString.call())",
-            options: ["functions"],
+            options: ["functions"]
         },
 
-        // "allowParensAfterComment" option
+        // "allowParensAfterCommentPattern" option
         {
             code: "const span = /**@type {HTMLSpanElement}*/(event.currentTarget);",
-            options: ["all", { allowParensAfterComment: true }],
+            options: ["all", { allowParensAfterCommentPattern: "@type" }],
             parserOptions: { ecmaVersion: 2020 }
         },
         {
             code: "if (/** @type {Compiler | MultiCompiler} */(options).hooks) console.log('good');",
-            options: ["all", { allowParensAfterComment: true }],
+            options: ["all", { allowParensAfterCommentPattern: "@type" }],
             parserOptions: { ecmaVersion: 2020 }
         },
         {
@@ -759,7 +759,7 @@ ruleTester.run("no-extra-parens", rule, {
                     baseDataPath: "options",
                 });
             `,
-            options: ["all", { allowParensAfterComment: true }],
+            options: ["all", { allowParensAfterCommentPattern: "@type" }],
             parserOptions: { ecmaVersion: 2020 }
         },
         {
@@ -769,12 +769,12 @@ ruleTester.run("no-extra-parens", rule, {
                     (options.server.options).requestCert = false;
                 }
             `,
-            options: ["all", { allowParensAfterComment: true }],
+            options: ["all", { allowParensAfterCommentPattern: "@type" }],
             parserOptions: { ecmaVersion: 2020 }
         },
         {
             code: "const net = ipaddr.parseCIDR(/** @type {string} */ (cidr));",
-            options: ["all", { allowParensAfterComment: true }],
+            options: ["all", { allowParensAfterCommentPattern: "@type" }],
             parserOptions: { ecmaVersion: 2020 }
         }
     ],
@@ -3228,18 +3228,18 @@ ruleTester.run("no-extra-parens", rule, {
             errors: [{ messageId: "unexpected" }]
         },
 
-        // "allowParensAfterComment" option
+        // "allowParensAfterCommentPattern" option (off by default)
         {
             code: "const span = /**@type {HTMLSpanElement}*/(event.currentTarget);",
             output: "const span = /**@type {HTMLSpanElement}*/event.currentTarget;",
-            options: ["all", { allowParensAfterComment: false }],
+            options: ["all"],
             parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
         {
             code: "if (/** @type {Compiler | MultiCompiler} */(options).hooks) console.log('good');",
             output: "if (/** @type {Compiler | MultiCompiler} */options.hooks) console.log('good');",
-            options: ["all", { allowParensAfterComment: false }],
+            options: ["all"],
             parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
@@ -3256,7 +3256,7 @@ ruleTester.run("no-extra-parens", rule, {
                     baseDataPath: "options",
                 });
             `,
-            options: ["all", { allowParensAfterComment: false }],
+            options: ["all"],
             parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
@@ -3273,14 +3273,69 @@ ruleTester.run("no-extra-parens", rule, {
                     options.server.options.requestCert = false;
                 }
             `,
-            options: ["all", { allowParensAfterComment: false }],
+            options: ["all"],
             parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
         {
             code: "const net = ipaddr.parseCIDR(/** @type {string} */ (cidr));",
             output: "const net = ipaddr.parseCIDR(/** @type {string} */ cidr);",
-            options: ["all", { allowParensAfterComment: false }],
+            options: ["all"],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "const span = /**@type {HTMLSpanElement}*/(event.currentTarget);",
+            output: "const span = /**@type {HTMLSpanElement}*/event.currentTarget;",
+            options: ["all", { allowParensAfterCommentPattern: "invalid" }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "if (/** @type {Compiler | MultiCompiler} */(options).hooks) console.log('good');",
+            output: "if (/** @type {Compiler | MultiCompiler} */options.hooks) console.log('good');",
+            options: ["all", { allowParensAfterCommentPattern: "invalid" }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: `
+                validate(/** @type {Schema} */ (schema), options, {
+                    name: "Dev Server",
+                    baseDataPath: "options",
+                });
+            `,
+            output: `
+                validate(/** @type {Schema} */ schema, options, {
+                    name: "Dev Server",
+                    baseDataPath: "options",
+                });
+            `,
+            options: ["all", { allowParensAfterCommentPattern: "invalid" }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: `
+                if (condition) {
+                    /** @type {ServerOptions} */
+                    (options.server.options).requestCert = false;
+                }
+            `,
+            output: `
+                if (condition) {
+                    /** @type {ServerOptions} */
+                    options.server.options.requestCert = false;
+                }
+            `,
+            options: ["all", { allowParensAfterCommentPattern: "invalid" }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "const net = ipaddr.parseCIDR(/** @type {string} */ (cidr));",
+            output: "const net = ipaddr.parseCIDR(/** @type {string} */ cidr);",
+            options: ["all", { allowParensAfterCommentPattern: "invalid" }],
             parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -739,6 +739,42 @@ ruleTester.run("no-extra-parens", rule, {
         {
             code: "(Object.prototype.toString.call())",
             options: ["functions"],
+        },
+
+        // "allowParensAfterComment" option
+        {
+            code: "const span = /**@type {HTMLSpanElement}*/(event.currentTarget);",
+            options: ["all", { allowParensAfterComment: true }],
+            parserOptions: { ecmaVersion: 2020 }
+        },
+        {
+            code: "if (/** @type {Compiler | MultiCompiler} */(options).hooks) console.log('good');",
+            options: ["all", { allowParensAfterComment: true }],
+            parserOptions: { ecmaVersion: 2020 }
+        },
+        {
+            code: `
+                validate(/** @type {Schema} */ (schema), options, {
+                    name: "Dev Server",
+                    baseDataPath: "options",
+                });
+            `,
+            options: ["all", { allowParensAfterComment: true }],
+            parserOptions: { ecmaVersion: 2020 }
+        },
+        {
+            code: `
+                if (condition) {
+                    /** @type {ServerOptions} */
+                    (options.server.options).requestCert = false;
+                }
+            `,
+            options: ["all", { allowParensAfterComment: true }],
+            parserOptions: { ecmaVersion: 2020 }
+        },
+        {
+            code: "const net = ipaddr.parseCIDR(/** @type {string} */ (cidr));",
+            options: ["all", { allowParensAfterComment: true }],
             parserOptions: { ecmaVersion: 2020 }
         }
     ],
@@ -3188,6 +3224,63 @@ ruleTester.run("no-extra-parens", rule, {
         {
             code: "var v = a | b ?? (c | d)",
             output: "var v = a | b ?? c | d",
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected" }]
+        },
+
+        // "allowParensAfterComment" option
+        {
+            code: "const span = /**@type {HTMLSpanElement}*/(event.currentTarget);",
+            output: "const span = /**@type {HTMLSpanElement}*/event.currentTarget;",
+            options: ["all", { allowParensAfterComment: false }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "if (/** @type {Compiler | MultiCompiler} */(options).hooks) console.log('good');",
+            output: "if (/** @type {Compiler | MultiCompiler} */options.hooks) console.log('good');",
+            options: ["all", { allowParensAfterComment: false }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: `
+                validate(/** @type {Schema} */ (schema), options, {
+                    name: "Dev Server",
+                    baseDataPath: "options",
+                });
+            `,
+            output: `
+                validate(/** @type {Schema} */ schema, options, {
+                    name: "Dev Server",
+                    baseDataPath: "options",
+                });
+            `,
+            options: ["all", { allowParensAfterComment: false }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: `
+                if (condition) {
+                    /** @type {ServerOptions} */
+                    (options.server.options).requestCert = false;
+                }
+            `,
+            output: `
+                if (condition) {
+                    /** @type {ServerOptions} */
+                    options.server.options.requestCert = false;
+                }
+            `,
+            options: ["all", { allowParensAfterComment: false }],
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "const net = ipaddr.parseCIDR(/** @type {string} */ (cidr));",
+            output: "const net = ipaddr.parseCIDR(/** @type {string} */ cidr);",
+            options: ["all", { allowParensAfterComment: false }],
             parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -744,13 +744,11 @@ ruleTester.run("no-extra-parens", rule, {
         // "allowParensAfterCommentPattern" option
         {
             code: "const span = /**@type {HTMLSpanElement}*/(event.currentTarget);",
-            options: ["all", { allowParensAfterCommentPattern: "@type" }],
-            parserOptions: { ecmaVersion: 2020 }
+            options: ["all", { allowParensAfterCommentPattern: "@type" }]
         },
         {
             code: "if (/** @type {Compiler | MultiCompiler} */(options).hooks) console.log('good');",
-            options: ["all", { allowParensAfterCommentPattern: "@type" }],
-            parserOptions: { ecmaVersion: 2020 }
+            options: ["all", { allowParensAfterCommentPattern: "@type" }]
         },
         {
             code: `
@@ -759,8 +757,7 @@ ruleTester.run("no-extra-parens", rule, {
                     baseDataPath: "options",
                 });
             `,
-            options: ["all", { allowParensAfterCommentPattern: "@type" }],
-            parserOptions: { ecmaVersion: 2020 }
+            options: ["all", { allowParensAfterCommentPattern: "@type" }]
         },
         {
             code: `
@@ -769,13 +766,11 @@ ruleTester.run("no-extra-parens", rule, {
                     (options.server.options).requestCert = false;
                 }
             `,
-            options: ["all", { allowParensAfterCommentPattern: "@type" }],
-            parserOptions: { ecmaVersion: 2020 }
+            options: ["all", { allowParensAfterCommentPattern: "@type" }]
         },
         {
             code: "const net = ipaddr.parseCIDR(/** @type {string} */ (cidr));",
-            options: ["all", { allowParensAfterCommentPattern: "@type" }],
-            parserOptions: { ecmaVersion: 2020 }
+            options: ["all", { allowParensAfterCommentPattern: "@type" }]
         }
     ],
 
@@ -3233,14 +3228,12 @@ ruleTester.run("no-extra-parens", rule, {
             code: "const span = /**@type {HTMLSpanElement}*/(event.currentTarget);",
             output: "const span = /**@type {HTMLSpanElement}*/event.currentTarget;",
             options: ["all"],
-            parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
         {
             code: "if (/** @type {Compiler | MultiCompiler} */(options).hooks) console.log('good');",
             output: "if (/** @type {Compiler | MultiCompiler} */options.hooks) console.log('good');",
             options: ["all"],
-            parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
         {
@@ -3257,7 +3250,6 @@ ruleTester.run("no-extra-parens", rule, {
                 });
             `,
             options: ["all"],
-            parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
         {
@@ -3274,28 +3266,24 @@ ruleTester.run("no-extra-parens", rule, {
                 }
             `,
             options: ["all"],
-            parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
         {
             code: "const net = ipaddr.parseCIDR(/** @type {string} */ (cidr));",
             output: "const net = ipaddr.parseCIDR(/** @type {string} */ cidr);",
             options: ["all"],
-            parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
         {
             code: "const span = /**@type {HTMLSpanElement}*/(event.currentTarget);",
             output: "const span = /**@type {HTMLSpanElement}*/event.currentTarget;",
             options: ["all", { allowParensAfterCommentPattern: "invalid" }],
-            parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
         {
             code: "if (/** @type {Compiler | MultiCompiler} */(options).hooks) console.log('good');",
             output: "if (/** @type {Compiler | MultiCompiler} */options.hooks) console.log('good');",
             options: ["all", { allowParensAfterCommentPattern: "invalid" }],
-            parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
         {
@@ -3312,7 +3300,6 @@ ruleTester.run("no-extra-parens", rule, {
                 });
             `,
             options: ["all", { allowParensAfterCommentPattern: "invalid" }],
-            parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
         {
@@ -3329,7 +3316,6 @@ ruleTester.run("no-extra-parens", rule, {
                 }
             `,
             options: ["all", { allowParensAfterCommentPattern: "invalid" }],
-            parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
         {
@@ -3348,14 +3334,46 @@ ruleTester.run("no-extra-parens", rule, {
                 }
             `,
             options: ["all", { allowParensAfterCommentPattern: "@type" }],
-            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: `
+                if (condition) {
+                    /** @type {ServerOptions} */
+                    ((options.server.options)).requestCert = false;
+                }
+            `,
+            output: `
+                if (condition) {
+                    /** @type {ServerOptions} */
+                    (options.server.options).requestCert = false;
+                }
+            `,
+            options: ["all", { allowParensAfterCommentPattern: "@type" }],
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: `
+                if (condition) {
+                    /** @type {ServerOptions} */
+                    let foo = "bar";
+                    (options.server.options).requestCert = false;
+                }
+            `,
+            output: `
+                if (condition) {
+                    /** @type {ServerOptions} */
+                    let foo = "bar";
+                    options.server.options.requestCert = false;
+                }
+            `,
+            options: ["all", { allowParensAfterCommentPattern: "@type" }],
             errors: [{ messageId: "unexpected" }]
         },
         {
             code: "const net = ipaddr.parseCIDR(/** @type {string} */ (cidr));",
             output: "const net = ipaddr.parseCIDR(/** @type {string} */ cidr);",
             options: ["all", { allowParensAfterCommentPattern: "invalid" }],
-            parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
         },
 


### PR DESCRIPTION

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Resolve https://github.com/eslint/eslint/issues/16386

Examples of **correct** code:

```js
/* eslint no-extra-parens: ["error", "all", { "allowParensAfterCommentPattern": "@type" }] */

const span = /**@type {HTMLSpanElement}*/(event.currentTarget);

if (/** @type {Foo | Bar} */(options).baz) console.log('Lint free');

foo(/** @type {Bar} */ (bar), options, {
    name: "name",
    path: "path",
});

if (foo) {
    /** @type {Bar} */
    (bar).prop = false;
}
```

#### Is there anything you'd like reviewers to focus on?
Open to suggestions for a better name for the option.

<!-- markdownlint-disable-file MD004 -->
