### PR TITLE
fix: do not report on `RegExp(...args)` in `require-unicode-regexp`

### DIFF
--- a/lib/rules/require-unicode-regexp.js
+++ b/lib/rules/require-unicode-regexp.js
@@ -78,6 +78,10 @@ module.exports = {
 
                 for (const { node: refNode } of tracker.iterateGlobalReferences(trackMap)) {
                     const [patternNode, flagsNode] = refNode.arguments;
+
+                    if (patternNode && patternNode.type === "SpreadElement") {
+                        continue;
+                    }
                     const pattern = getStringIfConstant(patternNode, scope);
                     const flags = getStringIfConstant(flagsNode, scope);
 

--- a/tests/lib/rules/require-unicode-regexp.js
+++ b/tests/lib/rules/require-unicode-regexp.js
@@ -29,6 +29,7 @@ ruleTester.run("require-unicode-regexp", rule, {
         "new RegExp('', 'u')",
         "RegExp('', 'gimuy')",
         "RegExp('', `gimuy`)",
+        "RegExp(...patternAndFlags)",
         "new RegExp('', 'gimuy')",
         "const flags = 'u'; new RegExp('', flags)",
         "const flags = 'g'; new RegExp('', flags + 'u')",

--- a/tests/lib/rules/require-unicode-regexp.js
+++ b/tests/lib/rules/require-unicode-regexp.js
@@ -36,6 +36,7 @@ ruleTester.run("require-unicode-regexp", rule, {
         "new RegExp('', flags)",
         "function f(flags) { return new RegExp('', flags) }",
         "function f(RegExp) { return new RegExp('foo') }",
+        "function f(patternAndFlags) { return new RegExp(...patternAndFlags) }",
         { code: "new globalThis.RegExp('foo')", env: { es6: true } },
         { code: "new globalThis.RegExp('foo')", env: { es2017: true } },
         { code: "new globalThis.RegExp('foo', 'u')", env: { es2020: true } },
@@ -75,6 +76,13 @@ ruleTester.run("require-unicode-regexp", rule, {
                         output: "/foo/gimyu"
                     }
                 ]
+            }]
+        },
+        {
+            code: "RegExp()",
+            errors: [{
+                messageId: "requireUFlag",
+                suggestions: null
             }]
         },
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```json
{
    "parserOptions": {
        "ecmaVersion": "latest"
    }
}
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint require-unicode-regexp: "error" */

var args = ['.', 'u'];
RegExp(...args);
new RegExp(...args);
```

[**DEMO**](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IHJlcXVpcmUtdW5pY29kZS1yZWdleHA6IFwiZXJyb3JcIiAqL1xuXG52YXIgYXJncyA9IFsnLicsICd1J107XG5SZWdFeHAoLi4uYXJncyk7XG5uZXcgUmVnRXhwKC4uLmFyZ3MpO1xuIiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjoibGF0ZXN0Iiwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

**What did you expect to happen?**

No problem should be reported.

**What actually happened? Please include the actual, raw output from ESLint.**

An error is reported:

> Use the 'u' flag.  ([require-unicode-regexp](https://eslint.org/docs/rules/require-unicode-regexp))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR fixes an issue in `require-unicode-regexp` that causes the rule to incorrectly report a problem when `RegExp` is called with a single `SpreadElement` argument, e.g. `new RegExp(...patternAndFlags)`. In this situation it is typically not possible to statically determine the effective argument values, so the rule should not report a missing flag.

This issue is not directly related to the recently merged  #17007. It existed before that change.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
