### PR TITLE
docs: 'a .eslint' -> 'an .eslint'

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ After that, you can run ESLint on any file or directory like this:
 
 ## Configuration
 
-After running `npm init @eslint/config`, you'll have a `.eslintrc` file in your directory. In it, you'll see some rules configured like this:
+After running `npm init @eslint/config`, you'll have an `.eslintrc` file in your directory. In it, you'll see some rules configured like this:
 
 ```json
 {

--- a/docs/src/use/configure/configuration-files.md
+++ b/docs/src/use/configure/configuration-files.md
@@ -136,7 +136,7 @@ your-project
   └── test.js
 ```
 
-The configuration cascade works based on the location of the file being linted. If there is a `.eslintrc` file in the same directory as the file being linted, then that configuration takes precedence. ESLint then searches up the directory structure, merging any `.eslintrc` files it finds along the way until reaching either a `.eslintrc` file with `root: true` or the root directory.
+The configuration cascade works based on the location of the file being linted. If there is an `.eslintrc` file in the same directory as the file being linted, then that configuration takes precedence. ESLint then searches up the directory structure, merging any `.eslintrc` files it finds along the way until reaching either an `.eslintrc` file with `root: true` or the root directory.
 
 In the same way, if there is a `package.json` file in the root directory with an `eslintConfig` field, the configuration it describes is applied to all subdirectories beneath it. However, the configuration described by the `.eslintrc` file in the `tests/` directory overrides conflicting specifications.
 
