### PR TITLE
feat: Print warnings count while in quite mode when tooManyWarnings found

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -447,10 +447,18 @@ const cli = {
                 options.exitOnFatalError && resultCounts.fatalErrorCount > 0;
 
             if (!resultCounts.errorCount && tooManyWarnings) {
-                log.error(
-                    "ESLint found too many warnings (maximum: %s).",
-                    options.maxWarnings
-                );
+                if (options.quiet) {
+                    log.error(
+                        "ESLint found too many warnings (maximum: %s, found: %s).",
+                        options.maxWarnings,
+                        resultCounts.warningCount
+                    );
+                } else {
+                    log.error(
+                        "ESLint found too many warnings (maximum: %s).",
+                        options.maxWarnings
+                    );
+                }
             }
 
             if (shouldExitForFatalErrors) {

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -679,15 +679,15 @@ describe("cli", () => {
 
                     assert.strictEqual(exitCode, 1);
                     assert.ok(log.error.calledOnce);
-                    assert.include(log.error.getCall(0).args[0], "ESLint found too many warnings");
+                    assert.include(log.error.getCall(0).args[0], "ESLint found too many warnings (maximum: %s).");
                 });
 
-                it(`should exit with exit code 1 without printing warnings if the quiet option is enabled and warning count exceeds threshold with configType:${configType}`, async () => {
+                it(`should exit with exit code 1 printing warning count and without printing warnings themselves if the quiet option is enabled and warning count exceeds threshold with configType:${configType}`, async () => {
                     const exitCode = await cli.execute(`--no-ignore --quiet --max-warnings 5 ${filePath} -c ${configFilePath}`, null, useFlatConfig);
 
                     assert.strictEqual(exitCode, 1);
                     assert.ok(log.error.calledOnce);
-                    assert.include(log.error.getCall(0).args[0], "ESLint found too many warnings");
+                    assert.include(log.error.getCall(0).args[0], "ESLint found too many warnings (maximum: %s, found: %s).");
                     assert.ok(log.info.notCalled); // didn't print warnings
                 });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
 - [x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hey hey, by default when you use `--quiet` mode you will get no stdout for warnings, when you use `--max-warnings` rule you will get exit code 1 if you reach max warnings with a message `ESLint found too many warnings (maximum: %s).`.

That is okay because you've got your total amount of warnings right above, but when you run `--quiet` and `--max-warnings` together you'll only receive a message above, and have do re-do the linting without `--quiet ` mode to get the amount of warning you've got.

Seems okay, but when you have a big ci/cd pipeline with large scale heavy repos this becomes a bit annoying and time-wasting.

So, here's a small change that goes like this: _When you run `--quiet` and `--max-warnings` rules together you are receiving warning count in the error message if you reached `tooManyWarnings`_

NOTE: I have only unit tested the change and haven't built the change myself and tested it with an actual code, please advise if i even need to do that.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
