### PR TITLE
feat: add `restrictDefaultExports` option to no-restricted-exports rule

### DIFF
--- a/docs/src/rules/no-restricted-exports.md
+++ b/docs/src/rules/no-restricted-exports.md
@@ -17,8 +17,16 @@ By default, this rule doesn't disallow any names. Only the names you specify in 
 This rule has an object option:
 
 * `"restrictedNamedExports"` is an array of strings, where each string is a name to be restricted.
+* `"restrictDefaultExports"` is an object option with boolean properties to restrict default exports in different formats. The option works only if the `restrictedNamedExports` option does not contain the `"default"` value. The following properties are allowed:
+  * `direct`: restricts `export default` declarations.
+  * `named`: restricts `export { foo as default };` declarations.
+  * `defaultFrom`: restricts `export { default } from 'foo';` declarations.
+  * `namedFrom`: restricts `export { foo as default } from 'foo';` declarations.
+  * `namespaceFrom`: restricts `export * as default from 'foo';` declarations.
 
-Examples of **incorrect** code for this rule:
+### restrictedNamedExports
+
+Examples of **incorrect** code for the `"restrictedNamedExports"` option:
 
 ::: incorrect
 
@@ -50,7 +58,7 @@ export { "👍" } from "some_module";
 
 :::
 
-Examples of **correct** code for this rule:
+Examples of **correct** code for the `"restrictedNamedExports"` option:
 
 ::: correct
 
@@ -82,11 +90,11 @@ export { "👍" as thumbsUp } from "some_module";
 
 :::
 
-### Default exports
+#### Default exports
 
-By design, this rule doesn't disallow `export default` declarations. If you configure `"default"` as a restricted name, that restriction will apply only to named export declarations.
+By design, the `"restrictedNamedExports"` option doesn't disallow `export default` declarations. If you configure `"default"` as a restricted name, that restriction will apply only to named export declarations.
 
-Examples of additional **incorrect** code for this rule:
+Examples of additional **incorrect** code for the `"restrictedNamedExports": ["default"]` option:
 
 ::: incorrect
 
@@ -110,7 +118,7 @@ export { default } from "some_module";
 
 :::
 
-Examples of additional **correct** code for this rule:
+Examples of additional **correct** code for the `"restrictedNamedExports": ["default"]` option:
 
 ::: correct
 
@@ -118,6 +126,85 @@ Examples of additional **correct** code for this rule:
 /*eslint no-restricted-exports: ["error", { "restrictedNamedExports": ["default", "foo"] }]*/
 
 export default function foo() {}
