### PR TITLE
feat: add ternaryOperandBinaryExpressions option to no-extra-parens rule

### DIFF
--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -31,6 +31,7 @@ This rule has a string option:
 This rule has an object option for exceptions to the `"all"` option:
 
 * `"conditionalAssign": false` allows extra parentheses around assignments in conditional test expressions
+* `"conditionalTernary": false` allows extra parentheses around condition in ternary expressions
 * `"returnAssign": false` allows extra parentheses around assignments in `return` statements
 * `"nestedBinaryExpressions": false` allows extra parentheses in nested binary expressions
 * `"ignoreJSX": "none|all|multi-line|single-line"` allows extra parentheses around no/all/multi-line/single-line JSX components. Defaults to `none`.
@@ -129,6 +130,18 @@ for (;(a = b););
 ```
 
 :::
+
+### conditionalTernary
+
+Examples of **correct** code for this rule with the `"all"` and `{ "conditionalTernary": false }` options:
+
+```js
+/* eslint no-extra-parens: ["error", "all", { "conditionalTernary": false }] */
+
+(a && b) ? foo : bar
+
+(a - b > a) ? foo : bar
+```
 
 ### returnAssign
 

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -31,7 +31,7 @@ This rule has a string option:
 This rule has an object option for exceptions to the `"all"` option:
 
 * `"conditionalAssign": false` allows extra parentheses around assignments in conditional test expressions
-* `"conditionalTernary": false` allows extra parentheses around condition in ternary expressions
+* `"ternaryOperandBinaryExpressions": false` allows extra parentheses around condition in ternary expressions
 * `"returnAssign": false` allows extra parentheses around assignments in `return` statements
 * `"nestedBinaryExpressions": false` allows extra parentheses in nested binary expressions
 * `"ignoreJSX": "none|all|multi-line|single-line"` allows extra parentheses around no/all/multi-line/single-line JSX components. Defaults to `none`.
@@ -131,12 +131,12 @@ for (;(a = b););
 
 :::
 
-### conditionalTernary
+### ternaryOperandBinaryExpressions
 
-Examples of **correct** code for this rule with the `"all"` and `{ "conditionalTernary": false }` options:
+Examples of **correct** code for this rule with the `"all"` and `{ "ternaryOperandBinaryExpressions": false }` options:
 
 ```js
-/* eslint no-extra-parens: ["error", "all", { "conditionalTernary": false }] */
+/* eslint no-extra-parens: ["error", "all", { "ternaryOperandBinaryExpressions": false }] */
 
 (a && b) ? foo : bar
 

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -131,24 +131,6 @@ for (;(a = b););
 
 :::
 
-### ternaryOperandBinaryExpressions
-
-Examples of **correct** code for this rule with the `"all"` and `{ "ternaryOperandBinaryExpressions": false }` options:
-
-```js
-/* eslint no-extra-parens: ["error", "all", { "ternaryOperandBinaryExpressions": false }] */
-
-(a && b) ? foo : bar
-
-(a - b > a) ? foo : bar
-
-foo ? (bar || baz) : qux
-
-foo ? bar : (baz || qux)
-
-(a, b) ? (c, d) : (e, f)
-```
-
 ### returnAssign
 
 Examples of **correct** code for this rule with the `"all"` and `{ "returnAssign": false }` options:
