### PR TITLE
feat: languageOptions.parser must be an object.

### DIFF
--- a/docs/src/use/configure/configuration-files-new.md
+++ b/docs/src/use/configure/configuration-files-new.md
@@ -41,8 +41,8 @@ Each configuration object contains all of the information ESLint needs to execut
     * `ecmaVersion` - The version of ECMAScript to support. May be any year (i.e., `2022`) or version (i.e., `5`). Set to `"latest"` for the most recent supported version. (default: `"latest"`)
     * `sourceType` - The type of JavaScript source code. Possible values are `"script"` for traditional script files, `"module"` for ECMAScript modules (ESM), and `"commonjs"` for CommonJS files. (default: `"module"` for `.js` and `.mjs` files; `"commonjs"` for `.cjs` files)
     * `globals` - An object specifying additional objects that should be added to the global scope during linting.
-    * `parser` - Either an object containing a `parse()` method or a string indicating the name of a parser inside of a plugin (i.e., `"pluginName/parserName"`). (default: `"@/espree"`)
-    * `parserOptions` - An object specifying additional options that are passed directly to the `parser()` method on the parser. The available options are parser-dependent.
+    * `parser` - An object containing a `parse()` method or a `parseForESLint()` method. (default: [`espree`](https://github.com/eslint/espree))
+    * `parserOptions` - An object specifying additional options that are passed directly to the `parse()` or `parseForESLint()` method on the parser. The available options are parser-dependent.
 * `linterOptions` - An object containing settings related to the linting process.
     * `noInlineConfig` - A Boolean value indicating if inline configuration is allowed.
     * `reportUnusedDisableDirectives` - A Boolean value indicating if unused disable directives should be tracked and reported.
@@ -251,7 +251,7 @@ export default [
 
 #### Configuring a custom parser and its options
 
-In many cases, you can use the default parser that ESLint ships with for parsing your JavaScript code. You can optionally override the default parser by using the `parser` property. The `parser` property can be either a string in the format `"pluginName/parserName"` (indicating to retrieve the parser from a plugin) or an object containing either a `parse()` method or a `parseForESLint()` method. For example, you can use the [`@babel/eslint-parser`](https://www.npmjs.com/package/@babel/eslint-parser) package to allow ESLint to parse experimental syntax:
+In many cases, you can use the default parser that ESLint ships with for parsing your JavaScript code. You can optionally override the default parser by using the `parser` property. The `parser` property must be an object containing either a `parse()` method or a `parseForESLint()` method. For example, you can use the [`@babel/eslint-parser`](https://www.npmjs.com/package/@babel/eslint-parser) package to allow ESLint to parse experimental syntax:
 
 ```js
 import babelParser from "@babel/eslint-parser";

--- a/lib/config/default-config.js
+++ b/lib/config/default-config.js
@@ -19,9 +19,6 @@ exports.defaultConfig = [
     {
         plugins: {
             "@": {
-                parsers: {
-                    espree: require("espree")
-                },
 
                 /*
                  * Because we try to delay loading rules until absolutely
@@ -43,7 +40,7 @@ exports.defaultConfig = [
         languageOptions: {
             sourceType: "module",
             ecmaVersion: "latest",
-            parser: "@/espree",
+            parser: require("espree"),
             parserOptions: {}
         }
     },

--- a/lib/config/flat-config-array.js
+++ b/lib/config/flat-config-array.js
@@ -192,17 +192,7 @@ class FlatConfigArray extends ConfigArray {
         if (languageOptions && languageOptions.parser) {
             const { parser } = languageOptions;
 
-            if (typeof parser === "string") {
-                const { pluginName, objectName: localParserName } = splitPluginIdentifier(parser);
-
-                parserName = parser;
-
-                if (!plugins || !plugins[pluginName] || !plugins[pluginName].parsers || !plugins[pluginName].parsers[localParserName]) {
-                    throw new TypeError(`Key "parser": Could not find "${localParserName}" in plugin "${pluginName}".`);
-                }
-
-                languageOptions.parser = plugins[pluginName].parsers[localParserName];
-            } else if (typeof parser === "object") {
+            if (typeof parser === "object") {
                 parserName = getObjectId(parser);
 
                 if (!parserName) {

--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -231,8 +231,7 @@ const parserSchema = {
     merge: "replace",
     validate(value) {
 
-        if (
-            typeof value !== "object" ||
+        if (!value || typeof value !== "object" ||
             (typeof value.parse !== "function" && typeof value.parseForESLint !== "function")
         ) {
             throw new TypeError("Expected object with parse() or parseForESLint() method.");

--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -179,18 +179,6 @@ function assertIsObject(value) {
     }
 }
 
-/**
- * Validates that a value is an object or a string.
- * @param {any} value The value to check.
- * @returns {void}
- * @throws {TypeError} If the value isn't an object or a string.
- */
-function assertIsObjectOrString(value) {
-    if ((!value || typeof value !== "object") && typeof value !== "string") {
-        throw new TypeError("Expected an object or string.");
-    }
-}
-
 //-----------------------------------------------------------------------------
 // Low-Level Schemas
 //-----------------------------------------------------------------------------
@@ -242,15 +230,14 @@ const globalsSchema = {
 const parserSchema = {
     merge: "replace",
     validate(value) {
-        assertIsObjectOrString(value);
 
-        if (typeof value === "object" && typeof value.parse !== "function" && typeof value.parseForESLint !== "function") {
-            throw new TypeError("Expected object to have a parse() or parseForESLint() method.");
+        if (
+            typeof value !== "object" ||
+            (typeof value.parse !== "function" && typeof value.parseForESLint !== "function")
+        ) {
+            throw new TypeError("Expected object with parse() or parseForESLint() method.");
         }
 
-        if (typeof value === "string") {
-            assertIsPluginMemberName(value);
-        }
     }
 };
 

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -16,6 +16,7 @@ const {
     recommended: recommendedConfig
 } = require("@eslint/js").configs;
 const stringify = require("json-stable-stringify-without-jsonify");
+const espree = require("espree");
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -190,6 +191,7 @@ describe("FlatConfigArray", () => {
     });
 
     describe("Serialization of configs", () => {
+
         it("should convert config into normalized JSON object", () => {
 
             const configs = new FlatConfigArray([{
@@ -207,7 +209,7 @@ describe("FlatConfigArray", () => {
                 languageOptions: {
                     ecmaVersion: "latest",
                     sourceType: "module",
-                    parser: "@/espree",
+                    parser: `espree@${espree.version}`,
                     parserOptions: {}
                 },
                 processor: void 0
@@ -463,7 +465,7 @@ describe("FlatConfigArray", () => {
             assert.deepStrictEqual(config.toJSON(), {
                 languageOptions: {
                     ecmaVersion: "latest",
-                    parser: "@/espree",
+                    parser: `espree@${espree.version}`,
                     parserOptions: {},
                     sourceType: "module"
                 },
@@ -490,7 +492,7 @@ describe("FlatConfigArray", () => {
             assert.deepStrictEqual(config.toJSON(), {
                 languageOptions: {
                     ecmaVersion: "latest",
-                    parser: "@/espree",
+                    parser: `espree@${espree.version}`,
                     parserOptions: {},
                     sourceType: "module"
                 },
@@ -521,7 +523,7 @@ describe("FlatConfigArray", () => {
             assert.deepStrictEqual(config.toJSON(), {
                 languageOptions: {
                     ecmaVersion: "latest",
-                    parser: "@/espree",
+                    parser: `espree@${espree.version}`,
                     parserOptions: {},
                     sourceType: "module"
                 },
@@ -550,7 +552,7 @@ describe("FlatConfigArray", () => {
             assert.deepStrictEqual(config.toJSON(), {
                 languageOptions: {
                     ecmaVersion: "latest",
-                    parser: "@/espree",
+                    parser: `espree@${espree.version}`,
                     parserOptions: {},
                     sourceType: "module"
                 },
@@ -1340,21 +1342,10 @@ describe("FlatConfigArray", () => {
                                 parser: true
                             }
                         }
-                    ], "Expected an object or string.");
+                    ], "Key \"languageOptions\": Key \"parser\": Expected object with parse() or parseForESLint() method.");
                 });
 
-                it("should error when an unexpected value is found", async () => {
-
-                    await assertInvalidConfig([
-                        {
-                            languageOptions: {
-                                parser: "true"
-                            }
-                        }
-                    ], /Expected string in the form "pluginName\/objectName"/u);
-                });
-
-                it("should error when a plugin parser can't be found", async () => {
+                it("should error when a parser is a string", async () => {
 
                     await assertInvalidConfig([
                         {
@@ -1362,7 +1353,7 @@ describe("FlatConfigArray", () => {
                                 parser: "foo/bar"
                             }
                         }
-                    ], "Key \"parser\": Could not find \"bar\" in plugin \"foo\".");
+                    ], "Key \"languageOptions\": Key \"parser\": Expected object with parse() or parseForESLint() method.");
                 });
 
                 it("should error when a value doesn't have a parse() method", async () => {
@@ -1373,7 +1364,7 @@ describe("FlatConfigArray", () => {
                                 parser: {}
                             }
                         }
-                    ], "Expected object to have a parse() or parseForESLint() method.");
+                    ], "Key \"languageOptions\": Key \"parser\": Expected object with parse() or parseForESLint() method.");
                 });
 
                 it("should merge two objects when second object has overrides", () => {
@@ -1388,24 +1379,12 @@ describe("FlatConfigArray", () => {
                             }
                         },
                         {
-                            plugins: {
-                                "@foo/baz": {
-                                    parsers: {
-                                        bar: stubParser
-                                    }
-                                }
-                            },
                             languageOptions: {
-                                parser: "@foo/baz/bar"
+                                parser: stubParser
                             }
                         }
                     ], {
                         plugins: {
-                            "@foo/baz": {
-                                parsers: {
-                                    bar: stubParser
-                                }
-                            },
                             ...baseConfig.plugins
                         },
                         languageOptions: {
@@ -1420,27 +1399,14 @@ describe("FlatConfigArray", () => {
 
                     return assertMergedResult([
                         {
-                            plugins: {
-                                foo: {
-                                    parsers: {
-                                        bar: stubParser
-                                    }
-                                }
-                            },
-
                             languageOptions: {
-                                parser: "foo/bar"
+                                parser: stubParser
                             }
                         },
                         {
                         }
                     ], {
                         plugins: {
-                            foo: {
-                                parsers: {
-                                    bar: stubParser
-                                }
-                            },
                             ...baseConfig.plugins
                         },
 
@@ -1460,25 +1426,12 @@ describe("FlatConfigArray", () => {
                         {
                         },
                         {
-                            plugins: {
-                                foo: {
-                                    parsers: {
-                                        bar: stubParser
-                                    }
-                                }
-                            },
-
                             languageOptions: {
-                                parser: "foo/bar"
+                                parser: stubParser
                             }
                         }
                     ], {
                         plugins: {
-                            foo: {
-                                parsers: {
-                                    bar: stubParser
-                                }
-                            },
                             ...baseConfig.plugins
                         },
 

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -1345,6 +1345,17 @@ describe("FlatConfigArray", () => {
                     ], "Key \"languageOptions\": Key \"parser\": Expected object with parse() or parseForESLint() method.");
                 });
 
+                it("should error when a null is found", async () => {
+
+                    await assertInvalidConfig([
+                        {
+                            languageOptions: {
+                                parser: null
+                            }
+                        }
+                    ], "Key \"languageOptions\": Key \"parser\": Expected object with parse() or parseForESLint() method.");
+                });
+
                 it("should error when a parser is a string", async () => {
 
                     await assertInvalidConfig([

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -773,7 +773,7 @@ describe("FlatESLint", () => {
                 overrideConfigFile: true
             });
 
-            await assert.rejects(async () => await eslint.lintFiles(["lib/cli.js"]), /Expected string in the form "pluginName\/objectName" but found "test11"/u);
+            await assert.rejects(async () => await eslint.lintFiles(["lib/cli.js"]), /Expected object with parse\(\) or parseForESLint\(\) method/u);
         });
 
         it("should report zero messages when given a directory with a .js2 file", async () => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7878,15 +7878,8 @@ describe("Linter with FlatConfigArray", () => {
                     };
 
                     const config = {
-                        plugins: {
-                            test: {
-                                parsers: {
-                                    "test-parser": parser
-                                }
-                            }
-                        },
                         languageOptions: {
-                            parser: "test/test-parser"
+                            parser
                         }
                     };
 
@@ -7925,15 +7918,8 @@ describe("Linter with FlatConfigArray", () => {
 
                 it("should use parseForESLint() in custom parser when custom parser is specified", () => {
                     const config = {
-                        plugins: {
-                            test: {
-                                parsers: {
-                                    "enhanced-parser": testParsers.enhancedParser
-                                }
-                            }
-                        },
                         languageOptions: {
-                            parser: "test/enhanced-parser"
+                            parser: testParsers.enhancedParser
                         }
                     };
 
@@ -7949,9 +7935,6 @@ describe("Linter with FlatConfigArray", () => {
                     const config = {
                         plugins: {
                             test: {
-                                parsers: {
-                                    "enhanced-parser": testParsers.enhancedParser
-                                },
                                 rules: {
                                     "test-service-rule": {
                                         create: context => ({
@@ -7967,7 +7950,7 @@ describe("Linter with FlatConfigArray", () => {
                             }
                         },
                         languageOptions: {
-                            parser: "test/enhanced-parser"
+                            parser: testParsers.enhancedParser
                         },
                         rules: {
                             "test/test-service-rule": 2
@@ -7988,9 +7971,6 @@ describe("Linter with FlatConfigArray", () => {
                     const config = {
                         plugins: {
                             test: {
-                                parsers: {
-                                    "enhanced-parser": testParsers.enhancedParser
-                                },
                                 rules: {
                                     "test-service-rule": {
                                         create: context => ({
@@ -8006,7 +7986,7 @@ describe("Linter with FlatConfigArray", () => {
                             }
                         },
                         languageOptions: {
-                            parser: "test/enhanced-parser"
+                            parser: testParsers.enhancedParser
                         },
                         rules: {
                             "test/test-service-rule": 2


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changes languageOptions.parser to disallow string values. Now parsers must always be an object.

Fixes #16930

#### Is there anything you'd like reviewers to focus on?

Do the test and documentation updates make sense?

<!-- markdownlint-disable-file MD004 -->
