### PR TITLE
Sort import members by original name

### DIFF
--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -48,6 +48,10 @@ module.exports = {
                     allowSeparatedGroups: {
                         type: "boolean",
                         default: false
+                    },
+                    sortMembersByOriginalName: {
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -71,6 +75,7 @@ module.exports = {
             ignoreMemberSort = configuration.ignoreMemberSort || false,
             memberSyntaxSortOrder = configuration.memberSyntaxSortOrder || ["none", "all", "multiple", "single"],
             allowSeparatedGroups = configuration.allowSeparatedGroups || false,
+            sortMembersByOriginalName = configuration.sortMembersByOriginalName || false,
             sourceCode = context.getSourceCode();
         let previousDeclaration = null;
 
@@ -114,7 +119,7 @@ module.exports = {
          */
         function getFirstLocalMemberName(node) {
             if (node.specifiers[0]) {
-                return node.specifiers[0].local.name;
+                return sortMembersByOriginalName ? node.specifiers[0].imported.name : node.specifiers[0].local.name;
             }
             return null;
 
@@ -131,6 +136,20 @@ module.exports = {
          */
         function getNumberOfLinesBetween(left, right) {
             return Math.max(right.loc.start.line - left.loc.end.line - 1, 0);
+        }
+
+        /**
+         * Retrieves the name of the member that should be used to sort the members of an import statement.
+         * @param {ASTNode} specifier node that should be sorted
+         * @returns {string} the name of the import to sort
+         */
+        function getSortableName(specifier) {
+            let name = sortMembersByOriginalName ? specifier.imported.name : specifier.local.name;
+
+            if (ignoreCase) {
+                name = name.toLowerCase();
+            }
+            return name;
         }
 
         return {
@@ -191,14 +210,15 @@ module.exports = {
 
                 if (!ignoreMemberSort) {
                     const importSpecifiers = node.specifiers.filter(specifier => specifier.type === "ImportSpecifier");
-                    const getSortableName = ignoreCase ? specifier => specifier.local.name.toLowerCase() : specifier => specifier.local.name;
                     const firstUnsortedIndex = importSpecifiers.map(getSortableName).findIndex((name, index, array) => array[index - 1] > name);
 
                     if (firstUnsortedIndex !== -1) {
+                        const firstUnsortedNode = importSpecifiers[firstUnsortedIndex];
+
                         context.report({
                             node: importSpecifiers[firstUnsortedIndex],
                             messageId: "sortMembersAlphabetically",
-                            data: { memberName: importSpecifiers[firstUnsortedIndex].local.name },
+                            data: { memberName: sortMembersByOriginalName ? firstUnsortedNode.imported.name : firstUnsortedNode.local.name },
                             fix(fixer) {
                                 if (importSpecifiers.some(specifier =>
                                     sourceCode.getCommentsBefore(specifier).length || sourceCode.getCommentsAfter(specifier).length)) {

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -139,6 +139,16 @@ ruleTester.run("sort-imports", rule, {
         {
             code: "import c from 'c';\n\nimport b from 'b';\n\nimport a from 'a';",
             options: [{ allowSeparatedGroups: true }]
+        },
+
+        // sortMembersByOriginalName
+        {
+            code: "import {B, a, c as e, d} from 'foo.js';",
+            options: [{ sortMembersByOriginalName: true }]
+        },
+        {
+            code: "import {B, a, d, c as e} from 'foo.js';",
+            options: [{ sortMembersByOriginalName: false }]
         }
     ],
     invalid: [
@@ -440,6 +450,26 @@ ruleTester.run("sort-imports", rule, {
             code: "import b from 'b';\n\nimport { c, a } from 'c';",
             output: "import b from 'b';\n\nimport { a, c } from 'c';",
             options: [{ allowSeparatedGroups: true }],
+            errors: [{
+                messageId: "sortMembersAlphabetically",
+                type: "ImportSpecifier"
+            }]
+        },
+
+        // sortMembersByOriginalName
+        {
+            code: "import { c as a, b, D } from 'foo.js';",
+            output: "import { D, b, c as a } from 'foo.js';",
+            options: [{ sortMembersByOriginalName: true }],
+            errors: [{
+                messageId: "sortMembersAlphabetically",
+                type: "ImportSpecifier"
+            }]
+        },
+        {
+            code: "import { c as a, b, D } from 'foo.js';",
+            output: "import { D, c as a, b } from 'foo.js';",
+            options: [{ sortMembersByOriginalName: false }],
             errors: [{
                 messageId: "sortMembersAlphabetically",
                 type: "ImportSpecifier"


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**
`sort-imports`

**What change do you want to make?**

[ ] Generate more warnings
[ ] Generate fewer warnings
[x] Implement autofix
[ ] Implement suggestions

**How will the change be implemented?**

[x] A new option
[ ] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
import { c as a, b } from 'foo.js';
// can become this when sortMembersByOriginalName === true
import { b, c as a } from 'foo.js';
```

**What does the rule currently do for this code?**
Currently the import members are sorted by the names you given them in your class (so in the example above the name that will be sorted will be `a`). This is however not ideal because it means that the members can be in a different order in different files if they are given a different name.

**What will the rule do after it's changed?**
This rule will allow you to sort the members on their original name (so in the example above the name that will be sorted will be `c`). The advantage of this change would be that the automatic member sorting from IntelliJ IDEA can be used to automatically sort the members

#### What changes did you make? (Give an overview)
- Added a new option `sortMembersByOriginalName` with a default `false` value to not change the way this rule worked
I changed all the occurences `member.local.name` to `member.imported.name` based on te 

#### Is there anything you'd like reviewers to focus on?
This new option is only relevant for when member sorting is enabled, so I don't know if this is valid PR or if I should just change the default behaviour to sort the members by their original name by default.