### PR TITLE
fix: autofix recursive functions in no-var

### DIFF
--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -159,7 +159,7 @@ function hasReferenceInTDZ(node) {
             return !reference.init && (
                 start < idStart ||
                 (defaultValue !== null && start >= defaultStart && end <= defaultEnd) ||
-                (start >= initStart && end <= initEnd)
+                (!astUtils.isFunction(node) && start >= initStart && end <= initEnd)
             );
         });
     };

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -319,6 +319,74 @@ ruleTester.run("no-var", rule, {
             code: "function foo() { var { let } = {}; }",
             output: null,
             errors: [{ messageId: "unexpectedVar" }]
+        },
+
+        // https://github.com/eslint/eslint/issues/16610
+        {
+            code: "var fx = function (i = 0) { if (i < 5) { return fx(i + 1); } console.log(i); }; fx();",
+            output: "let fx = function (i = 0) { if (i < 5) { return fx(i + 1); } console.log(i); }; fx();",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{ messageId: "unexpectedVar" }]
+        },
+        {
+            code: "var foo = function () { foo() };",
+            output: "let foo = function () { foo() };",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{ messageId: "unexpectedVar" }]
+        },
+        {
+            code: "var foo = () => foo();",
+            output: "let foo = () => foo();",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{ messageId: "unexpectedVar" }]
+        },
+        {
+            code: "var foo = (function () { foo(); })();",
+            output: null,
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{ messageId: "unexpectedVar" }]
+        },
+        {
+            code: "var foo = bar(function () { foo(); });",
+            output: null,
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{ messageId: "unexpectedVar" }]
+        },
+        {
+            code: "var bar = foo, foo = function () { foo(); };",
+            output: null,
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{ messageId: "unexpectedVar" }]
+        },
+        {
+            code: "var bar = foo; var foo = function () { foo(); };",
+            output: "let bar = foo; var foo = function () { foo(); };",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                { messageId: "unexpectedVar" },
+                { messageId: "unexpectedVar" }
+            ]
+        },
+        {
+            code: "var { foo = foo } = function () { foo(); };",
+            output: null,
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{ messageId: "unexpectedVar" }]
+        },
+        {
+            code: "var { bar = foo, foo } = function () { foo(); };",
+            output: null,
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [{ messageId: "unexpectedVar" }]
+        },
+        {
+            code: "var bar = function () { foo(); }; var foo = function() {};",
+            output: "let bar = function () { foo(); }; var foo = function() {};",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                { messageId: "unexpectedVar" },
+                { messageId: "unexpectedVar" }
+            ]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #16610

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In the `no-var` rule, I fixed the logic that checks whether a variable has a reference in TDZ to skip references in the variable initializer if the initializer is a function definition.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
