### PR TITLE
feat: Add findConfigFile() method to FlatESLint

### DIFF
--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -321,6 +321,42 @@ async function loadFlatConfigFile(filePath) {
 }
 
 /**
+ * Determines which config file to use. This is determined by seeing if an
+ * override config file was passed, and if so, using it; otherwise, as long
+ * as override config file is not explicitly set to `false`, it will search
+ * upwards from the cwd for a file named `eslint.config.js`.
+ * @param {import("./eslint").ESLintOptions} options The ESLint instance options.
+ * @returns {{configFilePath:string,basePath:string}} Location information for
+ *      the config file.
+ */
+async function locateConfigFileToUse({ configFile, cwd }) {
+
+    // determine where to load config file from
+    let configFilePath;
+    let basePath = cwd;
+
+    if (typeof configFile === "string") {
+        debug(`Override config file path is ${configFile}`);
+        configFilePath = path.resolve(cwd, configFile);
+    } else if (configFile !== false) {
+        debug("Searching for eslint.config.js");
+        configFilePath = await findFlatConfigFile(cwd);
+
+        if (!configFilePath) {
+            throw new Error("Could not find config file.");
+        }
+
+        basePath = path.resolve(path.dirname(configFilePath));
+    }
+
+    return {
+        configFilePath,
+        basePath
+    };
+
+}
+
+/**
  * Calculates the config array for this run based on inputs.
  * @param {FlatESLint} eslint The instance to create the config array for.
  * @param {import("./eslint").ESLintOptions} options The ESLint instance options.
@@ -342,25 +378,7 @@ async function calculateConfigArray(eslint, {
         return slots.configs;
     }
 
-    // determine where to load config file from
-    let configFilePath;
-    let basePath = cwd;
-
-    if (typeof configFile === "string") {
-        debug(`Override config file path is ${configFile}`);
-        configFilePath = path.resolve(cwd, configFile);
-    } else if (configFile !== false) {
-        debug("Searching for eslint.config.js");
-        configFilePath = await findFlatConfigFile(cwd);
-
-        if (!configFilePath) {
-            throw new Error("Could not find config file.");
-        }
-
-        basePath = path.resolve(path.dirname(configFilePath));
-    }
-
-
+    const { configFilePath, basePath } = await locateConfigFileToUse({ configFile, cwd });
     const configs = new FlatConfigArray(baseConfig || [], { basePath, shouldIgnore });
 
     // load config file
@@ -1158,6 +1176,19 @@ class FlatESLint {
         const configs = await calculateConfigArray(this, options);
 
         return configs.getConfig(absolutePath);
+    }
+
+    /**
+     * Finds the config file being used by this instance based on the options
+     * passed to the constructor.
+     * @returns {string|undefined} The path to the config file being used or
+     *      `undefined` if no config file is being used.
+     */
+    async findConfigFile() {
+        const options = privateMembers.get(this).options;
+        const { configFilePath } = await locateConfigFileToUse(options);
+
+        return configFilePath;
     }
 
     /**

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -3954,6 +3954,43 @@ describe("FlatESLint", () => {
         });
     });
 
+    describe("findConfigFile()", () => {
+
+        it("should return null when overrideConfigFile is true", async () => {
+            const engine = new FlatESLint({
+                overrideConfigFile: true
+            });
+
+            assert.strictEqual(await engine.findConfigFile(), void 0);
+        });
+
+        it("should return custom config file path when overrideConfigFile is a nonempty string", async () => {
+            const engine = new FlatESLint({
+                overrideConfigFile: "my-config.js"
+            });
+            const configFilePath = path.resolve(__dirname, "../../../my-config.js");
+
+            assert.strictEqual(await engine.findConfigFile(), configFilePath);
+        });
+
+        it("should return root level eslint.config.js when overrideConfigFile is null", async () => {
+            const engine = new FlatESLint({
+                overrideConfigFile: null
+            });
+            const configFilePath = path.resolve(__dirname, "../../../eslint.config.js");
+
+            assert.strictEqual(await engine.findConfigFile(), configFilePath);
+        });
+
+        it("should return root level eslint.config.js when overrideConfigFile is not specified", async () => {
+            const engine = new FlatESLint();
+            const configFilePath = path.resolve(__dirname, "../../../eslint.config.js");
+
+            assert.strictEqual(await engine.findConfigFile(), configFilePath);
+        });
+
+    });
+
     describe("getRulesMetaForResults()", () => {
 
         it("should throw an error when this instance did not lint any files", async () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Adds a `findConfigFile()` method to `FlatESLint`. The purpose of this method is to return the location of the config file this `FlatESLint` instance will use as the basis for its configuration without actually loading the file.

Fixes #17046

#### Is there anything you'd like reviewers to focus on?

I didn't include any caching for the config file path as I don't see this as a common enough use case to optimize what is typically a very fast search. Let me know if you think differently.

<!-- markdownlint-disable-file MD004 -->
