### PR TITLE
feat: Add `checkJSDoc` option to multiline-comment-style

### DIFF
--- a/docs/src/rules/multiline-comment-style.md
+++ b/docs/src/rules/multiline-comment-style.md
@@ -16,7 +16,7 @@ This rule aims to enforce a particular style for multiline comments.
 This rule has a string option, which can have one of the following values:
 
 * `"starred-block"` (default): Disallows consecutive line comments in favor of block comments. Additionally, requires block comments to have an aligned `*` character before each line.
-* `"bare-block"`: Disallows consecutive line comments in favor of block comments, and disallows block comments from having a `"*"` character before each line.
+* `"bare-block"`: Disallows consecutive line comments in favor of block comments, and disallows block comments from having a `"*"` character before each line. This option ignores JSDoc comments.
 * `"separate-lines"`: Disallows block comments in favor of consecutive line comments. By default, this option ignores JSDoc comments. To also apply this rule to JSDoc comments, set the `checkJSDoc` option to `true`.
 
 The rule always ignores directive comments such as `/* eslint-disable */`.

--- a/docs/src/rules/multiline-comment-style.md
+++ b/docs/src/rules/multiline-comment-style.md
@@ -17,9 +17,9 @@ This rule has a string option, which can have one of the following values:
 
 * `"starred-block"` (default): Disallows consecutive line comments in favor of block comments. Additionally, requires block comments to have an aligned `*` character before each line.
 * `"bare-block"`: Disallows consecutive line comments in favor of block comments, and disallows block comments from having a `"*"` character before each line.
-* `"separate-lines"`: Disallows block comments in favor of consecutive line comments
+* `"separate-lines"`: Disallows block comments in favor of consecutive line comments. By default, this option ignores JSDoc comments. To also apply this rule to JSDoc comments, set the `checkJSDoc` option to `true`.
 
-The rule always ignores directive comments such as `/* eslint-disable */`. Additionally, unless the mode is `"starred-block"`, the rule ignores JSDoc comments.
+The rule always ignores directive comments such as `/* eslint-disable */`.
 
 Examples of **incorrect** code for this rule with the default `"starred-block"` option:
 
@@ -140,6 +140,39 @@ Examples of **correct** code for this rule with the `"separate-lines"` option:
 
 // This line
 // calls foo()
