### PR TITLE
fix: Remove `no-extra-semi` autofix before potential directives

### DIFF
--- a/docs/src/rules/no-extra-semi.md
+++ b/docs/src/rules/no-extra-semi.md
@@ -16,6 +16,8 @@ Typing mistakes and misunderstandings about where semicolons are required can le
 
 This rule disallows unnecessary semicolons.
 
+Problems reported by this rule can be fixed automatically, except when removing a semicolon would cause a following statement to become a directive such as `"use strict"`.
+
 Examples of **incorrect** code for this rule:
 
 ::: incorrect

--- a/tests/lib/rules/no-extra-semi.js
+++ b/tests/lib/rules/no-extra-semi.js
@@ -190,6 +190,43 @@ ruleTester.run("no-extra-semi", rule, {
             output: "class A { static { a; } foo(){} }",
             parserOptions: { ecmaVersion: 2022 },
             errors: [{ messageId: "unexpected", type: "Punctuator", column: 24 }]
+        },
+
+        // https://github.com/eslint/eslint/issues/16988
+        {
+            code: "; 'use strict'",
+            output: null,
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
+        },
+        {
+            code: "; ; 'use strict'",
+            output: " ; 'use strict'",
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }, { messageId: "unexpected", type: "EmptyStatement" }]
+        },
+        {
+            code: "debugger;\n;\n'use strict'",
+            output: null,
+            errors: [{ messageId: "unexpected", type: "EmptyStatement", line: 2 }]
+        },
+        {
+            code: "function foo() { ; 'bar'; }",
+            output: null,
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
+        },
+        {
+            code: "{ ; 'foo'; }",
+            output: "{  'foo'; }",
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
+        },
+        {
+            code: "; ('use strict');",
+            output: " ('use strict');",
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
+        },
+        {
+            code: "; 1;",
+            output: " 1;",
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

References #16988

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR disables the autofix for the `no-extra-semi` rule if removing the semicolon could cause the following statement to become a directive. For example:

```js
function foo({ bar })
{
    ; // no autofix!
  
    "use strict";
}
```

The autofix is disabled:
* Only if a semicolon is followed by an `ExpressionStatement` that contains an unparenthesized string as its only child.
* Only at the top-level of a function body or a file.
* Regardless of any preceding tokens, because they could be changed or removed by other (third-party) rules.
* Not before template literals or strings in parentheses. Such nodes are no longer fixed into unparenthesized strings by any core rules. Also, it happens that the `no-extra-semi` autofix [retains surronding tokens](https://github.com/eslint/eslint/blob/cd6e718416de5959036a1681b39f522bff15f3d4/lib/rules/no-extra-semi.js#L76), and that makes it unlikely - although not impossible - that a concurrent autofix would leave a directive after the removed semicolon.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