+```
+
+:::
+
+### restrictDefaultExports
+
+This option allows you to restrict certain `default` declarations. The option works only if the `restrictedNamedExports` option does not contain the `"default"` value. This option accepts the following properties:
+
+#### direct
+
+Examples of **incorrect** code for the `"restrictDefaultExports": { "direct": true }` option:
+
+::: incorrect
+
+```js
+/*eslint no-restricted-exports: ["error", { "restrictDefaultExports": { "direct": true } }]*/
+
+export default foo;
+export default 42;
+export default function foo() {};
+```
+
+:::
+
+#### named
+
+Examples of **incorrect** code for the `"restrictDefaultExports": { "named": true }` option:
+
+::: incorrect
+
+```js
+/*eslint no-restricted-exports: ["error", { "restrictDefaultExports": { "named": true } }]*/
+
+const foo = 123;
+
+export { foo as default };
+```
+
+:::
+
+#### defaultFrom
+
+Examples of **incorrect** code for the `"restrictDefaultExports": { "defaultFrom": true }` option:
+
+::: incorrect
+
+```js
+/*eslint no-restricted-exports: ["error", { "restrictDefaultExports": { "defaultFrom": true } }]*/
+
+export { default } from 'foo';
+export { default as default } from 'foo';
+```
+
+:::
+
+#### namedFrom
+
+Examples of **incorrect** code for the `"restrictDefaultExports": { "namedFrom": true }` option:
+
+::: incorrect
+
+```js
+/*eslint no-restricted-exports: ["error", { "restrictDefaultExports": { "namedFrom": true } }]*/
+
+export { foo as default } from 'foo';
+```
+
+:::
+
+#### namespaceFrom
+
+Examples of **incorrect** code for the `"restrictDefaultExports": { "namespaceFrom": true }` option:
+
+::: incorrect
+
+```js
+/*eslint no-restricted-exports: ["error", { "restrictDefaultExports": { "namespaceFrom": true } }]*/
+
+export * as default from 'foo';
 ```
 
 :::

--- a/docs/src/rules/no-restricted-exports.md
+++ b/docs/src/rules/no-restricted-exports.md
@@ -18,11 +18,11 @@ This rule has an object option:
 
 * `"restrictedNamedExports"` is an array of strings, where each string is a name to be restricted.
 * `"restrictDefaultExports"` is an object option with boolean properties to restrict default exports in different formats. The option works only if the `restrictedNamedExports` option does not contain the `"default"` value. The following properties are allowed:
-  * `direct`: restricts `export default` declarations.
-  * `named`: restricts `export { foo as default };` declarations.
-  * `defaultFrom`: restricts `export { default } from 'foo';` declarations.
-  * `namedFrom`: restricts `export { foo as default } from 'foo';` declarations.
-  * `namespaceFrom`: restricts `export * as default from 'foo';` declarations.
+    * `direct`: restricts `export default` declarations.
+    * `named`: restricts `export { foo as default };` declarations.
+    * `defaultFrom`: restricts `export { default } from 'foo';` declarations.
+    * `namedFrom`: restricts `export { foo as default } from 'foo';` declarations.
+    * `namespaceFrom`: restricts `export * as default from 'foo';` declarations.
 
 ### restrictedNamedExports
 

--- a/docs/src/rules/no-restricted-exports.md
+++ b/docs/src/rules/no-restricted-exports.md
@@ -145,7 +145,7 @@ Examples of **incorrect** code for the `"restrictDefaultExports": { "direct": tr
 
 export default foo;
 export default 42;
-export default function foo() {};
+export default function foo() {}
 ```
 
 :::

--- a/docs/src/rules/no-restricted-exports.md
+++ b/docs/src/rules/no-restricted-exports.md
@@ -17,7 +17,7 @@ By default, this rule doesn't disallow any names. Only the names you specify in 
 This rule has an object option:
 
 * `"restrictedNamedExports"` is an array of strings, where each string is a name to be restricted.
-* `"restrictDefaultExports"` is an object option with boolean properties to restrict default exports in different formats. The option works only if the `restrictedNamedExports` option does not contain the `"default"` value. The following properties are allowed:
+* `"restrictDefaultExports"` is an object option with boolean properties to restrict certain default export declarations. The option works only if the `restrictedNamedExports` option does not contain the `"default"` value. The following properties are allowed:
     * `direct`: restricts `export default` declarations.
     * `named`: restricts `export { foo as default };` declarations.
     * `defaultFrom`: restricts `export { default } from 'foo';` declarations.

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -118,27 +118,38 @@ module.exports = {
             }
 
             if (name === "default") {
-                const isSourceSpecified = node.parent.source || node.parent.parent.source;
-                const specifierLocalName = node.parent.local && node.parent.local.name;
+                if (node.parent.type === "ExportAllDeclaration") {
+                    const isSourceSpecified = node.parent.source;
 
-                if (!isSourceSpecified && restrictDefaultExports && restrictDefaultExports.named) {
-                    context.report({
-                        node,
-                        messageId: "restrictedDefault"
-                    });
-                    return;
-                }
-
-                if (isSourceSpecified && restrictDefaultExports) {
-                    if (
-                        (specifierLocalName === "default" && restrictDefaultExports.defaultFrom) ||
-                        (specifierLocalName !== "default" && restrictDefaultExports.namedFrom) ||
-                        (node.parent.type === "ExportAllDeclaration" && restrictDefaultExports.namespaceFrom)
-                    ) {
+                    if (isSourceSpecified && restrictDefaultExports && restrictDefaultExports.namespaceFrom) {
                         context.report({
                             node,
                             messageId: "restrictedDefault"
                         });
+                    }
+
+                } else { // ExportSpecifier
+                    const isSourceSpecified = node.parent.parent.source;
+                    const specifierLocalName = astUtils.getModuleExportName(node.parent.local);
+
+                    if (!isSourceSpecified && restrictDefaultExports && restrictDefaultExports.named) {
+                        context.report({
+                            node,
+                            messageId: "restrictedDefault"
+                        });
+                        return;
+                    }
+
+                    if (isSourceSpecified && restrictDefaultExports) {
+                        if (
+                            (specifierLocalName === "default" && restrictDefaultExports.defaultFrom) ||
+                            (specifierLocalName !== "default" && restrictDefaultExports.namedFrom)
+                        ) {
+                            context.report({
+                                node,
+                                messageId: "restrictedDefault"
+                            });
+                        }
                     }
                 }
             }

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -98,7 +98,7 @@ module.exports = {
     create(context) {
 
         const restrictedNames = new Set(context.options[0] && context.options[0].restrictedNamedExports);
-        const restrictDefaultExports = context.options[0] && !restrictedNames.has("default") && context.options[0].restrictDefaultExports;
+        const restrictDefaultExports = context.options[0] && context.options[0].restrictDefaultExports;
 
         /**
          * Checks and reports given exported name.
@@ -119,9 +119,7 @@ module.exports = {
 
             if (name === "default") {
                 if (node.parent.type === "ExportAllDeclaration") {
-                    const isSourceSpecified = node.parent.source;
-
-                    if (isSourceSpecified && restrictDefaultExports && restrictDefaultExports.namespaceFrom) {
+                    if (restrictDefaultExports && restrictDefaultExports.namespaceFrom) {
                         context.report({
                             node,
                             messageId: "restrictedDefault"
@@ -129,7 +127,7 @@ module.exports = {
                     }
 
                 } else { // ExportSpecifier
-                    const isSourceSpecified = node.parent.parent.source;
+                    const isSourceSpecified = !!node.parent.parent.source;
                     const specifierLocalName = astUtils.getModuleExportName(node.parent.local);
 
                     if (!isSourceSpecified && restrictDefaultExports && restrictDefaultExports.named) {

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -27,9 +27,9 @@ module.exports = {
         },
 
         schema: [{
-            type: "object",
             anyOf: [
                 {
+                    type: "object",
                     properties: {
                         restrictedNamedExports: {
                             type: "array",
@@ -42,6 +42,7 @@ module.exports = {
                     additionalProperties: false
                 },
                 {
+                    type: "object",
                     properties: {
                         restrictedNamedExports: {
                             type: "array",

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -101,7 +101,6 @@ module.exports = {
             if (name === "default") {
                 const isDefaultFromFormat = node.parent.parent.source;
                 const specifierLocalName = node.parent.local.name;
-                console.log("🚀 ~ file: no-restricted-exports.js:104 ~ checkExportedName ~ specifierLocalName", specifierLocalName)
 
                 if (!isDefaultFromFormat && restrictDefaultExports && restrictDefaultExports.named) {
                     context.report({
@@ -111,11 +110,16 @@ module.exports = {
                     return;
                 }
 
-                if (isDefaultFromFormat && specifierLocalName === "default" && restrictDefaultExports && restrictDefaultExports.defaultFrom) {
-                    context.report({
-                        node,
-                        messageId: "restrictedDefault"
-                    });
+                if (isDefaultFromFormat) {
+                    if (
+                        (specifierLocalName === "default" && restrictDefaultExports && restrictDefaultExports.defaultFrom) ||
+                        (specifierLocalName !== "default" && restrictDefaultExports && restrictDefaultExports.namedFrom)
+                    ) {
+                        context.report({
+                            node,
+                            messageId: "restrictedDefault"
+                        });
+                    }
                 }
             }
         }

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -100,7 +100,7 @@ module.exports = {
 
             if (name === "default") {
                 const isDefaultFromFormat = node.parent.parent.source;
-                const specifierLocalName = node.parent.local.name;
+                const specifierLocalName = node.parent.local && node.parent.local.name;
 
                 if (!isDefaultFromFormat && restrictDefaultExports && restrictDefaultExports.named) {
                     context.report({

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -95,12 +95,13 @@ module.exports = {
                     messageId: "restrictedNamed",
                     data: { name }
                 });
-
                 return;
             }
 
             if (name === "default") {
                 const isDefaultFromFormat = node.parent.parent.source;
+                const specifierLocalName = node.parent.local.name;
+                console.log("🚀 ~ file: no-restricted-exports.js:104 ~ checkExportedName ~ specifierLocalName", specifierLocalName)
 
                 if (!isDefaultFromFormat && restrictDefaultExports && restrictDefaultExports.named) {
                     context.report({
@@ -110,7 +111,7 @@ module.exports = {
                     return;
                 }
 
-                if (isDefaultFromFormat && restrictDefaultExports && restrictDefaultExports.defaultFrom) {
+                if (isDefaultFromFormat && specifierLocalName === "default" && restrictDefaultExports && restrictDefaultExports.defaultFrom) {
                     context.report({
                         node,
                         messageId: "restrictedDefault"

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -95,11 +95,27 @@ module.exports = {
                     messageId: "restrictedNamed",
                     data: { name }
                 });
-            } else if (name === "default" && restrictDefaultExports && restrictDefaultExports.named) {
-                context.report({
-                    node,
-                    messageId: "restrictedDefault"
-                });
+
+                return;
+            }
+
+            if (name === "default") {
+                const isDefaultFromFormat = node.parent.parent.source;
+
+                if (!isDefaultFromFormat && restrictDefaultExports && restrictDefaultExports.named) {
+                    context.report({
+                        node,
+                        messageId: "restrictedDefault"
+                    });
+                    return;
+                }
+
+                if (isDefaultFromFormat && restrictDefaultExports && restrictDefaultExports.defaultFrom) {
+                    context.report({
+                        node,
+                        messageId: "restrictedDefault"
+                    });
+                }
             }
         }
 

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -28,46 +28,64 @@ module.exports = {
 
         schema: [{
             type: "object",
-            properties: {
-                restrictedNamedExports: {
-                    type: "array",
-                    items: {
-                        type: "string"
-                    },
-                    uniqueItems: true
-                },
-                restrictDefaultExports: {
-                    type: "object",
+            anyOf: [
+                {
                     properties: {
-
-                        // Allow/Disallow `export default foo; export default 42; export default function foo() {}` format
-                        direct: {
-                            type: "boolean"
-                        },
-
-                        // Allow/Disallow `export { foo as default };` declarations
-                        named: {
-                            type: "boolean"
-                        },
-
-                        //  Allow/Disallow `export { default } from "mod"; export { default as default } from "mod";` declarations
-                        defaultFrom: {
-                            type: "boolean"
-                        },
-
-                        //  Allow/Disallow `export { foo as default } from "mod";` declarations
-                        namedFrom: {
-                            type: "boolean"
-                        },
-
-                        //  Allow/Disallow `export * as default from "mod"`; declarations
-                        namespaceFrom: {
-                            type: "boolean"
+                        restrictedNamedExports: {
+                            type: "array",
+                            items: {
+                                type: "string"
+                            },
+                            uniqueItems: true
                         }
-                    }
+                    },
+                    additionalProperties: false
+                },
+                {
+                    properties: {
+                        restrictedNamedExports: {
+                            type: "array",
+                            items: {
+                                type: "string",
+                                pattern: "^(?!default$)"
+                            },
+                            uniqueItems: true
+                        },
+                        restrictDefaultExports: {
+                            type: "object",
+                            properties: {
+
+                                // Allow/Disallow `export default foo; export default 42; export default function foo() {}` format
+                                direct: {
+                                    type: "boolean"
+                                },
+
+                                // Allow/Disallow `export { foo as default };` declarations
+                                named: {
+                                    type: "boolean"
+                                },
+
+                                //  Allow/Disallow `export { default } from "mod"; export { default as default } from "mod";` declarations
+                                defaultFrom: {
+                                    type: "boolean"
+                                },
+
+                                //  Allow/Disallow `export { foo as default } from "mod";` declarations
+                                namedFrom: {
+                                    type: "boolean"
+                                },
+
+                                //  Allow/Disallow `export * as default from "mod"`; declarations
+                                namespaceFrom: {
+                                    type: "boolean"
+                                }
+                            },
+                            additionalProperties: false
+                        }
+                    },
+                    additionalProperties: false
                 }
-            },
-            additionalProperties: false
+            ]
         }],
 
         messages: {

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -91,7 +91,7 @@ module.exports = {
 
         messages: {
             restrictedNamed: "'{{name}}' is restricted from being used as an exported name.",
-            restrictedDefault: "Exporting the 'default' value is restricted."
+            restrictedDefault: "Exporting 'default' is restricted."
         }
     },
 

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -99,10 +99,10 @@ module.exports = {
             }
 
             if (name === "default") {
-                const isDefaultFromFormat = node.parent.parent.source;
+                const isSourceSpecified = node.parent.source || node.parent.parent.source;
                 const specifierLocalName = node.parent.local && node.parent.local.name;
 
-                if (!isDefaultFromFormat && restrictDefaultExports && restrictDefaultExports.named) {
+                if (!isSourceSpecified && restrictDefaultExports && restrictDefaultExports.named) {
                     context.report({
                         node,
                         messageId: "restrictedDefault"
@@ -110,10 +110,11 @@ module.exports = {
                     return;
                 }
 
-                if (isDefaultFromFormat) {
+                if (isSourceSpecified && restrictDefaultExports) {
                     if (
-                        (specifierLocalName === "default" && restrictDefaultExports && restrictDefaultExports.defaultFrom) ||
-                        (specifierLocalName !== "default" && restrictDefaultExports && restrictDefaultExports.namedFrom)
+                        (specifierLocalName === "default" && restrictDefaultExports.defaultFrom) ||
+                        (specifierLocalName !== "default" && restrictDefaultExports.namedFrom) ||
+                        (node.parent.type === "ExportAllDeclaration" && restrictDefaultExports.namespaceFrom)
                     ) {
                         context.report({
                             node,

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -35,19 +35,51 @@ module.exports = {
                         type: "string"
                     },
                     uniqueItems: true
+                },
+                restrictDefaultExports: {
+                    type: "object",
+                    properties: {
+
+                        // Allow/Disallow `export default foo; export default 42; export default function foo() {}` format
+                        direct: {
+                            type: "boolean"
+                        },
+
+                        // Allow/Disallow `export { foo as default };` format
+                        named: {
+                            type: "boolean"
+                        },
+
+                        //  Allow/Disallow `export { default } from "mod"; export { default as default } from "mod";` format
+                        defaultFrom: {
+                            type: "boolean"
+                        },
+
+                        //  Allow/Disallow `export { foo as default } from "mod";` format
+                        namedFrom: {
+                            type: "boolean"
+                        },
+
+                        //  Allow/Disallow `export * as default from "mod"`; format
+                        namespaceFrom: {
+                            type: "boolean"
+                        }
+                    }
                 }
             },
             additionalProperties: false
         }],
 
         messages: {
-            restrictedNamed: "'{{name}}' is restricted from being used as an exported name."
+            restrictedNamed: "'{{name}}' is restricted from being used as an exported name.",
+            restrictedDefault: "Exporting the 'default' value is restricted."
         }
     },
 
     create(context) {
 
         const restrictedNames = new Set(context.options[0] && context.options[0].restrictedNamedExports);
+        const restrictDefaultExports = context.options[0] && !restrictedNames.has("default") && context.options[0].restrictDefaultExports;
 
         /**
          * Checks and reports given exported name.
@@ -63,6 +95,11 @@ module.exports = {
                     messageId: "restrictedNamed",
                     data: { name }
                 });
+            } else if (name === "default" && restrictDefaultExports && restrictDefaultExports.named) {
+                context.report({
+                    node,
+                    messageId: "restrictedDefault"
+                });
             }
         }
 
@@ -70,6 +107,15 @@ module.exports = {
             ExportAllDeclaration(node) {
                 if (node.exported) {
                     checkExportedName(node.exported);
+                }
+            },
+
+            ExportDefaultDeclaration(node) {
+                if (restrictDefaultExports && restrictDefaultExports.direct) {
+                    context.report({
+                        node,
+                        messageId: "restrictedDefault"
+                    });
                 }
             },
 

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -45,22 +45,22 @@ module.exports = {
                             type: "boolean"
                         },
 
-                        // Allow/Disallow `export { foo as default };` format
+                        // Allow/Disallow `export { foo as default };` declarations
                         named: {
                             type: "boolean"
                         },
 
-                        //  Allow/Disallow `export { default } from "mod"; export { default as default } from "mod";` format
+                        //  Allow/Disallow `export { default } from "mod"; export { default as default } from "mod";` declarations
                         defaultFrom: {
                             type: "boolean"
                         },
 
-                        //  Allow/Disallow `export { foo as default } from "mod";` format
+                        //  Allow/Disallow `export { foo as default } from "mod";` declarations
                         namedFrom: {
                             type: "boolean"
                         },
 
-                        //  Allow/Disallow `export * as default from "mod"`; format
+                        //  Allow/Disallow `export * as default from "mod"`; declarations
                         namespaceFrom: {
                             type: "boolean"
                         }

--- a/tests/lib/rules/no-restricted-exports.js
+++ b/tests/lib/rules/no-restricted-exports.js
@@ -600,14 +600,14 @@ ruleTester.run("no-restricted-exports", rule, {
             errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 10 }]
         },
         {
-            code: "export { default as default } from 'mod';",
-            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: true } }],
-            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 21 }]
-        },
-        {
             code: "export { default } from 'mod';",
             options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: false } }],
             errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 10 }]
+        },
+        {
+            code: "export { default as default } from 'mod';",
+            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: true } }],
+            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 21 }]
         },
         {
             code: "export { default as default } from 'mod';",

--- a/tests/lib/rules/no-restricted-exports.js
+++ b/tests/lib/rules/no-restricted-exports.js
@@ -120,6 +120,8 @@ ruleTester.run("no-restricted-exports", rule, {
 
         // restrictDefaultExports.defaultFrom option
         { code: "export { default } from 'mod';", options: [{ restrictDefaultExports: { defaultFrom: false } }] },
+        { code: "export { default as default } from 'mod';", options: [{ restrictDefaultExports: { defaultFrom: false } }] },
+        { code: "export { foo as default } from 'mod';", options: [{ restrictDefaultExports: { defaultFrom: true } }] },
         { code: "export { default } from 'mod';", options: [{ restrictDefaultExports: { named: true, defaultFrom: false } }] }
     ],
 
@@ -582,14 +584,29 @@ ruleTester.run("no-restricted-exports", rule, {
             errors: [{ messageId: "restrictedDefault", type: "Identifier", line: 1, column: 10 }]
         },
         {
+            code: "export { default as default } from 'mod';",
+            options: [{ restrictDefaultExports: { defaultFrom: true } }],
+            errors: [{ messageId: "restrictedDefault", type: "Identifier", line: 1, column: 21 }]
+        },
+        {
             code: "export { default } from 'mod';",
             options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: true } }],
             errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 10 }]
         },
         {
+            code: "export { default as default } from 'mod';",
+            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: true } }],
+            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 21 }]
+        },
+        {
             code: "export { default } from 'mod';",
             options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: false } }],
             errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 10 }]
+        },
+        {
+            code: "export { default as default } from 'mod';",
+            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: false } }],
+            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 21 }]
         }
     ]
 });

--- a/tests/lib/rules/no-restricted-exports.js
+++ b/tests/lib/rules/no-restricted-exports.js
@@ -122,7 +122,12 @@ ruleTester.run("no-restricted-exports", rule, {
         { code: "export { default } from 'mod';", options: [{ restrictDefaultExports: { defaultFrom: false } }] },
         { code: "export { default as default } from 'mod';", options: [{ restrictDefaultExports: { defaultFrom: false } }] },
         { code: "export { foo as default } from 'mod';", options: [{ restrictDefaultExports: { defaultFrom: true } }] },
-        { code: "export { default } from 'mod';", options: [{ restrictDefaultExports: { named: true, defaultFrom: false } }] }
+        { code: "export { default } from 'mod';", options: [{ restrictDefaultExports: { named: true, defaultFrom: false } }] },
+
+        // restrictDefaultExports.namedFrom option
+        { code: "export { foo as default } from 'mod';", options: [{ restrictDefaultExports: { namedFrom: false } }] },
+        { code: "export { default as default } from 'mod';", options: [{ restrictDefaultExports: { namedFrom: true } }] },
+        { code: "export { default as default } from 'mod';", options: [{ restrictDefaultExports: { namedFrom: false } }] }
     ],
 
     invalid: [
@@ -607,6 +612,23 @@ ruleTester.run("no-restricted-exports", rule, {
             code: "export { default as default } from 'mod';",
             options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: false } }],
             errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 21 }]
+        },
+
+        // restrictDefaultExports.namedFrom option
+        {
+            code: "export { foo as default } from 'mod';",
+            options: [{ restrictDefaultExports: { namedFrom: true } }],
+            errors: [{ messageId: "restrictedDefault", type: "Identifier", line: 1, column: 17 }]
+        },
+        {
+            code: "export { foo as default } from 'mod';",
+            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { namedFrom: true } }],
+            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 17 }]
+        },
+        {
+            code: "export { foo as default } from 'mod';",
+            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { namedFrom: false } }],
+            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 17 }]
         }
     ]
 });

--- a/tests/lib/rules/no-restricted-exports.js
+++ b/tests/lib/rules/no-restricted-exports.js
@@ -122,11 +122,13 @@ ruleTester.run("no-restricted-exports", rule, {
         { code: "export { default as default } from 'mod';", options: [{ restrictDefaultExports: { defaultFrom: false } }] },
         { code: "export { foo as default } from 'mod';", options: [{ restrictDefaultExports: { defaultFrom: true } }] },
         { code: "export { default } from 'mod';", options: [{ restrictDefaultExports: { named: true, defaultFrom: false } }] },
+        { code: "export { 'default' } from 'mod'; ", options: [{ restrictDefaultExports: { defaultFrom: false } }] },
 
         // restrictDefaultExports.namedFrom option
         { code: "export { foo as default } from 'mod';", options: [{ restrictDefaultExports: { namedFrom: false } }] },
         { code: "export { default as default } from 'mod';", options: [{ restrictDefaultExports: { namedFrom: true } }] },
         { code: "export { default as default } from 'mod';", options: [{ restrictDefaultExports: { namedFrom: false } }] },
+        { code: "export { 'default' } from 'mod'; ", options: [{ restrictDefaultExports: { defaultFrom: false, namedFrom: true } }] },
 
         // restrictDefaultExports.namespaceFrom option
         { code: "export * as default from 'mod';", options: [{ restrictDefaultExports: { namespaceFrom: false } }] }
@@ -582,6 +584,11 @@ ruleTester.run("no-restricted-exports", rule, {
             code: "export { default as default } from 'mod';",
             options: [{ restrictDefaultExports: { defaultFrom: true } }],
             errors: [{ messageId: "restrictedDefault", type: "Identifier", line: 1, column: 21 }]
+        },
+        {
+            code: "export { 'default' } from 'mod';",
+            options: [{ restrictDefaultExports: { defaultFrom: true } }],
+            errors: [{ messageId: "restrictedDefault", type: "Literal", line: 1, column: 10 }]
         },
 
         // restrictDefaultExports.namedFrom option

--- a/tests/lib/rules/no-restricted-exports.js
+++ b/tests/lib/rules/no-restricted-exports.js
@@ -127,7 +127,10 @@ ruleTester.run("no-restricted-exports", rule, {
         // restrictDefaultExports.namedFrom option
         { code: "export { foo as default } from 'mod';", options: [{ restrictDefaultExports: { namedFrom: false } }] },
         { code: "export { default as default } from 'mod';", options: [{ restrictDefaultExports: { namedFrom: true } }] },
-        { code: "export { default as default } from 'mod';", options: [{ restrictDefaultExports: { namedFrom: false } }] }
+        { code: "export { default as default } from 'mod';", options: [{ restrictDefaultExports: { namedFrom: false } }] },
+
+        // restrictDefaultExports.namespaceFrom option
+        { code: "export * as default from 'mod';", options: [{ restrictDefaultExports: { namespaceFrom: false } }] }
     ],
 
     invalid: [
@@ -569,8 +572,6 @@ ruleTester.run("no-restricted-exports", rule, {
             options: [{ restrictDefaultExports: { named: true } }],
             errors: [{ messageId: "restrictedDefault", type: "Identifier", line: 2, column: 17 }]
         },
-
-        // restrictedNamedExports should take priority over restrictDefaultExports.named
         {
             code: "const foo = 123;\nexport { foo as default };",
             options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { named: false } }],
@@ -629,6 +630,23 @@ ruleTester.run("no-restricted-exports", rule, {
             code: "export { foo as default } from 'mod';",
             options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { namedFrom: false } }],
             errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 17 }]
+        },
+
+        // restrictDefaultExports.namespaceFrom option
+        {
+            code: "export * as default from 'mod';",
+            options: [{ restrictDefaultExports: { namespaceFrom: true } }],
+            errors: [{ messageId: "restrictedDefault", type: "Identifier", line: 1, column: 13 }]
+        },
+        {
+            code: "export * as default from 'mod';",
+            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { namespaceFrom: false } }],
+            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 13 }]
+        },
+        {
+            code: "export * as default from 'mod';",
+            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { namespaceFrom: true } }],
+            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 13 }]
         }
     ]
 });

--- a/tests/lib/rules/no-restricted-exports.js
+++ b/tests/lib/rules/no-restricted-exports.js
@@ -557,7 +557,7 @@ ruleTester.run("no-restricted-exports", rule, {
             errors: [{ messageId: "restrictedDefault", type: "ExportDefaultDeclaration", column: 1 }]
         },
         {
-            code: "export default function foo() {};",
+            code: "export default function foo() {}",
             options: [{ restrictDefaultExports: { direct: true } }],
             errors: [{ messageId: "restrictedDefault", type: "ExportDefaultDeclaration", column: 1 }]
         },

--- a/tests/lib/rules/no-restricted-exports.js
+++ b/tests/lib/rules/no-restricted-exports.js
@@ -116,7 +116,11 @@ ruleTester.run("no-restricted-exports", rule, {
         { code: "export default foo;", options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { direct: true } }] },
 
         // restrictDefaultExports.named option
-        { code: "const foo = 123;\nexport { foo as default };", options: [{ restrictDefaultExports: { named: false } }] }
+        { code: "const foo = 123;\nexport { foo as default };", options: [{ restrictDefaultExports: { named: false } }] },
+
+        // restrictDefaultExports.defaultFrom option
+        { code: "export { default } from 'mod';", options: [{ restrictDefaultExports: { defaultFrom: false } }] },
+        { code: "export { default } from 'mod';", options: [{ restrictDefaultExports: { named: true, defaultFrom: false } }] }
     ],
 
     invalid: [
@@ -569,6 +573,23 @@ ruleTester.run("no-restricted-exports", rule, {
             code: "const foo = 123;\nexport { foo as default };",
             options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { named: true } }],
             errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 2, column: 17 }]
+        },
+
+        // restrictDefaultExports.defaultFrom option
+        {
+            code: "export { default } from 'mod';",
+            options: [{ restrictDefaultExports: { defaultFrom: true } }],
+            errors: [{ messageId: "restrictedDefault", type: "Identifier", line: 1, column: 10 }]
+        },
+        {
+            code: "export { default } from 'mod';",
+            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: true } }],
+            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 10 }]
+        },
+        {
+            code: "export { default } from 'mod';",
+            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: false } }],
+            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 10 }]
         }
     ]
 });

--- a/tests/lib/rules/no-restricted-exports.js
+++ b/tests/lib/rules/no-restricted-exports.js
@@ -113,7 +113,6 @@ ruleTester.run("no-restricted-exports", rule, {
         { code: "export default foo;", options: [{ restrictDefaultExports: { direct: false } }] },
         { code: "export default 42;", options: [{ restrictDefaultExports: { direct: false } }] },
         { code: "export default function foo() {}", options: [{ restrictDefaultExports: { direct: false } }] },
-        { code: "export default foo;", options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { direct: true } }] },
 
         // restrictDefaultExports.named option
         { code: "const foo = 123;\nexport { foo as default };", options: [{ restrictDefaultExports: { named: false } }] },
@@ -572,16 +571,6 @@ ruleTester.run("no-restricted-exports", rule, {
             options: [{ restrictDefaultExports: { named: true } }],
             errors: [{ messageId: "restrictedDefault", type: "Identifier", line: 2, column: 17 }]
         },
-        {
-            code: "const foo = 123;\nexport { foo as default };",
-            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { named: false } }],
-            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 2, column: 17 }]
-        },
-        {
-            code: "const foo = 123;\nexport { foo as default };",
-            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { named: true } }],
-            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 2, column: 17 }]
-        },
 
         // restrictDefaultExports.defaultFrom option
         {
@@ -594,26 +583,6 @@ ruleTester.run("no-restricted-exports", rule, {
             options: [{ restrictDefaultExports: { defaultFrom: true } }],
             errors: [{ messageId: "restrictedDefault", type: "Identifier", line: 1, column: 21 }]
         },
-        {
-            code: "export { default } from 'mod';",
-            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: true } }],
-            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 10 }]
-        },
-        {
-            code: "export { default } from 'mod';",
-            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: false } }],
-            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 10 }]
-        },
-        {
-            code: "export { default as default } from 'mod';",
-            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: true } }],
-            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 21 }]
-        },
-        {
-            code: "export { default as default } from 'mod';",
-            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { defaultFrom: false } }],
-            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 21 }]
-        },
 
         // restrictDefaultExports.namedFrom option
         {
@@ -621,32 +590,12 @@ ruleTester.run("no-restricted-exports", rule, {
             options: [{ restrictDefaultExports: { namedFrom: true } }],
             errors: [{ messageId: "restrictedDefault", type: "Identifier", line: 1, column: 17 }]
         },
-        {
-            code: "export { foo as default } from 'mod';",
-            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { namedFrom: true } }],
-            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 17 }]
-        },
-        {
-            code: "export { foo as default } from 'mod';",
-            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { namedFrom: false } }],
-            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 17 }]
-        },
 
         // restrictDefaultExports.namespaceFrom option
         {
             code: "export * as default from 'mod';",
             options: [{ restrictDefaultExports: { namespaceFrom: true } }],
             errors: [{ messageId: "restrictedDefault", type: "Identifier", line: 1, column: 13 }]
-        },
-        {
-            code: "export * as default from 'mod';",
-            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { namespaceFrom: false } }],
-            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 13 }]
-        },
-        {
-            code: "export * as default from 'mod';",
-            options: [{ restrictedNamedExports: ["default"], restrictDefaultExports: { namespaceFrom: true } }],
-            errors: [{ messageId: "restrictedNamed", type: "Identifier", line: 1, column: 13 }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Resolve https://github.com/eslint/eslint/issues/15617

* `"restrictDefaultExports"` is an object option with boolean properties to restrict certain default export declarations. The option works only if the `restrictedNamedExports` option does not contain the `"default"` value. The following properties are allowed:
  * `direct`: restricts `export default` declarations.
  * `named`: restricts `export { foo as default };` declarations.
  * `defaultFrom`: restricts `export { default } from 'foo';`, `export { default as default } from 'foo';` declarations.
  * `namedFrom`: restricts `export { foo as default } from 'foo';` declarations.
  * `namespaceFrom`: restricts `export * as default from 'foo';` declarations.

- #### [Docs preview link](https://deploy-preview-16785--docs-eslint.netlify.app/rules/no-restricted-exports#restrictdefaultexports)

#### Is there anything you'd like reviewers to focus on?

Open to suggestions for the error message, if it should be different for each property.
<!-- markdownlint-disable-file MD004 -->
