### PR TITLE
feat: Allow `void` in rule `no-promise-executor-return`

### DIFF
--- a/docs/src/rules/no-promise-executor-return.md
+++ b/docs/src/rules/no-promise-executor-return.md
@@ -60,6 +60,10 @@ new Promise((resolve, reject) => getSomething((err, data) => {
     }
 }));
 
+new Promise(() => {
+    return 1;
+});
+
 new Promise(r => r(1));
 ```
 
@@ -95,15 +99,19 @@ new Promise((resolve, reject) => {
         } else {
             resolve(data);
         }
-    }
-}));
+    });
+});
 
 new Promise(r => { r(1) });
 // or just use Promise.resolve
 Promise.resolve(1);
 ```
 
-The option `allowVoid` will additionally allow returning `void` from the executor function.
+## Options
+
+This rule takes one option, an object, with the following properties:
+
+* `allowVoid`: If set to `true` (`false` by default), this rule will allow returning void values.
 
 ```js
 /*eslint no-promise-executor-return: ["error", { allowVoid: true }]*/

--- a/docs/src/rules/no-promise-executor-return.md
+++ b/docs/src/rules/no-promise-executor-return.md
@@ -107,6 +107,8 @@ new Promise(r => { r(1) });
 Promise.resolve(1);
 ```
 
+:::
+
 ## Options
 
 This rule takes one option, an object, with the following properties:

--- a/docs/src/rules/no-promise-executor-return.md
+++ b/docs/src/rules/no-promise-executor-return.md
@@ -88,6 +88,7 @@ new Promise((resolve, reject) => {
     });
 });
 
