### PR TITLE
[origin/add-arrow-function-statment-type] add arrow function statement

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -14,11 +14,11 @@ body:
     description: |
       Please tell us about how you're running ESLint (Run `npx eslint --env-info`.)
     value: |
-        Node version: 
-        npm version: 
-        Local ESLint version: 
-        Global ESLint version: 
-        Operating System: 
+        Node version: 12.7.0
+        npm version: 6.10.0
+        Local ESLint version: 7.32.0 
+        Global ESLint version: 7.32.0
+        Operating System: macos
   validations:
     required: true
 - type: dropdown
@@ -33,6 +33,7 @@ body:
       - "vue-eslint-parser"
       - "@angular-eslint/template-parser"
       - Other
+    value: "Default (Espree)"
   validations:
     required: true
 - type: textarea
@@ -45,12 +46,12 @@ body:
       <summary>Configuration</summary>
 
       ```
-      <!-- Paste your configuration here -->
+      <!-- Paste your configuration here --> I have tried to use padding-line-netween-statements to but a rule that mast be at least one line padding between any two sucessive funtions but this doesn't work in case the two function is in shape of one line arrow function so i have added a arrow function statemnet that work well in this case 
       ```
       </details>
 
       ```js
-      <!-- Paste your code here -->
+      <!-- Paste your code here --> https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgcGFkZGluZy1saW5lLWJldHdlZW4tc3RhdGVtZW50czogW1xuICAgIFwiZXJyb3JcIixcbiAgICB7IGJsYW5rTGluZTogXCJhbHdheXNcIiwgcHJldjogXCIqXCIsIG5leHQ6IFwiZnVuY3Rpb25cIiB9LFxuICAgIHsgYmxhbmtMaW5lOiBcImFsd2F5c1wiLCBwcmV2OiBcIipcIiwgbmV4dDogXCJibG9jay1saWtlXCIgfVxuXSovXG5cbi8vaXQgZG9lc24ndCBkZXRlY3QgYW55IGVycm9yXG5jb25zdCBmaXJzdEZ1bmMgPSAoKSA9PiBcImZpcnN0RnVuY1wiIC8vZXJyb3IgaXMgdGhlcmUgaXMgbm8gcGFkZGluZyBiZXR3ZWVuIHRoZSB0d28gYXJyb3cgZnVuY3Rpb25zXG5jb25zdCBzZWNvbmRGdW5jID0gKCkgPT4gXCJzZWNvbmRGdW5jXCJcblxuZmlyc3RGdW5jKClcbnNlY29uZEZ1bmMoKSIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6ImxhdGVzdCIsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnsiY29uc3RydWN0b3Itc3VwZXIiOlsiZXJyb3IiXSwiZm9yLWRpcmVjdGlvbiI6WyJlcnJvciJdLCJnZXR0ZXItcmV0dXJuIjpbImVycm9yIl0sIm5vLWFzeW5jLXByb21pc2UtZXhlY3V0b3IiOlsiZXJyb3IiXSwibm8tY2FzZS1kZWNsYXJhdGlvbnMiOlsiZXJyb3IiXSwibm8tY2xhc3MtYXNzaWduIjpbImVycm9yIl0sIm5vLWNvbXBhcmUtbmVnLXplcm8iOlsiZXJyb3IiXSwibm8tY29uZC1hc3NpZ24iOlsiZXJyb3IiXSwibm8tY29uc3QtYXNzaWduIjpbImVycm9yIl0sIm5vLWNvbnN0YW50LWNvbmRpdGlvbiI6WyJlcnJvciJdLCJuby1jb250cm9sLXJlZ2V4IjpbImVycm9yIl0sIm5vLWRlYnVnZ2VyIjpbImVycm9yIl0sIm5vLWRlbGV0ZS12YXIiOlsiZXJyb3IiXSwibm8tZHVwZS1hcmdzIjpbImVycm9yIl0sIm5vLWR1cGUtY2xhc3MtbWVtYmVycyI6WyJlcnJvciJdLCJuby1kdXBlLWVsc2UtaWYiOlsiZXJyb3IiXSwibm8tZHVwZS1rZXlzIjpbImVycm9yIl0sIm5vLWR1cGxpY2F0ZS1jYXNlIjpbImVycm9yIl0sIm5vLWVtcHR5IjpbImVycm9yIl0sIm5vLWVtcHR5LWNoYXJhY3Rlci1jbGFzcyI6WyJlcnJvciJdLCJuby1lbXB0eS1wYXR0ZXJuIjpbImVycm9yIl0sIm5vLWV4LWFzc2lnbiI6WyJlcnJvciJdLCJuby1leHRyYS1ib29sZWFuLWNhc3QiOlsiZXJyb3IiXSwibm8tZXh0cmEtc2VtaSI6WyJlcnJvciJdLCJuby1mYWxsdGhyb3VnaCI6WyJlcnJvciJdLCJuby1mdW5jLWFzc2lnbiI6WyJlcnJvciJdLCJuby1nbG9iYWwtYXNzaWduIjpbImVycm9yIl0sIm5vLWltcG9ydC1hc3NpZ24iOlsiZXJyb3IiXSwibm8taW5uZXItZGVjbGFyYXRpb25zIjpbImVycm9yIl0sIm5vLWludmFsaWQtcmVnZXhwIjpbImVycm9yIl0sIm5vLWlycmVndWxhci13aGl0ZXNwYWNlIjpbImVycm9yIl0sIm5vLWxvc3Mtb2YtcHJlY2lzaW9uIjpbImVycm9yIl0sIm5vLW1pc2xlYWRpbmctY2hhcmFjdGVyLWNsYXNzIjpbImVycm9yIl0sIm5vLW1peGVkLXNwYWNlcy1hbmQtdGFicyI6WyJlcnJvciJdLCJuby1uZXctc3ltYm9sIjpbImVycm9yIl0sIm5vLW5vbm9jdGFsLWRlY2ltYWwtZXNjYXBlIjpbImVycm9yIl0sIm5vLW9iai1jYWxscyI6WyJlcnJvciJdLCJuby1vY3RhbCI6WyJlcnJvciJdLCJuby1wcm90b3R5cGUtYnVpbHRpbnMiOlsiZXJyb3IiXSwibm8tcmVkZWNsYXJlIjpbImVycm9yIl0sIm5vLXJlZ2V4LXNwYWNlcyI6WyJlcnJvciJdLCJuby1zZWxmLWFzc2lnbiI6WyJlcnJvciJdLCJuby1zZXR0ZXItcmV0dXJuIjpbImVycm9yIl0sIm5vLXNoYWRvdy1yZXN0cmljdGVkLW5hbWVzIjpbImVycm9yIl0sIm5vLXNwYXJzZS1hcnJheXMiOlsiZXJyb3IiXSwibm8tdGhpcy1iZWZvcmUtc3VwZXIiOlsiZXJyb3IiXSwibm8tdW5kZWYiOlsiZXJyb3IiXSwibm8tdW5leHBlY3RlZC1tdWx0aWxpbmUiOlsiZXJyb3IiXSwibm8tdW5yZWFjaGFibGUiOlsiZXJyb3IiXSwibm8tdW5zYWZlLWZpbmFsbHkiOlsiZXJyb3IiXSwibm8tdW5zYWZlLW5lZ2F0aW9uIjpbImVycm9yIl0sIm5vLXVuc2FmZS1vcHRpb25hbC1jaGFpbmluZyI6WyJlcnJvciJdLCJuby11bnVzZWQtbGFiZWxzIjpbImVycm9yIl0sIm5vLXVudXNlZC12YXJzIjpbImVycm9yIl0sIm5vLXVzZWxlc3MtYmFja3JlZmVyZW5jZSI6WyJlcnJvciJdLCJuby11c2VsZXNzLWNhdGNoIjpbImVycm9yIl0sIm5vLXVzZWxlc3MtZXNjYXBlIjpbImVycm9yIl0sInJlcXVpcmUteWllbGQiOlsiZXJyb3IiXSwidXNlLWlzbmFuIjpbImVycm9yIl0sInZhbGlkLXR5cGVvZiI6WyJlcnJvciJdLCJwYWRkaW5nLWxpbmUtYmV0d2Vlbi1zdGF0ZW1lbnRzIjpbImVycm9yIl19LCJlbnYiOnsiZXM2Ijp0cnVlfX19
       ```
   validations:
     required: true
