### PR TITLE
docs: Describe guard options for guard-for-in.

### DIFF
--- a/docs/src/rules/guard-for-in.md
+++ b/docs/src/rules/guard-for-in.md
@@ -2,6 +2,7 @@
 title: guard-for-in
 rule_type: suggestion
 related_rules:
+- prefer-object-has-own
 - no-prototype-builtins
 further_reading:
 - https://javascriptweblog.wordpress.com/2011/01/04/exploring-javascript-for-in-loops/
@@ -16,6 +17,10 @@ for (key in foo) {
     doSomething(key);
 }
 ```
+
+For codebases that do not support ES2022, `Object.prototype.hasOwnProperty.call(foo, key)` can be used as a check that the property is not inherited.
+
+For codebases that do support ES2022, `Object.hasOwn(foo, key)` can be used as a shorter alternative; see [prefer-object-has-own](prefer-object-has-own).
 
 Note that simply checking `foo.hasOwnProperty(key)` is likely to cause an error in some cases; see [no-prototype-builtins](no-prototype-builtins).
 


### PR DESCRIPTION
Describes the different checks that can be used to satisfy guard-for-in and links prefer-object-has-own as a related rule.

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [ X ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ X ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Follows up on example added in #16983. Describes the different checks that can be used to satisfy guard-for-in and links prefer-object-has-own as a related rule.

#### Is there anything you'd like reviewers to focus on?

`Object.hasOwn(foo, key)` and `Object.prototype.hasOwnProperty.call(foo, key)` are now both discussed in the intro section. Should `{}.hasOwnProperty.call(foo, key)` also be mentioned, or is it sufficient to keep it just as an example?

<!-- markdownlint-disable-file MD004 -->
