### PR TITLE
feat: improve flat config errors for invalid rule options and severities

### DIFF
--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -127,31 +127,64 @@ function normalizeRuleOptions(ruleOptions) {
 //-----------------------------------------------------------------------------
 
 /**
+ * The error type when a rule's options are configured with an invalid type.
+ */
+class InvalidRuleOptionsError extends Error {
+
+    /**
+     * @param {string} ruleId Rule name being configured.
+     * @param {any} value The invalid value.
+     */
+    constructor(ruleId, value) {
+        super(`Configuration for rule "${ruleId}" is invalid. Expected severity of "off", 0, "warn", 1, "error", or 2.`);
+        this.messageTemplate = "invalid-rule-options";
+        this.messageData = { ruleId, value };
+    }
+}
+
+/**
  * Validates that a value is a valid rule options entry.
+ * @param {string} ruleId Rule name being configured.
  * @param {any} value The value to check.
  * @returns {void}
- * @throws {TypeError} If the value isn't a valid rule options.
+ * @throws {InvalidRuleOptionsError} If the value isn't a valid rule options.
  */
-function assertIsRuleOptions(value) {
-
+function assertIsRuleOptions(ruleId, value) {
     if (typeof value !== "string" && typeof value !== "number" && !Array.isArray(value)) {
-        throw new TypeError("Expected a string, number, or array.");
+        throw new InvalidRuleOptionsError(ruleId, value);
+    }
+}
+
+/**
+ * The error type when a rule's severity is invalid.
+ */
+class InvalidRuleSeverityError extends Error {
+
+    /**
+     * @param {string} ruleId Rule name being configured.
+     * @param {any} value The invalid value.
+     */
+    constructor(ruleId, value) {
+        super(`Configuration for rule "${ruleId}" is invalid. Expected severity of "off", 0, "warn", 1, "error", or 2.`);
+        this.messageTemplate = "invalid-rule-severity";
+        this.messageData = { ruleId, value };
     }
 }
 
 /**
  * Validates that a value is valid rule severity.
+ * @param {string} ruleId Rule name being configured.
  * @param {any} value The value to check.
  * @returns {void}
- * @throws {TypeError} If the value isn't a valid rule severity.
+ * @throws {InvalidRuleSeverityError} If the value isn't a valid rule severity.
  */
-function assertIsRuleSeverity(value) {
+function assertIsRuleSeverity(ruleId, value) {
     const severity = typeof value === "string"
         ? ruleSeverities.get(value.toLowerCase())
         : ruleSeverities.get(value);
 
     if (typeof severity === "undefined") {
-        throw new TypeError("Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
+        throw new InvalidRuleSeverityError(ruleId, value);
     }
 }
 
@@ -357,39 +390,28 @@ const rulesSchema = {
     validate(value) {
         assertIsObject(value);
 
-        let lastRuleId;
+        /*
+         * We are not checking the rule schema here because there is no
+         * guarantee that the rule definition is present at this point. Instead
+         * we wait and check the rule schema during the finalization step
+         * of calculating a config.
+         */
+        for (const ruleId of Object.keys(value)) {
 
-        // Performance: One try-catch has less overhead than one per loop iteration
-        try {
-
-            /*
-             * We are not checking the rule schema here because there is no
-             * guarantee that the rule definition is present at this point. Instead
-             * we wait and check the rule schema during the finalization step
-             * of calculating a config.
-             */
-            for (const ruleId of Object.keys(value)) {
-
-                // avoid hairy edge case
-                if (ruleId === "__proto__") {
-                    continue;
-                }
-
-                lastRuleId = ruleId;
-
-                const ruleOptions = value[ruleId];
-
-                assertIsRuleOptions(ruleOptions);
-
-                if (Array.isArray(ruleOptions)) {
-                    assertIsRuleSeverity(ruleOptions[0]);
-                } else {
-                    assertIsRuleSeverity(ruleOptions);
-                }
+            // avoid hairy edge case
+            if (ruleId === "__proto__") {
+                continue;
             }
-        } catch (error) {
-            error.message = `Key "${lastRuleId}": ${error.message}`;
-            throw error;
+
+            const ruleOptions = value[ruleId];
+
+            assertIsRuleOptions(ruleId, ruleOptions);
+
+            if (Array.isArray(ruleOptions)) {
+                assertIsRuleSeverity(ruleId, ruleOptions[0]);
+            } else {
+                assertIsRuleSeverity(ruleId, ruleOptions);
+            }
         }
     }
 };

--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -136,7 +136,7 @@ class InvalidRuleOptionsError extends Error {
      * @param {any} value The invalid value.
      */
     constructor(ruleId, value) {
-        super(`Configuration for rule "${ruleId}" is invalid. Expected severity of "off", 0, "warn", 1, "error", or 2.`);
+        super(`Key "${ruleId}": Expected severity of "off", 0, "warn", 1, "error", or 2.`);
         this.messageTemplate = "invalid-rule-options";
         this.messageData = { ruleId, value };
     }
@@ -165,7 +165,7 @@ class InvalidRuleSeverityError extends Error {
      * @param {any} value The invalid value.
      */
     constructor(ruleId, value) {
-        super(`Configuration for rule "${ruleId}" is invalid. Expected severity of "off", 0, "warn", 1, "error", or 2.`);
+        super(`Key "${ruleId}": Expected severity of "off", 0, "warn", 1, "error", or 2.`);
         this.messageTemplate = "invalid-rule-severity";
         this.messageData = { ruleId, value };
     }

--- a/messages/invalid-rule-options.js
+++ b/messages/invalid-rule-options.js
@@ -4,13 +4,13 @@ const { stringifyValueForError } = require("./shared");
 
 module.exports = function({ ruleId, value }) {
     return `
-Configuration for rule "${ruleId}" is invalid. Expected severity of "off", 0, "warn", 1, "error", or 2.
+Configuration for rule "${ruleId}" is invalid. Each rule must have a severity ("off", 0, "warn", 1, "error", or 2) and may be followed by additional options for the rule.
 
-You passed '${stringifyValueForError(value, 4)}'.
+You passed '${stringifyValueForError(value, 4)}', which doesn't contain a valid severity.
 
 If you're attempting to configure rule options, perhaps you meant:
 
-    ["error", ${stringifyValueForError(value, 8)}]
+    "${ruleId}": ["error", ${stringifyValueForError(value, 8)}]
 
 See https://eslint.org/docs/latest/use/configure/rules#using-configuration-files for configuring rules.
 `.trimStart();

--- a/messages/invalid-rule-options.js
+++ b/messages/invalid-rule-options.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const { stringifyValueForError } = require("./shared");
+
+module.exports = function({ ruleId, value }) {
+    return `
+Configuration for rule "${ruleId}" is invalid. Expected severity of "off", 0, "warn", 1, "error", or 2.
+
+You passed '${stringifyValueForError(value, 4)}'.
+
+If you're attempting to configure rule options, perhaps you meant:
+
+    ["error", ${stringifyValueForError(value, 8)}]
+
+See https://eslint.org/docs/latest/use/configure/rules#using-configuration-files for configuring rules.
+`.trimStart();
+};

--- a/messages/invalid-rule-severity.js
+++ b/messages/invalid-rule-severity.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const { stringifyValueForError } = require("./shared");
+
+module.exports = function({ ruleId, value }) {
+    return `
+Configuration for rule "${ruleId}" is invalid. Expected severity of "off", 0, "warn", 1, "error", or 2.
+
+You passed '${stringifyValueForError(value, 4)}'.
+
+See https://eslint.org/docs/latest/use/configure/rules#using-configuration-files for configuring rules.
+`.trimStart();
+};

--- a/messages/shared.js
+++ b/messages/shared.js
@@ -12,8 +12,7 @@
  * @returns {string} The value, stringified.
  */
 function stringifyValueForError(value, indentation) {
-    // eslint-disable-next-line no-undefined -- Users may provide it
-    return value === undefined ? `${value}` : JSON.stringify(value, null, 4).replace(/\n/gu, `\n${" ".repeat(indentation)}`);
+    return value ? JSON.stringify(value, null, 4).replace(/\n/gu, `\n${" ".repeat(indentation)}`) : `${value}`;
 }
 
 module.exports = { stringifyValueForError };

--- a/messages/shared.js
+++ b/messages/shared.js
@@ -1,0 +1,18 @@
+/**
+ * @fileoverview Shared utilities for error messages.
+ * @author Josh Goldberg
+ */
+
+"use strict";
+
+/**
+ * Converts a value to a string that may be printed in errors.
+ * @param {any} value The invalid value.
+ * @param {number} indentation How many spaces to indent
+ * @returns {string} The value, stringified.
+ */
+function stringifyValueForError(value, indentation) {
+    return JSON.stringify(value, null, 4).replace(/\n/gu, `\n${" ".repeat(indentation)}`);
+}
+
+module.exports = { stringifyValueForError };

--- a/messages/shared.js
+++ b/messages/shared.js
@@ -12,7 +12,8 @@
  * @returns {string} The value, stringified.
  */
 function stringifyValueForError(value, indentation) {
-    return JSON.stringify(value, null, 4).replace(/\n/gu, `\n${" ".repeat(indentation)}`);
+    // eslint-disable-next-line no-undefined -- Users may provide it
+    return value === undefined ? `${value}` : JSON.stringify(value, null, 4).replace(/\n/gu, `\n${" ".repeat(indentation)}`);
 }
 
 module.exports = { stringifyValueForError };

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -1712,7 +1712,7 @@ describe("FlatConfigArray", () => {
                             foo: true
                         }
                     }
-                ], "Key \"rules\": Key \"foo\": Expected a string, number, or array.");
+                ], "Key \"rules\": Configuration for rule \"foo\" is invalid. Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
             });
 
             it("should error when an invalid rule severity of the right type is set", async () => {
@@ -1723,7 +1723,7 @@ describe("FlatConfigArray", () => {
                             foo: 3
                         }
                     }
-                ], "Key \"rules\": Key \"foo\": Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
+                ], "Key \"rules\": Configuration for rule \"foo\" is invalid. Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
             });
 
             it("should error when an invalid rule severity is set in an array", async () => {
@@ -1734,7 +1734,7 @@ describe("FlatConfigArray", () => {
                             foo: [true]
                         }
                     }
-                ], "Key \"rules\": Key \"foo\": Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
+                ], "Configuration for rule \"foo\" is invalid. Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
             });
 
             it("should error when rule doesn't exist", async () => {

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -1712,7 +1712,7 @@ describe("FlatConfigArray", () => {
                             foo: true
                         }
                     }
-                ], "Key \"rules\": Configuration for rule \"foo\" is invalid. Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
+                ], "Key \"rules\": Key \"foo\": Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
             });
 
             it("should error when an invalid rule severity of the right type is set", async () => {
@@ -1723,7 +1723,7 @@ describe("FlatConfigArray", () => {
                             foo: 3
                         }
                     }
-                ], "Key \"rules\": Configuration for rule \"foo\" is invalid. Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
+                ], "Key \"rules\": Key \"foo\": Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
             });
 
             it("should error when an invalid rule severity is set in an array", async () => {
@@ -1734,7 +1734,7 @@ describe("FlatConfigArray", () => {
                             foo: [true]
                         }
                     }
-                ], "Configuration for rule \"foo\" is invalid. Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
+                ], "Key \"rules\": Key \"foo\": Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
             });
 
             it("should error when rule doesn't exist", async () => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -8811,7 +8811,7 @@ describe("Linter with FlatConfigArray", () => {
 
                 assert.throws(() => {
                     linter.verify(code, config, filename, true);
-                }, /Key "rules": Key "semi"/u);
+                }, /Key "rules": Configuration for rule "semi"/u);
             });
 
             it("should process empty config", () => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -8811,7 +8811,7 @@ describe("Linter with FlatConfigArray", () => {
 
                 assert.throws(() => {
                     linter.verify(code, config, filename, true);
-                }, /Key "rules": Configuration for rule "semi"/u);
+                }, /Key "rules": Key "semi": Expected severity/u);
             });
 
             it("should process empty config", () => {


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)


[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Adds a couple of new error messages for flat config schema parsing.

Fixes #17056

#### Is there anything you'd like reviewers to focus on?

* Unit tests don't seem to cover the full error messages - is this something you'd want added in?
* Please bikeshed my error messages 😄 I'm not confident in them, and mostly based them off the legacy config system's.
    * Additionally, this removes the _`Key: ...`_ portion of the error message, in favor of the traditional _`Configuration for rule ...`_. I see this change as more readable, perhaps?