### PR TITLE
fix: Fix embedding of rule option schema array so that $ref's work

### DIFF
--- a/lib/config/flat-config-helpers.js
+++ b/lib/config/flat-config-helpers.js
@@ -66,8 +66,55 @@ function getRuleFromConfig(ruleId, config) {
 }
 
 /**
+ * Builds a single options schema from an array of options schemas,
+ * allowing 0 or more matches in order, ignoring any schemas that aren't
+ * matched to elements in the configured options, and allowing
+ * references between the schemas in the array.
+ * @param {object[]} schemas The array of schemas to combine.
+ * @returns {Object} A single JSON Schema matching one or more of the schemas in the array in order.
+ */
+function buildArraySchema(schemas) {
+
+    if (schemas.length === 0) {
+        return {
+            type: "array",
+            minItems: 0,
+            maxItems: 0
+        };
+    }
+
+    /*
+     * Generate a random base URL for the embedded schemas so that rule writers can't
+     * reference them absolutely or override them, and so that ajv doesn't generate
+     * conflicts in its cache.
+     */
+    const ruleOptionsSchemaBase = `https://${Math.ceil(Math.random() * 1000000)}.eslint.org`;
+    const embeddedSchemas = schemas.map((schema, i) => {
+        if (schema.$id) {
+            return schema;
+        }
+
+        return {
+            $id: `${ruleOptionsSchemaBase}/${i}`,
+            ...schema
+        };
+    });
+
+    const embeddedSchemaRefs = schemas.map((schema, i) => schema.$id || `#/definitions/${i}`);
+
+    return {
+        type: "array",
+        items: embeddedSchemaRefs.map(ref => ({ $ref: ref })),
+        minItems: 0,
+        maxItems: schemas.length,
+
+        definitions: Object.fromEntries(embeddedSchemas.map((schema, i) => [i, schema]))
+    };
+}
+
+/**
  * Gets a complete options schema for a rule.
- * @param {{create: Function, schema: (Array|null)}} rule A new-style rule object
+ * @param {{schema?: (object[]|object|null), meta?: { schema?: (object[]|object|null)}}} rule A new-style rule object
  * @returns {Object} JSON Schema for the rule's options.
  */
 function getRuleOptionsSchema(rule) {
@@ -78,27 +125,14 @@ function getRuleOptionsSchema(rule) {
 
     const schema = rule.schema || rule.meta && rule.meta.schema;
 
-    if (Array.isArray(schema)) {
-        if (schema.length) {
-            return {
-                type: "array",
-                items: schema,
-                minItems: 0,
-                maxItems: schema.length
-            };
-        }
-        return {
-            type: "array",
-            minItems: 0,
-            maxItems: 0
-        };
-
+    if (!schema) {
+        return null;
     }
 
-    // Given a full schema, leave it alone
-    return schema || null;
+    return Array.isArray(schema)
+        ? buildArraySchema(schema)
+        : schema;
 }
-
 
 //-----------------------------------------------------------------------------
 // Exports

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -1259,7 +1259,7 @@ describe("FlatRuleTester", () => {
                     { code: "var answer = 6 * 7;", options: ["bar"], errors: [{ message: "Expected nothing." }] }
                 ]
             });
-        }, "Schema for rule no-invalid-schema is invalid:,\titems: should be object\n\titems[0].enum: should NOT have fewer than 1 items\n\titems: should match some schema in anyOf");
+        }, "Schema for rule no-invalid-schema is invalid:,\tdefinitions['0'].enum: should NOT have fewer than 1 items");
 
     });
 


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

#### What changes did you make? (Give an overview)

As documented at [Options Schemas](https://eslint.org/docs/latest/extend/custom-rules#options-schemas), ESLint will break `$ref`'s in schemas when providing an array of schemas (`$ref` will work fine in explicit schemas).

These `$ref`'s break because ESLint currently embeds these schemas directly into a new schema, and therefore the path that a `$ref` might have previously been referencing is no longer valid. It is _technically_ possible to construct a working `$ref` by having it account for the new structure, but this relies on implementation details and shouldn't be supported.

JSON Schemas do however support bundling multiple schemas together into a single document, allowing them to separately process `$ref`'s locally. This does require each bundled schema to have a unique `$id`, and any `$ref`'s below will be resolved relative to that schema. If the `$id` is chosen carefully, the schemas can also reference each other via `{ $ref: '/n/some/json/path' }`, so common definitions can be shared between them.

There's a few details I'm omitting here (but are in the code and the docs in the PR), but here's a before and after transform to show the change of layout:

```
const origSchema = [
    { enum: ['a', 'b', 'c'] },
    {
        type: 'object',
        properties: {
            someProperty: { $ref: '#/definitions/stringOrNumber' },
            someOtherProperty: { $ref: '#/definitions/stringOrNumber' }
        }
        definitions: {
            stringOrNumber: { anyOf: [ { type: 'number' }, { type: 'string' } ] }
        }
    }
];

const origTransformed = {
    type: 'array',
    items: [
        { enum: ['a', 'b', 'c'] },
        {
            type: 'object',
            properties: {
                someProperty: { $ref: '#/definitions/stringOrNumber' }, // This $ref is broken now!
                someOtherProperty: { $ref: '#/definitions/stringOrNumber' } // This $ref is broken now!
            }
            definitions: {
                stringOrNumber: { anyOf: [ { type: 'number' }, { type: 'string' } ] }
            }
        }
    ],
    minItems: 0,
    maxItems: 2
};

const newTransformed = {
    type: 'array',
    items: [ { $ref: '#/definitions/0', $ref: '#/definitions/1' } ],
    minItems: 0,
    maxItems: 2,
    definitions: {
        0: {
            $id: 'https://123456.eslint.org/0',
            enum: ['a', 'b', 'c']
        },
        1: {
            $id: 'https://123456.eslint.org/1',
            type: 'object',
            properties: {
                someProperty: { $ref: '#/definitions/stringOrNumber' }, // This $ref is relative to the original schema and still works!
                someOtherProperty: { $ref: '#/definitions/stringOrNumber' } // This $ref is relative to the original schema and still works!
            }
            definitions: {
                stringOrNumber: { anyOf: [ { type: 'number' }, { type: 'string' } ] }
            }
        }
    ]
};
```

For simple schemas without any `$ref`'s involved, there's no performance penalty, as ajv will inline those schemas when compiling the validation function.

#### Is there anything you'd like reviewers to focus on?

Since it's technically possible to make `$ref`'s work currently (by relying on implementation details), does this count as non-backwards-compatible, as it can in theory break existing rule schemas? Relying on undocumented behaviour seems like the kind of thing it's ok to break to me, but I'm not sure what ESLint's appetite for that is. I'd anticipate that it wouldn't be a big problem since the docs pretty clearly warn off using `$ref` for array schemas entirely.

I've only added tests for the new `$ref` support in `getRuleOptionsSchema`, but #17198 includes a more comprehensive set of tests to ensure this change doesn't break existing functionality if that is merged before this. I'll rebase and properly merge the tests in if/when that PR is merged, in the meantime, feedback on this change by itself would be welcome :)

<!-- markdownlint-disable-file MD004 -->
