### PR TITLE
docs: CLI documentation standardization

### DIFF
--- a/docs/src/_data/links.json
+++ b/docs/src/_data/links.json
@@ -14,7 +14,7 @@
     "team": "/team",
 
     "configuring": "https://eslint.org/docs/user-guide/configuring/",
-    "fixProblems": "https://eslint.org/docs/user-guide/command-line-interface#fixing-problems",
+    "fixProblems": "https://eslint.org/docs/user-guide/command-line-interface#fix-problems",
 
     "donate": "/donate",
     "openCollective": "https://opencollective.com/eslint",

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -286,12 +286,19 @@ This option specifies the rules to be used.
 
 These rules are merged with any rules specified with configuration files. If the rule is defined in a plugin, you have to prefix the rule ID with the plugin name and a `/`.
 
+To ignore rules in `.eslintrc` configuration files and only run rules specified in the command line, use the `--rules` flag in combination with the [`--no-eslintrc`](#--no-eslintrc) flag.
+
 ##### `--rule` example
 
 ```shell
+# Apply single rule
 npx eslint --rule 'quotes: [error, double]'
+# Apply multiple rules
 npx eslint --rule 'guard-for-in: error' --rule 'brace-style: [error, 1tbs]'
+# Apply rule from jquery plugin
 npx eslint --rule 'jquery/dollar-sign: error'
+# Only apply rule from the command line
+npx eslint --rule 'quotes: [error, double]' --no-eslintrc
 ```
 
 #### `--rulesdir`

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -103,7 +103,7 @@ npx eslint --env browser --env node file.js
 
 This option allows you to specify which file extensions ESLint uses when searching for target files in the directories you specify.
 
-* **Argument Type**: String. File glob pattern.
+* **Argument Type**: String. File extension.
 * **Multiple Arguments**: Yes
 * **Default Value**: `.js` and the files that match the `overrides` entries of your configuration.
 

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -52,6 +52,78 @@ npx eslint --ext .jsx,.js lib/
 
 ## Options
 
+You can view all the CLI options by running `npx eslint -h`.
+
+```txt
+eslint [options] file.js [file.js] [dir]
+
+Basic configuration:
+  --no-config-lookup             Disable look up for eslint.config.js
+  -c, --config path::String      Use this configuration instead of
+                                 eslint.config.js
+  --global [String]              Define global variables
+  --parser String                Specify the parser to be used
+  --parser-options Object        Specify parser options
+
+Specify rules and plugins:
+  --plugin [String]              Specify plugins
+  --rule Object                  Specify rules
+
+Fix problems:
+  --fix                          Automatically fix problems
+  --fix-dry-run                  Automatically fix problems without saving the
+                                 changes to the file system
+  --fix-type Array               Specify the types of fixes to apply
+                                 (directive, problem, suggestion, layout)
+
+Ignore files:
+  --no-ignore                    Disable use of ignore files and patterns
+  --ignore-pattern [String]      Pattern of files to ignore (in addition to
+                                 those in .eslintignore)
+
+Use stdin:
+  --stdin                        Lint code provided on <STDIN> - default: false
+  --stdin-filename String        Specify filename to process STDIN as
+
+Handling warnings:
+  --quiet                        Report errors only - default: false
+  --max-warnings Int             Number of warnings to trigger nonzero exit
+                                 code - default: -1
+
+Output:
+  -o, --output-file path::String  Specify file to write report to
+  -f, --format String            Use a specific output format - default:
+                                 stylish
+  --color, --no-color            Force enabling/disabling of color
+
+Inline configuration comments:
+  --no-inline-config             Prevent comments from changing config or rules
+  --report-unused-disable-directives  Adds reported errors for unused
+                                      eslint-disable directives
+
+Caching:
+  --cache                        Only check changed files - default: false
+  --cache-file path::String      Path to the cache file. Deprecated: use
+                                 --cache-location - default: .eslintcache
+  --cache-location path::String  Path to the cache file or directory
+  --cache-strategy String        Strategy to use for detecting changed files
+                                 in the cache - either: metadata or content -
+                                 default: metadata
+
+Miscellaneous:
+  --init                         Run config initialization wizard - default:
+                                 false
+  --env-info                     Output execution environment information -
+                                 default: false
+  --no-error-on-unmatched-pattern  Prevent errors when pattern is unmatched
+  --exit-on-fatal-error          Exit with exit code 2 in case of fatal error
+                                 - default: false
+  --debug                        Output debugging information
+  -h, --help                     Show help
+  -v, --version                  Output the version number
+  --print-config path::String    Print the configuration for the given file
+```
+
 ### Basic configuration
 
 #### `--no-eslintrc`

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -231,7 +231,7 @@ echo '3 ** 4' | npx eslint --stdin --parser-options ecmaVersion:7 # succeeds, ya
 
 #### `--resolve-plugins-relative-to`
 
-Changes the folder where plugins are resolved from.
+Changes the directory where plugins are resolved from.
 
 * **Argument Type**: String. Path to directory.
 * **Multiple Arguments**: No

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -91,7 +91,7 @@ This option enables specific environments.
 * **Argument Type**: String. One of the available environments.
 * **Multiple Arguments**: Yes
 
-Details about the global variables defined by each environment are available on the [Specifying Environments](configuring/language-options#specifying-environments) documentation. This option only enables environments; it does not disable environments set in other configuration files. To specify multiple environments, separate them using commas, or use the option multiple times.
+Details about the global variables defined by each environment are available in the [Specifying Environments](configuring/language-options#specifying-environments) documentation. This option only enables environments. It does not disable environments set in other configuration files. To specify multiple environments, separate them using commas, or use the option multiple times.
 
 ##### `--env` example
 
@@ -162,8 +162,8 @@ This option allows you to specify parser options to be used by ESLint. The avail
 ##### `--parser-options` example
 
 ```shell
-echo '3 ** 4' | npx eslint --stdin --parser-options=ecmaVersion:6 # fails with a parsing error
-echo '3 ** 4' | npx eslint --stdin --parser-options=ecmaVersion:7 # succeeds, yay!
+echo '3 ** 4' | npx eslint --stdin --parser-options ecmaVersion:6 # fails with a parsing error
+echo '3 ** 4' | npx eslint --stdin --parser-options ecmaVersion:7 # succeeds, yay!
 ```
 
 #### `--resolve-plugins-relative-to`
@@ -192,9 +192,9 @@ npx eslint --config ~/personal-eslintrc.js \
 
 #### `--plugin`
 
-This option specifies a plugin to load. You can omit the prefix `eslint-plugin-` from the plugin name.
+This option specifies a plugin to load.
 
-* **Argument Type**: String. Plugin name.
+* **Argument Type**: String. Plugin name. You can optionally omit the prefix `eslint-plugin-` from the plugin name.
 * **Multiple Arguments**: Yes
 
 Before using the plugin, you have to install it using npm.
@@ -213,7 +213,7 @@ This option specifies rules to be used.
 * **Argument Type**: Rules and their configuration specified with [levn](https://github.com/gkz/levn#levn--) format.
 * **Multiple Arguments**: Yes
 
-These rules are merged with any rules specified with configuration files. If the rule is defined within a plugin, you have to prefix the rule ID with the plugin name and a `/`.
+These rules are merged with any rules specified with configuration files. If the rule is defined in a plugin, you have to prefix the rule ID with the plugin name and a `/`.
 
 ##### `--rule` example
 
@@ -306,7 +306,7 @@ This option allows you to specify the file to use as your `.eslintignore`.
 
 * **Argument Type**: String. Path to file.
 * **Multiple Arguments**: No
-* **Default Value**:  By default, ESLint looks in the current working directory for `.eslintignore`.
+* **Default Value**:  By default, ESLint looks for `.eslintignore` in the current working directory.
 
 **Note:** `--ignore-path` is not supported when using [flat configuration](./configuring/configuration-files-new) (`eslint.config.js`).
 
@@ -319,7 +319,7 @@ npx eslint --ignore-path .gitignore file.js
 
 #### `--no-ignore`
 
-Disables excluding of files from `.eslintignore`, `--ignore-path`, `--ignore-pattern`, and `ignorePatterns` property in config files.
+Disables excluding of files from `.eslintignore` files, `--ignore-path` flags, `--ignore-pattern` flags, and  the `ignorePatterns` property in config files.
 
 * **Argument Type**: No argument.
 
@@ -333,14 +333,14 @@ npx eslint --no-ignore file.js
 
 This option allows you to specify patterns of files to ignore (in addition to those in `.eslintignore`).
 
-* **Argument Type**: String. The supported syntax is the same as for `.eslintignore` [files](configuring/ignoring-code#the-eslintignore-file), which use the same patterns as the `.gitignore` [specification](https://git-scm.com/docs/gitignore). You should quote your patterns in order to avoid shell interpretation of glob patterns.
+* **Argument Type**: String. The supported syntax is the same as for `.eslintignore` [files](configuring/ignoring-code#the-eslintignore-file), which use the same patterns as the [`.gitignore` specification](https://git-scm.com/docs/gitignore). You should quote your patterns in order to avoid shell interpretation of glob patterns.
 * **Multiple Arguments**: Yes
 * **Default Value**: whatever the default value is OR N/A
 
 ##### `--ignore-pattern` example
 
 ```shell
-npx eslint --ignore-pattern '/lib/' --ignore-pattern '/src/vendor/*' .
+npx eslint --ignore-pattern "/lib/" --ignore-pattern "/src/vendor/*" .
 ```
 
 ### Use stdin
@@ -417,7 +417,7 @@ Write output of linting results to a specified file.
 npx eslint -o ./test/test.html
 ```
 
-#### ``--format`
+#### `--format`
 
 This option specifies the output format for the console.
 
@@ -525,7 +525,7 @@ npx eslint --report-unused-disable-directives file.js
 
 #### `--cache`
 
-Store the info about processed files in order to only operate on the changed ones. Enabling this option can dramatically improve ESLint's running time by ensuring that only changed files are linted.
+Store the info about processed files in order to only operate on the changed ones. Enabling this option can dramatically improve ESLint's run time performance by ensuring that only changed files are linted.
 The cache is stored in `.eslintcache` by default.
 
 * **Argument Type**: No argument.
@@ -554,7 +554,7 @@ Specify the path to the cache location. Can be a file or a directory.
 * **Multiple Arguments**: No
 * **Default Value**: If no location is specified, `.eslintcache` is used. The file is created in the directory where the `eslint` command is executed.
 
-If the directory for the cache does not exist make sure you add a trailing `/` on \*nix systems or `\` in windows. Otherwise the path is assumed to be a file.
+If the directory for the cache does not exist make sure you add a trailing `/` on \*nix systems or `\` on Windows. Otherwise the path is assumed to be a file.
 
 ##### `--cache-location` example
 
@@ -568,7 +568,7 @@ Strategy for the cache to use for detecting changed files.
 
 * **Argument Type**: String. One of the following values:
   1. `metadata`
-  1. `content
+  1. `content`
 * **Multiple Arguments**: No
 * **Default Value**: `metadata`
 
@@ -598,7 +598,7 @@ npx eslint --init
 
 #### `--env-info`
 
-This option outputs information about the execution environment, including the version of Node, npm, and local and global installations of ESLint.
+This option outputs information about the execution environment, including the version of Node.js, npm, and local and global installations of ESLint.
 
 * **Argument Type**: No argument.
 
@@ -619,7 +619,7 @@ This option prevents errors when a quoted glob pattern or `--ext` is unmatched. 
 ##### `--no-error-on-unmatched-pattern` example
 
 ```shell
-npx eslint --no-error-on-unmatched-pattern --ext .ts lib/*
+npx eslint --no-error-on-unmatched-pattern --ext .ts "lib/*"
 ```
 
 #### `--exit-on-fatal-error`
@@ -636,7 +636,7 @@ npx eslint --exit-on-fatal-error file.js
 
 #### `--debug`
 
-This option outputs debugging information to the console. Add this flag to an ESLint command line invocation in order to get extra debug information as the command is run.
+This option outputs debugging information to the console. Add this flag to an ESLint command line invocation in order to get extra debugging information while the command runs.
 
 * **Argument Type**: No argument.
 
@@ -652,7 +652,7 @@ npx eslint --debug test.js
 
 This option outputs the help menu, displaying all of the available options. All other options are ignored when this is present. When you use this flag, the CLI does not perform linting.
 
-* **Alias**: `h`
+* **Alias**: `-h`
 * **Argument Type**: No argument.
 
 ##### `--help` example

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -8,6 +8,10 @@ eleventyNavigation:
 
 ---
 
+The ESLint CLI is a command line interface that lets you execute linting from the terminal. The CLI has a variety of options that you can pass to its commands.
+
+## Run the CLI
+
 ESLint requires Node.js for installation. Follow the instructions in the [Getting Started Guide](getting-started) to install ESLint.
 
 Most users use [`npx`](https://docs.npmjs.com/cli/v8/commands/npx) to run ESLint on the command line like this:
@@ -26,7 +30,7 @@ npx eslint file1.js file2.js
 npx eslint lib/**
 ```
 
-Please note that when passing a glob as a parameter, it will be expanded by your shell. The results of the expansion can vary depending on your shell, and its configuration. If you want to use node `glob` syntax, you have to quote your parameter (using double quotes if you need it to run in Windows), as follows:
+Please note that when passing a glob as a parameter, it is expanded by your shell. The results of the expansion can vary depending on your shell, and its configuration. If you want to use node `glob` syntax, you have to quote your parameter (using double quotes if you need it to run in Windows), as follows:
 
 ```shell
 npx eslint "lib/**"
@@ -106,7 +110,7 @@ Example:
 
 ```shell
 npx eslint --ext .jsx --ext .js lib/
-
+# OR
 npx eslint --ext .jsx,.js lib/
 ```
 
@@ -134,7 +138,7 @@ npx eslint -c ~/my-eslint.json file.js
 
 This example uses the configuration file at `~/my-eslint.json`.
 
-If `.eslintrc.*` and/or `package.json` files are also used for configuration (i.e., `--no-eslintrc` was not specified), the configurations will be merged. Options from this configuration file have precedence over the options from `.eslintrc.*` and `package.json` files.
+If `.eslintrc.*` and/or `package.json` files are also used for configuration (i.e., `--no-eslintrc` was not specified), the configurations are merged. Options from this configuration file have precedence over the options from `.eslintrc.*` and `package.json` files.
 
 #### `--env`
 
@@ -149,7 +153,7 @@ npx eslint --env browser --env node file.js
 
 #### `--ext`
 
-This option allows you to specify which file extensions ESLint will use when searching for target files in the directories you specify.
+This option allows you to specify which file extensions ESLint uses when searching for target files in the directories you specify.
 By default, ESLint lints `*.js` files and the files that match the `overrides` entries of your configuration.
 
 Examples:
@@ -167,11 +171,11 @@ npx eslint . --ext .js,.ts
 
 **Note:** `--ext` is only used when the arguments are directories. If you use glob patterns or file names, then `--ext` is ignored.
 
-For example, `npx eslint lib/* --ext .js` will match all files within the `lib/` directory, regardless of extension.
+For example, `npx eslint lib/* --ext .js` matches all files within the `lib/` directory, regardless of extension.
 
 #### `--global`
 
-This option defines global variables so that they will not be flagged as undefined by the `no-undef` rule. Any specified global variables are assumed to be read-only by default, but appending `:true` to a variable's name ensures that `no-undef` will also allow writes. To specify multiple global variables, separate them using commas, or use the option multiple times.
+This option defines global variables so that they are not  flagged as undefined by the `no-undef` rule. Any specified global variables are assumed to be read-only by default, but appending `:true` to a variable's name ensures that `no-undef` also allows writes. To specify multiple global variables, separate them using commas, or use the option multiple times.
 
 Examples:
 
@@ -182,7 +186,7 @@ npx eslint --global require --global exports:true
 
 #### `--parser`
 
-This option allows you to specify a parser to be used by ESLint. By default, `espree` will be used.
+This option allows you to specify a parser to be used by ESLint. By default, `espree` is used.
 
 #### `--parser-options`
 
@@ -191,7 +195,7 @@ This option allows you to specify parser options to be used by ESLint. Note that
 Examples:
 
 ```shell
-echo '3 ** 4' | npx eslint --stdin --parser-options=ecmaVersion:6 # will fail with a parsing error
+echo '3 ** 4' | npx eslint --stdin --parser-options=ecmaVersion:6 # fails with a parsing error
 echo '3 ** 4' | npx eslint --stdin --parser-options=ecmaVersion:7 # succeeds, yay!
 ```
 
@@ -219,7 +223,7 @@ npx eslint --plugin eslint-plugin-mocha file.js
 
 #### `--rule`
 
-This option specifies rules to be used. These rules will be merged with any rules specified with configuration files. (You can use `--no-eslintrc` to change that behavior.) To define multiple rules, separate them using commas, or use the option multiple times. The [levn](https://github.com/gkz/levn#levn--) format is used for specifying the rules.
+This option specifies rules to be used. These rules are merged with any rules specified with configuration files. (You can use `--no-eslintrc` to change that behavior.) To define multiple rules, separate them using commas, or use the option multiple times. The [levn](https://github.com/gkz/levn#levn--) format is used for specifying the rules.
 
 If the rule is defined within a plugin, you have to prefix the rule ID with the plugin name and a `/`.
 
@@ -366,7 +370,7 @@ npx eslint --quiet file.js
 
 This option allows you to specify a warning threshold, which can be used to force ESLint to exit with an error status if there are too many warning-level rule violations in your project.
 
-Normally, if ESLint runs and finds no errors (only warnings), it will exit with a success exit status. However, if `--max-warnings` is specified and the total warning count is greater than the specified threshold, ESLint will exit with an error status. Specifying a threshold of `-1` or omitting this option will prevent this behavior.
+Normally, if ESLint runs and finds no errors (only warnings), it exits with a success exit status. However, if `--max-warnings` is specified and the total warning count is greater than the specified threshold, ESLint exits with an error status. To prevent this behavior, omitting this option or specifying a threshold of `-1`.
 
 Example:
 
@@ -475,7 +479,7 @@ npx eslint --no-inline-config file.js
 
 This option causes ESLint to report directive comments like `// eslint-disable-line` when no errors would have been reported on that line anyway. This can be useful to prevent future errors from unexpectedly being suppressed, by cleaning up old `eslint-disable` comments which are no longer applicable.
 
-**Warning**: When using this option, it is possible that new errors will start being reported whenever ESLint or custom rules are upgraded. For example, suppose a rule has a bug that causes it to report a false positive, and an `eslint-disable` comment is added to suppress the incorrect report. If the bug is then fixed in a patch release of ESLint, the `eslint-disable` comment will become unused since ESLint is no longer generating an incorrect report. This will result in a new reported error for the unused directive if the `report-unused-disable-directives` option is used.
+**Warning**: When using this option, it is possible that new errors start being reported whenever ESLint or custom rules are upgraded. For example, suppose a rule has a bug that causes it to report a false positive, and an `eslint-disable` comment is added to suppress the incorrect report. If the bug is then fixed in a patch release of ESLint, the `eslint-disable` comment becomes unused since ESLint is no longer generating an incorrect report. This results in a new reported error for the unused directive if the `report-unused-disable-directives` option is used.
 
 Example:
 
@@ -495,15 +499,15 @@ Store the info about processed files in order to only operate on the changed one
 
 #### `--cache-file`
 
-Path to the cache file. If none specified `.eslintcache` will be used. The file will be created in the directory where the `eslint` command is executed. **Deprecated**: Use `--cache-location` instead.
+Path to the cache file. If none specified `.eslintcache` is used. The file is created in the directory where the `eslint` command is executed. **Deprecated**: Use `--cache-location` instead.
 
 #### `--cache-location`
 
-Path to the cache location. Can be a file or a directory. If no location is specified, `.eslintcache` will be used. In that case, the file will be created in the directory where the `eslint` command is executed.
+Path to the cache location. Can be a file or a directory. If no location is specified, `.eslintcache` is used. In that case, the file is created in the directory where the `eslint` command is executed.
 
-If a directory is specified, a cache file will be created inside the specified folder. The name of the file will be based on the hash of the current working directory (CWD). e.g.: `.cache_hashOfCWD`
+If a directory is specified, a cache file is created inside the specified folder. The name of the file is based on the hash of the current working directory (CWD). e.g.: `.cache_hashOfCWD`
 
-**Important note:** If the directory for the cache does not exist make sure you add a trailing `/` on \*nix systems or `\` in windows. Otherwise the path will be assumed to be a file.
+**Important note:** If the directory for the cache does not exist make sure you add a trailing `/` on \*nix systems or `\` in windows. Otherwise the path is assumed to be a file.
 
 Example:
 
@@ -513,7 +517,7 @@ npx eslint "src/**/*.js" --cache --cache-location "/Users/user/.eslintcache/"
 
 #### `--cache-strategy`
 
-Strategy for the cache to use for detecting changed files. Can be either `metadata` or `content`. If no strategy is specified, `metadata` will be used.
+Strategy for the cache to use for detecting changed files. Can be either `metadata` or `content`. If no strategy is specified, `metadata` is used.
 
 The `content` strategy can be useful in cases where the modification time of your files change even if their contents have not. For example, this can happen during git operations like git clone because git does not track file modification time.
 
@@ -527,9 +531,9 @@ npx eslint "src/**/*.js" --cache --cache-strategy content
 
 #### `--init`
 
-This option will run `npm init @eslint/config` to start config initialization wizard. It's designed to help new users quickly create .eslintrc file by answering a few questions, choosing a popular style guide.
+This option runs `npm init @eslint/config` to start config initialization wizard. It's designed to help new users quickly create .eslintrc file by answering a few questions, choosing a popular style guide.
 
-The resulting configuration file will be created in the current directory.
+The resulting configuration file is created in the current directory.
 
 #### `--env-info`
 
@@ -537,7 +541,7 @@ This option outputs information about the execution environment, including the v
 
 #### `--no-error-on-unmatched-pattern`
 
-This option prevents errors when a quoted glob pattern or `--ext` is unmatched. This will not prevent errors when your shell can't match a glob.
+This option prevents errors when a quoted glob pattern or `--ext` is unmatched. This does not prevent errors when your shell can't match a glob.
 
 #### `--exit-on-fatal-error`
 
@@ -568,7 +572,7 @@ npx eslint --print-config file.js
 
 ## Ignoring files from linting
 
-ESLint supports `.eslintignore` files to exclude files from the linting process when ESLint operates on a directory. Files given as individual CLI arguments will be exempt from exclusion. The `.eslintignore` file is a plain text file containing one pattern per line. It can be located in any of the target directory's ancestors; it will affect files in its containing directory as well as all sub-directories. Here's a simple example of a `.eslintignore` file:
+ESLint supports `.eslintignore` files to exclude files from the linting process when ESLint operates on a directory. Files given as individual CLI arguments are exempt from exclusion. The `.eslintignore` file is a plain text file containing one pattern per line. It can be located in any of the target directory's ancestors; it affects files in its containing directory as well as all sub-directories. Here's a simple example of a `.eslintignore` file:
 
 ```text
 temp.js
@@ -579,7 +583,7 @@ A more detailed breakdown of supported patterns and directories ESLint ignores b
 
 ## Exit codes
 
-When linting files, ESLint will exit with one of the following exit codes:
+When linting files, ESLint exits with one of the following exit codes:
 
 * `0`: Linting was successful and there are no linting errors. If the `--max-warnings` flag is set to `n`, the number of linting warnings is at most `n`.
 * `1`: Linting was successful and there is at least one linting error, or there are more linting warnings than allowed by the `--max-warnings` option.

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -171,7 +171,7 @@ This option allows you to specify which file extensions ESLint uses when searchi
 * **Multiple Arguments**: Yes
 * **Default Value**: `.js` and the files that match the `overrides` entries of your configuration.
 
-`--ext` is only used when the the patterns to lint are directories. If you use glob patterns or file names, then `--ext` is ignored. For example, `npx eslint lib/* --ext .js` matches all files within the `lib/` directory, regardless of extension.
+`--ext` is only used when the the patterns to lint are directories. If you use glob patterns or file names, then `--ext` is ignored. For example, `npx eslint "lib/*" --ext .js` matches all files within the `lib/` directory, regardless of extension.
 
 ##### `--ext` example
 
@@ -212,7 +212,7 @@ This option allows you to specify a parser to be used by ESLint.
 
 ```shell
 # Use TypeScript ESLint parser
-npx eslint --parser @typescript-eslint/parser files.ts
+npx eslint --parser @typescript-eslint/parser file.ts
 ```
 
 #### `--parser-options`
@@ -233,11 +233,11 @@ echo '3 ** 4' | npx eslint --stdin --parser-options ecmaVersion:7 # succeeds, ya
 
 Changes the folder where plugins are resolved from.
 
-* **Argument Type**: String. Path to file.
+* **Argument Type**: String. Path to directory.
 * **Multiple Arguments**: No
-* **Default Value**: By default, plugins are resolved from the current working directory.
+* **Default Value**: By default, plugins are resolved from the directory in which your configuration file is found.
 
-This option should be used when plugins were installed by someone other than the end user. It should be set to the project directory of the project that has a dependency on the necessary plugins. If you use npm to install plugins, the path ends with `/node_modules/`.
+This option should be used when plugins were installed by someone other than the end user. It should be set to the project directory of the project that has a dependency on the necessary plugins.
 
 For example:
 
@@ -248,7 +248,7 @@ For example:
 
 ```shell
 npx eslint --config ~/personal-eslintrc.js \
---resolve-plugins-relative-to /usr/local/lib/node_modules/
+--resolve-plugins-relative-to /usr/local/lib/
 ```
 
 ### Specify rules and plugins
@@ -406,7 +406,6 @@ This option allows you to specify patterns of files to ignore (in addition to th
 
 * **Argument Type**: String. The supported syntax is the same as for [`.eslintignore` files](configuring/ignoring-code#the-eslintignore-file), which use the same patterns as the [`.gitignore` specification](https://git-scm.com/docs/gitignore). You should quote your patterns in order to avoid shell interpretation of glob patterns.
 * **Multiple Arguments**: Yes
-* **Default Value**: whatever the default value is OR N/A
 
 ##### `--ignore-pattern` example
 
@@ -520,7 +519,7 @@ Use a local custom formatter:
 npx eslint -f ./customformat.js file.js
 ```
 
-Use npm-installed formatter:
+Use an npm-installed formatter:
 
 ```shell
 npm install eslint-formatter-pretty
@@ -532,7 +531,7 @@ npx eslint -f eslint-formatter-pretty file.js
 
 #### `--color` and `--no-color`
 
-These options forces the enabling/disabling of colorized output.
+These options force the enabling/disabling of colorized output.
 
 * **Argument Type**: No argument.
 

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -148,7 +148,10 @@ This option allows you to specify a parser to be used by ESLint.
 
 ##### `--parser` example
 
-TODO: add
+```shell
+# Use TypeScript ESLint parser
+npx eslint --parser @typescript-eslint/parser files.ts
+```
 
 #### `--parser-options`
 
@@ -172,7 +175,7 @@ Changes the folder where plugins are resolved from.
 * **Multiple Arguments**: No
 * **Default Value**: By default, plugins are resolved from the current working directory.
 
- This option should be used when plugins were installed by someone other than the end user. It should be set to the project directory of the project that has a dependency on the necessary plugins.
+This option should be used when plugins were installed by someone other than the end user. It should be set to the project directory of the project that has a dependency on the necessary plugins. If you use npm to install plugins, the path ends with `/node_modules/`.
 
 For example:
 
@@ -181,7 +184,10 @@ For example:
 
 ##### `--resolve-plugins-relative-to` example
 
-TODO: add
+```sh
+npx eslint --config ~/personal-eslintrc.js \
+--resolve-plugins-relative-to /usr/local/lib/node_modules/
+```
 
 ### Specify rules and plugins
 
@@ -241,11 +247,7 @@ npx eslint --rulesdir my-rules/ --rulesdir my-other-rules/ file.js
 
 This option instructs ESLint to try to fix as many issues as possible. The fixes are made to the actual files themselves and only the remaining unfixed issues are output.
 
-TODO: test out this flag and see what is needed here
-
-* **Alias**: `-fn`
-* **Argument Type**: Data type. Short description. If no data type, put 'No argument'
-* **Multiple Arguments**: Yes/No
+* **Argument Type**: No argument.
 
 Not all problems are fixable using this option, and the option does not work in these situations:
 
@@ -256,7 +258,9 @@ If you want to fix code from `stdin` or otherwise want to get the fixes without 
 
 ##### `--fix` example
 
-TODO: add
+```shell
+npx eslint --fix file.js
+```
 
 #### `--fix-dry-run`
 
@@ -594,8 +598,6 @@ npx eslint --init
 
 #### `--env-info`
 
-TODO: Resume here
-
 This option outputs information about the execution environment, including the version of Node, npm, and local and global installations of ESLint.
 
 * **Argument Type**: No argument.
@@ -616,7 +618,9 @@ This option prevents errors when a quoted glob pattern or `--ext` is unmatched. 
 
 ##### `--no-error-on-unmatched-pattern` example
 
-TODO: add
+```shell
+npx eslint --no-error-on-unmatched-pattern --ext .ts lib/*
+```
 
 #### `--exit-on-fatal-error`
 
@@ -626,7 +630,9 @@ This option causes ESLint to exit with exit code 2 if one or more fatal parsing 
 
 ##### `--exit-on-fatal-error` example
 
-TODO: add
+```shell
+npx eslint --exit-on-fatal-error file.js
+```
 
 #### `--debug`
 
@@ -679,17 +685,6 @@ This option outputs the configuration to be used for the file passed. When prese
 ```shell
 npx eslint --print-config file.js
 ```
-
-## Ignore files with `.eslintignore`
-
-ESLint supports `.eslintignore` files to exclude files from the linting process when ESLint operates on a directory. Files given as individual CLI arguments are exempt from exclusion. The `.eslintignore` file is a plain text file containing one pattern per line. It can be located in any of the target directory's ancestors; it affects files in its containing directory as well as all sub-directories. Here's a simple example of a `.eslintignore` file:
-
-```text
-temp.js
-**/vendor/*.js
-```
-
-A more detailed breakdown of supported patterns and directories ESLint ignores by default can be found in [Ignoring Code](configuring/ignoring-code).
 
 ## Exit codes
 

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -73,7 +73,7 @@ This option allows you to specify an additional configuration file for ESLint (s
 * **Argument Type**: String. Path to file.
 * **Multiple Arguments**: No
 
-##### `--config` example
+##### `--config`, `-c` example
 
 ```shell
 npx eslint -c ~/my-eslint.json file.js
@@ -155,7 +155,7 @@ npx eslint --parser @typescript-eslint/parser files.ts
 
 This option allows you to specify parser options to be used by ESLint. The available parser options are determined by the parser being used.
 
-* **Argument Type**: Key/Value pair. Separated by colon (`:`).
+* **Argument Type**: Key/value pair separated by colon (`:`).
 * **Multiple Arguments**: Yes
 
 ##### `--parser-options` example
@@ -410,7 +410,7 @@ Write the output of linting results to a specified file.
 * **Argument Type**: String. Path to file.
 * **Multiple Arguments**: No
 
-##### `--output-file` example
+##### `--output-file`, `-o` example
 
 ```shell
 npx eslint -o ./test/test.html
@@ -420,7 +420,7 @@ npx eslint -o ./test/test.html
 
 This option specifies the output format for the console.
 
-* **Argument Type**: String. One of the [built-in formatters](formatters) or a custom formatter.
+* **Argument Type**: String. One of the [built-in formatters](formatters/) or a custom formatter.
 **Multiple Arguments**: No
 * **Default Value**: [`stylish`](formatters/#stylish)
 
@@ -652,7 +652,7 @@ This option outputs the help menu, displaying all of the available options. All 
 
 * **Argument Type**: No argument.
 
-##### `--help` example
+##### `--help`, `-h` example
 
 ```shell
 npx eslint --help

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -116,7 +116,7 @@ Miscellaneous:
   --print-config path::String     Print the configuration for the given file
 ```
 
-### Basic configuration
+### Basic Configuration
 
 #### `--no-eslintrc`
 
@@ -545,7 +545,7 @@ npx eslint --color file.js | cat
 npx eslint --no-color file.js
 ```
 
-### Inline configuration comments
+### Inline Configuration Comments
 
 #### `--no-inline-config`
 

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -58,70 +58,62 @@ You can view all the CLI options by running `npx eslint -h`.
 eslint [options] file.js [file.js] [dir]
 
 Basic configuration:
-  --no-config-lookup             Disable look up for eslint.config.js
-  -c, --config path::String      Use this configuration instead of
-                                 eslint.config.js
-  --global [String]              Define global variables
-  --parser String                Specify the parser to be used
-  --parser-options Object        Specify parser options
+  --no-eslintrc                   Disable use of configuration from .eslintrc.*
+  -c, --config path::String       Use this configuration, overriding .eslintrc.* config options if present
+  --env [String]                  Specify environments
+  --ext [String]                  Specify JavaScript file extensions
+  --global [String]               Define global variables
+  --parser String                 Specify the parser to be used
+  --parser-options Object         Specify parser options
+  --resolve-plugins-relative-to path::String  A folder where plugins should be resolved from, CWD by default
 
 Specify rules and plugins:
-  --plugin [String]              Specify plugins
-  --rule Object                  Specify rules
+  --plugin [String]               Specify plugins
+  --rule Object                   Specify rules
+  --rulesdir [path::String]       Load additional rules from this directory. Deprecated: Use rules from plugins
 
 Fix problems:
-  --fix                          Automatically fix problems
-  --fix-dry-run                  Automatically fix problems without saving the
-                                 changes to the file system
-  --fix-type Array               Specify the types of fixes to apply
-                                 (directive, problem, suggestion, layout)
+  --fix                           Automatically fix problems
+  --fix-dry-run                   Automatically fix problems without saving the changes to the file system
+  --fix-type Array                Specify the types of fixes to apply (directive, problem, suggestion, layout)
 
 Ignore files:
-  --no-ignore                    Disable use of ignore files and patterns
-  --ignore-pattern [String]      Pattern of files to ignore (in addition to
-                                 those in .eslintignore)
+  --ignore-path path::String      Specify path of ignore file
+  --no-ignore                     Disable use of ignore files and patterns
+  --ignore-pattern [String]       Pattern of files to ignore (in addition to those in .eslintignore)
 
 Use stdin:
-  --stdin                        Lint code provided on <STDIN> - default: false
-  --stdin-filename String        Specify filename to process STDIN as
+  --stdin                         Lint code provided on <STDIN> - default: false
+  --stdin-filename String         Specify filename to process STDIN as
 
-Handling warnings:
-  --quiet                        Report errors only - default: false
-  --max-warnings Int             Number of warnings to trigger nonzero exit
-                                 code - default: -1
+Handle warnings:
+  --quiet                         Report errors only - default: false
+  --max-warnings Int              Number of warnings to trigger nonzero exit code - default: -1
 
 Output:
   -o, --output-file path::String  Specify file to write report to
-  -f, --format String            Use a specific output format - default:
-                                 stylish
-  --color, --no-color            Force enabling/disabling of color
+  -f, --format String             Use a specific output format - default: stylish
+  --color, --no-color             Force enabling/disabling of color
 
 Inline configuration comments:
-  --no-inline-config             Prevent comments from changing config or rules
-  --report-unused-disable-directives  Adds reported errors for unused
-                                      eslint-disable directives
+  --no-inline-config              Prevent comments from changing config or rules
+  --report-unused-disable-directives  Adds reported errors for unused eslint-disable directives
 
 Caching:
-  --cache                        Only check changed files - default: false
-  --cache-file path::String      Path to the cache file. Deprecated: use
-                                 --cache-location - default: .eslintcache
-  --cache-location path::String  Path to the cache file or directory
-  --cache-strategy String        Strategy to use for detecting changed files
-                                 in the cache - either: metadata or content -
-                                 default: metadata
+  --cache                         Only check changed files - default: false
+  --cache-file path::String       Path to the cache file. Deprecated: use --cache-location - default: .eslintcache
+  --cache-location path::String   Path to the cache file or directory
+  --cache-strategy String         Strategy to use for detecting changed files in the cache - either: metadata or content - default: metadata
 
 Miscellaneous:
-  --init                         Run config initialization wizard - default:
-                                 false
-  --env-info                     Output execution environment information -
-                                 default: false
+  --init                          Run config initialization wizard - default: false
+  --env-info                      Output execution environment information - default: false
   --no-error-on-unmatched-pattern  Prevent errors when pattern is unmatched
-  --exit-on-fatal-error          Exit with exit code 2 in case of fatal error
-                                 - default: false
-  --debug                        Output debugging information
-  -h, --help                     Show help
-  -v, --version                  Output the version number
-  --print-config path::String    Print the configuration for the given file
+  --exit-on-fatal-error           Exit with exit code 2 in case of fatal error - default: false
+  --debug                         Output debugging information
+  -h, --help                      Show help
+  -v, --version                   Output the version number
+  --print-config path::String     Print the configuration for the given file
 ```
 
 ### Basic configuration
@@ -138,14 +130,14 @@ Disables use of configuration from `.eslintrc.*` and `package.json` files.
 npx eslint --no-eslintrc file.js
 ```
 
-#### `--config`, `-c`
+#### `-c`, `--config`
 
 This option allows you to specify an additional configuration file for ESLint (see [Configuring ESLint](configuring/) for more).
 
 * **Argument Type**: String. Path to file.
 * **Multiple Arguments**: No
 
-##### `--config`, `-c` example
+##### `-c`, `--config` example
 
 ```shell
 npx eslint -c ~/my-eslint.json file.js
@@ -482,25 +474,25 @@ npx eslint --max-warnings 10 file.js
 
 ### Output
 
-#### `--output-file`, `-o`
+#### `-o`, `--output-file`
 
 Write the output of linting results to a specified file.
 
 * **Argument Type**: String. Path to file.
 * **Multiple Arguments**: No
 
-##### `--output-file`, `-o` example
+##### `-o`, `--output-file` example
 
 ```shell
 npx eslint -o ./test/test.html
 ```
 
-#### `--format`, `-f`
+#### `-f`, `--format`
 
 This option specifies the output format for the console.
 
 * **Argument Type**: String. One of the [built-in formatters](formatters/) or a custom formatter.
-**Multiple Arguments**: No
+* **Multiple Arguments**: No
 * **Default Value**: [`stylish`](formatters/#stylish)
 
 If you are using a custom formatter defined in a local file, you can specify the path to the custom formatter file.
@@ -514,7 +506,7 @@ When specified, the given format is output to the console. If you'd like to save
 npx eslint -f compact file.js > results.txt
 ```
 
-##### `--format` example
+##### `-f`, `--format` example
 
 Use the built-in `compact` formatter:
 
@@ -725,25 +717,25 @@ This information is useful when you're seeing a problem and having a hard time p
 npx eslint --debug test.js
 ```
 
-#### `--help`, `-h`
+#### `-h`, `--help`
 
 This option outputs the help menu, displaying all of the available options. All other options are ignored when this is present. When you use this flag, the CLI does not perform linting.
 
 * **Argument Type**: No argument.
 
-##### `--help`, `-h` example
+##### `-h`, `--help` example
 
 ```shell
 npx eslint --help
 ```
 
-#### `--version`, `-v`
+#### `-v`, `--version`
 
 This option outputs the current ESLint version onto the console. All other options are ignored when this is present. When you use this flag, the CLI does not perform linting.
 
 * **Argument Type**: No argument.
 
-##### `--version` example
+##### `-v`, `--version` example
 
 ```shell
 npx eslint --version

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -73,7 +73,6 @@ This option allows you to specify an additional configuration file for ESLint (s
 * **Alias**: `-c`
 * **Argument Type**: String. File name.
 * **Multiple Arguments**: No
-* **Default Value**: N/A
 
 ##### `--config` example
 
@@ -424,6 +423,7 @@ This option specifies the output format for the console.
 
 * **Alias**: `-f`
 * **Argument Type**: String. One of the [built-in formatters](formatters) or a custom formatter.
+**Multiple Arguments**: No
 * **Default Value**: [`stylish`](formatters/#stylish)
 
 If you are using a custom formatter defined in a local file, you can specify the path to the custom formatter file.
@@ -621,7 +621,6 @@ This option prevents errors when a quoted glob pattern or `--ext` is unmatched. 
 ```shell
 npx eslint --no-error-on-unmatched-pattern --ext .ts lib/*
 ```
-
 
 #### `--exit-on-fatal-error`
 

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -71,7 +71,7 @@ npx eslint --no-eslintrc file.js
 This option allows you to specify an additional configuration file for ESLint (see [Configuring ESLint](configuring/) for more).
 
 * **Alias**: `-c`
-* **Argument Type**: String. File name.
+* **Argument Type**: String. Path to file.
 * **Multiple Arguments**: No
 
 ##### `--config` example
@@ -106,7 +106,7 @@ This option allows you to specify which file extensions ESLint uses when searchi
 
 * **Argument Type**: String. File glob pattern.
 * **Multiple Arguments**: Yes
-* **Default Value**: `*.js` and the files that match the `overrides` entries of your configuration.
+* **Default Value**: `.js` and the files that match the `overrides` entries of your configuration.
 
 `--ext` is only used when the arguments are directories. If you use glob patterns or file names, then `--ext` is ignored. For example, `npx eslint lib/* --ext .js` matches all files within the `lib/` directory, regardless of extension.
 
@@ -127,7 +127,7 @@ npx eslint . --ext .js,.ts
 
 This option defines global variables so that they are not  flagged as undefined by the [`no-undef`](../rules/no-undef) rule.
 
-* **Argument Type**: String. Name of global variable. Any specified global variables are assumed to be read-only by default, but appending `:true` to a variable's name ensures that `no-undef` also allows writes.
+* **Argument Type**: String. Name of the global variable. Any specified global variables are assumed to be read-only by default, but appending `:true` to a variable's name ensures that `no-undef` also allows writes.
 * **Multiple Arguments**: Yes
 
 ##### `--global` example
@@ -170,7 +170,7 @@ echo '3 ** 4' | npx eslint --stdin --parser-options ecmaVersion:7 # succeeds, ya
 
 Changes the folder where plugins are resolved from.
 
-* **Argument Type**: File path.
+* **Argument Type**: String. Path to file.
 * **Multiple Arguments**: No
 * **Default Value**: By default, plugins are resolved from the current working directory.
 
@@ -183,7 +183,7 @@ For example:
 
 ##### `--resolve-plugins-relative-to` example
 
-```sh
+```shell
 npx eslint --config ~/personal-eslintrc.js \
 --resolve-plugins-relative-to /usr/local/lib/node_modules/
 ```
@@ -208,7 +208,7 @@ npx eslint --plugin eslint-plugin-mocha file.js
 
 #### `--rule`
 
-This option specifies rules to be used.
+This option specifies the rules to be used.
 
 * **Argument Type**: Rules and their configuration specified with [levn](https://github.com/gkz/levn#levn--) format.
 * **Multiple Arguments**: Yes
@@ -288,7 +288,7 @@ This option allows you to specify the type of fixes to apply when using either `
   1. `directive` - apply fixes to inline directives such as `// eslint-disable`
 * **Multiple Arguments**: Yes
 
-This option is helpful if you are using another program to format your code but you would still like ESLint to apply other types of fixes.
+This option is helpful if you are using another program to format your code, but you would still like ESLint to apply other types of fixes.
 
 ##### `--fix-type` example
 
@@ -319,7 +319,7 @@ npx eslint --ignore-path .gitignore file.js
 
 #### `--no-ignore`
 
-Disables excluding of files from `.eslintignore` files, `--ignore-path` flags, `--ignore-pattern` flags, and  the `ignorePatterns` property in config files.
+Disables excluding of files from `.eslintignore` files, `--ignore-path` flags, `--ignore-pattern` flags, and the `ignorePatterns` property in config files.
 
 * **Argument Type**: No argument.
 
@@ -333,7 +333,7 @@ npx eslint --no-ignore file.js
 
 This option allows you to specify patterns of files to ignore (in addition to those in `.eslintignore`).
 
-* **Argument Type**: String. The supported syntax is the same as for `.eslintignore` [files](configuring/ignoring-code#the-eslintignore-file), which use the same patterns as the [`.gitignore` specification](https://git-scm.com/docs/gitignore). You should quote your patterns in order to avoid shell interpretation of glob patterns.
+* **Argument Type**: String. The supported syntax is the same as for [`.eslintignore` files](configuring/ignoring-code#the-eslintignore-file), which use the same patterns as the [`.gitignore` specification](https://git-scm.com/docs/gitignore). You should quote your patterns in order to avoid shell interpretation of glob patterns.
 * **Multiple Arguments**: Yes
 * **Default Value**: whatever the default value is OR N/A
 
@@ -361,7 +361,7 @@ cat myfile.js | npx eslint --stdin
 
 This option allows you to specify a filename to process STDIN as.
 
-* **Argument Type**: String. File name.
+* **Argument Type**: String. Path to file.
 * **Multiple Arguments**: No
 
 This is useful when processing files from STDIN and you have rules which depend on the filename.
@@ -390,7 +390,7 @@ npx eslint --quiet file.js
 
 This option allows you to specify a warning threshold, which can be used to force ESLint to exit with an error status if there are too many warning-level rule violations in your project.
 
-* **Argument Type**: Integer. Maximum number of warnings to allow. To prevent this behavior, do not use this option or specify `-1` as the argument.
+* **Argument Type**: Integer. The maximum number of warnings to allow. To prevent this behavior, do not use this option or specify `-1` as the argument.
 * **Multiple Arguments**: No
 
 Normally, if ESLint runs and finds no errors (only warnings), it exits with a success exit status. However, if `--max-warnings` is specified and the total warning count is greater than the specified threshold, ESLint exits with an error status.
@@ -405,7 +405,7 @@ npx eslint --max-warnings 10 file.js
 
 #### `--output-file`
 
-Write output of linting results to a specified file.
+Write the output of linting results to a specified file.
 
 * **Alias**: `-o`
 * **Argument Type**: String. Path to file.
@@ -554,7 +554,7 @@ Specify the path to the cache location. Can be a file or a directory.
 * **Multiple Arguments**: No
 * **Default Value**: If no location is specified, `.eslintcache` is used. The file is created in the directory where the `eslint` command is executed.
 
-If the directory for the cache does not exist make sure you add a trailing `/` on \*nix systems or `\` on Windows. Otherwise the path is assumed to be a file.
+If the directory for the cache does not exist make sure you add a trailing `/` on \*nix systems or `\` on Windows. Otherwise, the path is assumed to be a file.
 
 ##### `--cache-location` example
 
@@ -572,7 +572,7 @@ Strategy for the cache to use for detecting changed files.
 * **Multiple Arguments**: No
 * **Default Value**: `metadata`
 
-The `content` strategy can be useful in cases where the modification time of your files change even if their contents have not. For example, this can happen during git operations like `git clone` because git does not track file modification time.
+The `content` strategy can be useful in cases where the modification time of your files changes even if their contents have not. For example, this can happen during git operations like `git clone` because git does not track file modification time.
 
 ##### `--cache-strategy` example
 
@@ -584,7 +584,7 @@ npx eslint "src/**/*.js" --cache --cache-strategy content
 
 #### `--init`
 
-This option runs `npm init @eslint/config` to start config initialization wizard. It's designed to help new users quickly create `.eslintrc` file by answering a few questions. When you use this flag, the CLI does not perform linting.
+This option runs `npm init @eslint/config` to start the config initialization wizard. It's designed to help new users quickly create an `.eslintrc` file by answering a few questions. When you use this flag, the CLI does not perform linting.
 
 * **Argument Type**: No argument.
 
@@ -678,7 +678,8 @@ npx eslint --version
 
 This option outputs the configuration to be used for the file passed. When present, no linting is performed and only config-related options are valid. When you use this flag, the CLI does not perform linting.
 
-* **Argument Type**: No argument.
+* **Argument Type**: String. Path to file.
+* **Multiple Arguments**: No
 
 ##### `--print-config` example
 

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -228,7 +228,8 @@ npx eslint --rule 'jquery/dollar-sign: error'
 
 This option allows you to specify another directory from which to load rules files. This allows you to dynamically load new rules at run time. This is useful when you have custom rules that aren't suitable for being bundled with ESLint.
 
-The rules in your custom rules directory must follow the same format as bundled rules to work properly. You can also specify multiple locations for custom rules by including multiple `--rulesdir` options.
+* **Argument Type**: String. Path to directory. The rules in your custom rules directory must follow the same format as bundled rules to work properly.
+* **Multiple Arguments**: Yes.
 
 Note that, as with core rules and plugin rules, you still need to enable the rules in configuration or via the `--rule` CLI option in order to actually run those rules during linting. Specifying a rules directory with `--rulesdir` does not automatically enable the rules within that directory.
 

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -58,7 +58,7 @@ npx eslint --ext .jsx,.js lib/
 
 Disables use of configuration from `.eslintrc.*` and `package.json` files.
 
-* **Argument Type**: No argument
+* **Argument Type**: No argument.
 
 ##### `--no-eslintrc` example
 
@@ -262,7 +262,7 @@ TODO: add
 
 This option has the same effect as `--fix` with the difference that the fixes are not saved to the file system. Because the default formatter does not output the fixed code, you'll have to use another formatter (e.g. `--format json`) to get the fixes.
 
-* **Argument Type**: No argument
+* **Argument Type**: No argument.
 
 This makes it possible to fix code from `stdin` when used with the `--stdin` flag.
 
@@ -596,7 +596,11 @@ npx eslint --init
 
 TODO: Resume here
 
-This option outputs information about the execution environment, including the version of Node, npm, and local and global installations of ESLint. The ESLint team may ask for this information to help solve bugs. When you use this flag, the CLI does not perform linting.
+This option outputs information about the execution environment, including the version of Node, npm, and local and global installations of ESLint.
+
+* **Argument Type**: No argument.
+
+The ESLint team may ask for this information to help solve bugs. When you use this flag, the CLI does not perform linting.
 
 ##### `--env-info` example
 
@@ -608,13 +612,17 @@ npx eslint --env-info
 
 This option prevents errors when a quoted glob pattern or `--ext` is unmatched. This does not prevent errors when your shell can't match a glob.
 
+* **Argument Type**: No argument.
+
 ##### `--no-error-on-unmatched-pattern` example
 
 TODO: add
 
 #### `--exit-on-fatal-error`
 
-This option causes ESLint to exit with exit code 2 if one or more fatal parsing errors occur. Without this option, fatal parsing errors are reported as rule violations.
+This option causes ESLint to exit with exit code 2 if one or more fatal parsing errors occur. Without this option, ESLint reports fatal parsing errors as rule violations.
+
+* **Argument Type**: No argument.
 
 ##### `--exit-on-fatal-error` example
 
@@ -622,8 +630,11 @@ TODO: add
 
 #### `--debug`
 
-This option outputs debugging information to the console. This information is useful when you're seeing a problem and having a hard time pinpointing it. The ESLint team may ask for this debugging information to help solve bugs.
-Add this flag to an ESLint command line invocation in order to get extra debug information as the command is run.
+This option outputs debugging information to the console. Add this flag to an ESLint command line invocation in order to get extra debug information as the command is run.
+
+* **Argument Type**: No argument.
+
+This information is useful when you're seeing a problem and having a hard time pinpointing it. The ESLint team may ask for this debugging information to help solve bugs.
 
 ##### `--debug` example
 
@@ -631,9 +642,12 @@ Add this flag to an ESLint command line invocation in order to get extra debug i
 npx eslint --debug test.js
 ```
 
-#### `-h`, `--help`
+#### `--help`
 
 This option outputs the help menu, displaying all of the available options. All other options are ignored when this is present. When you use this flag, the CLI does not perform linting.
+
+* **Alias**: `h`
+* **Argument Type**: No argument.
 
 ##### `--help` example
 
@@ -641,9 +655,12 @@ This option outputs the help menu, displaying all of the available options. All 
 npx eslint --help
 ```
 
-#### `-v`, `--version`
+#### `--version`
 
 This option outputs the current ESLint version onto the console. All other options are ignored when this is present. When you use this flag, the CLI does not perform linting.
+
+* **Alias**: `v`
+* **Argument Type**: No argument.
 
 ##### `--version` example
 
@@ -655,13 +672,15 @@ npx eslint --version
 
 This option outputs the configuration to be used for the file passed. When present, no linting is performed and only config-related options are valid. When you use this flag, the CLI does not perform linting.
 
+* **Argument Type**: No argument.
+
 ##### `--print-config` example
 
 ```shell
 npx eslint --print-config file.js
 ```
 
-## Ignoring files from linting
+## Ignore files with `.eslintignore`
 
 ESLint supports `.eslintignore` files to exclude files from the linting process when ESLint operates on a directory. Files given as individual CLI arguments are exempt from exclusion. The `.eslintignore` file is a plain text file containing one pattern per line. It can be located in any of the target directory's ancestors; it affects files in its containing directory as well as all sub-directories. Here's a simple example of a `.eslintignore` file:
 
@@ -676,6 +695,6 @@ A more detailed breakdown of supported patterns and directories ESLint ignores b
 
 When linting files, ESLint exits with one of the following exit codes:
 
-* `0`: Linting was successful and there are no linting errors. If the `--max-warnings` flag is set to `n`, the number of linting warnings is at most `n`.
+* `0`: Linting was successful and there are no linting errors. If the [`--max-warnings`](#--max-warnings) flag is set to `n`, the number of linting warnings is at most `n`.
 * `1`: Linting was successful and there is at least one linting error, or there are more linting warnings than allowed by the `--max-warnings` option.
 * `2`: Linting was unsuccessful due to a configuration problem or an internal error.

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -66,11 +66,10 @@ Disables use of configuration from `.eslintrc.*` and `package.json` files.
 npx eslint --no-eslintrc file.js
 ```
 
-#### `--config`
+#### `--config`, `-c`
 
 This option allows you to specify an additional configuration file for ESLint (see [Configuring ESLint](configuring/) for more).
 
-* **Alias**: `-c`
 * **Argument Type**: String. Path to file.
 * **Multiple Arguments**: No
 
@@ -403,11 +402,10 @@ npx eslint --max-warnings 10 file.js
 
 ### Output
 
-#### `--output-file`
+#### `--output-file`, `-o`
 
 Write the output of linting results to a specified file.
 
-* **Alias**: `-o`
 * **Argument Type**: String. Path to file.
 * **Multiple Arguments**: No
 
@@ -417,11 +415,10 @@ Write the output of linting results to a specified file.
 npx eslint -o ./test/test.html
 ```
 
-#### `--format`
+#### `--format`, `-f`
 
 This option specifies the output format for the console.
 
-* **Alias**: `-f`
 * **Argument Type**: String. One of the [built-in formatters](formatters) or a custom formatter.
 **Multiple Arguments**: No
 * **Default Value**: [`stylish`](formatters/#stylish)
@@ -648,11 +645,10 @@ This information is useful when you're seeing a problem and having a hard time p
 npx eslint --debug test.js
 ```
 
-#### `--help`
+#### `--help`, `-h`
 
 This option outputs the help menu, displaying all of the available options. All other options are ignored when this is present. When you use this flag, the CLI does not perform linting.
 
-* **Alias**: `-h`
 * **Argument Type**: No argument.
 
 ##### `--help` example
@@ -661,11 +657,10 @@ This option outputs the help menu, displaying all of the available options. All 
 npx eslint --help
 ```
 
-#### `--version`
+#### `--version`, `-v`
 
 This option outputs the current ESLint version onto the console. All other options are ignored when this is present. When you use this flag, the CLI does not perform linting.
 
-* **Alias**: `-v`
 * **Argument Type**: No argument.
 
 ##### `--version` example

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -38,75 +38,11 @@ npx eslint "lib/**"
 
 **Note:** You can also use alternative package managers such as [Yarn](https://yarnpkg.com/) or [pnpm](https://pnpm.io/) to run ESLint. Please refer to your package manager's documentation for the correct syntax.
 
-## Options
+## Pass multiple values to an option
 
-The command line utility has several options. You can view the options by running `npx eslint -h`.
+Options that accept multiple values can be specified by repeating the option or with a comma-delimited list (other than [`--ignore-pattern`](#--ignore-pattern), which does not allow the second style).
 
-```text
-eslint [options] file.js [file.js] [dir]
-
-Basic configuration:
-  --no-eslintrc                   Disable use of configuration from .eslintrc.*
-  -c, --config path::String       Use this configuration, overriding .eslintrc.* config options if present
-  --env [String]                  Specify environments
-  --ext [String]                  Specify JavaScript file extensions
-  --global [String]               Define global variables
-  --parser String                 Specify the parser to be used
-  --parser-options Object         Specify parser options
-  --resolve-plugins-relative-to path::String  A folder where plugins should be resolved from, CWD by default
-
-Specifying rules and plugins:
-  --plugin [String]               Specify plugins
-  --rule Object                   Specify rules
-  --rulesdir [path::String]       Load additional rules from this directory. Deprecated: Use rules from plugins
-
-Fixing problems:
-  --fix                           Automatically fix problems
-  --fix-dry-run                   Automatically fix problems without saving the changes to the file system
-  --fix-type Array                Specify the types of fixes to apply (directive, problem, suggestion, layout)
-
-Ignoring files:
-  --ignore-path path::String      Specify path of ignore file
-  --no-ignore                     Disable use of ignore files and patterns
-  --ignore-pattern [String]       Pattern of files to ignore (in addition to those in .eslintignore)
-
-Using stdin:
-  --stdin                         Lint code provided on <STDIN> - default: false
-  --stdin-filename String         Specify filename to process STDIN as
-
-Handling warnings:
-  --quiet                         Report errors only - default: false
-  --max-warnings Int              Number of warnings to trigger nonzero exit code - default: -1
-
-Output:
-  -o, --output-file path::String  Specify file to write report to
-  -f, --format String             Use a specific output format - default: stylish
-  --color, --no-color             Force enabling/disabling of color
-
-Inline configuration comments:
-  --no-inline-config              Prevent comments from changing config or rules
-  --report-unused-disable-directives  Adds reported errors for unused eslint-disable directives
-
-Caching:
-  --cache                         Only check changed files - default: false
-  --cache-file path::String       Path to the cache file. Deprecated: use --cache-location - default: .eslintcache
-  --cache-location path::String   Path to the cache file or directory
-  --cache-strategy String         Strategy to use for detecting changed files in the cache - either: metadata or content - default: metadata
-
-Miscellaneous:
-  --init                          Run config initialization wizard - default: false
-  --env-info                      Output execution environment information - default: false
-  --no-error-on-unmatched-pattern  Prevent errors when pattern is unmatched
-  --exit-on-fatal-error           Exit with exit code 2 in case of fatal error - default: false
-  --debug                         Output debugging information
-  -h, --help                      Show help
-  -v, --version                   Output the version number
-  --print-config path::String     Print the configuration for the given file
-```
-
-Options that accept array values can be specified by repeating the option or with a comma-delimited list (other than `--ignore-pattern` which does not allow the second style).
-
-Example:
+Examples of options that accept multiple values:
 
 ```shell
 npx eslint --ext .jsx --ext .js lib/
@@ -114,13 +50,15 @@ npx eslint --ext .jsx --ext .js lib/
 npx eslint --ext .jsx,.js lib/
 ```
 
+## Options
+
 ### Basic configuration
 
 #### `--no-eslintrc`
 
 Disables use of configuration from `.eslintrc.*` and `package.json` files.
 
-Example:
+##### `--no-eslintrc` example
 
 ```shell
 npx eslint --no-eslintrc file.js
@@ -130,7 +68,7 @@ npx eslint --no-eslintrc file.js
 
 This option allows you to specify an additional configuration file for ESLint (see [Configuring ESLint](configuring/) for more).
 
-Example:
+##### `--config` example
 
 ```shell
 npx eslint -c ~/my-eslint.json file.js
@@ -144,7 +82,7 @@ If `.eslintrc.*` and/or `package.json` files are also used for configuration (i.
 
 This option enables specific environments. Details about the global variables defined by each environment are available on the [Specifying Environments](configuring/language-options#specifying-environments) documentation. This option only enables environments; it does not disable environments set in other configuration files. To specify multiple environments, separate them using commas, or use the option multiple times.
 
-Examples:
+##### `--env` example
 
 ```shell
 npx eslint --env browser,node file.js
@@ -156,7 +94,7 @@ npx eslint --env browser --env node file.js
 This option allows you to specify which file extensions ESLint uses when searching for target files in the directories you specify.
 By default, ESLint lints `*.js` files and the files that match the `overrides` entries of your configuration.
 
-Examples:
+##### `--ext` example
 
 ```shell
 # Use only .ts extension
@@ -177,7 +115,7 @@ For example, `npx eslint lib/* --ext .js` matches all files within the `lib/` di
 
 This option defines global variables so that they are not  flagged as undefined by the `no-undef` rule. Any specified global variables are assumed to be read-only by default, but appending `:true` to a variable's name ensures that `no-undef` also allows writes. To specify multiple global variables, separate them using commas, or use the option multiple times.
 
-Examples:
+##### `--global` example
 
 ```shell
 npx eslint --global require,exports:true file.js
@@ -188,11 +126,15 @@ npx eslint --global require --global exports:true
 
 This option allows you to specify a parser to be used by ESLint. By default, `espree` is used.
 
+##### `--parser` example
+
+TODO: add
+
 #### `--parser-options`
 
 This option allows you to specify parser options to be used by ESLint. Note that the available parser options are determined by the parser being used.
 
-Examples:
+##### `--parser-options` example
 
 ```shell
 echo '3 ** 4' | npx eslint --stdin --parser-options=ecmaVersion:6 # fails with a parsing error
@@ -206,6 +148,10 @@ Changes the folder where plugins are resolved from. By default, plugins are reso
 * When using a config file that is located outside of the current project (with the `--config` flag), if the config uses plugins which are installed locally to itself, `--resolve-plugins-relative-to` should be set to the directory containing the config file.
 * If an integration has dependencies on ESLint and a set of plugins, and the tool invokes ESLint on behalf of the user with a preset configuration, the tool should set `--resolve-plugins-relative-to` to the top-level directory of the tool.
 
+##### `--resolve-plugins-relative-to` example
+
+TODO: add
+
 ### Specifying rules and plugins
 
 #### `--plugin`
@@ -214,12 +160,14 @@ This option specifies a plugin to load. You can omit the prefix `eslint-plugin-`
 
 Before using the plugin, you have to install it using npm.
 
-Examples:
+##### `--plugin` example
 
 ```shell
 npx eslint --plugin jquery file.js
 npx eslint --plugin eslint-plugin-mocha file.js
 ```
+
+TODO: resume here
 
 #### `--rule`
 
@@ -227,7 +175,7 @@ This option specifies rules to be used. These rules are merged with any rules sp
 
 If the rule is defined within a plugin, you have to prefix the rule ID with the plugin name and a `/`.
 
-Examples:
+##### `--rule` example
 
 ```shell
 npx eslint --rule 'quotes: [error, double]'
@@ -241,7 +189,7 @@ npx eslint --rule 'jquery/dollar-sign: error'
 
 This option allows you to specify another directory from which to load rules files. This allows you to dynamically load new rules at run time. This is useful when you have custom rules that aren't suitable for being bundled with ESLint.
 
-Example:
+##### `--rulesdir` example
 
 ```shell
 npx eslint --rulesdir my-rules/ file.js
@@ -266,17 +214,23 @@ This option instructs ESLint to try to fix as many issues as possible. The fixes
 
 If you want to fix code from `stdin` or otherwise want to get the fixes without actually writing them to the file, use the [`--fix-dry-run`](#--fix-dry-run) option.
 
+##### `--fix` example
+
+TODO: add
+
 #### `--fix-dry-run`
 
 This option has the same effect as `--fix` with one difference: the fixes are not saved to the file system. This makes it possible to fix code from `stdin` (when used with the `--stdin` flag).
 
-Because the default formatter does not output the fixed code, you'll have to use another one (e.g. `json`) to get the fixes. Here's an example of this pattern:
+Because the default formatter does not output the fixed code, you'll have to use another one (e.g. `json`) to get the fixes.
+
+This flag can be useful for integrations (e.g. editor plugins) which need to autofix text from the command line without saving it to the filesystem.
+
+##### `--fix-dry-run` example
 
 ```shell
 getSomeText | npx eslint --stdin --fix-dry-run --format=json
 ```
-
-This flag can be useful for integrations (e.g. editor plugins) which need to autofix text from the command line without saving it to the filesystem.
 
 #### `--fix-type`
 
@@ -287,15 +241,17 @@ This option allows you to specify the type of fixes to apply when using either `
 1. `layout` - apply fixes that do not change the program structure (AST)
 1. `directive` - apply fixes to inline directives such as `// eslint-disable`
 
-You can specify one or more fix type on the command line. Here are some examples:
+You can specify one or more fix type on the command line.
+
+This option is helpful if you are using another program to format your code but you would still like ESLint to apply other types of fixes.
+
+##### `--fix-type` example
 
 ```shell
 npx eslint --fix --fix-type suggestion .
 npx eslint --fix --fix-type suggestion --fix-type problem .
 npx eslint --fix --fix-type suggestion,layout .
 ```
-
-This option is helpful if you are using another program to format your code but you would still like ESLint to apply other types of fixes.
 
 ### Ignoring files
 
@@ -305,7 +261,7 @@ This option is helpful if you are using another program to format your code but 
 
 This option allows you to specify the file to use as your `.eslintignore`. By default, ESLint looks in the current working directory for `.eslintignore`. You can override this behavior by providing a path to a different file.
 
-Example:
+##### `--ignore-path` example
 
 ```shell
 npx eslint --ignore-path tmp/.eslintignore file.js
@@ -316,7 +272,7 @@ npx eslint --ignore-path .gitignore file.js
 
 Disables excluding of files from `.eslintignore`, `--ignore-path`, `--ignore-pattern`, and `ignorePatterns` property in config files.
 
-Example:
+##### `--no-ignore` example
 
 ```shell
 npx eslint --no-ignore file.js
@@ -326,7 +282,7 @@ npx eslint --no-ignore file.js
 
 This option allows you to specify patterns of files to ignore (in addition to those in `.eslintignore`). You can repeat the option to provide multiple patterns. The supported syntax is the same as for `.eslintignore` [files](configuring/ignoring-code#the-eslintignore-file), which use the same patterns as the `.gitignore` [specification](https://git-scm.com/docs/gitignore). You should quote your patterns in order to avoid shell interpretation of glob patterns.
 
-Example:
+##### `--ignore-pattern` example
 
 ```shell
 npx eslint --ignore-pattern '/lib/' --ignore-pattern '/src/vendor/*' .
@@ -338,7 +294,7 @@ npx eslint --ignore-pattern '/lib/' --ignore-pattern '/src/vendor/*' .
 
 This option tells ESLint to read and lint source code from STDIN instead of from files. You can use this to pipe code to ESLint.
 
-Example:
+##### `--stdin` example
 
 ```shell
 cat myfile.js | npx eslint --stdin
@@ -348,7 +304,7 @@ cat myfile.js | npx eslint --stdin
 
 This option allows you to specify a filename to process STDIN as. This is useful when processing files from STDIN and you have rules which depend on the filename.
 
-Example
+##### `--stdin-filename` example
 
 ```shell
 cat myfile.js | npx eslint --stdin --stdin-filename=myfile.js
@@ -360,7 +316,7 @@ cat myfile.js | npx eslint --stdin --stdin-filename=myfile.js
 
 This option allows you to disable reporting on warnings. If you enable this option, only errors are reported by ESLint.
 
-Example:
+##### `--quiet` example
 
 ```shell
 npx eslint --quiet file.js
@@ -372,7 +328,7 @@ This option allows you to specify a warning threshold, which can be used to forc
 
 Normally, if ESLint runs and finds no errors (only warnings), it exits with a success exit status. However, if `--max-warnings` is specified and the total warning count is greater than the specified threshold, ESLint exits with an error status. To prevent this behavior, omitting this option or specifying a threshold of `-1`.
 
-Example:
+##### `--max-warnings` example
 
 ```shell
 npx eslint --max-warnings 10 file.js
@@ -384,7 +340,7 @@ npx eslint --max-warnings 10 file.js
 
 Enable report to be written to a file.
 
-Example:
+##### `--output-file` example
 
 ```shell
 npx eslint -o ./test/test.html
@@ -407,46 +363,46 @@ This option specifies the output format for the console. Possible formats are:
 * [unix](formatters/#unix)
 * [visualstudio](formatters/#visualstudio)
 
-Example:
-
-```shell
-npx eslint -f compact file.js
-```
-
 You can also use a custom formatter from the command line by specifying a path to the custom formatter file.
 
-Example:
+An npm-installed formatter is resolved with or without `eslint-formatter-` prefix.
+
+When specified, the given format is output to the console. If you'd like to save that output into a file, you can do so on the command line like so:
+
+```shell
+# Saves the output into the `results.txt` file.
+npx eslint -f compact file.js > results.txt
+```
+
+##### `--format` example
+
+Use the built-in `compact` formatter:
+
+```shell
+npx eslint --format compact file.js
+```
+
+Use a local custom formatter:
 
 ```shell
 npx eslint -f ./customformat.js file.js
 ```
 
-An npm-installed formatter is resolved with or without `eslint-formatter-` prefix.
-
-Example:
+Use npm-installed formatter:
 
 ```shell
 npm install eslint-formatter-pretty
-
+# THEN
 npx eslint -f pretty file.js
-
-// equivalent:
+# OR
 npx eslint -f eslint-formatter-pretty file.js
 ```
 
-When specified, the given format is output to the console. If you'd like to save that output into a file, you can do so on the command line like so:
-
-```shell
-npx eslint -f compact file.js > results.txt
-```
-
-This saves the output into the `results.txt` file.
-
-#### `--color`, `--no-color`
+#### `--color` and `--no-color`
 
 This option forces the enabling/disabling of colorized output. You can use this to override the default behavior, which is to enable colorized output unless no TTY is detected, such as when piping `eslint` through `cat` or `less`.
 
-Examples:
+##### `--color` and `--no-color` example
 
 ```shell
 npx eslint --color file.js | cat
@@ -469,7 +425,7 @@ config without files modifying it. All inline config comments are ignored, e.g.:
 * `// eslint-disable-line`
 * `// eslint-disable-next-line`
 
-Example:
+##### `--no-inline-config` example
 
 ```shell
 npx eslint --no-inline-config file.js
@@ -481,7 +437,7 @@ This option causes ESLint to report directive comments like `// eslint-disable-l
 
 **Warning**: When using this option, it is possible that new errors start being reported whenever ESLint or custom rules are upgraded. For example, suppose a rule has a bug that causes it to report a false positive, and an `eslint-disable` comment is added to suppress the incorrect report. If the bug is then fixed in a patch release of ESLint, the `eslint-disable` comment becomes unused since ESLint is no longer generating an incorrect report. This results in a new reported error for the unused directive if the `report-unused-disable-directives` option is used.
 
-Example:
+##### `--report-unused-disable-directives` example
 
 ```shell
 npx eslint --report-unused-disable-directives file.js
@@ -497,9 +453,15 @@ Store the info about processed files in order to only operate on the changed one
 
 **Note:** Autofixed files are not placed in the cache. Subsequent linting that does not trigger an autofix will place it in the cache.
 
+##### `--cache` example
+
+TODO: add
+
 #### `--cache-file`
 
-Path to the cache file. If none specified `.eslintcache` is used. The file is created in the directory where the `eslint` command is executed. **Deprecated**: Use `--cache-location` instead.
+**Deprecated**: Use `--cache-location` instead.
+
+Path to the cache file. If none specified `.eslintcache` is used. The file is created in the directory where the `eslint` command is executed.
 
 #### `--cache-location`
 
@@ -509,7 +471,7 @@ If a directory is specified, a cache file is created inside the specified folder
 
 **Important note:** If the directory for the cache does not exist make sure you add a trailing `/` on \*nix systems or `\` in windows. Otherwise the path is assumed to be a file.
 
-Example:
+##### `--cache-location` example
 
 ```shell
 npx eslint "src/**/*.js" --cache --cache-location "/Users/user/.eslintcache/"
@@ -521,7 +483,7 @@ Strategy for the cache to use for detecting changed files. Can be either `metada
 
 The `content` strategy can be useful in cases where the modification time of your files change even if their contents have not. For example, this can happen during git operations like git clone because git does not track file modification time.
 
-Example:
+##### `--cache-strategy` example
 
 ```shell
 npx eslint "src/**/*.js" --cache --cache-strategy content
@@ -535,36 +497,74 @@ This option runs `npm init @eslint/config` to start config initialization wizard
 
 The resulting configuration file is created in the current directory.
 
+##### `--init` example
+
+```shell
+npx eslint --init
+```
+
 #### `--env-info`
 
 This option outputs information about the execution environment, including the version of Node, npm, and local and global installations of ESLint. The ESLint team may ask for this information to help solve bugs.
+
+##### `--env-info` example
+
+```shell
+npx eslint --env-info
+```
 
 #### `--no-error-on-unmatched-pattern`
 
 This option prevents errors when a quoted glob pattern or `--ext` is unmatched. This does not prevent errors when your shell can't match a glob.
 
+##### `--no-error-on-unmatched-pattern` example
+
+TODO: add
+
 #### `--exit-on-fatal-error`
 
 This option causes ESLint to exit with exit code 2 if one or more fatal parsing errors occur. Without this option, fatal parsing errors are reported as rule violations.
 
+##### `--exit-on-fatal-error` example
+
+TODO: add
+
 #### `--debug`
 
 This option outputs debugging information to the console. This information is useful when you're seeing a problem and having a hard time pinpointing it. The ESLint team may ask for this debugging information to help solve bugs.
-Add this flag to an ESLint command line invocation in order to get extra debug information as the command is run (e.g. `npx eslint --debug test.js` and `npx eslint test.js --debug` are equivalent)
+Add this flag to an ESLint command line invocation in order to get extra debug information as the command is run.
+
+##### `--debug` example
+
+```shell
+npx eslint --debug test.js
+```
 
 #### `-h`, `--help`
 
 This option outputs the help menu, displaying all of the available options. All other options are ignored when this is present.
 
+##### `--help` example
+
+```shell
+npx eslint --help
+```
+
 #### `-v`, `--version`
 
 This option outputs the current ESLint version onto the console. All other options are ignored when this is present.
+
+##### `--version` example
+
+```shell
+npx eslint --version
+```
 
 #### `--print-config`
 
 This option outputs the configuration to be used for the file passed. When present, no linting is performed and only config-related options are valid.
 
-Example:
+##### `--print-config` example
 
 ```shell
 npx eslint --print-config file.js

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -523,9 +523,10 @@ Use an npm-installed formatter:
 
 ```shell
 npm install eslint-formatter-pretty
-# THEN
+
+# Then run one of the following commands
 npx eslint -f pretty file.js
-# OR
+# or alternatively
 npx eslint -f eslint-formatter-pretty file.js
 ```
 

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -38,7 +38,7 @@ npx eslint "lib/**"
 
 **Note:** You can also use alternative package managers such as [Yarn](https://yarnpkg.com/) or [pnpm](https://pnpm.io/) to run ESLint. Please refer to your package manager's documentation for the correct syntax.
 
-## Pass multiple values to an option
+## Pass Multiple Values to an Option
 
 Options that accept multiple values can be specified by repeating the option or with a comma-delimited list (other than [`--ignore-pattern`](#--ignore-pattern), which does not allow the second style).
 
@@ -251,7 +251,7 @@ npx eslint --config ~/personal-eslintrc.js \
 --resolve-plugins-relative-to /usr/local/lib/
 ```
 
-### Specify rules and plugins
+### Specify Rules and Plugins
 
 #### `--plugin`
 
@@ -311,7 +311,7 @@ npx eslint --rulesdir my-rules/ file.js
 npx eslint --rulesdir my-rules/ --rulesdir my-other-rules/ file.js
 ```
 
-### Fix problems
+### Fix Problems
 
 #### `--fix`
 
@@ -369,7 +369,7 @@ npx eslint --fix --fix-type suggestion --fix-type problem .
 npx eslint --fix --fix-type suggestion,layout .
 ```
 
-### Ignore files
+### Ignore Files
 
 #### `--ignore-path`
 
@@ -442,7 +442,7 @@ This is useful when processing files from STDIN and you have rules which depend 
 cat myfile.js | npx eslint --stdin --stdin-filename myfile.js
 ```
 
-### Handle warnings
+### Handle Warnings
 
 #### `--quiet`
 
@@ -754,7 +754,7 @@ This option outputs the configuration to be used for the file passed. When prese
 npx eslint --print-config file.js
 ```
 
-## Exit codes
+## Exit Codes
 
 When linting files, ESLint exits with one of the following exit codes:
 

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -179,7 +179,7 @@ This option allows you to specify which file extensions ESLint uses when searchi
 * **Multiple Arguments**: Yes
 * **Default Value**: `.js` and the files that match the `overrides` entries of your configuration.
 
-`--ext` is only used when the arguments are directories. If you use glob patterns or file names, then `--ext` is ignored. For example, `npx eslint lib/* --ext .js` matches all files within the `lib/` directory, regardless of extension.
+`--ext` is only used when the the patterns to lint are directories. If you use glob patterns or file names, then `--ext` is ignored. For example, `npx eslint lib/* --ext .js` matches all files within the `lib/` directory, regardless of extension.
 
 ##### `--ext` example
 

--- a/docs/src/user-guide/command-line-interface.md
+++ b/docs/src/user-guide/command-line-interface.md
@@ -58,15 +58,22 @@ npx eslint --ext .jsx,.js lib/
 
 Disables use of configuration from `.eslintrc.*` and `package.json` files.
 
+* **Argument Type**: No argument
+
 ##### `--no-eslintrc` example
 
 ```shell
 npx eslint --no-eslintrc file.js
 ```
 
-#### `-c`, `--config`
+#### `--config`
 
 This option allows you to specify an additional configuration file for ESLint (see [Configuring ESLint](configuring/) for more).
+
+* **Alias**: `-c`
+* **Argument Type**: String. File name.
+* **Multiple Arguments**: No
+* **Default Value**: N/A
 
 ##### `--config` example
 
@@ -80,7 +87,12 @@ If `.eslintrc.*` and/or `package.json` files are also used for configuration (i.
 
 #### `--env`
 
-This option enables specific environments. Details about the global variables defined by each environment are available on the [Specifying Environments](configuring/language-options#specifying-environments) documentation. This option only enables environments; it does not disable environments set in other configuration files. To specify multiple environments, separate them using commas, or use the option multiple times.
+This option enables specific environments.
+
+* **Argument Type**: String. One of the available environments.
+* **Multiple Arguments**: Yes
+
+Details about the global variables defined by each environment are available on the [Specifying Environments](configuring/language-options#specifying-environments) documentation. This option only enables environments; it does not disable environments set in other configuration files. To specify multiple environments, separate them using commas, or use the option multiple times.
 
 ##### `--env` example
 
@@ -92,7 +104,12 @@ npx eslint --env browser --env node file.js
 #### `--ext`
 
 This option allows you to specify which file extensions ESLint uses when searching for target files in the directories you specify.
-By default, ESLint lints `*.js` files and the files that match the `overrides` entries of your configuration.
+
+* **Argument Type**: String. File glob pattern.
+* **Multiple Arguments**: Yes
+* **Default Value**: `*.js` and the files that match the `overrides` entries of your configuration.
+
+`--ext` is only used when the arguments are directories. If you use glob patterns or file names, then `--ext` is ignored. For example, `npx eslint lib/* --ext .js` matches all files within the `lib/` directory, regardless of extension.
 
 ##### `--ext` example
 
@@ -107,13 +124,12 @@ npx eslint . --ext .js --ext .ts
 npx eslint . --ext .js,.ts
 ```
 
-**Note:** `--ext` is only used when the arguments are directories. If you use glob patterns or file names, then `--ext` is ignored.
-
-For example, `npx eslint lib/* --ext .js` matches all files within the `lib/` directory, regardless of extension.
-
 #### `--global`
 
-This option defines global variables so that they are not  flagged as undefined by the `no-undef` rule. Any specified global variables are assumed to be read-only by default, but appending `:true` to a variable's name ensures that `no-undef` also allows writes. To specify multiple global variables, separate them using commas, or use the option multiple times.
+This option defines global variables so that they are not  flagged as undefined by the [`no-undef`](../rules/no-undef) rule.
+
+* **Argument Type**: String. Name of global variable. Any specified global variables are assumed to be read-only by default, but appending `:true` to a variable's name ensures that `no-undef` also allows writes.
+* **Multiple Arguments**: Yes
 
 ##### `--global` example
 
@@ -124,7 +140,11 @@ npx eslint --global require --global exports:true
 
 #### `--parser`
 
-This option allows you to specify a parser to be used by ESLint. By default, `espree` is used.
+This option allows you to specify a parser to be used by ESLint.
+
+* **Argument Type**: String. Parser to be used by ESLint.
+* **Multiple Arguments**: No
+* **Default Value**: `espree`
 
 ##### `--parser` example
 
@@ -132,7 +152,10 @@ TODO: add
 
 #### `--parser-options`
 
-This option allows you to specify parser options to be used by ESLint. Note that the available parser options are determined by the parser being used.
+This option allows you to specify parser options to be used by ESLint. The available parser options are determined by the parser being used.
+
+* **Argument Type**: Key/Value pair. Separated by colon (`:`).
+* **Multiple Arguments**: Yes
 
 ##### `--parser-options` example
 
@@ -143,7 +166,15 @@ echo '3 ** 4' | npx eslint --stdin --parser-options=ecmaVersion:7 # succeeds, ya
 
 #### `--resolve-plugins-relative-to`
 
-Changes the folder where plugins are resolved from. By default, plugins are resolved from the current working directory. This option should be used when plugins were installed by someone other than the end user. It should be set to the project directory of the project that has a dependency on the necessary plugins. For example:
+Changes the folder where plugins are resolved from.
+
+* **Argument Type**: File path.
+* **Multiple Arguments**: No
+* **Default Value**: By default, plugins are resolved from the current working directory.
+
+ This option should be used when plugins were installed by someone other than the end user. It should be set to the project directory of the project that has a dependency on the necessary plugins.
+
+For example:
 
 * When using a config file that is located outside of the current project (with the `--config` flag), if the config uses plugins which are installed locally to itself, `--resolve-plugins-relative-to` should be set to the directory containing the config file.
 * If an integration has dependencies on ESLint and a set of plugins, and the tool invokes ESLint on behalf of the user with a preset configuration, the tool should set `--resolve-plugins-relative-to` to the top-level directory of the tool.
@@ -152,11 +183,14 @@ Changes the folder where plugins are resolved from. By default, plugins are reso
 
 TODO: add
 
-### Specifying rules and plugins
+### Specify rules and plugins
 
 #### `--plugin`
 
 This option specifies a plugin to load. You can omit the prefix `eslint-plugin-` from the plugin name.
+
+* **Argument Type**: String. Plugin name.
+* **Multiple Arguments**: Yes
 
 Before using the plugin, you have to install it using npm.
 
@@ -167,13 +201,14 @@ npx eslint --plugin jquery file.js
 npx eslint --plugin eslint-plugin-mocha file.js
 ```
 
-TODO: resume here
-
 #### `--rule`
 
-This option specifies rules to be used. These rules are merged with any rules specified with configuration files. (You can use `--no-eslintrc` to change that behavior.) To define multiple rules, separate them using commas, or use the option multiple times. The [levn](https://github.com/gkz/levn#levn--) format is used for specifying the rules.
+This option specifies rules to be used.
 
-If the rule is defined within a plugin, you have to prefix the rule ID with the plugin name and a `/`.
+* **Argument Type**: Rules and their configuration specified with [levn](https://github.com/gkz/levn#levn--) format.
+* **Multiple Arguments**: Yes
+
+These rules are merged with any rules specified with configuration files. If the rule is defined within a plugin, you have to prefix the rule ID with the plugin name and a `/`.
 
 ##### `--rule` example
 
@@ -189,25 +224,30 @@ npx eslint --rule 'jquery/dollar-sign: error'
 
 This option allows you to specify another directory from which to load rules files. This allows you to dynamically load new rules at run time. This is useful when you have custom rules that aren't suitable for being bundled with ESLint.
 
+The rules in your custom rules directory must follow the same format as bundled rules to work properly. You can also specify multiple locations for custom rules by including multiple `--rulesdir` options.
+
+Note that, as with core rules and plugin rules, you still need to enable the rules in configuration or via the `--rule` CLI option in order to actually run those rules during linting. Specifying a rules directory with `--rulesdir` does not automatically enable the rules within that directory.
+
 ##### `--rulesdir` example
 
 ```shell
 npx eslint --rulesdir my-rules/ file.js
-```
-
-The rules in your custom rules directory must follow the same format as bundled rules to work properly. You can also specify multiple locations for custom rules by including multiple `--rulesdir` options:
-
-```shell
 npx eslint --rulesdir my-rules/ --rulesdir my-other-rules/ file.js
 ```
 
-Note that, as with core rules and plugin rules, you still need to enable the rules in configuration or via the `--rule` CLI option in order to actually run those rules during linting. Specifying a rules directory with `--rulesdir` does not automatically enable the rules within that directory.
-
-### Fixing problems
+### Fix problems
 
 #### `--fix`
 
-This option instructs ESLint to try to fix as many issues as possible. The fixes are made to the actual files themselves and only the remaining unfixed issues are output. Not all problems are fixable using this option, and the option does not work in these situations:
+This option instructs ESLint to try to fix as many issues as possible. The fixes are made to the actual files themselves and only the remaining unfixed issues are output.
+
+TODO: test out this flag and see what is needed here
+
+* **Alias**: `-fn`
+* **Argument Type**: Data type. Short description. If no data type, put 'No argument'
+* **Multiple Arguments**: Yes/No
+
+Not all problems are fixable using this option, and the option does not work in these situations:
 
 1. This option throws an error when code is piped to ESLint.
 1. This option has no effect on code that uses a processor, unless the processor opts into allowing autofixes.
@@ -220,28 +260,30 @@ TODO: add
 
 #### `--fix-dry-run`
 
-This option has the same effect as `--fix` with one difference: the fixes are not saved to the file system. This makes it possible to fix code from `stdin` (when used with the `--stdin` flag).
+This option has the same effect as `--fix` with the difference that the fixes are not saved to the file system. Because the default formatter does not output the fixed code, you'll have to use another formatter (e.g. `--format json`) to get the fixes.
 
-Because the default formatter does not output the fixed code, you'll have to use another one (e.g. `json`) to get the fixes.
+* **Argument Type**: No argument
+
+This makes it possible to fix code from `stdin` when used with the `--stdin` flag.
 
 This flag can be useful for integrations (e.g. editor plugins) which need to autofix text from the command line without saving it to the filesystem.
 
 ##### `--fix-dry-run` example
 
 ```shell
-getSomeText | npx eslint --stdin --fix-dry-run --format=json
+getSomeText | npx eslint --stdin --fix-dry-run --format json
 ```
 
 #### `--fix-type`
 
-This option allows you to specify the type of fixes to apply when using either `--fix` or `--fix-dry-run`. The four types of fixes are:
+This option allows you to specify the type of fixes to apply when using either `--fix` or `--fix-dry-run`.
 
-1. `problem` - fix potential errors in the code
-1. `suggestion` - apply fixes to the code that improve it
-1. `layout` - apply fixes that do not change the program structure (AST)
-1. `directive` - apply fixes to inline directives such as `// eslint-disable`
-
-You can specify one or more fix type on the command line.
+* **Argument Type**: String. One of the following fix types:
+  1. `problem` - fix potential errors in the code
+  1. `suggestion` - apply fixes to the code that improve it
+  1. `layout` - apply fixes that do not change the program structure (AST)
+  1. `directive` - apply fixes to inline directives such as `// eslint-disable`
+* **Multiple Arguments**: Yes
 
 This option is helpful if you are using another program to format your code but you would still like ESLint to apply other types of fixes.
 
@@ -253,13 +295,17 @@ npx eslint --fix --fix-type suggestion --fix-type problem .
 npx eslint --fix --fix-type suggestion,layout .
 ```
 
-### Ignoring files
+### Ignore files
 
 #### `--ignore-path`
 
-**Note:** `--ignore-path` is not supported when using flat config (`eslint.config.js`).
+This option allows you to specify the file to use as your `.eslintignore`.
 
-This option allows you to specify the file to use as your `.eslintignore`. By default, ESLint looks in the current working directory for `.eslintignore`. You can override this behavior by providing a path to a different file.
+* **Argument Type**: String. Path to file.
+* **Multiple Arguments**: No
+* **Default Value**:  By default, ESLint looks in the current working directory for `.eslintignore`.
+
+**Note:** `--ignore-path` is not supported when using [flat configuration](./configuring/configuration-files-new) (`eslint.config.js`).
 
 ##### `--ignore-path` example
 
@@ -272,6 +318,8 @@ npx eslint --ignore-path .gitignore file.js
 
 Disables excluding of files from `.eslintignore`, `--ignore-path`, `--ignore-pattern`, and `ignorePatterns` property in config files.
 
+* **Argument Type**: No argument.
+
 ##### `--no-ignore` example
 
 ```shell
@@ -280,7 +328,11 @@ npx eslint --no-ignore file.js
 
 #### `--ignore-pattern`
 
-This option allows you to specify patterns of files to ignore (in addition to those in `.eslintignore`). You can repeat the option to provide multiple patterns. The supported syntax is the same as for `.eslintignore` [files](configuring/ignoring-code#the-eslintignore-file), which use the same patterns as the `.gitignore` [specification](https://git-scm.com/docs/gitignore). You should quote your patterns in order to avoid shell interpretation of glob patterns.
+This option allows you to specify patterns of files to ignore (in addition to those in `.eslintignore`).
+
+* **Argument Type**: String. The supported syntax is the same as for `.eslintignore` [files](configuring/ignoring-code#the-eslintignore-file), which use the same patterns as the `.gitignore` [specification](https://git-scm.com/docs/gitignore). You should quote your patterns in order to avoid shell interpretation of glob patterns.
+* **Multiple Arguments**: Yes
+* **Default Value**: whatever the default value is OR N/A
 
 ##### `--ignore-pattern` example
 
@@ -288,11 +340,13 @@ This option allows you to specify patterns of files to ignore (in addition to th
 npx eslint --ignore-pattern '/lib/' --ignore-pattern '/src/vendor/*' .
 ```
 
-### Using stdin
+### Use stdin
 
 #### `--stdin`
 
 This option tells ESLint to read and lint source code from STDIN instead of from files. You can use this to pipe code to ESLint.
+
+* **Argument Type**: No argument.
 
 ##### `--stdin` example
 
@@ -302,19 +356,26 @@ cat myfile.js | npx eslint --stdin
 
 #### `--stdin-filename`
 
-This option allows you to specify a filename to process STDIN as. This is useful when processing files from STDIN and you have rules which depend on the filename.
+This option allows you to specify a filename to process STDIN as.
+
+* **Argument Type**: String. File name.
+* **Multiple Arguments**: No
+
+This is useful when processing files from STDIN and you have rules which depend on the filename.
 
 ##### `--stdin-filename` example
 
 ```shell
-cat myfile.js | npx eslint --stdin --stdin-filename=myfile.js
+cat myfile.js | npx eslint --stdin --stdin-filename myfile.js
 ```
 
-### Handling warnings
+### Handle warnings
 
 #### `--quiet`
 
 This option allows you to disable reporting on warnings. If you enable this option, only errors are reported by ESLint.
+
+* **Argument Type**: No argument.
 
 ##### `--quiet` example
 
@@ -326,7 +387,10 @@ npx eslint --quiet file.js
 
 This option allows you to specify a warning threshold, which can be used to force ESLint to exit with an error status if there are too many warning-level rule violations in your project.
 
-Normally, if ESLint runs and finds no errors (only warnings), it exits with a success exit status. However, if `--max-warnings` is specified and the total warning count is greater than the specified threshold, ESLint exits with an error status. To prevent this behavior, omitting this option or specifying a threshold of `-1`.
+* **Argument Type**: Integer. Maximum number of warnings to allow. To prevent this behavior, do not use this option or specify `-1` as the argument.
+* **Multiple Arguments**: No
+
+Normally, if ESLint runs and finds no errors (only warnings), it exits with a success exit status. However, if `--max-warnings` is specified and the total warning count is greater than the specified threshold, ESLint exits with an error status.
 
 ##### `--max-warnings` example
 
@@ -336,9 +400,13 @@ npx eslint --max-warnings 10 file.js
 
 ### Output
 
-#### `-o`, `--output-file`
+#### `--output-file`
 
-Enable report to be written to a file.
+Write output of linting results to a specified file.
+
+* **Alias**: `-o`
+* **Argument Type**: String. Path to file.
+* **Multiple Arguments**: No
 
 ##### `--output-file` example
 
@@ -346,24 +414,15 @@ Enable report to be written to a file.
 npx eslint -o ./test/test.html
 ```
 
-When specified, the given format is output into the provided file name.
+#### ``--format`
 
-#### `-f`, `--format`
+This option specifies the output format for the console.
 
-This option specifies the output format for the console. Possible formats are:
+* **Alias**: `-f`
+* **Argument Type**: String. One of the [built-in formatters](formatters) or a custom formatter.
+* **Default Value**: [`stylish`](formatters/#stylish)
 
-* [checkstyle](formatters/#checkstyle)
-* [compact](formatters/#compact)
-* [html](formatters/#html)
-* [jslint-xml](formatters/#jslint-xml)
-* [json](formatters/#json)
-* [junit](formatters/#junit)
-* [stylish](formatters/#stylish) (the default)
-* [tap](formatters/#tap)
-* [unix](formatters/#unix)
-* [visualstudio](formatters/#visualstudio)
-
-You can also use a custom formatter from the command line by specifying a path to the custom formatter file.
+If you are using a custom formatter defined in a local file, you can specify the path to the custom formatter file.
 
 An npm-installed formatter is resolved with or without `eslint-formatter-` prefix.
 
@@ -400,7 +459,11 @@ npx eslint -f eslint-formatter-pretty file.js
 
 #### `--color` and `--no-color`
 
-This option forces the enabling/disabling of colorized output. You can use this to override the default behavior, which is to enable colorized output unless no TTY is detected, such as when piping `eslint` through `cat` or `less`.
+These options forces the enabling/disabling of colorized output.
+
+* **Argument Type**: No argument.
+
+You can use these options to override the default behavior, which is to enable colorized output unless no TTY is detected, such as when piping `eslint` through `cat` or `less`.
 
 ##### `--color` and `--no-color` example
 
@@ -414,8 +477,11 @@ npx eslint --no-color file.js
 #### `--no-inline-config`
 
 This option prevents inline comments like `/*eslint-disable*/` or
-`/*global foo*/` from having any effect. This allows you to set an ESLint
-config without files modifying it. All inline config comments are ignored, e.g.:
+`/*global foo*/` from having any effect.
+
+* **Argument Type**: No argument.
+
+This allows you to set an ESLint config without files modifying it. All inline config comments are ignored, such as:
 
 * `/*eslint-disable*/`
 * `/*eslint-enable*/`
@@ -433,9 +499,17 @@ npx eslint --no-inline-config file.js
 
 #### `--report-unused-disable-directives`
 
-This option causes ESLint to report directive comments like `// eslint-disable-line` when no errors would have been reported on that line anyway. This can be useful to prevent future errors from unexpectedly being suppressed, by cleaning up old `eslint-disable` comments which are no longer applicable.
+This option causes ESLint to report directive comments like `// eslint-disable-line` when no errors would have been reported on that line anyway.
 
-**Warning**: When using this option, it is possible that new errors start being reported whenever ESLint or custom rules are upgraded. For example, suppose a rule has a bug that causes it to report a false positive, and an `eslint-disable` comment is added to suppress the incorrect report. If the bug is then fixed in a patch release of ESLint, the `eslint-disable` comment becomes unused since ESLint is no longer generating an incorrect report. This results in a new reported error for the unused directive if the `report-unused-disable-directives` option is used.
+* **Argument Type**: No argument.
+
+This can be useful to prevent future errors from unexpectedly being suppressed, by cleaning up old `eslint-disable` comments which are no longer applicable.
+
+::: warning
+When using this option, it is possible that new errors start being reported whenever ESLint or custom rules are upgraded.
+
+For example, suppose a rule has a bug that causes it to report a false positive, and an `eslint-disable` comment is added to suppress the incorrect report. If the bug is then fixed in a patch release of ESLint, the `eslint-disable` comment becomes unused since ESLint is no longer generating an incorrect report. This results in a new reported error for the unused directive if the `report-unused-disable-directives` option is used.
+:::
 
 ##### `--report-unused-disable-directives` example
 
@@ -447,15 +521,20 @@ npx eslint --report-unused-disable-directives file.js
 
 #### `--cache`
 
-Store the info about processed files in order to only operate on the changed ones. The cache is stored in `.eslintcache` by default. Enabling this option can dramatically improve ESLint's running time by ensuring that only changed files are linted.
+Store the info about processed files in order to only operate on the changed ones. Enabling this option can dramatically improve ESLint's running time by ensuring that only changed files are linted.
+The cache is stored in `.eslintcache` by default.
 
-**Note:** If you run ESLint with `--cache` and then run ESLint without `--cache`, the `.eslintcache` file will be deleted. This is necessary because the results of the lint might change and make `.eslintcache` invalid. If you want to control when the cache file is deleted, then use `--cache-location` to specify an alternate location for the cache file.
+* **Argument Type**: No argument.
 
-**Note:** Autofixed files are not placed in the cache. Subsequent linting that does not trigger an autofix will place it in the cache.
+If you run ESLint with `--cache` and then run ESLint without `--cache`, the `.eslintcache` file will be deleted. This is necessary because the results of the lint might change and make `.eslintcache` invalid. If you want to control when the cache file is deleted, then use `--cache-location` to specify an alternate location for the cache file.
+
+Autofixed files are not placed in the cache. Subsequent linting that does not trigger an autofix will place it in the cache.
 
 ##### `--cache` example
 
-TODO: add
+```shell
+npx eslint --cache file.js
+```
 
 #### `--cache-file`
 
@@ -465,11 +544,13 @@ Path to the cache file. If none specified `.eslintcache` is used. The file is cr
 
 #### `--cache-location`
 
-Path to the cache location. Can be a file or a directory. If no location is specified, `.eslintcache` is used. In that case, the file is created in the directory where the `eslint` command is executed.
+Specify the path to the cache location. Can be a file or a directory.
 
-If a directory is specified, a cache file is created inside the specified folder. The name of the file is based on the hash of the current working directory (CWD). e.g.: `.cache_hashOfCWD`
+* **Argument Type**: String. Path to file or directory. If a directory is specified, a cache file is created inside the specified folder. The name of the file is based on the hash of the current working directory, e.g.: `.cache_hashOfCWD`.
+* **Multiple Arguments**: No
+* **Default Value**: If no location is specified, `.eslintcache` is used. The file is created in the directory where the `eslint` command is executed.
 
-**Important note:** If the directory for the cache does not exist make sure you add a trailing `/` on \*nix systems or `\` in windows. Otherwise the path is assumed to be a file.
+If the directory for the cache does not exist make sure you add a trailing `/` on \*nix systems or `\` in windows. Otherwise the path is assumed to be a file.
 
 ##### `--cache-location` example
 
@@ -479,9 +560,15 @@ npx eslint "src/**/*.js" --cache --cache-location "/Users/user/.eslintcache/"
 
 #### `--cache-strategy`
 
-Strategy for the cache to use for detecting changed files. Can be either `metadata` or `content`. If no strategy is specified, `metadata` is used.
+Strategy for the cache to use for detecting changed files.
 
-The `content` strategy can be useful in cases where the modification time of your files change even if their contents have not. For example, this can happen during git operations like git clone because git does not track file modification time.
+* **Argument Type**: String. One of the following values:
+  1. `metadata`
+  1. `content
+* **Multiple Arguments**: No
+* **Default Value**: `metadata`
+
+The `content` strategy can be useful in cases where the modification time of your files change even if their contents have not. For example, this can happen during git operations like `git clone` because git does not track file modification time.
 
 ##### `--cache-strategy` example
 
@@ -493,7 +580,9 @@ npx eslint "src/**/*.js" --cache --cache-strategy content
 
 #### `--init`
 
-This option runs `npm init @eslint/config` to start config initialization wizard. It's designed to help new users quickly create .eslintrc file by answering a few questions, choosing a popular style guide.
+This option runs `npm init @eslint/config` to start config initialization wizard. It's designed to help new users quickly create `.eslintrc` file by answering a few questions. When you use this flag, the CLI does not perform linting.
+
+* **Argument Type**: No argument.
 
 The resulting configuration file is created in the current directory.
 
@@ -505,7 +594,9 @@ npx eslint --init
 
 #### `--env-info`
 
-This option outputs information about the execution environment, including the version of Node, npm, and local and global installations of ESLint. The ESLint team may ask for this information to help solve bugs.
+TODO: Resume here
+
+This option outputs information about the execution environment, including the version of Node, npm, and local and global installations of ESLint. The ESLint team may ask for this information to help solve bugs. When you use this flag, the CLI does not perform linting.
 
 ##### `--env-info` example
 
@@ -542,7 +633,7 @@ npx eslint --debug test.js
 
 #### `-h`, `--help`
 
-This option outputs the help menu, displaying all of the available options. All other options are ignored when this is present.
+This option outputs the help menu, displaying all of the available options. All other options are ignored when this is present. When you use this flag, the CLI does not perform linting.
 
 ##### `--help` example
 
@@ -552,7 +643,7 @@ npx eslint --help
 
 #### `-v`, `--version`
 
-This option outputs the current ESLint version onto the console. All other options are ignored when this is present.
+This option outputs the current ESLint version onto the console. All other options are ignored when this is present. When you use this flag, the CLI does not perform linting.
 
 ##### `--version` example
 
@@ -562,7 +653,7 @@ npx eslint --version
 
 #### `--print-config`
 
-This option outputs the configuration to be used for the file passed. When present, no linting is performed and only config-related options are valid.
+This option outputs the configuration to be used for the file passed. When present, no linting is performed and only config-related options are valid. When you use this flag, the CLI does not perform linting.
 
 ##### `--print-config` example
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -177,7 +177,7 @@ module.exports = function(usingFlatConfig) {
             },
             resolvePluginsFlag,
             {
-                heading: "Specifying rules and plugins"
+                heading: "Specify rules and plugins"
             },
             {
                 option: "plugin",
@@ -191,7 +191,7 @@ module.exports = function(usingFlatConfig) {
             },
             rulesDirFlag,
             {
-                heading: "Fixing problems"
+                heading: "Fix problems"
             },
             {
                 option: "fix",
@@ -211,7 +211,7 @@ module.exports = function(usingFlatConfig) {
                 description: "Specify the types of fixes to apply (directive, problem, suggestion, layout)"
             },
             {
-                heading: "Ignoring files"
+                heading: "Ignore files"
             },
             ignorePathFlag,
             {
@@ -229,7 +229,7 @@ module.exports = function(usingFlatConfig) {
                 }]
             },
             {
-                heading: "Using stdin"
+                heading: "Use stdin"
             },
             {
                 option: "stdin",
@@ -243,7 +243,7 @@ module.exports = function(usingFlatConfig) {
                 description: "Specify filename to process STDIN as"
             },
             {
-                heading: "Handling warnings"
+                heading: "Handle warnings"
             },
             {
                 option: "quiet",

--- a/lib/options.js
+++ b/lib/options.js
@@ -177,7 +177,7 @@ module.exports = function(usingFlatConfig) {
             },
             resolvePluginsFlag,
             {
-                heading: "Specify rules and plugins"
+                heading: "Specify Rules and Plugins"
             },
             {
                 option: "plugin",
@@ -191,7 +191,7 @@ module.exports = function(usingFlatConfig) {
             },
             rulesDirFlag,
             {
-                heading: "Fix problems"
+                heading: "Fix Problems"
             },
             {
                 option: "fix",
@@ -211,7 +211,7 @@ module.exports = function(usingFlatConfig) {
                 description: "Specify the types of fixes to apply (directive, problem, suggestion, layout)"
             },
             {
-                heading: "Ignore files"
+                heading: "Ignore Files"
             },
             ignorePathFlag,
             {
@@ -243,7 +243,7 @@ module.exports = function(usingFlatConfig) {
                 description: "Specify filename to process STDIN as"
             },
             {
-                heading: "Handle warnings"
+                heading: "Handle Warnings"
             },
             {
                 option: "quiet",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Standardized the documentation for CLI commands.

Used the general format: 

````md
#### ``--my-option`

Short description of option 
* **Alias**: If applicable add short command alias (ex: `-mo`)
* **Argument Type**:  "No Argument." or argument data type and short description as necessary.
**Multiple Arguments**: "Yes"/"No". If argument type specified, add this saying whether it takes multiple arguments or not.
* **Default Value**: Add default value for command if applicable.

Additional guidance for usage.

##### `--my-option` example

Description of example, if necessary.

```shell
npx eslint ...example of command usage
```

````

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

Resolves https://github.com/eslint/eslint/issues/16475
