### PR TITLE
fix!: Update ajv options to align with aims for behaviour

### DIFF
--- a/lib/shared/ajv.js
+++ b/lib/shared/ajv.js
@@ -25,6 +25,7 @@ module.exports = (additionalOptions = {}) => {
         verbose: true,
         schemaId: "auto",
         logger: false,
+        addUsedSchema: false,
         ...additionalOptions
     });
 

--- a/lib/shared/ajv.js
+++ b/lib/shared/ajv.js
@@ -21,6 +21,7 @@ module.exports = (additionalOptions = {}) => {
         useDefaults: true,
         validateSchema: false,
         missingRefs: "ignore",
+        allErrors: true,
         verbose: true,
         schemaId: "auto",
         ...additionalOptions

--- a/lib/shared/ajv.js
+++ b/lib/shared/ajv.js
@@ -24,6 +24,7 @@ module.exports = (additionalOptions = {}) => {
         allErrors: true,
         verbose: true,
         schemaId: "auto",
+        logger: false,
         ...additionalOptions
     });
 


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Updated the `ajv` options used to more closely align with the aims of rule option validation:

Added `allErrors: true` because [`RuleValidator.validate`](https://github.com/eslint/eslint/blob/b79b6fb64473969b426d086b484d2e29594a5e9a/lib/config/rule-validator.js#L147) seems to have been written to handle multiple validation errors, but by default, `ajv` will only return the _first_ validation error. Seems like better UX to tell a user everything wrong with their options at once rather than make them fix one issue at a time, and that seems to have been the original intent.

Added `logger: false` since the aim at lint-time seems to be that users receive no feedback about invalid schemas, and issues in schemas are just silently ignored - this ensures ajv won't ever write anything to the console.

Added `addSchemas: false`:

By default, ajv will add any compiled schemas to the ajv instance (the compilation cache is different and separate). This is usually to allow schemas with an `$id` to be referenced by other schemas after they've been added.

Technically, this allows rules to attempt to reference each other's schemas if they're clever with `$id` and `$ref`. However, because rules have no control over the order in which rules and their schemas might be loaded, this is inherently unreliable. In principle, all rule schemas should be completely independent.

I'm proposing that we should just outright eliminate this corner-case so that rule developers can't trick themselves into thinking this is a viable thing to do because it "works on their machine" when conditions/configuration are aligned just right.

This would technically be a breaking change, but I can't imagine that any sane rule developer would ever have thought this was a good idea to implement.
