### PR TITLE
fix: Correct ignore message for "node_modules" subfolders

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -591,7 +591,7 @@ function isErrorMessage(message) {
  */
 function createIgnoreResult(filePath, baseDir) {
     let message;
-    const isInNodeModules = baseDir && /(?:^|[\\/])node_modules[\\/]/u.test(path.relative(baseDir, filePath));
+    const isInNodeModules = baseDir && path.dirname(path.relative(baseDir, filePath)).split(path.sep).includes("node_modules");
 
     if (isInNodeModules) {
         message = "File ignored by default because it is located under the node_modules directory. Use ignore pattern \"!**/node_modules/\" to override.";

--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -591,7 +591,7 @@ function isErrorMessage(message) {
  */
 function createIgnoreResult(filePath, baseDir) {
     let message;
-    const isInNodeModules = baseDir && path.relative(baseDir, filePath).startsWith("node_modules");
+    const isInNodeModules = baseDir && /(?:^|[\\/])node_modules[\\/]/u.test(path.relative(baseDir, filePath));
 
     if (isInNodeModules) {
         message = "File ignored by default because it is located under the node_modules directory. Use ignore pattern \"!**/node_modules/\" to override.";

--- a/tests/fixtures/cli-engine/node_modules_cleaner.js
+++ b/tests/fixtures/cli-engine/node_modules_cleaner.js
@@ -1,0 +1,1 @@
+// not implemented

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -1191,7 +1191,7 @@ describe("FlatESLint", () => {
 
         describe("Ignoring Files", () => {
 
-            it("should report on all files passed explicitly, even if ignored by default", async () => {
+            it("should report on a file in the node_modules folder passed explicitly, even if ignored by default", async () => {
                 eslint = new FlatESLint({
                     cwd: getFixturePath("cli-engine")
                 });
@@ -1204,6 +1204,44 @@ describe("FlatESLint", () => {
                 assert.strictEqual(results[0].fatalErrorCount, 0);
                 assert.strictEqual(results[0].fixableErrorCount, 0);
                 assert.strictEqual(results[0].fixableWarningCount, 0);
+                assert.strictEqual(results[0].messages[0].severity, 1);
+                assert.strictEqual(results[0].messages[0].message, expectedMsg);
+                assert.strictEqual(results[0].suppressedMessages.length, 0);
+            });
+
+            it("should report on a file in a node_modules subfolder passed explicitly, even if ignored by default", async () => {
+                eslint = new FlatESLint({
+                    cwd: getFixturePath("cli-engine")
+                });
+                const results = await eslint.lintFiles(["nested_node_modules/subdir/node_modules/text.js"]);
+                const expectedMsg = "File ignored by default because it is located under the node_modules directory. Use ignore pattern \"!**/node_modules/\" to override.";
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].errorCount, 0);
+                assert.strictEqual(results[0].warningCount, 1);
+                assert.strictEqual(results[0].fatalErrorCount, 0);
+                assert.strictEqual(results[0].fixableErrorCount, 0);
+                assert.strictEqual(results[0].fixableWarningCount, 0);
+                assert.strictEqual(results[0].messages[0].severity, 1);
+                assert.strictEqual(results[0].messages[0].message, expectedMsg);
+                assert.strictEqual(results[0].suppressedMessages.length, 0);
+            });
+
+            it("should report on an ignored file with \"node_modules\" in its name", async () => {
+                eslint = new FlatESLint({
+                    cwd: getFixturePath("cli-engine"),
+                    ignorePatterns: ["*.js"]
+                });
+                const results = await eslint.lintFiles(["node_modules_cleaner.js"]);
+                const expectedMsg = "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override.";
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].errorCount, 0);
+                assert.strictEqual(results[0].warningCount, 1);
+                assert.strictEqual(results[0].fatalErrorCount, 0);
+                assert.strictEqual(results[0].fixableErrorCount, 0);
+                assert.strictEqual(results[0].fixableWarningCount, 0);
+                assert.strictEqual(results[0].messages[0].severity, 1);
                 assert.strictEqual(results[0].messages[0].message, expectedMsg);
                 assert.strictEqual(results[0].suppressedMessages.length, 0);
             });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v18.16.0
npm version: v9.5.1
Local ESLint version: v8.41.0 (Currently used)
Global ESLint version: Not found
Operating System: darwin 22.2.0

**What parser are you using (place an "X" next to just one item)?**

none

**Please show your full configuration:**

no configuration

**What did you do? Please include the actual source code causing the issue.**

In a terminal, I set the environment variable `ESLINT_USE_FLAT_CONFIG="true"`. Then I ran:

```shell
cd ..
node eslint/bin/eslint.js --no-config-lookup eslint/node_modules/espree/espree.js
```

**What did you expect to happen?**

A warning message suggesting to use the ignore pattern `"!**/node_modules/"` to unignore the provided file.

**What actually happened? Please include the actual, raw output from ESLint.**

The warning message suggests to use the CLI option `--no-ignore`, but that doesn't work to unignore predefined ignore patterns.

```text
.../eslint/node_modules/espree/espree.js
  0:0  warning  File ignored because of a matching ignore pattern. Use "--no-ignore" to override

✖ 1 problem (0 errors, 1 warning)
```

In fact, re-running with the `--no-ignore` option produces the same output.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I updated the logic that decides which warning message should be printed when an ignored file is reported. There is already a message that fits the case of an ignored file under `node_modules`:

https://github.com/eslint/eslint/blob/9b62ae00c6f6baadb68afae0c65614939ed15fef/lib/eslint/eslint-helpers.js#L597

After my change, this message will be reported for all files under `node_modules` folders, not just when the `node_modules` folder is located in the working directory. This also fixes an incorrect match for files whose name starts with `"node_modules"`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
