### PR TITLE
fix: In no-invalid-regexp, validate flags also for non-literal patterns

### DIFF
--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -60,6 +60,20 @@ module.exports = {
         }
 
         /**
+         * Reports error with the provided message.
+         * @param {ASTNode} node The node holding the invalid RegExp
+         * @param {string} message The message to report.
+         * @returns {void}
+         */
+        function report(node, message) {
+            context.report({
+                node,
+                messageId: "regexMessage",
+                data: { message }
+            });
+        }
+
+        /**
          * Check if node is a string
          * @param {ASTNode} node node to evaluate
          * @returns {boolean} True if its a string
@@ -108,10 +122,13 @@ module.exports = {
 
         /**
          * Check syntax error in a given flags.
-         * @param {string} flags The RegExp flags to validate.
+         * @param {string|null} flags The RegExp flags to validate.
          * @returns {string|null} The syntax error.
          */
         function validateRegExpFlags(flags) {
+            if (!flags) {
+                return null;
+            }
             try {
                 validator.validateFlags(flags);
                 return null;
@@ -122,34 +139,39 @@ module.exports = {
 
         return {
             "CallExpression, NewExpression"(node) {
-                if (node.callee.type !== "Identifier" || node.callee.name !== "RegExp" || !isString(node.arguments[0])) {
+                if (node.callee.type !== "Identifier" || node.callee.name !== "RegExp") {
                     return;
                 }
-                const pattern = node.arguments[0].value;
+
                 let flags = getFlags(node);
 
                 if (flags && allowedFlags) {
                     flags = flags.replace(allowedFlags, "");
                 }
 
-                const message =
-                    (
-                        flags && validateRegExpFlags(flags)
-                    ) ||
-                    (
-
-                        // If flags are unknown, report the regex only if its pattern is invalid both with and without the "u" flag
-                        flags === null
-                            ? validateRegExpPattern(pattern, true) && validateRegExpPattern(pattern, false)
-                            : validateRegExpPattern(pattern, flags.includes("u"))
-                    );
+                let message = validateRegExpFlags(flags);
 
                 if (message) {
-                    context.report({
-                        node,
-                        messageId: "regexMessage",
-                        data: { message }
-                    });
+                    report(node, message);
+                    return;
+                }
+
+                if (!isString(node.arguments[0])) {
+                    return;
+                }
+
+                const pattern = node.arguments[0].value;
+
+                message = (
+
+                    // If flags are unknown, report the regex only if its pattern is invalid both with and without the "u" flag
+                    flags === null
+                        ? validateRegExpPattern(pattern, true) && validateRegExpPattern(pattern, false)
+                        : validateRegExpPattern(pattern, flags.includes("u"))
+                );
+
+                if (message) {
+                    report(node, message);
                 }
             }
         };

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -57,6 +57,12 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a"] }]
         },
 
+        // unknown pattern
+        "new RegExp(pattern, 'g')",
+        "new RegExp('.' + '', 'g')",
+        "new RegExp(pattern, '')",
+        "new RegExp(pattern)",
+
         // ES2020
         "new RegExp('(?<\\\\ud835\\\\udc9c>.)', 'g')",
         "new RegExp('(?<\\\\u{1d49c}>.)', 'g')",
@@ -85,6 +91,14 @@ ruleTester.run("no-invalid-regexp", rule, {
         },
         {
             code: "new RegExp('.', 'ga')",
+            options: [{ allowConstructorFlags: ["a"] }]
+        },
+        {
+            code: "new RegExp(pattern, 'ga')",
+            options: [{ allowConstructorFlags: ["a"] }]
+        },
+        {
+            code: "new RegExp('.' + '', 'ga')",
             options: [{ allowConstructorFlags: ["a"] }]
         },
         {
@@ -235,6 +249,34 @@ ruleTester.run("no-invalid-regexp", rule, {
             errors: [{
                 messageId: "regexMessage",
                 data: { message: "Invalid regular expression: /\\/: \\ at end of pattern" },
+                type: "NewExpression"
+            }]
+        },
+
+        // https://github.com/eslint/eslint/issues/16573
+        {
+            code: "RegExp(')' + '', 'a');",
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'a'" },
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "new RegExp('.' + '', 'az');",
+            options: [{ allowConstructorFlags: ["z"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'a'" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "new RegExp(pattern, 'az');",
+            options: [{ allowConstructorFlags: ["a"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'z'" },
                 type: "NewExpression"
             }]
         }


### PR DESCRIPTION
Fixes #16573

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Previously, the no-invalid-regexp rule skipped flag validation for regexps with non-literal pattern.
This PR fixes the rule so that flags are validated no matter what the pattern is.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
The schema could be updated, adding a separate messageId for invalid flags, but I didn't do so - to stay focused and not to break existing tests.

I needed to reorganize the code somewhat, but I tried to keep the overall feel of the coding style established in the rule.