### PR TITLE
chore: update ignore patterns in `eslint.config.js`

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -548,7 +548,7 @@ target.lintDocsJS = function([fix = false] = []) {
     let errors = 0;
 
     echo("Validating JavaScript files in the docs directory");
-    const lastReturn = exec(`${ESLINT}${fix ? "--fix" : ""} docs/.eleventy.js`);
+    const lastReturn = exec(`${ESLINT}${fix ? "--fix" : ""} docs`);
 
     if (lastReturn.code !== 0) {
         errors++;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -82,7 +82,7 @@ module.exports = [
         ignores: [
             "build/**",
             "coverage/**",
-            "docs/**",
+            "docs/*",
             "!docs/.eleventy.js",
             "jsdoc/**",
             "templates/**",
@@ -91,8 +91,7 @@ module.exports = [
             "tests/performance/**",
             "tmp/**",
             "tools/internal-rules/node_modules/**",
-            "**/test.js",
-            "!.eslintrc.js"
+            "**/test.js"
         ]
     },
     {

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -4571,13 +4571,13 @@ describe("FlatESLint", () => {
             beforeEach(prepare);
             afterEach(cleanup);
 
-            it("'isPathIgnored()' should return 'true' for 'node_modules/foo/index.js'.", async () => {
+            it("'isPathIgnored()' should return 'false' for 'node_modules/foo/index.js'.", async () => {
                 const engine = new FlatESLint({ cwd: getPath() });
 
                 assert.strictEqual(await engine.isPathIgnored("node_modules/foo/index.js"), false);
             });
 
-            it("'isPathIgnored()' should return 'true' for 'node_modules/foo/.dot.js'.", async () => {
+            it("'isPathIgnored()' should return 'false' for 'node_modules/foo/.dot.js'.", async () => {
                 const engine = new FlatESLint({ cwd: getPath() });
 
                 assert.strictEqual(await engine.isPathIgnored("node_modules/foo/.dot.js"), false);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

After https://github.com/eslint/eslint/pull/16579, `docs/**` ignore pattern matches directory `docs/`, so `!docs/.eleventy.js` doesn't really unignore `docs/.eleventy.js` file because the file is in an ignored directory.

This is observable in our CI: https://github.com/eslint/eslint/actions/runs/3717239694/jobs/6304407905

```text
Run node Makefile lintDocsJS
Validating JavaScript files in the docs directory

/home/runner/work/eslint/eslint/docs/.eleventy.js
Warning:   0:0  warning  File ignored by default.  Use a negated ignore pattern (like "--ignore-pattern '!<relative/path/to/filename>'") to override

✖ 1 problem (0 errors, 1 warning)

```

This PR updates ignore patterns in our `eslint.config.js` to re-enable linting `docs/.eleventy.js`, and makes a few other updates related to ignore patterns.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Changed `docs/**` ignore pattern to `docs/*`. In combination with `!docs/.eleventy.js`, this means that everything under `docs/` is still ignored, except for `docs/.eleventy.js`.
* Removed `!.eslintrc.js` ignore pattern as it had no effect because the flat config system does not ignore dotfiles by default.
* Updated glob pattern we use to lint docs js files, from `docs/.eleventy.js` to `docs`. The command still lints only `docs/.eleventy.js` file, but it was supposed to have the whole `docs` directory as the target while the config file controls which files should be linted. Specifying the exact file in the command was only a temporary solution at a point when this didn't work well.
* Updated two test titles, per https://github.com/eslint/eslint/pull/16579#discussion_r1050651254 and https://github.com/eslint/eslint/pull/16579#discussion_r1050651701.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
