### PR TITLE
fix: Ensure FlatESLint#findConfigFile() doesn't throw.

### DIFF
--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -326,7 +326,7 @@ async function loadFlatConfigFile(filePath) {
  * as override config file is not explicitly set to `false`, it will search
  * upwards from the cwd for a file named `eslint.config.js`.
  * @param {import("./eslint").ESLintOptions} options The ESLint instance options.
- * @returns {{configFilePath:string,basePath:string}} Location information for
+ * @returns {{configFilePath:string,basePath:string,error:boolean}} Location information for
  *      the config file.
  */
 async function locateConfigFileToUse({ configFile, cwd }) {
@@ -334,6 +334,7 @@ async function locateConfigFileToUse({ configFile, cwd }) {
     // determine where to load config file from
     let configFilePath;
     let basePath = cwd;
+    let error = false;
 
     if (typeof configFile === "string") {
         debug(`Override config file path is ${configFile}`);
@@ -342,16 +343,18 @@ async function locateConfigFileToUse({ configFile, cwd }) {
         debug("Searching for eslint.config.js");
         configFilePath = await findFlatConfigFile(cwd);
 
-        if (!configFilePath) {
-            throw new Error("Could not find config file.");
+        if (configFilePath) {
+            basePath = path.resolve(path.dirname(configFilePath));
+        } else {
+            error = true;
         }
 
-        basePath = path.resolve(path.dirname(configFilePath));
     }
 
     return {
         configFilePath,
-        basePath
+        basePath,
+        error
     };
 
 }
@@ -378,7 +381,13 @@ async function calculateConfigArray(eslint, {
         return slots.configs;
     }
 
-    const { configFilePath, basePath } = await locateConfigFileToUse({ configFile, cwd });
+    const { configFilePath, basePath, error } = await locateConfigFileToUse({ configFile, cwd });
+
+    // config file is required to calculate config
+    if (error) {
+        throw new Error("Could not find config file.");
+    }
+
     const configs = new FlatConfigArray(baseConfig || [], { basePath, shouldIgnore });
 
     // load config file

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -3956,9 +3956,17 @@ describe("FlatESLint", () => {
 
     describe("findConfigFile()", () => {
 
-        it("should return null when overrideConfigFile is true", async () => {
+        it("should return undefined when overrideConfigFile is true", async () => {
             const engine = new FlatESLint({
                 overrideConfigFile: true
+            });
+
+            assert.strictEqual(await engine.findConfigFile(), void 0);
+        });
+
+        it("should return undefined when a config file isn't found", async () => {
+            const engine = new FlatESLint({
+                cwd: path.resolve(__dirname, "../../../../")
             });
 
             assert.strictEqual(await engine.findConfigFile(), void 0);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

If findConfigFile() can't find eslint.config.js, it now returns undefined instead of throwing an error.

Fixes #17150

#### Is there anything you'd like reviewers to focus on?

Did I miss any edge cases?

<!-- markdownlint-disable-file MD004 -->
