### PR TITLE
fix: unify `LintMessage` type

### DIFF
--- a/docs/src/extend/custom-processors.md
+++ b/docs/src/extend/custom-processors.md
@@ -59,19 +59,19 @@ Reported problems have the following location information in each lint message:
 type LintMessage = {
 
   /// The 1-based line number where the message occurs.
-  line: number;
+  line?: number;
 
    /// The 1-based column number where the message occurs.
-  column: number;
+  column?: number;
 
   /// The 1-based line number of the end location.
-  endLine: number;
+  endLine?: number;
 
   /// The 1-based column number of the end location.
-  endColumn: number;
+  endColumn?: number;
 
   /// If `true`, this is a fatal error.
-  fatal: boolean;
+  fatal?: boolean;
 
   /// Information for an autofix.
   fix: Fix;

--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -308,6 +308,7 @@ function createIgnoreResult(filePath, baseDir) {
         filePath: path.resolve(filePath),
         messages: [
             {
+                ruleId: null,
                 fatal: false,
                 severity: 1,
                 message

--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -311,7 +311,8 @@ function createIgnoreResult(filePath, baseDir) {
                 ruleId: null,
                 fatal: false,
                 severity: 1,
-                message
+                message,
+                nodeType: null
             }
         ],
         suppressedMessages: [],

--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -610,7 +610,8 @@ function createIgnoreResult(filePath, baseDir) {
                 ruleId: null,
                 fatal: false,
                 severity: 1,
-                message
+                message,
+                nodeType: null
             }
         ],
         suppressedMessages: [],

--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -607,6 +607,7 @@ function createIgnoreResult(filePath, baseDir) {
         filePath: path.resolve(filePath),
         messages: [
             {
+                ruleId: null,
                 fatal: false,
                 severity: 1,
                 message

--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -55,6 +55,7 @@ const LintResultCache = require("../cli-engine/lint-result-cache");
 /** @typedef {import("../shared/types").ConfigData} ConfigData */
 /** @typedef {import("../shared/types").DeprecatedRuleInfo} DeprecatedRuleInfo */
 /** @typedef {import("../shared/types").LintMessage} LintMessage */
+/** @typedef {import("../shared/types").LintResult} LintResult */
 /** @typedef {import("../shared/types").ParserOptions} ParserOptions */
 /** @typedef {import("../shared/types").Plugin} Plugin */
 /** @typedef {import("../shared/types").ResultsMeta} ResultsMeta */

--- a/lib/linter/apply-disable-directives.js
+++ b/lib/linter/apply-disable-directives.js
@@ -5,6 +5,16 @@
 
 "use strict";
 
+//------------------------------------------------------------------------------
+// Typedefs
+//------------------------------------------------------------------------------
+
+/** @typedef {import("../shared/types").LintMessage} LintMessage */
+
+//------------------------------------------------------------------------------
+// Module Definition
+//------------------------------------------------------------------------------
+
 const escapeRegExp = require("escape-string-regexp");
 
 /**
@@ -196,7 +206,7 @@ function processUnusedDisableDirectives(allDirectives) {
  * @param {Object} options options for applying directives. This is the same as the options
  * for the exported function, except that `reportUnusedDisableDirectives` is not supported
  * (this function always reports unused disable directives).
- * @returns {{problems: Problem[], unusedDisableDirectives: Problem[]}} An object with a list
+ * @returns {{problems: LintMessage[], unusedDisableDirectives: LintMessage[]}} An object with a list
  * of problems (including suppressed ones) and unused eslint-disable directives
  */
 function applyDirectives(options) {

--- a/lib/linter/config-comment-parser.js
+++ b/lib/linter/config-comment-parser.js
@@ -115,7 +115,8 @@ module.exports = class ConfigCommentParser {
                     severity: 2,
                     message: `Failed to parse JSON from '${normalizedString}': ${ex.message}`,
                     line: location.start.line,
-                    column: location.start.column + 1
+                    column: location.start.column + 1,
+                    nodeType: null
                 }
             };
 

--- a/lib/linter/config-comment-parser.js
+++ b/lib/linter/config-comment-parser.js
@@ -20,6 +20,12 @@ const levn = require("levn"),
 const debug = require("debug")("eslint:config-comment-parser");
 
 //------------------------------------------------------------------------------
+// Typedefs
+//------------------------------------------------------------------------------
+
+/** @typedef {import("../shared/types").LintMessage} LintMessage */
+
+//------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
@@ -61,7 +67,7 @@ module.exports = class ConfigCommentParser {
      * Parses a JSON-like config.
      * @param {string} string The string to parse.
      * @param {Object} location Start line and column of comments for potential error message.
-     * @returns {({success: true, config: Object}|{success: false, error: Problem})} Result map object
+     * @returns {({success: true, config: Object}|{success: false, error: LintMessage})} Result map object
      */
     parseJsonConfig(string, location) {
         debug("Parsing JSON config");

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -851,7 +851,8 @@ function parse(text, languageOptions, filePath) {
                 severity: 2,
                 message,
                 line: ex.lineNumber,
-                column: ex.column
+                column: ex.column,
+                nodeType: null
             }
         };
     }
@@ -1253,7 +1254,8 @@ class Linter {
                     severity: 2,
                     message: `Configured parser '${config.parser}' was not found.`,
                     line: 0,
-                    column: 0
+                    column: 0,
+                    nodeType: null
                 }];
             }
             parserName = config.parser;
@@ -1464,7 +1466,8 @@ class Linter {
                     severity: 2,
                     message,
                     line: ex.lineNumber,
-                    column: ex.column
+                    column: ex.column,
+                    nodeType: null
                 }
             ];
         }
@@ -1729,7 +1732,8 @@ class Linter {
                     severity: 1,
                     message: `No matching configuration found for ${filename}.`,
                     line: 0,
-                    column: 0
+                    column: 0,
+                    nodeType: null
                 }
             ];
         }
