### PR TITLE
feat: [logical-assignment-operators] flag a few more situations

### DIFF
--- a/lib/rules/logical-assignment-operators.js
+++ b/lib/rules/logical-assignment-operators.js
@@ -417,8 +417,8 @@ module.exports = {
                 if (
                     body.type === "ExpressionStatement" &&
                     body.expression.type === "AssignmentExpression" &&
-                    body.expression.operator === "=" &&
                     existence !== null &&
+                    (body.expression.operator === "=" || body.expression.operator === `${existence.operator}=`) &&
                     astUtils.isSameReference(existence.reference, body.expression.left)
                 ) {
                     const descriptor = {
@@ -452,7 +452,9 @@ module.exports = {
 
                             const operatorToken = getOperatorToken(body.expression);
 
-                            yield ruleFixer.insertTextBefore(operatorToken, existence.operator); // -> if (foo) foo ||= bar
+                            if (body.expression.operator === "=") {
+                                yield ruleFixer.insertTextBefore(operatorToken, existence.operator); // -> if (foo) foo ||= bar
+                            }
 
                             yield ruleFixer.removeRange([ifNode.range[0], body.range[0]]); // -> foo ||= bar
 

--- a/lib/rules/logical-assignment-operators.js
+++ b/lib/rules/logical-assignment-operators.js
@@ -418,7 +418,10 @@ module.exports = {
                     body.type === "ExpressionStatement" &&
                     body.expression.type === "AssignmentExpression" &&
                     existence !== null &&
-                    (body.expression.operator === "=" || body.expression.operator === `${existence.operator}=`) &&
+                    (body.expression.operator === "=" || (
+                        body.expression.operator === `${existence.operator}=` &&
+                        existence.operator !== "??"
+                    )) &&
                     astUtils.isSameReference(existence.reference, body.expression.left)
                 ) {
                     const descriptor = {

--- a/tests/lib/rules/logical-assignment-operators.js
+++ b/tests/lib/rules/logical-assignment-operators.js
@@ -121,6 +121,12 @@ ruleTester.run("logical-assignment-operators", rule, {
             code: "if (a) a ||= b",
             options: ["always", { enforceForIfStatements: true }]
         }, {
+            code: "if (a) a ??= b",
+            options: ["always", { enforceForIfStatements: true }]
+        }, {
+            code: "if (!a) a &&= b",
+            options: ["always", { enforceForIfStatements: true }]
+        }, {
             code: "if (a) b = a",
             options: ["always", { enforceForIfStatements: true }]
         }, {
@@ -908,6 +914,91 @@ ruleTester.run("logical-assignment-operators", rule, {
         }, {
             code: [
                 "if (a == undefined) a = b",
+                "{ const undefined = 0; }"
+            ].join("\n"),
+            output: [
+                "a ??= b",
+                "{ const undefined = 0; }"
+            ].join("\n"),
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
+        },
+
+        // If with logical assignment operator
+        {
+            code: "if (a) a &&= b",
+            output: "a &&= b",
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "&&=" } }]
+        }, {
+            code: "if (Boolean(a)) a &&= b",
+            output: "a &&= b",
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "&&=" } }]
+        }, {
+            code: "if (!!a) a &&= b",
+            output: "a &&= b",
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "&&=" } }]
+        }, {
+            code: "if (!a) a ||= b",
+            output: "a ||= b",
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "||=" } }]
+        }, {
+            code: "if (!Boolean(a)) a ||= b",
+            output: "a ||= b",
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "||=" } }]
+        }, {
+            code: "if (a == undefined) a ??= b",
+            output: "a ??= b",
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
+        }, {
+            code: "if (a == null) a ??= b",
+            output: "a ??= b",
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
+        }, {
+            code: "if (a === null || a === undefined) a ??= b",
+            output: "a ??= b",
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
+        }, {
+            code: "if (a === undefined || a === null) a ??= b",
+            output: "a ??= b",
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
+        }, {
+            code: "if (a === null || a === void 0) a ??= b",
+            output: "a ??= b",
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
+        }, {
+            code: "if (a === void 0 || a === null) a ??= b",
+            output: "a ??= b",
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
+        }, {
+            code: "if (a) { a &&= b; }",
+            output: "a &&= b;",
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "&&=" } }]
+        }, {
+            code: [
+                "{ const undefined = 0; }",
+                "if (a == undefined) a ??= b"
+            ].join("\n"),
+            output: [
+                "{ const undefined = 0; }",
+                "a ??= b"
+            ].join("\n"),
+            options: ["always", { enforceForIfStatements: true }],
+            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
+        }, {
+            code: [
+                "if (a == undefined) a ??= b",
                 "{ const undefined = 0; }"
             ].join("\n"),
             output: [

--- a/tests/lib/rules/logical-assignment-operators.js
+++ b/tests/lib/rules/logical-assignment-operators.js
@@ -336,6 +336,36 @@ ruleTester.run("logical-assignment-operators", rule, {
                 "}"
             ].join("\n"),
             options: ["always", { enforceForIfStatements: true }]
+        }, {
+            code: "if (a == undefined) a ??= b",
+            options: ["always", { enforceForIfStatements: true }]
+        }, {
+            code: "if (a == null) a ??= b",
+            options: ["always", { enforceForIfStatements: true }]
+        }, {
+            code: "if (a === null || a === undefined) a ??= b",
+            options: ["always", { enforceForIfStatements: true }]
+        }, {
+            code: "if (a === undefined || a === null) a ??= b",
+            options: ["always", { enforceForIfStatements: true }]
+        }, {
+            code: "if (a === null || a === void 0) a ??= b",
+            options: ["always", { enforceForIfStatements: true }]
+        }, {
+            code: "if (a === void 0 || a === null) a ??= b",
+            options: ["always", { enforceForIfStatements: true }]
+        }, {
+            code: [
+                "{ const undefined = 0; }",
+                "if (a == undefined) a ??= b"
+            ].join("\n"),
+            options: ["always", { enforceForIfStatements: true }]
+        }, {
+            code: [
+                "if (a == undefined) a ??= b",
+                "{ const undefined = 0; }"
+            ].join("\n"),
+            options: ["always", { enforceForIfStatements: true }]
         },
 
         // Never
@@ -951,62 +981,10 @@ ruleTester.run("logical-assignment-operators", rule, {
             options: ["always", { enforceForIfStatements: true }],
             errors: [{ messageId: "if", type: "IfStatement", data: { operator: "||=" } }]
         }, {
-            code: "if (a == undefined) a ??= b",
-            output: "a ??= b",
-            options: ["always", { enforceForIfStatements: true }],
-            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
-        }, {
-            code: "if (a == null) a ??= b",
-            output: "a ??= b",
-            options: ["always", { enforceForIfStatements: true }],
-            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
-        }, {
-            code: "if (a === null || a === undefined) a ??= b",
-            output: "a ??= b",
-            options: ["always", { enforceForIfStatements: true }],
-            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
-        }, {
-            code: "if (a === undefined || a === null) a ??= b",
-            output: "a ??= b",
-            options: ["always", { enforceForIfStatements: true }],
-            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
-        }, {
-            code: "if (a === null || a === void 0) a ??= b",
-            output: "a ??= b",
-            options: ["always", { enforceForIfStatements: true }],
-            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
-        }, {
-            code: "if (a === void 0 || a === null) a ??= b",
-            output: "a ??= b",
-            options: ["always", { enforceForIfStatements: true }],
-            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
-        }, {
             code: "if (a) { a &&= b; }",
             output: "a &&= b;",
             options: ["always", { enforceForIfStatements: true }],
             errors: [{ messageId: "if", type: "IfStatement", data: { operator: "&&=" } }]
-        }, {
-            code: [
-                "{ const undefined = 0; }",
-                "if (a == undefined) a ??= b"
-            ].join("\n"),
-            output: [
-                "{ const undefined = 0; }",
-                "a ??= b"
-            ].join("\n"),
-            options: ["always", { enforceForIfStatements: true }],
-            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
-        }, {
-            code: [
-                "if (a == undefined) a ??= b",
-                "{ const undefined = 0; }"
-            ].join("\n"),
-            output: [
-                "a ??= b",
-                "{ const undefined = 0; }"
-            ].join("\n"),
-            options: ["always", { enforceForIfStatements: true }],
-            errors: [{ messageId: "if", type: "IfStatement", data: { operator: "??=" } }]
         },
 
         // > Yoda


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

`logical-assignment-operators`

**What change do you want to make (place an "X" next to just one item)?**

[x] Generate more warnings
[ ] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[ ] A new option
[x] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
 // Previously, the rule ignored these cases. Now the rule can detect these:
if (!a) a ||= b;
if (a) a &&= b;
// edit: removed the third case for ??=

// This addresses a misconception where people will try to fix this situation:
if (!a) a = b
// by changing it to:
if (!a) a ||= b
// instead of changing it to:
a ||= b;
```

**What does the rule currently do for this code?**

nothing

**What will the rule do after it's changed?**

raise an error
