### PR TITLE
test: More test cases for no-case-declarations

### DIFF
--- a/tests/lib/rules/no-case-declarations.js
+++ b/tests/lib/rules/no-case-declarations.js
@@ -35,9 +35,49 @@ ruleTester.run("no-case-declarations", rule, {
         {
             code: "switch (a) { case 1: { class C {} break; } default: { class C {} break; } }",
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: `
+                switch (a) { 
+                    case 1: 
+                    case 2: {} 
+                }
+            `,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: `
+                switch (a) {
+                    case 1: var x; 
+                }
+            `,
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
     invalid: [
+        {
+            code: `
+                switch (a) { 
+                    case 1: 
+                        {} 
+                        function f() {} 
+                        break; 
+                }
+            `,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "FunctionDeclaration" }]
+        },
+        {
+            code: `
+                switch (a) { 
+                    case 1: 
+                    case 2: 
+                        let x; 
+                }
+            `,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "VariableDeclaration" }]
+        },
         {
             code: "switch (a) { case 1: let x = 1; break; }",
             parserOptions: { ecmaVersion: 6 },

--- a/tests/lib/rules/no-case-declarations.js
+++ b/tests/lib/rules/no-case-declarations.js
@@ -36,23 +36,17 @@ ruleTester.run("no-case-declarations", rule, {
             code: "switch (a) { case 1: { class C {} break; } default: { class C {} break; } }",
             parserOptions: { ecmaVersion: 6 }
         },
-        {
-            code: `
+        `
                 switch (a) { 
                     case 1: 
                     case 2: {} 
                 }
             `,
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: `
+        `
                 switch (a) {
                     case 1: var x; 
                 }
-            `,
-            parserOptions: { ecmaVersion: 6 }
-        }
+            `
     ],
     invalid: [
         {
@@ -64,7 +58,6 @@ ruleTester.run("no-case-declarations", rule, {
                         break; 
                 }
             `,
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ messageId: "unexpected", type: "FunctionDeclaration" }]
         },
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
	A (minor) perf improvement
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Improved heuristic for the rule, if there are no `consequents` or if the `case` block contains a block statement, then we can determine that the rule does not need to be executed.

#### Is there anything you'd like reviewers to focus on?

I benchmarked this with the `TIMING` env variable but sadly I didn't see any improvements, leaving this up to the maintainers if you want to merge it or not. I didn't know how to bench this in a larger codebase, maybe with `npm link`?

<!-- markdownlint-disable-file MD004 -->
