### PR TITLE
fix: validate `ignorePatterns` constructor option in `FlatESLint` class

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -758,8 +758,8 @@ function processOptions({
     if (typeof ignore !== "boolean") {
         errors.push("'ignore' must be a boolean.");
     }
-    if (!isNonEmptyString(ignorePatterns) && !isArrayOfNonEmptyString(ignorePatterns) && ignorePatterns !== null) {
-        errors.push("'ignorePatterns' must be a non-empty string, an array of non-empty strings, or null.");
+    if (!isArrayOfNonEmptyString(ignorePatterns) && ignorePatterns !== null) {
+        errors.push("'ignorePatterns' must be an array of non-empty strings or null.");
     }
     if (typeof overrideConfig !== "object") {
         errors.push("'overrideConfig' must be an object or null.");

--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -758,6 +758,9 @@ function processOptions({
     if (typeof ignore !== "boolean") {
         errors.push("'ignore' must be a boolean.");
     }
+    if (!isNonEmptyString(ignorePatterns) && !isArrayOfNonEmptyString(ignorePatterns) && ignorePatterns !== null) {
+        errors.push("'ignorePatterns' must be a non-empty string, an array of non-empty strings, or null.");
+    }
     if (typeof overrideConfig !== "object") {
         errors.push("'overrideConfig' must be an object or null.");
     }

--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -76,7 +76,7 @@ const LintResultCache = require("../cli-engine/lint-result-cache");
  * @property {string[]} [fixTypes] Array of rule types to apply fixes for.
  * @property {boolean} [globInputPaths] Set to false to skip glob resolution of input file paths to lint (default: true). If false, each input file paths is assumed to be a non-glob path to an existing file.
  * @property {boolean} [ignore] False disables all ignore patterns except for the default ones.
- * @property {string[]} [ignorePatterns] Ignore file patterns to use in addition to config ignores.
+ * @property {string|string[]} [ignorePatterns] Ignore file patterns to use in addition to config ignores. These patterns are relative to `cwd`.
  * @property {ConfigData} [overrideConfig] Override config object, overrides all configs used with this instance
  * @property {boolean|string} [overrideConfigFile] Searches for default config file when falsy;
  *      doesn't do any config file lookup when `true`; considered to be a config filename

--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -76,7 +76,7 @@ const LintResultCache = require("../cli-engine/lint-result-cache");
  * @property {string[]} [fixTypes] Array of rule types to apply fixes for.
  * @property {boolean} [globInputPaths] Set to false to skip glob resolution of input file paths to lint (default: true). If false, each input file paths is assumed to be a non-glob path to an existing file.
  * @property {boolean} [ignore] False disables all ignore patterns except for the default ones.
- * @property {string|string[]} [ignorePatterns] Ignore file patterns to use in addition to config ignores. These patterns are relative to `cwd`.
+ * @property {string[]} [ignorePatterns] Ignore file patterns to use in addition to config ignores. These patterns are relative to `cwd`.
  * @property {ConfigData} [overrideConfig] Override config object, overrides all configs used with this instance
  * @property {boolean|string} [overrideConfigFile] Searches for default config file when falsy;
  *      doesn't do any config file lookup when `true`; considered to be a config filename
@@ -377,45 +377,39 @@ async function calculateConfigArray(eslint, {
     // add in any configured defaults
     configs.push(...slots.defaultConfigs);
 
-    let allIgnorePatterns = [];
-
     // append command line ignore patterns
-    if (ignorePatterns) {
-        if (typeof ignorePatterns === "string") {
-            allIgnorePatterns.push(ignorePatterns);
+    if (ignorePatterns && ignorePatterns.length > 0) {
+
+        let relativeIgnorePatterns;
+
+        /*
+         * If the config file basePath is different than the cwd, then
+         * the ignore patterns won't work correctly. Here, we adjust the
+         * ignore pattern to include the correct relative path. Patterns
+         * passed as `ignorePatterns` are relative to the cwd, whereas
+         * the config file basePath can be an ancestor of the cwd.
+         */
+        if (basePath === cwd) {
+            relativeIgnorePatterns = ignorePatterns;
         } else {
-            allIgnorePatterns.push(...ignorePatterns);
-        }
-    }
 
-    /*
-     * If the config file basePath is different than the cwd, then
-     * the ignore patterns won't work correctly. Here, we adjust the
-     * ignore pattern to include the correct relative path. Patterns
-     * loaded from ignore files are always relative to the cwd, whereas
-     * the config file basePath can be an ancestor of the cwd.
-     */
-    if (basePath !== cwd && allIgnorePatterns.length) {
+            const relativeIgnorePath = path.relative(basePath, cwd);
 
-        const relativeIgnorePath = path.relative(basePath, cwd);
+            relativeIgnorePatterns = ignorePatterns.map(pattern => {
+                const negated = pattern.startsWith("!");
+                const basePattern = negated ? pattern.slice(1) : pattern;
 
-        allIgnorePatterns = allIgnorePatterns.map(pattern => {
-            const negated = pattern.startsWith("!");
-            const basePattern = negated ? pattern.slice(1) : pattern;
-
-            return (negated ? "!" : "") +
+                return (negated ? "!" : "") +
                 path.posix.join(relativeIgnorePath, basePattern);
-        });
-    }
-
-    if (allIgnorePatterns.length) {
+            });
+        }
 
         /*
          * Ignore patterns are added to the end of the config array
          * so they can override default ignores.
          */
         configs.push({
-            ignores: allIgnorePatterns
+            ignores: relativeIgnorePatterns
         });
     }
 

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -200,7 +200,7 @@ describe("FlatESLint", () => {
                     "- 'fixTypes' must be an array of any of \"directive\", \"problem\", \"suggestion\", and \"layout\".",
                     "- 'globInputPaths' must be a boolean.",
                     "- 'ignore' must be a boolean.",
-                    "- 'ignorePatterns' must be a non-empty string, an array of non-empty strings, or null.",
+                    "- 'ignorePatterns' must be an array of non-empty strings or null.",
                     "- 'overrideConfig' must be an object or null.",
                     "- 'overrideConfigFile' must be a non-empty string, null, or true.",
                     "- 'plugins' must be an object or null.",
@@ -209,12 +209,13 @@ describe("FlatESLint", () => {
             );
         });
 
-        it("should throw readable messages if 'ignorePatterns' is not a non-empty string or an array of non-empty strings.", () => {
+        it("should throw readable messages if 'ignorePatterns' is not an array of non-empty strings.", () => {
             const invalidIgnorePatterns = [
                 () => {},
                 false,
                 {},
                 "",
+                "foo",
                 [[]],
                 [() => {}],
                 [false],
@@ -230,7 +231,7 @@ describe("FlatESLint", () => {
                     () => new FlatESLint({ ignorePatterns }),
                     new RegExp(escapeStringRegExp([
                         "Invalid Options:",
-                        "- 'ignorePatterns' must be a non-empty string, an array of non-empty strings, or null."
+                        "- 'ignorePatterns' must be an array of non-empty strings or null."
                     ].join("\n")), "u")
                 );
             });
@@ -3578,7 +3579,7 @@ describe("FlatESLint", () => {
                 const engine = new FlatESLint({
                     cwd,
                     overrideConfigFile: true,
-                    ignorePatterns: "!node_modules/package/**"
+                    ignorePatterns: ["!node_modules/package/**"]
                 });
 
                 const result = await engine.isPathIgnored(getFixturePath("ignored-paths", "node_modules", "package", "file.js"));
@@ -4064,7 +4065,7 @@ describe("FlatESLint", () => {
             const engine = new FlatESLint({
                 overrideConfigFile: true,
                 cwd: path.join(fixtureDir, "foo", "bar"),
-                ignorePatterns: "*/**", // ignore all subdirectories of `cwd`
+                ignorePatterns: ["*/**"], // ignore all subdirectories of `cwd`
                 overrideConfig: {
                     rules: {
                         eqeqeq: "warn"
@@ -4082,7 +4083,7 @@ describe("FlatESLint", () => {
             const engine = new FlatESLint({
                 overrideConfigFile: true,
                 cwd: path.join(fixtureDir, "foo", "bar"),
-                ignorePatterns: "**"
+                ignorePatterns: ["**"]
             });
 
             const results = await engine.lintText("", { warnIgnored: true });
@@ -4095,7 +4096,7 @@ describe("FlatESLint", () => {
             const engine = new FlatESLint({
                 overrideConfigFile: true,
                 cwd: getFixturePath(),
-                ignorePatterns: "passing*",
+                ignorePatterns: ["passing*"],
                 overrideConfig: {
                     rules: {
                         "no-undef": 2,
@@ -4209,7 +4210,7 @@ describe("FlatESLint", () => {
         it("should ignore messages not related to a rule", async () => {
             const engine = new FlatESLint({
                 overrideConfigFile: true,
-                ignorePatterns: "ignored.js",
+                ignorePatterns: ["ignored.js"],
                 overrideConfig: {
                     rules: {
                         "no-var": "warn"

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -182,6 +182,7 @@ describe("FlatESLint", () => {
                     fixTypes: ["xyz"],
                     globInputPaths: "",
                     ignore: "",
+                    ignorePatterns: "",
                     overrideConfig: "",
                     overrideConfigFile: "",
                     plugins: "",
@@ -199,12 +200,40 @@ describe("FlatESLint", () => {
                     "- 'fixTypes' must be an array of any of \"directive\", \"problem\", \"suggestion\", and \"layout\".",
                     "- 'globInputPaths' must be a boolean.",
                     "- 'ignore' must be a boolean.",
+                    "- 'ignorePatterns' must be a non-empty string, an array of non-empty strings, or null.",
                     "- 'overrideConfig' must be an object or null.",
                     "- 'overrideConfigFile' must be a non-empty string, null, or true.",
                     "- 'plugins' must be an object or null.",
                     "- 'reportUnusedDisableDirectives' must be any of \"error\", \"warn\", \"off\", and null."
                 ].join("\n")), "u")
             );
+        });
+
+        it("should throw readable messages if 'ignorePatterns' is not a non-empty string or an array of non-empty strings.", () => {
+            const invalidIgnorePatterns = [
+                () => {},
+                false,
+                {},
+                "",
+                [[]],
+                [() => {}],
+                [false],
+                [{}],
+                [""],
+                ["foo", ""],
+                ["foo", "", "bar"],
+                ["foo", false, "bar"]
+            ];
+
+            invalidIgnorePatterns.forEach(ignorePatterns => {
+                assert.throws(
+                    () => new FlatESLint({ ignorePatterns }),
+                    new RegExp(escapeStringRegExp([
+                        "Invalid Options:",
+                        "- 'ignorePatterns' must be a non-empty string, an array of non-empty strings, or null."
+                    ].join("\n")), "u")
+                );
+            });
         });
 
         it("should throw readable messages if 'plugins' option contains empty key", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Adds missing validation for `ignorePatterns` constructor option of the `FlatESLint` class.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `function processOptions` to throw a readable message when `ignorePatterns` is not a non-empty string, an array of non-empty strings, or `null`.

#### Is there anything you'd like reviewers to focus on?

I'm not sure if this option should be accepting `string` value as that could be misleading. `ignorePatterns: string` might be interpreted as if the string can contain multiple patterns (e.g., a newline-delimited list).

<!-- markdownlint-disable-file MD004 -->