@@ -59,6 +60,8 @@ body:
     label: What did you expect to happen?
     description: |
       You can use Markdown in this field.
+    value: |
+      i expect to solve the problem and detect the padding lint error between any two successive one line arrow function
   validations:
     required: true
 - type: textarea
@@ -66,6 +69,8 @@ body:
     label: What actually happened?
     description: |
       Please copy-paste the actual ESLint output. You can use Markdown in this field.
+    value: |
+      it detects no linting error
   validations:
     required: true
 - type: checkboxes
@@ -74,6 +79,7 @@ body:
     options:
       - label: I am willing to submit a pull request for this issue.
         required: false
+    value: true
 - type: textarea
   attributes:
     label: Additional comments

--- a/docs/src/rules/padding-line-between-statements.md
+++ b/docs/src/rules/padding-line-between-statements.md
@@ -50,6 +50,7 @@ You can supply any number of configurations. If a statement pair matches multipl
 
 * `STATEMENT_TYPE` is one of the following, or an array of the following.
     * `"*"` is wildcard. This matches any statements.
+    * `"arrow-function"` is arrow Arrow Function decleration
     * `"block"` is lonely blocks.
     * `"block-like"` is block like statements. This matches statements that the last token is the closing brace of blocks; e.g. `{ }`, `if (a) { }`, and `while (a) { }`. Also matches immediately invoked function expression statements.
     * `"break"` is `break` statements.

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -131,6 +131,24 @@ function isBlockLikeStatement(sourceCode, node) {
 }
 
 /**
+ * Checks whether the given node is an arrow function.
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is a arrow-function statement.
+ * @private
+ */
+function isArrowFuntion(node) {
+    if (
+        node !== null &&
+        node.type === "VariableDeclaration" &&
+        node.declarations[0].init !== null &&
+        node.declarations[0].init.type === "ArrowFunctionExpression"
+    ) {
+        return true;
+    }
+    return false;
+}
+
+/**
  * Check whether the given node is a directive or not.
  * @param {ASTNode} node The node to check.
  * @param {SourceCode} sourceCode The source code object to get tokens.
@@ -350,7 +368,10 @@ const PaddingTypes = {
 const StatementTypes = {
     "*": { test: () => true },
     "block-like": {
-        test: (node, sourceCode) => isBlockLikeStatement(sourceCode, node)
+        test: (node, sourceCode) => isBlockLikeStatement(sourceCode, node),
+    },
+    "arrow-function": {
+        test: (node) => isArrowFuntion(node),
     },
     "cjs-export": {
         test: (node, sourceCode) =>


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [ X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
there is a problem with [padding-line-between-statements] in case of arrow function for example if have two arrow function 
and I want a rule to always have a new line between them there is not statement in the rule can help with this case

const foo = ()=>"foo"
const bar = ()=>"bar"

**Tell us about your environment (`npx eslint --env-info`):**

* **Node version:** 12.7.0
* **npm version:** 6.10.0
* **Local ESLint version:** 7.32.0
* **Global ESLint version:** 7.32.0
* **Operating System:** macos

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

I have tried to use padding-line-netween-statements to but a rule that mast be at least one line padding between any two sucessive funtions but this doesn't work in case the two function is in shape of one line arrow function so i have added a arrow function statemnet that work well in this case

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js

```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint padding-line-between-statements: [
    "error",
    { blankLine: "always", prev: "*", next: "function" },
    { blankLine: "always", prev: "*", next: "block-like" }
]*/

