### PR TITLE
fix: Update no-loop-func to not overlap with no-undef

### DIFF
--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -186,7 +186,7 @@ module.exports = {
             }
 
             const references = sourceCode.getScope(node).through;
-            const unsafeRefs = references.filter(r => !isSafe(loopNode, r)).map(r => r.identifier.name);
+            const unsafeRefs = references.filter(r => r.resolved && !isSafe(loopNode, r)).map(r => r.identifier.name);
 
             if (unsafeRefs.length > 0) {
                 context.report({


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v18.16.0
npm version: v9.5.1
Local ESLint version: v8.44.0 (Currently used)
Global ESLint version: Not found
Operating System: win32 10.0.23493

**What parser are you using (place an "X" next to just one item)?**

[X] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**
`eslint` repo's configuration.

**What did you do? Please include the actual source code causing the issue.**
Any loop form with a function declaration in it, where there is a reference to an undeclared variable in the function body.

e.g.
```
const arr = [];

for (let i = 0; i < 10; i++) {
    arr.push(() => a);
             ^^^^^^^ Function declared in a loop contains unsafe references to variable(s) 'a'. eslint(no-loop-func)
                   ^ 'a' is not defined. eslint(no-undef)
}
```

**What did you expect to happen?**
`no-loop-func` shouldn't report on this variable reference, it's not an unsafe loop variable capture, but rather an undeclared variable access that should solely be picked up by `no-undef`.

**What actually happened? Please include the actual, raw output from ESLint.**
<details>
<summary>ESLint Output</summary>

```
npm run lint

> eslint@8.44.0 lint
> node Makefile.js lint

Validating JavaScript files

C:\Code\eslint\tests\lib\rules\no-loop-func.js
  24:14  error  Function declared in a loop contains unsafe references to variable(s) 'a'  no-loop-func
  24:20  error  'a' is not defined                                                         no-undef

✖ 2 problems (2 errors, 0 warnings)

C:\Code\eslint\node_modules\shelljs\src\common.js:401
      if (config.fatal) throw e;
                        ^

Error: exec:
    at Object.error (C:\Code\eslint\node_modules\shelljs\src\common.js:110:27)
    at execSync (C:\Code\eslint\node_modules\shelljs\src\exec.js:120:12)
    at _exec (C:\Code\eslint\node_modules\shelljs\src\exec.js:223:12)
    at C:\Code\eslint\node_modules\shelljs\src\common.js:335:23
    at target.lint (C:\Code\eslint\Makefile.js:537:18)
    at global.target.<computed> [as lint] (C:\Code\eslint\node_modules\shelljs\make.js:36:40)
    at C:\Code\eslint\node_modules\shelljs\make.js:48:27
    at Array.forEach (<anonymous>)
    at Timeout._onTimeout (C:\Code\eslint\node_modules\shelljs\make.js:46:10)
    at listOnTimeout (node:internal/timers:569:17)

Node.js v18.16.0
NativeCommandExitException: Program "npm.cmd" ended with non-zero exit code: 1.
```

</details>

#### What changes did you make? (Give an overview)

Moved a couple of `while`/`do..while` loop tests from invalid to valid (the variable they test is undeclared, but _looks_ unsafe because it's the condition of the `while`).

Added some new valid test cases for loops where the function accesses an undeclared variable.

Updated `no-loop-func` to ignore any variable references that are unresolved. These will then be solely picked up by `no-undef` if enabled.

#### Why?

My understanding from the [Core Rule Guidelines](https://eslint.org/docs/latest/contribute/propose-new-rule#core-rule-guidelines) is that no two rules should overlap, and in this case, both `no-loop-func` and `no-undef` are warning for the same issue (though with different interpretations of the problem.)

Given that `no-loop-func` as documented is intended to find captures of loop variables that are shared by all iterations of the loop, it seems like it shouldn't warn on a variable reference that isn't a loop variable at all.
