### PR TITLE
fix: false positive with assignment in `no-extra-parens`

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -766,6 +766,36 @@ module.exports = {
             return false;
         }
 
+        /**
+         * Checks if the left-hand side of an assignment is an identifier and the right-hand side is
+         * an anonymous class or function.
+         *
+         * As per https://tc39.es/ecma262/#sec-assignment-operators-runtime-semantics-evaluation, an
+         * assignment where the right-hand side is an anonymous class or function and the left-hand
+         * side is an *unparenthesized* identifier has different semantics than other assignments.
+         * Specifically, when an expression like `foo = function () {}` is evaluated, `foo.name`
+         * will be set to the string "foo", i.e. the identifier name. The same thing does not happen
+         * when evaluating `(foo) = () => {}`.
+         * Since the parenthesizing of the identifier in the left-hand side is significant in this
+         * special case, the parentheses, if present, should not be flagged as unnecessary.
+         * @param {ASTNode} node an AssignmentExpression node.
+         * @returns {boolean} `true` if the left-hand side of the assignment is an identifier and
+         * the right-hand side is an anonymous class or function; otherwise, `false`.
+         */
+        function isAnonymousFunctionAssignmentException({ left, right }) {
+            if (left.type === "Identifier") {
+                const rhsType = right.type;
+
+                if (rhsType === "ArrowFunctionExpression") {
+                    return true;
+                }
+                if ((rhsType === "FunctionExpression" || rhsType === "ClassExpression") && !right.id) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         return {
             ArrayExpression(node) {
                 node.elements
@@ -804,7 +834,8 @@ module.exports = {
             },
 
             AssignmentExpression(node) {
-                if (canBeAssignmentTarget(node.left) && hasExcessParens(node.left)) {
+                if (canBeAssignmentTarget(node.left) && hasExcessParens(node.left) &&
+                    (!isAnonymousFunctionAssignmentException(node) || isParenthesisedTwice(node.left))) {
                     report(node.left);
                 }
 

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -767,23 +767,25 @@ module.exports = {
         }
 
         /**
-         * Checks if the left-hand side of an assignment is an identifier and the right-hand side is
-         * an anonymous class or function.
+         * Checks if the left-hand side of an assignment is an identifier, the operator is one of
+         * `=`, `&&=`, `||=` or `??=` and the right-hand side is an anonymous class or function.
          *
          * As per https://tc39.es/ecma262/#sec-assignment-operators-runtime-semantics-evaluation, an
-         * assignment where the right-hand side is an anonymous class or function and the left-hand
-         * side is an *unparenthesized* identifier has different semantics than other assignments.
+         * assignment involving one of the operators `=`, `&&=`, `||=` or `??=` where the right-hand
+         * side is an anonymous class or function and the left-hand side is an *unparenthesized*
+         * identifier has different semantics than other assignments.
          * Specifically, when an expression like `foo = function () {}` is evaluated, `foo.name`
          * will be set to the string "foo", i.e. the identifier name. The same thing does not happen
          * when evaluating `(foo) = function () {}`.
          * Since the parenthesizing of the identifier in the left-hand side is significant in this
          * special case, the parentheses, if present, should not be flagged as unnecessary.
          * @param {ASTNode} node an AssignmentExpression node.
-         * @returns {boolean} `true` if the left-hand side of the assignment is an identifier and
-         * the right-hand side is an anonymous class or function; otherwise, `false`.
+         * @returns {boolean} `true` if the left-hand side of the assignment is an identifier, the
+         * operator is one of `=`, `&&=`, `||=` or `??=` and the right-hand side is an anonymous
+         * class or function; otherwise, `false`.
          */
-        function isAnonymousFunctionAssignmentException({ left, right }) {
-            if (left.type === "Identifier") {
+        function isAnonymousFunctionAssignmentException({ left, operator, right }) {
+            if (left.type === "Identifier" && ["=", "&&=", "||=", "??="].includes(operator)) {
                 const rhsType = right.type;
 
                 if (rhsType === "ArrowFunctionExpression") {

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -775,7 +775,7 @@ module.exports = {
          * side is an *unparenthesized* identifier has different semantics than other assignments.
          * Specifically, when an expression like `foo = function () {}` is evaluated, `foo.name`
          * will be set to the string "foo", i.e. the identifier name. The same thing does not happen
-         * when evaluating `(foo) = () => {}`.
+         * when evaluating `(foo) = function () {}`.
          * Since the parenthesizing of the identifier in the left-hand side is significant in this
          * special case, the parentheses, if present, should not be flagged as unnecessary.
          * @param {ASTNode} node an AssignmentExpression node.

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -3437,6 +3437,13 @@ ruleTester.run("no-extra-parens", rule, {
             ]
         },
         invalid("((a)) = () => {};", "(a) = () => {};", "Identifier"),
-        invalid("(a) = (function () {})();", "a = (function () {})();", "Identifier")
+        invalid("(a) = (function () {})();", "a = (function () {})();", "Identifier"),
+        ...["**=", "*=", "/=", "%=", "+=", "-=", "<<=", ">>=", ">>>=", "&=", "^=", "|="].map(
+            operator => invalid(
+                `(a) ${operator} function () {};`,
+                `a ${operator} function () {};`,
+                "Identifier"
+            )
+        )
     ]
 });

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -771,6 +771,18 @@ ruleTester.run("no-extra-parens", rule, {
         {
             code: "const net = ipaddr.parseCIDR(/** @type {string} */ (cidr));",
             options: ["all", { allowParensAfterCommentPattern: "@type" }]
+        },
+
+        // https://github.com/eslint/eslint/issues/16850
+        "(a) = function () {};",
+        "(a) = () => {};",
+        "(a) = class {};",
+        "(a) ??= function () {};",
+        "(a) &&= class extends SuperClass {};",
+        "(a) ||= async () => {}",
+        {
+            code: "((a)) = function () {};",
+            options: ["functions"]
         }
     ],
 
@@ -3410,6 +3422,21 @@ ruleTester.run("no-extra-parens", rule, {
             options: ["all"],
             parserOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "unexpected" }]
-        }
+        },
+
+        // https://github.com/eslint/eslint/issues/16850
+        invalid("(a) = function foo() {};", "a = function foo() {};", "Identifier"),
+        invalid("(a) = class Bar {};", "a = class Bar {};", "Identifier"),
+        invalid("(a.b) = function () {};", "a.b = function () {};", "MemberExpression"),
+        {
+            code: "(newClass) = [(one)] = class { static * [Symbol.iterator]() { yield 1; } };",
+            output: "newClass = [one] = class { static * [Symbol.iterator]() { yield 1; } };",
+            errors: [
+                { messageId: "unexpected", type: "Identifier" },
+                { messageId: "unexpected", type: "Identifier" }
+            ]
+        },
+        invalid("((a)) = () => {};", "(a) = () => {};", "Identifier"),
+        invalid("(a) = (function () {})();", "a = (function () {})();", "Identifier")
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #16850

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added an exception to the rule `no-extra-parens`. Parentheses around a single identifier will no longer be reported if the identifier is the LHS of an assignment with `=`, `&&=`, `||=` or `??=` and the RHS being an anonymous class or function or an arrow function.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
