### PR TITLE
refactor: Use ESLint and FlatESLint from lib/api.js

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -10,6 +10,7 @@
 //-----------------------------------------------------------------------------
 
 const { ESLint } = require("./eslint");
+const { FlatESLint } = require("./eslint/flat-eslint");
 const { Linter } = require("./linter");
 const { RuleTester } = require("./rule-tester");
 const { SourceCode } = require("./source-code");
@@ -21,6 +22,7 @@ const { SourceCode } = require("./source-code");
 module.exports = {
     Linter,
     ESLint,
+    FlatESLint,
     RuleTester,
     SourceCode
 };

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -18,8 +18,7 @@
 const fs = require("fs"),
     path = require("path"),
     { promisify } = require("util"),
-    { ESLint } = require("./eslint"),
-    { FlatESLint } = require("./eslint/flat-eslint"),
+    { ESLint, FlatESLint } = require("./eslint"),
     createCLIOptions = require("./options"),
     log = require("./shared/logging"),
     RuntimeInfo = require("./shared/runtime-info");


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
Preparation for bundling "api.js" as part of the build process

#### What changes did you make? (Give an overview)

Replaced two `require` calls for `ESLint` and `FlatESLint` in `lib/cli.js` with a single call to obtain them from `lib/api.js`. Consequently "FlatESLint" is now being reexported from "lib/api.js".

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

Prerequisite for https://github.com/eslint/eslint/issues/16820 and addresses the comment https://github.com/eslint/eslint/issues/16820#issuecomment-1440517534.

Let me know if you'd prefer me to do all the changes related to bundling in a single PR.
