### PR TITLE
ci: fix npm v9 problem with `file:`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock = false
+install-links = false

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
     "@eslint/eslintrc": "^1.3.3",
-    "@humanwhocodes/config-array": "^0.11.6",
+    "@humanwhocodes/config-array": "0.11.7",
     "@humanwhocodes/module-importer": "^1.0.1",
     "@nodelib/fs.walk": "^1.2.8",
     "ajv": "^6.10.0",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

On the recently released Node v19.3.0, we're getting a lot of errors related to loading `eslint-plugin-internal-rules`, which is in our package.json specified as `"eslint-plugin-internal-rules": "file:tools/internal-rules"`. Node v19.3.0 is the first version that includes npm v9, and the cause of the problem seems to be the new default value `true` for the option [`install-links`](https://docs.npmjs.com/cli/v9/commands/npm-install#install-links). 

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In `.npmrc`, I added `install-links = false` to restore pre-v9 npm behavior.

#### Is there anything you'd like reviewers to focus on?

I'm not sure why exactly it doesn't work with the default `install-links = true`.

<!-- markdownlint-disable-file MD004 -->
