### PR TITLE
fix: Remove `no-unused-labels` autofix before potential directives

### DIFF
--- a/docs/src/rules/no-unused-labels.md
+++ b/docs/src/rules/no-unused-labels.md
@@ -30,6 +30,8 @@ Such labels take up space in the code and can lead to confusion by readers.
 
 This rule is aimed at eliminating unused labels.
 
+Problems reported by this rule can be fixed automatically, except when there are any comments between the label and the following statement, or when removing a label would cause the following statement to become a directive such as `"use strict"`.
+
 Examples of **incorrect** code for this rule:
 
 ::: incorrect

--- a/lib/rules/dot-notation.js
+++ b/lib/rules/dot-notation.js
@@ -133,8 +133,7 @@ module.exports = {
                 }
                 if (
                     node.computed &&
-                    node.property.type === "TemplateLiteral" &&
-                    node.property.expressions.length === 0
+                    astUtils.isStaticTemplateLiteral(node.property)
                 ) {
                     checkComputedProperty(node, node.property.quasis[0].value.cooked);
                 }

--- a/lib/rules/no-restricted-modules.js
+++ b/lib/rules/no-restricted-modules.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("./utils/ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -117,15 +123,6 @@ module.exports = {
         }
 
         /**
-         * Function to check if a node is a static string template literal.
-         * @param {ASTNode} node The node to check.
-         * @returns {boolean} If the node is a string template literal.
-         */
-        function isStaticTemplateLiteral(node) {
-            return node && node.type === "TemplateLiteral" && node.expressions.length === 0;
-        }
-
-        /**
          * Function to check if a node is a require call.
          * @param {ASTNode} node The node to check.
          * @returns {boolean} If the node is a require call.
@@ -144,7 +141,7 @@ module.exports = {
                 return node.value.trim();
             }
 
-            if (isStaticTemplateLiteral(node)) {
+            if (astUtils.isStaticTemplateLiteral(node)) {
                 return node.quasis[0].value.cooked.trim();
             }
 

--- a/lib/rules/no-unused-labels.js
+++ b/lib/rules/no-unused-labels.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("./utils/ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -47,6 +53,45 @@ module.exports = {
         }
 
         /**
+         * Checks if a `LabeledStatement` node is fixable.
+         * For a node to be fixable, there must be no comments between the label and the body.
+         * Furthermore, is must be possible to remove the label without turning the body statement into a
+         * directive after other fixes are applied.
+         * @param {ASTNode} node The node to evaluate.
+         * @returns {boolean} Whether or not the node is fixable.
+         */
+        function isFixable(node) {
+
+            /*
+             * Only perform a fix if there are no comments between the label and the body. This will be the case
+             * when there is exactly one token/comment (the ":") between the label and the body.
+             */
+            if (sourceCode.getTokenAfter(node.label, { includeComments: true }) !==
+                sourceCode.getTokenBefore(node.body, { includeComments: true })) {
+                return false;
+            }
+
+            // Looking for the node's deepest ancestor which is not a `LabeledStatement`.
+            let ancestor = node.parent;
+
+            while (ancestor.type === "LabeledStatement") {
+                ancestor = ancestor.parent;
+            }
+
+            if (ancestor.type === "Program" ||
+                (ancestor.type === "BlockStatement" && astUtils.isFunction(ancestor.parent))) {
+                const { body } = node;
+
+                if (body.type === "ExpressionStatement" &&
+                    ((body.expression.type === "Literal" && typeof body.expression.value === "string") ||
+                    astUtils.isStaticTemplateLiteral(body.expression))) {
+                    return false; // potential directive
+                }
+            }
+            return true;
+        }
+
+        /**
          * Removes the top of the stack.
          * At the same time, this reports the label if it's never used.
          * @param {ASTNode} node A node to report. This is a LabeledStatement.
@@ -58,19 +103,7 @@ module.exports = {
                     node: node.label,
                     messageId: "unused",
                     data: node.label,
-                    fix(fixer) {
-
-                        /*
-                         * Only perform a fix if there are no comments between the label and the body. This will be the case
-                         * when there is exactly one token/comment (the ":") between the label and the body.
-                         */
-                        if (sourceCode.getTokenAfter(node.label, { includeComments: true }) ===
-                                sourceCode.getTokenBefore(node.body, { includeComments: true })) {
-                            return fixer.removeRange([node.range[0], node.body.range[0]]);
-                        }
-
-                        return null;
-                    }
+                    fix: isFixable(node) ? fixer => fixer.removeRange([node.range[0], node.body.range[0]]) : null
                 });
             }
 

