### PR TITLE
fix: syntax error in `prefer-arrow-callback` autofix

### DIFF
--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -335,6 +335,7 @@ module.exports = {
                             // Convert the function expression to an arrow function.
                             const functionToken = sourceCode.getFirstToken(node, node.async ? 1 : 0);
                             const leftParenToken = sourceCode.getTokenAfter(functionToken, astUtils.isOpeningParenToken);
+                            const tokenBeforeBody = sourceCode.getTokenBefore(node.body);
 
                             if (sourceCode.commentsExistBetween(functionToken, leftParenToken)) {
 
@@ -348,7 +349,7 @@ module.exports = {
                                 // Remove extra tokens and spaces.
                                 yield fixer.removeRange([functionToken.range[0], leftParenToken.range[0]]);
                             }
-                            yield fixer.insertTextBefore(node.body, "=> ");
+                            yield fixer.insertTextAfter(tokenBeforeBody, " =>");
 
                             // Get the node that will become the new arrow function.
                             let replacedNode = callbackInfo.isLexicalThis ? node.parent.parent : node;

--- a/tests/lib/rules/prefer-arrow-callback.js
+++ b/tests/lib/rules/prefer-arrow-callback.js
@@ -205,6 +205,46 @@ ruleTester.run("prefer-arrow-callback", rule, {
             code: "foo((function() { return this; }?.bind)(this));",
             output: null,
             errors
+        },
+
+        // https://github.com/eslint/eslint/issues/16718
+        {
+            code: `
+            test(
+                function ()
+                { }
+            );
+            `,
+            output: `
+            test(
+                () =>
+                { }
+            );
+            `,
+            errors
+        },
+        {
+            code: `
+            test(
+                function (
+                    ...args
+                ) /* Lorem ipsum
+                dolor sit amet. */ {
+                    return args;
+                }
+            );
+            `,
+            output: `
+            test(
+                (
+                    ...args
+                ) => /* Lorem ipsum
+                dolor sit amet. */ {
+                    return args;
+                }
+            );
+            `,
+            errors
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
Fixes #16718
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed the autofix behavior of the `prefer-arrow-callback` rule. When converting a regular function to an arrow-style function, the fix will now add an arrow (`=>`) right after the closing parenthesis of the parameter list rather than before the function body.

This serves to avoid a syntax error when the function body starts on a new line, because in JavaScript (unlike in TypeScript as it seems) a line terminator after the parameter list of an arrow function is not allowed ([spec link](https://262.ecma-international.org/13.0/#sec-arrow-function-definitions)).

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
