### PR TITLE
fix: provide unique `fix` and `fix.range` objects in lint messages

### DIFF
--- a/lib/linter/report-translator.js
+++ b/lib/linter/report-translator.js
@@ -103,7 +103,7 @@ function normalizeReportLoc(descriptor) {
 /**
  * Clones the given fix object.
  * @param {Fix|null} fix The fix to clone.
- * @returns {Fix|null} Deep cloned fix object or `null` if `null` was passed in.
+ * @returns {Fix|null} Deep cloned fix object or `null` if `null` or `undefined` was passed in.
  */
 function cloneFix(fix) {
     if (!fix) {

--- a/lib/linter/report-translator.js
+++ b/lib/linter/report-translator.js
@@ -101,6 +101,22 @@ function normalizeReportLoc(descriptor) {
 }
 
 /**
+ * Clones the given fix object.
+ * @param {Fix|null} fix The fix to clone.
+ * @returns {Fix|null} Deep cloned fix object or `null` if `null` was passed in.
+ */
+function cloneFix(fix) {
+    if (!fix) {
+        return null;
+    }
+
+    return {
+        range: [fix.range[0], fix.range[1]],
+        text: fix.text
+    };
+}
+
+/**
  * Check that a fix has a valid range.
  * @param {Fix|null} fix The fix to validate.
  * @returns {void}
@@ -137,7 +153,7 @@ function mergeFixes(fixes, sourceCode) {
         return null;
     }
     if (fixes.length === 1) {
-        return fixes[0];
+        return cloneFix(fixes[0]);
     }
 
     fixes.sort(compareFixesByRange);
@@ -183,7 +199,7 @@ function normalizeFixes(descriptor, sourceCode) {
     }
 
     assertValidFix(fix);
-    return fix;
+    return cloneFix(fix);
 }
 
 /**

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -15917,6 +15917,171 @@ var a = "test2";
 
                 assert.strictEqual(suppressedMessages.length, 0);
             });
+
+            // https://github.com/eslint/eslint/issues/16716
+            it("should receive unique range arrays in suggestions", () => {
+                const configs = [
+                    {
+                        plugins: {
+                            "test-processors": {
+                                processors: {
+                                    "line-processor": (() => {
+                                        const blocksMap = new Map();
+
+                                        return {
+                                            preprocess(text, fileName) {
+                                                const lines = text.split("\n");
+
+                                                blocksMap.set(fileName, lines);
+
+                                                return lines.map((line, index) => ({
+                                                    text: line,
+                                                    filename: `${index}.js`
+                                                }));
+                                            },
+
+                                            postprocess(messageLists, fileName) {
+                                                const lines = blocksMap.get(fileName);
+                                                let rangeOffset = 0;
+
+                                                // intentionaly mutates objects and arrays
+                                                messageLists.forEach((messages, index) => {
+                                                    messages.forEach(message => {
+                                                        message.line += index;
+                                                        if (typeof message.endLine === "number") {
+                                                            message.endLine += index;
+                                                        }
+                                                        if (message.fix) {
+                                                            message.fix.range[0] += rangeOffset;
+                                                            message.fix.range[1] += rangeOffset;
+                                                        }
+                                                        if (message.suggestions) {
+                                                            message.suggestions.forEach(suggestion => {
+                                                                suggestion.fix.range[0] += rangeOffset;
+                                                                suggestion.fix.range[1] += rangeOffset;
+                                                            });
+                                                        }
+                                                    });
+                                                    rangeOffset += lines[index].length + 1;
+                                                });
+
+                                                return messageLists.flat();
+                                            },
+
+                                            supportsAutofix: true
+                                        };
+                                    })()
+                                }
+                            },
+
+                            "test-rules": {
+                                rules: {
+                                    "no-foo": {
+                                        meta: {
+                                            hasSuggestions: true,
+                                            messages: {
+                                                unexpected: "Don't use 'foo'.",
+                                                replaceWithBar: "Replace with 'bar'",
+                                                replaceWithBaz: "Replace with 'baz'"
+                                            }
+
+                                        },
+                                        create(context) {
+                                            return {
+                                                Identifier(node) {
+                                                    const { range } = node;
+
+                                                    if (node.name === "foo") {
+                                                        context.report({
+                                                            node,
+                                                            messageId: "unexpected",
+                                                            suggest: [
+                                                                {
+                                                                    messageId: "replaceWithBar",
+                                                                    fix: () => ({ range, text: "bar" })
+                                                                },
+                                                                {
+                                                                    messageId: "replaceWithBaz",
+                                                                    fix: () => ({ range, text: "baz" })
+                                                                }
+                                                            ]
+                                                        });
+                                                    }
+                                                }
+                                            };
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        files: ["**/*.txt"],
+                        processor: "test-processors/line-processor"
+                    },
+                    {
+                        files: ["**/*.js"],
+                        rules: {
+                            "test-rules/no-foo": 2
+                        }
+                    }
+                ];
+
+                const result = linter.verifyAndFix(
+                    "var a = 5;\nvar foo;\nfoo = a;",
+                    configs,
+                    { filename: "a.txt" }
+                );
+
+                assert.deepStrictEqual(result.messages, [
+                    {
+                        ruleId: "test-rules/no-foo",
+                        severity: 2,
+                        message: "Don't use 'foo'.",
+                        line: 2,
+                        column: 5,
+                        nodeType: "Identifier",
+                        messageId: "unexpected",
+                        endLine: 2,
+                        endColumn: 8,
+                        suggestions: [
+                            {
+                                messageId: "replaceWithBar",
+                                fix: { range: [15, 18], text: "bar" },
+                                desc: "Replace with 'bar'"
+                            },
+                            {
+                                messageId: "replaceWithBaz",
+                                fix: { range: [15, 18], text: "baz" },
+                                desc: "Replace with 'baz'"
+                            }
+                        ]
+                    },
+                    {
+                        ruleId: "test-rules/no-foo",
+                        severity: 2,
+                        message: "Don't use 'foo'.",
+                        line: 3,
+                        column: 1,
+                        nodeType: "Identifier",
+                        messageId: "unexpected",
+                        endLine: 3,
+                        endColumn: 4,
+                        suggestions: [
+                            {
+                                messageId: "replaceWithBar",
+                                fix: { range: [20, 23], text: "bar" },
+                                desc: "Replace with 'bar'"
+                            },
+                            {
+                                messageId: "replaceWithBaz",
+                                fix: { range: [20, 23], text: "baz" },
+                                desc: "Replace with 'baz'"
+                            }
+                        ]
+                    }
+                ]);
+            });
         });
     });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #16716

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `report-translator` to always create new `fix` objects and `fix.range` arrays. This ensures that lint messages do not share same instances, which could be problematic for processors that mutate these objects.

Added unit tests for `report-translator`, and one higher-level `linter` test that specifically targets the case described in #16716.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
