### PR TITLE
fix: Ensure flat config unignores work consistently like eslintrc

### DIFF
--- a/lib/config/default-config.js
+++ b/lib/config/default-config.js
@@ -51,7 +51,7 @@ exports.defaultConfig = [
     // default ignores are listed here
     {
         ignores: [
-            "**/node_modules/**",
+            "**/node_modules/*",
             ".git/"
         ]
     },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
     "@eslint/eslintrc": "^1.3.3",
-    "@humanwhocodes/config-array": "0.11.7",
+    "@humanwhocodes/config-array": "^0.11.8",
     "@humanwhocodes/module-importer": "^1.0.1",
     "@nodelib/fs.walk": "^1.2.8",
     "ajv": "^6.10.0",

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -4501,17 +4501,10 @@ describe("FlatESLint", () => {
             });
         });
 
-
-        /*
-         * These tests fail due to a bug in fast-glob that doesn't allow
-         * negated patterns inside of ignores. These tests won't work until
-         * this bug is fixed:
-         * https://github.com/mrmlnc/fast-glob/issues/356
-         */
-        xdescribe("ignorePatterns can unignore '/node_modules/foo'.", () => {
+        describe("ignores can unignore '/node_modules/foo'.", () => {
 
             const { prepare, cleanup, getPath } = createCustomTeardown({
-                cwd: root,
+                cwd: `${root}-unignores`,
                 files: {
                     "eslint.config.js": `module.exports = {
                         ignores: ["!**/node_modules/foo/**"]
@@ -4551,16 +4544,17 @@ describe("FlatESLint", () => {
                     .sort();
 
                 assert.deepStrictEqual(filePaths, [
-                    path.join(root, "eslint.config.js"),
-                    path.join(root, "foo.js"),
-                    path.join(root, "node_modules/foo/index.js")
+                    path.join(getPath(), "eslint.config.js"),
+                    path.join(getPath(), "foo.js"),
+                    path.join(getPath(), "node_modules/foo/.dot.js"),
+                    path.join(getPath(), "node_modules/foo/index.js")
                 ]);
             });
         });
 
-        xdescribe("ignore pattern can re-ignore files that are unignored by a previous pattern.", () => {
+        describe("ignore pattern can re-ignore files that are unignored by a previous pattern.", () => {
             const { prepare, cleanup, getPath } = createCustomTeardown({
-                cwd: root,
+                cwd: `${root}-reignore`,
                 files: {
                     "eslint.config.js": `module.exports = ${JSON.stringify({
                         ignores: ["!.*", ".foo*"]
@@ -4592,15 +4586,15 @@ describe("FlatESLint", () => {
                     .sort();
 
                 assert.deepStrictEqual(filePaths, [
-                    path.join(root, ".bar.js"),
-                    path.join(root, "eslint.config.js")
+                    path.join(getPath(), ".bar.js"),
+                    path.join(getPath(), "eslint.config.js")
                 ]);
             });
         });
 
-        xdescribe("ignore pattern can unignore files that are ignored by a previous pattern.", () => {
+        describe("ignore pattern can unignore files that are ignored by a previous pattern.", () => {
             const { prepare, cleanup, getPath } = createCustomTeardown({
-                cwd: root,
+                cwd: `${root}-dignore`,
                 files: {
                     "eslint.config.js": `module.exports = ${JSON.stringify({
                         ignores: ["**/*.js", "!foo.js"]
@@ -4632,7 +4626,7 @@ describe("FlatESLint", () => {
                     .sort();
 
                 assert.deepStrictEqual(filePaths, [
-                    path.join(root, "foo.js")
+                    path.join(getPath(), "foo.js")
                 ]);
             });
         });
@@ -5033,17 +5027,17 @@ describe("FlatESLint", () => {
             });
         });
 
-        // dependent on https://github.com/mrmlnc/fast-glob/issues/86
-        xdescribe("if { ignores: 'foo/*.js', ... } is present by '--config node_modules/myconf/eslint.config.js',", () => {
+        describe("if { ignores: 'foo/*.js', ... } is present by '--config node_modules/myconf/eslint.config.js',", () => {
             const { prepare, cleanup, getPath } = createCustomTeardown({
                 cwd: `${root}a3`,
                 files: {
-                    "node_modules/myconf/eslint.config.js": `module.exports = {
-                        ignores: ["**/eslint.config.js", "!node_modules/myconf", "foo/*.js"],
+                    "node_modules/myconf/eslint.config.js": `module.exports = [{
+                        ignores: ["!node_modules/myconf", "foo/*.js"],
+                    }, {
                         rules: {
                             eqeqeq: "error"
                         }
-                    }`,
+                    }]`,
                     "node_modules/myconf/foo/test.js": "a == b",
                     "foo/test.js": "a == b"
                 }
@@ -5052,7 +5046,7 @@ describe("FlatESLint", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'lintFiles()' with '**/*.js' should iterate 'node_modules/myconf/foo/test.js' but not 'foo/test.js'.", async () => {
+            it("'lintFiles()' with '**/*.js' should lint 'node_modules/myconf/foo/test.js' but not 'foo/test.js'.", async () => {
                 const engine = new FlatESLint({
                     overrideConfigFile: "node_modules/myconf/eslint.config.js",
                     cwd: getPath()
@@ -5062,6 +5056,7 @@ describe("FlatESLint", () => {
                     .sort();
 
                 assert.deepStrictEqual(files, [
+                    path.join(getPath(), "node_modules/myconf/eslint.config.js"),
                     path.join(getPath(), "node_modules/myconf/foo/test.js")
                 ]);
             });


### PR DESCRIPTION
We have several tests that were ignored back when we were waiting for fast-glob fixes. Because we no longer use fast-glob, the tests now work.

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Test updates

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

There were several tests that we were ignoring for `FlatESLint` due to bugs in `fast-glob`. Now that we no longer use `fast-glob`, we can make these tests run.

#### Is there anything you'd like reviewers to focus on?

I changed the last test a bit because `ignores` works a bit differently than `ignorePatterns` did. Please double-check that change.

<!-- markdownlint-disable-file MD004 -->
