### PR TITLE
feat: check assignment patterns in no-underscore-dangle

### DIFF
--- a/docs/src/rules/no-underscore-dangle.md
+++ b/docs/src/rules/no-underscore-dangle.md
@@ -28,7 +28,6 @@ Examples of **incorrect** code for this rule:
 var foo_;
 var __proto__ = {};
 foo._bar();
-const [_foo, ..._bar] = list;
 ```
 
 :::

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -205,60 +205,6 @@ module.exports = {
             checkForDanglingUnderscoreInFunctionParameters(node);
         }
 
-        /**
-         * Check if node has dangling underscore or if node is type of ArrayPattern check its elements recursively
-         * @param {ASTNode} node node to evaluate
-         * @param {string} parentNodeType the ASTNode['type'] of the node parent
-         * @returns {void}
-         * @private
-         */
-        function deepCheckDestructured(node, parentNodeType) {
-            let identifier;
-
-            if (!node || !node.type) {
-                return;
-            }
-
-            switch (node.type) {
-                case "ArrayPattern":
-                    node.elements.forEach(element => deepCheckDestructured(element, "ArrayPattern"));
-                    break;
-                case "ObjectPattern":
-                    node.properties.forEach(property => deepCheckDestructured(property, "ObjectPattern"));
-                    break;
-                case "RestElement":
-                    deepCheckDestructured(node.argument, parentNodeType);
-                    break;
-                case "Property":
-                    deepCheckDestructured(node.value, "ObjectPattern");
-                    break;
-                case "Identifier":
-                    identifier = node.name;
-                    break;
-                default:
-                    break;
-            }
-
-            const isFromDestructuredObject = parentNodeType === "ObjectPattern" && !allowInObjectDestructuring;
-            const isFromDestructuredArray = parentNodeType === "ArrayPattern" && !allowInArrayDestructuring;
-            const hasDisallowedDestructuring = isFromDestructuredObject || isFromDestructuredArray;
-
-            if (
-                identifier &&
-                hasDisallowedDestructuring &&
-                hasDanglingUnderscore(identifier) &&
-                !isSpecialCaseIdentifierInVariableExpression(identifier) &&
-                !isAllowed(identifier)
-            ) {
-                context.report({
-                    node,
-                    messageId: "unexpectedUnderscore",
-                    data: {
-                        identifier
-                    }
-                });
-            }
-        }
 
         /**
          * Check if variable expression has a dangling underscore
@@ -267,30 +213,32 @@ module.exports = {
          * @private
          */
         function checkForDanglingUnderscoreInVariableExpression(node) {
-            if (node.id.type === "ArrayPattern") {
-                node.id.elements.forEach(element => {
-                    deepCheckDestructured(element, node.id.type);
-                });
-            }
+            context.getDeclaredVariables(node).forEach(variable => {
+                const definition = variable.defs.find(def => def.node === node);
+                const identifierNode = definition.name;
+                const identifier = identifierNode.name;
+                let parent = identifierNode.parent;
 
-            if (node.id.type === "ObjectPattern") {
-                node.id.properties.forEach(element => {
-                    deepCheckDestructured(element, node.id.type);
-                });
-            }
+                while (!["VariableDeclarator", "ArrayPattern", "ObjectPattern"].includes(parent.type)) {
+                    parent = parent.parent;
+                }
 
-            const identifier = node.id.name;
-
-            if (typeof identifier !== "undefined" && hasDanglingUnderscore(identifier) &&
-                !isSpecialCaseIdentifierInVariableExpression(identifier) && !isAllowed(identifier)) {
-                context.report({
-                    node,
-                    messageId: "unexpectedUnderscore",
-                    data: {
-                        identifier
-                    }
-                });
-            }
+                if (
+                    hasDanglingUnderscore(identifier) &&
+                    !isSpecialCaseIdentifierInVariableExpression(identifier) &&
+                    !isAllowed(identifier) &&
+                    !(allowInArrayDestructuring && parent.type === "ArrayPattern") &&
+                    !(allowInObjectDestructuring && parent.type === "ObjectPattern")
+                ) {
+                    context.report({
+                        node,
+                        messageId: "unexpectedUnderscore",
+                        data: {
+                            identifier
+                        }
+                    });
+                }
+            });
         }
 
         /**

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -70,8 +70,14 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "function foo( { _bar }) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
         { code: "function foo( { _bar = 0 } = {}) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 6 } },
         { code: "function foo(...[_bar]) {}", options: [{ allowFunctionParams: false }], parserOptions: { ecmaVersion: 2016 } },
+        { code: "const [_foo] = arr", parserOptions: { ecmaVersion: 6 } },
+        { code: "const [_foo] = arr", options: [{}], parserOptions: { ecmaVersion: 6 } },
+        { code: "const [_foo] = arr", options: [{ allowInArrayDestructuring: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "const [foo, ...rest] = [1, 2, 3]", options: [{ allowInArrayDestructuring: false }], parserOptions: { ecmaVersion: 2022 } },
         { code: "const [foo, _bar] = [1, 2, 3]", options: [{ allowInArrayDestructuring: false, allow: ["_bar"] }], parserOptions: { ecmaVersion: 2022 } },
+        { code: "const { _foo } = obj", parserOptions: { ecmaVersion: 6 } },
+        { code: "const { _foo } = obj", options: [{}], parserOptions: { ecmaVersion: 6 } },
+        { code: "const { _foo } = obj", options: [{ allowInObjectDestructuring: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "const { foo, bar: _bar } = { foo: 1, bar: 2 }", options: [{ allowInObjectDestructuring: false, allow: ["_bar"] }], parserOptions: { ecmaVersion: 2022 } },
         { code: "const { foo, _bar } = { foo: 1, _bar: 2 }", options: [{ allowInObjectDestructuring: false, allow: ["_bar"] }], parserOptions: { ecmaVersion: 2022 } },
         { code: "const { foo, _bar: bar } = { foo: 1, _bar: 2 }", options: [{ allowInObjectDestructuring: false }], parserOptions: { ecmaVersion: 2022 } },
@@ -113,6 +119,11 @@ ruleTester.run("no-underscore-dangle", rule, {
             parserOptions: { ecmaVersion: 2022 },
             errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_bar" } }]
         }, {
+            code: "const [_foo = 1] = arr",
+            options: [{ allowInArrayDestructuring: false }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_foo" } }]
+        }, {
             code: "const [foo, ..._rest] = [1, 2, 3]",
             options: [{ allowInArrayDestructuring: false }],
             parserOptions: { ecmaVersion: 2022 },
@@ -124,6 +135,16 @@ ruleTester.run("no-underscore-dangle", rule, {
             errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "bar_" } }]
         }, {
             code: "const { _foo, bar } = { _foo: 1, bar: 2 }",
+            options: [{ allowInObjectDestructuring: false }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_foo" } }]
+        }, {
+            code: "const { _foo = 1 } = obj",
+            options: [{ allowInObjectDestructuring: false }],
+            parserOptions: { ecmaVersion: 2022 },
+            errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_foo" } }]
+        }, {
+            code: "const { bar: _foo = 1 } = obj",
             options: [{ allowInObjectDestructuring: false }],
             parserOptions: { ecmaVersion: 2022 },
             errors: [{ messageId: "unexpectedUnderscore", data: { identifier: "_foo" } }]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment:**

* **ESLint Version:** `main` branch
* **Node Version:** v16.14.0
* **npm Version:** 8.3.1

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: 2015
    },
    rules: {
        "no-underscore-dangle": ["error", { allowInArrayDestructuring: false, allowInObjectDestructuring: false }]
    }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
const [_foo = 1] = arr;

const { _bar = 1 } = obj;

```

**What did you expect to happen?**

Two `no-underscore-dangle` errors, on `_foo` and `_bar`.

**What actually happened? Please include the actual, raw output from ESLint.**

No errors.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In the `no-underscore-dangle` rule, the code that checks destructuring patterns in `VariableDeclarator` nodes didn't account for  `AssignmentPattern` nodes. I simplified the code by using scope analysis (in particular, `context.getDeclaredVariables`), and after the change it correctly accounts for `AssignmentPattern` nodes.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
