### PR TITLE
feat: fix no-useless-return false negative in try statement

### DIFF
--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -39,6 +39,15 @@ function isRemovable(node) {
 }
 
 /**
+ * Checks if given node is a try statement or not.
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is a try statement.
+ */
+function isTryStatement(node) {
+    return node.type === "TryStatement";
+}
+
+/**
  * Checks whether the given return statement is in a `finally` block or not.
  * @param {ASTNode} node The return statement node to check.
  * @returns {boolean} `true` if the node is in a `finally` block.
@@ -49,12 +58,25 @@ function isInFinally(node) {
         currentNode && currentNode.parent && !astUtils.isFunction(currentNode);
         currentNode = currentNode.parent
     ) {
-        if (currentNode.parent.type === "TryStatement" && currentNode.parent.finalizer === currentNode) {
+        if (isTryStatement(currentNode.parent) && currentNode.parent.finalizer === currentNode) {
             return true;
         }
     }
 
     return false;
+}
+
+/**
+ * Checks whether the given node is the last one in the parentNode.
+ * @param {ASTNode} node The node to check.
+ * @param {ASTNode} parentNode The node that possibly contains the given `node`.
+ * @param {any} sourceCode The source code
+ * @returns {boolean} `true` if the node is the last one in the `parentNode` children.
+ */
+function isLastNode(node, parentNode, sourceCode) {
+    const lastNodeInParent = parentNode.body[parentNode.body.length - 1];
+
+    return astUtils.equalTokens(node, lastNodeInParent, sourceCode);
 }
 
 //------------------------------------------------------------------------------
@@ -273,6 +295,22 @@ module.exports = {
                     }
                 }
                 scopeInfo.uselessReturns.push(node);
+            },
+            "BlockStatement:exit"(node) {
+                if (
+                    !isTryStatement(node.parent) ||
+                    !scopeInfo.upper ||
+                    !scopeInfo.uselessReturns
+                ) {
+                    return;
+                }
+
+                const lastUseselessReturn = scopeInfo.uselessReturns[scopeInfo.uselessReturns.length - 1];
+
+
+                if (lastUseselessReturn && isLastNode(lastUseselessReturn, node, sourceCode)) {
+                    scopeInfo.upper.uselessReturns.push(lastUseselessReturn);
+                }
             },
 
             /*

--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -74,7 +74,13 @@ function isInFinally(node) {
  * @returns {boolean} `true` if the node is the last one in the `parentNode` children.
  */
 function isLastNode(node, parentNode, sourceCode) {
-    const lastNodeInParent = parentNode.body[parentNode.body.length - 1];
+    if (!parentNode.body) {
+        return false;
+    }
+
+    const lastNodeInParent = Array.isArray(parentNode.body)
+        ? parentNode.body[parentNode.body.length - 1]
+        : parentNode.body;
 
     return astUtils.equalTokens(node, lastNodeInParent, sourceCode);
 }
@@ -297,19 +303,21 @@ module.exports = {
                 scopeInfo.uselessReturns.push(node);
             },
             "BlockStatement:exit"(node) {
+                const parentNode = node.parent;
+
                 if (
-                    !isTryStatement(node.parent) ||
+                    !(isTryStatement(parentNode) && isLastNode(parentNode, parentNode.parent, sourceCode)) ||
                     !scopeInfo.upper ||
                     !scopeInfo.uselessReturns
                 ) {
                     return;
                 }
 
-                const lastUseselessReturn = scopeInfo.uselessReturns[scopeInfo.uselessReturns.length - 1];
+                const lastUselessReturn = scopeInfo.uselessReturns[scopeInfo.uselessReturns.length - 1];
 
 
-                if (lastUseselessReturn && isLastNode(lastUseselessReturn, node, sourceCode)) {
-                    scopeInfo.upper.uselessReturns.push(lastUseselessReturn);
+                if (lastUselessReturn && isLastNode(lastUselessReturn, node, sourceCode)) {
+                    scopeInfo.upper.uselessReturns.push(lastUselessReturn);
                 }
             },
 

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -98,6 +98,15 @@ ruleTester.run("no-useless-return", rule, {
         `,
         `
           function foo() {
+            try {
+              bar();
+              return;
+            } catch (err) {}
+            baz();
+          }
+        `,
+        `
+          function foo() {
             return;
             doSomething();
           }

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -386,12 +386,48 @@ ruleTester.run("no-useless-return", rule, {
               }
             `
         },
-
-        /*
-         * FIXME: Re-add this case (removed due to https://github.com/eslint/eslint/issues/7481):
-         * https://github.com/eslint/eslint/blob/261d7287820253408ec87c344beccdba2fe829a4/tests/lib/rules/no-useless-return.js#L308-L329
-         */
-
+        {
+            code: `
+              function foo() {
+                try {
+                  foo();
+                  return;
+                } catch (err) {
+                  return 5;
+                }
+              }
+            `,
+            output: `
+              function foo() {
+                try {
+                  foo();
+                  
+                } catch (err) {
+                  return 5;
+                }
+              }
+            `
+        },
+        {
+            code: `
+              function foo() {
+                try {
+                  return;
+                } catch (err) {
+                  foo();
+                }
+              }
+            `,
+            output: `
+              function foo() {
+                try {
+                  
+                } catch (err) {
+                  foo();
+                }
+              }
+            `
+        },
         {
             code: `
               function foo() {


### PR DESCRIPTION
Promote up the useless returns in BlockStatement inside TryStatement when ESLint is going up in the tree during traversing the AST.

Fixes #7481

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)
Address false-negative errors for no-useless-return rule inside Try statements.

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment:**

* **ESLint Version:** 8.28.0
* **Node Version:** 16.18.1
* **npm Version:** 8.19.2

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**
default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
no-useless-return: error
```

</details>

**What did you do? Please include the actual source code causing the issue.**

From the issue, the following code is not triggering an error:

```js
function foo() {
  try {
    return;
  } catch (err) {
    foo();
  }
}
```

**What did you expect to happen?**

The useless return is marked as error and the fixer can remove it.

**What actually happened? Please include the actual, raw output from ESLint.**

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The useless return is properly marked and being pushed to `scopeInfo.uselessReturns` when analyzing the ReturnStatement, but not present when the code path analysis ends. I found a way to fix that promoting up the assignaled useless return node in `BlockStatement:exit`, so we've the return node to be removed in the TryStatement's scope info.

#### Is there anything you'd like reviewers to focus on?

Correctness and if the fix is being made in the correct place.

<!-- markdownlint-disable-file MD004 -->
