### PR TITLE
feat: Implement `SourceCode#markVariableAsUsed()`

### DIFF
--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -699,7 +699,7 @@ For examples of using `SourceCode#getScope()` to track variables, refer to the s
 
 **Deprecated:** The `context.markVariableAsUsed()` method is deprecated in favor of `sourceCode.markVariableAsUsed()`.
 
-Certain ESLint rules, such as [`no-unused-vars`](../rules/no-unused-vars), check to see if a rule has been used. ESLint itself only knows about the standard rules of variable access and so custom ways of accessing variables may not register as "used".
+Certain ESLint rules, such as [`no-unused-vars`](../rules/no-unused-vars), check to see if a variable has been used. ESLint itself only knows about the standard rules of variable access and so custom ways of accessing variables may not register as "used".
 
 To help with this, you can use the `sourceCode.markVariableAsUsed()` method. This method takes two arguments: the name of the variable to mark as used and an option reference node indicating the scope in which you are working. Here's an example:
 

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -723,7 +723,7 @@ module.exports = {
 };
 ```
 
-Here, the `myCustomVar` variable is marked as used relative to a `ReturnStatement` node, which means ESLint will start searching from the scope closest to that node. If you omit the second argument, then the global scope is used.
+Here, the `myCustomVar` variable is marked as used relative to a `ReturnStatement` node, which means ESLint will start searching from the scope closest to that node. If you omit the second argument, then the top-level scope is used. (For ESM files, the top-level scope is the module scope; for CommonJS files, the top-level scope is the first function scope.)
 
 ### Accessing Code Paths
 

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -697,7 +697,7 @@ For examples of using `SourceCode#getScope()` to track variables, refer to the s
 
 ### Marking Variables as Used
 
