### PR TITLE
refactor: remove unnecessary code in `flat-eslint.js`

### DIFF
--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -133,33 +133,6 @@ function calculateStatsPerFile(messages) {
 }
 
 /**
- * It will calculate the error and warning count for collection of results from all files
- * @param {LintResult[]} results Collection of messages from all the files
- * @returns {Object} Contains the stats
- * @private
- */
-function calculateStatsPerRun(results) {
-    const stat = {
-        errorCount: 0,
-        fatalErrorCount: 0,
-        warningCount: 0,
-        fixableErrorCount: 0,
-        fixableWarningCount: 0
-    };
-
-    for (let i = 0; i < results.length; i++) {
-        const result = results[i];
-
-        stat.errorCount += result.errorCount;
-        stat.fatalErrorCount += result.fatalErrorCount;
-        stat.warningCount += result.warningCount;
-        stat.fixableErrorCount += result.fixableErrorCount;
-        stat.fixableWarningCount += result.fixableWarningCount;
-    }
-    return stat;
-}
-
-/**
  * Create rulesMeta object.
  * @param {Map<string,Rule>} rules a map of rules from which to generate the object.
  * @returns {Object} metadata for all enabled rules.
@@ -559,43 +532,6 @@ function shouldMessageBeFixed(message, config, fixTypes) {
 }
 
 /**
- * Collect used deprecated rules.
- * @param {Array<FlatConfig>} configs The configs to evaluate.
- * @returns {IterableIterator<DeprecatedRuleInfo>} Used deprecated rules.
- */
-function *iterateRuleDeprecationWarnings(configs) {
-    const processedRuleIds = new Set();
-
-    for (const config of configs) {
-        for (const [ruleId, ruleConfig] of Object.entries(config.rules)) {
-
-            // Skip if it was processed.
-            if (processedRuleIds.has(ruleId)) {
-                continue;
-            }
-            processedRuleIds.add(ruleId);
-
-            // Skip if it's not used.
-            if (!getRuleSeverity(ruleConfig)) {
-                continue;
-            }
-            const rule = getRuleFromConfig(ruleId, config);
-
-            // Skip if it's not deprecated.
-            if (!(rule && rule.meta && rule.meta.deprecated)) {
-                continue;
-            }
-
-            // This rule was used and deprecated.
-            yield {
-                ruleId,
-                replacedBy: rule.meta.replacedBy || []
-            };
-        }
-    }
-}
-
-/**
  * Creates an error to be thrown when an array of results passed to `getRulesMetaForResults` was not created by the current engine.
  * @returns {TypeError} An error object.
  */
@@ -819,7 +755,6 @@ class FlatESLint {
             errorOnUnmatchedPattern
         } = eslintOptions;
         const startTime = Date.now();
-        const usedConfigs = [];
         const fixTypesSet = fixTypes ? new Set(fixTypes) : null;
 
         // Delete cache file; should this be done here?
@@ -875,15 +810,6 @@ class FlatESLint {
                  */
                 if (!config) {
                     return void 0;
-                }
-
-                /*
-                 * Store used configs for:
-                 * - this method uses to collect used deprecated rules.
-                 * - `--fix-type` option uses to get the loaded rule's meta data.
-                 */
-                if (!usedConfigs.includes(config)) {
-                    usedConfigs.push(config);
                 }
 
                 // Skip if there is cached result.
@@ -954,22 +880,10 @@ class FlatESLint {
             lintResultCache.reconcile();
         }
 
-        let usedDeprecatedRules;
         const finalResults = results.filter(result => !!result);
 
         return processLintReport(this, {
-            results: finalResults,
-            ...calculateStatsPerRun(finalResults),
-
-            // Initialize it lazily because CLI and `ESLint` API don't use it.
-            get usedDeprecatedRules() {
-                if (!usedDeprecatedRules) {
-                    usedDeprecatedRules = Array.from(
-                        iterateRuleDeprecationWarnings(usedConfigs)
-                    );
-                }
-                return usedDeprecatedRules;
-            }
+            results: finalResults
         });
     }
 
@@ -1031,7 +945,6 @@ class FlatESLint {
         const results = [];
         const startTime = Date.now();
         const resolvedFilename = path.resolve(cwd, filePath || "__placeholder__.js");
-        let config;
 
         // Clear the last used config arrays.
         if (resolvedFilename && await this.isPathIgnored(resolvedFilename)) {
@@ -1039,9 +952,6 @@ class FlatESLint {
                 results.push(createIgnoreResult(resolvedFilename, cwd));
             }
         } else {
-
-            // TODO: Needed?
-            config = configs.getConfig(resolvedFilename);
 
             // Do lint.
             results.push(verifyText({
@@ -1057,21 +967,9 @@ class FlatESLint {
         }
 
         debug(`Linting complete in: ${Date.now() - startTime}ms`);
-        let usedDeprecatedRules;
 
         return processLintReport(this, {
-            results,
-            ...calculateStatsPerRun(results),
-
-            // Initialize it lazily because CLI and `ESLint` API don't use it.
-            get usedDeprecatedRules() {
-                if (!usedDeprecatedRules) {
-                    usedDeprecatedRules = Array.from(
-                        iterateRuleDeprecationWarnings(config)
-                    );
-                }
-                return usedDeprecatedRules;
-            }
+            results
         });
 
     }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Removes unnecessary code in `flat-eslint.js`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`function processLintReport` uses only `results` property from the second argument. This removes code that calculates other (unused) properties, which mostly originates from `cli-engine.js` and is unnecessary in `flat-eslint.js`:

* stats per run: FlatESLint/ESLint, unlike CLIEngine, doesn't provide stats per run of `lintFiles`/`lintText`.
* `usedDeprecatedRules`: this is calculated in `function processLintReport`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
