### PR TITLE
feat: add `filename` to the rule context

### DIFF
--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -124,7 +124,7 @@ As the name implies, the `context` object contains information that is relevant 
 The `context` object has the following properties:
 
 * `id`: (`string`) The rule ID.
-* `filename`: (`string`) Returns the filename associated with the source.
+* `filename`: (`string`) The filename associated with the source.
 * `options`: (`array`) An array of the [configured options](../use/configure/rules) for this rule. This array does not include the rule severity (see the [dedicated section](#accessing-options-passed-to-a-rule)).
 * `settings`: (`object`) The [shared settings](../use/configure/configuration-files#adding-shared-settings) from the configuration.
 * `parserPath`: (`string`) The name of the `parser` from the configuration.

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -124,6 +124,7 @@ As the name implies, the `context` object contains information that is relevant 
 The `context` object has the following properties:
 
 * `id`: (`string`) The rule ID.
+* `filename`: (`string`) Returns the filename associated with the source.
 * `options`: (`array`) An array of the [configured options](../use/configure/rules) for this rule. This array does not include the rule severity (see the [dedicated section](#accessing-options-passed-to-a-rule)).
 * `settings`: (`object`) The [shared settings](../use/configure/configuration-files#adding-shared-settings) from the configuration.
 * `parserPath`: (`string`) The name of the `parser` from the configuration.
@@ -144,8 +145,7 @@ Additionally, the `context` object has the following methods:
     * If the node is an `ImportDeclaration`, variables for all of its specifiers are returned.
     * If the node is an `ImportSpecifier`, `ImportDefaultSpecifier`, or `ImportNamespaceSpecifier`, the declared variable is returned.
     * Otherwise, if the node does not declare any variables, an empty array is returned.
-* `getFilename()`: (**Deprecated:** Use `context#filename` instead.) Returns the filename associated with the source.
-* `filename`: Returns the filename associated with the source.
+* `getFilename()`: (**Deprecated:** Use `context.filename` instead.) Returns the filename associated with the source.
 * `getPhysicalFilename()`: When linting a file, it returns the full path of the file on disk without any code block information. When linting text, it returns the value passed to `—stdin-filename` or `<text>` if not specified.
 * `getScope()`: (**Deprecated:** Use `SourceCode#getScope(node)` instead.) Returns the [scope](./scope-manager-interface#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
 * `getSourceCode()`: Returns a `SourceCode` object that you can use to work with the source that was passed to ESLint (see [Accessing the Source Code](#accessing-the-source-code)).

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -144,7 +144,8 @@ Additionally, the `context` object has the following methods:
     * If the node is an `ImportDeclaration`, variables for all of its specifiers are returned.
     * If the node is an `ImportSpecifier`, `ImportDefaultSpecifier`, or `ImportNamespaceSpecifier`, the declared variable is returned.
     * Otherwise, if the node does not declare any variables, an empty array is returned.
-* `getFilename()`: Returns the filename associated with the source.
+* `getFilename()`: (**Deprecated:** Use `context#filename` instead.) Returns the filename associated with the source.
+* `filename`: Returns the filename associated with the source.
 * `getPhysicalFilename()`: When linting a file, it returns the full path of the file on disk without any code block information. When linting text, it returns the value passed to `—stdin-filename` or `<text>` if not specified.
 * `getScope()`: (**Deprecated:** Use `SourceCode#getScope(node)` instead.) Returns the [scope](./scope-manager-interface#scope-interface) of the currently-traversed node. This information can be used to track references to variables.
 * `getSourceCode()`: Returns a `SourceCode` object that you can use to work with the source that was passed to ESLint (see [Accessing the Source Code](#accessing-the-source-code)).

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -592,7 +592,7 @@ function findEslintEnv(text) {
  * Convert "/path/to/<text>" to "<text>".
  * `CLIEngine#executeOnText()` method gives "/path/to/<text>" if the filename
  * was omitted because `configArray.extractConfig()` requires an absolute path.
- * But the linter should pass `<text>` to `RuleContext#getFilename()` in that
+ * But the linter should pass `<text>` to `RuleContext#filename` in that
  * case.
  * Also, code blocks can have their virtual filename. If the parent filename was
  * `<text>`, the virtual filename is `<text>/0_foo.js` or something like (i.e.,
@@ -952,6 +952,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
                 getDeclaredVariables: node => sourceCode.getDeclaredVariables(node),
                 getCwd: () => cwd,
                 getFilename: () => filename,
+                filename,
                 getPhysicalFilename: () => physicalFilename || filename,
                 getScope: () => sourceCode.getScope(currentNode),
                 getSourceCode: () => sourceCode,

--- a/tests/fixtures/testers/rule-tester/no-test-filename
+++ b/tests/fixtures/testers/rule-tester/no-test-filename
@@ -17,7 +17,7 @@ module.exports = {
     create(context) {
         return {
             "Program": function(node) {
-                if (context.getFilename() === '<input>') {
+                if (context.filename === '<input>') {
                     context.report(node, "Filename test was not defined.");
                 }
             }

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -1826,7 +1826,7 @@ describe("Linter", () => {
             linter.defineRule(code, {
                 create: context => ({
                     Literal(node) {
-                        context.report(node, context.getFilename());
+                        context.report(node, context.filename);
                     }
                 })
             });
@@ -1866,7 +1866,7 @@ describe("Linter", () => {
             linter.defineRule(code, {
                 create: context => ({
                     Literal(node) {
-                        context.report(node, context.getFilename());
+                        context.report(node, context.filename);
                     }
                 })
             });
@@ -4817,7 +4817,7 @@ var a = "test2";
         describe("filenames", () => {
             it("should allow filename to be passed on options object", () => {
                 const filenameChecker = sinon.spy(context => {
-                    assert.strictEqual(context.getFilename(), "foo.js");
+                    assert.strictEqual(context.filename, "foo.js");
                     return {};
                 });
 
@@ -4828,7 +4828,7 @@ var a = "test2";
 
             it("should allow filename to be passed as third argument", () => {
                 const filenameChecker = sinon.spy(context => {
-                    assert.strictEqual(context.getFilename(), "bar.js");
+                    assert.strictEqual(context.filename, "bar.js");
                     return {};
                 });
 
@@ -4839,7 +4839,7 @@ var a = "test2";
 
             it("should default filename to <input> when options object doesn't have filename", () => {
                 const filenameChecker = sinon.spy(context => {
-                    assert.strictEqual(context.getFilename(), "<input>");
+                    assert.strictEqual(context.filename, "<input>");
                     return {};
                 });
 
@@ -4850,7 +4850,7 @@ var a = "test2";
 
             it("should default filename to <input> when only two arguments are passed", () => {
                 const filenameChecker = sinon.spy(context => {
-                    assert.strictEqual(context.getFilename(), "<input>");
+                    assert.strictEqual(context.filename, "<input>");
                     return {};
                 });
 
@@ -6751,7 +6751,7 @@ var a = "test2";
             linter.defineRule("report-original-text", {
                 create: context => ({
                     Program(ast) {
-                        receivedFilenames.push(context.getFilename());
+                        receivedFilenames.push(context.filename);
                         receivedPhysicalFilenames.push(context.getPhysicalFilename());
                         context.report({ node: ast, message: context.getSourceCode().text });
                     }
@@ -9109,6 +9109,67 @@ describe("Linter with FlatConfigArray", () => {
                 });
             });
 
+            describe("context.filename", () => {
+                const ruleId = "filename-rule";
+
+                it("has access to the filename", () => {
+
+                    const config = {
+                        plugins: {
+                            test: {
+                                rules: {
+                                    [ruleId]: {
+                                        create: context => ({
+                                            Literal(node) {
+                                                context.report(node, context.filename);
+                                            }
+                                        })
+                                    }
+                                }
+                            }
+                        },
+                        rules: {
+                            [`test/${ruleId}`]: 1
+                        }
+                    };
+
+                    const messages = linter.verify("0", config, filename);
+                    const suppressedMessages = linter.getSuppressedMessages();
+
+                    assert.strictEqual(messages[0].message, filename);
+                    assert.strictEqual(suppressedMessages.length, 0);
+                });
+
+                it("defaults filename to '<input>'", () => {
+
+                    const config = {
+                        plugins: {
+                            test: {
+                                rules: {
+                                    [ruleId]: {
+                                        create: context => ({
+                                            Literal(node) {
+                                                context.report(node, context.filename);
+                                            }
+                                        })
+                                    }
+                                }
+                            }
+                        },
+                        rules: {
+                            [`test/${ruleId}`]: 1
+                        }
+                    };
+
+
+                    const messages = linter.verify("0", config);
+                    const suppressedMessages = linter.getSuppressedMessages();
+
+                    assert.strictEqual(messages[0].message, "<input>");
+                    assert.strictEqual(suppressedMessages.length, 0);
+                });
+            });
+
             describe("context.getPhysicalFilename()", () => {
 
                 const ruleId = "filename-rule";
@@ -11063,7 +11124,7 @@ describe("Linter with FlatConfigArray", () => {
             describe("filename", () => {
                 it("should allow filename to be passed on options object", () => {
                     const filenameChecker = sinon.spy(context => {
-                        assert.strictEqual(context.getFilename(), "foo.js");
+                        assert.strictEqual(context.filename, "foo.js");
                         return {};
                     });
 
@@ -11086,7 +11147,7 @@ describe("Linter with FlatConfigArray", () => {
 
                 it("should allow filename to be passed as third argument", () => {
                     const filenameChecker = sinon.spy(context => {
-                        assert.strictEqual(context.getFilename(), "bar.js");
+                        assert.strictEqual(context.filename, "bar.js");
                         return {};
                     });
 
@@ -11109,7 +11170,7 @@ describe("Linter with FlatConfigArray", () => {
 
                 it("should default filename to <input> when options object doesn't have filename", () => {
                     const filenameChecker = sinon.spy(context => {
-                        assert.strictEqual(context.getFilename(), "<input>");
+                        assert.strictEqual(context.filename, "<input>");
                         return {};
                     });
 
@@ -11132,7 +11193,7 @@ describe("Linter with FlatConfigArray", () => {
 
                 it("should default filename to <input> when only two arguments are passed", () => {
                     const filenameChecker = sinon.spy(context => {
-                        assert.strictEqual(context.getFilename(), "<input>");
+                        assert.strictEqual(context.filename, "<input>");
                         return {};
                     });
 
@@ -15369,7 +15430,7 @@ var a = "test2";
                             create(context) {
                                 return {
                                     Program(ast) {
-                                        receivedFilenames.push(context.getFilename());
+                                        receivedFilenames.push(context.filename);
                                         receivedPhysicalFilenames.push(context.getPhysicalFilename());
                                         context.report({ node: ast, message: context.getSourceCode().text });
                                     }

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -1826,6 +1826,7 @@ describe("Linter", () => {
             linter.defineRule(code, {
                 create: context => ({
                     Literal(node) {
+                        assert.strictEqual(context.getFilename(), context.filename);
                         context.report(node, context.filename);
                     }
                 })
@@ -1866,6 +1867,7 @@ describe("Linter", () => {
             linter.defineRule(code, {
                 create: context => ({
                     Literal(node) {
+                        assert.strictEqual(context.getFilename(), context.filename);
                         context.report(node, context.filename);
                     }
                 })
@@ -9121,6 +9123,7 @@ describe("Linter with FlatConfigArray", () => {
                                     [ruleId]: {
                                         create: context => ({
                                             Literal(node) {
+                                                assert.strictEqual(context.getFilename(), context.filename);
                                                 context.report(node, context.filename);
                                             }
                                         })
@@ -9149,6 +9152,7 @@ describe("Linter with FlatConfigArray", () => {
                                     [ruleId]: {
                                         create: context => ({
                                             Literal(node) {
+                                                assert.strictEqual(context.getFilename(), context.filename);
                                                 context.report(node, context.filename);
                                             }
                                         })


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Refers #16999

This PR creates `context.filename` and deprecates `context.getFilename()`.

#### Is there anything you'd like reviewers to focus on?
Did I miss any reference?
<!-- markdownlint-disable-file MD004 -->
