### PR TITLE
fix: Fix suggestion message in `no-useless-escape`

### DIFF
--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -94,6 +94,7 @@ module.exports = {
         messages: {
             unnecessaryEscape: "Unnecessary escape character: \\{{character}}.",
             removeEscape: "Remove the `\\`. This maintains the current functionality.",
+            removeEscapeDoNotKeepSemantics: "Remove the `\\` if it was inserted by mistake.",
             escapeBackslash: "Replace the `\\` with `\\\\` to include the actual backslash character."
         },
 
@@ -125,7 +126,10 @@ module.exports = {
                 data: { character },
                 suggest: [
                     {
-                        messageId: "removeEscape",
+
+                        // Removing unnecessary `\` characters in a directive is not guaranteed to maintain functionality.
+                        messageId: astUtils.isDirective(node.parent, sourceCode)
+                            ? "removeEscapeDoNotKeepSemantics" : "removeEscape",
                         fix(fixer) {
                             return fixer.removeRange(range);
                         }

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -131,42 +131,6 @@ function isBlockLikeStatement(sourceCode, node) {
 }
 
 /**
- * Check whether the given node is a directive or not.
- * @param {ASTNode} node The node to check.
- * @param {SourceCode} sourceCode The source code object to get tokens.
- * @returns {boolean} `true` if the node is a directive.
- */
-function isDirective(node, sourceCode) {
-    return (
-        astUtils.isTopLevelExpressionStatement(node) &&
-        node.expression.type === "Literal" &&
-        typeof node.expression.value === "string" &&
-        !astUtils.isParenthesised(sourceCode, node.expression)
-    );
-}
-
-/**
- * Check whether the given node is a part of directive prologue or not.
- * @param {ASTNode} node The node to check.
- * @param {SourceCode} sourceCode The source code object to get tokens.
- * @returns {boolean} `true` if the node is a part of directive prologue.
- */
-function isDirectivePrologue(node, sourceCode) {
-    if (isDirective(node, sourceCode)) {
-        for (const sibling of node.parent.body) {
-            if (sibling === node) {
-                break;
-            }
-            if (!isDirective(sibling, sourceCode)) {
-                return false;
-            }
-        }
-        return true;
-    }
-    return false;
-}
-
-/**
  * Gets the actual last token.
  *
  * If a semicolon is semicolon-less style's semicolon, this ignores it.
@@ -359,12 +323,12 @@ const StatementTypes = {
             CJS_IMPORT.test(sourceCode.getText(node.declarations[0].init))
     },
     directive: {
-        test: isDirectivePrologue
+        test: astUtils.isDirective
     },
     expression: {
         test: (node, sourceCode) =>
             node.type === "ExpressionStatement" &&
-            !isDirectivePrologue(node, sourceCode)
+            !astUtils.isDirective(node, sourceCode)
     },
     iife: {
         test: isIIFEStatement
@@ -378,7 +342,7 @@ const StatementTypes = {
         test: (node, sourceCode) =>
             node.loc.start.line !== node.loc.end.line &&
             node.type === "ExpressionStatement" &&
-            !isDirectivePrologue(node, sourceCode)
+            !astUtils.isDirective(node, sourceCode)
     },
 
     "multiline-const": newMultilineKeywordTester("const"),

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1006,6 +1006,42 @@ function isTopLevelExpressionStatement(node) {
 
 }
 
+/**
+ * Check whether the given node is a directive or not.
+ * @param {ASTNode} node The node to check.
+ * @param {SourceCode} sourceCode The source code object to get tokens.
+ * @returns {boolean} `true` if the node is a directive.
+ */
+function isUnparenthesizedStringLiteral(node, sourceCode) {
+    return node.type === "Literal" && typeof node.value === "string" && !isParenthesised(sourceCode, node);
+}
+
+/**
+ * Check whether the given node is a part of a directive prologue or not.
+ * @param {ASTNode} node The node to check.
+ * @param {SourceCode} sourceCode The source code object to get tokens.
+ * @returns {boolean} `true` if the node is a part of directive prologue.
+ */
+function isDirective(node, sourceCode) {
+    if ("directive" in node) {
+        return true;
+    }
+
+    // Fallback for parsers that don't set a `directive` property.
+    if (isTopLevelExpressionStatement(node) && isUnparenthesizedStringLiteral(node.expression, sourceCode)) {
+        for (const sibling of node.parent.body) {
+            if (sibling === node) {
+                break;
+            }
+            if (sibling.type !== "ExpressionStatement" || !isUnparenthesizedStringLiteral(sibling.expression, sourceCode)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -2158,5 +2194,6 @@ module.exports = {
     getSwitchCaseColonToken,
     getModuleExportName,
     isConstant,
-    isTopLevelExpressionStatement
+    isTopLevelExpressionStatement,
+    isDirective
 };

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -1066,6 +1066,43 @@ ruleTester.run("no-useless-escape", rule, {
                     output: "`\\\\a```"
                 }]
             }]
+        },
+
+        // https://github.com/eslint/eslint/issues/16988
+        {
+            code: String.raw`"use\ strict";`,
+            errors: [{
+                line: 1,
+                column: 5,
+                endColumn: 6,
+                message: "Unnecessary escape character: \\ .",
+                type: "Literal",
+                suggestions: [{
+                    messageId: "removeEscapeDoNotKeepSemantics",
+                    output: String.raw`"use strict";`
+                }, {
+                    messageId: "escapeBackslash",
+                    output: String.raw`"use\\ strict";`
+                }]
+            }]
+        },
+        {
+            code: String.raw`({ foo() { "foo"; "bar"; "ba\z" } })`,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                line: 1,
+                column: 29,
+                endColumn: 30,
+                message: "Unnecessary escape character: \\z.",
+                type: "Literal",
+                suggestions: [{
+                    messageId: "removeEscapeDoNotKeepSemantics",
+                    output: String.raw`({ foo() { "foo"; "bar"; "baz" } })`
+                }, {
+                    messageId: "escapeBackslash",
+                    output: String.raw`({ foo() { "foo"; "bar"; "ba\\z" } })`
+                }]
+            }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [ ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #16988

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR changes the message of a suggestion reported by the `no-useless-escape` rule when the target node is a string in a directive. As per [specification](https://tc39.es/ecma262/#directive-prologue), `"use strict"` directives cannot contain escape sequences, and there is no guarantee about the evaluation of implementations-specific directives when the raw text is changed.

Since it cannot be assumed that replacing escape sequences in a directive will keep the existing functionality, the new message omits that information:

    Remove the `\` if it was inserted by mistake.

instead of

    Remove the `\`. This maintains the current functionality.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