+foo();
+
+```
+
+:::
+
+Examples of **incorrect** code for this rule with the `"separate-lines"` option and `checkJSDoc` set to `true`:
+
+::: incorrect
+
+```js
+
+/* eslint multiline-comment-style: ["error", "separate-lines", { "checkJSDoc": true }] */
+
+/**
+ * I am a JSDoc comment
+ * and I'm not allowed
+ */
+foo();
+
+```
+
+:::
+
+Examples of **correct** code for this rule with the `"separate-lines"` option and `checkJSDoc` set to `true`:
+
+::: correct
+
+```js
+/* eslint multiline-comment-style: ["error", "separate-lines", { "checkJSDoc": true }] */
+
+// I am a JSDoc comment
+// and I'm not allowed
 foo();
 
 ```

--- a/lib/rules/multiline-comment-style.js
+++ b/lib/rules/multiline-comment-style.js
@@ -373,7 +373,7 @@ module.exports = {
 
                 let commentLines = getCommentLines(commentGroup);
 
-                if (checkJSDoc && isJSDoc) {
+                if (isJSDoc) {
                     commentLines = commentLines.slice(1, commentLines.length - 1);
                 }
 

--- a/lib/rules/multiline-comment-style.js
+++ b/lib/rules/multiline-comment-style.js
@@ -22,7 +22,21 @@ module.exports = {
         },
 
         fixable: "whitespace",
-        schema: [{ enum: ["starred-block", "separate-lines", "bare-block"] }],
+        schema: [
+            {
+                enum: ["starred-block", "separate-lines", "bare-block"]
+            },
+            {
+                type: "object",
+                properties: {
+                    checkJSDoc: {
+                        type: "boolean",
+                        default: false
+                    }
+                },
+                additionalProperties: false
+            }
+        ],
         messages: {
             expectedBlock: "Expected a block comment instead of consecutive line comments.",
             expectedBareBlock: "Expected a block comment without padding stars.",
@@ -37,6 +51,8 @@ module.exports = {
     create(context) {
         const sourceCode = context.getSourceCode();
         const option = context.options[0] || "starred-block";
+        const params = context.options[1] || {};
+        const checkJSDoc = !!params.checkJSDoc;
 
         //----------------------------------------------------------------------
         // Helpers
@@ -333,11 +349,18 @@ module.exports = {
             "separate-lines"(commentGroup) {
                 const [firstComment] = commentGroup;
 
-                if (firstComment.type !== "Block" || isJSDocComment(commentGroup)) {
+                const isJSDoc = isJSDocComment(commentGroup);
+
+                if (firstComment.type !== "Block" || (!checkJSDoc && isJSDoc)) {
                     return;
                 }
 
-                const commentLines = getCommentLines(commentGroup);
+                let commentLines = getCommentLines(commentGroup);
+
+                if (checkJSDoc && isJSDoc) {
+                    commentLines = commentLines.slice(1, commentLines.length - 1);
+                }
+
                 const tokenAfter = sourceCode.getTokenAfter(firstComment, { includeComments: true });
 
                 if (tokenAfter && firstComment.loc.end.line === tokenAfter.loc.start.line) {

--- a/lib/rules/multiline-comment-style.js
+++ b/lib/rules/multiline-comment-style.js
@@ -22,21 +22,37 @@ module.exports = {
         },
 
         fixable: "whitespace",
-        schema: [
-            {
-                enum: ["starred-block", "separate-lines", "bare-block"]
-            },
-            {
-                type: "object",
-                properties: {
-                    checkJSDoc: {
-                        type: "boolean",
-                        default: false
-                    }
+        schema: {
+            anyOf: [
+                {
+                    type: "array",
+                    items: [
+                        {
+                            enum: ["starred-block", "bare-block"]
+                        }
+                    ],
+                    additionalItems: false
                 },
-                additionalProperties: false
-            }
-        ],
+                {
+                    type: "array",
+                    items: [
+                        {
+                            enum: ["separate-lines"]
+                        },
+                        {
+                            type: "object",
+                            properties: {
+                                checkJSDoc: {
+                                    type: "boolean"
+                                }
+                            },
+                            additionalProperties: false
+                        }
+                    ],
+                    additionalItems: false
+                }
+            ]
+        },
         messages: {
             expectedBlock: "Expected a block comment instead of consecutive line comments.",
             expectedBareBlock: "Expected a block comment without padding stars.",

--- a/tests/lib/rules/multiline-comment-style.js
+++ b/tests/lib/rules/multiline-comment-style.js
@@ -630,6 +630,20 @@ ruleTester.run("multiline-comment-style", rule, {
         },
         {
             code: `
+                /**
+                 * JSDoc
+                 * Comment
+                 */
+            `,
+            output: `
+                // JSDoc
+                // Comment
+            `,
+            options: ["separate-lines", { checkJSDoc: true }],
+            errors: [{ messageId: "expectedLines", line: 2 }]
+        },
+        {
+            code: `
                 /* foo
                  *bar
                  baz


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))

**What rule do you want to change?**

multiline-comment-style

**What change do you want to make (place an "X" next to just one item)?**

[ ] Generate more warnings
[ ] Generate fewer warnings
[x] Implement autofix
[x] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[x] A new option
[ ] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

With this rule: `'multiline-comment-style': ['error', 'separate-lines', { allowJsDoc: false }]`, this is not allowed:

```js
/**
 * Some
 * comment
 */
```

And is converted to this:

```js
// Some
// comment
```

By default `allowJsDoc` is `true` so all other behaviours remain the same.

The rational for adding this is that we disallow block comments in our codebase but some contributors (voluntarily or not) bypass this by formatting the block comment as a jsdoc comment. We don't want this, so this option would help with this.

I have just realised I forgot to update the documentation but happy to do so if you would consider this change.

<!-- markdownlint-disable-file MD004 -->
