### PR TITLE
docs: optimize code block structure

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -10,7 +10,7 @@ const Image = require("@11ty/eleventy-img");
 const path = require("path");
 const { slug } = require("github-slugger");
 const yaml = require("js-yaml");
-const { highlighter, preWrapperPlugin, lineNumberPlugin } = require("./src/_plugins/md-syntax-highlighter");
+const { highlighter, lineNumberPlugin } = require("./src/_plugins/md-syntax-highlighter");
 const {
     DateTime
 } = require("luxon");
@@ -208,7 +208,6 @@ module.exports = function(eleventyConfig) {
                 return generateAlertMarkup("important", tokens, idx);
             }
         })
-        .use(preWrapperPlugin)
         .use(lineNumberPlugin)
         .disable("code");
 

--- a/docs/src/_plugins/md-syntax-highlighter.js
+++ b/docs/src/_plugins/md-syntax-highlighter.js
@@ -47,23 +47,7 @@ const highlighter = function (md, str, lang) {
         result = md.utils.escapeHtml(str);
     }
 
-    return `<pre><code>${result}</code></pre>`;
-};
-
-/**
- *
- * modified from https://github.com/vuejs/vitepress/blob/main/src/node/markdown/plugins/preWrapper.ts
- * @param {MarkdownIt} md
- * @license MIT License. See file header.
- */
-const preWrapperPlugin = (md) => {
-    const fence = md.renderer.rules.fence;
-    md.renderer.rules.fence = (...args) => {
-        const [tokens, idx] = args;
-        const lang = tokens[idx].info.trim();
-        const rawCode = fence(...args);
-        return `<div class="language-${lang}">${rawCode}</div>`;
-    };
+    return `<pre class="language-${lang}"><code>${result}</code></pre>`;
 };
 
 /**
@@ -93,15 +77,13 @@ const lineNumberPlugin = (md) => {
         const lineNumbersWrapperCode = `<div class="line-numbers-wrapper" aria-hidden="true">${lineNumbersCode}</div>`;
 
         const finalCode = rawCode
-            .replace(/<\/div>$/, `${lineNumbersWrapperCode}</div>`)
+            .replace(/<\/pre>\n/, `${lineNumbersWrapperCode}</pre>`)
             .replace(/"(language-\S*?)"/, '"$1 line-numbers-mode"')
             .replace(/<code>/, `<code class="language-${lang}">`)
-            .replace(/<pre>/, `<pre class="language-${lang}">`);
 
         return finalCode;
     };
 };
 
 module.exports.highlighter = highlighter;
-module.exports.preWrapperPlugin = preWrapperPlugin;
 module.exports.lineNumberPlugin = lineNumberPlugin;

--- a/docs/src/_plugins/md-syntax-highlighter.js
+++ b/docs/src/_plugins/md-syntax-highlighter.js
@@ -32,7 +32,7 @@ const loadLanguages = require("prismjs/components/");
  * @param {MarkdownIt} md markdown-it
  * @param {string} str code
  * @param {string} lang code language
- * @returns
+ * @returns {string} highlighted result wrapped in pre
  */
 const highlighter = function (md, str, lang) {
     let result = "";
@@ -41,7 +41,9 @@ const highlighter = function (md, str, lang) {
             loadLanguages([lang]);
             result = Prism.highlight(str, Prism.languages[lang], lang);
         } catch (err) {
-            console.log(err);
+            console.log(lang, err);
+            // we still want to wrap the result later
+            result = md.utils.escapeHtml(str);
         }
     } else {
         result = md.utils.escapeHtml(str);

--- a/docs/src/assets/scss/syntax-highlighter.scss
+++ b/docs/src/assets/scss/syntax-highlighter.scss
@@ -32,7 +32,7 @@ pre[class*="language-"] {
 }
 
 /* Code blocks */
-div[class*="language-"] {
+pre[class*="language-"] {
     padding: 1.5rem;
     margin: 1.5rem 0;
     overflow: auto;
@@ -42,6 +42,10 @@ div[class*="language-"] {
 
     [data-theme="dark"] & {
         color: var(--color-neutral-100);
+    }
+
+    &.line-numbers-mode {
+        padding-left: calc(1.5rem + 2.4em + 1.2rem);
     }
 }
 
@@ -103,29 +107,20 @@ pre[class*="language-"] {
 .line-numbers-wrapper {
     position: absolute;
     top: 0;
+    left: 1.5rem;
     text-align: right;
     padding-top: 1.5rem;
     font-size: 1em;
     font-family: var(--mono-font), Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
     line-height: 1.5;
     color: var(--icon-color);
-}
 
-.line-number {
-    user-select: none;
-    color: var(--icon-color);
-    display: inline-block;
-    font-variant-numeric: tabular-nums;
-    text-align: right;
-    width: 1.2em;
-}
-
-div[class*="language-"].line-numbers-mode {
-    position: relative;
-
-    pre[class*="language-"] {
-        padding-left: calc(2.4em + 1.2rem);
-        margin-top: 0;
-        margin-bottom: 0;
+    .line-number {
+        user-select: none;
+        color: var(--icon-color);
+        display: inline-block;
+        font-variant-numeric: tabular-nums;
+        text-align: right;
+        width: 1.2em;
     }
 }

--- a/docs/src/assets/scss/syntax-highlighter.scss
+++ b/docs/src/assets/scss/syntax-highlighter.scss
@@ -114,6 +114,7 @@ pre[class*="language-"] {
     font-family: var(--mono-font), Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
     line-height: 1.5;
     color: var(--icon-color);
+    font-variant-ligatures: none;
 
     .line-number {
         user-select: none;

--- a/templates/formatter-examples.md.ejs
+++ b/templates/formatter-examples.md.ejs
@@ -66,7 +66,7 @@ Example output:
 
 <% if (formatterName !== "html") { -%>
 ```text
-<%- formatterResults[formatterName].result %>
+<%= formatterResults[formatterName].result %>
 ```
 <% } else {-%>
 <iframe src="html-formatter-example.html" width="100%" height="460px"></iframe>

--- a/templates/formatter-examples.md.ejs
+++ b/templates/formatter-examples.md.ejs
@@ -66,7 +66,7 @@ Example output:
 
 <% if (formatterName !== "html") { -%>
 ```text
-<%= formatterResults[formatterName].result %>
+<%- formatterResults[formatterName].result %>
 ```
 <% } else {-%>
 <iframe src="html-formatter-example.html" width="100%" height="460px"></iframe>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

A follow-up pull request as we discussed in https://github.com/eslint/eslint/pull/16636#issuecomment-1353732929. Thanks @amareshsm for raising that issue which was introduced by my pull request.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

1. refractor syntax highlighting code to minimize changes of CSS.
2. Add `font-variant-ligatures: none;` rule to fix a UI issue under firefox reported https://github.com/eslint/eslint/pull/16671 by @Tanujkanti4441 
3. closes https://github.com/eslint/eslint/issues/16676

Here's a diff image (a very long one) before and after this pull request tested under firefox, so hopefully it won't break anything else other than fixing the language switcher style and number alignment issue:

<img src='https://user-images.githubusercontent.com/1091472/208425615-7ed06399-63ae-48cb-bade-bc643f6d01d0.png' width='250' height='auto' />

And here's the page reported with [broken line number before](https://github.com/eslint/eslint/issues/16042): https://deploy-preview-16669--docs-eslint.netlify.app/rules/function-paren-newline#rule-details, no regression here.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
