### PR TITLE
fix: incorrect warning message for ignored dotfiles

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -591,13 +591,9 @@ function isErrorMessage(message) {
  */
 function createIgnoreResult(filePath, baseDir) {
     let message;
-    const isHidden = filePath.split(path.sep)
-        .find(segment => /^\./u.test(segment));
     const isInNodeModules = baseDir && path.relative(baseDir, filePath).startsWith("node_modules");
 
-    if (isHidden) {
-        message = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override.";
-    } else if (isInNodeModules) {
+    if (isInNodeModules) {
         message = "File ignored by default because it is located under the node_modules directory. Use ignore pattern \"!**/node_modules/\" to override.";
     } else {
         message = "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override.";

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -1340,6 +1340,26 @@ describe("FlatESLint", () => {
                 assert.strictEqual(results[0].suppressedMessages.length, 0);
             });
 
+            it("should return a warning about matching ignore patterns when an explicitly given dotfile is ignored", async () => {
+                eslint = new FlatESLint({
+                    overrideConfigFile: "eslint.config_with_ignores.js",
+                    cwd: getFixturePath()
+                });
+                const filePath = getFixturePath("dot-files/.a.js");
+                const results = await eslint.lintFiles([filePath]);
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].filePath, filePath);
+                assert.strictEqual(results[0].messages[0].severity, 1);
+                assert.strictEqual(results[0].messages[0].message, "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override.");
+                assert.strictEqual(results[0].errorCount, 0);
+                assert.strictEqual(results[0].warningCount, 1);
+                assert.strictEqual(results[0].fatalErrorCount, 0);
+                assert.strictEqual(results[0].fixableErrorCount, 0);
+                assert.strictEqual(results[0].fixableWarningCount, 0);
+                assert.strictEqual(results[0].suppressedMessages.length, 0);
+            });
+
             it("should return two messages when given a file in excluded files list while ignore is off", async () => {
                 eslint = new FlatESLint({
                     cwd: getFixturePath(),


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

* **Node version:** v16.14.0
* **npm version:** v8.3.1
* **Local ESLint version:** v8.40.0
* **Global ESLint version:** no
* **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

This project's [eslint.config.js](https://github.com/eslint/eslint/blob/ddc5291debd90ff476e17c532af7577e26720b91/eslint.config.js)

</details>

**What did you do? Please include the actual source code causing the issue.**

In eslint/eslint main branch, I ran this command:

```
eslint tests/fixtures/dot-files/.a.js
```

**What did you expect to happen?**

The flat config system doesn't ignore dotfiles by default. This file is ignored by pattern [`"tests/fixtures/**"`](https://github.com/eslint/eslint/blob/ddc5291debd90ff476e17c532af7577e26720b91/eslint.config.js#L93) in the config file.

I'd expect the common warning message for files ignored by the user's configuration:

```
 0:0  warning  File ignored because of a matching ignore pattern. Use "--no-ignore" to override
```

**What actually happened? Please include the actual, raw output from ESLint.**

The message suggests that the file is ignored by default:

```
  0:0  warning  File ignored by default.  Use a negated ignore pattern (like "--ignore-pattern '!<relative/path/to/filename>'") to override
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In `function createIgnoreResult`, I removed the conditional for dotfiles. After the change, this case will fall into the "File ignored because of a matching ignore pattern" branch.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
