### PR TITLE
fix: Fix `no-constructor-return` schema

### DIFF
--- a/lib/rules/no-constructor-return.js
+++ b/lib/rules/no-constructor-return.js
@@ -20,7 +20,7 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-constructor-return"
         },
 
-        schema: {},
+        schema: [],
 
         fixable: null,
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

https://github.com/Shinigami92/eslint-define-config/issues/140

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The `no-constructor-return` rule has empty schema, as can be seen on https://eslint.org/docs/latest/rules/no-constructor-return

However, it's schema is incorrectly whitten as `{}` instead of `[]` which breaks type codegen of [`eslint-define-config`](https://github.com/Shinigami92/eslint-define-config)

This PR changes the incorrect `{}` empty schema to `[]`
