### PR TITLE
docs: add playground links to correct and incorrect code blocks

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -205,11 +205,11 @@ module.exports = function(eleventyConfig) {
                     }
 
                     // See https://github.com/eslint/eslint.org/blob/ac38ab41f99b89a8798d374f74e2cce01171be8b/src/playground/App.js#L44
-                    const options = tokens[index].info?.split("correct ")[1]?.trim();
+                    const parserOptions = tokens[index].info?.split("correct ")[1]?.trim();
                     const { content } = tokens[index + 1];
                     const state = encodeToBase64(
                         JSON.stringify({
-                            ...(options && { options: JSON.parse(options) }),
+                            ...(parserOptions && { options: { parserOptions: JSON.parse(parserOptions) } }),
                             text: content
                         })
                     );

--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -220,7 +220,7 @@ module.exports = function(eleventyConfig) {
                     return `
                         <div class="${name}">
                             <a class="c-btn c-btn--secondary c-btn--playground" href="${prefix}/play#${state}" target="_blank">
-                                Open in Playground ↗️
+                                Open in Playground
                             </a>
                     `.trim();
                 }

--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -213,10 +213,13 @@ module.exports = function(eleventyConfig) {
                             text: content
                         })
                     );
+                    const prefix = process.env.CONTEXT && process.env.CONTEXT !== "deploy-preview"
+                        ? ""
+                        : "https://eslint.org";
 
                     return `
                         <div class="${name}">
-                            <a class="c-btn c-btn--secondary c-btn--playground" href="/play#${state}" target="_blank">
+                            <a class="c-btn c-btn--secondary c-btn--playground" href="${prefix}/play#${state}" target="_blank">
                                 Open in Playground ↗️
                             </a>
                     `.trim();

--- a/docs/src/assets/js/main.js
+++ b/docs/src/assets/js/main.js
@@ -192,24 +192,6 @@
     }
 })();
 