+// Add curly braces
 new Promise((resolve, reject) => {
     getSomething((err, data) => {
         if (err) {
@@ -97,6 +98,15 @@ new Promise((resolve, reject) => {
         }
     });
 });
+
+// Or add `void`
+new Promise((resolve, reject) => void getSomething((err, data) => {
+    if (err) {
+        reject(err);
+    } else {
+        resolve(data);
+    }
+}));
 
 Promise.resolve(1);
 ```

--- a/docs/src/rules/no-promise-executor-return.md
+++ b/docs/src/rules/no-promise-executor-return.md
@@ -60,9 +60,7 @@ new Promise((resolve, reject) => getSomething((err, data) => {
     }
 }));
 
-new Promise(() => {
-    return 1;
-});
+new Promise(r => r(1));
 ```
 
 :::
@@ -74,6 +72,7 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-promise-executor-return: "error"*/
 
+// Turn return inline into two lines
 new Promise((resolve, reject) => {
     if (someCondition) {
         resolve(defaultResult);
@@ -96,10 +95,32 @@ new Promise((resolve, reject) => {
         } else {
             resolve(data);
         }
+    }
+}));
+
+new Promise(r => { r(1) });
+// or just use Promise.resolve
+Promise.resolve(1);
+```
+
+The option `allowVoid` will additionally allow returning `void` from the executor function.
+
+```js
+/*eslint no-promise-executor-return: ["error", { allowVoid: true }]*/
+
+new Promise((resolve, reject) => {
+    if (someCondition) {
+        return void resolve(defaultResult);
+    }
+    getSomething((err, result) => {
+        if (err) {
+            reject(err);
+        } else {
+            resolve(result);
+        }
     });
 });
 
-// Or add `void`
 new Promise((resolve, reject) => void getSomething((err, data) => {
     if (err) {
         reject(err);
@@ -108,7 +129,7 @@ new Promise((resolve, reject) => void getSomething((err, data) => {
     }
 }));
 
-Promise.resolve(1);
+new Promise(r => void r(1));
 ```
 
 :::

--- a/docs/src/rules/no-promise-executor-return.md
+++ b/docs/src/rules/no-promise-executor-return.md
@@ -113,6 +113,12 @@ This rule takes one option, an object, with the following properties:
 
 * `allowVoid`: If set to `true` (`false` by default), this rule will allow returning void values.
 
+### allowVoid
+
+Examples of **correct** code for this rule with the `{ "allowVoid": true }` option:
+
+::: correct
+
 ```js
 /*eslint no-promise-executor-return: ["error", { allowVoid: true }]*/
 

--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -78,17 +78,13 @@ function expressionIsVoid(node) {
  */
 function voidPrependFixer(sourceCode, node, fixer) {
 
-    // prepending `void ` will fail if the node has a lower precedence than void
-    if (astUtils.getPrecedence(node) < astUtils.getPrecedence({ type: "UnaryExpression", operator: "void" })) {
+    const requiresParens =
+
+        // prepending `void ` will fail if the node has a lower precedence than void
+        astUtils.getPrecedence(node) < astUtils.getPrecedence({ type: "UnaryExpression", operator: "void" }) &&
 
         // check if there are parentheses around the node to avoid redundant parentheses
-        if (!astUtils.isParenthesised(sourceCode, node)) {
-            return [
-                fixer.insertTextBefore(node, "void ("),
-                fixer.insertTextAfter(node, ")")
-            ];
-        }
-    }
+        !astUtils.isParenthesised(sourceCode, node);
 
     // avoid parentheses issues
     const returnOrArrowToken = sourceCode.getTokenBefore(
@@ -100,10 +96,20 @@ function voidPrependFixer(sourceCode, node, fixer) {
             : token => token.type === "Keyword" && token.value === "return"
     );
 
-    // avoid spacing issue
     const firstToken = sourceCode.getTokenAfter(returnOrArrowToken);
 
-    return fixer.insertTextBefore(firstToken, "void ");
+    const prependSpace =
+
+        // is return token, as => allows ( to be adjacent
+        returnOrArrowToken.value === "return" &&
+
+        // If two tokens (return and ")") are adjacent
+        returnOrArrowToken.range[1] === firstToken.range[0];
+
+    return [
+        fixer.insertTextBefore(firstToken, `${prependSpace ? " " : ""}void ${requiresParens ? "(" : ""}`),
+        fixer.insertTextAfter(node, requiresParens ? ")" : "")
+    ];
 }
 
 /**

--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -74,7 +74,7 @@ function expressionIsVoid(node) {
  * @param {Object} sourceCode context given by context.sourceCode
  * @param {ASTNode} node The node to fix.
  * @param {Object} fixer The fixer object provided by ESLint.
- * @returns {Array<Object>|Object} - An array of fix objects or fix to apply to the node.
+ * @returns {Array<Object>} - An array of fix objects to apply to the node.
  */
 function voidPrependFixer(sourceCode, node, fixer) {
 
@@ -100,10 +100,10 @@ function voidPrependFixer(sourceCode, node, fixer) {
 
     const prependSpace =
 
-        // is return token, as => allows ( to be adjacent
+        // is return token, as => allows void to be adjacent
         returnOrArrowToken.value === "return" &&
 
-        // If two tokens (return and ")") are adjacent
+        // If two tokens (return and "(") are adjacent
         returnOrArrowToken.range[1] === firstToken.range[0];
 
     return [
@@ -117,11 +117,11 @@ function voidPrependFixer(sourceCode, node, fixer) {
  * @param {Object} sourceCode context given by context.sourceCode
  * @param {ASTNode} node The node to fix.
  * @param {Object} fixer The fixer object provided by ESLint.
- * @returns {Array<Object>} - An array of fix objects or fix to apply to the node.
+ * @returns {Array<Object>} - An array of fix objects to apply to the node.
  */
 function curlyWrapFixer(sourceCode, node, fixer) {
 
-    // @mdjermanovic https://github.com/eslint/eslint/pull/17282#issuecomment-1592795923
+    // https://github.com/eslint/eslint/pull/17282#issuecomment-1592795923
     const arrowToken = sourceCode.getTokenBefore(node.body, astUtils.isArrowToken);
     const firstToken = sourceCode.getTokenAfter(arrowToken);
     const lastToken = sourceCode.getLastToken(node);

--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -68,6 +68,28 @@ function expressionIsVoid(node) {
     return node.type === "UnaryExpression" && node.operator === "void";
 }
 
+/**
+ * Fixes a linting error by prepending "void " to the given node's body.
+ * @param {Object} node The node to fix.
+ * @param {Object} fixer The fixer object provided by ESLint.
+ * @returns {Array<Object>|Object} - An array of fix objects or fix to apply to the node.
+ */
+function voidPrependFixer(node, fixer) {
+
+    /*
+     * prepending `void ` will fail if
+     * the expression is () => void () => {}
+     * therefore, check if the expression is a function
+     */
+    if (node.body.type === "ArrowFunctionExpression") {
+        return [
+            fixer.insertTextBefore(node.body, "void ("),
+            fixer.insertTextAfter(node.body, ")")
+        ];
+    }
+    return fixer.insertTextBefore(node.body, "void ");
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -83,11 +105,17 @@ module.exports = {
             url: "https://eslint.org/docs/latest/rules/no-promise-executor-return"
         },
 
+        fixable: "code",
+
+        hasSuggestions: true,
+
         schema: [],
 
         messages: {
             returnsValue: "Return values from promise executor functions cannot be read.",
-            useVoid: "Return values from promise executor functions cannot be read. If you prefer to use arrow functions without `{...}`, prepend `void` to the expression."
+            useVoid: "Return values from promise executor functions cannot be read. If you prefer to use arrow functions without `{...}`, prepend `void` to the expression.",
+            prependVoid: "Prepend `void` to the expression.",
+            wrapBraces: "Wrap the expression in `{}`."
         }
     },
 
@@ -116,7 +144,37 @@ module.exports = {
                         // Except void
                         !expressionIsVoid(node.body)
                 ) {
-                    context.report({ node: node.body, messageId: "useVoid" });
+
+                    /*
+                     * This context both fixes and provides suggestions
+                     * the rationale behind is that
+                     * the `void ` prepend fix will be fixed by another rule
+                     * converting it to a `{}` body instead
+                     */
+                    context.report({
+                        node: node.body,
+                        messageId: "useVoid",
+                        fix(fixer) {
+                            return voidPrependFixer(node, fixer);
+                        },
+                        suggest: [
+                            {
+                                messageId: "prependVoid",
+                                fix(fixer) {
+                                    return voidPrependFixer(node, fixer);
+                                }
+                            },
+                            {
+                                messageId: "wrapBraces",
+                                fix(fixer) {
+                                    return [
+                                        fixer.insertTextBefore(node.body, "{"),
+                                        fixer.insertTextAfter(node.body, "}")
+                                    ];
+                                }
+                            }
+                        ]
+                    });
                 }
             },
 

--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -71,22 +71,32 @@ function expressionIsVoid(node) {
 
 /**
  * Fixes the linting error by prepending "void " to the given node
+ * @param {Object} sourceCode context given by context.sourceCode
  * @param {ASTNode} node The node to fix.
  * @param {Object} fixer The fixer object provided by ESLint.
  * @returns {Array<Object>|Object} - An array of fix objects or fix to apply to the node.
  */
-function voidPrependFixer(node, fixer) {
+function voidPrependFixer(sourceCode, node, fixer) {
 
     /*
-     * prepending `void ` will fail if
-     * the expression is () => void () => {}
-     * therefore, check if the expression is a function
+     * prepending `void ` will fail if the node has a lower precedence than void
      */
-    if (node.type === "ArrowFunctionExpression") {
-        return [
-            fixer.insertTextBefore(node, "void ("),
-            fixer.insertTextAfter(node, ")")
-        ];
+    if (astUtils.getPrecedence(node) < astUtils.getPrecedence({ type: "UnaryExpression", operator: "void" })) {
+
+        // check if there are parentheses around the node to avoid redundant parentheses
+        if (!(sourceCode.getTokenBefore(node).value === "(" && sourceCode.getTokenAfter(node).value === ")")) {
+            return [
+                fixer.insertTextBefore(node, "void ("),
+                fixer.insertTextAfter(node, ")")
+            ];
+        }
+    }
+
+    if (node.parent.type === "ArrowFunctionExpression") {
+        const arrowToken = sourceCode.getTokenBefore(node, astUtils.isArrowToken);
+        const firstToken = sourceCode.getTokenAfter(arrowToken);
+
+        return fixer.insertTextBefore(firstToken, "void ");
     }
 
     return fixer.insertTextBefore(node, "void ");
@@ -183,7 +193,7 @@ module.exports = {
                         suggest.push({
                             messageId: "prependVoid",
                             fix(fixer) {
-                                return voidPrependFixer(node.body, fixer);
+                                return voidPrependFixer(sourceCode, node.body, fixer);
                             }
                         });
                     }
@@ -229,7 +239,7 @@ module.exports = {
                     suggest: [{
                         messageId: "prependVoid",
                         fix(fixer) {
-                            return voidPrependFixer(node.argument, fixer);
+                            return voidPrependFixer(sourceCode, node.argument, fixer);
                         }
                     }]
                 });

--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -78,13 +78,11 @@ function expressionIsVoid(node) {
  */
 function voidPrependFixer(sourceCode, node, fixer) {
 
-    /*
-     * prepending `void ` will fail if the node has a lower precedence than void
-     */
+    // prepending `void ` will fail if the node has a lower precedence than void
     if (astUtils.getPrecedence(node) < astUtils.getPrecedence({ type: "UnaryExpression", operator: "void" })) {
 
         // check if there are parentheses around the node to avoid redundant parentheses
-        if (!(sourceCode.getTokenBefore(node).value === "(" && sourceCode.getTokenAfter(node).value === ")")) {
+        if (!astUtils.isParenthesised(sourceCode, node)) {
             return [
                 fixer.insertTextBefore(node, "void ("),
                 fixer.insertTextAfter(node, ")")
@@ -92,14 +90,20 @@ function voidPrependFixer(sourceCode, node, fixer) {
         }
     }
 
-    if (node.parent.type === "ArrowFunctionExpression") {
-        const arrowToken = sourceCode.getTokenBefore(node, astUtils.isArrowToken);
-        const firstToken = sourceCode.getTokenAfter(arrowToken);
+    // avoid parentheses issues
+    const returnOrArrowToken = sourceCode.getTokenBefore(
+        node,
+        node.parent.type === "ArrowFunctionExpression"
+            ? astUtils.isArrowToken
 
-        return fixer.insertTextBefore(firstToken, "void ");
-    }
+            // isReturnToken
+            : token => token.type === "Keyword" && token.value === "return"
+    );
 
-    return fixer.insertTextBefore(node, "void ");
+    // avoid spacing issue
+    const firstToken = sourceCode.getTokenAfter(returnOrArrowToken);
+
+    return fixer.insertTextBefore(firstToken, "void ");
 }
 
 /**

--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -70,7 +70,7 @@ function expressionIsVoid(node) {
 }
 
 /**
- * Fixes the linting error by prepending "void " to the given node's body.
+ * Fixes the linting error by prepending "void " to the given node
  * @param {ASTNode} node The node to fix.
  * @param {Object} fixer The fixer object provided by ESLint.
  * @returns {Array<Object>|Object} - An array of fix objects or fix to apply to the node.
@@ -82,13 +82,14 @@ function voidPrependFixer(node, fixer) {
      * the expression is () => void () => {}
      * therefore, check if the expression is a function
      */
-    if (node.body.type === "ArrowFunctionExpression") {
+    if (node.type === "ArrowFunctionExpression") {
         return [
-            fixer.insertTextBefore(node.body, "void ("),
-            fixer.insertTextAfter(node.body, ")")
+            fixer.insertTextBefore(node, "void ("),
+            fixer.insertTextAfter(node, ")")
         ];
     }
-    return fixer.insertTextBefore(node.body, "void ");
+
+    return fixer.insertTextBefore(node, "void ");
 }
 
 /**
@@ -140,8 +141,11 @@ module.exports = {
 
         messages: {
             returnsValue: "Return values from promise executor functions cannot be read.",
-            useVoid: "Return values from promise executor functions cannot be read. If you prefer to use arrow functions without `{...}`, prepend `void` to the expression.",
+
+            // arrow and function suggestions
             prependVoid: "Prepend `void` to the expression.",
+
+            // only arrow suggestions
             wrapBraces: "Wrap the expression in `{}`."
         }
     },
@@ -161,37 +165,40 @@ module.exports = {
                     upper: funcInfo,
                     shouldCheck:
                         functionTypesToCheck.has(node.type) &&
-                            isPromiseExecutor(node, sourceCode.getScope(node))
+                        isPromiseExecutor(node, sourceCode.getScope(node))
                 };
 
-                if (
-
-                    // Is a Promise executor
+                if (// Is a Promise executor
                     funcInfo.shouldCheck &&
-                        node.type === "ArrowFunctionExpression" &&
-                        node.expression &&
+                    node.type === "ArrowFunctionExpression" &&
+                    node.expression &&
 
-                        // Except void
-                        !(allowVoid && expressionIsVoid(node.body))
+                    // Except void
+                    !(allowVoid && expressionIsVoid(node.body))
                 ) {
+                    const suggest = [];
+
+                    // prevent useless refactors
+                    if (allowVoid) {
+                        suggest.push({
+                            messageId: "prependVoid",
+                            fix(fixer) {
+                                return voidPrependFixer(node.body, fixer);
+                            }
+                        });
+                    }
+
+                    suggest.push({
+                        messageId: "wrapBraces",
+                        fix(fixer) {
+                            return curlyWrapFixer(sourceCode, node, fixer);
+                        }
+                    });
 
                     context.report({
                         node: node.body,
-                        messageId: "useVoid",
-                        suggest: [
-                            {
-                                messageId: "prependVoid",
-                                fix(fixer) {
-                                    return voidPrependFixer(node, fixer);
-                                }
-                            },
-                            {
-                                messageId: "wrapBraces",
-                                fix(fixer) {
-                                    return curlyWrapFixer(sourceCode, node, fixer);
-                                }
-                            }
-                        ]
+                        messageId: "returnsValue",
+                        suggest
                     });
                 }
             },
@@ -201,9 +208,31 @@ module.exports = {
             },
 
             ReturnStatement(node) {
-                if (funcInfo.shouldCheck && node.argument) {
-                    context.report({ node, messageId: "returnsValue" });
+                if (!(funcInfo.shouldCheck && node.argument)) {
+                    return;
                 }
+
+                // node is `return <expression>`
+                if (!allowVoid) {
+                    context.report({ node, messageId: "returnsValue" });
+                    return;
+                }
+
+                if (expressionIsVoid(node.argument)) {
+                    return;
+                }
+
+                // allowVoid && !expressionIsVoid
+                context.report({
+                    node,
+                    messageId: "returnsValue",
+                    suggest: [{
+                        messageId: "prependVoid",
+                        fix(fixer) {
+                            return voidPrependFixer(node.argument, fixer);
+                        }
+                    }]
+                });
             }
         };
     }

--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -59,6 +59,15 @@ function isPromiseExecutor(node, scope) {
         isGlobalReference(parent.callee, getOuterScope(scope));
 }
 
+/**
+ * Checks if the given node is a void expression.
+ * @param {Object} node The node to check.
+ * @returns {boolean} - `true` if the node is a void expression
+ */
+function expressionIsVoid(node) {
+    return node.type === "UnaryExpression" && node.operator === "void";
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -77,7 +86,8 @@ module.exports = {
         schema: [],
 
         messages: {
-            returnsValue: "Return values from promise executor functions cannot be read."
+            returnsValue: "Return values from promise executor functions cannot be read.",
+            useVoid: "Return values from promise executor functions cannot be read. If you prefer to use arrow functions without `{...}`, prepend `void` to the expression."
         }
     },
 
@@ -86,25 +96,27 @@ module.exports = {
         let funcInfo = null;
         const sourceCode = context.sourceCode;
 
-        /**
-         * Reports the given node.
-         * @param {ASTNode} node Node to report.
-         * @returns {void}
-         */
-        function report(node) {
-            context.report({ node, messageId: "returnsValue" });
-        }
-
         return {
 
             onCodePathStart(_, node) {
                 funcInfo = {
                     upper: funcInfo,
-                    shouldCheck: functionTypesToCheck.has(node.type) && isPromiseExecutor(node, sourceCode.getScope(node))
+                    shouldCheck:
+                        functionTypesToCheck.has(node.type) &&
+                            isPromiseExecutor(node, sourceCode.getScope(node))
                 };
 
-                if (funcInfo.shouldCheck && node.type === "ArrowFunctionExpression" && node.expression) {
-                    report(node.body);
+                if (
+
+                    // Is a Promise executor
+                    funcInfo.shouldCheck &&
+                        node.type === "ArrowFunctionExpression" &&
+                        node.expression &&
+
+                        // Except void
+                        !expressionIsVoid(node.body)
+                ) {
+                    context.report({ node: node.body, messageId: "useVoid" });
                 }
             },
 
@@ -114,7 +126,7 @@ module.exports = {
 
             ReturnStatement(node) {
                 if (funcInfo.shouldCheck && node.argument) {
-                    report(node);
+                    context.report({ node, messageId: "returnsValue" });
                 }
             }
         };

--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -150,7 +150,8 @@ module.exports = {
                     type: "boolean",
                     default: false
                 }
-            }
+            },
+            additionalProperties: false
         }],
 
         messages: {

--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -10,6 +10,7 @@
 //------------------------------------------------------------------------------
 
 const { findVariable } = require("@eslint-community/eslint-utils");
+const astUtils = require("./utils/ast-utils");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -61,7 +62,7 @@ function isPromiseExecutor(node, scope) {
 
 /**
  * Checks if the given node is a void expression.
- * @param {Object} node The node to check.
+ * @param {ASTNode} node The node to check.
  * @returns {boolean} - `true` if the node is a void expression
  */
 function expressionIsVoid(node) {
@@ -69,8 +70,8 @@ function expressionIsVoid(node) {
 }
 
 /**
- * Fixes a linting error by prepending "void " to the given node's body.
- * @param {Object} node The node to fix.
+ * Fixes the linting error by prepending "void " to the given node's body.
+ * @param {ASTNode} node The node to fix.
  * @param {Object} fixer The fixer object provided by ESLint.
  * @returns {Array<Object>|Object} - An array of fix objects or fix to apply to the node.
  */
@@ -90,6 +91,26 @@ function voidPrependFixer(node, fixer) {
     return fixer.insertTextBefore(node.body, "void ");
 }
 
+/**
+ * Fixes the linting error by `wrapping {}` around the given node's body.
+ * @param {Object} sourceCode context given by context.sourceCode
+ * @param {ASTNode} node The node to fix.
+ * @param {Object} fixer The fixer object provided by ESLint.
+ * @returns {Array<Object>} - An array of fix objects or fix to apply to the node.
+ */
+function curlyWrapFixer(sourceCode, node, fixer) {
+
+    // @mdjermanovic https://github.com/eslint/eslint/pull/17282#issuecomment-1592795923
+    const arrowToken = sourceCode.getTokenBefore(node.body, astUtils.isArrowToken);
+    const firstToken = sourceCode.getTokenAfter(arrowToken);
+    const lastToken = sourceCode.getLastToken(node);
+
+    return [
+        fixer.insertTextBefore(firstToken, "{"),
+        fixer.insertTextAfter(lastToken, "}")
+    ];
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -105,11 +126,17 @@ module.exports = {
             url: "https://eslint.org/docs/latest/rules/no-promise-executor-return"
         },
 
-        fixable: "code",
-
         hasSuggestions: true,
 
-        schema: [],
+        schema: [{
+            type: "object",
+            properties: {
+                allowVoid: {
+                    type: "boolean",
+                    default: false
+                }
+            }
+        }],
 
         messages: {
             returnsValue: "Return values from promise executor functions cannot be read.",
@@ -123,6 +150,9 @@ module.exports = {
 
         let funcInfo = null;
         const sourceCode = context.sourceCode;
+        const {
+            allowVoid = false
+        } = context.options[0] || {};
 
         return {
 
@@ -142,21 +172,12 @@ module.exports = {
                         node.expression &&
 
                         // Except void
-                        !expressionIsVoid(node.body)
+                        !(allowVoid && expressionIsVoid(node.body))
                 ) {
 
-                    /*
-                     * This context both fixes and provides suggestions
-                     * the rationale behind is that
-                     * the `void ` prepend fix will be fixed by another rule
-                     * converting it to a `{}` body instead
-                     */
                     context.report({
                         node: node.body,
                         messageId: "useVoid",
-                        fix(fixer) {
-                            return voidPrependFixer(node, fixer);
-                        },
                         suggest: [
                             {
                                 messageId: "prependVoid",
@@ -167,10 +188,7 @@ module.exports = {
                             {
                                 messageId: "wrapBraces",
                                 fix(fixer) {
-                                    return [
-                                        fixer.insertTextBefore(node.body, "{"),
-                                        fixer.insertTextAfter(node.body, "}")
-                                    ];
+                                    return curlyWrapFixer(sourceCode, node, fixer);
                                 }
                             }
                         ]

--- a/tests/lib/rules/no-promise-executor-return.js
+++ b/tests/lib/rules/no-promise-executor-return.js
@@ -290,7 +290,7 @@ ruleTester.run("no-promise-executor-return", rule, {
             "new Promise(r => {() => {}})"
         ]),
 
-        //
+        // primitives
         suggestion({
             code:
                 "new Promise(r => null)",
@@ -311,7 +311,7 @@ ruleTester.run("no-promise-executor-return", rule, {
             "new Promise(r => {null})"
         ]),
 
-        //
+        // inline comments
         suggestion({
             code:
                 "new Promise(r => /*hi*/ ~0)",
@@ -350,7 +350,7 @@ ruleTester.run("no-promise-executor-return", rule, {
             }]
         }),
 
-
+        // multiple returns
         suggestion({
             code:
                 "new Promise(r => { if (foo) { return void 0 } return 0 })",
@@ -359,6 +359,25 @@ ruleTester.run("no-promise-executor-return", rule, {
             }]
         }, [
             "new Promise(r => { if (foo) { return void 0 } return void 0 })"
+        ]),
+
+        // return assignment
+        suggestion({
+            code: "new Promise(resolve => { return (foo = resolve(1)); })",
+            options: [{
+                allowVoid: true
+            }]
+        }, [
+            "new Promise(resolve => { return void (foo = resolve(1)); })"
+        ]),
+        suggestion({
+            code: "new Promise(resolve => r = resolve)",
+            options: [{
+                allowVoid: true
+            }]
+        }, [
+            "new Promise(resolve => void (r = resolve))",
+            "new Promise(resolve => {r = resolve})"
         ]),
 
         // snapshot

--- a/tests/lib/rules/no-promise-executor-return.js
+++ b/tests/lib/rules/no-promise-executor-return.js
@@ -149,7 +149,13 @@ ruleTester.run("no-promise-executor-return", rule, {
         {
             code: "new Promise(function (resolve, reject) {}); return 1;",
             env: { node: true }
-        }
+        },
+
+        /*
+         * void
+         * arrow functions + void return is allowed
+         */
+        "new Promise((r) => void cbf(r));"
     ],
 
     invalid: [
@@ -223,6 +229,12 @@ ruleTester.run("no-promise-executor-return", rule, {
         },
         {
             code: "new Promise(function (resolve, reject) { while (foo){ if (bar) break; else return 1; } })",
+            errors: [error()]
+        },
+
+        // void return is not allowed unless arrow function expression
+        {
+            code: "new Promise(() => { return void 1; })",
             errors: [error()]
         },
 

--- a/tests/lib/rules/no-promise-executor-return.js
+++ b/tests/lib/rules/no-promise-executor-return.js
@@ -380,6 +380,27 @@ ruleTester.run("no-promise-executor-return", rule, {
             "new Promise(resolve => {r = resolve})"
         ]),
 
+        // return<immediate token> (range check)
+        suggestion({
+            code:
+                "new Promise(r => { return(1) })",
+            options: [{
+                allowVoid: true
+            }]
+        }, [
+            "new Promise(r => { return void (1) })"
+        ]),
+        suggestion({
+            code:
+                "new Promise(r =>1)",
+            options: [{
+                allowVoid: true
+            }]
+        }, [
+            "new Promise(r =>void 1)",
+            "new Promise(r =>{1})"
+        ]),
+
         // snapshot
         suggestion({
             code:

--- a/tests/lib/rules/no-promise-executor-return.js
+++ b/tests/lib/rules/no-promise-executor-return.js
@@ -172,8 +172,8 @@ ruleTester.run("no-promise-executor-return", rule, {
         },
 
         /*
-         * void
-         * arrow functions + void return is allowed
+         * allowVoid: true
+         * `=> void` and `return void` are allowed
          */
         {
             code: "new Promise((r) => void cbf(r));",
@@ -475,7 +475,7 @@ ruleTester.run("no-promise-executor-return", rule, {
             errors: [eReturnsValue()]
         },
 
-        // void return is not allowed unless arrow function expression
+        // `return void` is not allowed without `allowVoid: true`
         {
             code: "new Promise(() => { return void 1; })",
             errors: [eReturnsValue()]

--- a/tests/lib/rules/no-promise-executor-return.js
+++ b/tests/lib/rules/no-promise-executor-return.js
@@ -252,13 +252,31 @@ ruleTester.run("no-promise-executor-return", rule, {
             "new Promise(r => {1})"
         ]),
         suggestion({
+            code: "new Promise(r => 1 ? 2 : 3)",
+            options: [{
+                allowVoid: true
+            }]
+        }, [
+            "new Promise(r => void (1 ? 2 : 3))",
+            "new Promise(r => {1 ? 2 : 3})"
+        ]),
+        suggestion({
+            code: "new Promise(r => (1 ? 2 : 3))",
+            options: [{
+                allowVoid: true
+            }]
+        }, [
+            "new Promise(r => void (1 ? 2 : 3))",
+            "new Promise(r => {(1 ? 2 : 3)})"
+        ]),
+        suggestion({
             code:
                 "new Promise(r => (1))",
             options: [{
                 allowVoid: true
             }]
         }, [
-            "new Promise(r => (void 1))",
+            "new Promise(r => void (1))",
             "new Promise(r => {(1)})"
         ]),
         suggestion({
@@ -351,7 +369,7 @@ ruleTester.run("no-promise-executor-return", rule, {
                 allowVoid: true
             }]
         }, [
-            "new Promise(r => ((void 1)))",
+            "new Promise(r => void ((1)))",
             "new Promise(r => {((1))})"
         ]),
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Allow void in `no-promise-executor`
- Update relevant documentation
- Add auto fix that adds a `void` in front of the returned expression (open for debate)
- Update relevant tests

#### Is there anything you'd like reviewers to focus on?

Edge cases that I might have not considered. I found one myself: adding `void` in front of `() => ...`  when it is in front of another `() =>`will cause the expression to not be parsed

resolves #17278, #13668
<!-- markdownlint-disable-file MD004 -->
