### PR TITLE
fix: correctly handle `null` default config in `RuleTester`

### DIFF
--- a/lib/rule-tester/flat-rule-tester.js
+++ b/lib/rule-tester/flat-rule-tester.js
@@ -345,7 +345,7 @@ class FlatRuleTester {
      * @returns {void}
      */
     static setDefaultConfig(config) {
-        if (typeof config !== "object") {
+        if (typeof config !== "object" || config === null) {
             throw new TypeError("FlatRuleTester.setDefaultConfig: config must be an object");
         }
         sharedDefaultConfig = config;

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -412,7 +412,7 @@ class RuleTester {
      * @returns {void}
      */
     static setDefaultConfig(config) {
-        if (typeof config !== "object") {
+        if (typeof config !== "object" || config === null) {
             throw new TypeError("RuleTester.setDefaultConfig: config must be an object");
         }
         defaultConfig = config;

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -142,12 +142,14 @@ describe("FlatRuleTester", () => {
                     FlatRuleTester.setDefaultConfig(config);
                 };
             }
-            assert.throw(setConfig());
-            assert.throw(setConfig(1));
-            assert.throw(setConfig(3.14));
-            assert.throw(setConfig("foo"));
-            assert.throw(setConfig(null));
-            assert.throw(setConfig(true));
+            const errorMessage = "FlatRuleTester.setDefaultConfig: config must be an object";
+
+            assert.throw(setConfig(), errorMessage);
+            assert.throw(setConfig(1), errorMessage);
+            assert.throw(setConfig(3.14), errorMessage);
+            assert.throw(setConfig("foo"), errorMessage);
+            assert.throw(setConfig(null), errorMessage);
+            assert.throw(setConfig(true), errorMessage);
         });
 
         it("should pass-through the globals config to the tester then to the to rule", () => {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1412,12 +1412,14 @@ describe("RuleTester", () => {
                 RuleTester.setDefaultConfig(config);
             };
         }
-        assert.throw(setConfig());
-        assert.throw(setConfig(1));
-        assert.throw(setConfig(3.14));
-        assert.throw(setConfig("foo"));
-        assert.throw(setConfig(null));
-        assert.throw(setConfig(true));
+        const errorMessage = "RuleTester.setDefaultConfig: config must be an object";
+
+        assert.throw(setConfig(), errorMessage);
+        assert.throw(setConfig(1), errorMessage);
+        assert.throw(setConfig(3.14), errorMessage);
+        assert.throw(setConfig("foo"), errorMessage);
+        assert.throw(setConfig(null), errorMessage);
+        assert.throw(setConfig(true), errorMessage);
     });
 
     it("should pass-through the globals config to the tester then to the to rule", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Bug fix

#### What changes did you make? (Give an overview)

I was playing around with RuleTester and I broke the test by changing the `setDefaultConfig` function to use `defaultConfig = { rules: {}, ...config }`.

Previously the method threw because `defaultConfig.rules` will throw due to property access on `null`. The test was passing before because it wasn't asserting the error message.

This PR simply updates the method so that it handles `null` explicitly and updates the test as appropriate.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