//it doesn't detect any error
const firstFunc = () => "firstFunc" //error is there is no padding between the two arrow functions
const secondFunc = () => "secondFunc"

firstFunc()
secondFunc()
```

[playground link](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgcGFkZGluZy1saW5lLWJldHdlZW4tc3RhdGVtZW50czogW1xuICAgIFwiZXJyb3JcIixcbiAgICB7IGJsYW5rTGluZTogXCJhbHdheXNcIiwgcHJldjogXCIqXCIsIG5leHQ6IFwiZnVuY3Rpb25cIiB9LFxuICAgIHsgYmxhbmtMaW5lOiBcImFsd2F5c1wiLCBwcmV2OiBcIipcIiwgbmV4dDogXCJibG9jay1saWtlXCIgfVxuXSovXG5cbi8vaXQgZG9lc24ndCBkZXRlY3QgYW55IGVycm9yXG5jb25zdCBmaXJzdEZ1bmMgPSAoKSA9PiBcImZpcnN0RnVuY1wiIC8vZXJyb3IgaXMgdGhlcmUgaXMgbm8gcGFkZGluZyBiZXR3ZWVuIHRoZSB0d28gYXJyb3cgZnVuY3Rpb25zXG5jb25zdCBzZWNvbmRGdW5jID0gKCkgPT4gXCJzZWNvbmRGdW5jXCJcblxuZmlyc3RGdW5jKClcbnNlY29uZEZ1bmMoKSIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6ImxhdGVzdCIsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnsiY29uc3RydWN0b3Itc3VwZXIiOlsiZXJyb3IiXSwiZm9yLWRpcmVjdGlvbiI6WyJlcnJvciJdLCJnZXR0ZXItcmV0dXJuIjpbImVycm9yIl0sIm5vLWFzeW5jLXByb21pc2UtZXhlY3V0b3IiOlsiZXJyb3IiXSwibm8tY2FzZS1kZWNsYXJhdGlvbnMiOlsiZXJyb3IiXSwibm8tY2xhc3MtYXNzaWduIjpbImVycm9yIl0sIm5vLWNvbXBhcmUtbmVnLXplcm8iOlsiZXJyb3IiXSwibm8tY29uZC1hc3NpZ24iOlsiZXJyb3IiXSwibm8tY29uc3QtYXNzaWduIjpbImVycm9yIl0sIm5vLWNvbnN0YW50LWNvbmRpdGlvbiI6WyJlcnJvciJdLCJuby1jb250cm9sLXJlZ2V4IjpbImVycm9yIl0sIm5vLWRlYnVnZ2VyIjpbImVycm9yIl0sIm5vLWRlbGV0ZS12YXIiOlsiZXJyb3IiXSwibm8tZHVwZS1hcmdzIjpbImVycm9yIl0sIm5vLWR1cGUtY2xhc3MtbWVtYmVycyI6WyJlcnJvciJdLCJuby1kdXBlLWVsc2UtaWYiOlsiZXJyb3IiXSwibm8tZHVwZS1rZXlzIjpbImVycm9yIl0sIm5vLWR1cGxpY2F0ZS1jYXNlIjpbImVycm9yIl0sIm5vLWVtcHR5IjpbImVycm9yIl0sIm5vLWVtcHR5LWNoYXJhY3Rlci1jbGFzcyI6WyJlcnJvciJdLCJuby1lbXB0eS1wYXR0ZXJuIjpbImVycm9yIl0sIm5vLWV4LWFzc2lnbiI6WyJlcnJvciJdLCJuby1leHRyYS1ib29sZWFuLWNhc3QiOlsiZXJyb3IiXSwibm8tZXh0cmEtc2VtaSI6WyJlcnJvciJdLCJuby1mYWxsdGhyb3VnaCI6WyJlcnJvciJdLCJuby1mdW5jLWFzc2lnbiI6WyJlcnJvciJdLCJuby1nbG9iYWwtYXNzaWduIjpbImVycm9yIl0sIm5vLWltcG9ydC1hc3NpZ24iOlsiZXJyb3IiXSwibm8taW5uZXItZGVjbGFyYXRpb25zIjpbImVycm9yIl0sIm5vLWludmFsaWQtcmVnZXhwIjpbImVycm9yIl0sIm5vLWlycmVndWxhci13aGl0ZXNwYWNlIjpbImVycm9yIl0sIm5vLWxvc3Mtb2YtcHJlY2lzaW9uIjpbImVycm9yIl0sIm5vLW1pc2xlYWRpbmctY2hhcmFjdGVyLWNsYXNzIjpbImVycm9yIl0sIm5vLW1peGVkLXNwYWNlcy1hbmQtdGFicyI6WyJlcnJvciJdLCJuby1uZXctc3ltYm9sIjpbImVycm9yIl0sIm5vLW5vbm9jdGFsLWRlY2ltYWwtZXNjYXBlIjpbImVycm9yIl0sIm5vLW9iai1jYWxscyI6WyJlcnJvciJdLCJuby1vY3RhbCI6WyJlcnJvciJdLCJuby1wcm90b3R5cGUtYnVpbHRpbnMiOlsiZXJyb3IiXSwibm8tcmVkZWNsYXJlIjpbImVycm9yIl0sIm5vLXJlZ2V4LXNwYWNlcyI6WyJlcnJvciJdLCJuby1zZWxmLWFzc2lnbiI6WyJlcnJvciJdLCJuby1zZXR0ZXItcmV0dXJuIjpbImVycm9yIl0sIm5vLXNoYWRvdy1yZXN0cmljdGVkLW5hbWVzIjpbImVycm9yIl0sIm5vLXNwYXJzZS1hcnJheXMiOlsiZXJyb3IiXSwibm8tdGhpcy1iZWZvcmUtc3VwZXIiOlsiZXJyb3IiXSwibm8tdW5kZWYiOlsiZXJyb3IiXSwibm8tdW5leHBlY3RlZC1tdWx0aWxpbmUiOlsiZXJyb3IiXSwibm8tdW5yZWFjaGFibGUiOlsiZXJyb3IiXSwibm8tdW5zYWZlLWZpbmFsbHkiOlsiZXJyb3IiXSwibm8tdW5zYWZlLW5lZ2F0aW9uIjpbImVycm9yIl0sIm5vLXVuc2FmZS1vcHRpb25hbC1jaGFpbmluZyI6WyJlcnJvciJdLCJuby11bnVzZWQtbGFiZWxzIjpbImVycm9yIl0sIm5vLXVudXNlZC12YXJzIjpbImVycm9yIl0sIm5vLXVzZWxlc3MtYmFja3JlZmVyZW5jZSI6WyJlcnJvciJdLCJuby11c2VsZXNzLWNhdGNoIjpbImVycm9yIl0sIm5vLXVzZWxlc3MtZXNjYXBlIjpbImVycm9yIl0sInJlcXVpcmUteWllbGQiOlsiZXJyb3IiXSwidXNlLWlzbmFuIjpbImVycm9yIl0sInZhbGlkLXR5cGVvZiI6WyJlcnJvciJdLCJwYWRkaW5nLWxpbmUtYmV0d2Vlbi1zdGF0ZW1lbnRzIjpbImVycm9yIl19LCJlbnYiOnsiZXM2Ijp0cnVlfX19)

**What did you expect to happen?**

i expect to solve the problem and detect the padding lint error between any two successive one line arrow function

**What actually happened? Please include the actual, raw output from ESLint.**

it detects no linting error


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
I have added an arrow function statement to cover the above case

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