@@ -1794,7 +1798,8 @@ class Linter {
                     severity: 2,
                     message,
                     line: ex.lineNumber,
-                    column: ex.column
+                    column: ex.column,
+                    nodeType: null
                 }
             ];
         }

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -364,7 +364,7 @@ function extractDirectiveComment(value) {
  * @param {ASTNode} ast The top node of the AST.
  * @param {function(string): {create: Function}} ruleMapper A map from rule IDs to defined rules
  * @param {string|null} warnInlineConfig If a string then it should warn directive comments as disabled. The string value is the config name what the setting came from.
- * @returns {{configuredRules: Object, enabledGlobals: {value:string,comment:Token}[], exportedVariables: Object, problems: Problem[], disableDirectives: DisableDirective[]}}
+ * @returns {{configuredRules: Object, enabledGlobals: {value:string,comment:Token}[], exportedVariables: Object, problems: LintMessage[], disableDirectives: DisableDirective[]}}
  * A collection of the directive comments that were found, along with any problems that occurred when parsing
  */
 function getDirectiveComments(ast, ruleMapper, warnInlineConfig) {
@@ -775,7 +775,7 @@ function analyzeScope(ast, languageOptions, visitorKeys) {
  * @param {string} text The text to parse.
  * @param {LanguageOptions} languageOptions Options to pass to the parser
  * @param {string} filePath The path to the file being parsed.
- * @returns {{success: false, error: Problem}|{success: true, sourceCode: SourceCode}}
+ * @returns {{success: false, error: LintMessage}|{success: true, sourceCode: SourceCode}}
  * An object containing the AST and parser services if parsing was successful, or the error if parsing failed
  * @private
  */
@@ -921,7 +921,7 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
  * @param {boolean} disableFixes If true, it doesn't make `fix` properties.
  * @param {string | undefined} cwd cwd of the cli
  * @param {string} physicalFilename The full path of the file on disk without any code block information
- * @returns {Problem[]} An array of reported problems
+ * @returns {LintMessage[]} An array of reported problems
  */
 function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageOptions, settings, filename, disableFixes, cwd, physicalFilename) {
     const emitter = createEmitter();
@@ -1840,7 +1840,7 @@ class Linter {
     /**
      * Given a list of reported problems, distinguish problems between normal messages and suppressed messages.
      * The normal messages will be returned and the suppressed messages will be stored as lastSuppressedMessages.
-     * @param {Problem[]} problems A list of reported problems.
+     * @param {Array<LintMessage|SuppressedLintMessage>} problems A list of reported problems.
      * @returns {LintMessage[]} A list of LintMessage.
      */
     _distinguishSuppressedMessages(problems) {

--- a/lib/linter/report-translator.js
+++ b/lib/linter/report-translator.js
@@ -17,6 +17,8 @@ const interpolate = require("./interpolate");
 // Typedefs
 //------------------------------------------------------------------------------
 
+/** @typedef {import("../shared/types").LintMessage} LintMessage */
+
 /**
  * An error message description
  * @typedef {Object} MessageDescriptor
@@ -27,23 +29,6 @@ const interpolate = require("./interpolate");
  *      message.
  * @property {Function} [fix] The function to call that creates a fix command.
  * @property {Array<{desc?: string, messageId?: string, fix: Function}>} suggest Suggestion descriptions and functions to create a the associated fixes.
- */
-
-/**
- * Information about the report
- * @typedef {Object} ReportInfo
- * @property {string} ruleId The rule ID
- * @property {(0|1|2)} severity Severity of the error
- * @property {(string|undefined)} message The message
- * @property {(string|undefined)} [messageId] The message ID
- * @property {number} line The line number
- * @property {number} column The column number
- * @property {(number|undefined)} [endLine] The ending line number
- * @property {(number|undefined)} [endColumn] The ending column number
- * @property {(string|null)} nodeType Type of node
- * @property {string} source Source text
- * @property {({text: string, range: (number[]|null)}|null)} [fix] The fix object
- * @property {Array<{text: string, range: (number[]|null)}|null>} [suggestions] Suggestion info
  */
 
 //------------------------------------------------------------------------------
@@ -239,7 +224,7 @@ function mapSuggestions(descriptor, sourceCode, messages) {
  * @param {{start: SourceLocation, end: (SourceLocation|null)}} options.loc Start and end location
  * @param {{text: string, range: (number[]|null)}} options.fix The fix object
  * @param {Array<{text: string, range: (number[]|null)}>} options.suggestions The array of suggestions objects
- * @returns {function(...args): ReportInfo} Function that returns information about the report
+ * @returns {LintMessage} Information about the report
  */
 function createProblem(options) {
     const problem = {
@@ -314,7 +299,7 @@ function validateSuggestions(suggest, messages) {
  * problem for the Node.js API.
  * @param {{ruleId: string, severity: number, sourceCode: SourceCode, messageIds: Object, disableFixes: boolean}} metadata Metadata for the reported problem
  * @param {SourceCode} sourceCode The `SourceCode` instance for the text being linted
- * @returns {function(...args): ReportInfo} Function that returns information about the report
+ * @returns {function(...args): LintMessage} Function that returns information about the report
  */
 
 module.exports = function createReportTranslator(metadata) {

--- a/lib/shared/types.js
+++ b/lib/shared/types.js
@@ -96,10 +96,12 @@ module.exports = {};
  * @property {number|undefined} column The 1-based column number.
  * @property {number} [endColumn] The 1-based column number of the end location.
  * @property {number} [endLine] The 1-based line number of the end location.
- * @property {boolean} fatal If `true` then this is a fatal error.
+ * @property {boolean} [fatal] If `true` then this is a fatal error.
  * @property {{range:[number,number], text:string}} [fix] Information for autofix.
  * @property {number|undefined} line The 1-based line number.
  * @property {string} message The error message.
+ * @property {string} [messageId] The ID of the message in the rule's meta.
+ * @property {(string|null)} [nodeType] Type of node
  * @property {string|null} ruleId The ID of the rule which makes this message.
  * @property {0|1|2} severity The severity of this message.
  * @property {Array<{desc?: string, messageId?: string, fix: {range: [number, number], text: string}}>} [suggestions] Information for suggestions.
@@ -110,10 +112,12 @@ module.exports = {};
  * @property {number|undefined} column The 1-based column number.
  * @property {number} [endColumn] The 1-based column number of the end location.
  * @property {number} [endLine] The 1-based line number of the end location.
- * @property {boolean} fatal If `true` then this is a fatal error.
+ * @property {boolean} [fatal] If `true` then this is a fatal error.
  * @property {{range:[number,number], text:string}} [fix] Information for autofix.
  * @property {number|undefined} line The 1-based line number.
  * @property {string} message The error message.
+ * @property {string} [messageId] The ID of the message in the rule's meta.
+ * @property {(string|null)} [nodeType] Type of node
  * @property {string|null} ruleId The ID of the rule which makes this message.
  * @property {0|1|2} severity The severity of this message.
  * @property {Array<{kind: string, justification: string}>} suppressions The suppression info.

--- a/lib/shared/types.js
+++ b/lib/shared/types.js
@@ -101,7 +101,7 @@ module.exports = {};
  * @property {number|undefined} line The 1-based line number.
  * @property {string} message The error message.
  * @property {string} [messageId] The ID of the message in the rule's meta.
- * @property {(string|null)} [nodeType] Type of node
+ * @property {(string|null)} nodeType Type of node
  * @property {string|null} ruleId The ID of the rule which makes this message.
  * @property {0|1|2} severity The severity of this message.
  * @property {Array<{desc?: string, messageId?: string, fix: {range: [number, number], text: string}}>} [suggestions] Information for suggestions.
@@ -117,7 +117,7 @@ module.exports = {};
  * @property {number|undefined} line The 1-based line number.
  * @property {string} message The error message.
  * @property {string} [messageId] The ID of the message in the rule's meta.
- * @property {(string|null)} [nodeType] Type of node
+ * @property {(string|null)} nodeType Type of node
  * @property {string|null} ruleId The ID of the rule which makes this message.
  * @property {0|1|2} severity The severity of this message.
  * @property {Array<{kind: string, justification: string}>} suppressions The suppression info.

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -577,7 +577,8 @@ describe("CLIEngine", () => {
                                 severity: 2,
                                 message: "Parsing error: Unexpected token is",
                                 line: 1,
-                                column: 19
+                                column: 19,
+                                nodeType: null
                             }
                         ],
                         suppressedMessages: [],
@@ -622,7 +623,8 @@ describe("CLIEngine", () => {
                                 severity: 2,
                                 message: "Parsing error: Unexpected token",
                                 line: 1,
-                                column: 10
+                                column: 10,
+                                nodeType: null
                             }
                         ],
                         suppressedMessages: [],
@@ -713,7 +715,8 @@ describe("CLIEngine", () => {
                                 severity: 2,
                                 message: "Parsing error: Unexpected token is",
                                 line: 1,
-                                column: 19
+                                column: 19,
+                                nodeType: null
                             }
                         ],
                         suppressedMessages: [],

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -690,7 +690,8 @@ describe("ESLint", () => {
                             severity: 2,
                             message: "Parsing error: Unexpected token is",
                             line: 1,
-                            column: 19
+                            column: 19,
+                            nodeType: null
                         }
                     ],
                     suppressedMessages: [],
@@ -730,7 +731,8 @@ describe("ESLint", () => {
                             severity: 2,
                             message: "Parsing error: Unexpected token",
                             line: 1,
-                            column: 10
+                            column: 10,
+                            nodeType: null
                         }
                     ],
                     suppressedMessages: [],
@@ -819,7 +821,8 @@ describe("ESLint", () => {
                             severity: 2,
                             message: "Parsing error: Unexpected token is",
                             line: 1,
-                            column: 19
+                            column: 19,
+                            nodeType: null
                         }
                     ],
                     suppressedMessages: [],

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -475,7 +475,8 @@ describe("FlatESLint", () => {
                             severity: 2,
                             message: "Parsing error: Unexpected token is",
                             line: 1,
-                            column: 19
+                            column: 19,
+                            nodeType: null
                         }
                     ],
                     suppressedMessages: [],
@@ -515,7 +516,8 @@ describe("FlatESLint", () => {
                             severity: 2,
                             message: "Parsing error: Unexpected token",
                             line: 1,
-                            column: 10
+                            column: 10,
+                            nodeType: null
                         }
                     ],
                     suppressedMessages: [],
@@ -605,7 +607,8 @@ describe("FlatESLint", () => {
                             severity: 2,
                             message: "Parsing error: Unexpected token is",
                             line: 1,
-                            column: 19
+                            column: 19,
+                            nodeType: null
                         }
                     ],
                     suppressedMessages: [],
@@ -5060,7 +5063,8 @@ describe("FlatESLint", () => {
                                 ruleId: null,
                                 fatal: false,
                                 message: "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override.",
-                                severity: 1
+                                severity: 1,
+                                nodeType: null
                             }
                         ],
                         usedDeprecatedRules: [],

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -5057,6 +5057,7 @@ describe("FlatESLint", () => {
                         fixableWarningCount: 0,
                         messages: [
                             {
+                                ruleId: null,
                                 fatal: false,
                                 message: "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override.",
                                 severity: 1

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -6882,7 +6882,8 @@ var a = "test2";
                         severity: 2,
                         message: "Preprocessing error: Invalid syntax",
                         line: 1,
-                        column: 1
+                        column: 1,
+                        nodeType: null
                     }
                 ]);
             });
@@ -8864,7 +8865,8 @@ describe("Linter with FlatConfigArray", () => {
                 severity: 1,
                 message: "No matching configuration found for filename.ts.",
                 line: 0,
-                column: 0
+                column: 0,
+                nodeType: null
             });
         });
 
@@ -15765,7 +15767,8 @@ var a = "test2";
                         severity: 2,
                         message: "Preprocessing error: Invalid syntax",
                         line: 1,
-                        column: 1
+                        column: 1,
+                        nodeType: null
                     }
                 ]);
             });

--- a/tests/tools/eslint-fuzzer.js
+++ b/tests/tools/eslint-fuzzer.js
@@ -183,7 +183,8 @@ describe("eslint-fuzzer", function() {
                     severity: 2,
                     message: `Parsing error: ${expectedSyntaxError.message}`,
                     line: expectedSyntaxError.lineNumber,
-                    column: expectedSyntaxError.column
+                    column: expectedSyntaxError.column,
+                    nodeType: null
                 });
             });
         });
