### PR TITLE
feat: Enhance no-tabs allowIndentationTabs option + add autofix

### DIFF
--- a/lib/rules/no-tabs.js
+++ b/lib/rules/no-tabs.js
@@ -48,12 +48,42 @@ module.exports = {
 
         return {
             Program(node) {
+                const lineComments = new Map();
+
+                /*
+                 * If indentation tabs are allowed then make a map of a line comments by their line
+                 * and column. We will use this to splice out the comment marker in order to allow
+                 * for tabs in "commented out" code.
+                 */
+                if (allowIndentationTabs) {
+                    for (const comment of sourceCode.getAllComments()) {
+                        if (comment.type === "Line") {
+                            lineComments.set(comment.loc.start.line, comment.loc.start.column);
+                        }
+                    }
+                }
+
                 sourceCode.getLines().forEach((line, index) => {
                     let match;
 
                     while ((match = tabRegex.exec(line)) !== null) {
-                        if (allowIndentationTabs && !anyNonWhitespaceRegex.test(line.slice(0, match.index))) {
-                            continue;
+                        const matchIndex = match.index;
+
+                        if (allowIndentationTabs) {
+                            const commentColumn = lineComments.get(index + 1);
+                            let lineToTab;
+
+                            if (typeof commentColumn === "undefined" || match.index < commentColumn) {
+                                lineToTab = line.slice(0, match.index);
+                            } else {
+
+                                // Slice out the comment "//" marker
+                                lineToTab = line.slice(0, commentColumn) + line.slice(commentColumn + 2, matchIndex);
+                            }
+
+                            if (!anyNonWhitespaceRegex.test(lineToTab)) {
+                                continue;
+                            }
                         }
 
                         context.report({

--- a/lib/rules/no-tabs.js
+++ b/lib/rules/no-tabs.js
@@ -20,6 +20,7 @@ const anyNonWhitespaceRegex = /\S/u;
 module.exports = {
     meta: {
         type: "layout",
+        fixable: "whitespace",
 
         docs: {
             description: "Disallow all tabs",
@@ -68,6 +69,7 @@ module.exports = {
 
                     while ((match = tabRegex.exec(line)) !== null) {
                         const matchIndex = match.index;
+                        const matchLength = match[0].length;
 
                         if (allowIndentationTabs) {
                             const commentColumn = lineComments.get(index + 1);
@@ -88,6 +90,11 @@ module.exports = {
 
                         context.report({
                             node,
+                            fix(fixer) {
+                                const startIndex = sourceCode.getIndexFromLoc({ line: index + 1, column: matchIndex });
+
+                                return fixer.replaceTextRange([startIndex, startIndex + matchLength], " ".repeat(matchLength));
+                            },
                             loc: {
                                 start: {
                                     line: index + 1,

--- a/tests/lib/rules/no-tabs.js
+++ b/tests/lib/rules/no-tabs.js
@@ -31,6 +31,10 @@ ruleTester.run("no-tabs", rule, {
         {
             code: "\t// comment",
             options: [{ allowIndentationTabs: true }]
+        },
+        {
+            code: "// \tcomment",
+            options: [{ allowIndentationTabs: true }]
         }
     ],
     invalid: [

--- a/tests/lib/rules/no-tabs.js
+++ b/tests/lib/rules/no-tabs.js
@@ -40,6 +40,7 @@ ruleTester.run("no-tabs", rule, {
     invalid: [
         {
             code: "function test(){\t}",
+            output: "function test(){ }",
             errors: [{
                 messageId: "unexpectedTab",
                 line: 1,
@@ -50,6 +51,7 @@ ruleTester.run("no-tabs", rule, {
         },
         {
             code: "/** \t comment test */",
+            output: "/**   comment test */",
             errors: [{
                 messageId: "unexpectedTab",
                 line: 1,
@@ -63,6 +65,10 @@ ruleTester.run("no-tabs", rule, {
             "function test(){\n" +
             "  //\tsdfdsf \n" +
             "}",
+            output:
+            "function test(){\n" +
+            "  // sdfdsf \n" +
+            "}",
             errors: [{
                 messageId: "unexpectedTab",
                 line: 2,
@@ -74,6 +80,10 @@ ruleTester.run("no-tabs", rule, {
         {
             code:
             "function\ttest(){\n" +
+            "  //sdfdsf \n" +
+            "}",
+            output:
+            "function test(){\n" +
             "  //sdfdsf \n" +
             "}",
             errors: [{
@@ -89,6 +99,10 @@ ruleTester.run("no-tabs", rule, {
             "function test(){\n" +
             "  //\tsdfdsf \n" +
             "\t}",
+            output:
+            "function test(){\n" +
+            "  // sdfdsf \n" +
+            " }",
             errors: [
                 {
                     messageId: "unexpectedTab",
@@ -108,6 +122,7 @@ ruleTester.run("no-tabs", rule, {
         },
         {
             code: "\t// Comment with leading tab \t and inline tab",
+            output: "\t// Comment with leading tab   and inline tab",
             options: [{ allowIndentationTabs: true }],
             errors: [{
                 messageId: "unexpectedTab",
@@ -119,6 +134,7 @@ ruleTester.run("no-tabs", rule, {
         },
         {
             code: "\t\ta =\t\t\tb +\tc\t\t;\t\t",
+            output: "  a =   b + c  ;  ",
             errors: [
                 {
                     messageId: "unexpectedTab",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[X] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**
no-tabs

**What change do you want to make (place an "X" next to just one item)?**

[ ] Generate more warnings
[X] Generate fewer warnings
[X] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[ ] A new option
[X] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

note: Here "\t" means literally a tab character
```js
// \tconst unused = 1;
```

**What does the rule currently do for this code?**

This rule raises an error since a tab is encountered in the source text. An exception is carved out for indentation tabs under the `allowIndentationTabs` option but since a comment is non-indentation text it will still fire in this case.

**What will the rule do after it's changed?**

After this change single-line comment markers "//" will not be considered non-indentation text. The reasoning for this is tools which "comment out" code (VS Code, vim plugins, lots of others) will generally prefix all code with "// ". After commenting out the code, previously-valid indentation characters will now be flagged as invalid.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

If `allowIndentationTabs` is enabled we first make a `Map` of all line-style comments from the line to column. When a tab character is encountered we use this information to "splice out" the comment marker so that the existing indentation detection code works.

I also added an auto-fix which replaces each tab with a single space. This has a risk of changing program meaning because `const a = "\t"` (again, an actual tab character not an escape sequence) would become `const a = " "`. I suspect such cases are rare but I'm happy to leave out the autofix.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
