### PR TITLE
fix: `getFirstToken`/`getLastToken` on comment-only node

### DIFF
--- a/lib/source-code/token-store/utils.js
+++ b/lib/source-code/token-store/utils.js
@@ -49,7 +49,7 @@ exports.getFirstIndex = function getFirstIndex(tokens, indexMap, startLoc) {
     }
     if ((startLoc - 1) in indexMap) {
         const index = indexMap[startLoc - 1];
-        const token = (index >= 0 && index < tokens.length) ? tokens[index] : null;
+        const token = tokens[index];
 
         /*
          * For the map of "comment's location -> token's index", it points the next token of a comment.
@@ -77,7 +77,7 @@ exports.getLastIndex = function getLastIndex(tokens, indexMap, endLoc) {
     }
     if ((endLoc - 1) in indexMap) {
         const index = indexMap[endLoc - 1];
-        const token = (index >= 0 && index < tokens.length) ? tokens[index] : null;
+        const token = tokens[index];
 
         /*
          * For the map of "comment's location -> token's index", it points the next token of a comment.

--- a/lib/source-code/token-store/utils.js
+++ b/lib/source-code/token-store/utils.js
@@ -51,11 +51,16 @@ exports.getFirstIndex = function getFirstIndex(tokens, indexMap, startLoc) {
         const index = indexMap[startLoc - 1];
         const token = tokens[index];
 
+        // If the mapped index is out of bounds, the returned cursor index will point after the end of the tokens array.
+        if (!token) {
+            return tokens.length;
+        }
+
         /*
          * For the map of "comment's location -> token's index", it points the next token of a comment.
          * In that case, +1 is unnecessary.
          */
-        if (!token || token.range[0] >= startLoc) {
+        if (token.range[0] >= startLoc) {
             return index;
         }
         return index + 1;
@@ -79,11 +84,16 @@ exports.getLastIndex = function getLastIndex(tokens, indexMap, endLoc) {
         const index = indexMap[endLoc - 1];
         const token = tokens[index];
 
+        // If the mapped index is out of bounds, the returned cursor index will point before the start of the tokens array.
+        if (!token) {
+            return -1;
+        }
+
         /*
          * For the map of "comment's location -> token's index", it points the next token of a comment.
          * In that case, -1 is necessary.
          */
-        if (!token || token.range[1] > endLoc) {
+        if (token.range[1] > endLoc) {
             return index - 1;
         }
         return index;

--- a/lib/source-code/token-store/utils.js
+++ b/lib/source-code/token-store/utils.js
@@ -84,9 +84,9 @@ exports.getLastIndex = function getLastIndex(tokens, indexMap, endLoc) {
         const index = indexMap[endLoc - 1];
         const token = tokens[index];
 
-        // If the mapped index is out of bounds, the returned cursor index will point before the start of the tokens array.
+        // If the mapped index is out of bounds, the returned cursor index will point before the end of the tokens array.
         if (!token) {
-            return -1;
+            return tokens.length - 1;
         }
 
         /*

--- a/lib/source-code/token-store/utils.js
+++ b/lib/source-code/token-store/utils.js
@@ -55,7 +55,7 @@ exports.getFirstIndex = function getFirstIndex(tokens, indexMap, startLoc) {
          * For the map of "comment's location -> token's index", it points the next token of a comment.
          * In that case, +1 is unnecessary.
          */
-        if (token && token.range[0] >= startLoc) {
+        if (!token || token.range[0] >= startLoc) {
             return index;
         }
         return index + 1;
@@ -83,7 +83,7 @@ exports.getLastIndex = function getLastIndex(tokens, indexMap, endLoc) {
          * For the map of "comment's location -> token's index", it points the next token of a comment.
          * In that case, -1 is necessary.
          */
-        if (token && token.range[1] > endLoc) {
+        if (!token || token.range[1] > endLoc) {
             return index - 1;
         }
         return index;

--- a/tests/fixtures/parsers/all-comments-parser.js
+++ b/tests/fixtures/parsers/all-comments-parser.js
@@ -1,0 +1,28 @@
+// Similar to the default parser, but considers leading and trailing comments to be part of the root node.
+// Some custom parsers like @typescript-eslint/parser behave in this way.
+
+const espree = require("espree");
+exports.parse = function(code, options) {
+    const ast = espree.parse(code, options);
+
+    if (ast.range && ast.comments && ast.comments.length > 0) {
+        const firstComment = ast.comments[0];
+        const lastComment = ast.comments[ast.comments.length - 1];
+
+        if (ast.range[0] > firstComment.range[0]) {
+            ast.range[0] = firstComment.range[0];
+            ast.start = firstComment.start;
+            if (ast.loc) {
+                ast.loc.start = firstComment.loc.start;
+            }
+        }
+        if (ast.range[1] < lastComment.range[1]) {
+            ast.range[1] = lastComment.range[1];
+            ast.end = lastComment.end;
+            if (ast.loc) {
+                ast.loc.end = lastComment.loc.end;
+            }
+        }
+    }
+    return ast;
+};

--- a/tests/lib/source-code/token-store.js
+++ b/tests/lib/source-code/token-store.js
@@ -654,6 +654,16 @@ describe("TokenStore", () => {
             assert.strictEqual(token.value, "c");
         });
 
+        it("should retrieve the first token if the root node contains a trailing comment", () => {
+            const parser = require("../../fixtures/parsers/all-comments-parser");
+            const code = "foo // comment";
+            const ast = parser.parse(code, { loc: true, range: true, tokens: true, comment: true });
+            const tokenStore = new TokenStore(ast.tokens, ast.comments);
+            const token = tokenStore.getFirstToken(ast);
+
+            assert.strictEqual(token, ast.tokens[0]);
+        });
+
         it("should return null if the source contains only comments", () => {
             const code = "// comment";
             const ast = espree.parse(code, { loc: true, range: true, tokens: true, comment: true });
@@ -861,6 +871,16 @@ describe("TokenStore", () => {
             );
 
             assert.strictEqual(token.value, "b");
+        });
+
+        it("should retrieve the last token if the root node contains a trailing comment", () => {
+            const parser = require("../../fixtures/parsers/all-comments-parser");
+            const code = "foo // comment";
+            const ast = parser.parse(code, { loc: true, range: true, tokens: true, comment: true });
+            const tokenStore = new TokenStore(ast.tokens, ast.comments);
+            const token = tokenStore.getLastToken(ast);
+
+            assert.strictEqual(token, ast.tokens[0]);
         });
 
         it("should return null if the source contains only comments", () => {

--- a/tests/lib/source-code/token-store.js
+++ b/tests/lib/source-code/token-store.js
@@ -676,16 +676,6 @@ describe("TokenStore", () => {
             assert.strictEqual(token, null);
         });
 
-        it("should retrieve a parent node's token if a node has no tokens", () => {
-            const code = "foo``";
-            const ast = espree.parse(code, { loc: true, range: true, tokens: true, comment: true, ecmaVersion: 6 });
-            const tokenStore = new TokenStore(ast.tokens, ast.comments);
-            const emptyTemplateElementNode = ast.body[0].expression.quasi.quasis[0];
-            const token = tokenStore.getFirstToken(emptyTemplateElementNode);
-
-            assert.strictEqual(token.value, "``");
-        });
-
     });
 
     describe("when calling getLastTokens", () => {
@@ -893,16 +883,6 @@ describe("TokenStore", () => {
             const token = tokenStore.getLastToken(ast);
 
             assert.strictEqual(token, null);
-        });
-
-        it("should retrieve a parent node's token if a node has no tokens", () => {
-            const code = "foo``";
-            const ast = espree.parse(code, { loc: true, range: true, tokens: true, comment: true, ecmaVersion: 6 });
-            const tokenStore = new TokenStore(ast.tokens, ast.comments);
-            const emptyTemplateElementNode = ast.body[0].expression.quasi.quasis[0];
-            const token = tokenStore.getLastToken(emptyTemplateElementNode);
-
-            assert.strictEqual(token.value, "``");
         });
 
     });

--- a/tests/lib/source-code/token-store.js
+++ b/tests/lib/source-code/token-store.js
@@ -627,8 +627,8 @@ describe("TokenStore", () => {
             const tokenStore = new TokenStore(ast.tokens, ast.comments);
 
             /*
-             * Actually, the first of nodes is always tokens, not comments.
-             * But I think this test case is needed for completeness.
+             * A node must not start with a token: it can start with a comment or be empty.
+             * This test case is needed for completeness.
              */
             const token = tokenStore.getFirstToken(
                 { range: [ast.comments[0].range[0], ast.tokens[5].range[1]] },
@@ -644,14 +644,46 @@ describe("TokenStore", () => {
             const tokenStore = new TokenStore(ast.tokens, ast.comments);
 
             /*
-             * Actually, the first of nodes is always tokens, not comments.
-             * But I think this test case is needed for completeness.
+             * A node must not start with a token: it can start with a comment or be empty.
+             * This test case is needed for completeness.
              */
             const token = tokenStore.getFirstToken(
                 { range: [ast.comments[0].range[0], ast.tokens[5].range[1]] }
             );
 
             assert.strictEqual(token.value, "c");
+        });
+
+        it("should return null if the source contains only comments", () => {
+            const code = "// comment";
+            const ast = espree.parse(code, { loc: true, range: true, tokens: true, comment: true });
+            const tokenStore = new TokenStore(ast.tokens, ast.comments);
+            const token = tokenStore.getFirstToken(ast, {
+                filter() {
+                    assert.fail("Unexpected call to filter callback");
+                }
+            });
+
+            assert.strictEqual(token, null);
+        });
+
+        it("should return null if the source is empty", () => {
+            const code = "";
+            const ast = espree.parse(code, { loc: true, range: true, tokens: true, comment: true });
+            const tokenStore = new TokenStore(ast.tokens, ast.comments);
+            const token = tokenStore.getFirstToken(ast);
+
+            assert.strictEqual(token, null);
+        });
+
+        it("should retrieve a parent node's token if a node has no tokens", () => {
+            const code = "foo``";
+            const ast = espree.parse(code, { loc: true, range: true, tokens: true, comment: true, ecmaVersion: 6 });
+            const tokenStore = new TokenStore(ast.tokens, ast.comments);
+            const emptyTemplateElementNode = ast.body[0].expression.quasi.quasis[0];
+            const token = tokenStore.getFirstToken(emptyTemplateElementNode);
+
+            assert.strictEqual(token.value, "``");
         });
 
     });
@@ -814,8 +846,8 @@ describe("TokenStore", () => {
             const tokenStore = new TokenStore(ast.tokens, ast.comments);
 
             /*
-             * Actually, the last of nodes is always tokens, not comments.
-             * But I think this test case is needed for completeness.
+             * A node must not end with a token: it can end with a comment or be empty.
+             * This test case is needed for completeness.
              */
             const token = tokenStore.getLastToken(
                 { range: [ast.tokens[0].range[0], ast.comments[0].range[1]] },
@@ -831,14 +863,46 @@ describe("TokenStore", () => {
             const tokenStore = new TokenStore(ast.tokens, ast.comments);
 
             /*
-             * Actually, the last of nodes is always tokens, not comments.
-             * But I think this test case is needed for completeness.
+             * A node must not end with a token: it can end with a comment or be empty.
+             * This test case is needed for completeness.
              */
             const token = tokenStore.getLastToken(
                 { range: [ast.tokens[0].range[0], ast.comments[0].range[1]] }
             );
 
             assert.strictEqual(token.value, "b");
+        });
+
+        it("should return null if the source contains only comments", () => {
+            const code = "// comment";
+            const ast = espree.parse(code, { loc: true, range: true, tokens: true, comment: true });
+            const tokenStore = new TokenStore(ast.tokens, ast.comments);
+            const token = tokenStore.getLastToken(ast, {
+                filter() {
+                    assert.fail("Unexpected call to filter callback");
+                }
+            });
+
+            assert.strictEqual(token, null);
+        });
+
+        it("should return null if the source is empty", () => {
+            const code = "";
+            const ast = espree.parse(code, { loc: true, range: true, tokens: true, comment: true });
+            const tokenStore = new TokenStore(ast.tokens, ast.comments);
+            const token = tokenStore.getLastToken(ast);
+
+            assert.strictEqual(token, null);
+        });
+
+        it("should retrieve a parent node's token if a node has no tokens", () => {
+            const code = "foo``";
+            const ast = espree.parse(code, { loc: true, range: true, tokens: true, comment: true, ecmaVersion: 6 });
+            const tokenStore = new TokenStore(ast.tokens, ast.comments);
+            const emptyTemplateElementNode = ast.body[0].expression.quasi.quasis[0];
+            const token = tokenStore.getLastToken(emptyTemplateElementNode);
+
+            assert.strictEqual(token.value, "``");
         });
 
     });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

---

This PR fixes an issue with some `SourceCode` methods that is causing unexpected behavior when the source code contains no tokens but one or more comments. The [`SourceCode`](https://eslint.org/docs/latest/extend/custom-rules#contextgetsourcecode) type is part of the public API and is used by virtually all rules, although the issue described here should not affect any built-in rules.

The problem shows up when `sourceCode.getFirstToken()` or `sourceCode.getLastToken()` is called with the `Program` node (the AST object) of a source code than contains no tokens but one or more comments, i.e. a comment-only file.

The **expected** behavior is that `sourceCode.getFirstToken(ast)` or `sourceCode.getLastToken(ast)` should return `null` as per [documentation](https://github.com/eslint/eslint/blob/v8.35.0/lib/source-code/token-store/index.js#L253). If a `filter` callback is passed, the callback should never be called.

The **actual** case is that `sourceCode.getFirstToken(ast)` returns `undefined`. If a `filter` callback is passed, the callback is called with an `undefined` argument.

My original, incomplete analysis of this problem can be found in issue #16742.

Closes #16742 

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Changed the handling of nodes without tokens in https://github.com/eslint/eslint/blob/main/lib/source-code/token-store/utils.js. In practice, this change only impacts `Program` nodes when the source code contains just comments.
* Added some unit tests to make sure that behavior does not change in other special cases.

#### Is there anything you'd like reviewers to focus on?

I am open to any suggestions.

<!-- markdownlint-disable-file MD004 -->