@@ -150,7 +150,7 @@ your-project
   └── test.js
 ```
 
-If there is a `.eslintrc` and a `package.json` file found in the same directory, `.eslintrc` takes priority and the `package.json` file is not used.
+If there is an `.eslintrc` and a `package.json` file found in the same directory, `.eslintrc` takes priority and the `package.json` file is not used.
 
 By default, ESLint looks for configuration files in all parent folders up to the root directory. This can be useful if you want all of your projects to follow a certain convention, but can sometimes lead to unexpected results. To limit ESLint to a specific project, place `"root": true` inside the `.eslintrc.*` file or `eslintConfig` field of the `package.json` file or in the `.eslintrc.*` file at your project's root level. ESLint stops looking in parent folders once it finds a configuration with `"root": true`.
 

--- a/docs/src/use/configure/ignore.md
+++ b/docs/src/use/configure/ignore.md
@@ -37,13 +37,13 @@ If a config is provided via the `--config` CLI option, the ignore patterns that 
 
 ## The `.eslintignore` File
 
-You can tell ESLint to ignore specific files and directories by creating a `.eslintignore` file in your project's root directory. The `.eslintignore` file is a plain text file where each line is a glob pattern indicating which paths should be omitted from linting. For example, the following omits all JavaScript files:
+You can tell ESLint to ignore specific files and directories by creating an `.eslintignore` file in your project's root directory. The `.eslintignore` file is a plain text file where each line is a glob pattern indicating which paths should be omitted from linting. For example, the following omits all JavaScript files:
 
 ```text
 **/*.js
 ```
 
-When ESLint is run, it looks in the current working directory to find a `.eslintignore` file before determining which files to lint. If this file is found, then those preferences are applied when traversing directories. Only one `.eslintignore` file can be used at a time, so `.eslintignore` files other than the one in the current working directory are not used.
+When ESLint is run, it looks in the current working directory to find an `.eslintignore` file before determining which files to lint. If this file is found, then those preferences are applied when traversing directories. Only one `.eslintignore` file can be used at a time, so `.eslintignore` files other than the one in the current working directory are not used.
 
 Globs are matched using [node-ignore](https://github.com/kaelzhang/node-ignore), so a number of features are available:
 

--- a/docs/src/use/getting-started.md
+++ b/docs/src/use/getting-started.md
@@ -64,7 +64,7 @@ yarn run eslint yourfile.js
 
 **Note:** If you are coming from a version before 1.0.0 please see the [migration guide](migrating-to-1.0.0).
 
-After running `npm init @eslint/config`, you'll have a `.eslintrc.{js,yml,json}` file in your directory. In it, you'll see some rules configured like this:
+After running `npm init @eslint/config`, you'll have an `.eslintrc.{js,yml,json}` file in your directory. In it, you'll see some rules configured like this:
 
 ```json
 {

--- a/docs/src/use/migrating-from-jscs.md
+++ b/docs/src/use/migrating-from-jscs.md
@@ -30,7 +30,7 @@ To convert your configuration file, pass in the location of your `.jscs.json` fi
 polyjuice --jscs .jscsrc.json > .eslintrc.json
 ```
 
-This creates a `.eslintrc.json` with the equivalent rules from `.jscsrc.json`.
+This creates an `.eslintrc.json` with the equivalent rules from `.jscsrc.json`.
 
 If you have multiple `.jscsrc.json` files, you can pass them all and Polyjuice will combine them into one `.eslintrc.json` file:
 

--- a/docs/src/use/migrating-to-3.0.0.md
+++ b/docs/src/use/migrating-to-3.0.0.md
@@ -15,7 +15,7 @@ With ESLint v3.0.0, we are dropping support for Node.js versions prior to 4. Nod
 
 ESLint v3.0.0 now requires that you use a configuration to run. A configuration can be any of the following:
 
-1. A `.eslintrc.js`, `.eslintrc.json`, `.eslintrc.yml`, `.eslintrc.yaml`, or `.eslintrc` file either in your project or home directory.
+1. An `.eslintrc.js`, `.eslintrc.json`, `.eslintrc.yml`, `.eslintrc.yaml`, or `.eslintrc` file either in your project or home directory.
 2. Configuration options passed on the command line using `--rule` (or to CLIEngine using `rules`).
 3. A configuration file passed on the command line using `-c` (or to CLIEngine using `configFile`).
 4. A base configuration is provided to CLIEngine using the `baseConfig` option.

--- a/docs/src/use/migrating-to-7.0.0.md
+++ b/docs/src/use/migrating-to-7.0.0.md
@@ -108,7 +108,7 @@ Personal config files have been deprecated since [v6.7.0](https://eslint.org/blo
 1. When a project does not have a configuration file present and ESLint loads configuration from `~/.eslintrc.*`.
 1. When a project has a configuration file and ESLint ignored a `~/.eslintrc.*` configuration file. This occurs when the `$HOME` directory is an ancestor directory of the project and the project's configuration files doesn't contain `root:true`.
 
-**To address:** Remove `~/.eslintrc.*` configuration files and add a `.eslintrc.*` configuration file to your project. Alternatively, use the `--config` option to use shared config files.
+**To address:** Remove `~/.eslintrc.*` configuration files and add an `.eslintrc.*` configuration file to your project. Alternatively, use the `--config` option to use shared config files.
 
 **Related issue(s):** [RFC32](https://github.com/eslint/rfcs/tree/master/designs/2019-deprecating-personal-config/README.md), [#12678](https://github.com/eslint/eslint/pull/12678)
 

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -4433,7 +4433,7 @@ describe("CLIEngine", () => {
                 const cwd = getFixturePath("ignored-paths", "configurations");
                 const engine = new CLIEngine({ cwd });
 
-                // a .eslintignore in parent directories includes `*.js`, but don't load it.
+                // an .eslintignore in parent directories includes `*.js`, but don't load it.
                 assert(!engine.isPathIgnored("foo.js"));
                 assert(engine.isPathIgnored("node_modules/foo.js"));
             });
@@ -4593,7 +4593,7 @@ describe("CLIEngine", () => {
                 const cwd = getFixturePath("ignored-paths", "no-ignore-file");
                 const engine = new CLIEngine({ ignorePath: false, cwd });
 
-                // a .eslintignore in parent directories includes `*.js`, but don't load it.
+                // an .eslintignore in parent directories includes `*.js`, but don't load it.
                 assert(!engine.isPathIgnored("foo.js"));
                 assert(engine.isPathIgnored("node_modules/foo.js"));
             });

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -4400,7 +4400,7 @@ describe("ESLint", () => {
                 const cwd = getFixturePath("ignored-paths", "configurations");
                 const engine = new ESLint({ cwd });
 
-                // a .eslintignore in parent directories includes `*.js`, but don't load it.
+                // an .eslintignore in parent directories includes `*.js`, but don't load it.
                 assert(!await engine.isPathIgnored("foo.js"));
                 assert(await engine.isPathIgnored("node_modules/foo.js"));
             });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

Consistently use 'an .eslint' rather than 'a .eslint' throughout project.
<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

"a .eslint" -> "an .eslint"

#### Is there anything you'd like reviewers to focus on?

this change came from https://github.com/eslint/eslint/pull/16510#discussion_r1021793537

<!-- markdownlint-disable-file MD004 -->
