### PR TITLE
Avoid reading/writing too many files simultaneously

### DIFF
--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -13,6 +13,7 @@
 const fs = require("fs").promises;
 const path = require("path");
 const findUp = require("find-up");
+const pLimit = require("p-limit");
 const { version } = require("../../package.json");
 const { Linter } = require("../linter");
 const { getRuleFromConfig } = require("../config/flat-config-helpers");
@@ -41,6 +42,9 @@ const {
 const { pathToFileURL } = require("url");
 const { FlatConfigArray } = require("../config/flat-config-array");
 const LintResultCache = require("../cli-engine/lint-result-cache");
+
+const DISK_IO_LIMIT = 1000;
+const limitDiskIO = pLimit(DISK_IO_LIMIT);
 
 /*
  * This is necessary to allow overwriting writeFile for testing purposes.
@@ -684,7 +688,7 @@ class FlatESLint {
                         path.isAbsolute(result.filePath)
                     );
                 })
-                .map(r => fs.writeFile(r.filePath, r.output))
+                .map(r => limitDiskIO(() => fs.writeFile(r.filePath, r.output)))
         );
     }
 
@@ -840,6 +844,7 @@ class FlatESLint {
 
         debug(`${filePaths.length} files found in: ${Date.now() - startTime}ms`);
 
+
         /*
          * Because we need to process multiple files, including reading from disk,
          * it is most efficient to start by reading each file via promises so that
@@ -910,7 +915,7 @@ class FlatESLint {
                     fixer = message => shouldMessageBeFixed(message, config, fixTypesSet) && originalFix(message);
                 }
 
-                return fs.readFile(filePath, "utf8")
+                return limitDiskIO(() => fs.readFile(filePath, "utf8"))
                     .then(text => {
 
                         // do the linting

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "minimatch": "^3.1.2",
     "natural-compare": "^1.4.0",
     "optionator": "^0.9.1",
+    "p-limit": "^3.1.0",
     "strip-ansi": "^6.0.1",
     "strip-json-comments": "^3.1.0",
     "text-table": "^0.2.0"


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See #17249 for the filled-out bugfix template.

#### What changes did you make?

This adds a concurrency limit to `fs.readFile` and `fs.writeFile` calls, resolving #17249.

#### Is there anything you'd like reviewers to focus on?

Not specifically. I suppose the addition of the dependency could be troublesome, but it was already a transitive dependency of ESLint.