### PR TITLE
feat: add suggestions for redundant wrapping in prefer-regex-literals

### DIFF
--- a/lib/rules/prefer-regex-literals.js
+++ b/lib/rules/prefer-regex-literals.js
@@ -342,6 +342,37 @@ module.exports = {
             return [...flagsSet].join("");
         }
 
+        /**
+         * Checks whether a give node can be fixed to the given regex pattern and flags.
+         * @param {ASTNode} node The node to check.
+         * @param {string} pattern The regex pattern to check.
+         * @param {string} flags The regex flags
+         * @returns {boolean} True if a node can be fixed to the given regex pattern and flags.
+         */
+        function isFixableTo(node, pattern, flags) {
+            const tokenBefore = sourceCode.getTokenBefore(node);
+
+            return sourceCode.getCommentsInside(node).length === 0 &&
+                (!tokenBefore || validPrecedingTokens.has(tokenBefore.value)) &&
+                isValidRegexForEcmaVersion(pattern, flags);
+        }
+
+        /**
+         * Returns a safe output code considering the before and after tokens.
+         * @param {ASTNode} node The regex node.
+         * @param {string} newRegExpValue The new regex expression value.
+         * @returns {string} The output code.
+         */
+        function getSafeOutput(node, newRegExpValue) {
+            const tokenBefore = sourceCode.getTokenBefore(node);
+            const tokenAfter = sourceCode.getTokenAfter(node);
+
+            return (tokenBefore && !canTokensBeAdjacent(tokenBefore, newRegExpValue) && tokenBefore.range[1] === node.range[0] ? " " : "") +
+                newRegExpValue +
+            (tokenAfter && !canTokensBeAdjacent(newRegExpValue, tokenAfter) && node.range[1] === tokenAfter.range[0] ? " " : "");
+
+        }
+
         return {
             Program() {
                 const scope = context.getScope();
@@ -360,23 +391,22 @@ module.exports = {
                         if (node.arguments.length === 2) {
                             const outputs = [];
 
-                            if (sourceCode.getCommentsInside(node).length === 0) {
-                                const literalFlags = regexNode.regex.flags || "";
-                                const argFlags = getStringValue(node.arguments[1]) || "";
+                            const argFlags = getStringValue(node.arguments[1]) || "";
 
-                                if (isValidRegexForEcmaVersion(regexNode.regex.pattern, argFlags)) {
-                                    outputs.push(`/${regexNode.regex.pattern}/${argFlags}`);
-                                }
+                            if (isFixableTo(node, regexNode.regex.pattern, argFlags)) {
+                                outputs.push(`/${regexNode.regex.pattern}/${argFlags}`);
+                            }
 
-                                if (literalFlags && argFlags) {
-                                    const mergedFlags = mergeRegexFlags(literalFlags, argFlags);
+                            const literalFlags = regexNode.regex.flags || "";
 
-                                    if (
-                                        !areFlagsEqual(mergedFlags, argFlags) &&
-                                        isValidRegexForEcmaVersion(regexNode.regex.pattern, mergedFlags)
-                                    ) {
-                                        outputs.push(`/${regexNode.regex.pattern}/${mergedFlags}`);
-                                    }
+                            if (argFlags && literalFlags) {
+                                const mergedFlags = mergeRegexFlags(literalFlags, argFlags);
+
+                                if (
+                                    !areFlagsEqual(mergedFlags, argFlags) &&
+                                    isFixableTo(node, regexNode.regex.pattern, mergedFlags)
+                                ) {
+                                    outputs.push(`/${regexNode.regex.pattern}/${mergedFlags}`);
                                 }
                             }
 
@@ -386,7 +416,7 @@ module.exports = {
                                 suggest: outputs.map(output => ({
                                     messageId: "replaceWithLiteralAndFlags",
                                     fix(fixer) {
-                                        return fixer.replaceText(node, output);
+                                        return fixer.replaceText(node, getSafeOutput(node, output));
                                     }
                                 }))
                             });
@@ -394,11 +424,11 @@ module.exports = {
                             const outputs = [];
 
                             if (
-                                sourceCode.getCommentsInside(node).length === 0 &&
-                                isValidRegexForEcmaVersion(regexNode.regex.pattern, regexNode.regex.flags)
+                                isFixableTo(node, regexNode.regex.pattern, regexNode.regex.flags)
                             ) {
                                 outputs.push(sourceCode.getText(regexNode));
                             }
+
 
                             context.report({
                                 node,
@@ -406,7 +436,10 @@ module.exports = {
                                 suggest: outputs.map(output => ({
                                     messageId: "replaceWithLiteral",
                                     fix(fixer) {
-                                        return fixer.replaceText(node, output);
+                                        return fixer.replaceText(
+                                            node,
+                                            getSafeOutput(node, output)
+                                        );
                                     }
                                 }))
                             });
@@ -420,21 +453,11 @@ module.exports = {
                             flags = getStringValue(node.arguments[1]);
                         }
 
-                        if (!isValidRegexForEcmaVersion(regexContent, flags)) {
-                            noFix = true;
-                        }
-
-                        const tokenBefore = sourceCode.getTokenBefore(node);
-
-                        if (tokenBefore && !validPrecedingTokens.has(tokenBefore.value)) {
+                        if (!isFixableTo(node, regexContent, flags)) {
                             noFix = true;
                         }
 
                         if (!/^[-a-zA-Z0-9\\[\](){} \t\r\n\v\f!@#$%^&*+^_=/~`.><?,'"|:;]*$/u.test(regexContent)) {
-                            noFix = true;
-                        }
-
-                        if (sourceCode.getCommentsInside(node).length > 0) {
                             noFix = true;
                         }
 
@@ -469,14 +492,7 @@ module.exports = {
                             suggest: noFix ? [] : [{
                                 messageId: "replaceWithLiteral",
                                 fix(fixer) {
-                                    const tokenAfter = sourceCode.getTokenAfter(node);
-
-                                    return fixer.replaceText(
-                                        node,
-                                        (tokenBefore && !canTokensBeAdjacent(tokenBefore, newRegExpValue) && tokenBefore.range[1] === node.range[0] ? " " : "") +
-                                            newRegExpValue +
-                                            (tokenAfter && !canTokensBeAdjacent(newRegExpValue, tokenAfter) && node.range[1] === tokenAfter.range[0] ? " " : "")
-                                    );
+                                    return fixer.replaceText(node, getSafeOutput(node, newRegExpValue));
                                 }
                             }]
                         });

--- a/lib/rules/prefer-regex-literals.js
+++ b/lib/rules/prefer-regex-literals.js
@@ -303,12 +303,12 @@ module.exports = {
          * @returns {boolean} True if the given regex pattern and flags are valid for the ecma version.
          */
         function isValidRegexForEcmaVersion(pattern, flags) {
-            const RegExpValidatorInstance = new RegExpValidator({ ecmaVersion: regexppEcmaVersion });
+            const validator = new RegExpValidator({ ecmaVersion: regexppEcmaVersion });
 
             try {
-                RegExpValidatorInstance.validatePattern(pattern, 0, pattern.length, flags ? flags.includes("u") : false);
+                validator.validatePattern(pattern, 0, pattern.length, flags ? flags.includes("u") : false);
                 if (flags) {
-                    RegExpValidatorInstance.validateFlags(flags);
+                    validator.validateFlags(flags);
                 }
                 return true;
             } catch {
@@ -322,7 +322,7 @@ module.exports = {
          * @param {string} flagsB The regex flags.
          * @returns {boolean} True if two regex flags contain same flags.
          */
-        function isFlagsEqual(flagsA, flagsB) {
+        function areFlagsEqual(flagsA, flagsB) {
             return [...flagsA].sort().join("") === [...flagsB].sort().join("");
         }
 
@@ -334,11 +334,12 @@ module.exports = {
          * @returns {string} The merged regex flags.
          */
         function mergeRegexFlags(flagsA, flagsB) {
-            return [
+            const flagsSet = new Set([
                 ...flagsA,
                 ...flagsB
-            ].filter((flag, index, self) => index === self.indexOf(flag))
-                .join("");
+            ]);
+
+            return [...flagsSet].join("");
         }
 
         return {
@@ -359,7 +360,7 @@ module.exports = {
                         if (node.arguments.length === 2) {
                             const outputs = [];
 
-                            if (sourceCode.getCommentsInside(node).length <= 0) {
+                            if (sourceCode.getCommentsInside(node).length === 0) {
                                 const literalFlags = regexNode.regex.flags || "";
                                 const argFlags = getStringValue(node.arguments[1]) || "";
 
@@ -371,7 +372,7 @@ module.exports = {
                                     const mergedFlags = mergeRegexFlags(literalFlags, argFlags);
 
                                     if (
-                                        !isFlagsEqual(mergedFlags, argFlags) &&
+                                        !areFlagsEqual(mergedFlags, argFlags) &&
                                         isValidRegexForEcmaVersion(regexNode.regex.pattern, mergedFlags)
                                     ) {
                                         outputs.push(`/${regexNode.regex.pattern}/${mergedFlags}`);
@@ -393,7 +394,7 @@ module.exports = {
                             const outputs = [];
 
                             if (
-                                sourceCode.getCommentsInside(node).length <= 0 &&
+                                sourceCode.getCommentsInside(node).length === 0 &&
                                 isValidRegexForEcmaVersion(regexNode.regex.pattern, regexNode.regex.flags)
                             ) {
                                 outputs.push(sourceCode.getText(regexNode));

--- a/lib/rules/prefer-regex-literals.js
+++ b/lib/rules/prefer-regex-literals.js
@@ -147,7 +147,6 @@ module.exports = {
             unexpectedRegExp: "Use a regular expression literal instead of the 'RegExp' constructor.",
             replaceWithLiteral: "Replace with an equivalent regular expression literal.",
             replaceWithLiteralAndFlags: "Replace with an equivalent regular expression literal with flags '{{ flags }}'.",
-            replaceWithIntendedLiteral: "Replace with a regular expression literal.",
             replaceWithIntendedLiteralAndFlags: "Replace with a regular expression literal with flags '{{ flags }}'.",
             unexpectedRedundantRegExp: "Regular expression literal is unnecessarily wrapped within a 'RegExp' constructor.",
             unexpectedRedundantRegExpWithFlags: "Use regular expression literal with flags instead of the 'RegExp' constructor."
@@ -397,7 +396,7 @@ module.exports = {
 
                             if (canFixTo(node, regexNode.regex.pattern, argFlags)) {
                                 suggests.push({
-                                    messageId: argFlags ? "replaceWithLiteralAndFlags" : "replaceWithLiteral",
+                                    messageId: "replaceWithLiteralAndFlags",
                                     pattern: regexNode.regex.pattern,
                                     flags: argFlags
                                 });
@@ -411,7 +410,7 @@ module.exports = {
                                 canFixTo(node, regexNode.regex.pattern, mergedFlags)
                             ) {
                                 suggests.push({
-                                    messageId: mergedFlags ? "replaceWithIntendedLiteralAndFlags" : "replaceWithIntendedLiteral",
+                                    messageId: "replaceWithIntendedLiteralAndFlags",
                                     pattern: regexNode.regex.pattern,
                                     flags: mergedFlags
                                 });

--- a/lib/rules/prefer-regex-literals.js
+++ b/lib/rules/prefer-regex-literals.js
@@ -146,7 +146,7 @@ module.exports = {
         messages: {
             unexpectedRegExp: "Use a regular expression literal instead of the 'RegExp' constructor.",
             replaceWithLiteral: "Replace with an equivalent regular expression literal.",
-            replaceWithLiteralAndFlags: "Replace with an equivalent regular expression literal with flags.",
+            replaceWithLiteralAndFlags: "Replace with an equivalent regular expression literal with flags({{ flags }}).",
             unexpectedRedundantRegExp: "Regular expression literal is unnecessarily wrapped within a 'RegExp' constructor.",
             unexpectedRedundantRegExpWithFlags: "Use regular expression literal with flags instead of the 'RegExp' constructor."
         }
@@ -349,7 +349,7 @@ module.exports = {
          * @param {string} flags The regex flags
          * @returns {boolean} True if a node can be fixed to the given regex pattern and flags.
          */
-        function isFixableTo(node, pattern, flags) {
+        function canFixTo(node, pattern, flags) {
             const tokenBefore = sourceCode.getTokenBefore(node);
 
             return sourceCode.getCommentsInside(node).length === 0 &&
@@ -389,12 +389,15 @@ module.exports = {
                         const regexNode = node.arguments[0];
 
                         if (node.arguments.length === 2) {
-                            const outputs = [];
+                            const outputRegExps = [];
 
                             const argFlags = getStringValue(node.arguments[1]) || "";
 
-                            if (isFixableTo(node, regexNode.regex.pattern, argFlags)) {
-                                outputs.push(`/${regexNode.regex.pattern}/${argFlags}`);
+                            if (canFixTo(node, regexNode.regex.pattern, argFlags)) {
+                                outputRegExps.push({
+                                    pattern: regexNode.regex.pattern,
+                                    flags: argFlags
+                                });
                             }
 
                             const literalFlags = regexNode.regex.flags || "";
@@ -404,28 +407,32 @@ module.exports = {
 
                                 if (
                                     !areFlagsEqual(mergedFlags, argFlags) &&
-                                    isFixableTo(node, regexNode.regex.pattern, mergedFlags)
+                                    canFixTo(node, regexNode.regex.pattern, mergedFlags)
                                 ) {
-                                    outputs.push(`/${regexNode.regex.pattern}/${mergedFlags}`);
+                                    outputRegExps.push({
+                                        pattern: regexNode.regex.pattern,
+                                        flags: mergedFlags
+                                    });
                                 }
                             }
 
                             context.report({
                                 node,
                                 messageId: "unexpectedRedundantRegExpWithFlags",
-                                suggest: outputs.map(output => ({
-                                    messageId: "replaceWithLiteralAndFlags",
+                                suggest: outputRegExps.map(({ flags, pattern }) => ({
+                                    messageId: flags ? "replaceWithLiteralAndFlags" : "replaceWithLiteral",
+                                    data: {
+                                        flags
+                                    },
                                     fix(fixer) {
-                                        return fixer.replaceText(node, getSafeOutput(node, output));
+                                        return fixer.replaceText(node, getSafeOutput(node, `/${pattern}/${flags}`));
                                     }
                                 }))
                             });
                         } else {
                             const outputs = [];
 
-                            if (
-                                isFixableTo(node, regexNode.regex.pattern, regexNode.regex.flags)
-                            ) {
+                            if (canFixTo(node, regexNode.regex.pattern, regexNode.regex.flags)) {
                                 outputs.push(sourceCode.getText(regexNode));
                             }
 
@@ -453,7 +460,7 @@ module.exports = {
                             flags = getStringValue(node.arguments[1]);
                         }
 
-                        if (!isFixableTo(node, regexContent, flags)) {
+                        if (!canFixTo(node, regexContent, flags)) {
                             noFix = true;
                         }
 

--- a/lib/rules/prefer-regex-literals.js
+++ b/lib/rules/prefer-regex-literals.js
@@ -358,9 +358,8 @@ module.exports = {
 
                         if (node.arguments.length === 2) {
                             const outputs = [];
-                            const fixable = sourceCode.getCommentsInside(node).length <= 0;
 
-                            if (fixable) {
+                            if (sourceCode.getCommentsInside(node).length <= 0) {
                                 const literalFlags = regexNode.regex.flags || "";
                                 const argFlags = getStringValue(node.arguments[1]) || "";
 
@@ -368,14 +367,13 @@ module.exports = {
                                     outputs.push(`/${regexNode.regex.pattern}/${argFlags}`);
                                 }
 
-                                const mergedFlags = mergeRegexFlags(literalFlags, argFlags);
+                                if (literalFlags && argFlags) {
+                                    const mergedFlags = mergeRegexFlags(literalFlags, argFlags);
 
-                                if (
-                                    literalFlags &&
-                                    argFlags &&
-                                    !isFlagsEqual(mergedFlags, argFlags)
-                                ) {
-                                    if (isValidRegexForEcmaVersion(regexNode.regex.pattern, mergedFlags)) {
+                                    if (
+                                        !isFlagsEqual(mergedFlags, argFlags) &&
+                                        isValidRegexForEcmaVersion(regexNode.regex.pattern, mergedFlags)
+                                    ) {
                                         outputs.push(`/${regexNode.regex.pattern}/${mergedFlags}`);
                                     }
                                 }
@@ -392,21 +390,24 @@ module.exports = {
                                 }))
                             });
                         } else {
-                            const output = sourceCode.getText(regexNode);
-                            const fixable = sourceCode.getCommentsInside(node).length <= 0 &&
-                                isValidRegexForEcmaVersion(regexNode.regex.pattern, regexNode.regex.flags);
+                            const outputs = [];
+
+                            if (
+                                sourceCode.getCommentsInside(node).length <= 0 &&
+                                isValidRegexForEcmaVersion(regexNode.regex.pattern, regexNode.regex.flags)
+                            ) {
+                                outputs.push(sourceCode.getText(regexNode));
+                            }
 
                             context.report({
                                 node,
                                 messageId: "unexpectedRedundantRegExp",
-                                suggest: fixable ? [
-                                    {
-                                        messageId: "replaceWithLiteral",
-                                        fix(fixer) {
-                                            return fixer.replaceText(node, output);
-                                        }
+                                suggest: outputs.map(output => ({
+                                    messageId: "replaceWithLiteral",
+                                    fix(fixer) {
+                                        return fixer.replaceText(node, output);
                                     }
-                                ] : null
+                                }))
                             });
                         }
                     } else if (hasOnlyStaticStringArguments(node)) {

--- a/lib/rules/prefer-regex-literals.js
+++ b/lib/rules/prefer-regex-literals.js
@@ -146,6 +146,7 @@ module.exports = {
         messages: {
             unexpectedRegExp: "Use a regular expression literal instead of the 'RegExp' constructor.",
             replaceWithLiteral: "Replace with an equivalent regular expression literal.",
+            replaceWithLiteralAndFlags: "Replace with an equivalent regular expression literal with flags.",
             unexpectedRedundantRegExp: "Regular expression literal is unnecessarily wrapped within a 'RegExp' constructor.",
             unexpectedRedundantRegExpWithFlags: "Use regular expression literal with flags instead of the 'RegExp' constructor."
         }
@@ -258,6 +259,8 @@ module.exports = {
             return Math.min(ecmaVersion, REGEXPP_LATEST_ECMA_VERSION);
         }
 
+        const regexppEcmaVersion = getRegexppEcmaVersion(context.languageOptions.ecmaVersion);
+
         /**
          * Makes a character escaped or else returns null.
          * @param {string} character The character to escape.
@@ -293,6 +296,51 @@ module.exports = {
             }
         }
 
+        /**
+         * Checks whether the given regex and flags are valid for the ecma version or not.
+         * @param {string} pattern The regex pattern to check.
+         * @param {string | undefined} flags The regex flags to check.
+         * @returns {boolean} True if the given regex pattern and flags are valid for the ecma version.
+         */
+        function isValidRegexForEcmaVersion(pattern, flags) {
+            const RegExpValidatorInstance = new RegExpValidator({ ecmaVersion: regexppEcmaVersion });
+
+            try {
+                RegExpValidatorInstance.validatePattern(pattern, 0, pattern.length, flags ? flags.includes("u") : false);
+                if (flags) {
+                    RegExpValidatorInstance.validateFlags(flags);
+                }
+                return true;
+            } catch {
+                return false;
+            }
+        }
+
+        /**
+         * Checks whether two given regex flags contain the same flags or not.
+         * @param {string} flagsA The regex flags.
+         * @param {string} flagsB The regex flags.
+         * @returns {boolean} True if two regex flags contain same flags.
+         */
+        function isFlagsEqual(flagsA, flagsB) {
+            return [...flagsA].sort().join("") === [...flagsB].sort().join("");
+        }
+
+
+        /**
+         * Merges two regex flags.
+         * @param {string} flagsA The regex flags.
+         * @param {string} flagsB The regex flags.
+         * @returns {string} The merged regex flags.
+         */
+        function mergeRegexFlags(flagsA, flagsB) {
+            return [
+                ...flagsA,
+                ...flagsB
+            ].filter((flag, index, self) => index === self.indexOf(flag))
+                .join("");
+        }
+
         return {
             Program() {
                 const scope = context.getScope();
@@ -306,10 +354,60 @@ module.exports = {
 
                 for (const { node } of tracker.iterateGlobalReferences(traceMap)) {
                     if (disallowRedundantWrapping && isUnnecessarilyWrappedRegexLiteral(node)) {
+                        const regexNode = node.arguments[0];
+
                         if (node.arguments.length === 2) {
-                            context.report({ node, messageId: "unexpectedRedundantRegExpWithFlags" });
+                            const outputs = [];
+                            const fixable = sourceCode.getCommentsInside(node).length <= 0;
+
+                            if (fixable) {
+                                const literalFlags = regexNode.regex.flags || "";
+                                const argFlags = getStringValue(node.arguments[1]) || "";
+
+                                if (isValidRegexForEcmaVersion(regexNode.regex.pattern, argFlags)) {
+                                    outputs.push(`/${regexNode.regex.pattern}/${argFlags}`);
+                                }
+
+                                const mergedFlags = mergeRegexFlags(literalFlags, argFlags);
+
+                                if (
+                                    literalFlags &&
+                                    argFlags &&
+                                    !isFlagsEqual(mergedFlags, argFlags)
+                                ) {
+                                    if (isValidRegexForEcmaVersion(regexNode.regex.pattern, mergedFlags)) {
+                                        outputs.push(`/${regexNode.regex.pattern}/${mergedFlags}`);
+                                    }
+                                }
+                            }
+
+                            context.report({
+                                node,
+                                messageId: "unexpectedRedundantRegExpWithFlags",
+                                suggest: outputs.map(output => ({
+                                    messageId: "replaceWithLiteralAndFlags",
+                                    fix(fixer) {
+                                        return fixer.replaceText(node, output);
+                                    }
+                                }))
+                            });
                         } else {
-                            context.report({ node, messageId: "unexpectedRedundantRegExp" });
+                            const output = sourceCode.getText(regexNode);
+                            const fixable = sourceCode.getCommentsInside(node).length <= 0 &&
+                                isValidRegexForEcmaVersion(regexNode.regex.pattern, regexNode.regex.flags);
+
+                            context.report({
+                                node,
+                                messageId: "unexpectedRedundantRegExp",
+                                suggest: fixable ? [
+                                    {
+                                        messageId: "replaceWithLiteral",
+                                        fix(fixer) {
+                                            return fixer.replaceText(node, output);
+                                        }
+                                    }
+                                ] : null
+                            });
                         }
                     } else if (hasOnlyStaticStringArguments(node)) {
                         let regexContent = getStringValue(node.arguments[0]);
@@ -320,15 +418,7 @@ module.exports = {
                             flags = getStringValue(node.arguments[1]);
                         }
 
-                        const regexppEcmaVersion = getRegexppEcmaVersion(context.languageOptions.ecmaVersion);
-                        const RegExpValidatorInstance = new RegExpValidator({ ecmaVersion: regexppEcmaVersion });
-
-                        try {
-                            RegExpValidatorInstance.validatePattern(regexContent, 0, regexContent.length, flags ? flags.includes("u") : false);
-                            if (flags) {
-                                RegExpValidatorInstance.validateFlags(flags);
-                            }
-                        } catch {
+                        if (!isValidRegexForEcmaVersion(regexContent, flags)) {
                             noFix = true;
                         }
 

--- a/lib/rules/prefer-regex-literals.js
+++ b/lib/rules/prefer-regex-literals.js
@@ -146,7 +146,9 @@ module.exports = {
         messages: {
             unexpectedRegExp: "Use a regular expression literal instead of the 'RegExp' constructor.",
             replaceWithLiteral: "Replace with an equivalent regular expression literal.",
-            replaceWithLiteralAndFlags: "Replace with an equivalent regular expression literal with flags({{ flags }}).",
+            replaceWithLiteralAndFlags: "Replace with an equivalent regular expression literal with flags '{{ flags }}'.",
+            replaceWithIntendedLiteral: "Replace with a regular expression literal.",
+            replaceWithIntendedLiteralAndFlags: "Replace with a regular expression literal with flags '{{ flags }}'.",
             unexpectedRedundantRegExp: "Regular expression literal is unnecessarily wrapped within a 'RegExp' constructor.",
             unexpectedRedundantRegExpWithFlags: "Use regular expression literal with flags instead of the 'RegExp' constructor."
         }
@@ -389,38 +391,37 @@ module.exports = {
                         const regexNode = node.arguments[0];
 
                         if (node.arguments.length === 2) {
-                            const outputRegExps = [];
+                            const suggests = [];
 
                             const argFlags = getStringValue(node.arguments[1]) || "";
 
                             if (canFixTo(node, regexNode.regex.pattern, argFlags)) {
-                                outputRegExps.push({
+                                suggests.push({
+                                    messageId: argFlags ? "replaceWithLiteralAndFlags" : "replaceWithLiteral",
                                     pattern: regexNode.regex.pattern,
                                     flags: argFlags
                                 });
                             }
 
                             const literalFlags = regexNode.regex.flags || "";
+                            const mergedFlags = mergeRegexFlags(literalFlags, argFlags);
 
-                            if (argFlags && literalFlags) {
-                                const mergedFlags = mergeRegexFlags(literalFlags, argFlags);
-
-                                if (
-                                    !areFlagsEqual(mergedFlags, argFlags) &&
-                                    canFixTo(node, regexNode.regex.pattern, mergedFlags)
-                                ) {
-                                    outputRegExps.push({
-                                        pattern: regexNode.regex.pattern,
-                                        flags: mergedFlags
-                                    });
-                                }
+                            if (
+                                !areFlagsEqual(mergedFlags, argFlags) &&
+                                canFixTo(node, regexNode.regex.pattern, mergedFlags)
+                            ) {
+                                suggests.push({
+                                    messageId: mergedFlags ? "replaceWithIntendedLiteralAndFlags" : "replaceWithIntendedLiteral",
+                                    pattern: regexNode.regex.pattern,
+                                    flags: mergedFlags
+                                });
                             }
 
                             context.report({
                                 node,
                                 messageId: "unexpectedRedundantRegExpWithFlags",
-                                suggest: outputRegExps.map(({ flags, pattern }) => ({
-                                    messageId: flags ? "replaceWithLiteralAndFlags" : "replaceWithLiteral",
+                                suggest: suggests.map(({ flags, pattern, messageId }) => ({
+                                    messageId,
                                     data: {
                                         flags
                                     },

--- a/tests/lib/rules/prefer-regex-literals.js
+++ b/tests/lib/rules/prefer-regex-literals.js
@@ -852,6 +852,76 @@ ruleTester.run("prefer-regex-literals", rule, {
             ]
         },
         {
+            code: "(a)\nnew RegExp(/b/);",
+            options: [{
+                disallowRedundantWrapping: true
+            }],
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExp",
+                    type: "NewExpression",
+                    line: 2,
+                    column: 1,
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "(a)\nnew RegExp(/b/, 'g');",
+            options: [{
+                disallowRedundantWrapping: true
+            }],
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    type: "NewExpression",
+                    line: 2,
+                    column: 1,
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "a/RegExp(/foo/);",
+            options: [{
+                disallowRedundantWrapping: true
+            }],
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExp",
+                    type: "CallExpression",
+                    line: 1,
+                    column: 3,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteral",
+                            output: "a/ /foo/;"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "RegExp(/foo/)in a;",
+            options: [{
+                disallowRedundantWrapping: true
+            }],
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExp",
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteral",
+                            output: "/foo/ in a;"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             code: "new RegExp((String?.raw)`a`);",
             errors: [
                 {

--- a/tests/lib/rules/prefer-regex-literals.js
+++ b/tests/lib/rules/prefer-regex-literals.js
@@ -602,10 +602,10 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/u;",
                             data: {
                                 flags: "u"
-                            },
-                            output: "/a/u;"
+                            }
                         }
                     ]
                 }
@@ -627,11 +627,17 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
-                            output: "/a/;"
+                            output: "/a/;",
+                            data: {
+                                flags: ""
+                            }
                         },
                         {
                             messageId: "replaceWithIntendedLiteralAndFlags",
-                            output: "/a/g;"
+                            output: "/a/g;",
+                            data: {
+                                flags: "g"
+                            }
                         }
                     ]
                 }
@@ -653,7 +659,10 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
-                            output: "/a/g;"
+                            output: "/a/g;",
+                            data: {
+                                flags: "g"
+                            }
                         }
                     ]
                 }
@@ -675,11 +684,17 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
-                            output: "/a/g;"
+                            output: "/a/g;",
+                            data: {
+                                flags: "g"
+                            }
                         },
                         {
                             messageId: "replaceWithIntendedLiteralAndFlags",
-                            output: "/a/ig;"
+                            output: "/a/ig;",
+                            data: {
+                                flags: "ig"
+                            }
                         }
                     ]
                 }
@@ -701,7 +716,10 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
-                            output: "/a/ig;"
+                            output: "/a/ig;",
+                            data: {
+                                flags: "ig"
+                            }
                         }
                     ]
                 }
@@ -723,17 +741,17 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/g;",
                             data: {
                                 flags: "g"
-                            },
-                            output: "/a/g;"
+                            }
                         },
                         {
                             messageId: "replaceWithIntendedLiteralAndFlags",
+                            output: "/a/ig;",
                             data: {
                                 flags: "ig"
-                            },
-                            output: "/a/ig;"
+                            }
                         }
                     ]
                 }
@@ -755,10 +773,10 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/i;",
                             data: {
                                 flags: "i"
-                            },
-                            output: "/a/i;"
+                            }
                         }
                     ]
                 }
@@ -780,10 +798,10 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/u;",
                             data: {
                                 flags: "u"
-                            },
-                            output: "/a/u;"
+                            }
                         }
                     ]
                 }
@@ -805,10 +823,10 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/gi;",
                             data: {
                                 flags: "gi"
-                            },
-                            output: "/a/gi;"
+                            }
                         }
                     ]
                 }
@@ -852,7 +870,10 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
-                            output: "/a/u;"
+                            output: "/a/u;",
+                            data: {
+                                flags: "u"
+                            }
                         }
                     ]
                 }

--- a/tests/lib/rules/prefer-regex-literals.js
+++ b/tests/lib/rules/prefer-regex-literals.js
@@ -576,12 +576,18 @@ ruleTester.run("prefer-regex-literals", rule, {
                     messageId: "unexpectedRedundantRegExp",
                     type: "NewExpression",
                     line: 1,
-                    column: 1
+                    column: 1,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteral",
+                            output: "/a/;"
+                        }
+                    ]
                 }
             ]
         },
         {
-            code: "new RegExp(/a/, 'u');",
+            code: "new RegExp(/a/, 'g');",
             options: [
                 {
                     disallowRedundantWrapping: true
@@ -592,7 +598,109 @@ ruleTester.run("prefer-regex-literals", rule, {
                     messageId: "unexpectedRedundantRegExpWithFlags",
                     type: "NewExpression",
                     line: 1,
-                    column: 1
+                    column: 1,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/g;"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/a/g, 'g');",
+            options: [
+                {
+                    disallowRedundantWrapping: true
+                }
+            ],
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    type: "NewExpression",
+                    line: 1,
+                    column: 1,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/g;"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/a/ig, 'g');",
+            options: [
+                {
+                    disallowRedundantWrapping: true
+                }
+            ],
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    type: "NewExpression",
+                    line: 1,
+                    column: 1,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/g;"
+                        },
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/ig;"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/a/g, 'ig');",
+            options: [
+                {
+                    disallowRedundantWrapping: true
+                }
+            ],
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    type: "NewExpression",
+                    line: 1,
+                    column: 1,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/ig;"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/a/i, 'g');",
+            options: [
+                {
+                    disallowRedundantWrapping: true
+                }
+            ],
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    type: "NewExpression",
+                    line: 1,
+                    column: 1,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/g;"
+                        },
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/ig;"
+                        }
+                    ]
                 }
             ]
         },
@@ -608,7 +716,13 @@ ruleTester.run("prefer-regex-literals", rule, {
                     messageId: "unexpectedRedundantRegExpWithFlags",
                     type: "NewExpression",
                     line: 1,
-                    column: 1
+                    column: 1,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/u;"
+                        }
+                    ]
                 }
             ]
         },
@@ -624,12 +738,18 @@ ruleTester.run("prefer-regex-literals", rule, {
                     messageId: "unexpectedRedundantRegExpWithFlags",
                     type: "NewExpression",
                     line: 1,
-                    column: 1
+                    column: 1,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/u;"
+                        }
+                    ]
                 }
             ]
         },
         {
-            code: "new RegExp('a');",
+            code: "new RegExp(/a/ /* comment */);",
             options: [
                 {
                     disallowRedundantWrapping: true
@@ -637,16 +757,31 @@ ruleTester.run("prefer-regex-literals", rule, {
             ],
             errors: [
                 {
-                    messageId: "unexpectedRegExp",
+                    messageId: "unexpectedRedundantRegExp",
                     type: "NewExpression",
                     line: 1,
                     column: 1,
-                    suggestions: [
-                        {
-                            messageId: "replaceWithLiteral",
-                            output: "/a/;"
-                        }
-                    ]
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/a/, 'd');",
+            options: [
+                {
+                    disallowRedundantWrapping: true
+                }
+            ],
+            parserOptions: {
+                ecmaVersion: 2021
+            },
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    type: "NewExpression",
+                    line: 1,
+                    column: 1,
+                    suggestions: null
                 }
             ]
         },

--- a/tests/lib/rules/prefer-regex-literals.js
+++ b/tests/lib/rules/prefer-regex-literals.js
@@ -628,6 +628,10 @@ ruleTester.run("prefer-regex-literals", rule, {
                         {
                             messageId: "replaceWithLiteral",
                             output: "/a/;"
+                        },
+                        {
+                            messageId: "replaceWithIntendedLiteralAndFlags",
+                            output: "/a/g;"
                         }
                     ]
                 }
@@ -674,7 +678,7 @@ ruleTester.run("prefer-regex-literals", rule, {
                             output: "/a/g;"
                         },
                         {
-                            messageId: "replaceWithLiteralAndFlags",
+                            messageId: "replaceWithIntendedLiteralAndFlags",
                             output: "/a/ig;"
                         }
                     ]
@@ -725,11 +729,36 @@ ruleTester.run("prefer-regex-literals", rule, {
                             output: "/a/g;"
                         },
                         {
-                            messageId: "replaceWithLiteralAndFlags",
+                            messageId: "replaceWithIntendedLiteralAndFlags",
                             data: {
                                 flags: "ig"
                             },
                             output: "/a/ig;"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/a/i, 'i');",
+            options: [
+                {
+                    disallowRedundantWrapping: true
+                }
+            ],
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    type: "NewExpression",
+                    line: 1,
+                    column: 1,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            data: {
+                                flags: "i"
+                            },
+                            output: "/a/i;"
                         }
                     ]
                 }

--- a/tests/lib/rules/prefer-regex-literals.js
+++ b/tests/lib/rules/prefer-regex-literals.js
@@ -587,7 +587,7 @@ ruleTester.run("prefer-regex-literals", rule, {
             ]
         },
         {
-            code: "new RegExp(/a/, 'g');",
+            code: "new RegExp(/a/, 'u');",
             options: [
                 {
                     disallowRedundantWrapping: true
@@ -602,7 +602,29 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
-                            output: "/a/g;"
+                            output: "/a/u;"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/a/g, '');",
+            options: [
+                {
+                    disallowRedundantWrapping: true
+                }
+            ],
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    type: "NewExpression",
+                    line: 1,
+                    column: 1,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/;"
                         }
                     ]
                 }
@@ -743,6 +765,28 @@ ruleTester.run("prefer-regex-literals", rule, {
                         {
                             messageId: "replaceWithLiteralAndFlags",
                             output: "/a/gi;"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "new RegExp('a');",
+            options: [
+                {
+                    disallowRedundantWrapping: true
+                }
+            ],
+            errors: [
+                {
+                    messageId: "unexpectedRegExp",
+                    type: "NewExpression",
+                    line: 1,
+                    column: 1,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteral",
+                            output: "/a/;"
                         }
                     ]
                 }

--- a/tests/lib/rules/prefer-regex-literals.js
+++ b/tests/lib/rules/prefer-regex-literals.js
@@ -626,7 +626,7 @@ ruleTester.run("prefer-regex-literals", rule, {
                     column: 1,
                     suggestions: [
                         {
-                            messageId: "replaceWithLiteral",
+                            messageId: "replaceWithLiteralAndFlags",
                             output: "/a/;"
                         },
                         {

--- a/tests/lib/rules/prefer-regex-literals.js
+++ b/tests/lib/rules/prefer-regex-literals.js
@@ -727,6 +727,28 @@ ruleTester.run("prefer-regex-literals", rule, {
             ]
         },
         {
+            code: "new RegExp(/a/, `gi`);",
+            options: [
+                {
+                    disallowRedundantWrapping: true
+                }
+            ],
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    type: "NewExpression",
+                    line: 1,
+                    column: 1,
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/gi;"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             code: "new RegExp(/a/, String.raw`u`);",
             options: [
                 {

--- a/tests/lib/rules/prefer-regex-literals.js
+++ b/tests/lib/rules/prefer-regex-literals.js
@@ -602,6 +602,9 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
+                            data: {
+                                flags: "u"
+                            },
                             output: "/a/u;"
                         }
                     ]
@@ -623,7 +626,7 @@ ruleTester.run("prefer-regex-literals", rule, {
                     column: 1,
                     suggestions: [
                         {
-                            messageId: "replaceWithLiteralAndFlags",
+                            messageId: "replaceWithLiteral",
                             output: "/a/;"
                         }
                     ]
@@ -716,10 +719,16 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
+                            data: {
+                                flags: "g"
+                            },
                             output: "/a/g;"
                         },
                         {
                             messageId: "replaceWithLiteralAndFlags",
+                            data: {
+                                flags: "ig"
+                            },
                             output: "/a/ig;"
                         }
                     ]
@@ -742,6 +751,9 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
+                            data: {
+                                flags: "u"
+                            },
                             output: "/a/u;"
                         }
                     ]
@@ -764,6 +776,9 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: [
                         {
                             messageId: "replaceWithLiteralAndFlags",
+                            data: {
+                                flags: "gi"
+                            },
                             output: "/a/gi;"
                         }
                     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Add suggestions to a rule

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

fixes #16516 

#### Is there anything you'd like reviewers to focus on?


```js
new RegExp(/a/, 'g'); 

// suggestions
/a/g;
```

In this case, this change will make two suggestions. - https://github.com/eslint/eslint/issues/16516#issuecomment-1305776045

```js
new RegExp(/a/i, 'g');

// suggestions
/a/g;
/a/ig;
```

<!-- markdownlint-disable-file MD004 -->
