### PR TITLE
refactor: remove `Identifier` listener in no-irregular-whitespace

### DIFF
--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -100,12 +100,12 @@ module.exports = {
         }
 
         /**
-         * Checks identifier or literal nodes for errors that we are choosing to ignore and calls the relevant methods to remove the errors
+         * Checks literal nodes for errors that we are choosing to ignore and calls the relevant methods to remove the errors
          * @param {ASTNode} node to check for matching errors.
          * @returns {void}
          * @private
          */
-        function removeInvalidNodeErrorsInIdentifierOrLiteral(node) {
+        function removeInvalidNodeErrorsInLiteral(node) {
             const shouldCheckStrings = skipStrings && (typeof node.value === "string");
             const shouldCheckRegExps = skipRegExps && Boolean(node.regex);
 
@@ -237,8 +237,7 @@ module.exports = {
                 checkForIrregularLineTerminators(node);
             };
 
-            nodes.Identifier = removeInvalidNodeErrorsInIdentifierOrLiteral;
-            nodes.Literal = removeInvalidNodeErrorsInIdentifierOrLiteral;
+            nodes.Literal = removeInvalidNodeErrorsInLiteral;
             nodes.TemplateElement = skipTemplates ? removeInvalidNodeErrorsInTemplateLiteral : noop;
             nodes["Program:exit"] = function() {
                 if (skipComments) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

In the `no-irregular-whitespace` rule, this removes an `Identifier` listener that is essentially a no-op since the `removeInvalidNodeErrorsInIdentifierOrLiteral` function has effects only when it's given a string literal node (the `typeof node.value === "string"` condition) or a regex literal node (the `Boolean(node.regex)` condition).

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed the listener and renamed function `removeInvalidNodeErrorsInIdentifierOrLiteral` to `removeInvalidNodeErrorsInLiteral`.

#### Is there anything you'd like reviewers to focus on?

I checked the commits/PRs/issues history for this rule and have no idea why it was checking Identifier nodes. The listener is present since the original commit https://github.com/eslint/eslint/commit/77b0181d00949e2d8fc697c7a4f36a7fc98ccdb6. The only comment I could find about it (and generally about identifiers in regard to this rule) is https://github.com/eslint/eslint/pull/2381/files#r29104317.

<!-- markdownlint-disable-file MD004 -->
