### PR TITLE
perf: Fast path for NodeEventGenerator

### DIFF
--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -231,6 +231,7 @@ function parseSelector(rawSelector, knownTypes) {
         rawSelector,
         isExit: rawSelector.endsWith(":exit"),
         parsedSelector,
+        isIdentifier: parseSelector.type === "identifier",
         listenerTypes: getPossibleTypes(parsedSelector),
         attributeCount: countClassAttributes(parsedSelector),
         identifierCount: countIdentifiers(parsedSelector)
@@ -309,7 +310,7 @@ class NodeEventGenerator {
      */
     applySelector(node, selector) {
 
-        if (this.knownTypes.has(selector.rawSelector)) {
+        if (selector.isIdentifier) {
             this.emitter.emit(selector.rawSelector, node);
             return;
         }

--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -185,12 +185,24 @@ function compareSpecificity(selectorA, selectorB) {
 /**
  * Parses a raw selector string, and throws a useful error if parsing fails.
  * @param {string} rawSelector A raw AST selector
+ * @param {Set<string>} knownTypes The known node types
  * @returns {Object} An object (from esquery) describing the matching behavior of this selector
  * @throws {Error} An error if the selector is invalid
  */
-function tryParseSelector(rawSelector) {
+function tryParseSelector(rawSelector, knownTypes) {
+
+    const rawSelectorWithoutExit = rawSelector.replace(/:exit$/u, "");
+
+    // no need to parse known types
+    if (knownTypes.has(rawSelectorWithoutExit)) {
+        return {
+            type: "identifier",
+            value: rawSelectorWithoutExit
+        };
+    }
+
     try {
-        return esquery.parse(rawSelector.replace(/:exit$/u, ""));
+        return esquery.parse(rawSelectorWithoutExit);
     } catch (err) {
         if (err.location && err.location.start && typeof err.location.start.offset === "number") {
             throw new SyntaxError(`Syntax error in selector "${rawSelector}" at position ${err.location.start.offset}: ${err.message}`);
@@ -204,14 +216,16 @@ const selectorCache = new Map();
 /**
  * Parses a raw selector string, and returns the parsed selector along with specificity and type information.
  * @param {string} rawSelector A raw AST selector
+ * @param {Set<string>} knownTypes The known node types that don't require parsing.
  * @returns {ASTSelector} A selector descriptor
  */
-function parseSelector(rawSelector) {
+function parseSelector(rawSelector, knownTypes) {
     if (selectorCache.has(rawSelector)) {
         return selectorCache.get(rawSelector);
     }
 
-    const parsedSelector = tryParseSelector(rawSelector);
+    // no need to parse anything that matches node.type
+    const parsedSelector = tryParseSelector(rawSelector, knownTypes);
 
     const result = {
         rawSelector,
@@ -260,9 +274,10 @@ class NodeEventGenerator {
         this.exitSelectorsByNodeType = new Map();
         this.anyTypeEnterSelectors = [];
         this.anyTypeExitSelectors = [];
+        this.knownTypes = new Set(Object.keys(esqueryOptions.visitorKeys));
 
         emitter.eventNames().forEach(rawSelector => {
-            const selector = parseSelector(rawSelector);
+            const selector = parseSelector(rawSelector, this.knownTypes);
 
             if (selector.listenerTypes) {
                 const typeMap = selector.isExit ? this.exitSelectorsByNodeType : this.enterSelectorsByNodeType;
@@ -293,6 +308,12 @@ class NodeEventGenerator {
      * @returns {void}
      */
     applySelector(node, selector) {
+
+        if (this.knownTypes.has(selector.rawSelector)) {
+            this.emitter.emit(selector.rawSelector, node);
+            return;
+        }
+
         if (esquery.matches(node, selector.parsedSelector, this.currentAncestry, this.esqueryOptions)) {
             this.emitter.emit(selector.rawSelector, node);
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Perf changes
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added a "fast path" for NodeEventGenerator that skips matching and parsing of selectors when they are simple.

Refs #16962

#### Is there anything you'd like reviewers to focus on?

I'm not seeing any noticeable improvement with this work. Did I do something wrong?


<!-- markdownlint-disable-file MD004 -->
