### PR TITLE
feat: group properties with values in parentheses in `key-spacing`

### DIFF
--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -348,7 +348,7 @@ module.exports = {
         }
 
         /**
-         * Starting from the given a node (a property.key node here) looks forward
+         * Starting from the given node (a property.key node here) looks forward
          * until it finds the colon punctuator and returns it.
          * @param {ASTNode} node The node to start looking from.
          * @returns {ASTNode} The colon punctuator.
@@ -358,7 +358,7 @@ module.exports = {
         }
 
         /**
-         * Starting from the given a node (a property.key node here) looks forward
+         * Starting from the given node (a property.key node here) looks forward
          * until it finds the last token before a colon punctuator and returns it.
          * @param {ASTNode} node The node to start looking from.
          * @returns {ASTNode} The last token before a colon punctuator.
@@ -370,7 +370,7 @@ module.exports = {
         }
 
         /**
-         * Starting from the given a node (a property.key node here) looks forward
+         * Starting from the given node (a property.key node here) looks forward
          * until it finds the first token after a colon punctuator and returns it.
          * @param {ASTNode} node The node to start looking from.
          * @returns {ASTNode} The first token after a colon punctuator.

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -348,6 +348,40 @@ module.exports = {
         }
 
         /**
+         * Starting from the given a node (a property.key node here) looks forward
+         * until it finds the colon punctuator and returns it.
+         * @param {ASTNode} node The node to start looking from.
+         * @returns {ASTNode} The colon punctuator.
+         */
+        function getNextColon(node) {
+            return sourceCode.getTokenAfter(node, astUtils.isColonToken);
+        }
+
+        /**
+         * Starting from the given a node (a property.key node here) looks forward
+         * until it finds the last token before a colon punctuator and returns it.
+         * @param {ASTNode} node The node to start looking from.
+         * @returns {ASTNode} The last token before a colon punctuator.
+         */
+        function getLastTokenBeforeColon(node) {
+            const colonToken = getNextColon(node);
+
+            return sourceCode.getTokenBefore(colonToken);
+        }
+
+        /**
+         * Starting from the given a node (a property.key node here) looks forward
+         * until it finds the first token after a colon punctuator and returns it.
+         * @param {ASTNode} node The node to start looking from.
+         * @returns {ASTNode} The first token after a colon punctuator.
+         */
+        function getFirstTokenAfterColon(node) {
+            const colonToken = getNextColon(node);
+
+            return sourceCode.getTokenAfter(colonToken);
+        }
+
+        /**
          * Checks whether a property is a member of the property group it follows.
          * @param {ASTNode} lastMember The last Property known to be in the group.
          * @param {ASTNode} candidate The next Property that might be in the group.
@@ -355,7 +389,7 @@ module.exports = {
          */
         function continuesPropertyGroup(lastMember, candidate) {
             const groupEndLine = lastMember.loc.start.line,
-                candidateValueStartLine = (isKeyValueProperty(candidate) ? candidate.value : candidate).loc.start.line;
+                candidateValueStartLine = (isKeyValueProperty(candidate) ? getFirstTokenAfterColon(candidate.key) : candidate).loc.start.line;
 
             if (candidateValueStartLine - groupEndLine <= 1) {
                 return true;
@@ -382,28 +416,6 @@ module.exports = {
             }
 
             return false;
-        }
-
-        /**
-         * Starting from the given a node (a property.key node here) looks forward
-         * until it finds the last token before a colon punctuator and returns it.
-         * @param {ASTNode} node The node to start looking from.
-         * @returns {ASTNode} The last token before a colon punctuator.
-         */
-        function getLastTokenBeforeColon(node) {
-            const colonToken = sourceCode.getTokenAfter(node, astUtils.isColonToken);
-
-            return sourceCode.getTokenBefore(colonToken);
-        }
-
-        /**
-         * Starting from the given a node (a property.key node here) looks forward
-         * until it finds the colon punctuator and returns it.
-         * @param {ASTNode} node The node to start looking from.
-         * @returns {ASTNode} The colon punctuator.
-         */
-        function getNextColon(node) {
-            return sourceCode.getTokenAfter(node, astUtils.isColonToken);
         }
 
         /**

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -1055,6 +1055,35 @@ ruleTester.run("key-spacing", rule, {
             align: "value"
         }],
         parserOptions: { ecmaVersion: 6 }
+    },
+
+    // https://github.com/eslint/eslint/issues/16674
+    {
+        code: `
+        a = {
+            item       : 123,
+            longerItem : (
+              1 + 1
+            ),
+        };
+        `,
+        options: [{
+            align: {
+                beforeColon: true,
+                afterColon: true,
+                on: "colon"
+            }
+        }]
+    },
+    {
+        code: `
+        a = {
+            item: 123,
+            longerItem: // a comment - not a token
+            (1 + 1),
+        };
+        `,
+        options: [{ align: "value" }]
     }],
     invalid: [{
         code: "var a ={'key' : value };",
@@ -2579,6 +2608,32 @@ ruleTester.run("key-spacing", rule, {
         errors: [
             { messageId: "extraKey", data: { computed: "", key: "singleLine" }, line: 2, column: 15, type: "Identifier" },
             { messageId: "extraKey", data: { computed: "", key: "newGroup" }, line: 3, column: 13, type: "Identifier" }
+        ]
+    },
+
+    // https://github.com/eslint/eslint/issues/16674
+    {
+        code:
+        `
+        c = {
+            item: 123,
+            longerItem: (
+              1 + 1
+            ),
+        };
+        `,
+        output:
+        `
+        c = {
+            item      : 123,
+            longerItem: (
+              1 + 1
+            ),
+        };
+        `,
+        options: [{ align: "colon" }],
+        errors: [
+            { messageId: "missingKey", data: { computed: "", key: "item" }, line: 3, column: 13, type: "Identifier" }
         ]
     }]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #16674

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR fixes a bug introduced in a previous change in the `key-spacing` rule that would cause certain properties to be erroneously excluded from a group.
Specifically, a property having its value wrapped in parentheses was treated as not continuing the previous group if the value started on a different line than the opening parenthesis.

* Changed the logic in `continuesPropertyGroup` to look for the first token after the colon instead of the property value node.
* Added new function `getFirstTokenAfterColon`, similar to `getLastTokenBeforeColon`.
* Rearranged functions to comply with lint settings.
* Added unit tests.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
