### PR TITLE
chore: Remove triage label from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/change.yml
+++ b/.github/ISSUE_TEMPLATE/change.yml
@@ -3,7 +3,6 @@ description: "Request a change that is not a bug fix, rule change, or new rule"
 title: "Change Request: (fill in)"
 labels:
   - enhancement
-  - triage
   - core
 body:
 - type: markdown


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Updated issue template

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed the "triage" label from the change request template. We don't really use this label any more and this was the only remaining template where it was automatically added. 

Related: https://github.com/eslint/eslint-github-bot/pull/191

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
