### PR TITLE
feat: allow flat config files to export a Promise

### DIFF
--- a/docs/src/use/configure/configuration-files-new.md
+++ b/docs/src/use/configure/configuration-files-new.md
@@ -31,7 +31,7 @@ export default [
 
 In this example, the configuration array contains just one configuration object. The configuration object enables two rules: `semi` and `prefer-const`. These rules are applied to all of the files ESLint processes using this config file.
 
-If your project does not specify `"type":"module"` in its `package.json` file, then `eslint.config.js` must be in the CommonJS format:
+If your project does not specify `"type":"module"` in its `package.json` file, then `eslint.config.js` must be in CommonJS format, such as:
 
 ```js
 module.exports = [

--- a/docs/src/use/configure/configuration-files-new.md
+++ b/docs/src/use/configure/configuration-files-new.md
@@ -44,7 +44,7 @@ module.exports = [
 ];
 ```
 
-The configuration file can also export a Promise that resolves to the configuration array. This can be useful for using ESM dependencies in CommonJS configuration files:
+The configuration file can also export a promise that resolves to the configuration array. This can be useful for using ESM dependencies in CommonJS configuration files, as in this example:
 
 ```js
 module.exports = (async () => {

--- a/docs/src/use/configure/configuration-files-new.md
+++ b/docs/src/use/configure/configuration-files-new.md
@@ -26,10 +26,37 @@ export default [
             "prefer-const": "error"
         }
     }
-]
+];
 ```
 
 In this example, the configuration array contains just one configuration object. The configuration object enables two rules: `semi` and `prefer-const`. These rules are applied to all of the files ESLint processes using this config file.
+
+If your project does not specify `"type":"module"` in its `package.json` file, then `eslint.config.js` must be in the CommonJS format:
+
+```js
+module.exports = [
+    {
+        rules: {
+            semi: "error",
+            "prefer-const": "error"
+        }
+    }
+];
+```
+
+The configuration file can also export a Promise that resolves to the configuration array. This can be useful for using ESM dependencies in CommonJS configuration files:
+
+```js
+module.exports = (async () => {
+
+    const someDependency = await import("some-esm-dependency");
+
+    return [
+        // ... use `someDependency` here
+    ];
+
+})();
+```
 
 ## Configuration Objects
 

--- a/tests/fixtures/promise-config/a.js
+++ b/tests/fixtures/promise-config/a.js
@@ -1,0 +1,1 @@
+var foo = "bar";

--- a/tests/fixtures/promise-config/eslint.config.js
+++ b/tests/fixtures/promise-config/eslint.config.js
@@ -1,0 +1,5 @@
+module.exports = Promise.resolve([{
+    rules: {
+        quotes: ["error", "single"]
+    }
+}]);

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -761,6 +761,18 @@ describe("FlatESLint", () => {
             eslint = new FlatESLint();
             await assert.rejects(() => eslint.lintText("var a = 0", { warnIgnored: "" }), /'options.warnIgnored' must be a boolean or undefined/u);
         });
+
+        it("should work with config file that exports a promise", async () => {
+            eslint = new FlatESLint({
+                cwd: getFixturePath("promise-config")
+            });
+            const results = await eslint.lintText('var foo = "bar";');
+
+            assert.strictEqual(results.length, 1);
+            assert.strictEqual(results[0].messages.length, 1);
+            assert.strictEqual(results[0].messages[0].severity, 2);
+            assert.strictEqual(results[0].messages[0].ruleId, "quotes");
+        });
     });
 
     describe("lintFiles()", () => {
@@ -989,6 +1001,19 @@ describe("FlatESLint", () => {
                 getFixturePath("{curly-path}/server/src/two.js")
             );
             assert.strictEqual(results[0].suppressedMessages.length, 0);
+        });
+
+        it("should work with config file that exports a promise", async () => {
+            eslint = new FlatESLint({
+                cwd: getFixturePath("promise-config")
+            });
+            const results = await eslint.lintFiles(["a*.js"]);
+
+            assert.strictEqual(results.length, 1);
+            assert.strictEqual(results[0].filePath, getFixturePath("promise-config", "a.js"));
+            assert.strictEqual(results[0].messages.length, 1);
+            assert.strictEqual(results[0].messages[0].severity, 2);
+            assert.strictEqual(results[0].messages[0].ruleId, "quotes");
         });
 
         // https://github.com/eslint/eslint/issues/16265


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

Fixes https://github.com/eslint/eslint/issues/16864, Fixes https://github.com/eslint/eslint/issues/16580

Officially adds support for exporting Promises from `eslint.config.js` files. Technically, this was already working.

Note that this doesn't mean that a config object inside the config array can be a Promise, just that project's config file can export a Promise.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Added tests.
* Updated documentation with this feature.
* Added a note that in CommonJS projects `eslint.config.js` must be in the CommonJS format (fixes https://github.com/eslint/eslint/issues/16580).

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