@@ -188,6 +170,26 @@ x = (a * b) / c;
 ```
 
 :::
+
+### ternaryOperandBinaryExpressions
+
+Examples of **correct** code for this rule with the `"all"` and `{ "ternaryOperandBinaryExpressions": false }` options:
+
+```js
+/* eslint no-extra-parens: ["error", "all", { "ternaryOperandBinaryExpressions": false }] */
+
+(a && b) ? foo : bar;
+
+(a - b > a) ? foo : bar;
+
+foo ? (bar || baz) : qux;
+
+foo ? bar : (baz || qux);
+
+(a, b) ? (c, d) : (e, f);
+
+(a = b) ? c : d;
+```
 
 ### ignoreJSX
 

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -33,7 +33,7 @@ This rule has an object option for exceptions to the `"all"` option:
 * `"conditionalAssign": false` allows extra parentheses around assignments in conditional test expressions
 * `"returnAssign": false` allows extra parentheses around assignments in `return` statements
 * `"nestedBinaryExpressions": false` allows extra parentheses in nested binary expressions
-* `"ternaryOperandBinaryExpressions": false` allows extra parentheses around binary expressions that are operands of ternary` ?:`
+* `"ternaryOperandBinaryExpressions": false` allows extra parentheses around binary expressions that are operands of ternary `?:`
 * `"ignoreJSX": "none|all|multi-line|single-line"` allows extra parentheses around no/all/multi-line/single-line JSX components. Defaults to `none`.
 * `"enforceForArrowConditionals": false` allows extra parentheses around ternary expressions which are the body of an arrow function
 * `"enforceForSequenceExpressions": false` allows extra parentheses around sequence expressions

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -31,9 +31,9 @@ This rule has a string option:
 This rule has an object option for exceptions to the `"all"` option:
 
 * `"conditionalAssign": false` allows extra parentheses around assignments in conditional test expressions
-* `"ternaryOperandBinaryExpressions": false` allows extra parentheses around condition in ternary expressions
 * `"returnAssign": false` allows extra parentheses around assignments in `return` statements
 * `"nestedBinaryExpressions": false` allows extra parentheses in nested binary expressions
+* `"ternaryOperandBinaryExpressions": false` allows extra parentheses around binary expressions that are operands of ternary` ?:`
 * `"ignoreJSX": "none|all|multi-line|single-line"` allows extra parentheses around no/all/multi-line/single-line JSX components. Defaults to `none`.
 * `"enforceForArrowConditionals": false` allows extra parentheses around ternary expressions which are the body of an arrow function
 * `"enforceForSequenceExpressions": false` allows extra parentheses around sequence expressions
@@ -141,6 +141,12 @@ Examples of **correct** code for this rule with the `"all"` and `{ "ternaryOpera
 (a && b) ? foo : bar
 
 (a - b > a) ? foo : bar
+
+foo ? (bar || baz) : qux
+
+foo ? bar : (baz || qux)
+
+(a, b) ? (c, d) : (e, f)
 ```
 
 ### returnAssign

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -185,10 +185,6 @@ Examples of **correct** code for this rule with the `"all"` and `{ "ternaryOpera
 foo ? (bar || baz) : qux;
 
 foo ? bar : (baz || qux);
-
-(a, b) ? (c, d) : (e, f);
-
-(a = b) ? c : d;
 ```
 
 ### ignoreJSX

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -175,6 +175,8 @@ x = (a * b) / c;
 
 Examples of **correct** code for this rule with the `"all"` and `{ "ternaryOperandBinaryExpressions": false }` options:
 
+::: correct
+
 ```js
 /* eslint no-extra-parens: ["error", "all", { "ternaryOperandBinaryExpressions": false }] */
 
@@ -186,6 +188,8 @@ foo ? (bar || baz) : qux;
 
 foo ? bar : (baz || qux);
 ```
+
+:::
 
 ### ignoreJSX
 

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -235,16 +235,6 @@ module.exports = {
         }
 
         /**
-         * Determines if a node test expression is allowed to have a parenthesised condition in ternary expression
-         * @param {ASTNode} node The node to be checked.
-         * @returns {boolean} True if the conditional in ternary expression can be parenthesised.
-         * @private
-         */
-        function isCondTernaryException(node) {
-            return EXCEPT_COND_TERNARY && node.test && node.consequent && node.alternate;
-        }
-
-        /**
          * Determines if a node is in a return statement
          * @param {ASTNode} node The node to be checked.
          * @returns {boolean} True if the node is in a return statement.
@@ -875,31 +865,23 @@ module.exports = {
 
                 const availableTypes = new Set(["BinaryExpression", "LogicalExpression", "SequenceExpression"]);
 
-                if (isCondTernaryException(node)) {
-                    if (!availableTypes.has(node.test.type) && isParenthesised(node.test)) {
-                        report(node.test);
-                    }
-                    if (!availableTypes.has(node.consequent.type) && isParenthesised(node.consequent)) {
-                        report(node.consequent);
-                    }
-                    if (!availableTypes.has(node.alternate.type) && isParenthesised(node.alternate)) {
-                        report(node.alternate);
-                    }
-                    return;
-                }
-
                 if (
+                    !(EXCEPT_COND_TERNARY && availableTypes.has(node.test.type)) &&
                     !isCondAssignException(node) &&
                     hasExcessParensWithPrecedence(node.test, precedence({ type: "LogicalExpression", operator: "||" }))
                 ) {
                     report(node.test);
                 }
 
-                if (hasExcessParensWithPrecedence(node.consequent, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
+                if (
+                    !(EXCEPT_COND_TERNARY && availableTypes.has(node.consequent.type)) &&
+                    hasExcessParensWithPrecedence(node.consequent, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                     report(node.consequent);
                 }
 
-                if (hasExcessParensWithPrecedence(node.alternate, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
+                if (
+                    !(EXCEPT_COND_TERNARY && availableTypes.has(node.alternate.type)) &&
+                    hasExcessParensWithPrecedence(node.alternate, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                     report(node.alternate);
                 }
             },

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -46,6 +46,7 @@ module.exports = {
                             type: "object",
                             properties: {
                                 conditionalAssign: { type: "boolean" },
+                                conditionalTernary: { type: "boolean" },
                                 nestedBinaryExpressions: { type: "boolean" },
                                 returnAssign: { type: "boolean" },
                                 ignoreJSX: { enum: ["none", "all", "single-line", "multi-line"] },
@@ -76,6 +77,7 @@ module.exports = {
         const precedence = astUtils.getPrecedence;
         const ALL_NODES = context.options[0] !== "functions";
         const EXCEPT_COND_ASSIGN = ALL_NODES && context.options[1] && context.options[1].conditionalAssign === false;
+        const EXCEPT_COND_TERNARY = ALL_NODES && context.options[1] && context.options[1].conditionalTernary === false;
         const NESTED_BINARY = ALL_NODES && context.options[1] && context.options[1].nestedBinaryExpressions === false;
         const EXCEPT_RETURN_ASSIGN = ALL_NODES && context.options[1] && context.options[1].returnAssign === false;
         const IGNORE_JSX = ALL_NODES && context.options[1] && context.options[1].ignoreJSX;
@@ -230,6 +232,16 @@ module.exports = {
          */
         function isCondAssignException(node) {
             return EXCEPT_COND_ASSIGN && node.test.type === "AssignmentExpression";
+        }
+
+        /**
+         * Determines if a node test expression is allowed to have a parenthesised condition in ternary expression
+         * @param {ASTNode} node The node to be checked.
+         * @returns {boolean} True if the conditional in ternary expression can be parenthesised.
+         * @private
+         */
+        function isCondTernaryException(node) {
+            return EXCEPT_COND_TERNARY && node.test.type && node.consequent && node.alternate && node.test.type !== "Identifier";
         }
 
         /**
@@ -857,7 +869,10 @@ module.exports = {
             CallExpression: checkCallNew,
 
             ConditionalExpression(node) {
-                if (isReturnAssignException(node)) {
+                if (
+                    isReturnAssignException(node) ||
+                    isCondTernaryException(node)
+                ) {
                     return;
                 }
                 if (

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -241,7 +241,13 @@ module.exports = {
          * @private
          */
         function isCondTernaryException(node) {
-            return EXCEPT_COND_TERNARY && node.test.type && node.consequent && node.alternate && node.test.type !== "Identifier";
+            const filterType = new Set(["Identifier", "CallExpression"]);
+
+            return EXCEPT_COND_TERNARY &&
+                node.test.type && node.consequent && node.alternate && (
+                !filterType.has(node.test.type) ||
+                !filterType.has(node.consequent.type) ||
+                !filterType.has(node.alternate.type));
         }
 
         /**

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -873,16 +873,16 @@ module.exports = {
                     return;
                 }
 
-                const availableType = new Set(["BinaryExpression", "LogicalExpression"]);
+                const availableTypes = new Set(["BinaryExpression", "LogicalExpression", "SequenceExpression"]);
 
                 if (isCondTernaryException(node)) {
-                    if (!availableType.has(node.test.type) && isParenthesised(node.test)) {
+                    if (!availableTypes.has(node.test.type) && isParenthesised(node.test)) {
                         report(node.test);
                     }
-                    if (!availableType.has(node.consequent.type) && isParenthesised(node.consequent)) {
+                    if (!availableTypes.has(node.consequent.type) && isParenthesised(node.consequent)) {
                         report(node.consequent);
                     }
-                    if (!availableType.has(node.alternate.type) && isParenthesised(node.alternate)) {
+                    if (!availableTypes.has(node.alternate.type) && isParenthesised(node.alternate)) {
                         report(node.alternate);
                     }
                     return;

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -241,13 +241,7 @@ module.exports = {
          * @private
          */
         function isCondTernaryException(node) {
-            const filterType = new Set(["Identifier", "CallExpression"]);
-
-            return EXCEPT_COND_TERNARY &&
-                node.test.type && node.consequent && node.alternate && (
-                !filterType.has(node.test.type) ||
-                !filterType.has(node.consequent.type) ||
-                !filterType.has(node.alternate.type));
+            return EXCEPT_COND_TERNARY && node.test && node.consequent && node.alternate;
         }
 
         /**
@@ -875,12 +869,25 @@ module.exports = {
             CallExpression: checkCallNew,
 
             ConditionalExpression(node) {
-                if (
-                    isReturnAssignException(node) ||
-                    isCondTernaryException(node)
-                ) {
+                if (isReturnAssignException(node)) {
                     return;
                 }
+
+                const availableType = new Set(["BinaryExpression", "LogicalExpression"]);
+
+                if (isCondTernaryException(node)) {
+                    if (!availableType.has(node.test.type) && isParenthesised(node.test)) {
+                        report(node.test);
+                    }
+                    if (!availableType.has(node.consequent.type) && isParenthesised(node.consequent)) {
+                        report(node.consequent);
+                    }
+                    if (!availableType.has(node.alternate.type) && isParenthesised(node.alternate)) {
+                        report(node.alternate);
+                    }
+                    return;
+                }
+
                 if (
                     !isCondAssignException(node) &&
                     hasExcessParensWithPrecedence(node.test, precedence({ type: "LogicalExpression", operator: "||" }))

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -863,7 +863,7 @@ module.exports = {
                     return;
                 }
 
-                const availableTypes = new Set(["BinaryExpression", "LogicalExpression", "SequenceExpression"]);
+                const availableTypes = new Set(["BinaryExpression", "LogicalExpression"]);
 
                 if (
                     !(EXCEPT_COND_TERNARY && availableTypes.has(node.test.type)) &&

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -46,7 +46,7 @@ module.exports = {
                             type: "object",
                             properties: {
                                 conditionalAssign: { type: "boolean" },
-                                conditionalTernary: { type: "boolean" },
+                                ternaryOperandBinaryExpressions: { type: "boolean" },
                                 nestedBinaryExpressions: { type: "boolean" },
                                 returnAssign: { type: "boolean" },
                                 ignoreJSX: { enum: ["none", "all", "single-line", "multi-line"] },
@@ -77,7 +77,7 @@ module.exports = {
         const precedence = astUtils.getPrecedence;
         const ALL_NODES = context.options[0] !== "functions";
         const EXCEPT_COND_ASSIGN = ALL_NODES && context.options[1] && context.options[1].conditionalAssign === false;
-        const EXCEPT_COND_TERNARY = ALL_NODES && context.options[1] && context.options[1].conditionalTernary === false;
+        const EXCEPT_COND_TERNARY = ALL_NODES && context.options[1] && context.options[1].ternaryOperandBinaryExpressions === false;
         const NESTED_BINARY = ALL_NODES && context.options[1] && context.options[1].nestedBinaryExpressions === false;
         const EXCEPT_RETURN_ASSIGN = ALL_NODES && context.options[1] && context.options[1].returnAssign === false;
         const IGNORE_JSX = ALL_NODES && context.options[1] && context.options[1].ignoreJSX;

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -303,12 +303,12 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "while (((foo = bar()))) {}", options: ["all", { conditionalAssign: false }] },
         { code: "var a = (((b = c))) ? foo : bar;", options: ["all", { conditionalAssign: false }] },
 
-        // ["all", { conditionalTernary: false }] enables extra parens around conditional ternary
-        { code: "(a && b) ? foo : bar", options: ["all", { conditionalTernary: false }] },
-        { code: "(a - b > a) ? foo : bar", options: ["all", { conditionalTernary: false }] },
-        { code: "foo ? (bar || baz) : qux", options: ["all", { conditionalTernary: false }] },
-        { code: "foo ? bar : (baz || qux)", options: ["all", { conditionalTernary: false }] },
-        { code: "(a, b) ? (c, d) : (e, f)", options: ["all", { conditionalTernary: false }] },
+        // ["all", { ternaryOperandBinaryExpressions: false }] enables extra parens around conditional ternary
+        { code: "(a && b) ? foo : bar", options: ["all", { ternaryOperandBinaryExpressions: false }] },
+        { code: "(a - b > a) ? foo : bar", options: ["all", { ternaryOperandBinaryExpressions: false }] },
+        { code: "foo ? (bar || baz) : qux", options: ["all", { ternaryOperandBinaryExpressions: false }] },
+        { code: "foo ? bar : (baz || qux)", options: ["all", { ternaryOperandBinaryExpressions: false }] },
+        { code: "(a, b) ? (c, d) : (e, f)", options: ["all", { ternaryOperandBinaryExpressions: false }] },
 
         // ["all", { nestedBinaryExpressions: false }] enables extra parens around conditional assignments
         { code: "a + (b * c)", options: ["all", { nestedBinaryExpressions: false }] },
@@ -922,10 +922,10 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("a ? b : (c = d)", "a ? b : c = d", "AssignmentExpression"),
         invalid("(c = d) ? (b) : c", "(c = d) ? b : c", "Identifier", null, { options: ["all", { conditionalAssign: false }] }),
         invalid("(c = d) ? b : (c)", "(c = d) ? b : c", "Identifier", null, { options: ["all", { conditionalAssign: false }] }),
-        invalid("(a) ? foo : bar", "a ? foo : bar", "Identifier", null, { options: ["all", { conditionalTernary: false }] }),
-        invalid("(a()) ? foo : bar", "a() ? foo : bar", "CallExpression", null, { options: ["all", { conditionalTernary: false }] }),
-        invalid("(a.b) ? foo : bar", "a.b ? foo : bar", "MemberExpression", null, { options: ["all", { conditionalTernary: false }] }),
-        invalid("(a || b) ? foo : (bar)", "(a || b) ? foo : bar", "Identifier", null, { options: ["all", { conditionalTernary: false }] }),
+        invalid("(a) ? foo : bar", "a ? foo : bar", "Identifier", null, { options: ["all", { ternaryOperandBinaryExpressions: false }] }),
+        invalid("(a()) ? foo : bar", "a() ? foo : bar", "CallExpression", null, { options: ["all", { ternaryOperandBinaryExpressions: false }] }),
+        invalid("(a.b) ? foo : bar", "a.b ? foo : bar", "MemberExpression", null, { options: ["all", { ternaryOperandBinaryExpressions: false }] }),
+        invalid("(a || b) ? foo : (bar)", "(a || b) ? foo : bar", "Identifier", null, { options: ["all", { ternaryOperandBinaryExpressions: false }] }),
         invalid("f((a = b))", "f(a = b)", "AssignmentExpression"),
         invalid("a, (b = c)", "a, b = c", "AssignmentExpression"),
         invalid("a = (b * c)", "a = b * c", "BinaryExpression"),

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -309,6 +309,7 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "foo ? (bar || baz) : qux", options: ["all", { ternaryOperandBinaryExpressions: false }] },
         { code: "foo ? bar : (baz || qux)", options: ["all", { ternaryOperandBinaryExpressions: false }] },
         { code: "(a, b) ? (c, d) : (e, f)", options: ["all", { ternaryOperandBinaryExpressions: false }] },
+        { code: "(a = b) ? c : d", options: ["all", { ternaryOperandBinaryExpressions: false }] },
 
         // ["all", { nestedBinaryExpressions: false }] enables extra parens around conditional assignments
         { code: "a + (b * c)", options: ["all", { nestedBinaryExpressions: false }] },

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -923,6 +923,8 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("(c = d) ? b : (c)", "(c = d) ? b : c", "Identifier", null, { options: ["all", { conditionalAssign: false }] }),
         invalid("(a) ? foo : bar", "a ? foo : bar", "Identifier", null, { options: ["all", { conditionalTernary: false }] }),
         invalid("(a()) ? foo : bar", "a() ? foo : bar", "CallExpression", null, { options: ["all", { conditionalTernary: false }] }),
+        invalid("(a.b) ? foo : bar", "a.b ? foo : bar", "MemberExpression", null, { options: ["all", { conditionalTernary: false }] }),
+        invalid("(a || b) ? foo : (bar)", "(a || b) ? foo : bar", "Identifier", null, { options: ["all", { conditionalTernary: false }] }),
         invalid("f((a = b))", "f(a = b)", "AssignmentExpression"),
         invalid("a, (b = c)", "a, b = c", "AssignmentExpression"),
         invalid("a = (b * c)", "a = b * c", "BinaryExpression"),

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -308,6 +308,7 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "(a - b > a) ? foo : bar", options: ["all", { conditionalTernary: false }] },
         { code: "foo ? (bar || baz) : qux", options: ["all", { conditionalTernary: false }] },
         { code: "foo ? bar : (baz || qux)", options: ["all", { conditionalTernary: false }] },
+        { code: "(a, b) ? (c, d) : (e, f)", options: ["all", { conditionalTernary: false }] },
 
         // ["all", { nestedBinaryExpressions: false }] enables extra parens around conditional assignments
         { code: "a + (b * c)", options: ["all", { nestedBinaryExpressions: false }] },

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -306,6 +306,8 @@ ruleTester.run("no-extra-parens", rule, {
         // ["all", { conditionalTernary: false }] enables extra parens around conditional ternary
         { code: "(a && b) ? foo : bar", options: ["all", { conditionalTernary: false }] },
         { code: "(a - b > a) ? foo : bar", options: ["all", { conditionalTernary: false }] },
+        { code: "foo ? (bar || baz) : qux", options: ["all", { conditionalTernary: false }] },
+        { code: "foo ? bar : (baz || qux)", options: ["all", { conditionalTernary: false }] },
 
         // ["all", { nestedBinaryExpressions: false }] enables extra parens around conditional assignments
         { code: "a + (b * c)", options: ["all", { nestedBinaryExpressions: false }] },
@@ -920,6 +922,7 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("(c = d) ? (b) : c", "(c = d) ? b : c", "Identifier", null, { options: ["all", { conditionalAssign: false }] }),
         invalid("(c = d) ? b : (c)", "(c = d) ? b : c", "Identifier", null, { options: ["all", { conditionalAssign: false }] }),
         invalid("(a) ? foo : bar", "a ? foo : bar", "Identifier", null, { options: ["all", { conditionalTernary: false }] }),
+        invalid("(a()) ? foo : bar", "a() ? foo : bar", "CallExpression", null, { options: ["all", { conditionalTernary: false }] }),
         invalid("f((a = b))", "f(a = b)", "AssignmentExpression"),
         invalid("a, (b = c)", "a, b = c", "AssignmentExpression"),
         invalid("a = (b * c)", "a = b * c", "BinaryExpression"),

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -303,6 +303,10 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "while (((foo = bar()))) {}", options: ["all", { conditionalAssign: false }] },
         { code: "var a = (((b = c))) ? foo : bar;", options: ["all", { conditionalAssign: false }] },
 
+        // ["all", { conditionalTernary: false }] enables extra parens around conditional ternary
+        { code: "(a && b) ? foo : bar", options: ["all", { conditionalTernary: false }] },
+        { code: "(a - b > a) ? foo : bar", options: ["all", { conditionalTernary: false }] },
+
         // ["all", { nestedBinaryExpressions: false }] enables extra parens around conditional assignments
         { code: "a + (b * c)", options: ["all", { nestedBinaryExpressions: false }] },
         { code: "(a * b) + c", options: ["all", { nestedBinaryExpressions: false }] },
@@ -915,6 +919,7 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("a ? b : (c = d)", "a ? b : c = d", "AssignmentExpression"),
         invalid("(c = d) ? (b) : c", "(c = d) ? b : c", "Identifier", null, { options: ["all", { conditionalAssign: false }] }),
         invalid("(c = d) ? b : (c)", "(c = d) ? b : c", "Identifier", null, { options: ["all", { conditionalAssign: false }] }),
+        invalid("(a) ? foo : bar", "a ? foo : bar", "Identifier", null, { options: ["all", { conditionalTernary: false }] }),
         invalid("f((a = b))", "f(a = b)", "AssignmentExpression"),
         invalid("a, (b = c)", "a, b = c", "AssignmentExpression"),
         invalid("a = (b * c)", "a = b * c", "BinaryExpression"),


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

```js
a && b ? foo : bar
```

Such code may not be clear to readers who do not know enough about priorities, whether it is

```js
(a && b) ? foo : bar
```

or

```js
a && (b ? foo : bar)
```

To better express the priority, one may choose to add parentheses to it and use `no-mixed-operators` rule with `groups: [['||' , '&&', '?:']]` option to check it.

However, `no-extra-parens` currently reports an error for first case. If there are no parentheses, then `no-mixed-operators` rule will report another error.

**What rule do you want to change?**

`no-extra-parens`

**What change do you want to make (place an "X" next to just one item)?**

[ ] Generate more warnings
[x] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[x] A new option
[ ] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
(a && b) ? foo : bar
```

**What does the rule currently do for this code?**

```
error  Unnecessary parentheses around expression                              no-extra-parens
```

**What will the rule do after it's changed?**



#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
