### PR TITLE
perf: upgrade to esquery@1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-utils": "^3.0.0",
     "eslint-visitor-keys": "^3.3.0",
     "espree": "^9.4.0",
-    "esquery": "1.4.0",
+    "esquery": "^1.4.2",
     "esutils": "^2.0.2",
     "fast-deep-equal": "^3.1.3",
     "file-entry-cache": "^6.0.1",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Upgrades to esquery@1.4.2, which brings performance improvements: https://github.com/estools/esquery/pull/134, per [Speeding up the JavaScript ecosystem - eslint](https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-3/).

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

`npm run test:performance` before:

```

> eslint@8.34.0 test:performance
> node Makefile.js perf


Loading:
  Load performance Run #1:  223.2577ms
  Load performance Run #2:  261.1178ms
  Load performance Run #3:  212.2345ms
  Load performance Run #4:  248.4629ms
  Load performance Run #5:  222.5063ms

  Load Performance median:  223.2577ms


Single File:
  CPU Speed is 2695 with multiplier 13000000
  Performance Run #1:  5149.5298ms
  Performance Run #2:  5783.5248ms
  Performance Run #3:  5380.0233ms
  Performance Run #4:  5097.0999ms
  Performance Run #5:  5060.0131ms

  Performance budget exceeded: 5149.5298ms (limit: 4823.747680890538ms)


Multi Files (450 files):
  CPU Speed is 2695 with multiplier 39000000
  Performance Run #1:  14100.6858ms
  Performance Run #2:  14042.072ms
  Performance Run #3:  14044.7797ms
  Performance Run #4:  14020.2634ms
  Performance Run #5:  13980.2464ms

  Performance budget ok:  14042.072ms (limit: 14471.243042671615ms)


```

`npm run test:performance` after:

```

> eslint@8.34.0 test:performance
> node Makefile.js perf


Loading:
  Load performance Run #1:  214.9901ms
  Load performance Run #2:  301.6212ms
  Load performance Run #3:  215.1469ms
  Load performance Run #4:  260.8772ms
  Load performance Run #5:  227.4377ms

  Load Performance median:  227.4377ms


Single File:
  CPU Speed is 2695 with multiplier 13000000
  Performance Run #1:  4763.6277ms
  Performance Run #2:  4772.6266ms
  Performance Run #3:  4703.1183ms
  Performance Run #4:  4742.6275000000005ms
  Performance Run #5:  4722.9899000000005ms

  Performance budget ok:  4742.6275000000005ms (limit: 4823.747680890538ms)


Multi Files (450 files):
  CPU Speed is 2695 with multiplier 39000000
  Performance Run #1:  13130.4004ms
  Performance Run #2:  13025.6748ms
  Performance Run #3:  13111.0195ms
  Performance Run #4:  12994.8904ms
  Performance Run #5:  13015.6519ms

  Performance budget ok:  13025.6748ms (limit: 14471.243042671615ms)


```

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated dependency in package.json.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
