### PR TITLE
feat: Move getDeclaredVariables and getAncestors to SourceCode

### DIFF
--- a/docs/src/extend/code-path-analysis.md
+++ b/docs/src/extend/code-path-analysis.md
@@ -259,7 +259,8 @@ Please use a map of information instead.
 ```js
 function hasCb(node, context) {
     if (node.type.indexOf("Function") !== -1) {
-        return context.getDeclaredVariables(node).some(function(v) {
+        const sourceCode = context.getSourceCode();
+        return sourceCode.getDeclaredVariables(node).some(function(v) {
             return v.type === "Parameter" && v.name === "cb";
         });
     }

--- a/docs/src/extend/custom-rules-deprecated.md
+++ b/docs/src/extend/custom-rules-deprecated.md
@@ -93,16 +93,16 @@ Additionally, the `context` object has the following methods:
 **Deprecated:** The following methods on the `context` object are deprecated. Please use the corresponding methods on `SourceCode` instead:
 
 * `getAllComments()` - returns an array of all comments in the source. Use `sourceCode.getAllComments()` instead.
-* `getAncestors()` - returns an array of ancestor nodes based on the current traversal.
+* `getAncestors()` - returns an array of ancestor nodes based on the current traversal. Use `sourceCode.getAncestors(node)` instead.
 * `getComments(node)` - returns the leading and trailing comments arrays for the given node. Use `sourceCode.getComments(node)` instead.
-* `getDeclaredVariables(node)` - returns the declared variables on the given node.
+* `getDeclaredVariables(node)` - returns the declared variables on the given node. Use `sourceCode.getDeclaredVariables(node)` instead.
 * `getFirstToken(node)` - returns the first token representing the given node. Use `sourceCode.getFirstToken(node)` instead.
 * `getFirstTokens(node, count)` - returns the first `count` tokens representing the given node. Use `sourceCode.getFirstTokens(node, count)` instead.
 * `getJSDocComment(node)` - returns the JSDoc comment for a given node or `null` if there is none. Use `sourceCode.getJSDocComment(node)` instead.
 * `getLastToken(node)` - returns the last token representing the given node.  Use `sourceCode.getLastToken(node)` instead.
 * `getLastTokens(node, count)` - returns the last `count` tokens representing the given node. Use `sourceCode.getLastTokens(node, count)` instead.
 * `getNodeByRangeIndex(index)` - returns the deepest node in the AST containing the given source index. Use `sourceCode.getNodeByRangeIndex(index)` instead.
-* `getScope()` - returns the current scope.
+* `getScope()` - returns the current scope. Use `sourceCode.getScope(node)` instead.
 * `getSource(node)` - returns the source code for the given node. Omit `node` to get the whole source. Use `sourceCode.getText(node)` instead.
 * `getSourceLines()` - returns the entire source code split into an array of string lines. Use `sourceCode.lines` instead.
 * `getTokenAfter(nodeOrToken)` - returns the first token after the given node or token. Use `sourceCode.getTokenAfter(nodeOrToken)` instead.

--- a/docs/src/extend/custom-rules-deprecated.md
+++ b/docs/src/extend/custom-rules-deprecated.md
@@ -85,10 +85,7 @@ The `context` object contains additional functionality that is helpful for rules
 
 Additionally, the `context` object has the following methods:
 
-* `getAncestors()` - returns an array of ancestor nodes based on the current traversal.
-* `getDeclaredVariables(node)` - returns the declared variables on the given node.
 * `getFilename()` - returns the filename associated with the source.
-* `getScope()` - returns the current scope.
 * `getSourceCode()` - returns a `SourceCode` object that you can use to work with the source that was passed to ESLint
 * `markVariableAsUsed(name)` - marks the named variable in scope as used. This affects the [no-unused-vars](../rules/no-unused-vars) rule.
 * `report(descriptor)` - reports a problem in the code.
@@ -96,13 +93,16 @@ Additionally, the `context` object has the following methods:
 **Deprecated:** The following methods on the `context` object are deprecated. Please use the corresponding methods on `SourceCode` instead:
 
 * `getAllComments()` - returns an array of all comments in the source. Use `sourceCode.getAllComments()` instead.
+* `getAncestors()` - returns an array of ancestor nodes based on the current traversal.
 * `getComments(node)` - returns the leading and trailing comments arrays for the given node. Use `sourceCode.getComments(node)` instead.
+* `getDeclaredVariables(node)` - returns the declared variables on the given node.
 * `getFirstToken(node)` - returns the first token representing the given node. Use `sourceCode.getFirstToken(node)` instead.
 * `getFirstTokens(node, count)` - returns the first `count` tokens representing the given node. Use `sourceCode.getFirstTokens(node, count)` instead.
 * `getJSDocComment(node)` - returns the JSDoc comment for a given node or `null` if there is none. Use `sourceCode.getJSDocComment(node)` instead.
 * `getLastToken(node)` - returns the last token representing the given node.  Use `sourceCode.getLastToken(node)` instead.
 * `getLastTokens(node, count)` - returns the last `count` tokens representing the given node. Use `sourceCode.getLastTokens(node, count)` instead.
 * `getNodeByRangeIndex(index)` - returns the deepest node in the AST containing the given source index. Use `sourceCode.getNodeByRangeIndex(index)` instead.
+* `getScope()` - returns the current scope.
 * `getSource(node)` - returns the source code for the given node. Omit `node` to get the whole source. Use `sourceCode.getText(node)` instead.
 * `getSourceLines()` - returns the entire source code split into an array of string lines. Use `sourceCode.lines` instead.
 * `getTokenAfter(nodeOrToken)` - returns the first token after the given node or token. Use `sourceCode.getTokenAfter(nodeOrToken)` instead.

--- a/docs/src/extend/custom-rules-deprecated.md
+++ b/docs/src/extend/custom-rules-deprecated.md
@@ -85,7 +85,10 @@ The `context` object contains additional functionality that is helpful for rules
 
 Additionally, the `context` object has the following methods:
 
+* `getAncestors()` - returns an array of ancestor nodes based on the current traversal.
+* `getDeclaredVariables(node)` - returns the declared variables on the given node.
 * `getFilename()` - returns the filename associated with the source.
+* `getScope()` - returns the current scope.
 * `getSourceCode()` - returns a `SourceCode` object that you can use to work with the source that was passed to ESLint
 * `markVariableAsUsed(name)` - marks the named variable in scope as used. This affects the [no-unused-vars](../rules/no-unused-vars) rule.
 * `report(descriptor)` - reports a problem in the code.
@@ -93,16 +96,13 @@ Additionally, the `context` object has the following methods:
 **Deprecated:** The following methods on the `context` object are deprecated. Please use the corresponding methods on `SourceCode` instead:
 
 * `getAllComments()` - returns an array of all comments in the source. Use `sourceCode.getAllComments()` instead.
-* `getAncestors()` - returns an array of ancestor nodes based on the current traversal. Use `sourceCode.getAncestors(node)` instead.
 * `getComments(node)` - returns the leading and trailing comments arrays for the given node. Use `sourceCode.getComments(node)` instead.
-* `getDeclaredVariables(node)` - returns the declared variables on the given node. Use `sourceCode.getDeclaredVariables(node)` instead.
 * `getFirstToken(node)` - returns the first token representing the given node. Use `sourceCode.getFirstToken(node)` instead.
 * `getFirstTokens(node, count)` - returns the first `count` tokens representing the given node. Use `sourceCode.getFirstTokens(node, count)` instead.
 * `getJSDocComment(node)` - returns the JSDoc comment for a given node or `null` if there is none. Use `sourceCode.getJSDocComment(node)` instead.
 * `getLastToken(node)` - returns the last token representing the given node.  Use `sourceCode.getLastToken(node)` instead.
 * `getLastTokens(node, count)` - returns the last `count` tokens representing the given node. Use `sourceCode.getLastTokens(node, count)` instead.
 * `getNodeByRangeIndex(index)` - returns the deepest node in the AST containing the given source index. Use `sourceCode.getNodeByRangeIndex(index)` instead.
-* `getScope()` - returns the current scope. Use `sourceCode.getScope(node)` instead.
 * `getSource(node)` - returns the source code for the given node. Omit `node` to get the whole source. Use `sourceCode.getText(node)` instead.
 * `getSourceLines()` - returns the entire source code split into an array of string lines. Use `sourceCode.lines` instead.
 * `getTokenAfter(nodeOrToken)` - returns the first token after the given node or token. Use `sourceCode.getTokenAfter(nodeOrToken)` instead.

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -117,9 +117,9 @@ The `context` object contains additional functionality that is helpful for rules
 
 Additionally, the `context` object has the following methods:
 
-* `getAncestors()` - returns an array of the ancestors of the currently-traversed node, starting at the root of the AST and continuing through the direct parent of the current node. This array does not include the currently-traversed node itself.
+* `getAncestors()` - (**Deprecated:** Use `SourceCode.getAncestors(node)` instead.) returns an array of the ancestors of the currently-traversed node, starting at the root of the AST and continuing through the direct parent of the current node. This array does not include the currently-traversed node itself.
 * `getCwd()` - returns the `cwd` passed to [Linter](../integrate/nodejs-api#linter). It is a path to a directory that should be considered as the current working directory.
-* `getDeclaredVariables(node)` - returns a list of [variables](./scope-manager-interface#variable-interface) declared by the given node. This information can be used to track references to variables.
+* `getDeclaredVariables(node)` - (**Deprecated:** Use `SourceCode.getDeclaredVariables(node)` instead.) returns a list of [variables](./scope-manager-interface#variable-interface) declared by the given node. This information can be used to track references to variables.
     * If the node is a `VariableDeclaration`, all variables declared in the declaration are returned.
     * If the node is a `VariableDeclarator`, all variables declared in the declarator are returned.
     * If the node is a `FunctionDeclaration` or `FunctionExpression`, the variable for the function name is returned, in addition to variables for the function parameters.
@@ -131,7 +131,7 @@ Additionally, the `context` object has the following methods:
     * Otherwise, if the node does not declare any variables, an empty array is returned.
 * `getFilename()` - returns the filename associated with the source.
 * `getPhysicalFilename()` - when linting a file, it returns the full path of the file on disk without any code block information. When linting text, it returns the value passed to `—stdin-filename` or `<text>` if not specified.
-* `getScope()` - (**Deprecated: Use `SourceCode.getScope(node)` instead.**) returns the [scope](./scope-manager-interface#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
+* `getScope()` - (**Deprecated:** Use `SourceCode.getScope(node)` instead.) returns the [scope](./scope-manager-interface#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
 * `getSourceCode()` - returns a [`SourceCode`](#contextgetsourcecode) object that you can use to work with the source that was passed to ESLint.
 * `markVariableAsUsed(name)` - marks a variable with the given name in the current scope as used. This affects the [no-unused-vars](../rules/no-unused-vars) rule. Returns `true` if a variable with the given name was found and marked as used, otherwise `false`.
 * `report(descriptor)` - reports a problem in the code (see the [dedicated section](#contextreport)).

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -117,9 +117,9 @@ The `context` object contains additional functionality that is helpful for rules
 
 Additionally, the `context` object has the following methods:
 
-* `getAncestors()` - (**Deprecated:** Use `SourceCode.getAncestors(node)` instead.) returns an array of the ancestors of the currently-traversed node, starting at the root of the AST and continuing through the direct parent of the current node. This array does not include the currently-traversed node itself.
+* `getAncestors()` - (**Deprecated:** Use `SourceCode#getAncestors(node)` instead.) returns an array of the ancestors of the currently-traversed node, starting at the root of the AST and continuing through the direct parent of the current node. This array does not include the currently-traversed node itself.
 * `getCwd()` - returns the `cwd` passed to [Linter](../integrate/nodejs-api#linter). It is a path to a directory that should be considered as the current working directory.
-* `getDeclaredVariables(node)` - (**Deprecated:** Use `SourceCode.getDeclaredVariables(node)` instead.) returns a list of [variables](./scope-manager-interface#variable-interface) declared by the given node. This information can be used to track references to variables.
+* `getDeclaredVariables(node)` - (**Deprecated:** Use `SourceCode#getDeclaredVariables(node)` instead.) returns a list of [variables](./scope-manager-interface#variable-interface) declared by the given node. This information can be used to track references to variables.
     * If the node is a `VariableDeclaration`, all variables declared in the declaration are returned.
     * If the node is a `VariableDeclarator`, all variables declared in the declarator are returned.
     * If the node is a `FunctionDeclaration` or `FunctionExpression`, the variable for the function name is returned, in addition to variables for the function parameters.
@@ -131,7 +131,7 @@ Additionally, the `context` object has the following methods:
     * Otherwise, if the node does not declare any variables, an empty array is returned.
 * `getFilename()` - returns the filename associated with the source.
 * `getPhysicalFilename()` - when linting a file, it returns the full path of the file on disk without any code block information. When linting text, it returns the value passed to `—stdin-filename` or `<text>` if not specified.
-* `getScope()` - (**Deprecated:** Use `SourceCode.getScope(node)` instead.) returns the [scope](./scope-manager-interface#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
+* `getScope()` - (**Deprecated:** Use `SourceCode#getScope(node)` instead.) returns the [scope](./scope-manager-interface#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
 * `getSourceCode()` - returns a [`SourceCode`](#contextgetsourcecode) object that you can use to work with the source that was passed to ESLint.
 * `markVariableAsUsed(name)` - marks a variable with the given name in the current scope as used. This affects the [no-unused-vars](../rules/no-unused-vars) rule. Returns `true` if a variable with the given name was found and marked as used, otherwise `false`.
 * `report(descriptor)` - reports a problem in the code (see the [dedicated section](#contextreport)).

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -905,22 +905,6 @@ function createRuleListeners(rule, ruleContext) {
     }
 }
 
-/**
- * Gets all the ancestors of a given node
- * @param {ASTNode} node The node
- * @returns {ASTNode[]} All the ancestor nodes in the AST, not including the provided node, starting
- * from the root node and going inwards to the parent node.
- */
-function getAncestors(node) {
-    const ancestorsStartingAtParent = [];
-
-    for (let ancestor = node.parent; ancestor; ancestor = ancestor.parent) {
-        ancestorsStartingAtParent.push(ancestor);
-    }
-
-    return ancestorsStartingAtParent.reverse();
-}
-
 // methods that exist on SourceCode object
 const DEPRECATED_SOURCECODE_PASSTHROUGHS = {
     getSource: "getText",
@@ -996,8 +980,8 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
         Object.assign(
             Object.create(BASE_TRAVERSAL_CONTEXT),
             {
-                getAncestors: () => getAncestors(currentNode),
-                getDeclaredVariables: sourceCode.scopeManager.getDeclaredVariables.bind(sourceCode.scopeManager),
+                getAncestors: () => sourceCode.getAncestors(currentNode),
+                getDeclaredVariables: node => sourceCode.getDeclaredVariables(node),
                 getCwd: () => cwd,
                 getFilename: () => filename,
                 getPhysicalFilename: () => physicalFilename || filename,

--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -28,6 +28,7 @@ module.exports = {
 
     create(context) {
         let stack = [];
+        const sourceCode = context.getSourceCode();
 
         /**
          * Makes a block scope.
@@ -83,7 +84,7 @@ module.exports = {
             }
 
             // Gets declared variables, and checks its references.
-            const variables = context.getDeclaredVariables(node);
+            const variables = sourceCode.getDeclaredVariables(node);
 
             for (let i = 0; i < variables.length; ++i) {
 

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -296,7 +296,7 @@ module.exports = {
                 "ClassExpression",
                 "CatchClause"
             ]](node) {
-                for (const variable of context.getDeclaredVariables(node)) {
+                for (const variable of sourceCode.getDeclaredVariables(node)) {
                     if (isGoodName(variable.name)) {
                         continue;
                     }
@@ -346,7 +346,7 @@ module.exports = {
 
             // Report camelcase in import --------------------------------------
             ImportDeclaration(node) {
-                for (const variable of context.getDeclaredVariables(node)) {
+                for (const variable of sourceCode.getDeclaredVariables(node)) {
                     if (isGoodName(variable.name)) {
                         continue;
                     }

--- a/lib/rules/func-names.js
+++ b/lib/rules/func-names.js
@@ -159,7 +159,7 @@ module.exports = {
         function handleFunction(node) {
 
             // Skip recursive functions.
-            const nameVar = context.getDeclaredVariables(node)[0];
+            const nameVar = sourceCode.getDeclaredVariables(node)[0];
 
             if (isFunctionName(nameVar) && nameVar.references.length > 0) {
                 return;

--- a/lib/rules/global-require.js
+++ b/lib/rules/global-require.js
@@ -78,7 +78,7 @@ module.exports = {
                 const currentScope = sourceCode.getScope(node);
 
                 if (node.callee.name === "require" && !isShadowed(currentScope, node.callee)) {
-                    const isGoodRequire = context.getAncestors().every(parent => ACCEPTABLE_PARENTS.has(parent.type));
+                    const isGoodRequire = sourceCode.getAncestors(node).every(parent => ACCEPTABLE_PARENTS.has(parent.type));
 
                     if (!isGoodRequire) {
                         context.report({ node, messageId: "unexpected" });

--- a/lib/rules/no-class-assign.js
+++ b/lib/rules/no-class-assign.js
@@ -31,6 +31,8 @@ module.exports = {
 
     create(context) {
 
+        const sourceCode = context.getSourceCode();
+
         /**
          * Finds and reports references that are non initializer and writable.
          * @param {Variable} variable A variable to check.
@@ -49,7 +51,7 @@ module.exports = {
          * @returns {void}
          */
         function checkForClass(node) {
-            context.getDeclaredVariables(node).forEach(checkVariable);
+            sourceCode.getDeclaredVariables(node).forEach(checkVariable);
         }
 
         return {

--- a/lib/rules/no-const-assign.js
+++ b/lib/rules/no-const-assign.js
@@ -31,6 +31,8 @@ module.exports = {
 
     create(context) {
 
+        const sourceCode = context.getSourceCode();
+
         /**
          * Finds and reports references that are non initializer and writable.
          * @param {Variable} variable A variable to check.
@@ -45,7 +47,7 @@ module.exports = {
         return {
             VariableDeclaration(node) {
                 if (node.kind === "const") {
-                    context.getDeclaredVariables(node).forEach(checkVariable);
+                    sourceCode.getDeclaredVariables(node).forEach(checkVariable);
                 }
             }
         };

--- a/lib/rules/no-dupe-args.js
+++ b/lib/rules/no-dupe-args.js
@@ -29,6 +29,8 @@ module.exports = {
 
     create(context) {
 
+        const sourceCode = context.getSourceCode();
+
         //--------------------------------------------------------------------------
         // Helpers
         //--------------------------------------------------------------------------
@@ -49,7 +51,7 @@ module.exports = {
          * @private
          */
         function checkParams(node) {
-            const variables = context.getDeclaredVariables(node);
+            const variables = sourceCode.getDeclaredVariables(node);
 
             for (let i = 0; i < variables.length; ++i) {
                 const variable = variables[i];

--- a/lib/rules/no-ex-assign.js
+++ b/lib/rules/no-ex-assign.js
@@ -31,6 +31,8 @@ module.exports = {
 
     create(context) {
 
+        const sourceCode = context.getSourceCode();
+
         /**
          * Finds and reports references that are non initializer and writable.
          * @param {Variable} variable A variable to check.
@@ -44,7 +46,7 @@ module.exports = {
 
         return {
             CatchClause(node) {
-                context.getDeclaredVariables(node).forEach(checkVariable);
+                sourceCode.getDeclaredVariables(node).forEach(checkVariable);
             }
         };
 

--- a/lib/rules/no-func-assign.js
+++ b/lib/rules/no-func-assign.js
@@ -31,6 +31,8 @@ module.exports = {
 
     create(context) {
 
+        const sourceCode = context.getSourceCode();
+
         /**
          * Reports a reference if is non initializer and writable.
          * @param {References} references Collection of reference to check.
@@ -65,7 +67,7 @@ module.exports = {
          * @returns {void}
          */
         function checkForFunction(node) {
-            context.getDeclaredVariables(node).forEach(checkVariable);
+            sourceCode.getDeclaredVariables(node).forEach(checkVariable);
         }
 
         return {

--- a/lib/rules/no-import-assign.js
+++ b/lib/rules/no-import-assign.js
@@ -200,7 +200,7 @@ module.exports = {
             ImportDeclaration(node) {
                 const scope = sourceCode.getScope(node);
 
-                for (const variable of context.getDeclaredVariables(node)) {
+                for (const variable of sourceCode.getDeclaredVariables(node)) {
                     const shouldCheckMembers = variable.defs.some(
                         d => d.node.type === "ImportNamespaceSpecifier"
                     );

--- a/lib/rules/no-lone-blocks.js
+++ b/lib/rules/no-lone-blocks.js
@@ -68,14 +68,15 @@ module.exports = {
         /**
          * Checks the enclosing block of the current node for block-level bindings,
          * and "marks it" as valid if any.
+         * @param {ASTNode} node The current node to check.
          * @returns {void}
          */
-        function markLoneBlock() {
+        function markLoneBlock(node) {
             if (loneBlocks.length === 0) {
                 return;
             }
 
-            const block = context.getAncestors().pop();
+            const block = sourceCode.getAncestors(node).pop();
 
             if (loneBlocks[loneBlocks.length - 1] === block) {
                 loneBlocks.pop();
@@ -117,13 +118,13 @@ module.exports = {
 
             ruleDef.VariableDeclaration = function(node) {
                 if (node.kind === "let" || node.kind === "const") {
-                    markLoneBlock();
+                    markLoneBlock(node);
                 }
             };
 
             ruleDef.FunctionDeclaration = function(node) {
                 if (sourceCode.getScope(node).isStrict) {
-                    markLoneBlock();
+                    markLoneBlock(node);
                 }
             };
 

--- a/lib/rules/no-lonely-if.js
+++ b/lib/rules/no-lonely-if.js
@@ -32,7 +32,7 @@ module.exports = {
 
         return {
             IfStatement(node) {
-                const ancestors = context.getAncestors(),
+                const ancestors = sourceCode.getAncestors(node),
                     parent = ancestors.pop(),
                     grandparent = ancestors.pop();
 

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -70,6 +70,7 @@ module.exports = {
         const props = context.options[0] && context.options[0].props;
         const ignoredPropertyAssignmentsFor = context.options[0] && context.options[0].ignorePropertyModificationsFor || [];
         const ignoredPropertyAssignmentsForRegex = context.options[0] && context.options[0].ignorePropertyModificationsForRegex || [];
+        const sourceCode = context.getSourceCode();
 
         /**
          * Checks whether or not the reference modifies properties of its variable.
@@ -214,7 +215,7 @@ module.exports = {
          * @returns {void}
          */
         function checkForFunction(node) {
-            context.getDeclaredVariables(node).forEach(checkVariable);
+            sourceCode.getDeclaredVariables(node).forEach(checkVariable);
         }
 
         return {

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -99,6 +99,7 @@ module.exports = {
 
         const restrictedNames = new Set(context.options[0] && context.options[0].restrictedNamedExports);
         const restrictDefaultExports = context.options[0] && context.options[0].restrictDefaultExports;
+        const sourceCode = context.getSourceCode();
 
         /**
          * Checks and reports given exported name.
@@ -176,7 +177,7 @@ module.exports = {
                     if (declaration.type === "FunctionDeclaration" || declaration.type === "ClassDeclaration") {
                         checkExportedName(declaration.id);
                     } else if (declaration.type === "VariableDeclaration") {
-                        context.getDeclaredVariables(declaration)
+                        sourceCode.getDeclaredVariables(declaration)
                             .map(v => v.defs.find(d => d.parent === declaration))
                             .map(d => d.name) // Identifier nodes
                             .forEach(checkExportedName);

--- a/lib/rules/no-shadow-restricted-names.js
+++ b/lib/rules/no-shadow-restricted-names.js
@@ -43,10 +43,11 @@ module.exports = {
 
 
         const RESTRICTED = new Set(["undefined", "NaN", "Infinity", "arguments", "eval"]);
+        const sourceCode = context.getSourceCode();
 
         return {
             "VariableDeclaration, :function, CatchClause"(node) {
-                for (const variable of context.getDeclaredVariables(node)) {
+                for (const variable of sourceCode.getDeclaredVariables(node)) {
                     if (variable.defs.length > 0 && RESTRICTED.has(variable.name) && !safelyShadowsUndefined(variable)) {
                         context.report({
                             node: variable.defs[0].name,

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -84,6 +84,7 @@ module.exports = {
         const allowFunctionParams = typeof options.allowFunctionParams !== "undefined" ? options.allowFunctionParams : true;
         const allowInArrayDestructuring = typeof options.allowInArrayDestructuring !== "undefined" ? options.allowInArrayDestructuring : true;
         const allowInObjectDestructuring = typeof options.allowInObjectDestructuring !== "undefined" ? options.allowInObjectDestructuring : true;
+        const sourceCode = context.getSourceCode();
 
         //-------------------------------------------------------------------------
         // Helpers
@@ -213,7 +214,7 @@ module.exports = {
          * @private
          */
         function checkForDanglingUnderscoreInVariableExpression(node) {
-            context.getDeclaredVariables(node).forEach(variable => {
+            sourceCode.getDeclaredVariables(node).forEach(variable => {
                 const definition = variable.defs.find(def => def.node === node);
                 const identifierNode = definition.name;
                 const identifier = identifierNode.name;

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -70,7 +70,8 @@ module.exports = {
             allowShortCircuit = config.allowShortCircuit || false,
             allowTernary = config.allowTernary || false,
             allowTaggedTemplates = config.allowTaggedTemplates || false,
-            enforceForJSX = config.enforceForJSX || false;
+            enforceForJSX = config.enforceForJSX || false,
+            sourceCode = context.getSourceCode();
 
         /**
          * Has AST suggesting a directive.
@@ -180,7 +181,7 @@ module.exports = {
 
         return {
             ExpressionStatement(node) {
-                if (Checker.isDisallowed(node.expression) && !isDirective(node, context.getAncestors())) {
+                if (Checker.isDisallowed(node.expression) && !isDirective(node, sourceCode.getAncestors(node))) {
                     context.report({ node, messageId: "unusedExpression" });
                 }
             }

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -555,7 +555,7 @@ module.exports = {
          */
         function isAfterLastUsedArg(variable) {
             const def = variable.defs[0];
-            const params = context.getDeclaredVariables(def.node);
+            const params = sourceCode.getDeclaredVariables(def.node);
             const posteriorParams = params.slice(params.indexOf(variable) + 1);
 
             // If any used parameters occur after this parameter, do not report.

--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -210,7 +210,7 @@ module.exports = {
             if (!declarator.init) {
                 return false;
             }
-            const variables = context.getDeclaredVariables(declarator);
+            const variables = sourceCode.getDeclaredVariables(declarator);
 
             return variables.some(hasReferenceInTDZ(declarator.init));
         }
@@ -268,7 +268,7 @@ module.exports = {
          * @returns {boolean} `true` if it can fix the node.
          */
         function canFix(node) {
-            const variables = context.getDeclaredVariables(node);
+            const variables = sourceCode.getDeclaredVariables(node);
             const scopeNode = getScopeNode(node);
 
             if (node.parent.type === "SwitchCase" ||

--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -263,7 +263,7 @@ module.exports = {
                 }
 
                 // Skip recursive functions.
-                const nameVar = context.getDeclaredVariables(node)[0];
+                const nameVar = sourceCode.getDeclaredVariables(node)[0];
 
                 if (isFunctionName(nameVar) && nameVar.references.length > 0) {
                     return;

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -493,7 +493,7 @@ module.exports = {
 
             VariableDeclaration(node) {
                 if (node.kind === "let" && !isInitOfForStatement(node)) {
-                    variables.push(...context.getDeclaredVariables(node));
+                    variables.push(...sourceCode.getDeclaredVariables(node));
                 }
             }
         };

--- a/lib/rules/prefer-promise-reject-errors.js
+++ b/lib/rules/prefer-promise-reject-errors.js
@@ -41,6 +41,7 @@ module.exports = {
     create(context) {
 
         const ALLOW_EMPTY_REJECT = context.options.length && context.options[0].allowEmptyReject;
+        const sourceCode = context.getSourceCode();
 
         //----------------------------------------------------------------------
         // Helpers
@@ -100,7 +101,7 @@ module.exports = {
                     node.arguments.length && astUtils.isFunction(node.arguments[0]) &&
                     node.arguments[0].params.length > 1 && node.arguments[0].params[1].type === "Identifier"
                 ) {
-                    context.getDeclaredVariables(node.arguments[0])
+                    sourceCode.getDeclaredVariables(node.arguments[0])
 
                         /*
                          * Find the first variable that matches the second parameter's name.

--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -83,7 +83,7 @@ module.exports = {
 
             UnaryExpression(node) {
                 if (isTypeofExpression(node)) {
-                    const parent = context.getAncestors().pop();
+                    const parent = sourceCode.getAncestors(node).pop();
 
                     if (parent.type === "BinaryExpression" && OPERATORS.has(parent.operator)) {
                         const sibling = parent.left === node ? parent.right : parent.left;

--- a/lib/rules/wrap-regex.js
+++ b/lib/rules/wrap-regex.js
@@ -40,7 +40,7 @@ module.exports = {
                 if (nodeType === "RegularExpression") {
                     const beforeToken = sourceCode.getTokenBefore(node);
                     const afterToken = sourceCode.getTokenAfter(node);
-                    const ancestors = context.getAncestors();
+                    const ancestors = sourceCode.getAncestors(node);
                     const grandparent = ancestors[ancestors.length - 1];
 
                     if (grandparent.type === "MemberExpression" && grandparent.object === node &&

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -343,7 +343,7 @@ module.exports = {
                     ) &&
                     !(!isEqualityOperator(node.operator) && onlyEquality) &&
                     isComparisonOperator(node.operator) &&
-                    !(exceptRange && isRangeTest(context.getAncestors().pop()))
+                    !(exceptRange && isRangeTest(sourceCode.getAncestors(node).pop()))
                 ) {
                     context.report({
                         node,

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -685,6 +685,8 @@ class SourceCode extends TokenStore {
 
         for (let ancestor = node.parent; ancestor; ancestor = ancestor.parent) {
 
+            ancestorsStartingAtParent.unshift(ancestor);
+
             // check to see if the ancestry of the ancestor is cached
             const ancestorAncestry = cache.get(ancestor);
 
@@ -693,7 +695,6 @@ class SourceCode extends TokenStore {
                 break;
             }
 
-            ancestorsStartingAtParent.unshift(ancestor);
         }
 
         cache.set(node, ancestorsStartingAtParent.concat());

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -663,8 +663,13 @@ class SourceCode extends TokenStore {
      * @param {ASTNode} node The node
      * @returns {Array<ASTNode>} All the ancestor nodes in the AST, not including the provided node, starting
      * from the root node at index 0 and going inwards to the parent node.
+     * @throws {TypeError} When `node` is missing.
      */
     getAncestors(node) {
+
+        if (!node) {
+            throw new TypeError("Missing required argument: node.");
+        }
 
         const cache = this[caches].get("ancestors");
         const cachedAncestry = cache.get(node);

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -187,7 +187,8 @@ class SourceCode extends TokenStore {
          * General purpose caching for the class.
          */
         this[caches] = new Map([
-            ["scopes", new WeakMap()]
+            ["scopes", new WeakMap()],
+            ["ancestors", new WeakMap()]
         ]);
 
         /**
@@ -657,24 +658,48 @@ class SourceCode extends TokenStore {
         return this.scopeManager.getDeclaredVariables(node);
     }
 
-    /* eslint-disable class-methods-use-this -- node is owned by SourceCode */
     /**
      * Gets all the ancestors of a given node
      * @param {ASTNode} node The node
      * @returns {Array<ASTNode>} All the ancestor nodes in the AST, not including the provided node, starting
-     * from the root node and going inwards to the parent node.
+     * from the root node at index 0 and going inwards to the parent node.
      */
     getAncestors(node) {
+
+        const cache = this[caches].get("ancestors");
+        const cachedAncestry = cache.get(node);
+
+        /*
+         * Important! The array returned from this method must be mutable
+         * without side effects, meaning each rule must receive its own copy
+         * of the array that it can mutate without affecting other rules.
+         * Historically, this method calculated and returned a new array for
+         * each call, but that's pretty inefficient. So we cache the result
+         * and then create a new array with the same elements here.
+         */
+        if (cachedAncestry) {
+            return cachedAncestry.concat();
+        }
+
         const ancestorsStartingAtParent = [];
 
         for (let ancestor = node.parent; ancestor; ancestor = ancestor.parent) {
-            ancestorsStartingAtParent.push(ancestor);
+
+            // check to see if the ancestry of the ancestor is cached
+            const ancestorAncestry = cache.get(ancestor);
+
+            if (ancestorAncestry) {
+                ancestorsStartingAtParent.unshift(...ancestorAncestry);
+                break;
+            }
+
+            ancestorsStartingAtParent.unshift(ancestor);
         }
 
-        return ancestorsStartingAtParent.reverse();
-    }
-    /* eslint-enable class-methods-use-this -- node is owned by SourceCode */
+        cache.set(node, ancestorsStartingAtParent.concat());
 
+        return ancestorsStartingAtParent;
+    }
 
 }
 

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -15,6 +15,12 @@ const
     Traverser = require("../shared/traverser");
 
 //------------------------------------------------------------------------------
+// Type Definitions
+//------------------------------------------------------------------------------
+
+/** @typedef {import("eslint-scope").Variable} Variable */
+
+//------------------------------------------------------------------------------
 // Private
 //------------------------------------------------------------------------------
 
@@ -638,6 +644,37 @@ class SourceCode extends TokenStore {
         cache.set(currentNode, this.scopeManager.scopes[0]);
         return this.scopeManager.scopes[0];
     }
+
+    /**
+     * Gets all of the declared variables in the scope represented
+     * by `node`. This is a convenience method that passes through
+     * to the same method on the `scopeManager`.
+     * @param {ASTNode} node The node representing the scope to check.
+     * @returns {Array<Variable>} An array of variable nodes representing
+     *      the declared variables in the scope.
+     */
+    getDeclaredVariables(node) {
+        return this.scopeManager.getDeclaredVariables(node);
+    }
+
+    /* eslint-disable class-methods-use-this -- node is owned by SourceCode */
+    /**
+     * Gets all the ancestors of a given node
+     * @param {ASTNode} node The node
+     * @returns {Array<ASTNode>} All the ancestor nodes in the AST, not including the provided node, starting
+     * from the root node and going inwards to the parent node.
+     */
+    getAncestors(node) {
+        const ancestorsStartingAtParent = [];
+
+        for (let ancestor = node.parent; ancestor; ancestor = ancestor.parent) {
+            ancestorsStartingAtParent.push(ancestor);
+        }
+
+        return ancestorsStartingAtParent.reverse();
+    }
+    /* eslint-enable class-methods-use-this -- node is owned by SourceCode */
+
 
 }
 

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -647,12 +647,12 @@ class SourceCode extends TokenStore {
     }
 
     /**
-     * Gets all of the declared variables in the scope represented
-     * by `node`. This is a convenience method that passes through
+     * Gets all of the declared variables in the scope associated
+     * with `node`. This is a convenience method that passes through
      * to the same method on the `scopeManager`.
-     * @param {ASTNode} node The node representing the scope to check.
+     * @param {ASTNode} node The node from which to retrieve the scope to check.
      * @returns {Array<Variable>} An array of variable nodes representing
-     *      the declared variables in the scope.
+     *      the declared variables in the scope associated with `node`.
      */
     getDeclaredVariables(node) {
         return this.scopeManager.getDeclaredVariables(node);

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -187,8 +187,7 @@ class SourceCode extends TokenStore {
          * General purpose caching for the class.
          */
         this[caches] = new Map([
-            ["scopes", new WeakMap()],
-            ["ancestors", new WeakMap()]
+            ["scopes", new WeakMap()]
         ]);
 
         /**
@@ -658,6 +657,7 @@ class SourceCode extends TokenStore {
         return this.scopeManager.getDeclaredVariables(node);
     }
 
+    /* eslint-disable class-methods-use-this -- node is owned by SourceCode */
     /**
      * Gets all the ancestors of a given node
      * @param {ASTNode} node The node
@@ -671,41 +671,15 @@ class SourceCode extends TokenStore {
             throw new TypeError("Missing required argument: node.");
         }
 
-        const cache = this[caches].get("ancestors");
-        const cachedAncestry = cache.get(node);
-
-        /*
-         * Important! The array returned from this method must be mutable
-         * without side effects, meaning each rule must receive its own copy
-         * of the array that it can mutate without affecting other rules.
-         * Historically, this method calculated and returned a new array for
-         * each call, but that's pretty inefficient. So we cache the result
-         * and then create a new array with the same elements here.
-         */
-        if (cachedAncestry) {
-            return cachedAncestry.concat();
-        }
-
         const ancestorsStartingAtParent = [];
 
         for (let ancestor = node.parent; ancestor; ancestor = ancestor.parent) {
-
-            ancestorsStartingAtParent.unshift(ancestor);
-
-            // check to see if the ancestry of the ancestor is cached
-            const ancestorAncestry = cache.get(ancestor);
-
-            if (ancestorAncestry) {
-                ancestorsStartingAtParent.unshift(...ancestorAncestry);
-                break;
-            }
-
+            ancestorsStartingAtParent.push(ancestor);
         }
 
-        cache.set(node, ancestorsStartingAtParent.concat());
-
-        return ancestorsStartingAtParent;
+        return ancestorsStartingAtParent.reverse();
     }
+    /* eslint-enable class-methods-use-this -- node is owned by SourceCode */
 
 }
 

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -3352,7 +3352,7 @@ describe("SourceCode", () => {
     describe("getDeclaredVariables(node)", () => {
 
         /**
-         * Assert `context.getDeclaredVariables(node)` is valid.
+         * Assert `sourceCode.getDeclaredVariables(node)` is valid.
          * @param {string} code A code to check.
          * @param {string} type A type string of ASTNode. This method checks variables on the node of the type.
          * @param {Array<Array<string>>} expectedNamesList An array of expected variable names. The expected variable names is an array of string.

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -3425,7 +3425,7 @@ describe("SourceCode", () => {
 
                         rule[type] = function(node) {
                             const expectedNames = expectedNamesList.shift();
-                            const variables = context.getDeclaredVariables(node);
+                            const variables = sourceCode.getDeclaredVariables(node);
 
                             assert(Array.isArray(expectedNames));
                             assert(Array.isArray(variables));

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -3346,6 +3346,37 @@ describe("SourceCode", () => {
             flatLinter.verify(code, config);
             assert(spy && spy.calledOnce, "Spy was not called.");
         });
+
+        it("should throw an error when the argument is missing", () => {
+            let spy;
+
+            const config = {
+                plugins: {
+                    test: {
+                        rules: {
+                            checker: {
+                                create(context) {
+                                    spy = sinon.spy(() => {
+                                        const sourceCode = context.getSourceCode();
+
+                                        assert.throws(() => {
+                                            sourceCode.getAncestors();
+                                        }, /Missing required argument: node/u);
+
+                                    });
+
+                                    return { Program: spy };
+                                }
+                            }
+                        }
+                    }
+                },
+                rules: { "test/checker": "error" }
+            };
+
+            flatLinter.verify(code, config);
+            assert(spy && spy.calledOnce, "Spy was not called.");
+        });
     });
 
 

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -3366,7 +3366,7 @@ describe("SourceCode", () => {
                         const sourceCode = context.getSourceCode();
 
                         /**
-                         * Assert `context.getDeclaredVariables(node)` is empty.
+                         * Assert `sourceCode.getDeclaredVariables(node)` is empty.
                          * @param {ASTNode} node A node to check.
                          * @returns {void}
                          */


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This copies `getDeclaredVariables()` and `getAncestors()` to the `SourceCode` class as a continuation of the work for the language plugins. I updated all existing rules to use the new methods.

I also updated `getAncestors()` to cache its results. It's a little bit surprising that we weren't already doing caching here and just continued to calculate ancestry on every call. I also made the logic a little more efficient by removing the unnecessary call to `.reverse()`.

Refs #16999

#### Is there anything you'd like reviewers to focus on?

Did I miss any references?

<!-- markdownlint-disable-file MD004 -->
