### PR TITLE
docs: only build when change docs directory

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../docs"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Now builds are done when there is a PR and the bot also comments. These are very noisy for PR contributors who have not modified files in the `docs/` directory.

Using the ignored build provided by Netlify instantly eliminates this.

#### Is there anything you'd like reviewers to focus on?

[Ignore builds | Netlify Docs](https://docs.netlify.com/configure-builds/ignore-builds/)

In addition to this PR, changes may need to be made to the Netlify site's notification settings to avoid redundant comments.

<img width="1280" alt="截屏2023-02-08 15 07 54" src="https://user-images.githubusercontent.com/45708948/217459193-93560fc9-5a16-4817-bdd7-2c2e0782928d.png">

<!-- markdownlint-disable-file MD004 -->