--- a/lib/rules/prefer-regex-literals.js
+++ b/lib/rules/prefer-regex-literals.js
@@ -37,15 +37,6 @@ function isRegexLiteral(node) {
     return node.type === "Literal" && Object.prototype.hasOwnProperty.call(node, "regex");
 }
 
-/**
- * Determines whether the given node is a template literal without expressions.
- * @param {ASTNode} node Node to check.
- * @returns {boolean} True if the node is a template literal without expressions.
- */
-function isStaticTemplateLiteral(node) {
-    return node.type === "TemplateLiteral" && node.expressions.length === 0;
-}
-
 const validPrecedingTokens = new Set([
     "(",
     ";",
@@ -178,7 +169,7 @@ module.exports = {
             return node.type === "TaggedTemplateExpression" &&
                 astUtils.isSpecificMemberAccess(node.tag, "String", "raw") &&
                 isGlobalReference(astUtils.skipChainExpression(node.tag).object) &&
-                isStaticTemplateLiteral(node.quasi);
+                astUtils.isStaticTemplateLiteral(node.quasi);
         }
 
         /**
@@ -191,7 +182,7 @@ module.exports = {
                 return node.value;
             }
 
-            if (isStaticTemplateLiteral(node)) {
+            if (astUtils.isStaticTemplateLiteral(node)) {
                 return node.quasis[0].value.cooked;
             }
 
@@ -209,7 +200,7 @@ module.exports = {
          */
         function isStaticString(node) {
             return isStringLiteral(node) ||
-                isStaticTemplateLiteral(node) ||
+                astUtils.isStaticTemplateLiteral(node) ||
                 isStringRawTaggedStaticTemplateLiteral(node);
         }
 

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -2123,6 +2123,15 @@ module.exports = {
         return OCTAL_OR_NON_OCTAL_DECIMAL_ESCAPE_PATTERN.test(rawString);
     },
 
+    /**
+     * Determines whether the given node is a template literal without expressions.
+     * @param {ASTNode} node Node to check.
+     * @returns {boolean} True if the node is a template literal without expressions.
+     */
+    isStaticTemplateLiteral(node) {
+        return node.type === "TemplateLiteral" && node.expressions.length === 0;
+    },
+
     isReferenceToGlobalVariable,
     isLogicalExpression,
     isCoalesceExpression,

--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -5,6 +5,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("./utils/ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -88,7 +94,7 @@ module.exports = {
                     if (parent.type === "BinaryExpression" && OPERATORS.has(parent.operator)) {
                         const sibling = parent.left === node ? parent.right : parent.left;
 
-                        if (sibling.type === "Literal" || sibling.type === "TemplateLiteral" && !sibling.expressions.length) {
+                        if (sibling.type === "Literal" || astUtils.isStaticTemplateLiteral(sibling)) {
                             const value = sibling.type === "Literal" ? sibling.value : sibling.quasis[0].value.cooked;
 
                             if (!VALID_TYPES.has(value)) {

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -59,21 +59,12 @@ function isNegativeNumericLiteral(node) {
 }
 
 /**
- * Determines whether a node is a Template Literal which can be determined statically.
- * @param {ASTNode} node Node to test
- * @returns {boolean} True if the node is a Template Literal without expression.
- */
-function isStaticTemplateLiteral(node) {
-    return node.type === "TemplateLiteral" && node.expressions.length === 0;
-}
-
-/**
  * Determines whether a non-Literal node should be treated as a single Literal node.
  * @param {ASTNode} node Node to test
  * @returns {boolean} True if the node should be treated as a single Literal node.
  */
 function looksLikeLiteral(node) {
-    return isNegativeNumericLiteral(node) || isStaticTemplateLiteral(node);
+    return isNegativeNumericLiteral(node) || astUtils.isStaticTemplateLiteral(node);
 }
 
 /**
@@ -100,7 +91,7 @@ function getNormalizedLiteral(node) {
         };
     }
 
-    if (isStaticTemplateLiteral(node)) {
+    if (astUtils.isStaticTemplateLiteral(node)) {
         return {
             type: "Literal",
             value: node.quasis[0].value.cooked,

--- a/tests/lib/rules/no-unused-labels.js
+++ b/tests/lib/rules/no-unused-labels.js
@@ -73,6 +73,69 @@ ruleTester.run("no-unused-labels", rule, {
             code: "A /* comment */: foo",
             output: null,
             errors: [{ messageId: "unused" }]
+        },
+
+        // https://github.com/eslint/eslint/issues/16988
+        {
+            code: 'A: "use strict"',
+            output: null,
+            errors: [{ messageId: "unused" }]
+        },
+        {
+            code: '"use strict"; foo: "bar"',
+            output: null,
+            errors: [{ messageId: "unused" }]
+        },
+        {
+            code: 'A: ("use strict")', // Parentheses may be removed by another rule.
+            output: null,
+            errors: [{ messageId: "unused" }]
+        },
+        {
+            code: "A: `use strict`", // `use strict` may be changed to "use strict" by another rule.
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unused" }]
+        },
+        {
+            code: "if (foo) { bar: 'baz' }",
+            output: "if (foo) { 'baz' }",
+            errors: [{ messageId: "unused" }]
+        },
+        {
+            code: "A: B: 'foo'",
+            output: "B: 'foo'",
+            errors: [{ messageId: "unused" }, { messageId: "unused" }]
+        },
+        {
+            code: "A: B: C: 'foo'",
+            output: "B: C: 'foo'", // Becomes "C: 'foo'" on the second pass.
+            errors: [{ messageId: "unused" }, { messageId: "unused" }, { messageId: "unused" }]
+        },
+        {
+            code: "A: B: C: D: 'foo'",
+            output: "B: D: 'foo'", // Becomes "D: 'foo'" on the second pass.
+            errors: [
+                { messageId: "unused" },
+                { messageId: "unused" },
+                { messageId: "unused" },
+                { messageId: "unused" }]
+        },
+        {
+            code: "A: B: C: D: E: 'foo'",
+            output: "B: D: E: 'foo'", // Becomes "E: 'foo'" on the third pass.
+            errors: [
+                { messageId: "unused" },
+                { messageId: "unused" },
+                { messageId: "unused" },
+                { messageId: "unused" },
+                { messageId: "unused" }
+            ]
+        },
+        {
+            code: "A: 42",
+            output: "42",
+            errors: [{ messageId: "unused" }]
         }
 
         /*

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -1857,4 +1857,22 @@ describe("ast-utils", () => {
             });
         });
     });
+
+    describe("isStaticTemplateLiteral", () => {
+        const expectedResults = {
+            "``": true,
+            "`foo`": true,
+            "`foo${bar}`": false,
+            "\"foo\"": false,
+            "foo`bar`": false
+        };
+
+        Object.entries(expectedResults).forEach(([code, expectedResult]) => {
+            it(`returns ${expectedResult} for ${code}`, () => {
+                const ast = espree.parse(code, { ecmaVersion: 6 });
+
+                assert.strictEqual(astUtils.isStaticTemplateLiteral(ast.body[0].expression), expectedResult);
+            });
+        });
+    });
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

References #16988

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR disables the autofix for the `no-unused-labels` rule if removing a label could cause the following statement to become a directive. For example:

```js
/* eslint no-unused-labels: "error" */

UnusedLabel: "use strict"; // There should be no autofix!
```

Following the changes in this PR, the autofix will disabled if all of the following conditions are met:
* The label is at the top-level of a function body or a file, or in a chain of labels that starts at the top-level of a function body or a file (e.g. `lab1: lab2: lab3: "not a directive"`).
* The statement after the label is an `ExpressionStatement`.
* The `ExpressionStatement` after the label contains a string `Literal`, or a `TemplateLiteral` without expressions as its only child. This accounts for the rules `no-extra-parens` and `quotes`, whose autofixes can convert certain expressions into unparenthesized strings, making a statement like this directive-like.

The autofix is disabled regardless of any preceding tokens, because they could be changed or removed by other (third-party) rules.

Additionally, this PR refactors the function `isStaticTemplateLiteral()` into `ast-utils.js` to remove repeated code across the rules.

#### Is there anything you'd like reviewers to focus on?

I'm not completely sure about the criteria I'm using to disable the autofix, so I'm open to changes.

<!-- markdownlint-disable-file MD004 -->
