### PR TITLE
perf: switch from JSON schema `oneOf` to `anyOf`

### DIFF
--- a/docs/src/developer-guide/working-with-rules.md
+++ b/docs/src/developer-guide/working-with-rules.md
@@ -660,6 +660,8 @@ To learn more about JSON Schema, we recommend looking at some examples in [websi
 
 **Note:** Currently you need to use full JSON Schema object rather than array in case your schema has references ($ref), because in case of array format ESLint transforms this array into a single schema without updating references that makes them incorrect (they are ignored).
 
+**Note:** A common pitfall for JSON schema authors is to use `"oneOf"`, when `"anyOf"` could be used. Usually `"anyOf"` is preferable, because it’s more performant.
+
 ### Getting the Source
 
 If your rule needs to get the actual JavaScript source to work with, then use the `sourceCode.getText()` method. This method works as follows:

--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -26,7 +26,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         enum: ["always", "never", "consistent"]
                     },

--- a/lib/rules/array-element-newline.js
+++ b/lib/rules/array-element-newline.js
@@ -27,7 +27,7 @@ module.exports = {
         schema: {
             definitions: {
                 basicConfig: {
-                    oneOf: [
+                    anyOf: [
                         {
                             enum: ["always", "never", "consistent"]
                         },
@@ -49,7 +49,7 @@ module.exports = {
             },
             items: [
                 {
-                    oneOf: [
+                    anyOf: [
                         {
                             $ref: "#/definitions/basicConfig"
                         },

--- a/lib/rules/capitalized-comments.js
+++ b/lib/rules/capitalized-comments.js
@@ -115,7 +115,7 @@ module.exports = {
         schema: [
             { enum: ["always", "never"] },
             {
-                oneOf: [
+                anyOf: [
                     SCHEMA_BODY,
                     {
                         type: "object",

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -106,7 +106,7 @@ module.exports = {
             type: "array",
             items: [
                 {
-                    oneOf: [
+                    anyOf: [
                         {
                             $ref: "#/definitions/value"
                         },

--- a/lib/rules/complexity.js
+++ b/lib/rules/complexity.js
@@ -30,7 +30,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         type: "integer",
                         minimum: 0

--- a/lib/rules/function-paren-newline.js
+++ b/lib/rules/function-paren-newline.js
@@ -29,7 +29,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         enum: ["always", "never", "consistent", "multiline", "multiline-arguments"]
                     },

--- a/lib/rules/generator-star-spacing.js
+++ b/lib/rules/generator-star-spacing.js
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 const OVERRIDE_SCHEMA = {
-    oneOf: [
+    anyOf: [
         {
             enum: ["before", "after", "both", "neither"]
         },
@@ -40,7 +40,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         enum: ["before", "after", "both", "neither"]
                     },

--- a/lib/rules/indent-legacy.js
+++ b/lib/rules/indent-legacy.js
@@ -39,7 +39,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         enum: ["tab"]
                     },
@@ -57,7 +57,7 @@ module.exports = {
                         minimum: 0
                     },
                     VariableDeclarator: {
-                        oneOf: [
+                        anyOf: [
                             {
                                 type: "integer",
                                 minimum: 0
@@ -93,7 +93,7 @@ module.exports = {
                         type: "object",
                         properties: {
                             parameters: {
-                                oneOf: [
+                                anyOf: [
                                     {
                                         type: "integer",
                                         minimum: 0
@@ -113,7 +113,7 @@ module.exports = {
                         type: "object",
                         properties: {
                             parameters: {
-                                oneOf: [
+                                anyOf: [
                                     {
                                         type: "integer",
                                         minimum: 0
@@ -133,7 +133,7 @@ module.exports = {
                         type: "object",
                         properties: {
                             parameters: {
-                                oneOf: [
+                                anyOf: [
                                     {
                                         type: "integer",
                                         minimum: 0
@@ -146,7 +146,7 @@ module.exports = {
                         }
                     },
                     ArrayExpression: {
-                        oneOf: [
+                        anyOf: [
                             {
                                 type: "integer",
                                 minimum: 0
@@ -157,7 +157,7 @@ module.exports = {
                         ]
                     },
                     ObjectExpression: {
-                        oneOf: [
+                        anyOf: [
                             {
                                 type: "integer",
                                 minimum: 0

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -491,7 +491,7 @@ class OffsetStorage {
 }
 
 const ELEMENT_LIST_SCHEMA = {
-    oneOf: [
+    anyOf: [
         {
             type: "integer",
             minimum: 0
@@ -517,7 +517,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         enum: ["tab"]
                     },
@@ -536,7 +536,7 @@ module.exports = {
                         default: 0
                     },
                     VariableDeclarator: {
-                        oneOf: [
+                        anyOf: [
                             ELEMENT_LIST_SCHEMA,
                             {
                                 type: "object",
@@ -550,7 +550,7 @@ module.exports = {
                         ]
                     },
                     outerIIFEBody: {
-                        oneOf: [
+                        anyOf: [
                             {
                                 type: "integer",
                                 minimum: 0
@@ -561,7 +561,7 @@ module.exports = {
                         ]
                     },
                     MemberExpression: {
-                        oneOf: [
+                        anyOf: [
                             {
                                 type: "integer",
                                 minimum: 0

--- a/lib/rules/line-comment-position.js
+++ b/lib/rules/line-comment-position.js
@@ -23,7 +23,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         enum: ["above", "beside"]
                     },

--- a/lib/rules/lines-around-directive.js
+++ b/lib/rules/lines-around-directive.js
@@ -24,7 +24,7 @@ module.exports = {
         },
 
         schema: [{
-            oneOf: [
+            anyOf: [
                 {
                     enum: ["always", "never"]
                 },

--- a/lib/rules/logical-assignment-operators.js
+++ b/lib/rules/logical-assignment-operators.js
@@ -166,7 +166,7 @@ module.exports = {
 
         schema: {
             type: "array",
-            oneOf: [{
+            anyOf: [{
                 items: [
                     { const: "always" },
                     {

--- a/lib/rules/max-classes-per-file.js
+++ b/lib/rules/max-classes-per-file.js
@@ -26,7 +26,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         type: "integer",
                         minimum: 1

--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -22,7 +22,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         type: "integer",
                         minimum: 0

--- a/lib/rules/max-lines-per-function.js
+++ b/lib/rules/max-lines-per-function.js
@@ -36,7 +36,7 @@ const OPTIONS_SCHEMA = {
 };
 
 const OPTIONS_OR_INTEGER_SCHEMA = {
-    oneOf: [
+    anyOf: [
         OPTIONS_SCHEMA,
         {
             type: "integer",

--- a/lib/rules/max-lines.js
+++ b/lib/rules/max-lines.js
@@ -41,7 +41,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         type: "integer",
                         minimum: 0

--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -22,7 +22,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         type: "integer",
                         minimum: 0

--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -29,7 +29,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         type: "integer",
                         minimum: 0

--- a/lib/rules/max-statements.js
+++ b/lib/rules/max-statements.js
@@ -29,7 +29,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         type: "integer",
                         minimum: 0

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -27,7 +27,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         type: "boolean"
                     },

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -23,7 +23,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         type: "object",
                         properties: {

--- a/lib/rules/no-restricted-globals.js
+++ b/lib/rules/no-restricted-globals.js
@@ -22,7 +22,7 @@ module.exports = {
         schema: {
             type: "array",
             items: {
-                oneOf: [
+                anyOf: [
                     {
                         type: "string"
                     },

--- a/lib/rules/no-restricted-syntax.js
+++ b/lib/rules/no-restricted-syntax.js
@@ -22,7 +22,7 @@ module.exports = {
         schema: {
             type: "array",
             items: {
-                oneOf: [
+                anyOf: [
                     {
                         type: "string"
                     },

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -40,7 +40,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         enum: ["all", "local"]
                     },

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -233,7 +233,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         enum: ["nofunc"]
                     },

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -17,7 +17,7 @@ const astUtils = require("./utils/ast-utils");
 
 // Schema objects.
 const OPTION_VALUE = {
-    oneOf: [
+    anyOf: [
         {
             enum: ["always", "never"]
         },
@@ -159,7 +159,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     OPTION_VALUE,
                     {
                         type: "object",

--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -43,7 +43,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         enum: ["always", "never", "consecutive"]
                     },

--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -30,7 +30,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         enum: ["always", "never"]
                     },

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -40,7 +40,7 @@ module.exports = {
                  * old support {array: Boolean, object: Boolean}
                  * new support {VariableDeclarator: {}, AssignmentExpression: {}}
                  */
-                oneOf: [
+                anyOf: [
                     {
                         type: "object",
                         properties: {

--- a/lib/rules/space-before-blocks.js
+++ b/lib/rules/space-before-blocks.js
@@ -49,7 +49,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         enum: ["always", "never"]
                     },

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -29,7 +29,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         enum: ["always", "never"]
                     },

--- a/lib/rules/yield-star-spacing.js
+++ b/lib/rules/yield-star-spacing.js
@@ -24,7 +24,7 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
+                anyOf: [
                     {
                         enum: ["before", "after", "both", "neither"]
                     },


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

It’s a performance enhancement.

#### What changes did you make? (Give an overview)

I replaced `oneOf` with `anyOf` in the JSON schemas for all rules. Also I updated the documentation to discourage the use of `oneOf`.

#### Is there anything you'd like reviewers to focus on?

I replaced all occurrences of `oneOf` with `anyOf` in the rules. Since I looked over the changes and tests pass, I’m pretty confident that’s all fine. There may be better wording for the documentation update though. Also a similar note could be added for reminding people to defined `additionalProperties`, as in my experience this is easy to forget.

Closes #16691
