### PR TITLE
feat: add `sourceCode` property to the rule context

### DIFF
--- a/docs/src/extend/code-path-analysis.md
+++ b/docs/src/extend/code-path-analysis.md
@@ -259,7 +259,7 @@ Please use a map of information instead.
 ```js
 function hasCb(node, context) {
     if (node.type.indexOf("Function") !== -1) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         return sourceCode.getDeclaredVariables(node).some(function(v) {
             return v.type === "Parameter" && v.name === "cb";
         });

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -522,7 +522,7 @@ module.exports = {
 };
 ```
 
-**Deprecated:** The `context.getScope()` method is deprecated; make sure to use `context.sourceCode` property instead.
+**Deprecated:** The `context.getSourceCode()` method is deprecated; make sure to use `context.sourceCode` property instead.
 
 Once you have an instance of `SourceCode`, you can use the following methods on it to work with the code:
 

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -150,7 +150,8 @@ Additionally, the `context` object has the following methods:
 * `getFilename()`: (**Deprecated:** Use `context.filename` instead.) Returns the filename associated with the source.
 * `getPhysicalFilename()`: (**Deprecated:** Use `context.physicalFilename` instead.) When linting a file, it returns the full path of the file on disk without any code block information. When linting text, it returns the value passed to `—stdin-filename` or `<text>` if not specified.
 * `getScope()`: (**Deprecated:** Use `SourceCode#getScope(node)` instead.) Returns the [scope](./scope-manager-interface#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
-* `getSourceCode()`: Returns a `SourceCode` object that you can use to work with the source that was passed to ESLint (see [Accessing the Source Code](#accessing-the-source-code)).
+* `getSourceCode()`: (**Deprecated:** Use `context#sourceCode` instead.) Returns a `SourceCode` object that you can use to work with the source that was passed to ESLint (see [Accessing the Source Code](#accessing-the-source-code)).
+* `sourceCode`: Returns a `SourceCode` object that you can use to work with the source that was passed to ESLint (see [Accessing the Source Code](#accessing-the-source-code)).
 * `markVariableAsUsed(name)`: (**Deprecated:** Use `SourceCode#markVariableAsUsed(name, node)` instead.)  Marks a variable with the given name in the current scope as used. This affects the [no-unused-vars](../rules/no-unused-vars) rule. Returns `true` if a variable with the given name was found and marked as used, otherwise `false`.
 * `report(descriptor)`. Reports a problem in the code (see the [dedicated section](#reporting-problems)).
 
@@ -514,7 +515,7 @@ The `SourceCode` object is the main object for getting more information about th
 ```js
 module.exports = {
     create: function(context) {
-        var sourceCode = context.getSourceCode();
+        var sourceCode = context.sourceCode; // or use "context.getSourceCode()", but that is deprecated.
 
         // ...
     }
@@ -712,7 +713,7 @@ To help with this, you can use the `sourceCode.markVariableAsUsed()` method. Thi
 ```js
 module.exports = {
     create: function(context) {
-        var sourceCode = context.getSourceCode();
+        var sourceCode = context.sourceCode;
 
         return {
             ReturnStatement(node) {

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -128,6 +128,7 @@ The `context` object has the following properties:
 * `physicalFilename`: (`string`) When linting a file, it provides the full path of the file on disk without any code block information. When linting text, it provides the value passed to `—stdin-filename` or `<text>` if not specified.
 * `cwd`: (`string`) The `cwd` option passed to the [Linter](../integrate/nodejs-api#linter). It is a path to a directory that should be considered the current working directory.
 * `options`: (`array`) An array of the [configured options](../use/configure/rules) for this rule. This array does not include the rule severity (see the [dedicated section](#accessing-options-passed-to-a-rule)).
+* `sourceCode`: (`object`) A `SourceCode` object that you can use to work with the source that was passed to ESLint (see [Accessing the Source Code](#accessing-the-source-code)).
 * `settings`: (`object`) The [shared settings](../use/configure/configuration-files#adding-shared-settings) from the configuration.
 * `parserPath`: (`string`) The name of the `parser` from the configuration.
 * `parserServices`: (`object`) Contains parser-provided services for rules. The default parser does not provide any services. However, if a rule is intended to be used with a custom parser, it could use `parserServices` to access anything provided by that parser. (For example, a TypeScript parser could provide the ability to get the computed type of a given node.)
@@ -151,7 +152,6 @@ Additionally, the `context` object has the following methods:
 * `getPhysicalFilename()`: (**Deprecated:** Use `context.physicalFilename` instead.) When linting a file, it returns the full path of the file on disk without any code block information. When linting text, it returns the value passed to `—stdin-filename` or `<text>` if not specified.
 * `getScope()`: (**Deprecated:** Use `SourceCode#getScope(node)` instead.) Returns the [scope](./scope-manager-interface#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
 * `getSourceCode()`: (**Deprecated:** Use `context#sourceCode` instead.) Returns a `SourceCode` object that you can use to work with the source that was passed to ESLint (see [Accessing the Source Code](#accessing-the-source-code)).
-* `sourceCode`: Returns a `SourceCode` object that you can use to work with the source that was passed to ESLint (see [Accessing the Source Code](#accessing-the-source-code)).
 * `markVariableAsUsed(name)`: (**Deprecated:** Use `SourceCode#markVariableAsUsed(name, node)` instead.)  Marks a variable with the given name in the current scope as used. This affects the [no-unused-vars](../rules/no-unused-vars) rule. Returns `true` if a variable with the given name was found and marked as used, otherwise `false`.
 * `report(descriptor)`. Reports a problem in the code (see the [dedicated section](#reporting-problems)).
 

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -151,7 +151,7 @@ Additionally, the `context` object has the following methods:
 * `getFilename()`: (**Deprecated:** Use `context.filename` instead.) Returns the filename associated with the source.
 * `getPhysicalFilename()`: (**Deprecated:** Use `context.physicalFilename` instead.) When linting a file, it returns the full path of the file on disk without any code block information. When linting text, it returns the value passed to `—stdin-filename` or `<text>` if not specified.
 * `getScope()`: (**Deprecated:** Use `SourceCode#getScope(node)` instead.) Returns the [scope](./scope-manager-interface#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
-* `getSourceCode()`: (**Deprecated:** Use `context#sourceCode` instead.) Returns a `SourceCode` object that you can use to work with the source that was passed to ESLint (see [Accessing the Source Code](#accessing-the-source-code)).
+* `getSourceCode()`: (**Deprecated:** Use `context.sourceCode` instead.) Returns a `SourceCode` object that you can use to work with the source that was passed to ESLint (see [Accessing the Source Code](#accessing-the-source-code)).
 * `markVariableAsUsed(name)`: (**Deprecated:** Use `SourceCode#markVariableAsUsed(name, node)` instead.)  Marks a variable with the given name in the current scope as used. This affects the [no-unused-vars](../rules/no-unused-vars) rule. Returns `true` if a variable with the given name was found and marked as used, otherwise `false`.
 * `report(descriptor)`. Reports a problem in the code (see the [dedicated section](#reporting-problems)).
 
@@ -510,17 +510,19 @@ When using options, make sure that your rule has some logical defaults in case t
 
 ### Accessing the Source Code
 
-The `SourceCode` object is the main object for getting more information about the source code being linted. You can retrieve the `SourceCode` object at any time by using the `context.getSourceCode()` method:
+The `SourceCode` object is the main object for getting more information about the source code being linted. You can retrieve the `SourceCode` object at any time by using the `context.sourceCode` property:
 
 ```js
 module.exports = {
     create: function(context) {
-        var sourceCode = context.sourceCode; // or use "context.getSourceCode()", but that is deprecated.
+        var sourceCode = context.sourceCode;
 
         // ...
     }
 };
 ```
+
+**Deprecated:** The `context.getScope()` method is deprecated; make sure to use `context.sourceCode` property instead.
 
 Once you have an instance of `SourceCode`, you can use the following methods on it to work with the code:
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -902,7 +902,7 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
         (contextInfo, methodName) =>
             Object.assign(contextInfo, {
                 [methodName](...args) {
-                    return this.getSourceCode()[DEPRECATED_SOURCECODE_PASSTHROUGHS[methodName]](...args);
+                    return this.sourceCode[DEPRECATED_SOURCECODE_PASSTHROUGHS[methodName]](...args);
                 }
             }),
         {}

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -958,6 +958,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
                 physicalFilename: physicalFilename || filename,
                 getScope: () => sourceCode.getScope(currentNode),
                 getSourceCode: () => sourceCode,
+                sourceCode,
                 markVariableAsUsed: name => sourceCode.markVariableAsUsed(name, currentNode),
                 parserOptions: {
                     ...languageOptions.parserOptions

--- a/lib/rules/accessor-pairs.js
+++ b/lib/rules/accessor-pairs.js
@@ -178,7 +178,7 @@ module.exports = {
         const checkGetWithoutSet = config.getWithoutSet === true;
         const checkSetWithoutGet = config.setWithoutGet !== false;
         const enforceForClassMembers = config.enforceForClassMembers !== false;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports the given node.

--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -56,7 +56,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
 
         //----------------------------------------------------------------------

--- a/lib/rules/array-bracket-spacing.js
+++ b/lib/rules/array-bracket-spacing.js
@@ -53,7 +53,7 @@ module.exports = {
     },
     create(context) {
         const spaced = context.options[0] === "always",
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
 
         /**
          * Determines whether an option is set, relative to the spacing option.

--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -172,7 +172,7 @@ module.exports = {
     create(context) {
 
         const options = context.options[0] || { allowImplicit: false, checkForEach: false };
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         let funcInfo = {
             arrayMethodName: null,

--- a/lib/rules/array-element-newline.js
+++ b/lib/rules/array-element-newline.js
@@ -79,7 +79,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //----------------------------------------------------------------------
         // Helpers

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -74,7 +74,7 @@ module.exports = {
         const asNeeded = !options[0] || options[0] === "as-needed";
         const never = options[0] === "never";
         const requireReturnForObjectLiteral = options[1] && options[1].requireReturnForObjectLiteral;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         let funcInfo = null;
 
         /**

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -69,7 +69,7 @@ module.exports = {
         const asNeeded = context.options[0] === "as-needed";
         const requireForBlockBody = asNeeded && context.options[1] && context.options[1].requireForBlockBody === true;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Finds opening paren of parameters for the given arrow function, if it exists.

--- a/lib/rules/arrow-spacing.js
+++ b/lib/rules/arrow-spacing.js
@@ -61,7 +61,7 @@ module.exports = {
         rule.before = rule.before !== false;
         rule.after = rule.after !== false;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Get tokens of arrow(`=>`) and before/after arrow.

--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -28,7 +28,7 @@ module.exports = {
 
     create(context) {
         let stack = [];
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Makes a block scope.

--- a/lib/rules/block-spacing.js
+++ b/lib/rules/block-spacing.js
@@ -37,7 +37,7 @@ module.exports = {
     create(context) {
         const always = (context.options[0] !== "never"),
             messageId = always ? "missing" : "extra",
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
 
         /**
          * Gets the open brace token from a given node.

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -53,7 +53,7 @@ module.exports = {
     create(context) {
         const style = context.options[0] || "1tbs",
             params = context.options[1] || {},
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/callback-return.js
+++ b/lib/rules/callback-return.js
@@ -37,7 +37,7 @@ module.exports = {
     create(context) {
 
         const callbacks = context.options[0] || ["callback", "cb", "next"],
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -73,7 +73,7 @@ module.exports = {
         const ignoreImports = options.ignoreImports;
         const ignoreGlobals = options.ignoreGlobals;
         const allow = options.allow || [];
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/capitalized-comments.js
+++ b/lib/rules/capitalized-comments.js
@@ -139,7 +139,7 @@ module.exports = {
 
         const capitalize = context.options[0] || "always",
             normalizedOptions = getAllNormalizedOptions(context.options[1]),
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
 
         createRegExpForIgnorePatterns(normalizedOptions);
 

--- a/lib/rules/class-methods-use-this.js
+++ b/lib/rules/class-methods-use-this.js
@@ -133,7 +133,7 @@ module.exports = {
             if (isIncludedInstanceMethod(node.parent) && !methodUsesThis) {
                 context.report({
                     node,
-                    loc: astUtils.getFunctionHeadLoc(node, context.getSourceCode()),
+                    loc: astUtils.getFunctionHeadLoc(node, context.sourceCode),
                     messageId: "missingThis",
                     data: {
                         name: astUtils.getFunctionNameWithKind(node)

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -136,7 +136,7 @@ module.exports = {
     create(context) {
         const options = normalizeOptions(context.options[0], context.languageOptions.ecmaVersion);
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Gets the last item of the given node.

--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -48,7 +48,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const tokensAndComments = sourceCode.tokensAndComments;
 
         const options = {

--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -51,7 +51,7 @@ module.exports = {
 
     create(context) {
         const style = context.options[0] || "last",
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
         const exceptions = {
             ArrayPattern: true,
             ArrowFunctionExpression: true,

--- a/lib/rules/computed-property-spacing.js
+++ b/lib/rules/computed-property-spacing.js
@@ -49,7 +49,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const propertyNameMustBeSpaced = context.options[0] === "always"; // default is "never"
         const enforceForClassMembers = !context.options[1] || context.options[1].enforceForClassMembers;
 

--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -104,7 +104,7 @@ module.exports = {
             } else if (node.type === "ArrowFunctionExpression") {
 
                 // `=>` token
-                loc = context.getSourceCode().getTokenBefore(node.body, astUtils.isArrowToken).loc;
+                loc = context.sourceCode.getTokenBefore(node.body, astUtils.isArrowToken).loc;
             } else if (
                 node.parent.type === "MethodDefinition" ||
                 (node.parent.type === "Property" && node.parent.method)
@@ -115,7 +115,7 @@ module.exports = {
             } else {
 
                 // Function name or `function` keyword.
-                loc = (node.id || context.getSourceCode().getFirstToken(node)).loc;
+                loc = (node.id || context.sourceCode.getFirstToken(node)).loc;
             }
 
             if (!name) {

--- a/lib/rules/consistent-this.js
+++ b/lib/rules/consistent-this.js
@@ -36,7 +36,7 @@ module.exports = {
 
     create(context) {
         let aliases = [];
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         if (context.options.length === 0) {
             aliases.push("that");

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -70,7 +70,7 @@ module.exports = {
         const multiOrNest = (context.options[0] === "multi-or-nest");
         const consistent = (context.options[1] === "consistent");
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/default-case.js
+++ b/lib/rules/default-case.js
@@ -42,7 +42,7 @@ module.exports = {
             ? new RegExp(options.commentPattern, "u")
             : DEFAULT_COMMENT_PATTERN;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/dot-location.js
+++ b/lib/rules/dot-location.js
@@ -43,7 +43,7 @@ module.exports = {
         // default to onObject if no preference is passed
         const onObject = config === "object" || !config;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports if the dot between object and property is on the correct location.

--- a/lib/rules/dot-notation.js
+++ b/lib/rules/dot-notation.js
@@ -59,7 +59,7 @@ module.exports = {
     create(context) {
         const options = context.options[0] || {};
         const allowKeywords = options.allowKeywords === void 0 || options.allowKeywords;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         let allowPattern;
 

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -40,7 +40,7 @@ module.exports = {
 
         return {
             Program: function checkBadEOF(node) {
-                const sourceCode = context.getSourceCode(),
+                const sourceCode = context.sourceCode,
                     src = sourceCode.getText(),
                     lastLine = sourceCode.lines[sourceCode.lines.length - 1],
                     location = {

--- a/lib/rules/eqeqeq.js
+++ b/lib/rules/eqeqeq.js
@@ -68,7 +68,7 @@ module.exports = {
     create(context) {
         const config = context.options[0] || "always";
         const options = context.options[1] || {};
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         const nullOption = (config === "always")
             ? options.null || "always"

--- a/lib/rules/func-call-spacing.js
+++ b/lib/rules/func-call-spacing.js
@@ -73,7 +73,7 @@ module.exports = {
 
         const never = context.options[0] !== "always";
         const allowNewlines = !never && context.options[1] && context.options[1].allowNewlines;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const text = sourceCode.getText();
 
         /**

--- a/lib/rules/func-names.js
+++ b/lib/rules/func-names.js
@@ -69,7 +69,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Returns the config option for the given node.

--- a/lib/rules/function-call-argument-newline.js
+++ b/lib/rules/function-call-argument-newline.js
@@ -35,7 +35,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         const checkers = {
             unexpected: {

--- a/lib/rules/function-paren-newline.js
+++ b/lib/rules/function-paren-newline.js
@@ -57,7 +57,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const rawOption = context.options[0] || "multiline";
         const multilineOption = rawOption === "multiline";
         const multilineArgumentsOption = rawOption === "multiline-arguments";

--- a/lib/rules/generator-star-spacing.js
+++ b/lib/rules/generator-star-spacing.js
@@ -102,7 +102,7 @@ module.exports = {
             };
         }(context.options[0] || {}));
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Checks if the given token is a star token or not.

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -64,7 +64,7 @@ module.exports = {
     create(context) {
 
         const options = context.options[0] || { allowImplicit: false };
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         let funcInfo = {
             upper: null,

--- a/lib/rules/global-require.js
+++ b/lib/rules/global-require.js
@@ -71,7 +71,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             CallExpression(node) {

--- a/lib/rules/grouped-accessor-pairs.js
+++ b/lib/rules/grouped-accessor-pairs.js
@@ -115,7 +115,7 @@ module.exports = {
 
     create(context) {
         const order = context.options[0] || "anyOrder";
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports the given accessor pair.

--- a/lib/rules/handle-callback-err.js
+++ b/lib/rules/handle-callback-err.js
@@ -38,7 +38,7 @@ module.exports = {
     create(context) {
 
         const errorArgument = context.options[0] || "err";
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Checks if the given argument should be interpreted as a regexp pattern.

--- a/lib/rules/id-blacklist.js
+++ b/lib/rules/id-blacklist.js
@@ -140,7 +140,7 @@ module.exports = {
 
         const denyList = new Set(context.options);
         const reportedNodes = new Set();
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         let globalScope;
 

--- a/lib/rules/id-denylist.js
+++ b/lib/rules/id-denylist.js
@@ -121,7 +121,7 @@ module.exports = {
 
         const denyList = new Set(context.options);
         const reportedNodes = new Set();
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         let globalScope;
 

--- a/lib/rules/id-match.js
+++ b/lib/rules/id-match.js
@@ -67,7 +67,7 @@ module.exports = {
             onlyDeclarations = !!options.onlyDeclarations,
             ignoreDestructuring = !!options.ignoreDestructuring;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         let globalScope;
 
         //--------------------------------------------------------------------------

--- a/lib/rules/implicit-arrow-linebreak.js
+++ b/lib/rules/implicit-arrow-linebreak.js
@@ -34,7 +34,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const option = context.options[0] || "beside";
 
         /**

--- a/lib/rules/indent-legacy.js
+++ b/lib/rules/indent-legacy.js
@@ -206,7 +206,7 @@ module.exports = {
             ObjectExpression: 1
         };
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         if (context.options.length) {
             if (context.options[0] === "tab") {

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -703,7 +703,7 @@ module.exports = {
             }
         }
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const tokenInfo = new TokenInfo(sourceCode);
         const offsets = new OffsetStorage(tokenInfo, indentSize, indentType === "space" ? " " : "\t");
         const parameterParens = new WeakSet();

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -326,7 +326,7 @@ module.exports = {
             singleLineOptions = ruleOptions.singleLine,
             alignmentOptions = ruleOptions.align || null;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Determines if the given property is key-value property.

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -108,7 +108,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         const tokensToIgnore = new WeakSet();
 

--- a/lib/rules/line-comment-position.js
+++ b/lib/rules/line-comment-position.js
@@ -78,7 +78,7 @@ module.exports = {
         const defaultIgnoreRegExp = astUtils.COMMENTS_IGNORE_PATTERN;
         const fallThroughRegExp = /^\s*falls?\s?through/u;
         const customIgnoreRegExp = new RegExp(ignorePattern, "u");
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Public

--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -40,7 +40,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -138,7 +138,7 @@ module.exports = {
 
         options.beforeBlockComment = typeof options.beforeBlockComment !== "undefined" ? options.beforeBlockComment : true;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         const lines = sourceCode.lines,
             numLines = lines.length + 1,

--- a/lib/rules/lines-around-directive.js
+++ b/lib/rules/lines-around-directive.js
@@ -54,7 +54,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const config = context.options[0] || "always";
         const expectLineBefore = typeof config === "string" ? config : config.before;
         const expectLineAfter = typeof config === "string" ? config : config.after;

--- a/lib/rules/lines-between-class-members.js
+++ b/lib/rules/lines-between-class-members.js
@@ -55,7 +55,7 @@ module.exports = {
         options[0] = context.options[0] || "always";
         options[1] = context.options[1] || { exceptAfterSingleLine: false };
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Gets a pair of tokens that should be used to check lines between two class member nodes.

--- a/lib/rules/logical-assignment-operators.js
+++ b/lib/rules/logical-assignment-operators.js
@@ -205,7 +205,7 @@ module.exports = {
     create(context) {
         const mode = context.options[0] === "never" ? "never" : "always";
         const checkIf = mode === "always" && context.options.length > 1 && context.options[1].enforceForIfStatements;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const isStrict = sourceCode.getScope(sourceCode.ast).isStrict;
 
         /**

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -97,7 +97,7 @@ module.exports = {
          */
         const URL_REGEXP = /[^:/?#]:\/\/[^?#]/u;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Computes the length of a line that may contain tabs. The width of each

--- a/lib/rules/max-lines-per-function.js
+++ b/lib/rules/max-lines-per-function.js
@@ -85,7 +85,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const lines = sourceCode.lines;
 
         const option = context.options[0];

--- a/lib/rules/max-lines.js
+++ b/lib/rules/max-lines.js
@@ -87,7 +87,7 @@ module.exports = {
         const skipComments = option && option.skipComments;
         const skipBlankLines = option && option.skipBlankLines;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Returns whether or not a token is a comment node type

--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -57,7 +57,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const option = context.options[0];
         let numParams = 3;
 

--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -45,7 +45,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode(),
+        const sourceCode = context.sourceCode,
             options = context.options[0] || {},
             maxStatementsPerLine = typeof options.max !== "undefined" ? options.max : 1;
 

--- a/lib/rules/multiline-comment-style.js
+++ b/lib/rules/multiline-comment-style.js
@@ -65,7 +65,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const option = context.options[0] || "starred-block";
         const params = context.options[1] || {};
         const checkJSDoc = !!params.checkJSDoc;

--- a/lib/rules/multiline-ternary.js
+++ b/lib/rules/multiline-ternary.js
@@ -39,7 +39,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const option = context.options[0];
         const multiline = option !== "never";
         const allowSingleLine = option === "always-multiline";

--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -147,7 +147,7 @@ module.exports = {
 
         const listeners = {};
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/new-parens.js
+++ b/lib/rules/new-parens.js
@@ -46,7 +46,7 @@ module.exports = {
         const options = context.options;
         const always = options[0] !== "never"; // Default is always
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             NewExpression(node) {

--- a/lib/rules/newline-after-var.js
+++ b/lib/rules/newline-after-var.js
@@ -43,7 +43,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         // Default `mode` to "always".
         const mode = context.options[0] === "never" ? "never" : "always";

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -31,7 +31,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/newline-per-chained-call.js
+++ b/lib/rules/newline-per-chained-call.js
@@ -47,7 +47,7 @@ module.exports = {
         const options = context.options[0] || {},
             ignoreChainWithDepth = options.ignoreChainWithDepth || 2;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Get the prefix of a given MemberExpression node.

--- a/lib/rules/no-alert.js
+++ b/lib/rules/no-alert.js
@@ -101,7 +101,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             CallExpression(node) {

--- a/lib/rules/no-async-promise-executor.js
+++ b/lib/rules/no-async-promise-executor.js
@@ -30,7 +30,7 @@ module.exports = {
         return {
             "NewExpression[callee.name='Promise'][arguments.0.async=true]"(node) {
                 context.report({
-                    node: context.getSourceCode().getFirstToken(node.arguments[0], token => token.value === "async"),
+                    node: context.sourceCode.getFirstToken(node.arguments[0], token => token.value === "async"),
                     messageId: "async"
                 });
             }

--- a/lib/rules/no-catch-shadow.js
+++ b/lib/rules/no-catch-shadow.js
@@ -39,7 +39,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/no-class-assign.js
+++ b/lib/rules/no-class-assign.js
@@ -31,7 +31,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Finds and reports references that are non initializer and writable.

--- a/lib/rules/no-cond-assign.js
+++ b/lib/rules/no-cond-assign.js
@@ -57,7 +57,7 @@ module.exports = {
 
         const prohibitAssign = (context.options[0] || "except-parens");
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Check whether an AST node is the test expression for a conditional statement.

--- a/lib/rules/no-confusing-arrow.js
+++ b/lib/rules/no-confusing-arrow.js
@@ -56,7 +56,7 @@ module.exports = {
         const config = context.options[0] || {};
         const allowParens = config.allowParens || (config.allowParens === void 0);
         const onlyOneSimpleParam = config.onlyOneSimpleParam;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
 
         /**

--- a/lib/rules/no-console.js
+++ b/lib/rules/no-console.js
@@ -51,7 +51,7 @@ module.exports = {
     create(context) {
         const options = context.options[0] || {};
         const allowed = options.allow || [];
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Checks whether the given reference is 'console' or not.

--- a/lib/rules/no-const-assign.js
+++ b/lib/rules/no-const-assign.js
@@ -31,7 +31,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Finds and reports references that are non initializer and writable.

--- a/lib/rules/no-constant-binary-expression.js
+++ b/lib/rules/no-constant-binary-expression.js
@@ -453,7 +453,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             LogicalExpression(node) {

--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -48,7 +48,7 @@ module.exports = {
         const options = context.options[0] || {},
             checkLoops = options.checkLoops !== false,
             loopSetStack = [];
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         let loopsInCurrentScope = new Set();
 

--- a/lib/rules/no-div-regex.js
+++ b/lib/rules/no-div-regex.js
@@ -30,7 +30,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
 

--- a/lib/rules/no-dupe-args.js
+++ b/lib/rules/no-dupe-args.js
@@ -29,7 +29,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/no-dupe-else-if.js
+++ b/lib/rules/no-dupe-else-if.js
@@ -65,7 +65,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Determines whether the two given nodes are considered to be equal. In particular, given that the nodes

--- a/lib/rules/no-duplicate-case.js
+++ b/lib/rules/no-duplicate-case.js
@@ -35,7 +35,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Determines whether the two given nodes are considered to be equal.

--- a/lib/rules/no-else-return.js
+++ b/lib/rules/no-else-return.js
@@ -47,7 +47,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/no-empty-function.js
+++ b/lib/rules/no-empty-function.js
@@ -123,7 +123,7 @@ module.exports = {
         const options = context.options[0] || {};
         const allowed = options.allow || [];
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports a given function node if the node matches the following patterns.

--- a/lib/rules/no-empty-static-block.js
+++ b/lib/rules/no-empty-static-block.js
@@ -27,7 +27,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             StaticBlock(node) {

--- a/lib/rules/no-empty.js
+++ b/lib/rules/no-empty.js
@@ -49,7 +49,7 @@ module.exports = {
         const options = context.options[0] || {},
             allowEmptyCatch = options.allowEmptyCatch || false;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             BlockStatement(node) {

--- a/lib/rules/no-eval.js
+++ b/lib/rules/no-eval.js
@@ -68,7 +68,7 @@ module.exports = {
             context.options[0] &&
             context.options[0].allowIndirect
         );
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         let funcInfo = null;
 
         /**

--- a/lib/rules/no-ex-assign.js
+++ b/lib/rules/no-ex-assign.js
@@ -31,7 +31,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Finds and reports references that are non initializer and writable.

--- a/lib/rules/no-extend-native.js
+++ b/lib/rules/no-extend-native.js
@@ -51,7 +51,7 @@ module.exports = {
     create(context) {
 
         const config = context.options[0] || {};
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const exceptions = new Set(config.exceptions || []);
         const modifiedBuiltins = new Set(
             Object.keys(globals.builtin)

--- a/lib/rules/no-extra-bind.js
+++ b/lib/rules/no-extra-bind.js
@@ -40,7 +40,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         let scopeInfo = null;
 
         /**

--- a/lib/rules/no-extra-boolean-cast.js
+++ b/lib/rules/no-extra-boolean-cast.js
@@ -48,7 +48,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         // Node types which have a test which will coerce values to booleans.
         const BOOLEAN_NODE_TYPES = new Set([

--- a/lib/rules/no-extra-label.js
+++ b/lib/rules/no-extra-label.js
@@ -35,7 +35,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         let scopeInfo = null;
 
         /**

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -70,7 +70,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         const tokensToIgnore = new WeakSet();
         const precedence = astUtils.getPrecedence;

--- a/lib/rules/no-extra-semi.js
+++ b/lib/rules/no-extra-semi.js
@@ -36,7 +36,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports an unnecessary semicolon error.
@@ -54,7 +54,7 @@ module.exports = {
                      * tokens to avoid conflicting with semi.
                      * https://github.com/eslint/eslint/issues/7928
                      */
-                    return new FixTracker(fixer, context.getSourceCode())
+                    return new FixTracker(fixer, context.sourceCode)
                         .retainSurroundingTokens(nodeOrToken)
                         .remove(nodeOrToken);
                 }

--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -35,7 +35,7 @@ function isFallThroughComment(comment, fallthroughCommentPattern) {
  * @returns {boolean} `true` if the case has a valid fallthrough comment.
  */
 function hasFallthroughComment(caseWhichFallsThrough, subsequentCase, context, fallthroughCommentPattern) {
-    const sourceCode = context.getSourceCode();
+    const sourceCode = context.sourceCode;
 
     if (caseWhichFallsThrough.consequent.length === 1 && caseWhichFallsThrough.consequent[0].type === "BlockStatement") {
         const trailingCloseBrace = sourceCode.getLastToken(caseWhichFallsThrough.consequent[0]);
@@ -110,7 +110,7 @@ module.exports = {
     create(context) {
         const options = context.options[0] || {};
         let currentCodePath = null;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const allowEmptyCase = options.allowEmptyCase || false;
 
         /*

--- a/lib/rules/no-floating-decimal.js
+++ b/lib/rules/no-floating-decimal.js
@@ -35,7 +35,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             Literal(node) {

--- a/lib/rules/no-func-assign.js
+++ b/lib/rules/no-func-assign.js
@@ -31,7 +31,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports a reference if is non initializer and writable.

--- a/lib/rules/no-global-assign.js
+++ b/lib/rules/no-global-assign.js
@@ -41,7 +41,7 @@ module.exports = {
 
     create(context) {
         const config = context.options[0];
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const exceptions = (config && config.exceptions) || [];
 
         /**

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -235,7 +235,7 @@ module.exports = {
 
     create(context) {
         const options = parseOptions(context.options[0] || {});
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports an error and autofixes the node

--- a/lib/rules/no-implicit-globals.js
+++ b/lib/rules/no-implicit-globals.js
@@ -43,7 +43,7 @@ module.exports = {
     create(context) {
 
         const checkLexicalBindings = context.options[0] && context.options[0].lexicalBindings === true;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports the node.

--- a/lib/rules/no-implied-eval.js
+++ b/lib/rules/no-implied-eval.js
@@ -37,7 +37,7 @@ module.exports = {
     create(context) {
         const GLOBAL_CANDIDATES = Object.freeze(["global", "window", "globalThis"]);
         const EVAL_LIKE_FUNC_PATTERN = /^(?:set(?:Interval|Timeout)|execScript)$/u;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Checks whether a node is evaluated as a string or not.

--- a/lib/rules/no-import-assign.js
+++ b/lib/rules/no-import-assign.js
@@ -194,7 +194,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             ImportDeclaration(node) {

--- a/lib/rules/no-inline-comments.js
+++ b/lib/rules/no-inline-comments.js
@@ -39,7 +39,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const options = context.options[0];
         let customIgnoreRegExp;
 

--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -63,7 +63,7 @@ module.exports = {
         const options = context.options[0] || {};
         const capIsConstructor = options.capIsConstructor !== false;
         const stack = [],
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
 
         /**
          * Gets the current checking context.

--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -78,7 +78,7 @@ module.exports = {
         const skipRegExps = !!options.skipRegExps;
         const skipTemplates = !!options.skipTemplates;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const commentNodes = sourceCode.getAllComments();
 
         /**

--- a/lib/rules/no-label-var.js
+++ b/lib/rules/no-label-var.js
@@ -34,7 +34,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/no-lone-blocks.js
+++ b/lib/rules/no-lone-blocks.js
@@ -33,7 +33,7 @@ module.exports = {
         // A stack of lone blocks to be checked for block-level bindings
         const loneBlocks = [];
         let ruleDef;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports a node as invalid.

--- a/lib/rules/no-lonely-if.js
+++ b/lib/rules/no-lonely-if.js
@@ -28,7 +28,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             IfStatement(node) {

--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -168,7 +168,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports functions which match the following condition:

--- a/lib/rules/no-misleading-character-class.js
+++ b/lib/rules/no-misleading-character-class.js
@@ -125,7 +125,7 @@ module.exports = {
         }
     },
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const parser = new RegExpParser();
 
         /**

--- a/lib/rules/no-mixed-operators.js
+++ b/lib/rules/no-mixed-operators.js
@@ -122,7 +122,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const options = normalizeOptions(context.options[0]);
 
         /**

--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -31,7 +31,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         let smartTabs;
 

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -52,7 +52,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const options = context.options[0] || {};
         const ignoreEOLComments = options.ignoreEOLComments;
         const exceptions = Object.assign({ Property: true }, options.exceptions);

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -64,7 +64,7 @@ module.exports = {
             maxBOF = typeof context.options[0].maxBOF !== "undefined" ? context.options[0].maxBOF : max;
         }
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         // Swallow the final newline, as some editors add it automatically and we don't want it to cause an issue
         const allLines = sourceCode.lines[sourceCode.lines.length - 1] === "" ? sourceCode.lines.slice(0, -1) : sourceCode.lines;

--- a/lib/rules/no-native-reassign.js
+++ b/lib/rules/no-native-reassign.js
@@ -47,7 +47,7 @@ module.exports = {
     create(context) {
         const config = context.options[0];
         const exceptions = (config && config.exceptions) || [];
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports write references.

--- a/lib/rules/no-new-func.js
+++ b/lib/rules/no-new-func.js
@@ -40,7 +40,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             "Program:exit"(node) {

--- a/lib/rules/no-new-native-nonconstructor.js
+++ b/lib/rules/no-new-native-nonconstructor.js
@@ -35,7 +35,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             "Program:exit"(node) {

--- a/lib/rules/no-new-object.js
+++ b/lib/rules/no-new-object.js
@@ -35,7 +35,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             NewExpression(node) {

--- a/lib/rules/no-new-symbol.js
+++ b/lib/rules/no-new-symbol.js
@@ -29,7 +29,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             "Program:exit"(node) {

--- a/lib/rules/no-nonoctal-decimal-escape.js
+++ b/lib/rules/no-nonoctal-decimal-escape.js
@@ -49,7 +49,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Creates a new Suggestion object.

--- a/lib/rules/no-obj-calls.js
+++ b/lib/rules/no-obj-calls.js
@@ -58,7 +58,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             Program(node) {

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -70,7 +70,7 @@ module.exports = {
         const props = context.options[0] && context.options[0].props;
         const ignoredPropertyAssignmentsFor = context.options[0] && context.options[0].ignorePropertyModificationsFor || [];
         const ignoredPropertyAssignmentsForRegex = context.options[0] && context.options[0].ignorePropertyModificationsForRegex || [];
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Checks whether or not the reference modifies properties of its variable.

--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -84,7 +84,7 @@ module.exports = {
     create(context) {
 
         let funcInfo = null;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports the given node.

--- a/lib/rules/no-redeclare.js
+++ b/lib/rules/no-redeclare.js
@@ -50,7 +50,7 @@ module.exports = {
                 context.options[0].builtinGlobals
             )
         };
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Iterate declarations of a given variable.

--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -54,7 +54,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Validate regular expression

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -99,7 +99,7 @@ module.exports = {
 
         const restrictedNames = new Set(context.options[0] && context.options[0].restrictedNamedExports);
         const restrictDefaultExports = context.options[0] && context.options[0].restrictDefaultExports;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Checks and reports given exported name.

--- a/lib/rules/no-restricted-globals.js
+++ b/lib/rules/no-restricted-globals.js
@@ -50,7 +50,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         // If no globals are restricted, we don't need to do anything
         if (context.options.length === 0) {

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -147,7 +147,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const options = Array.isArray(context.options) ? context.options : [];
         const isPathAndPatternsObject =
             typeof options[0] === "object" &&

--- a/lib/rules/no-return-assign.js
+++ b/lib/rules/no-return-assign.js
@@ -45,7 +45,7 @@ module.exports = {
 
     create(context) {
         const always = (context.options[0] || "except-parens") !== "except-parens";
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             AssignmentExpression(node) {

--- a/lib/rules/no-return-await.js
+++ b/lib/rules/no-return-await.js
@@ -44,14 +44,14 @@ module.exports = {
          */
         function reportUnnecessaryAwait(node) {
             context.report({
-                node: context.getSourceCode().getFirstToken(node),
+                node: context.sourceCode.getFirstToken(node),
                 loc: node.loc,
                 messageId: "redundantUseOfAwait",
                 suggest: [
                     {
                         messageId: "removeAwait",
                         fix(fixer) {
-                            const sourceCode = context.getSourceCode();
+                            const sourceCode = context.sourceCode;
                             const [awaitToken, tokenAfterAwait] = sourceCode.getFirstTokens(node, 2);
 
                             const areAwaitAndAwaitedExpressionOnTheSameLine = awaitToken.loc.start.line === tokenAfterAwait.loc.start.line;

--- a/lib/rules/no-self-assign.js
+++ b/lib/rules/no-self-assign.js
@@ -154,7 +154,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const [{ props = true } = {}] = context.options;
 
         /**

--- a/lib/rules/no-self-compare.js
+++ b/lib/rules/no-self-compare.js
@@ -29,7 +29,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Determines whether two nodes are composed of the same tokens.

--- a/lib/rules/no-sequences.js
+++ b/lib/rules/no-sequences.js
@@ -51,7 +51,7 @@ module.exports = {
 
     create(context) {
         const options = Object.assign({}, DEFAULT_OPTIONS, context.options[0]);
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Parts of the grammar that are required to have parens.

--- a/lib/rules/no-setter-return.js
+++ b/lib/rules/no-setter-return.js
@@ -156,7 +156,7 @@ module.exports = {
 
     create(context) {
         let funcInfo = null;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Creates and pushes to the stack a function info object for the given function node.

--- a/lib/rules/no-shadow-restricted-names.js
+++ b/lib/rules/no-shadow-restricted-names.js
@@ -43,7 +43,7 @@ module.exports = {
 
 
         const RESTRICTED = new Set(["undefined", "NaN", "Infinity", "arguments", "eval"]);
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             "VariableDeclaration, :function, CatchClause"(node) {

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -67,7 +67,7 @@ module.exports = {
             allow: (context.options[0] && context.options[0].allow) || [],
             ignoreOnInitialization: context.options[0] && context.options[0].ignoreOnInitialization
         };
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Checks whether or not a given location is inside of the range of a given node.

--- a/lib/rules/no-spaced-func.js
+++ b/lib/rules/no-spaced-func.js
@@ -35,7 +35,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Check if open space is present in a function name

--- a/lib/rules/no-tabs.js
+++ b/lib/rules/no-tabs.js
@@ -43,7 +43,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const allowIndentationTabs = context.options && context.options[0] && context.options[0].allowIndentationTabs;
 
         return {

--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -50,7 +50,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         const BLANK_CLASS = "[ \t\u00a0\u2000-\u200b\u3000]",
             SKIP_BLANK = `^${BLANK_CLASS}*$`,

--- a/lib/rules/no-undef-init.js
+++ b/lib/rules/no-undef-init.js
@@ -32,7 +32,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
 

--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -54,7 +54,7 @@ module.exports = {
     create(context) {
         const options = context.options[0];
         const considerTypeOf = options && options.typeof === true || false;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             "Program:exit"(node) {

--- a/lib/rules/no-undefined.js
+++ b/lib/rules/no-undefined.js
@@ -28,7 +28,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Report an invalid "undefined" identifier node.

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -84,7 +84,7 @@ module.exports = {
         const allowFunctionParams = typeof options.allowFunctionParams !== "undefined" ? options.allowFunctionParams : true;
         const allowInArrayDestructuring = typeof options.allowInArrayDestructuring !== "undefined" ? options.allowInArrayDestructuring : true;
         const allowInObjectDestructuring = typeof options.allowInObjectDestructuring !== "undefined" ? options.allowInObjectDestructuring : true;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //-------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/no-unexpected-multiline.js
+++ b/lib/rules/no-unexpected-multiline.js
@@ -38,7 +38,7 @@ module.exports = {
 
         const REGEX_FLAG_MATCHER = /^[gimsuy]+$/u;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Check to see if there is a newline between the node and the following open bracket

--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -175,7 +175,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         let groupMap = null;
 
         /**

--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -58,7 +58,7 @@ module.exports = {
     create(context) {
         const options = context.options[0] || {};
         const defaultAssignment = options.defaultAssignment !== false;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Test if the node is a boolean literal

--- a/lib/rules/no-unreachable.js
+++ b/lib/rules/no-unreachable.js
@@ -130,7 +130,7 @@ module.exports = {
         let constructorInfo = null;
 
         /** @type {ConsecutiveRange} */
-        const range = new ConsecutiveRange(context.getSourceCode());
+        const range = new ConsecutiveRange(context.sourceCode);
 
         /**
          * Reports a given node if it's unreachable.

--- a/lib/rules/no-unsafe-negation.js
+++ b/lib/rules/no-unsafe-negation.js
@@ -82,7 +82,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const options = context.options[0] || {};
         const enforceForOrderingRelations = options.enforceForOrderingRelations === true;
 

--- a/lib/rules/no-unused-labels.js
+++ b/lib/rules/no-unused-labels.js
@@ -30,7 +30,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         let scopeInfo = null;
 
         /**

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -84,7 +84,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         const REST_PROPERTY_TYPE = /^(?:RestElement|(?:Experimental)?RestProperty)$/u;
 

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -258,7 +258,7 @@ module.exports = {
 
     create(context) {
         const options = parseOptions(context.options[0]);
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Determines whether a given reference should be checked.

--- a/lib/rules/no-useless-backreference.js
+++ b/lib/rules/no-useless-backreference.js
@@ -82,7 +82,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Checks and reports useless backreferences in the given regular expression.

--- a/lib/rules/no-useless-call.js
+++ b/lib/rules/no-useless-call.js
@@ -68,7 +68,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             CallExpression(node) {

--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -113,7 +113,7 @@ module.exports = {
         }
     },
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const enforceForClassMembers = context.options[0] && context.options[0].enforceForClassMembers;
 
         /**

--- a/lib/rules/no-useless-concat.js
+++ b/lib/rules/no-useless-concat.js
@@ -83,7 +83,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             BinaryExpression(node) {

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -101,7 +101,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports a node

--- a/lib/rules/no-useless-rename.js
+++ b/lib/rules/no-useless-rename.js
@@ -46,7 +46,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode(),
+        const sourceCode = context.sourceCode,
             options = context.options[0] || {},
             ignoreDestructuring = options.ignoreDestructuring === true,
             ignoreImport = options.ignoreImport === true,

--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -83,7 +83,7 @@ module.exports = {
     create(context) {
         const segmentInfoMap = new WeakMap();
         const usedUnreachableSegments = new WeakSet();
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         let scopeInfo = null;
 
         /**

--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -199,7 +199,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Checks whether the variables which are defined by the given declarator node have their references in TDZ.

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -58,7 +58,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode(),
+        const sourceCode = context.sourceCode,
             configuration = context.options[0] || {},
             warningTerms = configuration.terms || ["todo", "fixme", "xxx"],
             location = configuration.location || "start",

--- a/lib/rules/no-whitespace-before-property.js
+++ b/lib/rules/no-whitespace-before-property.js
@@ -34,7 +34,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/nonblock-statement-body-position.js
+++ b/lib/rules/nonblock-statement-body-position.js
@@ -49,7 +49,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //----------------------------------------------------------------------
         // Helpers

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -185,7 +185,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const normalizedOptions = normalizeOptions(context.options[0]);
 
         /**

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -51,7 +51,7 @@ module.exports = {
 
     create(context) {
         const spaced = context.options[0] === "always",
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
 
         /**
          * Determines whether an option is set, relative to the spacing option.
@@ -81,7 +81,7 @@ module.exports = {
          * @returns {void}
          */
         function reportNoBeginningSpace(node, token) {
-            const nextToken = context.getSourceCode().getTokenAfter(token, { includeComments: true });
+            const nextToken = context.sourceCode.getTokenAfter(token, { includeComments: true });
 
             context.report({
                 node,
@@ -103,7 +103,7 @@ module.exports = {
          * @returns {void}
          */
         function reportNoEndingSpace(node, token) {
-            const previousToken = context.getSourceCode().getTokenBefore(token, { includeComments: true });
+            const previousToken = context.sourceCode.getTokenBefore(token, { includeComments: true });
 
             context.report({
                 node,

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -53,7 +53,7 @@ module.exports = {
             ? "propertiesOnNewlineAll"
             : "propertiesOnNewline";
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             ObjectExpression(node) {

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -123,7 +123,7 @@ module.exports = {
             : null;
         const AVOID_QUOTES = PARAMS.avoidQuotes;
         const AVOID_EXPLICIT_RETURN_ARROWS = !!PARAMS.avoidExplicitReturnArrows;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -121,7 +121,7 @@ module.exports = {
             }
         }
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/operator-assignment.js
+++ b/lib/rules/operator-assignment.js
@@ -83,7 +83,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Returns the operator token of an AssignmentExpression or BinaryExpression

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -69,7 +69,7 @@ module.exports = {
             styleOverrides[":"] = "before";
         }
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -96,7 +96,7 @@ module.exports = {
             options.allowSingleLineBlocks = exceptOptions.allowSingleLineBlocks === true;
         }
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Gets the open brace token from a given node.

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -253,7 +253,7 @@ function verifyForNever(context, _, nextNode, paddingLines) {
             const nextToken = paddingLines[0][1];
             const start = prevToken.range[1];
             const end = nextToken.range[0];
-            const text = context.getSourceCode().text
+            const text = context.sourceCode.text
                 .slice(start, end)
                 .replace(PADDING_LINE_SEQUENCE, replacerToRemovePaddingLines);
 
@@ -284,7 +284,7 @@ function verifyForAlways(context, prevNode, nextNode, paddingLines) {
         node: nextNode,
         messageId: "expectedBlankLine",
         fix(fixer) {
-            const sourceCode = context.getSourceCode();
+            const sourceCode = context.sourceCode;
             let prevToken = getActualLastToken(sourceCode, prevNode);
             const nextToken = sourceCode.getFirstTokenBetween(
                 prevToken,
@@ -475,7 +475,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const configureList = context.options || [];
         let scopeInfo = null;
 

--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -185,7 +185,7 @@ module.exports = {
 
         const allowUnboundThis = options.allowUnboundThis !== false; // default to true
         const allowNamedFunctions = options.allowNamedFunctions;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /*
          * {Array<{this: boolean, super: boolean, meta: boolean}>}

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -356,7 +356,7 @@ module.exports = {
 
     create(context) {
         const options = context.options[0] || {};
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const shouldMatchAnyDestructuredVariable = options.destructuring !== "all";
         const ignoreReadBeforeAssign = options.ignoreReadBeforeAssign === true;
         const variables = [];

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -190,7 +190,7 @@ module.exports = {
          */
         function fixIntoObjectDestructuring(fixer, node) {
             const rightNode = node.init;
-            const sourceCode = context.getSourceCode();
+            const sourceCode = context.sourceCode;
 
             // Don't fix if that would remove any comments. Only comments inside `rightNode.object` can be preserved.
             if (sourceCode.getCommentsInside(node).length > sourceCode.getCommentsInside(rightNode.object).length) {

--- a/lib/rules/prefer-exponentiation-operator.js
+++ b/lib/rules/prefer-exponentiation-operator.js
@@ -104,7 +104,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports the given node.

--- a/lib/rules/prefer-named-capture-group.js
+++ b/lib/rules/prefer-named-capture-group.js
@@ -105,7 +105,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Function to check regular expression.

--- a/lib/rules/prefer-numeric-literals.js
+++ b/lib/rules/prefer-numeric-literals.js
@@ -60,7 +60,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //----------------------------------------------------------------------
         // Public

--- a/lib/rules/prefer-object-has-own.js
+++ b/lib/rules/prefer-object-has-own.js
@@ -62,7 +62,7 @@ module.exports = {
     },
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             CallExpression(node) {

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -261,7 +261,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             Program(node) {

--- a/lib/rules/prefer-promise-reject-errors.js
+++ b/lib/rules/prefer-promise-reject-errors.js
@@ -41,7 +41,7 @@ module.exports = {
     create(context) {
 
         const ALLOW_EMPTY_REJECT = context.options.length && context.options[0].allowEmptyReject;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //----------------------------------------------------------------------
         // Helpers

--- a/lib/rules/prefer-regex-literals.js
+++ b/lib/rules/prefer-regex-literals.js
@@ -154,7 +154,7 @@ module.exports = {
 
     create(context) {
         const [{ disallowRedundantWrapping = false } = {}] = context.options;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Determines whether the given identifier node is a reference to a global variable.

--- a/lib/rules/prefer-rest-params.js
+++ b/lib/rules/prefer-rest-params.js
@@ -79,7 +79,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports a given reference.

--- a/lib/rules/prefer-spread.js
+++ b/lib/rules/prefer-spread.js
@@ -63,7 +63,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             CallExpression(node) {

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -142,7 +142,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         let done = Object.create(null);
 
         /**

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -86,7 +86,7 @@ module.exports = {
             CHECK_UNNECESSARY = !context.options[1] || context.options[1].unnecessary !== false,
             NUMBERS = context.options[1] && context.options[1].numbers,
 
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
 
 
         /**

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -123,7 +123,7 @@ module.exports = {
             settings = QUOTE_SETTINGS[quoteOption || "double"],
             options = context.options[1],
             allowTemplateLiterals = options && options.allowTemplateLiterals === true,
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
         let avoidEscape = options && options.avoidEscape === true;
 
         // deprecated

--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -104,7 +104,7 @@ module.exports = {
 
     create(context) {
         const mode = context.options[0] || MODE_ALWAYS;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Checks the arguments of a given CallExpression node and reports it if it

--- a/lib/rules/require-atomic-updates.js
+++ b/lib/rules/require-atomic-updates.js
@@ -198,7 +198,7 @@ module.exports = {
     create(context) {
         const allowProperties = !!context.options[0] && context.options[0].allowProperties;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const assignmentReferences = new Map();
         const segmentInfo = new SegmentInfo();
         let stack = null;

--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -47,7 +47,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         let scopeInfo = null;
 
         /**

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -61,7 +61,7 @@ module.exports = {
     },
 
     create(context) {
-        const source = context.getSourceCode();
+        const source = context.sourceCode;
         const DEFAULT_OPTIONS = {
             FunctionDeclaration: true,
             MethodDefinition: false,

--- a/lib/rules/require-unicode-regexp.js
+++ b/lib/rules/require-unicode-regexp.js
@@ -45,7 +45,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             "Literal[regex]"(node) {

--- a/lib/rules/rest-spread-spacing.js
+++ b/lib/rules/rest-spread-spacing.js
@@ -35,7 +35,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode(),
+        const sourceCode = context.sourceCode,
             alwaysSpace = context.options[0] === "always";
 
         //--------------------------------------------------------------------------

--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -52,7 +52,7 @@ module.exports = {
     create(context) {
 
         const config = context.options[0],
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
         let requireSpaceBefore = false,
             requireSpaceAfter = true;
 

--- a/lib/rules/semi-style.js
+++ b/lib/rules/semi-style.js
@@ -87,7 +87,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const option = context.options[0] || "last";
 
         /**

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -86,7 +86,7 @@ module.exports = {
         const exceptOneLine = Boolean(options && options.omitLastInOneLineBlock);
         const exceptOneLineClassBody = Boolean(options && options.omitLastInOneLineClassBody);
         const beforeStatementContinuationChars = options && options.beforeStatementContinuationChars || "any";
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -71,7 +71,7 @@ module.exports = {
             ignoreMemberSort = configuration.ignoreMemberSort || false,
             memberSyntaxSortOrder = configuration.memberSyntaxSortOrder || ["none", "all", "multiple", "single"],
             allowSeparatedGroups = configuration.allowSeparatedGroups || false,
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
         let previousDeclaration = null;
 
         /**

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -135,7 +135,7 @@ module.exports = {
 
         // The stack to save the previous property's name for each object literals.
         let stack = null;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             ObjectExpression(node) {

--- a/lib/rules/sort-vars.js
+++ b/lib/rules/sort-vars.js
@@ -44,7 +44,7 @@ module.exports = {
 
         const configuration = context.options[0] || {},
             ignoreCase = configuration.ignoreCase || false,
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
 
         return {
             VariableDeclaration(node) {

--- a/lib/rules/space-before-blocks.js
+++ b/lib/rules/space-before-blocks.js
@@ -80,7 +80,7 @@ module.exports = {
 
     create(context) {
         const config = context.options[0],
-            sourceCode = context.getSourceCode();
+            sourceCode = context.sourceCode;
         let alwaysFunctions = true,
             alwaysKeywords = true,
             alwaysClasses = true,

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -59,7 +59,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const baseConfig = typeof context.options[0] === "string" ? context.options[0] : "always";
         const overrideConfig = typeof context.options[0] === "object" ? context.options[0] : {};
 

--- a/lib/rules/space-in-parens.js
+++ b/lib/rules/space-in-parens.js
@@ -102,7 +102,7 @@ module.exports = {
         //--------------------------------------------------------------------------
         // Helpers
         //--------------------------------------------------------------------------
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Determines if a token is one of the exceptions for the opener paren

--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -43,7 +43,7 @@ module.exports = {
 
     create(context) {
         const int32Hint = context.options[0] ? context.options[0].int32Hint === true : false;
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Returns the first token which violates the rule

--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -62,7 +62,7 @@ module.exports = {
     create(context) {
         const options = context.options[0] || { words: true, nonwords: false };
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -235,7 +235,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         // Unless the first option is never, require a space
         const requireSpace = context.options[0] !== "never";

--- a/lib/rules/switch-colon-spacing.js
+++ b/lib/rules/switch-colon-spacing.js
@@ -46,7 +46,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const options = context.options[0] || {};
         const beforeSpacing = options.before === true; // false by default
         const afterSpacing = options.after !== false; // true by default

--- a/lib/rules/symbol-description.js
+++ b/lib/rules/symbol-description.js
@@ -35,7 +35,7 @@ module.exports = {
 
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Reports if node does not conform the rule in case rule is set to

--- a/lib/rules/template-curly-spacing.js
+++ b/lib/rules/template-curly-spacing.js
@@ -40,7 +40,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const always = context.options[0] === "always";
 
         /**

--- a/lib/rules/template-tag-spacing.js
+++ b/lib/rules/template-tag-spacing.js
@@ -33,7 +33,7 @@ module.exports = {
 
     create(context) {
         const never = context.options[0] !== "always";
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Check if a space is present between a template tag and its literal

--- a/lib/rules/unicode-bom.js
+++ b/lib/rules/unicode-bom.js
@@ -42,7 +42,7 @@ module.exports = {
 
             Program: function checkUnicodeBOM(node) {
 
-                const sourceCode = context.getSourceCode(),
+                const sourceCode = context.sourceCode,
                     location = { column: 0, line: 1 },
                     requireBOM = context.options[0] || "never";
 

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -96,7 +96,7 @@ module.exports = {
 
         const options = context.options[0] || {},
             prefer = options.prefer || {},
-            sourceCode = context.getSourceCode(),
+            sourceCode = context.sourceCode,
 
             // these both default to true, so you have to explicitly make them false
             requireReturn = options.requireReturn !== false,

--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -44,7 +44,7 @@ module.exports = {
 
         const VALID_TYPES = new Set(["symbol", "undefined", "object", "boolean", "number", "string", "function", "bigint"]),
             OPERATORS = new Set(["==", "===", "!=", "!=="]);
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const requireStringLiterals = context.options[0] && context.options[0].requireStringLiterals;
 
         let globalScope;

--- a/lib/rules/wrap-iife.js
+++ b/lib/rules/wrap-iife.js
@@ -77,7 +77,7 @@ module.exports = {
         const style = context.options[0] || "outside";
         const includeFunctionPrototypeMethods = context.options[1] && context.options[1].functionPrototypeMethods;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Check if the node is wrapped in any (). All parens count: grouping parens and parens for constructs such as if()

--- a/lib/rules/wrap-regex.js
+++ b/lib/rules/wrap-regex.js
@@ -29,7 +29,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
 

--- a/lib/rules/yield-star-spacing.js
+++ b/lib/rules/yield-star-spacing.js
@@ -48,7 +48,7 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         const mode = (function(option) {
             if (!option || typeof option === "string") {

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -162,7 +162,7 @@ module.exports = {
         const onlyEquality =
             context.options[1] && context.options[1].onlyEquality;
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Determines whether node represents a range test.

--- a/tests/fixtures/testers/rule-tester/no-test-global.js
+++ b/tests/fixtures/testers/rule-tester/no-test-global.js
@@ -16,7 +16,7 @@ module.exports = {
     },
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             "Program"(node) {

--- a/tests/fixtures/testers/rule-tester/no-var.js
+++ b/tests/fixtures/testers/rule-tester/no-var.js
@@ -15,7 +15,7 @@ module.exports = {
         schema: []
     },
     create(context) {
-        var sourceCode = context.getSourceCode();
+        var sourceCode = context.sourceCode;
 
         return {
             "VariableDeclaration": function(node) {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -116,6 +116,7 @@ describe("Linter", () => {
 
         it("has all the `parent` properties on nodes when the rule listeners are created", () => {
             const spy = sinon.spy(context => {
+                assert.strictEqual(context.getSourceCode(), context.sourceCode);
                 const ast = context.sourceCode.ast;
 
                 assert.strictEqual(ast.body[0].parent, ast);
@@ -3780,6 +3781,7 @@ var a = "test2";
                             const sourceCode = context.sourceCode;
                             const comments = sourceCode.getAllComments();
 
+                            assert.strictEqual(context.getSourceCode(), sourceCode);
                             assert.strictEqual(1, comments.length);
 
                             const foo = getVariable(scope, "foo");
@@ -5436,6 +5438,7 @@ var a = "test2";
                             const sourceCode = context.sourceCode;
                             const comments = sourceCode.getAllComments();
 
+                            assert.strictEqual(context.getSourceCode(), sourceCode);
                             assert.strictEqual(2, comments.length);
 
                             const foo = getVariable(scope, "foo");
@@ -8962,6 +8965,7 @@ describe("Linter with FlatConfigArray", () => {
 
             it("should have all the `parent` properties on nodes when the rule visitors are created", () => {
                 const spy = sinon.spy(context => {
+                    assert.strictEqual(context.getSourceCode(), context.sourceCode);
                     const ast = context.sourceCode.ast;
 
                     assert.strictEqual(ast.body[0].parent, ast);
@@ -11617,6 +11621,7 @@ describe("Linter with FlatConfigArray", () => {
                                                 const sourceCode = context.sourceCode;
                                                 const comments = sourceCode.getAllComments();
 
+                                                assert.strictEqual(context.getSourceCode(), sourceCode);
                                                 assert.strictEqual(2, comments.length);
 
                                                 const foo = getVariable(scope, "foo");
@@ -13899,6 +13904,7 @@ var a = "test2";
                                                     const sourceCode = context.sourceCode;
                                                     const comments = sourceCode.getAllComments();
 
+                                                    assert.strictEqual(context.getSourceCode(), sourceCode);
                                                     assert.strictEqual(1, comments.length);
 
                                                     const foo = getVariable(scope, "foo");

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -3777,7 +3777,7 @@ var a = "test2";
                     create: context => ({
                         Program() {
                             const scope = context.getScope();
-                            const sourceCode = context.getSourceCode();
+                            const sourceCode = context.sourceCode;
                             const comments = sourceCode.getAllComments();
 
                             assert.strictEqual(1, comments.length);
@@ -5433,7 +5433,7 @@ var a = "test2";
                     create: context => ({
                         Program() {
                             const scope = context.getScope();
-                            const sourceCode = context.getSourceCode();
+                            const sourceCode = context.sourceCode;
                             const comments = sourceCode.getAllComments();
 
                             assert.strictEqual(2, comments.length);
@@ -6765,7 +6765,8 @@ var a = "test2";
 
                         receivedFilenames.push(context.filename);
                         receivedPhysicalFilenames.push(context.physicalFilename);
-                        context.report({ node: ast, message: context.getSourceCode().text });
+
+                        context.report({ node: ast, message: context.sourceCode.text });
                     }
                 })
             });
@@ -7384,7 +7385,7 @@ var a = "test2";
                 });
                 linter.defineRule("save-scope-manager", {
                     create(context) {
-                        scopeManager = context.getSourceCode().scopeManager;
+                        scopeManager = context.sourceCode.scopeManager;
 
                         return {};
                     }
@@ -8206,7 +8207,7 @@ describe("Linter with FlatConfigArray", () => {
                                             },
                                             "save-scope-manager": {
                                                 create(context) {
-                                                    scopeManager = context.getSourceCode().scopeManager;
+                                                    scopeManager = context.sourceCode.scopeManager;
 
                                                     return {};
                                                 }
@@ -8961,7 +8962,7 @@ describe("Linter with FlatConfigArray", () => {
 
             it("should have all the `parent` properties on nodes when the rule visitors are created", () => {
                 const spy = sinon.spy(context => {
-                    const ast = context.getSourceCode().ast;
+                    const ast = context.sourceCode.ast;
 
                     assert.strictEqual(ast.body[0].parent, ast);
                     assert.strictEqual(ast.body[0].expression.parent, ast.body[0]);
@@ -11613,7 +11614,7 @@ describe("Linter with FlatConfigArray", () => {
                                         create: context => ({
                                             Program() {
                                                 const scope = context.getScope();
-                                                const sourceCode = context.getSourceCode();
+                                                const sourceCode = context.sourceCode;
                                                 const comments = sourceCode.getAllComments();
 
                                                 assert.strictEqual(2, comments.length);
@@ -13895,7 +13896,7 @@ var a = "test2";
                                             create: context => ({
                                                 Program() {
                                                     const scope = context.getScope();
-                                                    const sourceCode = context.getSourceCode();
+                                                    const sourceCode = context.sourceCode;
                                                     const comments = sourceCode.getAllComments();
 
                                                     assert.strictEqual(1, comments.length);
@@ -15572,7 +15573,8 @@ var a = "test2";
 
                                         receivedFilenames.push(context.filename);
                                         receivedPhysicalFilenames.push(context.physicalFilename);
-                                        context.report({ node: ast, message: context.getSourceCode().text });
+
+                                        context.report({ node: ast, message: context.sourceCode.text });
                                     }
                                 };
                             }

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -116,7 +116,7 @@ describe("Linter", () => {
 
         it("has all the `parent` properties on nodes when the rule listeners are created", () => {
             const spy = sinon.spy(context => {
-                const ast = context.getSourceCode().ast;
+                const ast = context.sourceCode.ast;
 
                 assert.strictEqual(ast.body[0].parent, ast);
                 assert.strictEqual(ast.body[0].expression.parent, ast.body[0]);

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -1447,7 +1447,7 @@ describe("FlatRuleTester", () => {
         const usesStartEndRule = {
             create(context) {
 
-                const sourceCode = context.getSourceCode();
+                const sourceCode = context.sourceCode;
 
                 return {
                     CallExpression(node) {
@@ -2550,7 +2550,7 @@ describe("FlatRuleTester", () => {
         const useGetCommentsRule = {
             create: context => ({
                 Program(node) {
-                    const sourceCode = context.getSourceCode();
+                    const sourceCode = context.sourceCode;
 
                     sourceCode.getComments(node);
                 }

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1498,7 +1498,7 @@ describe("RuleTester", () => {
         const usesStartEndRule = {
             create(context) {
 
-                const sourceCode = context.getSourceCode();
+                const sourceCode = context.sourceCode;
 
                 return {
                     CallExpression(node) {
@@ -2793,7 +2793,7 @@ describe("RuleTester", () => {
         const useGetCommentsRule = {
             create: context => ({
                 Program(node) {
-                    const sourceCode = context.getSourceCode();
+                    const sourceCode = context.sourceCode;
 
                     sourceCode.getComments(node);
                 }

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -44,7 +44,7 @@ ruleTester.defineRule("add-named-import", {
     create(context) {
         return {
             ImportDeclaration(node) {
-                const sourceCode = context.getSourceCode();
+                const sourceCode = context.sourceCode;
                 const closingBrace = sourceCode.getLastToken(node, token => token.value === "}");
                 const addComma = sourceCode.getTokenBefore(closingBrace).value !== ",";
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -21,7 +21,7 @@ const ruleTester = new RuleTester();
 ruleTester.defineRule("use-every-a", {
     create(context) {
 
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         /**
          * Mark a variable as used

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -21,7 +21,7 @@ const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.defineRule("use-x", {
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.sourceCode;
 
         return {
             VariableDeclaration(node) {

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -3032,7 +3032,7 @@ describe("SourceCode", () => {
             linter.defineRule("get-scope", {
                 create: context => ({
                     Program() {
-                        context.getSourceCode().getScope();
+                        context.sourceCode.getScope();
                     }
                 })
             });
@@ -3062,7 +3062,7 @@ describe("SourceCode", () => {
                 create: context => ({
                     [astSelector](node0) {
                         node = node0;
-                        scope = context.getSourceCode().getScope(node);
+                        scope = context.sourceCode.getScope(node);
                     }
                 })
             });
@@ -3312,7 +3312,7 @@ describe("SourceCode", () => {
                             checker: {
                                 create(context) {
                                     spy = sinon.spy(node => {
-                                        const sourceCode = context.getSourceCode();
+                                        const sourceCode = context.sourceCode;
                                         const ancestors = sourceCode.getAncestors(node);
 
                                         assert.strictEqual(ancestors.length, 3);
@@ -3340,7 +3340,7 @@ describe("SourceCode", () => {
                             checker: {
                                 create(context) {
                                     spy = sinon.spy(node => {
-                                        const sourceCode = context.getSourceCode();
+                                        const sourceCode = context.sourceCode;
                                         const ancestors = sourceCode.getAncestors(node);
 
                                         assert.strictEqual(ancestors.length, 0);
@@ -3369,7 +3369,7 @@ describe("SourceCode", () => {
                             checker: {
                                 create(context) {
                                     spy = sinon.spy(() => {
-                                        const sourceCode = context.getSourceCode();
+                                        const sourceCode = context.sourceCode;
 
                                         assert.throws(() => {
                                             sourceCode.getAncestors();
@@ -3406,7 +3406,7 @@ describe("SourceCode", () => {
                 test: {
                     create(context) {
 
-                        const sourceCode = context.getSourceCode();
+                        const sourceCode = context.sourceCode;
 
                         /**
                          * Assert `sourceCode.getDeclaredVariables(node)` is empty.
@@ -3643,7 +3643,7 @@ describe("SourceCode", () => {
 
             linter.defineRule("checker", {
                 create(context) {
-                    const sourceCode = context.getSourceCode();
+                    const sourceCode = context.sourceCode;
 
                     spy = sinon.spy(() => {
                         assert.isTrue(sourceCode.markVariableAsUsed("a"));
@@ -3668,7 +3668,7 @@ describe("SourceCode", () => {
 
             linter.defineRule("checker", {
                 create(context) {
-                    const sourceCode = context.getSourceCode();
+                    const sourceCode = context.sourceCode;
 
                     spy = sinon.spy(node => {
                         assert.isTrue(sourceCode.markVariableAsUsed("a", node));
@@ -3693,7 +3693,7 @@ describe("SourceCode", () => {
 
             linter.defineRule("checker", {
                 create(context) {
-                    const sourceCode = context.getSourceCode();
+                    const sourceCode = context.sourceCode;
 
                     returnSpy = sinon.spy(node => {
                         assert.isTrue(sourceCode.markVariableAsUsed("a", node));
@@ -3720,7 +3720,7 @@ describe("SourceCode", () => {
 
             linter.defineRule("checker", {
                 create(context) {
-                    const sourceCode = context.getSourceCode();
+                    const sourceCode = context.sourceCode;
 
                     spy = sinon.spy(() => {
                         const globalScope = context.getScope(),
@@ -3746,7 +3746,7 @@ describe("SourceCode", () => {
 
             linter.defineRule("checker", {
                 create(context) {
-                    const sourceCode = context.getSourceCode();
+                    const sourceCode = context.sourceCode;
 
                     spy = sinon.spy(() => {
                         const globalScope = context.getScope(),
@@ -3772,7 +3772,7 @@ describe("SourceCode", () => {
 
             linter.defineRule("checker", {
                 create(context) {
-                    const sourceCode = context.getSourceCode();
+                    const sourceCode = context.sourceCode;
 
                     spy = sinon.spy(() => {
                         assert.isFalse(sourceCode.markVariableAsUsed("c"));

--- a/tests/tools/eslint-fuzzer.js
+++ b/tests/tools/eslint-fuzzer.js
@@ -52,7 +52,7 @@ describe("eslint-fuzzer", function() {
                 linter.defineRule("test-fuzzer-rule", {
                     create: context => ({
                         Program() {
-                            if (context.getSourceCode().text === "foo") {
+                            if (context.sourceCode.text === "foo") {
                                 throw CRASH_BUG;
                             }
                         }
@@ -93,7 +93,7 @@ describe("eslint-fuzzer", function() {
                 linter.defineRule("test-fuzzer-rule", {
                     create: context => ({
                         Program() {
-                            if (context.getSourceCode().text === "foo") {
+                            if (context.sourceCode.text === "foo") {
                                 throw CRASH_BUG;
                             }
                         }
@@ -118,7 +118,7 @@ describe("eslint-fuzzer", function() {
                     meta: { fixable: "code" },
                     create: context => ({
                         Program(node) {
-                            if (context.getSourceCode().text === `foo ${disableFixableRulesComment}`) {
+                            if (context.sourceCode.text === `foo ${disableFixableRulesComment}`) {
                                 context.report({
                                     node,
                                     message: "no foos allowed",
@@ -153,7 +153,7 @@ describe("eslint-fuzzer", function() {
                     meta: { fixable: "code" },
                     create: context => ({
                         Program(node) {
-                            const sourceCode = context.getSourceCode();
+                            const sourceCode = context.sourceCode;
 
                             if (sourceCode.text === `foo ${disableFixableRulesComment}`) {
                                 context.report({
@@ -197,7 +197,7 @@ describe("eslint-fuzzer", function() {
                     meta: { fixable: "code" },
                     create: context => ({
                         Program(node) {
-                            const sourceCode = context.getSourceCode();
+                            const sourceCode = context.sourceCode;
 
                             if (sourceCode.text.startsWith("foo") || sourceCode.text === intermediateCode) {
                                 context.report({
@@ -245,7 +245,7 @@ describe("eslint-fuzzer", function() {
                     meta: { fixable: "code" },
                     create: context => ({
                         Program(node) {
-                            const sourceCode = context.getSourceCode();
+                            const sourceCode = context.sourceCode;
 
                             if (sourceCode.text.startsWith("foo")) {
                                 context.report({


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Refers #16999

This PR creates `context.sourceCode` and deprecates `context.getSourceCode()`.

#### Is there anything you'd like reviewers to focus on?
Did I miss any references?

I intentionally didn't update [custom-rules-deprecated.md ](https://github.com/eslint/eslint/blob/main/docs/src/extend/custom-rules-deprecated.md)
<!-- markdownlint-disable-file MD004 -->