-**Deprecated:** The `context.markVariableAsUsed()` method is deprecated in favor of `sourceCode.markVariableAsUsEd()`.
+**Deprecated:** The `context.markVariableAsUsed()` method is deprecated in favor of `sourceCode.markVariableAsUsed()`.
 
 Certain ESLint rules, such as [`no-unused-vars`](/docs/latest/rules/no-unused-vars), check to see if a rule has been used. ESLint itself only knows about the standard rules of variable access and so custom ways of accessing variables may not register as "used."
 

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -131,6 +131,7 @@ The `context` object has the following properties:
 * `parserOptions`: The parser options configured for this run (more details [here](../use/configure/language-options#specifying-parser-options)).
 
 Additionally, the `context` object has the following methods:
+
 * `getAncestors()` - (**Deprecated:** Use `SourceCode#getAncestors(node)` instead.) Returns an array of the ancestors of the currently-traversed node, starting at the root of the AST and continuing through the direct parent of the current node. This array does not include the currently-traversed node itself.
 * `getCwd()` - Returns the `cwd` option passed to the [Linter](../integrate/nodejs-api#linter). It is a path to a directory that should be considered the current working directory.
 * `getDeclaredVariables(node)` - (**Deprecated:** Use `SourceCode#getDeclaredVariables(node)` instead.) Returns a list of [variables](./scope-manager-interface#variable-interface) declared by the given node. This information can be used to track references to variables.
@@ -147,7 +148,7 @@ Additionally, the `context` object has the following methods:
 * `getPhysicalFilename()`: When linting a file, it returns the full path of the file on disk without any code block information. When linting text, it returns the value passed to `—stdin-filename` or `<text>` if not specified.
 * `getScope()`: (**Deprecated:** Use `SourceCode#getScope(node)` instead.) Returns the [scope](./scope-manager-interface#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
 * `getSourceCode()`: Returns a `SourceCode` object that you can use to work with the source that was passed to ESLint (see [Accessing the Source Code](#accessing-the-source-code)).
-* * `markVariableAsUsed(name)` - (**Deprecated:** Use `SourceCode#markVariableAsUsed(name, node)` instead.)  Marks a variable with the given name in the current scope as used. This affects the [no-unused-vars](../rules/no-unused-vars) rule. Returns `true` if a variable with the given name was found and marked as used, otherwise `false`.
+* `markVariableAsUsed(name)` - (**Deprecated:** Use `SourceCode#markVariableAsUsed(name, node)` instead.)  Marks a variable with the given name in the current scope as used. This affects the [no-unused-vars](../rules/no-unused-vars) rule. Returns `true` if a variable with the given name was found and marked as used, otherwise `false`.
 * `report(descriptor)`. Reports a problem in the code (see the [dedicated section](#reporting-problems)).
 
 **Note:** Earlier versions of ESLint supported additional methods on the `context` object. Those methods were removed in the new format and should not be relied upon.

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -147,7 +147,7 @@ Additionally, the `context` object has the following methods:
 * `getPhysicalFilename()`: When linting a file, it returns the full path of the file on disk without any code block information. When linting text, it returns the value passed to `—stdin-filename` or `<text>` if not specified.
 * `getScope()`: (**Deprecated:** Use `SourceCode#getScope(node)` instead.) Returns the [scope](./scope-manager-interface#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
 * `getSourceCode()`: Returns a `SourceCode` object that you can use to work with the source that was passed to ESLint (see [Accessing the Source Code](#accessing-the-source-code)).
-* `markVariableAsUsed(name)`: Marks a variable with the given name in the current scope as used. This affects the [no-unused-vars](../rules/no-unused-vars) rule. Returns `true` if a variable with the given name was found and marked as used, otherwise `false`.
+* * `markVariableAsUsed(name)` - (**Deprecated:** Use `SourceCode#markVariableAsUsed(node)` instead.)  Marks a variable with the given name in the current scope as used. This affects the [no-unused-vars](../rules/no-unused-vars) rule. Returns `true` if a variable with the given name was found and marked as used, otherwise `false`.
 * `report(descriptor)`. Reports a problem in the code (see the [dedicated section](#reporting-problems)).
 
 **Note:** Earlier versions of ESLint supported additional methods on the `context` object. Those methods were removed in the new format and should not be relied upon.

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -147,7 +147,7 @@ Additionally, the `context` object has the following methods:
 * `getPhysicalFilename()`: When linting a file, it returns the full path of the file on disk without any code block information. When linting text, it returns the value passed to `—stdin-filename` or `<text>` if not specified.
 * `getScope()`: (**Deprecated:** Use `SourceCode#getScope(node)` instead.) Returns the [scope](./scope-manager-interface#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
 * `getSourceCode()`: Returns a `SourceCode` object that you can use to work with the source that was passed to ESLint (see [Accessing the Source Code](#accessing-the-source-code)).
-* * `markVariableAsUsed(name)` - (**Deprecated:** Use `SourceCode#markVariableAsUsed(node)` instead.)  Marks a variable with the given name in the current scope as used. This affects the [no-unused-vars](../rules/no-unused-vars) rule. Returns `true` if a variable with the given name was found and marked as used, otherwise `false`.
+* * `markVariableAsUsed(name)` - (**Deprecated:** Use `SourceCode#markVariableAsUsed(name, node)` instead.)  Marks a variable with the given name in the current scope as used. This affects the [no-unused-vars](../rules/no-unused-vars) rule. Returns `true` if a variable with the given name was found and marked as used, otherwise `false`.
 * `report(descriptor)`. Reports a problem in the code (see the [dedicated section](#reporting-problems)).
 
 **Note:** Earlier versions of ESLint supported additional methods on the `context` object. Those methods were removed in the new format and should not be relied upon.
@@ -694,6 +694,36 @@ For examples of using `SourceCode#getScope()` to track variables, refer to the s
 
 * [no-shadow](https://github.com/eslint/eslint/blob/main/lib/rules/no-shadow.js): Calls `sourceCode.getScope()` at the `Program` node and inspects all child scopes to make sure a variable name is not reused at a lower scope. ([no-shadow](../rules/no-shadow) documentation)
 * [no-redeclare](https://github.com/eslint/eslint/blob/main/lib/rules/no-redeclare.js): Calls `sourceCode.getScope()` at each scope to make sure that a variable is not declared twice in the same scope. ([no-redeclare](../rules/no-redeclare) documentation)
+
+### Marking Variables as Used
+
+**Deprecated:** The `context.markVariableAsUsed()` method is deprecated in favor of `sourceCode.markVariableAsUsEd()`.
+
+Certain ESLint rules, such as [`no-unused-vars`](/docs/latest/rules/no-unused-vars), check to see if a rule has been used. ESLint itself only knows about the standard rules of variable access and so custom ways of accessing variables may not register as "used."
+
+To help with this, you can use the `sourceCode.markVariableAsUsed()` method. This method takes two arguments: the name of the variable to mark as used and an option reference node indicating the scope in which you are working. Here's an example:
+
+```js
+module.exports = {
+    create: function(context) {
+        var sourceCode = context.getSourceCode();
+
+        return {
+            ReturnStatement(node) {
+
+                // look in the scope of the function for myCustomVar and mark as used
+                sourceCode.markVariableAsUsed("myCustomVar", node);
+
+                // or: look in the global scope for myCustomVar and mark as used
+                sourceCode.markVariableAsUsed("myCustomVar");
+            }
+        }
+        // ...
+    }
+};
+```
+
+Here, the `myCustomVar` variable is marked as used relative to a `ReturnStatement` node, which means ESLint will start searching from the scope closest to that node. If you omit the second argument, then the global scope is used.
 
 ### Accessing Code Paths
 

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -699,7 +699,7 @@ For examples of using `SourceCode#getScope()` to track variables, refer to the s
 
 **Deprecated:** The `context.markVariableAsUsed()` method is deprecated in favor of `sourceCode.markVariableAsUsed()`.
 
-Certain ESLint rules, such as [`no-unused-vars`](/docs/latest/rules/no-unused-vars), check to see if a rule has been used. ESLint itself only knows about the standard rules of variable access and so custom ways of accessing variables may not register as "used."
+Certain ESLint rules, such as [`no-unused-vars`](../rules/no-unused-vars), check to see if a rule has been used. ESLint itself only knows about the standard rules of variable access and so custom ways of accessing variables may not register as "used".
 
 To help with this, you can use the `sourceCode.markVariableAsUsed()` method. This method takes two arguments: the name of the variable to mark as used and an option reference node indicating the scope in which you are working. Here's an example:
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -858,38 +858,6 @@ function parse(text, languageOptions, filePath) {
 }
 
 /**
- * Marks a variable as used in the current scope
- * @param {SourceCode} sourceCode The source code for the currently linted file.
- * @param {ASTNode} currentNode The node currently being traversed
- * @param {LanguageOptions} languageOptions The options used to parse this text
- * @param {string} name The name of the variable that should be marked as used.
- * @returns {boolean} True if the variable was found and marked as used, false if not.
- */
-function markVariableAsUsed(sourceCode, currentNode, languageOptions, name) {
-    const parserOptions = languageOptions.parserOptions;
-    const sourceType = languageOptions.sourceType;
-    const hasGlobalReturn =
-        (parserOptions.ecmaFeatures && parserOptions.ecmaFeatures.globalReturn) ||
-        sourceType === "commonjs";
-    const specialScope = hasGlobalReturn || sourceType === "module";
-    const currentScope = sourceCode.getScope(currentNode);
-
-    // Special Node.js scope means we need to start one level deeper
-    const initialScope = currentScope.type === "global" && specialScope ? currentScope.childScopes[0] : currentScope;
-
-    for (let scope = initialScope; scope; scope = scope.upper) {
-        const variable = scope.variables.find(scopeVar => scopeVar.name === name);
-
-        if (variable) {
-            variable.eslintUsed = true;
-            return true;
-        }
-    }
-
-    return false;
-}
-
-/**
  * Runs a rule, and gets its listeners
  * @param {Rule} rule A normalized rule with a `create` method
  * @param {Context} ruleContext The context that should be passed to the rule
@@ -987,7 +955,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
                 getPhysicalFilename: () => physicalFilename || filename,
                 getScope: () => sourceCode.getScope(currentNode),
                 getSourceCode: () => sourceCode,
-                markVariableAsUsed: name => markVariableAsUsed(sourceCode, currentNode, languageOptions, name),
+                markVariableAsUsed: name => sourceCode.markVariableAsUsed(name, currentNode),
                 parserOptions: {
                     ...languageOptions.parserOptions
                 },

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -683,13 +683,13 @@ class SourceCode extends TokenStore {
 
     /**
      * Marks a variable as used in the current scope
-     * @param {ASTNode} identifier The identifier node representing the variable.
+     * @param {string} name The name of the variable to mark as used.
+     * @param {ASTNode} [refNode] The closest node to the variable reference.
      * @returns {boolean} True if the variable was found and marked as used, false if not.
      */
-    markVariableAsUsed(identifier) {
+    markVariableAsUsed(name, refNode = this.ast) {
 
-        const currentScope = this.getScope(identifier);
-        const name = identifier.name;
+        const currentScope = this.getScope(refNode);
         const hasSpecialScope = this.scopeManager.isGlobalReturn() ||
             this.scopeManager.isModule();
 

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -681,6 +681,36 @@ class SourceCode extends TokenStore {
     }
     /* eslint-enable class-methods-use-this -- node is owned by SourceCode */
 
+    /**
+     * Marks a variable as used in the current scope
+     * @param {ASTNode} identifier The identifier node representing the variable.
+     * @returns {boolean} True if the variable was found and marked as used, false if not.
+     */
+    markVariableAsUsed(identifier) {
+
+        const currentScope = this.getScope(identifier);
+        const name = identifier.name;
+        const hasSpecialScope = this.scopeManager.isGlobalReturn() ||
+            this.scopeManager.isModule();
+
+        // Special Node.js scope means we need to start one level deeper
+        const initialScope = currentScope.type === "global" && hasSpecialScope
+            ? currentScope.childScopes[0]
+            : currentScope;
+
+        for (let scope = initialScope; scope; scope = scope.upper) {
+            const variable = scope.variables.find(scopeVar => scopeVar.name === name);
+
+            if (variable) {
+                variable.eslintUsed = true;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
 }
 
 module.exports = SourceCode;

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -690,13 +690,26 @@ class SourceCode extends TokenStore {
     markVariableAsUsed(name, refNode = this.ast) {
 
         const currentScope = this.getScope(refNode);
-        const hasSpecialScope = this.scopeManager.isGlobalReturn() ||
-            this.scopeManager.isModule();
+        let initialScope = currentScope;
 
-        // Special Node.js scope means we need to start one level deeper
-        const initialScope = currentScope.type === "global" && hasSpecialScope
-            ? currentScope.childScopes[0]
-            : currentScope;
+        /*
+         * When we are in an ESM or CommonJS module, we need to start searching
+         * from the top-level scope, not the global scope. For ESM the top-level
+         * scope is the module scope; for CommonJS the top-level scope is the
+         * outer function scope.
+         *
+         * Without this check, we might miss a variable declared with `var` at
+         * the top-level because it won't exist in the global scope.
+         */
+        if (
+            currentScope.type === "global" &&
+            currentScope.childScopes.length > 0 &&
+
+            // top-level scopes refer to a `Program` node
+            currentScope.childScopes[0].block === this.ast
+        ) {
+            initialScope = currentScope.childScopes[0];
+        }
 
         for (let scope = initialScope; scope; scope = scope.upper) {
             const variable = scope.variables.find(scopeVar => scopeVar.name === name);

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "debug": "^4.3.2",
     "doctrine": "^3.0.0",
     "escape-string-regexp": "^4.0.0",
-    "eslint-scope": "^7.1.1",
+    "eslint-scope": "^7.2.0",
     "eslint-visitor-keys": "^3.4.0",
     "espree": "^9.5.1",
     "esquery": "^1.4.2",

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -21,13 +21,16 @@ const ruleTester = new RuleTester();
 ruleTester.defineRule("use-every-a", {
     create(context) {
 
+        const sourceCode = context.getSourceCode();
+
         /**
          * Mark a variable as used
+         * @param {ASTNode} node The node representing the scope to search
          * @returns {void}
          * @private
          */
-        function useA() {
-            context.markVariableAsUsed("a");
+        function useA(node) {
+            sourceCode.markVariableAsUsed("a", node);
         }
         return {
             VariableDeclaration: useA,

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -20,11 +20,15 @@ const rule = require("../../../lib/rules/prefer-const"),
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.defineRule("use-x", {
-    create: context => ({
-        VariableDeclaration() {
-            context.markVariableAsUsed("x");
-        }
-    })
+    create(context) {
+        const sourceCode = context.getSourceCode();
+
+        return {
+            VariableDeclaration(node) {
+                sourceCode.markVariableAsUsed("x", node);
+            }
+        };
+    }
 });
 
 ruleTester.run("prefer-const", rule, {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Implements `SourceCode#markVariableAsUsed()` and sets `context.markVariableAsUsed()` to use it.

Refs #16999

#### Is there anything you'd like reviewers to focus on?

I'm not sure of how I implemented this method. I started out by passing in an `Identifier` node because we can use that to get the scope and determine if it's a declared variable. This also seemed like it would be the most developer-friendly.

Based on my feedback from @ljharb, I change it to accept a string and optionally a node. I'd like some more feedback on whether this makes sense.

<!-- markdownlint-disable-file MD004 -->
