### PR TITLE
feat: add `anonymous` property to `no-restricted-exports`

### DIFF
--- a/docs/src/rules/no-restricted-exports.md
+++ b/docs/src/rules/no-restricted-exports.md
@@ -23,6 +23,7 @@ This rule has an object option:
     * `defaultFrom`: restricts `export { default } from 'foo';` declarations.
     * `namedFrom`: restricts `export { foo as default } from 'foo';` declarations.
     * `namespaceFrom`: restricts `export * as default from 'foo';` declarations.
+    * `anonymous`: restrict `export default "value";` or `export default () => {};` declarations.
 
 ### restrictedNamedExports
 
@@ -205,6 +206,40 @@ Examples of **incorrect** code for the `"restrictDefaultExports": { "namespaceFr
 /*eslint no-restricted-exports: ["error", { "restrictDefaultExports": { "namespaceFrom": true } }]*/
 
 export * as default from 'foo';
+```
+
+:::
+
+#### anonymous
+
+With `"restrictDefaultExports": { "anonymous": true }` option, only identifiers and named function/class declarations are allowed for `default export`.
+
+Examples of **incorrect** code for the `"restrictDefaultExports": { "anonymous": true }` option:
+
+::: incorrect
+
+```js
+/*eslint no-restricted-exports: ["error", { "restrictDefaultExports": { "namespaceFrom": true } }]*/
+
+export default 123;
+export default num + 1;
+export default (value) => value * 2;
+export default function() {};
+export default class {};
+```
+
+:::
+
+Examples of **correct** code for the `"restrictDefaultExports": { "anonymous": true }` option:
+
+::: correct
+
+```js
+/*eslint no-restricted-exports: ["error", { "restrictDefaultExports": { "namespaceFrom": true } }]*/
+
+export default num;
+export default function myFunc() {};
+export default class MyClass {};
 ```
 
 :::

--- a/lib/rules/no-restricted-exports.js
+++ b/lib/rules/no-restricted-exports.js
@@ -79,6 +79,11 @@ module.exports = {
                                 //  Allow/Disallow `export * as default from "mod"`; declarations
                                 namespaceFrom: {
                                     type: "boolean"
+                                },
+
+                                // Allow/Disallow `export default 'hello'` but `export default function Hello() {}` declarations
+                                anonymous: {
+                                    type: "boolean"
                                 }
                             },
                             additionalProperties: false
@@ -154,6 +159,32 @@ module.exports = {
             }
         }
 
+        /**
+         * Checks if `export default` declaration is anonymous.
+         * @param {ASTNode} node default-exported declaration node to check.
+         * @returns {void}
+         */
+        function checkAnonymousDefaultExport(node) {
+            if (!(restrictDefaultExports && restrictDefaultExports.anonymous)) {
+                return;
+            }
+
+            if (node.type === "Identifier") {
+                return;
+            }
+            if (
+                (node.type === "FunctionDeclaration" || node.type === "ClassDeclaration") &&
+                node.id !== null
+            ) {
+                return;
+            }
+
+            context.report({
+                node,
+                messageId: "restrictedDefault"
+            });
+        }
+
         return {
             ExportAllDeclaration(node) {
                 if (node.exported) {
@@ -167,6 +198,10 @@ module.exports = {
                         node,
                         messageId: "restrictedDefault"
                     });
+                }
+
+                if (node.declaration) {
+                    checkAnonymousDefaultExport(node.declaration);
                 }
             },
 

--- a/tests/lib/rules/no-restricted-exports.js
+++ b/tests/lib/rules/no-restricted-exports.js
@@ -131,7 +131,16 @@ ruleTester.run("no-restricted-exports", rule, {
         { code: "export { 'default' } from 'mod'; ", options: [{ restrictDefaultExports: { defaultFrom: false, namedFrom: true } }] },
 
         // restrictDefaultExports.namespaceFrom option
-        { code: "export * as default from 'mod';", options: [{ restrictDefaultExports: { namespaceFrom: false } }] }
+        { code: "export * as default from 'mod';", options: [{ restrictDefaultExports: { namespaceFrom: false } }] },
+
+        // restrictDefaultExports.anonymous option
+        { code: "export default 123;", options: [{ restrictDefaultExports: { anonymous: false } }] },
+        { code: "export default a + 1;", options: [{ restrictDefaultExports: { anonymous: false } }] },
+        { code: "export default a;", options: [{ restrictDefaultExports: { anonymous: true } }] },
+        { code: "export default function() {};", options: [{ restrictDefaultExports: { anonymous: false } }] },
+        { code: "export default function f() {};", options: [{ restrictDefaultExports: { anonymous: true } }] },
+        { code: "export default class {};", options: [{ restrictDefaultExports: { anonymous: false } }] },
+        { code: "export default class C {};", options: [{ restrictDefaultExports: { anonymous: true } }] }
     ],
 
     invalid: [
@@ -603,6 +612,33 @@ ruleTester.run("no-restricted-exports", rule, {
             code: "export * as default from 'mod';",
             options: [{ restrictDefaultExports: { namespaceFrom: true } }],
             errors: [{ messageId: "restrictedDefault", type: "Identifier", line: 1, column: 13 }]
+        },
+
+        // restrictDefaultExports.anonymous option
+        {
+            code: "export default 123;",
+            options: [{ restrictDefaultExports: { anonymous: true } }],
+            errors: [{ messageId: "restrictedDefault", type: "Literal", line: 1, column: 16 }]
+        },
+        {
+            code: "export default a + 1;",
+            options: [{ restrictDefaultExports: { anonymous: true } }],
+            errors: [{ messageId: "restrictedDefault", type: "BinaryExpression", line: 1, column: 16 }]
+        },
+        {
+            code: "export default function() {};",
+            options: [{ restrictDefaultExports: { anonymous: true } }],
+            errors: [{ messageId: "restrictedDefault", type: "FunctionDeclaration", line: 1, column: 16 }]
+        },
+        {
+            code: "export default () => {};",
+            options: [{ restrictDefaultExports: { anonymous: true } }],
+            errors: [{ messageId: "restrictedDefault", type: "ArrowFunctionExpression", line: 1, column: 16 }]
+        },
+        {
+            code: "export default class {};",
+            options: [{ restrictDefaultExports: { anonymous: true } }],
+            errors: [{ messageId: "restrictedDefault", type: "ClassDeclaration", line: 1, column: 16 }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

[no-restricted-exports](https://eslint.org/docs/latest/rules/no-restricted-exports)

**What change do you want to make (place an "X" next to just one item)?**

[x] Generate more warnings
[ ] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[x] A new option
[ ] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
// eslint no-restricted-exports: ["error", { "restrictDefaultExports": { "namespaceFrom": true } }]

// invalid
export default 32;
export default x * 10;
export default function() {};
export default () => {};
export default class {};

// valid
export default foo;
export default function myFunc() {};
export default class MyClass {};
```

**What does the rule currently do for this code?**

Though `direct: true` can restrict `export default something`, there is no way to to allow only identifiers and named function/class declarations.

**What will the rule do after it's changed?**

With `anonymous: true`, only identifiers and named function/class declarations are allowed for `export default`.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Add `anonymous` property to `restrictDefaultExports` option of `no-restricted-exports` rule.
If its value is true, only items with name (identifiers and named function/class declarations) are allowed for `export default`.
Such named items are available for auto-import feature on editors (like VSCode).

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
