### PR TITLE
fix: rules/indent - handle node.declarations.length < 1

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1518,7 +1518,7 @@ module.exports = {
                     variableIndent = DEFAULT_VARIABLE_INDENT;
                 }
 
-                if (node.declarations[node.declarations.length - 1].loc.start.line > node.loc.start.line) {
+                if (node.declarations[node.declarations.length - 1]?.loc.start.line > node.loc.start.line) {
 
                     /*
                      * VariableDeclarator indentation is a bit different from other forms of indentation, in that the


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment:**

* **ESLint Version:** 8.30.0
* **Node Version:** v16.14.2
* **npm Version:** 8.19.2

**What parser (default, `@babel/eslint-parser`, `@typescript-eslint/parser`, etc.) are you using?**
`@typescript-eslint/parser`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  env: {
    browser: true,
    es2021: true,
    node: true,
    jest: true,
  },
  extends: [
    'plugin:promise/recommended',
    'eslint:recommended',
    'plugin:@next/next/recommended',
    'next/core-web-vitals',
    'prettier',
  ],
  overrides: [],
  parser: '@typescript-eslint/parser',
  parserOptions: {
    ecmaVersion: 'latest',
    sourceType: 'module',
    ecmaFeatures: {
      jsx: true,
    },
  },
  plugins: [ 'import', 'prettier', 'react' ],
  rules: {
    indent: [ 'error', 2 ],
    quotes: [ 'error', 'single' ],
    semi: [ 'error', 'always' ],
    'arrow-parens': [ 'error', 'always' ],
    'quote-props': [ 'error', 'as-needed' ],
    'max-len': [ 'error', {} ],
    'no-multi-spaces': 'error',
    'array-bracket-newline': [ 'error', { multiline: true } ],
    'array-element-newline': [ 'error', 'consistent' ],
    'key-spacing': [ 'error', { beforeColon: false, afterColon: true } ],
    'comma-spacing': [ 'error', { before: false, after: true } ],
    'eol-last': [ 'error', 'always' ],
    'object-curly-spacing': [ 'error', 'always' ],
    // 'array-bracket-spacing': ['error', 'never', { singleValue: true }],
    'array-bracket-spacing': [ 'error', 'always' ],
    'no-multiple-empty-lines': [ 'error', { max: 1, maxBOF: 0 } ],
    'no-console': [ 'warn', { allow: [ 'warn', 'error' ] } ],
    'comma-dangle': [ 'error', 'always-multiline' ],
    'import/order': [
      'error',
      {
        'newlines-between': 'always',
        groups: [
          [ 'builtin', 'external', 'internal' ],
          [ 'parent' ],
          [ 'sibling', 'index' ],
        ],
        warnOnUnassignedImports: true,
      },
    ],
    'import/newline-after-import': [ 'error', { count: 1 } ],
    '@next/next/no-html-link-for-pages': [ 'error', 'my-app/pages' ],
  },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

For the line below, if you type just `const` (as you continue to type out the rest of your code), it'll throw a type error, as it'll attempt to access a node declaration that doesn't exist. I'm adding optional chaining to `node.declarations[node.declarations.length - 1]` in order to guard against this error.

`if (node.declarations[node.declarations.length - 1].loc.start.line > node.loc.start.line) {`

**What did you expect to happen?**

I don't expect the `indent` rule to throw a TypeError, accessing property of undefined

**What actually happened? Please include the actual, raw output from ESLint.**

```[Error - 11:39:50 PM] ESLint stack trace:
[Error - 11:39:50 PM] TypeError: Cannot read properties of undefined (reading 'loc')
Occurred while linting /Users/mchan/projects/kdfksjfnsdkjfndfsd/my-app/theme/test.ts:1
Rule: "indent"
    at Object.VariableDeclaration [as listener] (/Users/mchan/projects/kdfksjfnsdkjfndfsd/my-app/node_modules/eslint/lib/rules/indent.js:1521:69)
    at /Users/mchan/projects/kdfksjfnsdkjfndfsd/my-app/node_modules/eslint/lib/rules/indent.js:1732:55
    at Array.forEach (<anonymous>)
    at Program:exit (/Users/mchan/projects/kdfksjfnsdkjfndfsd/my-app/node_modules/eslint/lib/rules/indent.js:1732:26)
    at ruleErrorHandler (/Users/mchan/projects/kdfksjfnsdkjfndfsd/my-app/node_modules/eslint/lib/linter/linter.js:1115:28)
    at /Users/mchan/projects/kdfksjfnsdkjfndfsd/my-app/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/mchan/projects/kdfksjfnsdkjfndfsd/my-app/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/Users/mchan/projects/kdfksjfnsdkjfndfsd/my-app/node_modules/eslint/lib/linter/node-event-generator.js:297:26)
    at NodeEventGenerator.applySelectors (/Users/mchan/projects/kdfksjfnsdkjfndfsd/my-app/node_modules/eslint/lib/linter/node-event-generator.js:326:22)
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added optional chaining to gracefully handle situations where node.declarations.length is less than 1.

#### Is there anything you'd like reviewers to focus on?

No.

<!-- markdownlint-disable-file MD004 -->
