### PR TITLE
feat: add `cwd` to rule context

### DIFF
--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -134,7 +134,8 @@ The `context` object has the following properties:
 Additionally, the `context` object has the following methods:
 
 * `getAncestors()`: (**Deprecated:** Use `SourceCode#getAncestors(node)` instead.) Returns an array of the ancestors of the currently-traversed node, starting at the root of the AST and continuing through the direct parent of the current node. This array does not include the currently-traversed node itself.
-* `getCwd()`: Returns the `cwd` option passed to the [Linter](../integrate/nodejs-api#linter). It is a path to a directory that should be considered the current working directory.
+* `getCwd()`: (**Deprecated:** Use `Context#cwd` instead.) Returns the `cwd` option passed to the [Linter](../integrate/nodejs-api#linter). It is a path to a directory that should be considered the current working directory.
+* `cwd`: Returns the `cwd` option passed to the [Linter](../integrate/nodejs-api#linter). It is a path to a directory that should be considered the current working directory.
 * `getDeclaredVariables(node)`: (**Deprecated:** Use `SourceCode#getDeclaredVariables(node)` instead.) Returns a list of [variables](./scope-manager-interface#variable-interface) declared by the given node. This information can be used to track references to variables.
     * If the node is a `VariableDeclaration`, all variables declared in the declaration are returned.
     * If the node is a `VariableDeclarator`, all variables declared in the declarator are returned.

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -125,6 +125,7 @@ The `context` object has the following properties:
 
 * `id`: (`string`) The rule ID.
 * `filename`: (`string`) The filename associated with the source.
+* `cwd`: (`string`) The `cwd` option passed to the [Linter](../integrate/nodejs-api#linter). It is a path to a directory that should be considered the current working directory.
 * `options`: (`array`) An array of the [configured options](../use/configure/rules) for this rule. This array does not include the rule severity (see the [dedicated section](#accessing-options-passed-to-a-rule)).
 * `settings`: (`object`) The [shared settings](../use/configure/configuration-files#adding-shared-settings) from the configuration.
 * `parserPath`: (`string`) The name of the `parser` from the configuration.
@@ -134,8 +135,7 @@ The `context` object has the following properties:
 Additionally, the `context` object has the following methods:
 
 * `getAncestors()`: (**Deprecated:** Use `SourceCode#getAncestors(node)` instead.) Returns an array of the ancestors of the currently-traversed node, starting at the root of the AST and continuing through the direct parent of the current node. This array does not include the currently-traversed node itself.
-* `getCwd()`: (**Deprecated:** Use `Context#cwd` instead.) Returns the `cwd` option passed to the [Linter](../integrate/nodejs-api#linter). It is a path to a directory that should be considered the current working directory.
-* `cwd`: Returns the `cwd` option passed to the [Linter](../integrate/nodejs-api#linter). It is a path to a directory that should be considered the current working directory.
+* `getCwd()`: (**Deprecated:** Use `context.cwd` instead.) Returns the `cwd` option passed to the [Linter](../integrate/nodejs-api#linter). It is a path to a directory that should be considered the current working directory.
 * `getDeclaredVariables(node)`: (**Deprecated:** Use `SourceCode#getDeclaredVariables(node)` instead.) Returns a list of [variables](./scope-manager-interface#variable-interface) declared by the given node. This information can be used to track references to variables.
     * If the node is a `VariableDeclaration`, all variables declared in the declaration are returned.
     * If the node is a `VariableDeclarator`, all variables declared in the declarator are returned.

--- a/docs/src/integrate/nodejs-api.md
+++ b/docs/src/integrate/nodejs-api.md
@@ -510,7 +510,7 @@ The `Linter` object does the actual evaluation of the JavaScript code. It doesn'
 
 The `Linter` is a constructor, and you can create a new instance by passing in the options you want to use. The available options are:
 
-* `cwd` - Path to a directory that should be considered as the current working directory. It is accessible to rules by calling `context.getCwd()` or `context.cwd` (see [The Context Object](../extend/custom-rules#the-context-object)). If `cwd` is `undefined`, it will be normalized to `process.cwd()` if the global `process` object is defined (for example, in the Node.js runtime) , or `undefined` otherwise.
+* `cwd` - Path to a directory that should be considered as the current working directory. It is accessible to rules from `context.cwd` or by calling `context.getCwd()` (see [The Context Object](../extend/custom-rules#the-context-object)). If `cwd` is `undefined`, it will be normalized to `process.cwd()` if the global `process` object is defined (for example, in the Node.js runtime) , or `undefined` otherwise.
 
 For example:
 
@@ -520,7 +520,7 @@ const linter1 = new Linter({ cwd: 'path/to/project' });
 const linter2 = new Linter();
 ```
 
-In this example, rules run on `linter1` will get `path/to/project` when calling `context.getCwd()` or `context.cwd`.
+In this example, rules run on `linter1` will get `path/to/project` from `context.cwd` or when calling `context.getCwd()`.
 Those run on `linter2` will get `process.cwd()` if the global `process` object is defined or `undefined` otherwise (e.g. on the browser <https://eslint.org/demo>).
 
 ### Linter#verify

--- a/docs/src/integrate/nodejs-api.md
+++ b/docs/src/integrate/nodejs-api.md
@@ -510,7 +510,7 @@ The `Linter` object does the actual evaluation of the JavaScript code. It doesn'
 
 The `Linter` is a constructor, and you can create a new instance by passing in the options you want to use. The available options are:
 
-* `cwd` - Path to a directory that should be considered as the current working directory. It is accessible to rules by calling `context.getCwd()` (see [The Context Object](../extend/custom-rules#the-context-object)). If `cwd` is `undefined`, it will be normalized to `process.cwd()` if the global `process` object is defined (for example, in the Node.js runtime) , or `undefined` otherwise.
+* `cwd` - Path to a directory that should be considered as the current working directory. It is accessible to rules by calling `context.getCwd()` or `context.cwd` (see [The Context Object](../extend/custom-rules#the-context-object)). If `cwd` is `undefined`, it will be normalized to `process.cwd()` if the global `process` object is defined (for example, in the Node.js runtime) , or `undefined` otherwise.
 
 For example:
 

--- a/docs/src/integrate/nodejs-api.md
+++ b/docs/src/integrate/nodejs-api.md
@@ -520,7 +520,7 @@ const linter1 = new Linter({ cwd: 'path/to/project' });
 const linter2 = new Linter();
 ```
 
-In this example, rules run on `linter1` will get `path/to/project` when calling `context.getCwd()`.
+In this example, rules run on `linter1` will get `path/to/project` when calling `context.getCwd()` or `context.cwd`.
 Those run on `linter2` will get `process.cwd()` if the global `process` object is defined or `undefined` otherwise (e.g. on the browser <https://eslint.org/demo>).
 
 ### Linter#verify

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -951,6 +951,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
                 getAncestors: () => sourceCode.getAncestors(currentNode),
                 getDeclaredVariables: node => sourceCode.getDeclaredVariables(node),
                 getCwd: () => cwd,
+                cwd,
                 getFilename: () => filename,
                 filename,
                 getPhysicalFilename: () => physicalFilename || filename,

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -3947,7 +3947,7 @@ var a = "test2";
             linterWithOption.defineRule("checker", {
                 create(context) {
                     spy = sinon.spy(() => {
-                        assert.strictEqual(context.getCwd(), cwd);
+                        assert.strictEqual(context.cwd, cwd);
                     });
                     return { Program: spy };
                 }
@@ -3965,7 +3965,7 @@ var a = "test2";
                 create(context) {
 
                     spy = sinon.spy(() => {
-                        assert.strictEqual(context.getCwd(), process.cwd());
+                        assert.strictEqual(context.cwd, process.cwd());
                     });
                     return { Program: spy };
                 }
@@ -3982,7 +3982,7 @@ var a = "test2";
                 create(context) {
 
                     spy = sinon.spy(() => {
-                        assert.strictEqual(context.getCwd(), process.cwd());
+                        assert.strictEqual(context.cwd, process.cwd());
                     });
                     return { Program: spy };
                 }
@@ -11005,6 +11005,89 @@ describe("Linter with FlatConfigArray", () => {
 
                                             spy = sinon.spy(() => {
                                                 assert.strictEqual(context.getCwd(), process.cwd());
+                                            });
+                                            return { Program: spy };
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        ...baseConfig
+                    };
+
+                    linter.verify(code, config);
+                    assert(spy && spy.calledOnce);
+                });
+            });
+
+            describe("context.cwd", () => {
+                const code = "a;\nb;";
+                const baseConfig = { rules: { "test/checker": "error" } };
+
+                it("should get cwd correctly in the context", () => {
+                    const cwd = "cwd";
+                    const linterWithOption = new Linter({ cwd, configType: "flat" });
+                    let spy;
+                    const config = {
+                        plugins: {
+                            test: {
+                                rules: {
+                                    checker: {
+                                        create(context) {
+                                            spy = sinon.spy(() => {
+                                                assert.strictEqual(context.cwd, cwd);
+                                            });
+                                            return { Program: spy };
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        ...baseConfig
+                    };
+
+                    linterWithOption.verify(code, config);
+                    assert(spy && spy.calledOnce);
+                });
+
+                it("should assign process.cwd() to it if cwd is undefined", () => {
+
+                    const linterWithOption = new Linter({ configType: "flat" });
+                    let spy;
+                    const config = {
+                        plugins: {
+                            test: {
+                                rules: {
+                                    checker: {
+                                        create(context) {
+
+                                            spy = sinon.spy(() => {
+                                                assert.strictEqual(context.cwd, process.cwd());
+                                            });
+                                            return { Program: spy };
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        ...baseConfig
+                    };
+
+                    linterWithOption.verify(code, config);
+                    assert(spy && spy.calledOnce);
+                });
+
+                it("should assign process.cwd() to it if the option is undefined", () => {
+                    let spy;
+                    const config = {
+                        plugins: {
+                            test: {
+                                rules: {
+                                    checker: {
+                                        create(context) {
+
+                                            spy = sinon.spy(() => {
+                                                assert.strictEqual(context.cwd, process.cwd());
                                             });
                                             return { Program: spy };
                                         }

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -3947,6 +3947,7 @@ var a = "test2";
             linterWithOption.defineRule("checker", {
                 create(context) {
                     spy = sinon.spy(() => {
+                        assert.strictEqual(context.getCwd(), context.cwd);
                         assert.strictEqual(context.cwd, cwd);
                     });
                     return { Program: spy };

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -3965,6 +3965,7 @@ var a = "test2";
                 create(context) {
 
                     spy = sinon.spy(() => {
+                        assert.strictEqual(context.getCwd(), context.cwd);
                         assert.strictEqual(context.cwd, process.cwd());
                     });
                     return { Program: spy };
@@ -3982,6 +3983,7 @@ var a = "test2";
                 create(context) {
 
                     spy = sinon.spy(() => {
+                        assert.strictEqual(context.getCwd(), context.cwd);
                         assert.strictEqual(context.cwd, process.cwd());
                     });
                     return { Program: spy };
@@ -11062,6 +11064,7 @@ describe("Linter with FlatConfigArray", () => {
                                         create(context) {
 
                                             spy = sinon.spy(() => {
+                                                assert.strictEqual(context.getCwd(), context.cwd);
                                                 assert.strictEqual(context.cwd, process.cwd());
                                             });
                                             return { Program: spy };
@@ -11087,6 +11090,7 @@ describe("Linter with FlatConfigArray", () => {
                                         create(context) {
 
                                             spy = sinon.spy(() => {
+                                                assert.strictEqual(context.getCwd(), context.cwd);
                                                 assert.strictEqual(context.cwd, process.cwd());
                                             });
                                             return { Program: spy };


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Refers #16999 

This PR creates `context.cwd` and deprecates `context.getCwd()`.

#### Is there anything you'd like reviewers to focus on?
Did I miss any references?
<!-- markdownlint-disable-file MD004 -->
