### PR TITLE
perf: don't use `grapheme-splitter` on ASCII strings in key-spacing rule

### DIFF
--- a/lib/rules/id-length.js
+++ b/lib/rules/id-length.js
@@ -9,41 +9,8 @@
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
-const GraphemeSplitter = require("grapheme-splitter");
 
-//------------------------------------------------------------------------------
-// Helpers
-//------------------------------------------------------------------------------
-
-/**
- * Checks if the string given as argument is ASCII or not.
- * @param {string} value A string that you want to know if it is ASCII or not.
- * @returns {boolean} `true` if `value` is ASCII string.
- */
-function isASCII(value) {
-    if (typeof value !== "string") {
-        return false;
-    }
-    return /^[\u0020-\u007f]*$/u.test(value);
-}
-
-/** @type {GraphemeSplitter | undefined} */
-let splitter;
-
-/**
- * Gets the length of the string. If the string is not in ASCII, counts graphemes.
- * @param {string} value A string that you want to get the length.
- * @returns {number} The length of `value`.
- */
-function getStringLength(value) {
-    if (isASCII(value)) {
-        return value.length;
-    }
-    if (!splitter) {
-        splitter = new GraphemeSplitter();
-    }
-    return splitter.countGraphemes(value);
-}
+const { getGraphemeCount } = require("../shared/string-utils");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -169,7 +136,7 @@ module.exports = {
                 const name = node.name;
                 const parent = node.parent;
 
-                const nameLength = getStringLength(name);
+                const nameLength = getGraphemeCount(name);
 
                 const isShort = nameLength < minLength;
                 const isLong = nameLength > maxLength;

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -11,11 +11,32 @@
 const astUtils = require("./utils/ast-utils");
 const GraphemeSplitter = require("grapheme-splitter");
 
-const splitter = new GraphemeSplitter();
-
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
+
+// eslint-disable-next-line no-control-regex -- intentionally including control characters
+const ASCII_REGEX = /^[\u0000-\u007f]*$/u;
+
+/** @type {GraphemeSplitter | undefined} */
+let splitter;
+
+/**
+ * Gets the length of the string. If the string is not in ASCII, counts graphemes.
+ * @param {string} value A string to get the length.
+ * @returns {number} The length of `value`.
+ */
+function getStringLength(value) {
+    if (ASCII_REGEX.test(value)) {
+        return value.length;
+    }
+
+    if (!splitter) {
+        splitter = new GraphemeSplitter();
+    }
+
+    return splitter.countGraphemes(value);
+}
 
 /**
  * Checks whether a string contains a line terminator as defined in
@@ -523,7 +544,7 @@ module.exports = {
             const startToken = sourceCode.getFirstToken(property);
             const endToken = getLastTokenBeforeColon(property.key);
 
-            return splitter.countGraphemes(sourceCode.getText().slice(startToken.range[0], endToken.range[1]));
+            return getStringLength(sourceCode.getText().slice(startToken.range[0], endToken.range[1]));
         }
 
         /**

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -9,34 +9,7 @@
 //------------------------------------------------------------------------------
 
 const astUtils = require("./utils/ast-utils");
-const GraphemeSplitter = require("grapheme-splitter");
-
-//------------------------------------------------------------------------------
-// Helpers
-//------------------------------------------------------------------------------
-
-// eslint-disable-next-line no-control-regex -- intentionally including control characters
-const ASCII_REGEX = /^[\u0000-\u007f]*$/u;
-
-/** @type {GraphemeSplitter | undefined} */
-let splitter;
-
-/**
- * Gets the length of the string. If the string is not in ASCII, counts graphemes.
- * @param {string} value A string to get the length.
- * @returns {number} The length of `value`.
- */
-function getStringLength(value) {
-    if (ASCII_REGEX.test(value)) {
-        return value.length;
-    }
-
-    if (!splitter) {
-        splitter = new GraphemeSplitter();
-    }
-
-    return splitter.countGraphemes(value);
-}
+const { getGraphemeCount } = require("../shared/string-utils");
 
 /**
  * Checks whether a string contains a line terminator as defined in
@@ -544,7 +517,7 @@ module.exports = {
             const startToken = sourceCode.getFirstToken(property);
             const endToken = getLastTokenBeforeColon(property.key);
 
-            return getStringLength(sourceCode.getText().slice(startToken.range[0], endToken.range[1]));
+            return getGraphemeCount(sourceCode.getText().slice(startToken.range[0], endToken.range[1]));
         }
 
         /**

--- a/lib/shared/string-utils.js
+++ b/lib/shared/string-utils.js
@@ -5,6 +5,26 @@
 
 "use strict";
 
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const GraphemeSplitter = require("grapheme-splitter");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+// eslint-disable-next-line no-control-regex -- intentionally including control characters
+const ASCII_REGEX = /^[\u0000-\u007f]*$/u;
+
+/** @type {GraphemeSplitter | undefined} */
+let splitter;
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
 /**
  * Converts the first letter of a string to uppercase.
  * @param {string} string The string to operate on
@@ -17,6 +37,24 @@ function upperCaseFirst(string) {
     return string[0].toUpperCase() + string.slice(1);
 }
 
+/**
+ * Counts graphemes in a given string.
+ * @param {string} value A string to count graphemes.
+ * @returns {number} The number of graphemes in `value`.
+ */
+function getGraphemeCount(value) {
+    if (ASCII_REGEX.test(value)) {
+        return value.length;
+    }
+
+    if (!splitter) {
+        splitter = new GraphemeSplitter();
+    }
+
+    return splitter.countGraphemes(value);
+}
+
 module.exports = {
-    upperCaseFirst
+    upperCaseFirst,
+    getGraphemeCount
 };

--- a/tests/lib/shared/string-utils.js
+++ b/tests/lib/shared/string-utils.js
@@ -17,7 +17,6 @@ const { upperCaseFirst, getGraphemeCount } = require("../../../lib/shared/string
 // Helpers
 //------------------------------------------------------------------------------
 
-
 /**
  * Replaces raw control characters with the `\xXX` form.
  * @param {string} text The text to process.

--- a/tests/lib/shared/string-utils.js
+++ b/tests/lib/shared/string-utils.js
@@ -11,7 +11,24 @@
 
 const assert = require("chai").assert;
 
-const { upperCaseFirst } = require("../../../lib/shared/string-utils");
+const { upperCaseFirst, getGraphemeCount } = require("../../../lib/shared/string-utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+
+/**
+ * Replaces raw control characters with the `\xXX` form.
+ * @param {string} text The text to process.
+ * @returns {string} `text` with escaped control characters.
+ */
+function escapeControlCharacters(text) {
+    return text.replace(
+        /[\u0000-\u001F\u007F-\u009F]/gu, // eslint-disable-line no-control-regex -- intentionally including control characters
+        c => `\\x${c.codePointAt(0).toString(16).padStart(2, "0")}`
+    );
+}
 
 //------------------------------------------------------------------------------
 // Tests
@@ -37,5 +54,36 @@ describe("upperCaseFirst", () => {
 
     it("properly handles an empty string", () => {
         assert(upperCaseFirst("") === "");
+    });
+});
+
+describe("getGraphemeCount", () => {
+    /* eslint-disable quote-props -- Make consistent here for readability */
+    const expectedResults = {
+        "": 0,
+        "a": 1,
+        "ab": 2,
+        "aa": 2,
+        "123": 3,
+        "cccc": 4,
+        [Array.from({ length: 128 }, (_, i) => String.fromCharCode(i)).join("")]: 128, // all ASCII characters
+        "👍": 1, // 1 grapheme, 1 code point, 2 code units
+        "👍👍": 2,
+        "👍9👍": 3,
+        "a👍b": 3,
+        "👶🏽": 1, // 1 grapheme, 2 code points, 4 code units
+        "👨‍👩‍👦": 1, // 1 grapheme, 5 code points, 8 code units
+        "👨‍👩‍👦👨‍👩‍👦": 2,
+        "👨‍👩‍👦a👨‍👩‍👦": 3,
+        "a👨‍👩‍👦b👨‍👩‍👦c": 5,
+        "👨‍👩‍👦👍": 2,
+        "👶🏽👨‍👩‍👦": 2
+    };
+    /* eslint-enable quote-props -- Make consistent here for readability */
+
+    Object.entries(expectedResults).forEach(([key, value]) => {
+        it(`should return ${value} for ${escapeControlCharacters(key)}`, () => {
+            assert.strictEqual(getGraphemeCount(key), value);
+        });
     });
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Improves performance of the `key-spacing` rule when used with options that [enforce alignment](https://eslint.org/docs/latest/rules/key-spacing#align) of keys/values.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Similar to the logic we already have in the `id-length` rule, the `key-spacing` rule will now use `grapheme-splitter` only on non-ASCII strings. For ASCII strings, the length is simply `String#length`.

To test the change, I configured the rule to enforce alignments:

```
"key-spacing": ["error", { align: "colon" }]
```

and then ran `npm run lint` with `TIMING=all` on the eslint codebase.

<details>

<summary>Before the change</summary>

Rule                                          | Time (ms) | Relative
:---------------------------------------------|----------:|--------:
indent                                        |  5803.389 |    17.7%
key-spacing                                   |  1624.221 |     4.9%
n/no-missing-require                          |  1012.187 |     3.1%
jsdoc/valid-types                             |   984.791 |     3.0%
n/no-extraneous-require                       |   946.470 |     2.9%
jsdoc/check-access                            |   939.912 |     2.9%
n/no-unpublished-require                      |   765.049 |     2.3%
jsdoc/check-types                             |   743.973 |     2.3%
jsdoc/check-tag-names                         |   654.592 |     2.0%
eslint-plugin/no-identical-tests              |   581.670 |     1.8%
jsdoc/check-values                            |   581.308 |     1.8%
jsdoc/check-property-names                    |   549.333 |     1.7%
jsdoc/check-alignment                         |   533.875 |     1.6%
jsdoc/check-line-alignment                    |   525.408 |     1.6%
jsdoc/tag-lines                               |   494.075 |     1.5%
jsdoc/require-hyphen-before-param-description |   489.275 |     1.5%
jsdoc/require-property-type                   |   486.857 |     1.5%
jsdoc/empty-tags                              |   483.745 |     1.5%
jsdoc/require-property-name                   |   483.625 |     1.5%
jsdoc/require-asterisk-prefix                 |   482.618 |     1.5%
jsdoc/check-syntax                            |   475.649 |     1.4%
jsdoc/require-property-description            |   472.485 |     1.4%
jsdoc/no-multi-asterisks                      |   468.754 |     1.4%
jsdoc/newline-after-description               |   462.040 |     1.4%
jsdoc/require-property                        |   459.579 |     1.4%
jsdoc/multiline-blocks                        |   455.708 |     1.4%
max-len                                       |   413.761 |     1.3%
n/no-restricted-require                       |   387.555 |     1.2%
comma-style                                   |   355.997 |     1.1%
n/no-unsupported-features/es-syntax           |   242.630 |     0.7%
no-loss-of-precision                          |   232.619 |     0.7%
jsdoc/check-param-names                       |   212.945 |     0.6%
jsdoc/require-param                           |   184.566 |     0.6%
object-curly-newline                          |   175.361 |     0.5%
comma-spacing                                 |   169.776 |     0.5%
no-trailing-spaces                            |   169.392 |     0.5%
padding-line-between-statements               |   161.647 |     0.5%
n/no-deprecated-api                           |   157.374 |     0.5%
no-dupe-keys                                  |   154.636 |     0.5%
keyword-spacing                               |   154.257 |     0.5%
space-in-parens                               |   153.011 |     0.5%
camelcase                                     |   147.187 |     0.4%
jsdoc/require-description                     |   143.875 |     0.4%
object-shorthand                              |   142.182 |     0.4%
comma-dangle                                  |   139.848 |     0.4%
quote-props                                   |   135.829 |     0.4%
jsdoc/require-returns                         |   128.608 |     0.4%
jsdoc/require-throws                          |   125.841 |     0.4%
n/no-unsupported-features/es-builtins         |   118.164 |     0.4%
object-curly-spacing                          |   118.073 |     0.4%
function-paren-newline                        |   115.019 |     0.4%
no-multi-spaces                               |   114.802 |     0.3%
jsdoc/require-returns-check                   |   114.239 |     0.3%
space-infix-ops                               |   113.177 |     0.3%
internal-rules/multiline-comment-style        |   113.001 |     0.3%
no-unused-vars                                |   110.005 |     0.3%
jsdoc/require-returns-type                    |   104.511 |     0.3%
jsdoc/implements-on-classes                   |   102.024 |     0.3%
no-regex-spaces                               |   100.119 |     0.3%
no-whitespace-before-property                 |    99.040 |     0.3%
jsdoc/require-yields-check                    |    98.910 |     0.3%
jsdoc/require-param-description               |    95.366 |     0.3%
func-call-spacing                             |    95.156 |     0.3%
no-useless-return                             |    93.465 |     0.3%
no-multiple-empty-lines                       |    91.642 |     0.3%
jsdoc/require-returns-description             |    89.636 |     0.3%
jsdoc/require-param-type                      |    88.984 |     0.3%
lines-around-comment                          |    88.547 |     0.3%
unicorn/prefer-array-flat                     |    87.987 |     0.3%
no-redeclare                                  |    85.983 |     0.3%
no-underscore-dangle                          |    83.439 |     0.3%
jsdoc/require-param-name                      |    82.208 |     0.3%
no-script-url                                 |    80.253 |     0.2%
semi-spacing                                  |    78.623 |     0.2%
no-useless-escape                             |    77.859 |     0.2%
operator-linebreak                            |    77.191 |     0.2%
max-statements-per-line                       |    74.123 |     0.2%
no-unmodified-loop-condition                  |    70.787 |     0.2%
no-unexpected-multiline                       |    69.064 |     0.2%
grouped-accessor-pairs                        |    69.051 |     0.2%
no-control-regex                              |    68.506 |     0.2%
no-alert                                      |    66.034 |     0.2%
array-bracket-spacing                         |    65.207 |     0.2%
no-mixed-spaces-and-tabs                      |    62.385 |     0.2%
no-misleading-character-class                 |    61.431 |     0.2%
no-octal-escape                               |    60.364 |     0.2%
spaced-comment                                |    56.460 |     0.2%
n/no-unpublished-import                       |    55.642 |     0.2%
n/no-unsupported-features/node-builtins       |    54.729 |     0.2%
object-property-newline                       |    50.414 |     0.2%
no-tabs                                       |    50.116 |     0.2%
quotes                                        |    47.739 |     0.1%
new-cap                                       |    47.433 |     0.1%
consistent-return                             |    46.872 |     0.1%
constructor-super                             |    46.408 |     0.1%
function-call-argument-newline                |    44.560 |     0.1%
semi-style                                    |    43.715 |     0.1%
block-spacing                                 |    43.533 |     0.1%
no-unsafe-optional-chaining                   |    42.200 |     0.1%
dot-location                                  |    41.877 |     0.1%
computed-property-spacing                     |    41.696 |     0.1%
no-this-before-super                          |    40.650 |     0.1%
no-nonoctal-decimal-escape                    |    40.543 |     0.1%
no-multi-str                                  |    39.859 |     0.1%
prefer-template                               |    39.441 |     0.1%
brace-style                                   |    39.007 |     0.1%
no-use-before-define                          |    38.465 |     0.1%
jsdoc/require-jsdoc                           |    37.888 |     0.1%
n/no-extraneous-import                        |    37.265 |     0.1%
semi                                          |    36.943 |     0.1%
no-undef-init                                 |    36.581 |     0.1%
no-unreachable                                |    36.558 |     0.1%
no-restricted-properties                      |    36.009 |     0.1%
getter-return                                 |    35.564 |     0.1%
space-before-blocks                           |    34.614 |     0.1%
n/no-path-concat                              |    34.267 |     0.1%
no-extend-native                              |    33.440 |     0.1%
no-invalid-this                               |    32.815 |     0.1%
jsdoc/no-bad-blocks                           |    32.685 |     0.1%
no-constant-binary-expression                 |    32.357 |     0.1%
n/handle-callback-err                         |    31.583 |     0.1%
eslint-comments/disable-enable-pair           |    29.676 |     0.1%
n/no-mixed-requires                           |    29.603 |     0.1%
no-useless-backreference                      |    29.560 |     0.1%
arrow-spacing                                 |    29.004 |     0.1%
no-useless-computed-key                       |    27.592 |     0.1%
no-shadow                                     |    27.160 |     0.1%
no-constant-condition                         |    27.069 |     0.1%
no-unreachable-loop                           |    26.969 |     0.1%
array-callback-return                         |    26.617 |     0.1%
eslint-plugin/fixer-return                    |    26.471 |     0.1%
no-lone-blocks                                |    26.400 |     0.1%
no-floating-decimal                           |    25.997 |     0.1%
no-eval                                       |    25.933 |     0.1%
no-octal                                      |    25.752 |     0.1%
no-self-compare                               |    25.597 |     0.1%
space-unary-ops                               |    25.266 |     0.1%
no-setter-return                              |    24.184 |     0.1%
space-before-function-paren                   |    23.417 |     0.1%
eslint-plugin/no-only-tests                   |    23.257 |     0.1%
n/callback-return                             |    22.994 |     0.1%
no-irregular-whitespace                       |    22.712 |     0.1%
n/shebang                                     |    22.561 |     0.1%
eslint-plugin/no-missing-message-ids          |    22.424 |     0.1%
n/no-unpublished-bin                          |    21.857 |     0.1%
no-implied-eval                               |    21.579 |     0.1%
no-unused-expressions                         |    21.290 |     0.1%
no-const-assign                               |    21.177 |     0.1%
no-dupe-else-if                               |    20.836 |     0.1%
strict                                        |    20.458 |     0.1%
eslint-plugin/consistent-output               |    20.280 |     0.1%
no-prototype-builtins                         |    20.129 |     0.1%
no-param-reassign                             |    19.573 |     0.1%
prefer-promise-reject-errors                  |    18.296 |     0.1%
prefer-const                                  |    18.164 |     0.1%
no-useless-call                               |    18.132 |     0.1%
prefer-spread                                 |    18.130 |     0.1%
eslint-plugin/no-missing-placeholders         |    17.843 |     0.1%
curly                                         |    17.461 |     0.1%
no-iterator                                   |    16.987 |     0.1%
no-shadow-restricted-names                    |    16.728 |     0.1%
eslint-plugin/no-unused-message-ids           |    16.562 |     0.1%
wrap-iife                                     |    15.990 |     0.0%
prefer-numeric-literals                       |    15.577 |     0.0%
func-style                                    |    15.389 |     0.0%
dot-notation                                  |    14.964 |     0.0%
no-caller                                     |    14.413 |     0.0%
unicorn/prefer-includes                       |    14.304 |     0.0%
prefer-arrow-callback                         |    14.194 |     0.0%
no-extra-bind                                 |    14.140 |     0.0%
unicorn/prefer-set-has                        |    13.951 |     0.0%
class-methods-use-this                        |    13.725 |     0.0%
no-loop-func                                  |    13.601 |     0.0%
no-extra-boolean-cast                         |    13.427 |     0.0%
no-unsafe-finally                             |    13.364 |     0.0%
eslint-plugin/prefer-message-ids              |    13.347 |     0.0%
eslint-plugin/test-case-property-ordering     |    12.801 |     0.0%
no-invalid-regexp                             |    12.701 |     0.0%
arrow-body-style                              |    12.471 |     0.0%
no-constructor-return                         |    12.441 |     0.0%
use-isnan                                     |    12.263 |     0.0%
no-proto                                      |    11.984 |     0.0%
no-dupe-args                                  |    11.962 |     0.0%
eslint-comments/no-unlimited-disable          |    11.473 |     0.0%
no-self-assign                                |    11.401 |     0.0%
eslint-plugin/require-meta-schema             |    11.226 |     0.0%
eslint-plugin/no-deprecated-context-methods   |    11.007 |     0.0%
template-curly-spacing                        |    10.939 |     0.0%
no-return-assign                              |    10.216 |     0.0%
eslint-plugin/require-meta-fixable            |    10.043 |     0.0%
no-inner-declarations                         |     9.828 |     0.0%
no-array-constructor                          |     9.656 |     0.0%
prefer-regex-literals                         |     9.493 |     0.0%
no-global-assign                              |     9.415 |     0.0%
no-sparse-arrays                              |     9.383 |     0.0%
no-compare-neg-zero                           |     9.307 |     0.0%
no-obj-calls                                  |     9.307 |     0.0%
no-func-assign                                |     9.233 |     0.0%
eslint-plugin/prefer-output-null              |     9.151 |     0.0%
no-undefined                                  |     8.991 |     0.0%
eslint-plugin/report-message-format           |     8.973 |     0.0%
unicorn/prefer-array-find                     |     8.905 |     0.0%
eslint-plugin/require-meta-has-suggestions    |     8.784 |     0.0%
no-fallthrough                                |     8.771 |     0.0%
eslint-plugin/prefer-replace-text             |     8.722 |     0.0%
prefer-exponentiation-operator                |     8.715 |     0.0%
yoda                                          |     8.704 |     0.0%
n/no-exports-assign                           |     8.503 |     0.0%
eslint-plugin/no-useless-token-range          |     8.105 |     0.0%
require-unicode-regexp                        |     7.865 |     0.0%
no-empty                                      |     7.820 |     0.0%
one-var-declaration-per-line                  |     7.688 |     0.0%
eqeqeq                                        |     7.609 |     0.0%
eslint-comments/require-description           |     7.466 |     0.0%
default-param-last                            |     7.313 |     0.0%
eslint-plugin/require-meta-docs-url           |     6.932 |     0.0%
generator-star-spacing                        |     6.897 |     0.0%
eslint-plugin/no-deprecated-report-api        |     6.811 |     0.0%
eslint-plugin/test-case-shorthand-strings     |     6.437 |     0.0%
eslint-plugin/no-unused-placeholders          |     6.371 |     0.0%
prefer-rest-params                            |     6.361 |     0.0%
eslint-plugin/prefer-placeholders             |     6.245 |     0.0%
n/no-missing-import                           |     5.843 |     0.0%
no-console                                    |     5.829 |     0.0%
no-unsafe-negation                            |     5.826 |     0.0%
no-useless-concat                             |     5.778 |     0.0%
no-else-return                                |     5.277 |     0.0%
eslint-plugin/prefer-object-rule              |     5.270 |     0.0%
no-new-object                                 |     5.200 |     0.0%
valid-typeof                                  |     5.071 |     0.0%
eslint-plugin/require-meta-docs-description   |     5.038 |     0.0%
eslint-plugin/require-meta-type               |     4.973 |     0.0%
require-yield                                 |     4.886 |     0.0%
no-cond-assign                                |     4.828 |     0.0%
no-dupe-class-members                         |     4.651 |     0.0%
no-var                                        |     4.586 |     0.0%
unicorn/prefer-array-some                     |     4.554 |     0.0%
no-confusing-arrow                            |     4.466 |     0.0%
arrow-parens                                  |     4.368 |     0.0%
eol-last                                      |     4.111 |     0.0%
new-parens                                    |     3.394 |     0.0%
radix                                         |     3.386 |     0.0%
internal-rules/no-invalid-meta                |     3.329 |     0.0%
no-duplicate-case                             |     3.205 |     0.0%
switch-colon-spacing                          |     3.050 |     0.0%
operator-assignment                           |     3.040 |     0.0%
no-useless-rename                             |     3.011 |     0.0%
sort-keys                                     |     2.986 |     0.0%
template-tag-spacing                          |     2.985 |     0.0%
unicorn/prefer-string-starts-ends-with        |     2.915 |     0.0%
no-new-symbol                                 |     2.756 |     0.0%
yield-star-spacing                            |     2.595 |     0.0%
unicorn/prefer-array-index-of                 |     2.587 |     0.0%
no-extra-semi                                 |     2.585 |     0.0%
no-new-wrappers                               |     2.568 |     0.0%
no-sequences                                  |     2.240 |     0.0%
eslint-comments/no-aggregating-enable         |     2.218 |     0.0%
symbol-description                            |     2.108 |     0.0%
default-case                                  |     1.950 |     0.0%
no-restricted-syntax                          |     1.926 |     0.0%
unicorn/prefer-string-slice                   |     1.871 |     0.0%
no-unneeded-ternary                           |     1.869 |     0.0%
no-empty-character-class                      |     1.852 |     0.0%
unicorn/prefer-array-flat-map                 |     1.835 |     0.0%
unicode-bom                                   |     1.829 |     0.0%
rest-spread-spacing                           |     1.762 |     0.0%
no-new-func                                   |     1.754 |     0.0%
no-delete-var                                 |     1.724 |     0.0%
n/no-new-require                              |     1.668 |     0.0%
for-direction                                 |     1.647 |     0.0%
no-undef                                      |     1.585 |     0.0%
eslint-comments/no-unused-enable              |     1.572 |     0.0%
eslint-comments/no-duplicate-disable          |     1.560 |     0.0%
no-empty-pattern                              |     1.548 |     0.0%
unicorn/prefer-string-trim-start-end          |     1.474 |     0.0%
no-labels                                     |     1.438 |     0.0%
no-useless-constructor                        |     1.253 |     0.0%
no-throw-literal                              |     1.210 |     0.0%
no-ex-assign                                  |     1.184 |     0.0%
no-class-assign                               |     1.139 |     0.0%
no-nested-ternary                             |     1.095 |     0.0%
no-unused-labels                              |     1.017 |     0.0%
no-case-declarations                          |     1.009 |     0.0%
no-label-var                                  |     0.730 |     0.0%
no-new                                        |     0.682 |     0.0%
no-useless-catch                              |     0.674 |     0.0%
default-case-last                             |     0.615 |     0.0%
guard-for-in                                  |     0.615 |     0.0%
n/no-process-exit                             |     0.578 |     0.0%
no-debugger                                   |     0.567 |     0.0%
no-import-assign                              |     0.543 |     0.0%
no-async-promise-executor                     |     0.506 |     0.0%
no-with                                       |     0.453 |     0.0%
n/process-exit-as-throw                       |     0.345 |     0.0%
eslint-comments/no-unused-disable             |     0.265 |     0.0%

</details>

<details>

<summary>After the change</summary>

Rule                                          | Time (ms) | Relative
:---------------------------------------------|----------:|--------:
indent                                        |  5576.342 |    17.5%
n/no-missing-require                          |  1002.046 |     3.1%
jsdoc/valid-types                             |   973.920 |     3.1%
n/no-extraneous-require                       |   944.363 |     3.0%
jsdoc/check-access                            |   922.792 |     2.9%
key-spacing                                   |   813.738 |     2.5%
jsdoc/check-types                             |   757.250 |     2.4%
n/no-unpublished-require                      |   755.041 |     2.4%
jsdoc/check-tag-names                         |   683.788 |     2.1%
eslint-plugin/no-identical-tests              |   618.421 |     1.9%
jsdoc/check-values                            |   574.391 |     1.8%
jsdoc/check-alignment                         |   557.769 |     1.7%
jsdoc/check-line-alignment                    |   547.425 |     1.7%
jsdoc/check-property-names                    |   542.057 |     1.7%
jsdoc/require-asterisk-prefix                 |   514.762 |     1.6%
jsdoc/require-property-name                   |   506.609 |     1.6%
jsdoc/require-hyphen-before-param-description |   499.367 |     1.6%
jsdoc/tag-lines                               |   494.530 |     1.5%
jsdoc/newline-after-description               |   494.522 |     1.5%
jsdoc/no-multi-asterisks                      |   489.440 |     1.5%
jsdoc/empty-tags                              |   488.835 |     1.5%
jsdoc/require-property-type                   |   486.719 |     1.5%
jsdoc/require-property                        |   485.963 |     1.5%
jsdoc/check-syntax                            |   480.721 |     1.5%
jsdoc/require-property-description            |   479.674 |     1.5%
jsdoc/multiline-blocks                        |   475.227 |     1.5%
max-len                                       |   423.814 |     1.3%
comma-style                                   |   383.209 |     1.2%
n/no-restricted-require                       |   373.241 |     1.2%
n/no-unsupported-features/es-syntax           |   236.569 |     0.7%
no-loss-of-precision                          |   215.842 |     0.7%
jsdoc/check-param-names                       |   211.978 |     0.7%
jsdoc/require-param                           |   203.541 |     0.6%
no-trailing-spaces                            |   199.614 |     0.6%
object-curly-newline                          |   170.588 |     0.5%
padding-line-between-statements               |   162.919 |     0.5%
keyword-spacing                               |   154.745 |     0.5%
comma-spacing                                 |   154.171 |     0.5%
no-dupe-keys                                  |   153.507 |     0.5%
n/no-deprecated-api                           |   151.808 |     0.5%
camelcase                                     |   143.107 |     0.4%
jsdoc/require-description                     |   141.782 |     0.4%
comma-dangle                                  |   138.693 |     0.4%
object-shorthand                              |   138.220 |     0.4%
quote-props                                   |   136.864 |     0.4%
object-curly-spacing                          |   129.069 |     0.4%
jsdoc/require-returns                         |   124.473 |     0.4%
function-paren-newline                        |   119.830 |     0.4%
no-multi-spaces                               |   119.103 |     0.4%
space-in-parens                               |   118.062 |     0.4%
n/no-unsupported-features/es-builtins         |   116.423 |     0.4%
jsdoc/implements-on-classes                   |   115.893 |     0.4%
jsdoc/require-returns-check                   |   114.282 |     0.4%
jsdoc/require-throws                          |   110.748 |     0.3%
internal-rules/multiline-comment-style        |   108.166 |     0.3%
space-infix-ops                               |   103.236 |     0.3%
no-redeclare                                  |    98.330 |     0.3%
no-whitespace-before-property                 |    97.440 |     0.3%
lines-around-comment                          |    97.171 |     0.3%
no-useless-return                             |    97.090 |     0.3%
jsdoc/require-param-description               |    96.000 |     0.3%
no-regex-spaces                               |    95.831 |     0.3%
no-unused-vars                                |    95.393 |     0.3%
func-call-spacing                             |    92.702 |     0.3%
no-multiple-empty-lines                       |    91.742 |     0.3%
jsdoc/require-yields-check                    |    89.443 |     0.3%
no-underscore-dangle                          |    87.400 |     0.3%
jsdoc/require-param-type                      |    86.853 |     0.3%
jsdoc/require-returns-description             |    85.683 |     0.3%
no-useless-escape                             |    84.887 |     0.3%
jsdoc/require-param-name                      |    84.843 |     0.3%
no-script-url                                 |    80.183 |     0.3%
jsdoc/require-returns-type                    |    78.725 |     0.2%
operator-linebreak                            |    78.340 |     0.2%
semi-spacing                                  |    78.155 |     0.2%
max-statements-per-line                       |    77.321 |     0.2%
unicorn/prefer-array-flat                     |    76.181 |     0.2%
no-control-regex                              |    72.832 |     0.2%
no-unexpected-multiline                       |    70.125 |     0.2%
array-bracket-spacing                         |    69.211 |     0.2%
no-alert                                      |    65.921 |     0.2%
no-unmodified-loop-condition                  |    65.918 |     0.2%
no-octal-escape                               |    63.990 |     0.2%
grouped-accessor-pairs                        |    61.649 |     0.2%
no-mixed-spaces-and-tabs                      |    59.231 |     0.2%
no-misleading-character-class                 |    55.641 |     0.2%
n/no-unpublished-import                       |    54.616 |     0.2%
n/no-unsupported-features/node-builtins       |    52.449 |     0.2%
spaced-comment                                |    51.087 |     0.2%
semi-style                                    |    49.516 |     0.2%
object-property-newline                       |    49.166 |     0.2%
quotes                                        |    47.993 |     0.2%
no-tabs                                       |    47.082 |     0.1%
new-cap                                       |    46.066 |     0.1%
computed-property-spacing                     |    44.650 |     0.1%
function-call-argument-newline                |    44.620 |     0.1%
no-unsafe-optional-chaining                   |    43.356 |     0.1%
consistent-return                             |    43.131 |     0.1%
constructor-super                             |    41.722 |     0.1%
brace-style                                   |    40.625 |     0.1%
no-nonoctal-decimal-escape                    |    40.125 |     0.1%
no-use-before-define                          |    39.775 |     0.1%
no-multi-str                                  |    39.504 |     0.1%
jsdoc/no-bad-blocks                           |    39.401 |     0.1%
prefer-template                               |    39.319 |     0.1%
block-spacing                                 |    39.212 |     0.1%
no-undef-init                                 |    38.637 |     0.1%
n/no-extraneous-import                        |    38.331 |     0.1%
no-this-before-super                          |    38.097 |     0.1%
dot-location                                  |    37.857 |     0.1%
no-restricted-properties                      |    37.313 |     0.1%
jsdoc/require-jsdoc                           |    37.240 |     0.1%
eslint-comments/disable-enable-pair           |    36.327 |     0.1%
no-unreachable                                |    35.639 |     0.1%
getter-return                                 |    35.424 |     0.1%
n/no-path-concat                              |    34.520 |     0.1%
semi                                          |    34.054 |     0.1%
no-invalid-this                               |    32.846 |     0.1%
space-before-blocks                           |    32.382 |     0.1%
no-extend-native                              |    30.011 |     0.1%
no-constant-binary-expression                 |    28.979 |     0.1%
n/no-mixed-requires                           |    27.831 |     0.1%
array-callback-return                         |    27.654 |     0.1%
no-shadow                                     |    27.089 |     0.1%
no-constant-condition                         |    26.916 |     0.1%
no-octal                                      |    26.566 |     0.1%
arrow-spacing                                 |    26.546 |     0.1%
no-eval                                       |    26.485 |     0.1%
no-lone-blocks                                |    26.253 |     0.1%
no-floating-decimal                           |    26.103 |     0.1%
no-useless-backreference                      |    25.933 |     0.1%
no-self-compare                               |    25.818 |     0.1%
n/shebang                                     |    25.631 |     0.1%
no-useless-computed-key                       |    25.621 |     0.1%
eslint-plugin/fixer-return                    |    25.436 |     0.1%
no-unreachable-loop                           |    24.870 |     0.1%
n/callback-return                             |    24.394 |     0.1%
n/handle-callback-err                         |    23.597 |     0.1%
no-setter-return                              |    22.978 |     0.1%
no-irregular-whitespace                       |    22.747 |     0.1%
space-before-function-paren                   |    22.527 |     0.1%
space-unary-ops                               |    22.322 |     0.1%
n/no-unpublished-bin                          |    22.291 |     0.1%
no-implied-eval                               |    22.049 |     0.1%
no-const-assign                               |    22.030 |     0.1%
strict                                        |    21.989 |     0.1%
no-dupe-else-if                               |    21.886 |     0.1%
no-prototype-builtins                         |    21.787 |     0.1%
eslint-plugin/no-missing-message-ids          |    21.720 |     0.1%
no-unused-expressions                         |    20.743 |     0.1%
no-param-reassign                             |    20.623 |     0.1%
eslint-plugin/no-only-tests                   |    20.222 |     0.1%
prefer-promise-reject-errors                  |    18.227 |     0.1%
prefer-const                                  |    18.142 |     0.1%
curly                                         |    17.470 |     0.1%
eslint-plugin/consistent-output               |    17.310 |     0.1%
no-useless-call                               |    17.203 |     0.1%
dot-notation                                  |    17.040 |     0.1%
eslint-plugin/no-missing-placeholders         |    17.014 |     0.1%
no-shadow-restricted-names                    |    16.654 |     0.1%
eslint-plugin/no-unused-message-ids           |    15.468 |     0.0%
prefer-spread                                 |    15.450 |     0.0%
prefer-numeric-literals                       |    15.046 |     0.0%
no-iterator                                   |    15.008 |     0.0%
func-style                                    |    15.005 |     0.0%
no-unsafe-finally                             |    14.064 |     0.0%
eslint-plugin/test-case-property-ordering     |    13.926 |     0.0%
eslint-plugin/prefer-message-ids              |    13.727 |     0.0%
prefer-arrow-callback                         |    13.722 |     0.0%
no-caller                                     |    13.509 |     0.0%
no-loop-func                                  |    13.480 |     0.0%
no-extra-boolean-cast                         |    13.439 |     0.0%
no-extra-bind                                 |    13.250 |     0.0%
no-invalid-regexp                             |    13.157 |     0.0%
no-constructor-return                         |    13.088 |     0.0%
wrap-iife                                     |    12.897 |     0.0%
class-methods-use-this                        |    12.672 |     0.0%
no-dupe-args                                  |    12.474 |     0.0%
eslint-comments/no-unlimited-disable          |    12.202 |     0.0%
arrow-body-style                              |    12.126 |     0.0%
prefer-regex-literals                         |    11.955 |     0.0%
unicorn/prefer-includes                       |    11.829 |     0.0%
eslint-plugin/test-case-shorthand-strings     |    11.661 |     0.0%
no-obj-calls                                  |    11.444 |     0.0%
no-proto                                      |    11.358 |     0.0%
use-isnan                                     |    10.851 |     0.0%
no-self-assign                                |    10.840 |     0.0%
eslint-plugin/require-meta-schema             |    10.645 |     0.0%
template-curly-spacing                        |    10.547 |     0.0%
unicorn/prefer-set-has                        |    10.356 |     0.0%
no-sparse-arrays                              |    10.325 |     0.0%
no-return-assign                              |    10.098 |     0.0%
no-fallthrough                                |     9.485 |     0.0%
eslint-plugin/prefer-output-null              |     9.466 |     0.0%
no-global-assign                              |     9.274 |     0.0%
unicorn/prefer-array-find                     |     9.247 |     0.0%
no-inner-declarations                         |     9.184 |     0.0%
require-unicode-regexp                        |     9.173 |     0.0%
no-undefined                                  |     9.131 |     0.0%
yoda                                          |     8.888 |     0.0%
eslint-plugin/require-meta-fixable            |     8.843 |     0.0%
no-func-assign                                |     8.823 |     0.0%
no-array-constructor                          |     8.790 |     0.0%
prefer-exponentiation-operator                |     8.655 |     0.0%
eslint-plugin/no-deprecated-context-methods   |     8.621 |     0.0%
no-compare-neg-zero                           |     8.544 |     0.0%
eslint-plugin/report-message-format           |     8.437 |     0.0%
n/no-exports-assign                           |     8.089 |     0.0%
eqeqeq                                        |     8.077 |     0.0%
one-var-declaration-per-line                  |     7.877 |     0.0%
no-empty                                      |     7.695 |     0.0%
eslint-plugin/no-useless-token-range          |     7.647 |     0.0%
eslint-plugin/require-meta-has-suggestions    |     7.233 |     0.0%
default-param-last                            |     7.137 |     0.0%
eslint-comments/require-description           |     6.937 |     0.0%
eslint-plugin/require-meta-docs-url           |     6.848 |     0.0%
eslint-plugin/prefer-placeholders             |     6.826 |     0.0%
generator-star-spacing                        |     6.824 |     0.0%
eslint-plugin/prefer-replace-text             |     6.649 |     0.0%
eslint-plugin/no-unused-placeholders          |     6.074 |     0.0%
prefer-rest-params                            |     5.991 |     0.0%
no-console                                    |     5.985 |     0.0%
eslint-plugin/no-deprecated-report-api        |     5.940 |     0.0%
n/no-missing-import                           |     5.612 |     0.0%
no-unsafe-negation                            |     5.398 |     0.0%
no-useless-concat                             |     5.385 |     0.0%
no-new-object                                 |     5.210 |     0.0%
no-var                                        |     5.041 |     0.0%
eslint-plugin/require-meta-type               |     4.981 |     0.0%
no-else-return                                |     4.977 |     0.0%
require-yield                                 |     4.966 |     0.0%
eslint-plugin/require-meta-docs-description   |     4.900 |     0.0%
valid-typeof                                  |     4.863 |     0.0%
eslint-plugin/prefer-object-rule              |     4.743 |     0.0%
no-dupe-class-members                         |     4.731 |     0.0%
no-confusing-arrow                            |     4.574 |     0.0%
unicorn/prefer-array-some                     |     4.551 |     0.0%
no-cond-assign                                |     4.545 |     0.0%
eol-last                                      |     4.204 |     0.0%
arrow-parens                                  |     4.101 |     0.0%
no-unneeded-ternary                           |     3.741 |     0.0%
no-duplicate-case                             |     3.326 |     0.0%
no-useless-rename                             |     3.161 |     0.0%
internal-rules/no-invalid-meta                |     3.147 |     0.0%
radix                                         |     3.138 |     0.0%
operator-assignment                           |     3.073 |     0.0%
new-parens                                    |     3.048 |     0.0%
no-debugger                                   |     3.018 |     0.0%
sort-keys                                     |     2.996 |     0.0%
no-new-symbol                                 |     2.962 |     0.0%
switch-colon-spacing                          |     2.898 |     0.0%
unicorn/prefer-string-starts-ends-with        |     2.856 |     0.0%
template-tag-spacing                          |     2.694 |     0.0%
yield-star-spacing                            |     2.548 |     0.0%
unicorn/prefer-array-index-of                 |     2.381 |     0.0%
no-sequences                                  |     2.348 |     0.0%
no-extra-semi                                 |     2.307 |     0.0%
no-new-wrappers                               |     2.282 |     0.0%
eslint-comments/no-aggregating-enable         |     2.141 |     0.0%
unicorn/prefer-string-slice                   |     2.088 |     0.0%
n/no-new-require                              |     1.952 |     0.0%
no-new-func                                   |     1.934 |     0.0%
unicode-bom                                   |     1.908 |     0.0%
no-restricted-syntax                          |     1.902 |     0.0%
default-case                                  |     1.867 |     0.0%
unicorn/prefer-array-flat-map                 |     1.790 |     0.0%
no-empty-character-class                      |     1.788 |     0.0%
no-delete-var                                 |     1.716 |     0.0%
symbol-description                            |     1.694 |     0.0%
rest-spread-spacing                           |     1.647 |     0.0%
eslint-comments/no-unused-enable              |     1.644 |     0.0%
no-undef                                      |     1.641 |     0.0%
eslint-comments/no-duplicate-disable          |     1.513 |     0.0%
for-direction                                 |     1.502 |     0.0%
unicorn/prefer-string-trim-start-end          |     1.411 |     0.0%
no-empty-pattern                              |     1.359 |     0.0%
no-class-assign                               |     1.320 |     0.0%
no-labels                                     |     1.306 |     0.0%
no-case-declarations                          |     1.224 |     0.0%
no-unused-labels                              |     1.195 |     0.0%
no-throw-literal                              |     1.190 |     0.0%
no-ex-assign                                  |     1.095 |     0.0%
no-useless-constructor                        |     1.041 |     0.0%
no-nested-ternary                             |     0.989 |     0.0%
no-new                                        |     0.948 |     0.0%
default-case-last                             |     0.934 |     0.0%
n/no-process-exit                             |     0.785 |     0.0%
no-label-var                                  |     0.776 |     0.0%
no-useless-catch                              |     0.735 |     0.0%
guard-for-in                                  |     0.638 |     0.0%
no-async-promise-executor                     |     0.594 |     0.0%
no-import-assign                              |     0.568 |     0.0%
no-with                                       |     0.539 |     0.0%
n/process-exit-as-throw                       |     0.299 |     0.0%
eslint-comments/no-unused-disable             |     0.277 |     0.0%
</details>

Linting time for this rule is reduced by ~50%.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
