### PR TITLE
chore: type property to nonblock-statement-body-position root and child schema added

### DIFF
--- a/lib/rules/nonblock-statement-body-position.js
+++ b/lib/rules/nonblock-statement-body-position.js
@@ -26,8 +26,10 @@ module.exports = {
         schema: [
             POSITION_SCHEMA,
             {
+                type: "object",
                 properties: {
                     overrides: {
+                        type: "object",
                         properties: {
                             if: POSITION_SCHEMA,
                             else: POSITION_SCHEMA,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

It seems the `nonblock-statement-body-position` rule schema has a `properties : [...]` property without its `type : "object"` associated property. Same with `overrides` child property. 

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I added `type: "object"` on line 29 and 32 on the schema object of the `nonblock-statement-body-position` rule

#### Is there anything you'd like reviewers to focus on?

no 

<!-- markdownlint-disable-file MD004 -->
