### PR TITLE
docs: fix language option styling

### DIFF
--- a/docs/src/assets/scss/syntax-highlighter.scss
+++ b/docs/src/assets/scss/syntax-highlighter.scss
@@ -32,7 +32,7 @@ pre[class*="language-"] {
 }
 
 /* Code blocks */
-div[class*="language-"] {
+div[class*="language-"]:not(.language-switcher) {
     padding: 1.5rem;
     margin: 1.5rem 0;
     overflow: auto;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
Fixed language option styling.
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Due to the style change (`pre[class*="language-"]` to `div[class*="language-"]` - `syntax-highlighter.scss`) in #16606, language option styles were affected. Fixed by excluding the `.language-switcher` class.


| Before | After |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/30730124/206850755-df75b48a-3b80-4e9d-9a1e-272a32779064.png) |  ![image](https://user-images.githubusercontent.com/30730124/206850798-f7bbaa19-f51a-4a83-8c87-eb7b3d882541.png) |
|  ![image](https://user-images.githubusercontent.com/30730124/206850821-b04905f6-d13a-4bd7-b0a6-c0a3ebbc873c.png) |  ![image](https://user-images.githubusercontent.com/30730124/206850839-fc6b9e15-5f9a-45f7-bd46-0de074b677b0.png) |