@@ -232,7 +233,8 @@ describe("eslint-fuzzer", function() {
                     severity: 2,
                     message: `Parsing error: ${expectedSyntaxError.message}`,
                     line: expectedSyntaxError.lineNumber,
-                    column: expectedSyntaxError.column
+                    column: expectedSyntaxError.column,
+                    nodeType: null
                 });
             });
         });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Update JSDoc types

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fix #16968, changing runtime code as little as possible. First, this updates the `LintMessage` type to match the most common implementation. It also combines some undefined types or duplicate definitions into `LintMessage` so everything references the single definition. Finally, it normalizes the few remaining divergent implementations in three ways: 1) always set a `line` and `column`, even if they're 1/0, 2) always set `ruleId`, even if it's `null`, and 3) always set `nodeType`, even if it's `null`. Were we designing the API from scratch, we might make those properties optional, but for this existing API, I followed the most common precedent of providing dummy values.

#### Is there anything you'd like reviewers to focus on?

This will be easiest to review going one commit at a time, and see each commit message for more context.

For `nodeType`, I changed direction from where we were leaning in #16968 after the original direction became a bit more complicated. There are three possible solutions:

1. Make `nodeType` non-nullable but optional. This is where we were originally leaning. However, it had the most significant runtime code change, adding branching in `report-translator` to set it conditionally.
2. Preserve the existing type definition with `nodeType` nullable and required. This is what's currently in this PR. This way, all three changes do conceptually the same thing of providing an "emtpy" value for a required property. That felt cleaner than making `line`/`column`/`ruleId` required yet `nodeType` optional. It's larger in terms of absolute lines in the diff because I had to add more `null`s, but that's all I had to do.
3. Make `nodeType` nullable and optional. This would only require changing the type definition. After seeing the `null`s added in the `nodeType` commit, let me know if you'd like me to go with this option instead. It's not consistent with the others, but it does match current reality.

<!-- markdownlint-disable-file MD004 -->