### PR TITLE
fix: new instance of FlatESLint should load latest config file version

### DIFF
--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -93,6 +93,7 @@ const FLAT_CONFIG_FILENAME = "eslint.config.js";
 const debug = require("debug")("eslint:flat-eslint");
 const removedFormatters = new Set(["table", "codeframe"]);
 const privateMembers = new WeakMap();
+const importedConfigFileModificationTime = new Map();
 
 /**
  * It will calculate the error and warning count for collection of messages per file
@@ -277,14 +278,46 @@ function findFlatConfigFile(cwd) {
 async function loadFlatConfigFile(filePath) {
     debug(`Loading config from ${filePath}`);
 
-    const { mtime } = await fs.stat(filePath);
     const fileURL = pathToFileURL(filePath);
-
-    fileURL.searchParams.append("mtime", mtime.getTime());
 
     debug(`Config file URL is ${fileURL}`);
 
-    return (await import(fileURL)).default;
+    const mtime = (await fs.stat(filePath)).mtime.getTime();
+
+    /*
+     * Append a query with the config file's modification time (`mtime`) in order
+     * to import the current version of the config file. Without the query, `import()` would
+     * cache the config file module by the pathname only, and then always return
+     * the same version (the one that was actual when the module was imported for the first time).
+     *
+     * This ensures that the config file module is loaded and executed again
+     * if it has been changed since the last time it was imported.
+     * If it hasn't been changed, `import()` will just return the cached version.
+     *
+     * Note that we should not overuse queries (e.g., by appending the current time
+     * to always reload the config file module) as that could cause memory leaks
+     * because entries are never removed from the import cache.
+     */
+    fileURL.searchParams.append("mtime", mtime);
+
+    /*
+     * With queries, we can bypass the import cache. However, when import-ing a CJS module,
+     * Node.js uses the require infrastructure under the hood. That includes the require cache,
+     * which caches the config file module by its file path (queries have no effect).
+     * Therefore, we also need to clear the require cache before importing the config file module.
+     * In order to get the same behavior with ESM and CJS config files, in particular - to reload
+     * the config file only if it has been changed, we track file modification times and clear
+     * the require cache only if the file has been changed.
+     */
+    if (importedConfigFileModificationTime.get(filePath) !== mtime) {
+        delete require.cache[filePath];
+    }
+
+    const config = (await import(fileURL)).default;
+
+    importedConfigFileModificationTime.set(filePath, mtime);
+
+    return config;
 }
 
 /**

--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -277,7 +277,10 @@ function findFlatConfigFile(cwd) {
 async function loadFlatConfigFile(filePath) {
     debug(`Loading config from ${filePath}`);
 
+    const { mtime } = await fs.stat(filePath);
     const fileURL = pathToFileURL(filePath);
+
+    fileURL.searchParams.append("mtime", mtime.getTime());
 
     debug(`Config file URL is ${fileURL}`);
 

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -11,6 +11,7 @@
 //------------------------------------------------------------------------------
 
 const assert = require("assert");
+const util = require("util");
 const fs = require("fs");
 const fsp = fs.promises;
 const os = require("os");
@@ -39,6 +40,15 @@ function ensureDirectoryExists(dirPath) {
     } catch {
         fs.mkdirSync(dirPath);
     }
+}
+
+/**
+ * Does nothing for a given time.
+ * @param {number} time Time in ms.
+ * @returns {void}
+ */
+async function sleep(time) {
+    await util.promisify(setTimeout)(time);
 }
 
 //------------------------------------------------------------------------------
@@ -5280,6 +5290,7 @@ describe("FlatESLint", () => {
             assert.strictEqual(messages[0].messageId, "missingSemi");
             assert.strictEqual(messages[0].line, 1);
 
+            await sleep(100);
             await fsp.writeFile(path.join(cwd, "eslint.config.js"), configFileContent.replace("always", "never"));
 
             eslint = new FlatESLint({ cwd });
@@ -5312,6 +5323,7 @@ describe("FlatESLint", () => {
             assert.strictEqual(messages[0].messageId, "missingSemi");
             assert.strictEqual(messages[0].line, 1);
 
+            await sleep(100);
             await fsp.writeFile(path.join(cwd, "eslint.config.js"), configFileContent.replace("always", "never"));
 
             eslint = new FlatESLint({ cwd });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Aims to fix https://github.com/eslint/eslint/issues/16576.

#### What changes did you make? (Give an overview)

This change appends query string with config file's `mtime` to its URL in order to force reload of the config file when it has been changed since the last load.

#### Is there anything you'd like reviewers to focus on?

Marked as draft as this approach doesn't seem to work with CJS config files.

<!-- markdownlint-disable-file MD004 -->
