### PR TITLE
perf: Store indent descriptors in a plain array

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -152,7 +152,7 @@ class IndexMap {
     /**
      * Finds the value of the entry with the largest key less than or equal to the provided key
      * @param {number} key The provided key
-     * @returns {number|undefined} The value of the found entry, or undefined if no such entry exists.
+     * @returns {*|undefined} The value of the found entry, or undefined if no such entry exists.
      */
     findLastNotAfter(key) {
         const values = this._values;

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -12,8 +12,6 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const { OrderedMap } = require("js-sdsl");
-
 const astUtils = require("./utils/ast-utils");
 
 //------------------------------------------------------------------------------
@@ -125,43 +123,48 @@ const KNOWN_NODES = new Set([
 
 
 /**
- * A mutable balanced binary search tree that stores (key, value) pairs. The keys are numeric, and must be unique.
- * This is intended to be a generic wrapper around a balanced binary search tree library, so that the underlying implementation
+ * A mutable map that stores (key, value) pairs. The keys are numeric indices, and must be unique.
+ * This is intended to be a generic wrapper around a map with non-negative integer keys, so that the underlying implementation
  * can easily be swapped out.
  */
-class BinarySearchTree {
+class IndexMap {
 
     /**
-     * Creates an empty tree
+     * Creates an empty map
+     * @param {number} maxKey The maximum key
      */
-    constructor() {
-        this._orderedMap = new OrderedMap();
-        this._orderedMapEnd = this._orderedMap.end();
+    constructor(maxKey) {
+
+        // Initializing the array with the maximum expected size avoids dynamic reallocations that could degrade performance.
+        this._values = Array(maxKey + 1);
     }
 
     /**
-     * Inserts an entry into the tree.
+     * Inserts an entry into the map.
      * @param {number} key The entry's key
      * @param {any} value The entry's value
      * @returns {void}
      */
     insert(key, value) {
-        this._orderedMap.setElement(key, value);
+        this._values[key] = value;
     }
 
     /**
-     * Finds the entry with the largest key less than or equal to the provided key
+     * Finds the value of the entry with the largest key less than or equal to the provided key
      * @param {number} key The provided key
-     * @returns {{key: number, value: *}|null} The found entry, or null if no such entry exists.
+     * @returns {number|undefined} The value of the found entry, or undefined if no such entry exists.
      */
-    findLe(key) {
-        const iterator = this._orderedMap.reverseLowerBound(key);
+    findLastNotAfter(key) {
+        const values = this._values;
 
-        if (iterator.equals(this._orderedMapEnd)) {
-            return {};
+        for (let index = key; index >= 0; index--) {
+            const value = values[index];
+
+            if (value) {
+                return value;
+            }
         }
-
-        return { key: iterator.pointer[0], value: iterator.pointer[1] };
+        return void 0;
     }
 
     /**
@@ -171,26 +174,7 @@ class BinarySearchTree {
      * @returns {void}
      */
     deleteRange(start, end) {
-
-        // Exit without traversing the tree if the range has zero size.
-        if (start === end) {
-            return;
-        }
-        const iterator = this._orderedMap.lowerBound(start);
-
-        if (iterator.equals(this._orderedMapEnd)) {
-            return;
-        }
-
-        if (end > this._orderedMap.back()[0]) {
-            while (!iterator.equals(this._orderedMapEnd)) {
-                this._orderedMap.eraseElementByIterator(iterator);
-            }
-        } else {
-            while (iterator.pointer[0] < end) {
-                this._orderedMap.eraseElementByIterator(iterator);
-            }
-        }
+        this._values.fill(void 0, start, end);
     }
 }
 
@@ -252,14 +236,15 @@ class OffsetStorage {
      * @param {TokenInfo} tokenInfo a TokenInfo instance
      * @param {number} indentSize The desired size of each indentation level
      * @param {string} indentType The indentation character
+     * @param {number} maxIndex The maximum end index of any token
      */
-    constructor(tokenInfo, indentSize, indentType) {
+    constructor(tokenInfo, indentSize, indentType, maxIndex) {
         this._tokenInfo = tokenInfo;
         this._indentSize = indentSize;
         this._indentType = indentType;
 
-        this._tree = new BinarySearchTree();
-        this._tree.insert(0, { offset: 0, from: null, force: false });
+        this._indexMap = new IndexMap(maxIndex);
+        this._indexMap.insert(0, { offset: 0, from: null, force: false });
 
         this._lockedFirstTokens = new WeakMap();
         this._desiredIndentCache = new WeakMap();
@@ -267,7 +252,7 @@ class OffsetStorage {
     }
 
     _getOffsetDescriptor(token) {
-        return this._tree.findLe(token.range[0]).value;
+        return this._indexMap.findLastNotAfter(token.range[0]);
     }
 
     /**
@@ -388,37 +373,36 @@ class OffsetStorage {
          * * key: 820, value: { offset: 1, from: bazToken }
          *
          * To find the offset descriptor for any given token, one needs to find the node with the largest key
-         * which is <= token.start. To make this operation fast, the nodes are stored in a balanced binary
-         * search tree indexed by key.
+         * which is <= token.start. To make this operation fast, the nodes are stored in a map indexed by key.
          */
 
         const descriptorToInsert = { offset, from: fromToken, force };
 
-        const descriptorAfterRange = this._tree.findLe(range[1]).value;
+        const descriptorAfterRange = this._indexMap.findLastNotAfter(range[1]);
 
         const fromTokenIsInRange = fromToken && fromToken.range[0] >= range[0] && fromToken.range[1] <= range[1];
         const fromTokenDescriptor = fromTokenIsInRange && this._getOffsetDescriptor(fromToken);
 
-        // First, remove any existing nodes in the range from the tree.
-        this._tree.deleteRange(range[0] + 1, range[1]);
+        // First, remove any existing nodes in the range from the map.
+        this._indexMap.deleteRange(range[0] + 1, range[1]);
 
-        // Insert a new node into the tree for this range
-        this._tree.insert(range[0], descriptorToInsert);
+        // Insert a new node into the map for this range
+        this._indexMap.insert(range[0], descriptorToInsert);
 
         /*
          * To avoid circular offset dependencies, keep the `fromToken` token mapped to whatever it was mapped to previously,
          * even if it's in the current range.
          */
         if (fromTokenIsInRange) {
-            this._tree.insert(fromToken.range[0], fromTokenDescriptor);
-            this._tree.insert(fromToken.range[1], descriptorToInsert);
+            this._indexMap.insert(fromToken.range[0], fromTokenDescriptor);
+            this._indexMap.insert(fromToken.range[1], descriptorToInsert);
         }
 
         /*
          * To avoid modifying the offset of tokens after the range, insert another node to keep the offset of the following
          * tokens the same as it was before.
          */
-        this._tree.insert(range[1], descriptorAfterRange);
+        this._indexMap.insert(range[1], descriptorAfterRange);
     }
 
     /**
@@ -705,7 +689,7 @@ module.exports = {
 
         const sourceCode = context.sourceCode;
         const tokenInfo = new TokenInfo(sourceCode);
-        const offsets = new OffsetStorage(tokenInfo, indentSize, indentType === "space" ? " " : "\t");
+        const offsets = new OffsetStorage(tokenInfo, indentSize, indentType === "space" ? " " : "\t", sourceCode.text.length);
         const parameterParens = new WeakSet();
 
         /**

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "imurmurhash": "^0.1.4",
     "is-glob": "^4.0.0",
     "is-path-inside": "^3.0.3",
-    "js-sdsl": "^4.1.4",
     "js-yaml": "^4.1.0",
     "json-stable-stringify-without-jsonify": "^1.0.1",
     "levn": "^0.4.1",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Improves performance of the `indent` rule. Makes the build faster.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR changes the underlying implementation of `BinarySearchTree` in the `indent` rule to a plain array. The name `BinarySearchTree` is changed to `IndexMap` to avoid confusion now that a tree-like structure is no longer used. I also renamed a few other identifiers for clarity.

##### How it works

The `BinarySearchTree`/`IndexMap` class is used by the `indent` rule to map runtime information (*descriptors*) to indices in the source code. You can think of it as a mapping of integers in a known interval to arbitrary objects.
The performance of this map is determined by the time consumed by the three methods that operate on it.
* Add a mapping (`insert`)
* Remove all mappings in a specified index range (`deleteRange`)
* Search backwards for the first mapping, starting at a specified index (`findLe`/`findLastNotAfter`)

In the previous implementation, a red-black tree (provided by [this package](https://www.npmjs.com/package/js-sdsl)) was used to store the mappings, whereas the new implementation uses a constant-size array. With this new implementation, adding a mapping only requires setting an element of the array. Deleting a range takes a single call to the built-in method `fill`. Obviously, both operations are much more efficient compared to their red-black tree counterparts.
As for the backward search, it now requires iterating indices one by one until a mapping is found. The exact number of iterations depends on the length and arrangement of tokens and spaces in the source file. While this value can grow up to the number of characters in the file + 1 in the worst case, it will typically not depend on the file size, but rather on the coding style. For reference, when linting the `eslint` repo, the average search takes about 47 iterations, and performs still much faster than the same search with the old implementation.

##### Measuring performance

I run `npm run lint` after setting the environment variable `TIMING=1`, and compared the results before and after the change.

##### Results

I tested these changes on MacOS and Windows with different versions of Node.js, with similar results. After the changes, the `indent` rule runs about 40% faster than before.

Example run:

**Before**

```text
Rule                                          | Time (ms) | Relative
:---------------------------------------------|----------:|--------:
indent                                        |  3228.423 |    17.8%
```

**After**

```text
Rule                             | Time (ms) | Relative
:--------------------------------|----------:|--------:
indent                           |  1656.434 |    10.0%
```

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
