### PR TITLE
docs: Fix custom rule schema docs

### DIFF
--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -606,14 +606,19 @@ You can also access comments through many of `sourceCode`'s methods using the `i
 
 ### Options Schemas
 
-Rules may export a `schema` property, which is a [JSON Schema](https://json-schema.org/) format description of a rule's options which will be used by ESLint to validate configuration options and prevent invalid or unexpected inputs before they are passed to the rule in `context.options`.
+Rules may export a `schema` property, which is a [JSON Schema](https://json-schema.org/learn/) format description of a rule's options which will be used by ESLint to validate configuration options and prevent invalid or unexpected inputs before they are passed to the rule in `context.options`.
 
-There are two formats for a rule's exported `schema`. The first is a full JSON Schema object describing all possible options the rule accepts, including the rule's error level as the first argument and any optional arguments thereafter.
+There are two formats for a rule's exported `schema`:
 
-However, to simplify schema creation, rules may also export an array of schemas for each optional positional argument. ESLint automatically validates the required error level first. For example, the `yoda` rule accepts a primary mode argument, as well as an extra options object with named properties.
+1. A full JSON Schema object describing all possible options the rule accepts.
+2. An array of JSON Schema objects for each optional positional argument.
+
+In both cases, these should exclude the [severity](../use/configure/rules#rule-severities), as ESLint automatically validates this first.
+
+For example, the `yoda` rule accepts a primary mode argument of `"always"` or `"never"`, as well as an extra options object with an optional property `exceptRange`:
 
 ```js
-// "yoda": [2, "never", { "exceptRange": true }]
+// "yoda": ["error", "never", { "exceptRange": true }]
 module.exports = {
     meta: {
         schema: [
@@ -633,10 +638,6 @@ module.exports = {
     },
 };
 ```
-
-In the preceding example, the error level is assumed to be the first argument. It is followed by the first optional argument, a string that may be either `"always"` or `"never"`. The final optional argument is an object, which may have a boolean property named `exceptRange`.
-
-To learn more about JSON Schema, we recommend looking at some examples in [website](https://json-schema.org/learn/) to start, and also reading [Understanding JSON Schema](https://json-schema.org/understanding-json-schema/) (a free ebook).
 
 **Note:** If your rule schema uses JSON schema [`$ref`](https://json-schema.org/understanding-json-schema/structuring.html#ref) properties, you must use the full JSON Schema object rather than the array of positional property schemas. This is because ESLint transforms the array shorthand into a single schema without updating references that makes them incorrect (they are ignored).
 

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -606,7 +606,7 @@ You can also access comments through many of `sourceCode`'s methods using the `i
 
 ### Options Schemas
 
-Rules may export a `schema` property, which is a [JSON Schema](https://json-schema.org/learn/) format description of a rule's options which will be used by ESLint to validate configuration options and prevent invalid or unexpected inputs before they are passed to the rule in `context.options`.
+Rules may export a `schema` property, which is a [JSON Schema](https://json-schema.org/) format description of a rule's options which will be used by ESLint to validate configuration options and prevent invalid or unexpected inputs before they are passed to the rule in `context.options`.
 
 There are two formats for a rule's exported `schema`:
 
@@ -640,6 +640,8 @@ module.exports = {
 ```
 
 **Note:** If your rule schema uses JSON schema [`$ref`](https://json-schema.org/understanding-json-schema/structuring.html#ref) properties, you must use the full JSON Schema object rather than the array of positional property schemas. This is because ESLint transforms the array shorthand into a single schema without updating references that makes them incorrect (they are ignored).
+
+To learn more about JSON Schema, we recommend looking at some examples on the [JSON Schema website](https://json-schema.org/learn/), or reading the free [Understanding JSON Schema](https://json-schema.org/understanding-json-schema/) ebook.
 
 ### Accessing Shebangs
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Corrected the docs to state that either way option schemas are specified, they should no longer include severities. This has been the behaviour [since ESLint 2.x](https://github.com/eslint/eslint/blob/9d1b8fc60cc31f12618e58c10a2669506b7ce9bf/docs/src/use/migrating-to-2.0.0.md?plain=1#L10-L30)! (git blame shows that these lines haven't been changed for over 8 years, way back to ESLint 1.x).

I've also removed some superfluous content: the text after the code sample can be coalesced into the sentence before it, and the comment on how to learn about JSON schema is unnecessary given the link to the JSON Schema site can be updated to the learn page (which itself already contains the ebook recommendation). Removing this duplicated content makes it easier to quickly read, and avoid breaking up the content so developers don't miss the specific eslint gotchas (e.g. the `$ref` breaking).

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
