### PR TITLE
feat: add option for equal operator with unsage-negations

### DIFF
--- a/lib/rules/no-unsafe-negation.js
+++ b/lib/rules/no-unsafe-negation.js
@@ -34,6 +34,15 @@ function isOrderingRelationalOperator(op) {
 }
 
 /**
+ * Checks whether the given operator is an equal operator or not.
+ * @param {string} op The operator type to check.
+ * @returns {boolean} `true` if the operator is an equal operator.
+ */
+function isEqualOperator(op) {
+    return op === "==" || op === "===";
+}
+
+/**
  * Checks whether the given node is a logical negation expression or not.
  * @param {ASTNode} node The node to check.
  * @returns {boolean} `true` if the node is a logical negation expression.
@@ -66,6 +75,10 @@ module.exports = {
                     enforceForOrderingRelations: {
                         type: "boolean",
                         default: false
+                    },
+                    enforceForEqualRelations: {
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -85,14 +98,16 @@ module.exports = {
         const sourceCode = context.getSourceCode();
         const options = context.options[0] || {};
         const enforceForOrderingRelations = options.enforceForOrderingRelations === true;
+        const enforceForEqualRelations = options.enforceForEqualRelations === true;
 
         return {
             BinaryExpression(node) {
                 const operator = node.operator;
                 const orderingRelationRuleApplies = enforceForOrderingRelations && isOrderingRelationalOperator(operator);
+                const equalRelationRuleApplies = enforceForEqualRelations && isEqualOperator(operator);
 
                 if (
-                    (isInOrInstanceOfOperator(operator) || orderingRelationRuleApplies) &&
+                    (isInOrInstanceOfOperator(operator) || orderingRelationRuleApplies || equalRelationRuleApplies) &&
                     isNegation(node.left) &&
                     !astUtils.isParenthesised(sourceCode, node.left)
                 ) {

--- a/tests/lib/rules/no-unsafe-negation.js
+++ b/tests/lib/rules/no-unsafe-negation.js
@@ -57,200 +57,283 @@ ruleTester.run("no-unsafe-negation", rule, {
         {
             code: "foo = a > b;",
             options: [{ enforceForOrderingRelations: true }]
-        }
+        },
+        // tests cases for enforceForEqualRelations option:
+        {
+            code: "foo = ! a === b;",
+            options: [{ enforceForEqualRelations: false }]
+        },
+        {
+            code: "foo = (!a) == b;",
+            options: [{ enforceForEqualRelations: true }]
+        },
+        {
+            code: "a === b",
+            options: [{ enforceForEqualRelations: true }]
+        },
+        {
+            code: "!(a === b)",
+            options: [{ enforceForEqualRelations: true }]
+        },
+        {
+            code: "foo = a === b;",
+            options: [{ enforceForEqualRelations: true }]
+        },
     ],
     invalid: [
         {
             code: "!a in b",
-            errors: [{
-                messageId: "unexpected",
-                data: { operator: "in" },
-                suggestions: [
-                    {
-                        desc: "Negate 'in' expression instead of its left operand. This changes the current behavior.",
-                        output: "!(a in b)"
-                    },
-                    {
-                        desc: "Wrap negation in '()' to make the intention explicit. This preserves the current behavior.",
-                        output: "(!a) in b"
-                    }
-                ]
-            }]
+            errors: [
+                {
+                    messageId: "unexpected",
+                    data: { operator: "in" },
+                    suggestions: [
+                        {
+                            desc: "Negate 'in' expression instead of its left operand. This changes the current behavior.",
+                            output: "!(a in b)"
+                        },
+                        {
+                            desc: "Wrap negation in '()' to make the intention explicit. This preserves the current behavior.",
+                            output: "(!a) in b"
+                        }
+                    ]
+                },
+            ]
         },
         {
             code: "(!a in b)",
-            errors: [{
-                messageId: "unexpected",
-                data: { operator: "in" },
-                suggestions: [
-                    {
-                        messageId: "suggestNegatedExpression",
-                        output: "(!(a in b))"
-                    },
-                    {
-                        messageId: "suggestParenthesisedNegation",
-                        output: "((!a) in b)"
-                    }
-                ]
-            }]
+            errors: [
+                {
+                    messageId: "unexpected",
+                    data: { operator: "in" },
+                    suggestions: [
+                        {
+                            messageId: "suggestNegatedExpression",
+                            output: "(!(a in b))"
+                        },
+                        {
+                            messageId: "suggestParenthesisedNegation",
+                            output: "((!a) in b)"
+                        }
+                    ]
+                }
+            ]
         },
         {
             code: "!(a) in b",
-            errors: [{
-                messageId: "unexpected",
-                data: { operator: "in" },
-                suggestions: [
-                    {
-                        messageId: "suggestNegatedExpression",
-                        output: "!((a) in b)"
-                    },
-                    {
-                        messageId: "suggestParenthesisedNegation",
-                        output: "(!(a)) in b"
-                    }
-                ]
-            }]
+            errors: [
+                {
+                    messageId: "unexpected",
+                    data: { operator: "in" },
+                    suggestions: [
+                        {
+                            messageId: "suggestNegatedExpression",
+                            output: "!((a) in b)"
+                        },
+                        {
+                            messageId: "suggestParenthesisedNegation",
+                            output: "(!(a)) in b"
+                        },
+                    ]
+                }
+            ]
         },
         {
             code: "!a instanceof b",
-            errors: [{
-                messageId: "unexpected",
-                data: { operator: "instanceof" },
-                suggestions: [
-                    {
-                        messageId: "suggestNegatedExpression",
-                        output: "!(a instanceof b)"
-                    },
-                    {
-                        messageId: "suggestParenthesisedNegation",
-                        output: "(!a) instanceof b"
-                    }
-                ]
-            }]
+            errors: [
+                {
+                    messageId: "unexpected",
+                    data: { operator: "instanceof" },
+                    suggestions: [
+                        {
+                            messageId: "suggestNegatedExpression",
+                            output: "!(a instanceof b)"
+                        },
+                        {
+                            messageId: "suggestParenthesisedNegation",
+                            output: "(!a) instanceof b"
+                        }
+                    ]
+                }
+            ]
         },
         {
             code: "(!a instanceof b)",
-            errors: [{
-                messageId: "unexpected",
-                data: { operator: "instanceof" },
-                suggestions: [
-                    {
-                        messageId: "suggestNegatedExpression",
-                        output: "(!(a instanceof b))"
-                    },
-                    {
-                        messageId: "suggestParenthesisedNegation",
-                        output: "((!a) instanceof b)"
-                    }
-                ]
-            }]
+            errors: [
+                {
+                    messageId: "unexpected",
+                    data: { operator: "instanceof" },
+                    suggestions: [
+                        {
+                            messageId: "suggestNegatedExpression",
+                            output: "(!(a instanceof b))"
+                        },
+                        {
+                            messageId: "suggestParenthesisedNegation",
+                            output: "((!a) instanceof b)"
+                        }
+                    ]
+                }
+            ]
         },
         {
             code: "!(a) instanceof b",
-            errors: [{
-                messageId: "unexpected",
-                data: { operator: "instanceof" },
-                suggestions: [
-                    {
-                        messageId: "suggestNegatedExpression",
-                        output: "!((a) instanceof b)"
-                    },
-                    {
-                        messageId: "suggestParenthesisedNegation",
-                        output: "(!(a)) instanceof b"
-                    }
-                ]
-            }]
+            errors: [
+                {
+                    messageId: "unexpected",
+                    data: { operator: "instanceof" },
+                    suggestions: [
+                        {
+                            messageId: "suggestNegatedExpression",
+                            output: "!((a) instanceof b)"
+                        },
+                        {
+                            messageId: "suggestParenthesisedNegation",
+                            output: "(!(a)) instanceof b"
+                        }
+                    ]
+                }
+            ]
         },
         {
             code: "if (! a < b) {}",
             options: [{ enforceForOrderingRelations: true }],
-            errors: [{
-                messageId: "unexpected",
-                data: { operator: "<" },
-                suggestions: [
-                    {
-                        messageId: "suggestNegatedExpression",
-                        output: "if (!( a < b)) {}"
-                    },
-                    {
-                        messageId: "suggestParenthesisedNegation",
-                        output: "if ((! a) < b) {}"
-                    }
-                ]
-            }]
+            errors: [
+                {
+                    messageId: "unexpected",
+                    data: { operator: "<" },
+                    suggestions: [
+                        {
+                            messageId: "suggestNegatedExpression",
+                            output: "if (!( a < b)) {}",
+                        },
+                        {
+                            messageId: "suggestParenthesisedNegation",
+                            output: "if ((! a) < b) {}"
+                        }
+                    ]
+                }
+            ]
         },
         {
             code: "while (! a > b) {}",
             options: [{ enforceForOrderingRelations: true }],
-            errors: [{
-                messageId: "unexpected",
-                data: { operator: ">" },
-                suggestions: [
-                    {
-                        messageId: "suggestNegatedExpression",
-                        output: "while (!( a > b)) {}"
-                    },
-                    {
-                        messageId: "suggestParenthesisedNegation",
-                        output: "while ((! a) > b) {}"
-                    }
-                ]
-            }]
+            errors: [
+                {
+                    messageId: "unexpected",
+                    data: { operator: ">" },
+                    suggestions: [
+                        {
+                            messageId: "suggestNegatedExpression",
+                            output: "while (!( a > b)) {}"
+                        },
+                        {
+                            messageId: "suggestParenthesisedNegation",
+                            output: "while ((! a) > b) {}"
+                        }
+                    ]
+                }
+            ]
         },
         {
             code: "foo = ! a <= b;",
             options: [{ enforceForOrderingRelations: true }],
-            errors: [{
-                messageId: "unexpected",
-                data: { operator: "<=" },
-                suggestions: [
-                    {
-                        messageId: "suggestNegatedExpression",
-                        output: "foo = !( a <= b);"
-                    },
-                    {
-                        messageId: "suggestParenthesisedNegation",
-                        output: "foo = (! a) <= b;"
-                    }
-                ]
-            }]
+            errors: [
+                {
+                    messageId: "unexpected",
+                    data: { operator: "<=" },
+                    suggestions: [
+                        {
+                            messageId: "suggestNegatedExpression",
+                            output: "foo = !( a <= b);"
+                        },
+                        {
+                            messageId: "suggestParenthesisedNegation",
+                            output: "foo = (! a) <= b;"
+                        }
+                    ]
+                }
+            ]
         },
         {
             code: "foo = ! a >= b;",
             options: [{ enforceForOrderingRelations: true }],
-            errors: [{
-                messageId: "unexpected",
-                data: { operator: ">=" },
-                suggestions: [
-                    {
-                        messageId: "suggestNegatedExpression",
-                        output: "foo = !( a >= b);"
-                    },
-                    {
-                        messageId: "suggestParenthesisedNegation",
-                        output: "foo = (! a) >= b;"
-                    }
-                ]
-            }]
+            errors: [
+                {
+                    messageId: "unexpected",
+                    data: { operator: ">=" },
+                    suggestions: [
+                        {
+                            messageId: "suggestNegatedExpression",
+                            output: "foo = !( a >= b);"
+                        },
+                        {
+                            messageId: "suggestParenthesisedNegation",
+                            output: "foo = (! a) >= b;"
+                        }
+                    ]
+                }
+            ]
         },
         {
             code: "! a <= b",
             options: [{ enforceForOrderingRelations: true }],
-            errors: [{
-                messageId: "unexpected",
-                data: { operator: "<=" },
-                suggestions: [
-                    {
-                        messageId: "suggestNegatedExpression",
-                        output: "!( a <= b)"
-                    },
-                    {
-                        messageId: "suggestParenthesisedNegation",
-                        output: "(! a) <= b"
-                    }
-                ]
-            }]
+            errors: [
+                {
+                    messageId: "unexpected",
+                    data: { operator: "<=" },
+                    suggestions: [
+                        {
+                            messageId: "suggestNegatedExpression",
+                            output: "!( a <= b)"
+                        },
+                        {
+                            messageId: "suggestParenthesisedNegation",
+                            output: "(! a) <= b"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "! a === b",
+            options: [{ enforceForEqualRelations: true }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    data: { operator: "===" },
+                    suggestions: [
+                        {
+                            messageId: "suggestNegatedExpression",
+                            output: "!( a === b)"
+                        },
+                        {
+                            messageId: "suggestParenthesisedNegation",
+                            output: "(! a) === b"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "foo = ! a == b;",
+            options: [{ enforceForEqualRelations: true }],
+            errors: [
+                {
+                    messageId: "unexpected",
+                    data: { operator: "==" },
+                    suggestions: [
+                        {
+                            messageId: "suggestNegatedExpression",
+                            output: "foo = !( a == b);"
+                        },
+                        {
+                            messageId: "suggestParenthesisedNegation",
+                            output: "foo = (! a) == b;"
+                        }
+                    ]
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

no-unsafe-negation

**What change do you want to make (place an "X" next to just one item)?**

[X] Generate more warnings
[ ] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[X] A new option
[ ] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
! X === 'Hello'
// is different than 
 X !=== 'Hello'
```
i've seen a few of these in the wild, and they are hard to spot 

**What does the rule currently do for this code?**

nothing, just doing if the operator is a < with an option

**What will the rule do after it's changed?**
warn users if the new option is activated

#### What changes did you make? (Give an overview)
add an option to broader the scope of the lint

#### Is there anything you'd like reviewers to focus on?

