### PR TITLE
feat: Expose LegacyESLint in unsupported API

### DIFF
--- a/lib/unsupported-api.js
+++ b/lib/unsupported-api.js
@@ -14,6 +14,7 @@
 const { FileEnumerator } = require("./cli-engine/file-enumerator");
 const { FlatESLint, shouldUseFlatConfig } = require("./eslint/flat-eslint");
 const FlatRuleTester = require("./rule-tester/flat-rule-tester");
+const { ESLint } = require("./eslint/eslint");
 
 //-----------------------------------------------------------------------------
 // Exports
@@ -24,5 +25,6 @@ module.exports = {
     FlatESLint,
     shouldUseFlatConfig,
     FlatRuleTester,
-    FileEnumerator
+    FileEnumerator,
+    LegacyESLint: ESLint
 };

--- a/tests/lib/unsupported-api.js
+++ b/tests/lib/unsupported-api.js
@@ -27,6 +27,14 @@ describe("unsupported-api", () => {
         assert.isFunction(api.FlatESLint);
     });
 
+    it("should have LegacyESLint exposed", () => {
+        assert.isFunction(api.LegacyESLint);
+    });
+
+    it("should not have ESLint exposed", () => {
+        assert.isUndefined(api.ESLint);
+    });
+
     it("should have shouldUseFlatConfig exposed", () => {
         assert.isFunction(api.shouldUseFlatConfig);
     });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Adds a `LegacyESLint` class to `/use-at-your-own-risk` as a transitional class meant to ease migration to flat config in ESLint v9.0.0.

fixes #17340

#### Is there anything you'd like reviewers to focus on?



<!-- markdownlint-disable-file MD004 -->