-// add "Open in Playground" button to code blocks
-// (function() {
-//     let blocks = document.querySelectorAll('pre[class*="language-"]');
-//     if (blocks) {
-//         blocks.forEach(function(block) {
-//             let button = document.createElement("a");
-//             button.classList.add('c-btn--playground');
-//             button.classList.add('c-btn');
-//             button.classList.add('c-btn--secondary');
-//             button.setAttribute("href", "#");
-//             button.innerText = "Open in Playground";
-//             block.appendChild(button);
-//         });
-//     }
-// })();
-
-
-
 // add utilities
 var util = {
     keyCodes: {

--- a/docs/src/assets/scss/docs.scss
+++ b/docs/src/assets/scss/docs.scss
@@ -149,7 +149,7 @@ pre[class*="language-"] {
     z-index: 1;
 
     @media all and (min-width: 768px) {
-        bottom: 1rem;
+        bottom: 1.5rem;
     }
 }
 

--- a/docs/src/assets/scss/docs.scss
+++ b/docs/src/assets/scss/docs.scss
@@ -142,11 +142,15 @@ pre[class*="language-"] {
 .c-btn.c-btn--playground {
     position: absolute;
     font-size: var(--step--1);
-    bottom: 0.5rem;
-    right: 0.5rem;
+    bottom: -1rem;
+    right: 1rem;
     offset-block-end: 0.5rem;
     offset-inline-end: 0.5rem;
     z-index: 1;
+
+    @media all and (min-width: 768px) {
+        bottom: 1rem;
+    }
 }
 
 @media (hover: none) {

--- a/docs/src/assets/scss/docs.scss
+++ b/docs/src/assets/scss/docs.scss
@@ -126,6 +126,29 @@ div.incorrect {
     }
 }
 
+div.with-playground-link {
+    position: relative;
+}
+
+a.open-in-playground {
+    background-color: var(--lightest-background-color);
+    border-radius: 0.25rem;
+    border: 1px solid var(--border-color);
+    color: unset;
+    opacity: 0;
+    padding: 0.5rem 0.75rem;
+    position: absolute;
+    right: 0.5rem;
+    text-decoration: none;
+    top: 0.5rem;
+    transition: opacity 0.2s linear;
+    z-index: 1;
+}
+
+a.open-in-playground:is(:focus, :hover) {
+    opacity: 1;
+}
+
 div.img-container {
     background-color: var(--img-background-color);
     border-radius: var(--border-radius);

--- a/docs/src/assets/scss/docs.scss
+++ b/docs/src/assets/scss/docs.scss
@@ -126,29 +126,6 @@ div.incorrect {
     }
 }
 
-div.with-playground-link {
-    position: relative;
-}
-
-a.open-in-playground {
-    background-color: var(--lightest-background-color);
-    border-radius: 0.25rem;
-    border: 1px solid var(--border-color);
-    color: unset;
-    opacity: 0;
-    padding: 0.5rem 0.75rem;
-    position: absolute;
-    right: 0.5rem;
-    text-decoration: none;
-    top: 0.5rem;
-    transition: opacity 0.2s linear;
-    z-index: 1;
-}
-
-a.open-in-playground:is(:focus, :hover) {
-    opacity: 1;
-}
-
 div.img-container {
     background-color: var(--img-background-color);
     border-radius: var(--border-radius);
@@ -169,10 +146,7 @@ pre[class*="language-"] {
     right: 0.5rem;
     offset-block-end: 0.5rem;
     offset-inline-end: 0.5rem;
-
-    @media all and (max-width: 768px) {
-        display: none;
-    }
+    z-index: 1;
 }
 
 @media (hover: none) {

--- a/docs/src/rules/no-implicit-globals.md
+++ b/docs/src/rules/no-implicit-globals.md
@@ -2,15 +2,14 @@
 title: no-implicit-globals
 rule_type: suggestion
 related_rules:
-- no-undef
-- no-global-assign
-- no-unused-vars
+    - no-undef
+    - no-global-assign
+    - no-unused-vars
 further_reading:
-- https://benalman.com/news/2010/11/immediately-invoked-function-expression/
-- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var
-- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone
+    - https://benalman.com/news/2010/11/immediately-invoked-function-expression/
+    - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var
+    - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone
 ---
-
 
 It is the best practice to avoid 'polluting' the global scope with variables that are intended to be local to the script.
 
@@ -19,9 +18,9 @@ usually lead to runtime errors or unexpected behavior.
 
 This rule disallows the following:
 
-* Declarations that create one or more variables in the global scope.
-* Global variable leaks.
-* Redeclarations of read-only global variables and assignments to read-only global variables.
+-   Declarations that create one or more variables in the global scope.
+-   Global variable leaks.
+-   Redeclarations of read-only global variables and assignments to read-only global variables.
 
 There is an explicit way to create a global variable when needed, by assigning to a property of the global object.
 
@@ -32,7 +31,7 @@ By default, this rule does not check `const`, `let` and `class` declarations.
 
 This rule has an object option with one option:
 
-* Set `"lexicalBindings"` to `true` if you want this rule to check `const`, `let` and `class` declarations as well.
+-   Set `"lexicalBindings"` to `true` if you want this rule to check `const`, `let` and `class` declarations as well.
 
 ## Rule Details
 
@@ -44,7 +43,7 @@ This rule disallows `var` and `function` declarations at the top-level script sc
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "parserOptions": { "sourceType": "script" } }
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-implicit-globals: "error"*/
@@ -58,20 +57,20 @@ function bar() {}
 
 Examples of **correct** code for this rule:
 
-::: correct { "parserOptions": { "sourceType": "script" } }
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-implicit-globals: "error"*/
 
 // explicitly set on window
 window.foo = 1;
-window.bar = function() {};
+window.bar = function () {};
 
 // intended to be scope to this file
-(function() {
-  var foo = 1;
+(function () {
+    var foo = 1;
 
-  function bar() {}
+    function bar() {}
 })();
 ```
 
@@ -79,7 +78,7 @@ window.bar = function() {};
 
 Examples of **correct** code for this rule with `"parserOptions": { "sourceType": "module" }` in the ESLint configuration:
 
-::: correct { "parserOptions": { "sourceType": "script" } }
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-implicit-globals: "error"*/
@@ -100,7 +99,7 @@ This does not apply to ES modules since the module code is implicitly in `strict
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "parserOptions": { "sourceType": "script" } }
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-implicit-globals: "error"*/
@@ -122,12 +121,12 @@ A read-only global variable can be a built-in ES global (e.g. `Array`), an envir
 (e.g. `window` in the browser environment), or a global variable defined as `readonly` in the configuration file
 or in a `/*global */` comment.
 
-* [Specifying Environments](../use/configure#specifying-environments)
-* [Specifying Globals](../use/configure#specifying-globals)
+-   [Specifying Environments](../use/configure#specifying-environments)
+-   [Specifying Globals](../use/configure#specifying-globals)
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "parserOptions": { "sourceType": "script" } }
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-implicit-globals: "error"*/
@@ -149,13 +148,13 @@ Lexical declarations `const` and `let`, as well as `class` declarations, create 
 However, when declared in the top-level of a browser script these variables are not 'script-scoped'.
 They are actually created in the global scope and could produce name collisions with
 `var`, `const` and `let` variables and `function` and `class` declarations from other scripts.
-This does not apply to ES and CommonJS  modules.
+This does not apply to ES and CommonJS modules.
 
 If the variable is intended to be local to the script, wrap the code with a block or with an immediately-invoked function expression (IIFE).
 
 Examples of **correct** code for this rule with `"lexicalBindings"` option set to `false` (default):
 
-::: correct { "parserOptions": { "sourceType": "script" } }
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": false}]*/
@@ -171,7 +170,7 @@ class Bar {}
 
 Examples of **incorrect** code for this rule with `"lexicalBindings"` option set to `true`:
 
-::: incorrect { "parserOptions": { "sourceType": "script" } }
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
@@ -187,7 +186,7 @@ class Bar {}
 
 Examples of **correct** code for this rule with `"lexicalBindings"` option set to `true`:
 
-::: correct { "parserOptions": { "sourceType": "script" } }
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
@@ -198,11 +197,11 @@ Examples of **correct** code for this rule with `"lexicalBindings"` option set t
     class Bar {}
 }
 
-(function() {
+(function () {
     const foo = 1;
     let baz;
     class Bar {}
-}());
+})();
 ```
 
 :::
@@ -210,47 +209,47 @@ Examples of **correct** code for this rule with `"lexicalBindings"` option set t
 If you intend to create a global `const` or `let` variable or a global `class` declaration, to be used from other scripts,
 be aware that there are certain differences when compared to the traditional methods, which are `var` declarations and assigning to a property of the global `window` object:
 
-* Lexically declared variables cannot be conditionally created. A script cannot check for the existence of
-a variable and then create a new one. `var` variables are also always created, but redeclarations do not
-cause runtime exceptions.
-* Lexically declared variables do not create properties on the global object, which is what a consuming script might expect.
-* Lexically declared variables are shadowing properties of the global object, which might produce errors if a
-consuming script is using both the variable and the property.
-* Lexically declared variables can produce a permanent Temporal Dead Zone (TDZ) if the initialization throws an exception.
-Even the `typeof` check is not safe from TDZ reference exceptions.
+-   Lexically declared variables cannot be conditionally created. A script cannot check for the existence of
+    a variable and then create a new one. `var` variables are also always created, but redeclarations do not
+    cause runtime exceptions.
+-   Lexically declared variables do not create properties on the global object, which is what a consuming script might expect.
+-   Lexically declared variables are shadowing properties of the global object, which might produce errors if a
+    consuming script is using both the variable and the property.
+-   Lexically declared variables can produce a permanent Temporal Dead Zone (TDZ) if the initialization throws an exception.
+    Even the `typeof` check is not safe from TDZ reference exceptions.
 
 Examples of **incorrect** code for this rule with `"lexicalBindings"` option set to `true`:
 
-::: incorrect { "parserOptions": { "sourceType": "script" } }
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
 
-const MyGlobalFunction = (function() {
+const MyGlobalFunction = (function () {
     const a = 1;
     let b = 2;
-    return function() {
+    return function () {
         return a + b;
-    }
-}());
+    };
+})();
 ```
 
 :::
 
 Examples of **correct** code for this rule with `"lexicalBindings"` option set to `true`:
 
-::: correct { "parserOptions": { "sourceType": "script" } }
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
 
-window.MyGlobalFunction = (function() {
+window.MyGlobalFunction = (function () {
     const a = 1;
     let b = 2;
-    return function() {
+    return function () {
         return a + b;
-    }
-}());
+    };
+})();
 ```
 
 :::
@@ -261,7 +260,7 @@ You can use `/* exported variableName */` block comments in the same way as in [
 
 Examples of **correct** code for `/* exported variableName */` operation:
 
-::: correct { "parserOptions": { "sourceType": "script" } }
+::: correct { "sourceType": "script" }
 
 ```js
 /* exported global_var */

--- a/docs/src/rules/no-implicit-globals.md
+++ b/docs/src/rules/no-implicit-globals.md
@@ -44,7 +44,7 @@ This rule disallows `var` and `function` declarations at the top-level script sc
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "script" } }
 
 ```js
 /*eslint no-implicit-globals: "error"*/
@@ -58,7 +58,7 @@ function bar() {}
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "parserOptions": { "sourceType": "script" } }
 
 ```js
 /*eslint no-implicit-globals: "error"*/
@@ -79,7 +79,7 @@ window.bar = function() {};
 
 Examples of **correct** code for this rule with `"parserOptions": { "sourceType": "module" }` in the ESLint configuration:
 
-::: correct
+::: correct { "parserOptions": { "sourceType": "script" } }
 
 ```js
 /*eslint no-implicit-globals: "error"*/
@@ -100,7 +100,7 @@ This does not apply to ES modules since the module code is implicitly in `strict
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "script" } }
 
 ```js
 /*eslint no-implicit-globals: "error"*/
@@ -127,7 +127,7 @@ or in a `/*global */` comment.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "script" } }
 
 ```js
 /*eslint no-implicit-globals: "error"*/
@@ -155,7 +155,7 @@ If the variable is intended to be local to the script, wrap the code with a bloc
 
 Examples of **correct** code for this rule with `"lexicalBindings"` option set to `false` (default):
 
-::: correct
+::: correct { "parserOptions": { "sourceType": "script" } }
 
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": false}]*/
@@ -171,7 +171,7 @@ class Bar {}
 
 Examples of **incorrect** code for this rule with `"lexicalBindings"` option set to `true`:
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "script" } }
 
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
@@ -187,7 +187,7 @@ class Bar {}
 
 Examples of **correct** code for this rule with `"lexicalBindings"` option set to `true`:
 
-::: correct
+::: correct { "parserOptions": { "sourceType": "script" } }
 
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
@@ -221,7 +221,7 @@ Even the `typeof` check is not safe from TDZ reference exceptions.
 
 Examples of **incorrect** code for this rule with `"lexicalBindings"` option set to `true`:
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "script" } }
 
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
@@ -239,7 +239,7 @@ const MyGlobalFunction = (function() {
 
 Examples of **correct** code for this rule with `"lexicalBindings"` option set to `true`:
 
-::: correct
+::: correct { "parserOptions": { "sourceType": "script" } }
 
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
@@ -261,7 +261,7 @@ You can use `/* exported variableName */` block comments in the same way as in [
 
 Examples of **correct** code for `/* exported variableName */` operation:
 
-::: correct
+::: correct { "parserOptions": { "sourceType": "script" } }
 
 ```js
 /* exported global_var */

--- a/docs/src/rules/no-implicit-globals.md
+++ b/docs/src/rules/no-implicit-globals.md
@@ -2,14 +2,15 @@
 title: no-implicit-globals
 rule_type: suggestion
 related_rules:
-    - no-undef
-    - no-global-assign
-    - no-unused-vars
+- no-undef
+- no-global-assign
+- no-unused-vars
 further_reading:
-    - https://benalman.com/news/2010/11/immediately-invoked-function-expression/
-    - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var
-    - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone
+- https://benalman.com/news/2010/11/immediately-invoked-function-expression/
+- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var
+- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone
 ---
+
 
 It is the best practice to avoid 'polluting' the global scope with variables that are intended to be local to the script.
 
@@ -18,9 +19,9 @@ usually lead to runtime errors or unexpected behavior.
 
 This rule disallows the following:
 
--   Declarations that create one or more variables in the global scope.
--   Global variable leaks.
--   Redeclarations of read-only global variables and assignments to read-only global variables.
+* Declarations that create one or more variables in the global scope.
+* Global variable leaks.
+* Redeclarations of read-only global variables and assignments to read-only global variables.
 
 There is an explicit way to create a global variable when needed, by assigning to a property of the global object.
 
@@ -31,7 +32,7 @@ By default, this rule does not check `const`, `let` and `class` declarations.
 
 This rule has an object option with one option:
 
--   Set `"lexicalBindings"` to `true` if you want this rule to check `const`, `let` and `class` declarations as well.
+* Set `"lexicalBindings"` to `true` if you want this rule to check `const`, `let` and `class` declarations as well.
 
 ## Rule Details
 
@@ -64,13 +65,13 @@ Examples of **correct** code for this rule:
 
 // explicitly set on window
 window.foo = 1;
-window.bar = function () {};
+window.bar = function() {};
 
 // intended to be scope to this file
-(function () {
-    var foo = 1;
+(function() {
+  var foo = 1;
 
-    function bar() {}
+  function bar() {}
 })();
 ```
 
@@ -121,8 +122,8 @@ A read-only global variable can be a built-in ES global (e.g. `Array`), an envir
 (e.g. `window` in the browser environment), or a global variable defined as `readonly` in the configuration file
 or in a `/*global */` comment.
 
--   [Specifying Environments](../use/configure#specifying-environments)
--   [Specifying Globals](../use/configure#specifying-globals)
+* [Specifying Environments](../use/configure#specifying-environments)
+* [Specifying Globals](../use/configure#specifying-globals)
 
 Examples of **incorrect** code for this rule:
 
@@ -148,7 +149,7 @@ Lexical declarations `const` and `let`, as well as `class` declarations, create 
 However, when declared in the top-level of a browser script these variables are not 'script-scoped'.
 They are actually created in the global scope and could produce name collisions with
 `var`, `const` and `let` variables and `function` and `class` declarations from other scripts.
-This does not apply to ES and CommonJS modules.
+This does not apply to ES and CommonJS  modules.
 
 If the variable is intended to be local to the script, wrap the code with a block or with an immediately-invoked function expression (IIFE).
 
@@ -197,11 +198,11 @@ Examples of **correct** code for this rule with `"lexicalBindings"` option set t
     class Bar {}
 }
 
-(function () {
+(function() {
     const foo = 1;
     let baz;
     class Bar {}
-})();
+}());
 ```
 
 :::
@@ -209,14 +210,14 @@ Examples of **correct** code for this rule with `"lexicalBindings"` option set t
 If you intend to create a global `const` or `let` variable or a global `class` declaration, to be used from other scripts,
 be aware that there are certain differences when compared to the traditional methods, which are `var` declarations and assigning to a property of the global `window` object:
 
--   Lexically declared variables cannot be conditionally created. A script cannot check for the existence of
-    a variable and then create a new one. `var` variables are also always created, but redeclarations do not
-    cause runtime exceptions.
--   Lexically declared variables do not create properties on the global object, which is what a consuming script might expect.
--   Lexically declared variables are shadowing properties of the global object, which might produce errors if a
-    consuming script is using both the variable and the property.
--   Lexically declared variables can produce a permanent Temporal Dead Zone (TDZ) if the initialization throws an exception.
-    Even the `typeof` check is not safe from TDZ reference exceptions.
+* Lexically declared variables cannot be conditionally created. A script cannot check for the existence of
+a variable and then create a new one. `var` variables are also always created, but redeclarations do not
+cause runtime exceptions.
+* Lexically declared variables do not create properties on the global object, which is what a consuming script might expect.
+* Lexically declared variables are shadowing properties of the global object, which might produce errors if a
+consuming script is using both the variable and the property.
+* Lexically declared variables can produce a permanent Temporal Dead Zone (TDZ) if the initialization throws an exception.
+Even the `typeof` check is not safe from TDZ reference exceptions.
 
 Examples of **incorrect** code for this rule with `"lexicalBindings"` option set to `true`:
 
@@ -225,13 +226,13 @@ Examples of **incorrect** code for this rule with `"lexicalBindings"` option set
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
 
-const MyGlobalFunction = (function () {
+const MyGlobalFunction = (function() {
     const a = 1;
     let b = 2;
-    return function () {
+    return function() {
         return a + b;
-    };
-})();
+    }
+}());
 ```
 
 :::
@@ -243,13 +244,13 @@ Examples of **correct** code for this rule with `"lexicalBindings"` option set t
 ```js
 /*eslint no-implicit-globals: ["error", {"lexicalBindings": true}]*/
 
-window.MyGlobalFunction = (function () {
+window.MyGlobalFunction = (function() {
     const a = 1;
     let b = 2;
-    return function () {
+    return function() {
         return a + b;
-    };
-})();
+    }
+}());
 ```
 
 :::

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -3,14 +3,13 @@ title: no-restricted-imports
 rule_type: suggestion
 ---
 
-
 Imports are an ES6/ES2015 standard for making the functionality of other modules available in your current module. In CommonJS this is implemented through the `require()` call which makes this ESLint rule roughly equivalent to its CommonJS counterpart `no-restricted-modules`.
 
 Why would you want to restrict imports?
 
-* Some imports might not make sense in a particular environment. For example, Node.js' `fs` module would not make sense in an environment that didn't have a file system.
+-   Some imports might not make sense in a particular environment. For example, Node.js' `fs` module would not make sense in an environment that didn't have a file system.
 
-* Some modules provide similar or identical functionality, think `lodash` and `underscore`. Your project may have standardized on a module. You want to make sure that the other alternatives are not being used as this would unnecessarily bloat the project and provide a higher maintenance cost of two dependencies when one would suffice.
+-   Some modules provide similar or identical functionality, think `lodash` and `underscore`. Your project may have standardized on a module. You want to make sure that the other alternatives are not being used as this would unnecessarily bloat the project and provide a higher maintenance cost of two dependencies when one would suffice.
 
 ## Rule Details
 
@@ -130,57 +129,57 @@ To restrict the use of all Node.js core imports (via <https://github.com/nodejs/
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "parserOptions": { "sourceType": "module" } }
+::: incorrect { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
 
-import fs from 'fs';
+import fs from "fs";
 ```
 
 :::
 
-::: incorrect { "parserOptions": { "sourceType": "module" } }
+::: incorrect { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
 
-export { fs } from 'fs';
+export { fs } from "fs";
 ```
 
 :::
 
-::: incorrect { "parserOptions": { "sourceType": "module" } }
+::: incorrect { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
 
-export * from 'fs';
+export * from "fs";
 ```
 
 :::
 
-::: incorrect { "parserOptions": { "sourceType": "module" } }
+::: incorrect { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { "paths": ["cluster"] }]*/
 
-import cluster from 'cluster';
+import cluster from "cluster";
 ```
 
 :::
 
-::: incorrect { "parserOptions": { "sourceType": "module" } }
+::: incorrect { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { "patterns": ["lodash/*"] }]*/
 
-import pick from 'lodash/pick';
+import pick from "lodash/pick";
 ```
 
 :::
 
-::: incorrect { "parserOptions": { "sourceType": "module" } }
+::: incorrect { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{
@@ -194,7 +193,7 @@ import DisallowedObject from "foo";
 
 :::
 
-::: incorrect { "parserOptions": { "sourceType": "module" } }
+::: incorrect { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{
@@ -212,7 +211,7 @@ import { "DisallowedObject" as AllowedObject } from "foo";
 
 :::
 
-::: incorrect { "parserOptions": { "sourceType": "module" } }
+::: incorrect { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{
@@ -226,7 +225,7 @@ import * as Foo from "foo";
 
 :::
 
-::: incorrect { "parserOptions": { "sourceType": "module" } }
+::: incorrect { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
@@ -234,12 +233,12 @@ import * as Foo from "foo";
     message: "Please use the default import from 'lodash' instead."
 }]}]*/
 
-import pick from 'lodash/pick';
+import pick from "lodash/pick";
 ```
 
 :::
 
-::: incorrect { "parserOptions": { "sourceType": "module" } }
+::: incorrect { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
@@ -247,12 +246,12 @@ import pick from 'lodash/pick';
     caseSensitive: true
 }]}]*/
 
-import pick from 'fooBar';
+import pick from "fooBar";
 ```
 
 :::
 
-::: incorrect { "parserOptions": { "sourceType": "module" } }
+::: incorrect { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
@@ -261,47 +260,47 @@ import pick from 'fooBar';
     message: "Use 'isEmpty' from lodash instead."
 }]}]*/
 
-import { isEmpty } from 'utils/collection-utils';
+import { isEmpty } from "utils/collection-utils";
 ```
 
 :::
 
 Examples of **correct** code for this rule:
 
-::: correct { "parserOptions": { "sourceType": "module" } }
+::: correct { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
 
-import crypto from 'crypto';
+import crypto from "crypto";
 export { foo } from "bar";
 ```
 
 :::
 
-::: correct { "parserOptions": { "sourceType": "module" } }
+::: correct { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { "paths": ["fs"], "patterns": ["eslint/*"] }]*/
 
-import crypto from 'crypto';
-import eslint from 'eslint';
+import crypto from "crypto";
+import eslint from "eslint";
 export * from "path";
 ```
 
 :::
 
-::: correct { "parserOptions": { "sourceType": "module" } }
+::: correct { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{ name: "foo", importNames: ["DisallowedObject"] }] }]*/
 
-import DisallowedObject from "foo"
+import DisallowedObject from "foo";
 ```
 
 :::
 
-::: correct { "parserOptions": { "sourceType": "module" } }
+::: correct { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{
@@ -315,7 +314,7 @@ import { AllowedObject as DisallowedObject } from "foo";
 
 :::
 
-::: correct { "parserOptions": { "sourceType": "module" } }
+::: correct { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
@@ -323,12 +322,12 @@ import { AllowedObject as DisallowedObject } from "foo";
     message: "Please use the default import from 'lodash' instead."
 }]}]*/
 
-import lodash from 'lodash';
+import lodash from "lodash";
 ```
 
 :::
 
-::: correct { "parserOptions": { "sourceType": "module" } }
+::: correct { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
@@ -336,12 +335,12 @@ import lodash from 'lodash';
     caseSensitive: true
 }]}]*/
 
-import pick from 'food';
+import pick from "food";
 ```
 
 :::
 
-::: correct { "parserOptions": { "sourceType": "module" } }
+::: correct { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
@@ -350,7 +349,7 @@ import pick from 'food';
     message: "Use 'isEmpty' from lodash instead."
 }]}]*/
 
-import { hasValues } from 'utils/collection-utils';
+import { hasValues } from "utils/collection-utils";
 ```
 
 :::

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -130,7 +130,7 @@ To restrict the use of all Node.js core imports (via <https://github.com/nodejs/
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
@@ -140,7 +140,7 @@ import fs from 'fs';
 
 :::
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
@@ -150,7 +150,7 @@ export { fs } from 'fs';
 
 :::
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
@@ -160,7 +160,7 @@ export * from 'fs';
 
 :::
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { "paths": ["cluster"] }]*/
@@ -170,7 +170,7 @@ import cluster from 'cluster';
 
 :::
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { "patterns": ["lodash/*"] }]*/
@@ -180,7 +180,7 @@ import pick from 'lodash/pick';
 
 :::
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{
@@ -194,7 +194,7 @@ import DisallowedObject from "foo";
 
 :::
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{
@@ -212,7 +212,7 @@ import { "DisallowedObject" as AllowedObject } from "foo";
 
 :::
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{
@@ -226,7 +226,7 @@ import * as Foo from "foo";
 
 :::
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
@@ -239,7 +239,7 @@ import pick from 'lodash/pick';
 
 :::
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
@@ -252,7 +252,7 @@ import pick from 'fooBar';
 
 :::
 
-::: incorrect
+::: incorrect { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
@@ -268,7 +268,7 @@ import { isEmpty } from 'utils/collection-utils';
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
@@ -279,7 +279,7 @@ export { foo } from "bar";
 
 :::
 
-::: correct
+::: correct { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { "paths": ["fs"], "patterns": ["eslint/*"] }]*/
@@ -291,7 +291,7 @@ export * from "path";
 
 :::
 
-::: correct
+::: correct { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{ name: "foo", importNames: ["DisallowedObject"] }] }]*/
@@ -301,7 +301,7 @@ import DisallowedObject from "foo"
 
 :::
 
-::: correct
+::: correct { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{
@@ -315,7 +315,7 @@ import { AllowedObject as DisallowedObject } from "foo";
 
 :::
 
-::: correct
+::: correct { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
@@ -328,7 +328,7 @@ import lodash from 'lodash';
 
 :::
 
-::: correct
+::: correct { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
@@ -341,7 +341,7 @@ import pick from 'food';
 
 :::
 
-::: correct
+::: correct { "parserOptions": { "sourceType": "module" } }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -3,13 +3,14 @@ title: no-restricted-imports
 rule_type: suggestion
 ---
 
+
 Imports are an ES6/ES2015 standard for making the functionality of other modules available in your current module. In CommonJS this is implemented through the `require()` call which makes this ESLint rule roughly equivalent to its CommonJS counterpart `no-restricted-modules`.
 
 Why would you want to restrict imports?
 
--   Some imports might not make sense in a particular environment. For example, Node.js' `fs` module would not make sense in an environment that didn't have a file system.
+* Some imports might not make sense in a particular environment. For example, Node.js' `fs` module would not make sense in an environment that didn't have a file system.
 
--   Some modules provide similar or identical functionality, think `lodash` and `underscore`. Your project may have standardized on a module. You want to make sure that the other alternatives are not being used as this would unnecessarily bloat the project and provide a higher maintenance cost of two dependencies when one would suffice.
+* Some modules provide similar or identical functionality, think `lodash` and `underscore`. Your project may have standardized on a module. You want to make sure that the other alternatives are not being used as this would unnecessarily bloat the project and provide a higher maintenance cost of two dependencies when one would suffice.
 
 ## Rule Details
 
@@ -134,7 +135,7 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
 
-import fs from "fs";
+import fs from 'fs';
 ```
 
 :::
@@ -144,7 +145,7 @@ import fs from "fs";
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
 
-export { fs } from "fs";
+export { fs } from 'fs';
 ```
 
 :::
@@ -154,7 +155,7 @@ export { fs } from "fs";
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
 
-export * from "fs";
+export * from 'fs';
 ```
 
 :::
@@ -164,7 +165,7 @@ export * from "fs";
 ```js
 /*eslint no-restricted-imports: ["error", { "paths": ["cluster"] }]*/
 
-import cluster from "cluster";
+import cluster from 'cluster';
 ```
 
 :::
@@ -174,7 +175,7 @@ import cluster from "cluster";
 ```js
 /*eslint no-restricted-imports: ["error", { "patterns": ["lodash/*"] }]*/
 
-import pick from "lodash/pick";
+import pick from 'lodash/pick';
 ```
 
 :::
@@ -233,7 +234,7 @@ import * as Foo from "foo";
     message: "Please use the default import from 'lodash' instead."
 }]}]*/
 
-import pick from "lodash/pick";
+import pick from 'lodash/pick';
 ```
 
 :::
@@ -246,7 +247,7 @@ import pick from "lodash/pick";
     caseSensitive: true
 }]}]*/
 
-import pick from "fooBar";
+import pick from 'fooBar';
 ```
 
 :::
@@ -260,7 +261,7 @@ import pick from "fooBar";
     message: "Use 'isEmpty' from lodash instead."
 }]}]*/
 
-import { isEmpty } from "utils/collection-utils";
+import { isEmpty } from 'utils/collection-utils';
 ```
 
 :::
@@ -272,7 +273,7 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
 
-import crypto from "crypto";
+import crypto from 'crypto';
 export { foo } from "bar";
 ```
 
@@ -283,8 +284,8 @@ export { foo } from "bar";
 ```js
 /*eslint no-restricted-imports: ["error", { "paths": ["fs"], "patterns": ["eslint/*"] }]*/
 
-import crypto from "crypto";
-import eslint from "eslint";
+import crypto from 'crypto';
+import eslint from 'eslint';
 export * from "path";
 ```
 
@@ -295,7 +296,7 @@ export * from "path";
 ```js
 /*eslint no-restricted-imports: ["error", { paths: [{ name: "foo", importNames: ["DisallowedObject"] }] }]*/
 
-import DisallowedObject from "foo";
+import DisallowedObject from "foo"
 ```
 
 :::
@@ -322,7 +323,7 @@ import { AllowedObject as DisallowedObject } from "foo";
     message: "Please use the default import from 'lodash' instead."
 }]}]*/
 
-import lodash from "lodash";
+import lodash from 'lodash';
 ```
 
 :::
@@ -335,7 +336,7 @@ import lodash from "lodash";
     caseSensitive: true
 }]}]*/
 
-import pick from "food";
+import pick from 'food';
 ```
 
 :::
@@ -349,7 +350,7 @@ import pick from "food";
     message: "Use 'isEmpty' from lodash instead."
 }]}]*/
 
-import { hasValues } from "utils/collection-utils";
+import { hasValues } from 'utils/collection-utils';
 ```
 
 :::


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Adds a [markdown-it-container `render`](https://github.com/markdown-it/markdown-it-container#api) method for `:::correct` and `:::incorrect` blocks that adds a playground link. That link is hidden when not focused or hovered.

#### Is there anything you'd like reviewers to focus on?

* Is this a visual design that brings you joy?
* From https://github.com/eslint/eslint/issues/17018#issuecomment-1523747750 - specifying parser options & other important rule bits

<!-- markdownlint-disable-file MD004 -->
