### PR TITLE
feat: add new `omitLastInOneLineClassBody` option to the `semi` rule

### DIFF
--- a/docs/src/rules/semi.md
+++ b/docs/src/rules/semi.md
@@ -81,6 +81,7 @@ String option:
 Object option (when `"always"`):
 
 * `"omitLastInOneLineBlock": true` ignores the last semicolon in a block in which its braces (and therefore the content of the block) are in the same line
+* `"omitLastInOneLineClassBody": true` ignores the last semicolon in a class body in which its braces (and therefore the content of the class body) are in the same line
 
 Object option (when `"never"`):
 
@@ -210,6 +211,27 @@ class C {
 
     static { bar(); baz() }
 }
+```
+
+:::
+
+#### omitLastInOneLineClassBody
+
+Examples of additional **correct** code for this rule with the `"always", { "omitLastInOneLineClassBody": true }` options:
+
+::: correct
+
+```js
+/*eslint semi: ["error", "always", { "omitLastInOneLineClassBody": true}] */
+
+export class SomeClass{
+    logType(){
+        console.log(this.type);
+    }
+}
+
+export class Variant1 extends SomeClass{type=1}
+export class Variant2 extends SomeClass{type=2}
 ```
 
 :::

--- a/docs/src/rules/semi.md
+++ b/docs/src/rules/semi.md
@@ -133,6 +133,51 @@ class Foo {
 
 :::
 
+#### omitLastInOneLineBlock
+
+Examples of additional **correct** code for this rule with the `"always", { "omitLastInOneLineBlock": true }` options:
+
+::: correct
+
+```js
+/*eslint semi: ["error", "always", { "omitLastInOneLineBlock": true}] */
+
+if (foo) { bar() }
+
+if (foo) { bar(); baz() }
+
+function f() { bar(); baz() }
+
+class C {
+    foo() { bar(); baz() }
+
+    static { bar(); baz() }
+}
+```
+
+:::
+
+#### omitLastInOneLineClassBody
+
+Examples of additional **correct** code for this rule with the `"always", { "omitLastInOneLineClassBody": true }` options:
+
+::: correct
+
+```js
+/*eslint semi: ["error", "always", { "omitLastInOneLineClassBody": true}] */
+
+export class SomeClass{
+    logType(){
+        console.log(this.type);
+    }
+}
+
+export class Variant1 extends SomeClass{type=1}
+export class Variant2 extends SomeClass{type=2}
+```
+
+:::
+
 ### never
 
 Examples of **incorrect** code for this rule with the `"never"` option:
@@ -187,51 +232,6 @@ import b from "b"
 class Foo {
     bar = 1
 }
-```
-
-:::
-
-#### omitLastInOneLineBlock
-
-Examples of additional **correct** code for this rule with the `"always", { "omitLastInOneLineBlock": true }` options:
-
-::: correct
-
-```js
-/*eslint semi: ["error", "always", { "omitLastInOneLineBlock": true}] */
-
-if (foo) { bar() }
-
-if (foo) { bar(); baz() }
-
-function f() { bar(); baz() }
-
-class C {
-    foo() { bar(); baz() }
-
-    static { bar(); baz() }
-}
-```
-
-:::
-
-#### omitLastInOneLineClassBody
-
-Examples of additional **correct** code for this rule with the `"always", { "omitLastInOneLineClassBody": true }` options:
-
-::: correct
-
-```js
-/*eslint semi: ["error", "always", { "omitLastInOneLineClassBody": true}] */
-
-export class SomeClass{
-    logType(){
-        console.log(this.type);
-    }
-}
-
-export class Variant1 extends SomeClass{type=1}
-export class Variant2 extends SomeClass{type=2}
 ```
 
 :::

--- a/docs/src/rules/semi.md
+++ b/docs/src/rules/semi.md
@@ -80,8 +80,8 @@ String option:
 
 Object option (when `"always"`):
 
