### PR TITLE
feat: fix indent rule for else-if

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1250,7 +1250,7 @@ module.exports = {
 
             IfStatement(node) {
                 addBlocklessNodeIndent(node.consequent);
-                if (node.alternate && node.alternate.type !== "IfStatement") {
+                if (node.alternate) {
                     addBlocklessNodeIndent(node.alternate);
                 }
             },

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -13555,6 +13555,407 @@ ruleTester.run("indent", rule, {
                 [5, 1, 0, "Keyword"],
                 [6, 1, 0, "Keyword"]
             ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                \tif (bar) doSomething();
+                \telse doSomething();
+                else
+                \t\tif (bar) doSomething();
+                \t\telse doSomething();
+            `,
+            output: unIndent`
+                if (foo)
+                \tif (bar) doSomething();
+                \telse doSomething();
+                else
+                \tif (bar) doSomething();
+                \telse doSomething();
+            `,
+            options: ["tab"],
+            errors: expectedErrors("tab", [
+                [5, 1, 2, "Keyword"],
+                [6, 1, 2, "Keyword"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                if (bar) doSomething();
+                else doSomething();
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                    if (bar) doSomething();
+                    else doSomething();
+            `,
+            errors: expectedErrors([
+                [5, 4, 0, "Keyword"],
+                [6, 4, 0, "Keyword"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                if (bar)
+                doSomething();
+                else doSomething();
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                    if (bar)
+                        doSomething();
+                    else doSomething();
+            `,
+            errors: expectedErrors([
+                [5, 4, 0, "Keyword"],
+                [6, 8, 0, "Identifier"],
+                [7, 4, 0, "Keyword"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                if (bar) doSomething();
+                else
+                doSomething();
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                    if (bar) doSomething();
+                    else
+                        doSomething();
+            `,
+            errors: expectedErrors([
+                [5, 4, 0, "Keyword"],
+                [6, 4, 0, "Keyword"],
+                [7, 8, 0, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                if (bar)
+                    doSomething();
+                else
+                doSomething();
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                    if (bar)
+                        doSomething();
+                    else
+                        doSomething();
+            `,
+            errors: expectedErrors([
+                [5, 4, 0, "Keyword"],
+                [6, 8, 4, "Identifier"],
+                [7, 4, 0, "Keyword"],
+                [8, 8, 0, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else if (bar) doSomething();
+                    else doSomething();
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else if (bar) doSomething();
+                else doSomething();
+            `,
+            errors: expectedErrors([
+                [5, 0, 4, "Keyword"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                    else if (bar)
+                        doSomething();
+                    else doSomething();
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else if (bar)
+                    doSomething();
+                else doSomething();
+            `,
+            errors: expectedErrors([
+                [4, 0, 4, "Keyword"],
+                [5, 4, 8, "Identifier"],
+                [6, 0, 4, "Keyword"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else if (bar) doSomething();
+                     else
+                         doSomething();
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else if (bar) doSomething();
+                else
+                    doSomething();
+            `,
+            errors: expectedErrors([
+                [5, 0, 5, "Keyword"],
+                [6, 4, 9, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else if (bar)
+                doSomething();
+                else
+                doSomething();
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else if (bar)
+                    doSomething();
+                else
+                    doSomething();
+            `,
+            errors: expectedErrors([
+                [5, 4, 0, "Identifier"],
+                [7, 4, 0, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                    if (bar) doSomething();
+                    else doSomething();
+
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                    if (foo)
+                        if (bar) doSomething();
+                        else doSomething();
+                    else
+                        if (bar) doSomething();
+                        else doSomething();
+
+            `,
+            errors: expectedErrors([
+                [5, 4, 0, "Keyword"],
+                [6, 8, 4, "Keyword"],
+                [7, 8, 4, "Keyword"],
+                [8, 4, 0, "Keyword"],
+                [9, 8, 4, "Keyword"],
+                [10, 8, 4, "Keyword"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                if (foo)
+                if (bar) doSomething();
+                else
+                if (bar) doSomething();
+                else doSomething();
+                else doSomething();
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                    if (foo)
+                        if (bar) doSomething();
+                        else
+                            if (bar) doSomething();
+                            else doSomething();
+                    else doSomething();
+            `,
+            errors: expectedErrors([
+                [5, 4, 0, "Keyword"],
+                [6, 8, 0, "Keyword"],
+                [7, 8, 0, "Keyword"],
+                [8, 12, 0, "Keyword"],
+                [9, 12, 0, "Keyword"],
+                [10, 4, 0, "Keyword"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                if (bar) doSomething();
+                else doSomething();
+                else if (foo) doSomething();
+                    else doSomething();
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else if (foo) doSomething();
+                else doSomething();
+            `,
+            errors: expectedErrors([
+                [2, 4, 0, "Keyword"],
+                [3, 4, 0, "Keyword"],
+                [5, 0, 4, "Keyword"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else if (foo) {
+                doSomething();
+                }
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else if (foo) {
+                    doSomething();
+                }
+            `,
+            errors: expectedErrors([
+                [5, 4, 0, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else if (foo)
+                    {
+                        doSomething();
+                    }
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else if (foo)
+                {
+                    doSomething();
+                }
+            `,
+            errors: expectedErrors([
+                [5, 0, 4, "Punctuator"],
+                [6, 4, 8, "Identifier"],
+                [7, 0, 4, "Punctuator"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                if (foo) {
+                    doSomething();
+                }
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                    if (foo) {
+                        doSomething();
+                    }
+            `,
+            errors: expectedErrors([
+                [5, 4, 0, "Keyword"],
+                [6, 8, 4, "Identifier"],
+                [7, 4, 0, "Punctuator"]
+            ])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                if (foo)
+                {
+                    doSomething();
+                }
+            `,
+            output: unIndent`
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                    if (foo)
+                    {
+                        doSomething();
+                    }
+            `,
+            errors: expectedErrors([
+                [5, 4, 0, "Keyword"],
+                [6, 4, 0, "Punctuator"],
+                [7, 8, 4, "Identifier"],
+                [8, 4, 0, "Punctuator"]
+            ])
         }
     ]
 });

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -6361,7 +6361,156 @@ ruleTester.run("indent", rule, {
                 ;[1, 2, 3].forEach(x=>console.log(x))
             `,
             options: [4]
-        }
+        },
+
+        // https://github.com/eslint/eslint/issues/17316
+        {
+            code: unIndent`
+                if (foo)
+                \tif (bar) doSomething();
+                \telse doSomething();
+                else
+                \tif (bar) doSomething();
+                \telse doSomething();
+            `,
+            options: ["tab"]
+        },
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else
+                if (bar) doSomething();
+                else doSomething();
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else
+                if (bar)
+                    doSomething();
+                else doSomething();
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else
+                if (bar) doSomething();
+                else
+                    doSomething();
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else
+                if (bar)
+                    doSomething();
+                else
+                    doSomething();
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else if (bar) doSomething();
+            else doSomething();
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else if (bar)
+                doSomething();
+            else doSomething();
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else if (bar) doSomething();
+            else
+                doSomething();
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else if (bar)
+                doSomething();
+            else
+                doSomething();
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else
+                if (foo)
+                    if (bar) doSomething();
+                    else doSomething();
+                else
+                    if (bar) doSomething();
+                    else doSomething();
+
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else
+                if (foo)
+                    if (bar) doSomething();
+                    else
+                        if (bar) doSomething();
+                        else doSomething();
+                else doSomething();
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else if (foo) doSomething();
+            else doSomething();
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else if (foo) {
+                doSomething();
+            }
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else if (foo)
+            {
+                doSomething();
+            }
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else
+                if (foo) {
+                    doSomething();
+                }
+        `,
+        unIndent`
+            if (foo)
+                if (bar) doSomething();
+                else doSomething();
+            else
+                if (foo)
+                {
+                    doSomething();
+                }
+        `
     ],
 
     invalid: [
@@ -13381,6 +13530,31 @@ ruleTester.run("indent", rule, {
             `,
             options: [4],
             errors: expectedErrors([4, 0, 4, "Punctuator"])
+        },
+
+        // https://github.com/eslint/eslint/issues/17316
+        {
+            code: unIndent`
+                if (foo)
+                \tif (bar) doSomething();
+                \telse doSomething();
+                else
+                if (bar) doSomething();
+                else doSomething();
+            `,
+            output: unIndent`
+                if (foo)
+                \tif (bar) doSomething();
+                \telse doSomething();
+                else
+                \tif (bar) doSomething();
+                \telse doSomething();
+            `,
+            options: ["tab"],
+            errors: expectedErrors("tab", [
+                [5, 1, 0, "Keyword"],
+                [6, 1, 0, "Keyword"]
+            ])
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #17316

This bug fix can generate more warnings from the `indent` rule in existing code, so marked as `feat`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed a condition that causes indentation not to be applied to `if` in else-if positions.

#### Is there anything you'd like reviewers to focus on?

Please check if this change could cause any unwanted behavior. All existing tests are passing after this change, so I'm not sure which cases this condition was targeting. The condition was added in https://github.com/eslint/eslint/commit/cc534819c739006a9d2680635b90fae9fbdec58e. I tried removing the same condition in that version, and some tests from that version are indeed failing, but those tests are still here and are now passing without the condition. I've added a few test cases that target this part of the code and the behavior seems fine to me.

<!-- markdownlint-disable-file MD004 -->
