### PR TITLE
refactor: remove unnecessary use of `SourceCode#getAncestors` in rules

### DIFF
--- a/lib/rules/no-lone-blocks.js
+++ b/lib/rules/no-lone-blocks.js
@@ -76,7 +76,7 @@ module.exports = {
                 return;
             }
 
-            const block = sourceCode.getAncestors(node).pop();
+            const block = node.parent;
 
             if (loneBlocks[loneBlocks.length - 1] === block) {
                 loneBlocks.pop();

--- a/lib/rules/no-lonely-if.js
+++ b/lib/rules/no-lonely-if.js
@@ -32,9 +32,8 @@ module.exports = {
 
         return {
             IfStatement(node) {
-                const ancestors = sourceCode.getAncestors(node),
-                    parent = ancestors.pop(),
-                    grandparent = ancestors.pop();
+                const parent = node.parent,
+                    grandparent = parent.parent;
 
                 if (parent && parent.type === "BlockStatement" &&
                         parent.body.length === 1 && grandparent &&

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -70,8 +70,7 @@ module.exports = {
             allowShortCircuit = config.allowShortCircuit || false,
             allowTernary = config.allowTernary || false,
             allowTaggedTemplates = config.allowTaggedTemplates || false,
-            enforceForJSX = config.enforceForJSX || false,
-            sourceCode = context.getSourceCode();
+            enforceForJSX = config.enforceForJSX || false;
 
         /**
          * Has AST suggesting a directive.
@@ -110,12 +109,11 @@ module.exports = {
         /**
          * Detect if a Node is a directive.
          * @param {ASTNode} node any node
-         * @param {ASTNode[]} ancestors the given node's ancestors
          * @returns {boolean} whether the given node is considered a directive in its current position
          */
-        function isDirective(node, ancestors) {
-            const parent = ancestors[ancestors.length - 1],
-                grandparent = ancestors[ancestors.length - 2];
+        function isDirective(node) {
+            const parent = node.parent,
+                grandparent = parent.parent;
 
             /**
              * https://tc39.es/ecma262/#directive-prologue
@@ -181,7 +179,7 @@ module.exports = {
 
         return {
             ExpressionStatement(node) {
-                if (Checker.isDisallowed(node.expression) && !isDirective(node, sourceCode.getAncestors(node))) {
+                if (Checker.isDisallowed(node.expression) && !isDirective(node)) {
                     context.report({ node, messageId: "unusedExpression" });
                 }
             }

--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -83,7 +83,7 @@ module.exports = {
 
             UnaryExpression(node) {
                 if (isTypeofExpression(node)) {
-                    const parent = sourceCode.getAncestors(node).pop();
+                    const { parent } = node;
 
                     if (parent.type === "BinaryExpression" && OPERATORS.has(parent.operator)) {
                         const sibling = parent.left === node ? parent.right : parent.left;

--- a/lib/rules/wrap-regex.js
+++ b/lib/rules/wrap-regex.js
@@ -40,10 +40,9 @@ module.exports = {
                 if (nodeType === "RegularExpression") {
                     const beforeToken = sourceCode.getTokenBefore(node);
                     const afterToken = sourceCode.getTokenAfter(node);
-                    const ancestors = sourceCode.getAncestors(node);
-                    const grandparent = ancestors[ancestors.length - 1];
+                    const { parent } = node;
 
-                    if (grandparent.type === "MemberExpression" && grandparent.object === node &&
+                    if (parent.type === "MemberExpression" && parent.object === node &&
                         !(beforeToken && beforeToken.value === "(" && afterToken && afterToken.value === ")")) {
                         context.report({
                             node,

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -343,7 +343,7 @@ module.exports = {
                     ) &&
                     !(!isEqualityOperator(node.operator) && onlyEquality) &&
                     isComparisonOperator(node.operator) &&
-                    !(exceptRange && isRangeTest(sourceCode.getAncestors(node).pop()))
+                    !(exceptRange && isRangeTest(node.parent))
                 ) {
                     context.report({
                         node,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

While reviewing https://github.com/eslint/eslint/pull/17059, I noticed that several rules use `SourceCode#getAncestors` just to get the parent or grandparent node. This logic probably originates from time when nodes didn't have the `parent` property.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Since it's more efficient and more common in core rules to simply use the `parent` property, I replaced `SourceCode#getAncestors ` usage with `node.parent` in 6 core rules.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
