### PR TITLE
test: Add `FlatESLint` tests with missing config files

### DIFF
--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -676,7 +676,7 @@ describe("FlatESLint", () => {
                 cwd: getFixturePath(""),
                 overrideConfigFile: "does-not-exist.js"
             });
-            await assert.rejects(() => eslint.lintText("var foo = 'bar';"));
+            await assert.rejects(() => eslint.lintText("var foo = 'bar';"), { code: "ENOENT" });
         });
 
         it("should throw if non-string value is given to 'code' parameter", async () => {
@@ -822,7 +822,7 @@ describe("FlatESLint", () => {
                 cwd: getFixturePath(),
                 overrideConfigFile: "does-not-exist.js"
             });
-            await assert.rejects(() => eslint.lintFiles("undef*.js"));
+            await assert.rejects(() => eslint.lintFiles("undef*.js"), { code: "ENOENT" });
         });
 
         it("should throw an error when given a config file and a valid file and invalid parser", async () => {

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -648,6 +648,37 @@ describe("FlatESLint", () => {
             );
         });
 
+        it("should throw if eslint.config.js file is not present", async () => {
+            eslint = new FlatESLint({
+                cwd: getFixturePath("..")
+            });
+            await assert.rejects(() => eslint.lintText("var foo = 'bar';"), /Could not find config file/u);
+        });
+
+        it("should not throw if eslint.config.js file is not present and overrideConfigFile is `true`", async () => {
+            eslint = new FlatESLint({
+                cwd: getFixturePath(".."),
+                overrideConfigFile: true
+            });
+            await eslint.lintText("var foo = 'bar';");
+        });
+
+        it("should not throw if eslint.config.js file is not present and overrideConfigFile is path to a config file", async () => {
+            eslint = new FlatESLint({
+                cwd: getFixturePath(".."),
+                overrideConfigFile: "fixtures/configurations/quotes-error.js"
+            });
+            await eslint.lintText("var foo = 'bar';");
+        });
+
+        it("should throw if overrideConfigFile is path to a file that doesn't exist", async () => {
+            eslint = new FlatESLint({
+                cwd: getFixturePath(""),
+                overrideConfigFile: "does-not-exist.js"
+            });
+            await assert.rejects(() => eslint.lintText("var foo = 'bar';"));
+        });
+
         it("should throw if non-string value is given to 'code' parameter", async () => {
             eslint = new FlatESLint();
             await assert.rejects(() => eslint.lintText(100), /'code' must be a string/u);
@@ -761,6 +792,37 @@ describe("FlatESLint", () => {
             assert.strictEqual(results.length, 1);
             assert.strictEqual(results[0].messages.length, 0);
             assert.strictEqual(results[0].suppressedMessages.length, 0);
+        });
+
+        it("should throw if eslint.config.js file is not present", async () => {
+            eslint = new FlatESLint({
+                cwd: getFixturePath("..")
+            });
+            await assert.rejects(() => eslint.lintFiles("fixtures/undef*.js"), /Could not find config file/u);
+        });
+
+        it("should not throw if eslint.config.js file is not present and overrideConfigFile is `true`", async () => {
+            eslint = new FlatESLint({
+                cwd: getFixturePath(".."),
+                overrideConfigFile: true
+            });
+            await eslint.lintFiles("fixtures/undef*.js");
+        });
+
+        it("should not throw if eslint.config.js file is not present and overrideConfigFile is path to a config file", async () => {
+            eslint = new FlatESLint({
+                cwd: getFixturePath(".."),
+                overrideConfigFile: "fixtures/configurations/quotes-error.js"
+            });
+            await eslint.lintFiles("fixtures/undef*.js");
+        });
+
+        it("should throw if overrideConfigFile is path to a file that doesn't exist", async () => {
+            eslint = new FlatESLint({
+                cwd: getFixturePath(),
+                overrideConfigFile: "does-not-exist.js"
+            });
+            await assert.rejects(() => eslint.lintFiles("undef*.js"));
         });
 
         it("should throw an error when given a config file and a valid file and invalid parser", async () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

While reviewing https://github.com/eslint/eslint/pull/17142, I noticed we didn't have tests where `eslint.config.js` is missing. In particular, a test that would confirm that `FlatESLint` lint methods should throw if a config file was not found.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added a few tests for `FlatESLint#lintText()` and `FlatESLint#lintFiles()`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