-* `"omitLastInOneLineBlock": true` ignores the last semicolon in a block in which its braces (and therefore the content of the block) are in the same line
-* `"omitLastInOneLineClassBody": true` ignores the last semicolon in a class body in which its braces (and therefore the content of the class body) are in the same line
+* `"omitLastInOneLineBlock": true` disallows the last semicolon in a block in which its braces (and therefore the content of the block) are in the same line
+* `"omitLastInOneLineClassBody": true` disallows the last semicolon in a class body in which its braces (and therefore the content of the class body) are in the same line
 
 Object option (when `"never"`):
 
@@ -169,11 +169,12 @@ Examples of additional **correct** code for this rule with the `"always", { "omi
 export class SomeClass{
     logType(){
         console.log(this.type);
+        console.log(this.anotherType);
     }
 }
 
 export class Variant1 extends SomeClass{type=1}
-export class Variant2 extends SomeClass{type=2}
+export class Variant2 extends SomeClass{type=2; anotherType=3}
 ```
 
 :::

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -58,7 +58,8 @@ module.exports = {
                         {
                             type: "object",
                             properties: {
-                                omitLastInOneLineBlock: { type: "boolean" }
+                                omitLastInOneLineBlock: { type: "boolean" },
+                                omitLastInOneLineClassBody: { type: "boolean" }
                             },
                             additionalProperties: false
                         }
@@ -83,6 +84,7 @@ module.exports = {
         const options = context.options[1];
         const never = context.options[0] === "never";
         const exceptOneLine = Boolean(options && options.omitLastInOneLineBlock);
+        const exceptOneLineClassBody = Boolean(options && options.omitLastInOneLineClassBody);
         const beforeStatementContinuationChars = options && options.beforeStatementContinuationChars || "any";
         const sourceCode = context.getSourceCode();
 
@@ -321,7 +323,7 @@ module.exports = {
                 return false;
             }
 
-            if (parent.type === "BlockStatement") {
+            if (parent.type === "BlockStatement" || (exceptOneLineClassBody && parent.type === "ClassBody")) {
                 return parent.loc.start.line === parent.loc.end.line;
             }
 
@@ -353,7 +355,7 @@ module.exports = {
                     report(node);
                 }
             } else {
-                const oneLinerBlock = (exceptOneLine && isLastInOneLinerBlock(node));
+                const oneLinerBlock = ((exceptOneLine || exceptOneLineClassBody) && isLastInOneLinerBlock(node));
 
                 if (isSemi && oneLinerBlock) {
                     report(node, true);

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -323,7 +323,7 @@ module.exports = {
                 return false;
             }
 
-            if (parent.type === "BlockStatement" || (exceptOneLineClassBody && parent.type === "ClassBody")) {
+            if (parent.type === "BlockStatement") {
                 return parent.loc.start.line === parent.loc.end.line;
             }
 
@@ -331,6 +331,27 @@ module.exports = {
                 const openingBrace = sourceCode.getFirstToken(parent, { skip: 1 }); // skip the `static` token
 
                 return openingBrace.loc.start.line === parent.loc.end.line;
+            }
+
+            return false;
+        }
+
+        /**
+         * Checks a node to see if it's the last item in a one-liner `ClassBody` node.
+         * ClassBody is a one-liner if its braces (and consequently everything between them) are on the same line.
+         * @param {ASTNode} node The node to check.
+         * @returns {boolean} whether the node is the last item in a one-liner ClassBody.
+         */
+        function isLastInOneLinerClassBody(node) {
+            const parent = node.parent;
+            const nextToken = sourceCode.getTokenAfter(node);
+
+            if (!nextToken || nextToken.value !== "}") {
+                return false;
+            }
+
+            if (parent.type === "ClassBody") {
+                return parent.loc.start.line === parent.loc.end.line;
             }
 
             return false;
@@ -355,11 +376,13 @@ module.exports = {
                     report(node);
                 }
             } else {
-                const oneLinerBlock = ((exceptOneLine || exceptOneLineClassBody) && isLastInOneLinerBlock(node));
+                const oneLinerBlock = (exceptOneLine && isLastInOneLinerBlock(node));
+                const oneLinerClassBody = (exceptOneLineClassBody && isLastInOneLinerClassBody(node));
+                const oneLinerBlockOrClassBody = oneLinerBlock || oneLinerClassBody;
 
-                if (isSemi && oneLinerBlock) {
+                if (isSemi && oneLinerBlockOrClassBody) {
                     report(node, true);
-                } else if (!isSemi && !oneLinerBlock) {
+                } else if (!isSemi && !oneLinerBlockOrClassBody) {
                     report(node);
                 }
             }

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -134,6 +134,20 @@ ruleTester.run("semi", rule, {
                 export class SomeClass{
                     logType(){
                         console.log(this.type);
+                        console.log(this.anotherType);
+                    }
+                }
+
+                export class Variant1 extends SomeClass{type=1; anotherType=2}
+            `,
+            options: ["always", { omitLastInOneLineClassBody: true }],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" }
+        },
+        {
+            code: `
+                export class SomeClass{
+                    logType(){
+                        console.log(this.type);
                     }
                 }
 
@@ -2438,6 +2452,39 @@ ruleTester.run("semi", rule, {
                     column: 63,
                     endLine: 8,
                     endColumn: 64
+                }
+            ]
+        },
+        {
+            code: `
+                export class SomeClass{
+                    logType(){
+                        console.log(this.type);
+                        console.log(this.anotherType);
+                    }
+                }
+
+                export class Variant1 extends SomeClass{type=1; anotherType=2}
+            `,
+            output: `
+                export class SomeClass{
+                    logType(){
+                        console.log(this.type);
+                        console.log(this.anotherType);
+                    }
+                }
+
+                export class Variant1 extends SomeClass{type=1; anotherType=2;}
+            `,
+            options: ["always", { omitLastInOneLineClassBody: false, omitLastInOneLineBlock: true }],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: [
+                {
+                    messageId: "missingSemi",
+                    line: 9,
+                    column: 78,
+                    endLine: 9,
+                    endColumn: 79
                 }
             ]
         }

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -111,6 +111,42 @@ ruleTester.run("semi", rule, {
         { code: "class C {\n static {\n bar(); baz(); } \n}", options: ["always", { omitLastInOneLineBlock: true }], parserOptions: { ecmaVersion: 2022 } },
         { code: "class C {\n static { bar(); baz(); \n} \n}", options: ["always", { omitLastInOneLineBlock: true }], parserOptions: { ecmaVersion: 2022 } },
 
+        // omitLastInOneLineClassBody: true
+        {
+            code: `
+                export class SomeClass{
+                    logType(){
+                        console.log(this.type);
+                    }
+                }
+
+                export class Variant1 extends SomeClass{type=1}
+                export class Variant2 extends SomeClass{type=2}
+                export class Variant3 extends SomeClass{type=3}
+                export class Variant4 extends SomeClass{type=4}
+                export class Variant5 extends SomeClass{type=5}
+            `,
+            options: ["always", { omitLastInOneLineClassBody: true }],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" }
+        },
+        {
+            code: `
+                export class SomeClass{
+                    logType(){
+                        console.log(this.type);
+                    }
+                }
+
+                export class Variant1 extends SomeClass{type=1;}
+                export class Variant2 extends SomeClass{type=2;}
+                export class Variant3 extends SomeClass{type=3;}
+                export class Variant4 extends SomeClass{type=4;}
+                export class Variant5 extends SomeClass{type=5;}
+            `,
+            options: ["always", { omitLastInOneLineClassBody: false }],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" }
+        },
+
         // method definitions and static blocks don't have a semicolon.
         { code: "class A { a() {} b() {} }", parserOptions: { ecmaVersion: 6 } },
         { code: "var A = class { a() {} b() {} };", parserOptions: { ecmaVersion: 6 } },
@@ -2309,6 +2345,101 @@ ruleTester.run("semi", rule, {
                 endLine: 1,
                 endColumn: 18
             }]
+        },
+
+        // omitLastInOneLineClassBody
+        {
+            code: `
+                export class SomeClass{
+                    logType(){
+                        console.log(this.type);
+                    }
+                }
+
+                export class Variant1 extends SomeClass{type=1}
+            `,
+            output: `
+                export class SomeClass{
+                    logType(){
+                        console.log(this.type);
+                    }
+                }
+
+                export class Variant1 extends SomeClass{type=1;}
+            `,
+            options: ["always", { omitLastInOneLineClassBody: false }],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: [
+                {
+                    messageId: "missingSemi",
+                    line: 8,
+                    column: 63,
+                    endLine: 8,
+                    endColumn: 64
+                }
+            ]
+        },
+        {
+            code: `
+                export class SomeClass{
+                    logType(){
+                        console.log(this.type);
+                    }
+                }
+
+                export class Variant1 extends SomeClass{type=1}
+            `,
+            output: `
+                export class SomeClass{
+                    logType(){
+                        console.log(this.type);
+                    }
+                }
+
+                export class Variant1 extends SomeClass{type=1;}
+            `,
+            options: ["always", { omitLastInOneLineClassBody: false, omitLastInOneLineBlock: true }],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: [
+                {
+                    messageId: "missingSemi",
+                    line: 8,
+                    column: 63,
+                    endLine: 8,
+                    endColumn: 64
+                }
+            ]
+        },
+        {
+            code: `
+                export class SomeClass{
+                    logType(){
+                        console.log(this.type);
+                    }
+                }
+
+                export class Variant1 extends SomeClass{type=1;}
+            `,
+            output: `
+                export class SomeClass{
+                    logType(){
+                        console.log(this.type);
+                    }
+                }
+
+                export class Variant1 extends SomeClass{type=1}
+            `,
+            options: ["always", { omitLastInOneLineClassBody: true, omitLastInOneLineBlock: false }],
+            parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+            errors: [
+                {
+                    messageId: "extraSemi",
+                    line: 8,
+                    column: 63,
+                    endLine: 8,
+                    endColumn: 64
+                }
+            ]
         }
     ]
 });

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -160,6 +160,31 @@ ruleTester.run("semi", rule, {
             options: ["always", { omitLastInOneLineClassBody: false }],
             parserOptions: { ecmaVersion: 2022, sourceType: "module" }
         },
+        {
+            code: "class C {\nfoo;}",
+            options: ["always", { omitLastInOneLineClassBody: true }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C {foo;\n}",
+            options: ["always", { omitLastInOneLineClassBody: true }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C {foo;\nbar;}",
+            options: ["always", { omitLastInOneLineClassBody: true }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "{ foo; }",
+            options: ["always", { omitLastInOneLineClassBody: true }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class C\n{ foo }",
+            options: ["always", { omitLastInOneLineClassBody: true }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
 
         // method definitions and static blocks don't have a semicolon.
         { code: "class A { a() {} b() {} }", parserOptions: { ecmaVersion: 6 } },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Resolve https://github.com/eslint/eslint/issues/17035

1. This PR adds a new `omitLastInOneLineClassBody` option to the `semi` rule. The following code will not throw any error now:

    ```js
    /*eslint semi: ["error", "always", { "omitLastInOneLineClassBody": true}] */
    
    export class SomeClass{
        logType(){
            console.log(this.type);
        }
    }
    
    export class Variant1 extends SomeClass{type=1}
    export class Variant2 extends SomeClass{type=2}
    ```

2. Also fixed the order of options in the semi-rule documentation
    - `omitLastInOneLineClassBody` and `omitLastInOneLineBlock` under `"always"`.
    - `beforeStatementContinuationChars` under `"never"`


    | before   | after  |
    |---|---|
    |  <img width="207" alt="Screenshot 2023-04-22 at 7 32 55 AM" src="https://user-images.githubusercontent.com/46647141/233756159-e2c70e32-0d5a-41d6-9603-2c53fe609fec.png"> |  <img width="251" alt="Screenshot 2023-04-22 at 7 27 16 AM" src="https://user-images.githubusercontent.com/46647141/233756077-7a215792-c6f2-4779-8b65-dce59b9ba025.png"> |

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
