### PR TITLE
chore: type property to array-element-newline schema added

### DIFF
--- a/lib/rules/array-element-newline.js
+++ b/lib/rules/array-element-newline.js
@@ -47,6 +47,7 @@ module.exports = {
                     ]
                 }
             },
+            type: "array",
             items: [
                 {
                     oneOf: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

It seems the `array-element-newline` rule schema has a `items : [...]` property without its `type : "array"` associated property. I compared to another rule structurally almost similar `comma-dangle` having it and json-schema language doesn't seem to accept a single `items` property for an array object.  

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I added `type: "array",` on line 50 of the schema object of the `array-element-newline` rule 

#### Is there anything you'd like reviewers to focus on?

no

<!-- markdownlint-disable-file MD004 -->
