### PR TITLE
docs: Give advice on when to use warn

### DIFF
--- a/docs/src/user-guide/configuring/rules.md
+++ b/docs/src/user-guide/configuring/rules.md
@@ -20,6 +20,8 @@ To change a rule's severity, set the rule ID equal to one of these values:
 * `"warn"` or `1` - turn the rule on as a warning (doesn't affect exit code)
 * `"error"` or `2` - turn the rule on as an error (exit code is 1 when triggered)
 
+The `"warn"` severity is meant to be used as a temporary measure. It can be used to enable a rule so that new reported issues can be addressed, without breaking the build due to existing ones. It is recommended to keep the number of these issues low so that new issues get more easily noticed and don't get ignored.
+
 ### Using configuration comments
 
 To configure rules inside of a file using configuration comments, use a comment in the following format:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I added an explanation of when to use the `"warn"` severity, as I often feel like it's being misused and misunderstood. I asked what they were used for [in this Twitter thread](https://twitter.com/jfmengels/status/1578292783571353601) and @nzakas replied

> Warnings were designed to aid in transitioning to using new rules. Mark as a warning to let people know this rule will become an error in the future without breaking the build now. It’s intended as a temporary measure.

which I used as the basis of the explanation.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

I have been using and contributing to ESLint and linters for years, and had never known that this was the intent behind them. I imagine this will actually surprise people. I for a long time thought it was about more or less important rules.

I don't necessarily agree that warnings are a good use for this considering that it will easily lead a large wall of errors, which is why I have added some advice on keeping the number of these issues low.

I think it's important to give good advice here so I'm open to suggestions to improve the message.