### PR TITLE
chore: don't use deprecated `context` methods in `ast-utils` tests

### DIFF
--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -64,7 +64,7 @@ describe("ast-utils", () => {
             linter.defineRule("checker", {
                 create: mustCall(context => ({
                     BlockStatement: mustCall(node => {
-                        assert.isFalse(astUtils.isTokenOnSameLine(context.getTokenBefore(node), node));
+                        assert.isFalse(astUtils.isTokenOnSameLine(context.sourceCode.getTokenBefore(node), node));
                     })
                 }))
             });
@@ -77,7 +77,7 @@ describe("ast-utils", () => {
             linter.defineRule("checker", {
                 create: mustCall(context => ({
                     BlockStatement: mustCall(node => {
-                        assert.isTrue(astUtils.isTokenOnSameLine(context.getTokenBefore(node), node));
+                        assert.isTrue(astUtils.isTokenOnSameLine(context.sourceCode.getTokenBefore(node), node));
                     })
                 }))
             });
@@ -123,7 +123,7 @@ describe("ast-utils", () => {
             linter.defineRule("checker", {
                 create: mustCall(context => ({
                     CatchClause: mustCall(node => {
-                        const variables = context.getDeclaredVariables(node);
+                        const variables = context.sourceCode.getDeclaredVariables(node);
 
                         assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 1);
                     })
@@ -138,7 +138,7 @@ describe("ast-utils", () => {
             linter.defineRule("checker", {
                 create: mustCall(context => ({
                     VariableDeclaration: mustCall(node => {
-                        const variables = context.getDeclaredVariables(node);
+                        const variables = context.sourceCode.getDeclaredVariables(node);
 
                         assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 1);
                     })
@@ -152,7 +152,7 @@ describe("ast-utils", () => {
             linter.defineRule("checker", {
                 create: mustCall(context => ({
                     VariableDeclaration: mustCall(node => {
-                        const variables = context.getDeclaredVariables(node);
+                        const variables = context.sourceCode.getDeclaredVariables(node);
 
                         assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 0);
                     })
@@ -167,7 +167,7 @@ describe("ast-utils", () => {
             linter.defineRule("checker", {
                 create: mustCall(context => ({
                     ClassDeclaration: mustCall(node => {
-                        const variables = context.getDeclaredVariables(node);
+                        const variables = context.sourceCode.getDeclaredVariables(node);
 
                         assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 1);
                         assert.lengthOf(astUtils.getModifyingReferences(variables[1].references), 0);
@@ -182,7 +182,7 @@ describe("ast-utils", () => {
             linter.defineRule("checker", {
                 create: mustCall(context => ({
                     ClassDeclaration: mustCall(node => {
-                        const variables = context.getDeclaredVariables(node);
+                        const variables = context.sourceCode.getDeclaredVariables(node);
 
                         assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 0);
                     })


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Follow up to https://github.com/eslint/eslint/pull/17059.

Updates `ast-utils` tests to use `SourceCode#getDeclaredVariables()` instead of now-deprecated `context.getDeclaredVariables()`. Also updates two tests that were using `context.getTokenBefore()`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated tests.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
