### PR TITLE
chore: Fix return type of `findFlatConfigFile`

### DIFF
--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -261,7 +261,7 @@ function compareResultsByFilePath(a, b) {
  * Searches from the current working directory up until finding the
  * given flat config filename.
  * @param {string} cwd The current working directory to search from.
- * @returns {Promise<string|null>} The filename if found or `null` if not.
+ * @returns {Promise<string|undefined>} The filename if found or `undefined` if not.
  */
 function findFlatConfigFile(cwd) {
     return findUp(
@@ -326,7 +326,7 @@ async function loadFlatConfigFile(filePath) {
  * as override config file is not explicitly set to `false`, it will search
  * upwards from the cwd for a file named `eslint.config.js`.
  * @param {import("./eslint").ESLintOptions} options The ESLint instance options.
- * @returns {{configFilePath:string,basePath:string,error:Error|null}} Location information for
+ * @returns {{configFilePath:string|undefined,basePath:string,error:Error|null}} Location information for
  *      the config file.
  */
 async function locateConfigFileToUse({ configFile, cwd }) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Fixes return type in JSDoc of internal function `findFlatConfigFile`. When it doesn't find a file, `find-up` returns `undefined`, not `null.`

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed JSDoc.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
