### PR TITLE
docs: Fix examples in no-multiple-empty-lines rule

### DIFF
--- a/docs/src/rules/no-multiple-empty-lines.md
+++ b/docs/src/rules/no-multiple-empty-lines.md
@@ -31,6 +31,7 @@ Examples of **incorrect** code for this rule with the default `{ "max": 2 }` opt
 var foo = 5;
 
 
+
 var bar = 3;
 ```
 
@@ -44,6 +45,7 @@ Examples of **correct** code for this rule with the default `{ "max": 2 }` optio
 /*eslint no-multiple-empty-lines: "error"*/
 
 var foo = 5;
+
 
 var bar = 3;
 ```
@@ -61,7 +63,9 @@ Examples of **incorrect** code for this rule with the `{ max: 2, maxEOF: 0 }` op
 
 var foo = 5;
 
+
 var bar = 3;
+
 
 ```
 
@@ -75,6 +79,7 @@ Examples of **correct** code for this rule with the `{ max: 2, maxEOF: 0 }` opti
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/
 
 var foo = 5;
+
 
 var bar = 3;
 ```
@@ -117,7 +122,9 @@ Examples of **incorrect** code for this rule with the `{ max: 2, maxBOF: 1 }` op
 ```js
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxBOF": 1 }]*/
 
+
 var foo = 5;
+
 
 var bar = 3;
 ```
@@ -132,6 +139,7 @@ Examples of **correct** code for this rule with the `{ max: 2, maxBOF: 1 }` opti
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxBOF": 1}]*/
 
 var foo = 5;
+
 
 var bar = 3;
 ```

--- a/docs/src/rules/no-multiple-empty-lines.md
+++ b/docs/src/rules/no-multiple-empty-lines.md
@@ -90,6 +90,8 @@ var bar = 3;
 
 **Incorrect**:
 
+::: incorrect
+
 ```js
 1    /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/⏎
 2    ⏎
@@ -101,7 +103,11 @@ var bar = 3;
 8
 ```
 
+:::
+
 **Correct**:
+
+::: correct
 
 ```js
 1    /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/⏎
@@ -112,6 +118,8 @@ var bar = 3;
 6    var bar = 3;⏎
 7
 ```
+
+:::
 
 ### maxBOF
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

This PR adding back missing empty lines, which accidentally removed via https://github.com/eslint/eslint/commit/db28f2c9ea6b654f615daf2f7e6f1a2034b85062#diff-bb702378ac043bca3c41565355c85509c8bf26510156a27be567f42eb10744cd (thanks to mdjermanovic provides this information: https://github.com/eslint/eslint/issues/16832#issuecomment-1407378468)

Close #16832 

#### Is there anything you'd like reviewers to focus on?

I notice one of the example is missing the `::: correct` and `::: incorrect`, so I add them back via an additional commit:

| Before | After |
| --- | --- |
| ![](https://user-images.githubusercontent.com/16042676/215276672-167eae16-993f-4633-8411-192d5335bf70.png) | ![](https://user-images.githubusercontent.com/16042676/215276670-d75da4f0-4ff3-40e8-a0fa-78dc1940862f.png) |

I not sure the "double line number" was intended or not, so I leave it as same as before.
I would probably make a new issue for this, and then, we could discuss the issue there.