### PR TITLE
fix: only warn about literals and undefined on no-return-await

### DIFF
--- a/docs/src/_data/further_reading_links.json
+++ b/docs/src/_data/further_reading_links.json
@@ -433,11 +433,11 @@
         "title": "async function - JavaScript | MDN",
         "description": "An async function is a function declared with the async keyword, and the await keyword is permitted within it. The async and await keywords enable asynchronous, promise-based behavior to be written in a cleaner style, avoiding the need to explicitly configure promise chains."
     },
-    "https://jakearchibald.com/2017/await-vs-return-vs-return-await/": {
-        "domain": "jakearchibald.com",
-        "url": "https://jakearchibald.com/2017/await-vs-return-vs-return-await/",
-        "logo": "https://jakearchibald.com/c/favicon-67801369.png",
-        "title": "await vs return vs return await",
+    "https://v8.dev/blog/fast-async": {
+        "domain": "v8.dev",
+        "url": "https://v8.dev/blog/fast-async",
+        "logo": "https://v8.dev/_img/v8.svg",
+        "title": "Faster async functions and promises",
         "description": null
     },
     "https://stackoverflow.com/questions/13497971/what-is-the-matter-with-script-targeted-urls": {

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -3,17 +3,18 @@ title: no-return-await
 rule_type: suggestion
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function
-- https://jakearchibald.com/2017/await-vs-return-vs-return-await/
+- https://v8.dev/blog/fast-async
 ---
 
+If the value to be returned is a *native* Promise, then there is a performance gain in wrapping or preceding the `Promise` with `await``.
 
-Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited has resolved, at the cost of an extra microtask before resolving the outer Promise. `return await` can also be used in a try/catch statement to catch errors from another function that returns a Promise.
+If the value to be returned is **not** a Promise, such as a `Literal` node or `undefined`, then using `await` will incur a performance penalty due to an extra microtask.
 
-You can avoid the extra microtask by not awaiting the return value, with the trade off of the function no longer being a part of the stack trace if an error is thrown asynchronously from the Promise being returned. This can make debugging more difficult.
+Returning `await` is not necessary for a `Promise` to be returned by an `async` function, regardless of the return value.
 
 ## Rule Details
 
-This rule aims to prevent a likely common performance hazard due to a lack of understanding of the semantics of `async function`.
+This rule aims to detect `Literal` types or `undefined` being awaited which causes a performance penalty.
 
 Examples of **incorrect** code for this rule:
 
@@ -23,8 +24,21 @@ Examples of **incorrect** code for this rule:
 /*eslint no-return-await: "error"*/
 
 async function foo() {
-    return await bar();
+    return await 'foo';
 }
+
+async function asyncNull() {
+    return await null;
+}
+
+async function foo(writeToLog) {
+    return await (writeToLog ? writeLog() : null);
+}
+
+async function foo(write) {
+    return await (sync ? void deleteSync() : deleteAsync());
+}
+
 ```
 
 :::
@@ -37,7 +51,16 @@ Examples of **correct** code for this rule:
 /*eslint no-return-await: "error"*/
 
 async function foo() {
-    return bar();
+    await otherPromise();
+    return 'foo';
+}
+
+async function foo() {
+    return 'foo';
+}
+
+async function foo() {
+    return await bar();
 }
 
 async function foo() {
@@ -45,26 +68,39 @@ async function foo() {
     return;
 }
 
-// This is essentially the same as `return await bar();`, but the rule checks only `await` in `return` statements
+// The rule can only check for await in return statements
 async function foo() {
-    const x = await bar();
+  let answer = 42;
+  return await answer;
+}
+
+// The rule can only check for Literal nodes
+async function foo() {
+  return await ('foo'.toString());
+}
+
+// The rule cannot check `CallExpression` nodes
+async function foo() {
+  return await Promise.resolve('foo');
+}
+
+// This is essentially the same as `return await 42;`, but the rule checks only `await` in `return` statements
+async function foo() {
+    const x = await 42;
     return x;
 }
 
-// In this example the `await` is necessary to be able to catch errors thrown from `bar()`
-async function foo() {
-    try {
-        return await bar();
-    } catch (error) {}
+async function foo(sync) {
+    return sync ? void deleteSync() : await deleteAsync();
 }
+
 ```
 
 :::
 
 ## When Not To Use It
 
-There are a few reasons you might want to turn this rule off:
-
-* If you want to use `await` to denote a value that is a thenable
-* If you do not want the performance benefit of avoiding `return await`
-* If you want the functions to show up in stack traces (useful for debugging purposes)
+* If you are not concerned with the performance penalty of awaited `Literal` nodes or `undefined`.
+* If you want to intentionally wait an extra microtask.
+* If want to keep a balanced `async` / `await` syntax to ensure a function returns a `Promise`.
+* If you have redefined `undefined`.

--- a/lib/rules/no-return-await.js
+++ b/lib/rules/no-return-await.js
@@ -51,6 +51,10 @@ module.exports = {
                     {
                         messageId: "removeAwait",
                         fix(fixer) {
+                            if (node.argument.type === "ConditionalExpression") {
+                                return null;
+                            }
+
                             const sourceCode = context.sourceCode;
                             const [awaitToken, tokenAfterAwait] = sourceCode.getFirstTokens(node, 2);
 
@@ -119,9 +123,27 @@ module.exports = {
             return false;
         }
 
+        /**
+         * Checks if a node will return a `Literal` type or `undefined`
+         * @param {ASTNode} node A node representing the expression to check
+         * @returns {boolean} The checking result
+         */
+        function willReturnLiteralOrUndefined(node) {
+            switch (node.type) {
+                case "Literal": return true;
+                case "Identifier": return node.name === "undefined";
+                case "UnaryExpression": return node.operator === "void";
+                case "AwaitExpression": return willReturnLiteralOrUndefined(node.argument);
+                case "ConditionalExpression":
+                    return willReturnLiteralOrUndefined(node.consequent) || willReturnLiteralOrUndefined(node.alternate);
+                default:
+                    return false;
+            }
+        }
+
         return {
             AwaitExpression(node) {
-                if (isInTailCallPosition(node) && !hasErrorHandler(node)) {
+                if (isInTailCallPosition(node) && !hasErrorHandler(node) && willReturnLiteralOrUndefined(node)) {
                     reportUnnecessaryAwait(node);
                 }
             }

--- a/tests/lib/rules/no-return-await.js
+++ b/tests/lib/rules/no-return-await.js
@@ -148,116 +148,140 @@ ruleTester.run("no-return-await", rule, {
               baz();
             }
           }
+        `,
+        `
+          async function foo() {
+            return await bar();
+          }
+        `,
+        `
+          async function foo() {
+            return await new Promise(resolve => {
+              resolve(5);
+            });
+          }
+        `,
+        `
+          async () => {
+            return await (
+              foo()
+            )
+          };
+        `,
+        `
+          async function foo() {
+            return await (true ? bar() : baz());
+          }
         `
     ],
 
     invalid: [
         {
-            code: "\nasync function foo() {\n\treturn await bar();\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn bar();\n}\n" })
+            code: "\nasync function foo() {\n\treturn await 'bar';\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn 'bar';\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn await(bar());\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (bar());\n}\n" })
+            code: "\nasync function foo() {\n\treturn await('bar');\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn ('bar');\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (a, await bar());\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a, bar());\n}\n" })
+            code: "\nasync function foo() {\n\treturn (a, await 'bar');\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a, 'bar');\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (a, b, await bar());\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a, b, bar());\n}\n" })
+            code: "\nasync function foo() {\n\treturn (a, b, await 'bar');\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a, b, 'bar');\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (a && await bar());\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a && bar());\n}\n" })
+            code: "\nasync function foo() {\n\treturn (a && await 'bar');\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a && 'bar');\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (a && b && await bar());\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a && b && bar());\n}\n" })
+            code: "\nasync function foo() {\n\treturn (a && b && await 'bar');\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a && b && 'bar');\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (a || await bar());\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a || bar());\n}\n" })
+            code: "\nasync function foo() {\n\treturn (a || await 'bar');\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a || 'bar');\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (a, b, (c, d, await bar()));\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a, b, (c, d, bar()));\n}\n" })
+            code: "\nasync function foo() {\n\treturn (a, b, (c, d, await 'bar'));\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a, b, (c, d, 'bar'));\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (a, b, (c && await bar()));\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a, b, (c && bar()));\n}\n" })
+            code: "\nasync function foo() {\n\treturn (a, b, (c && await 'bar'));\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (a, b, (c && 'bar'));\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (await baz(), b, await bar());\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (await baz(), b, bar());\n}\n" })
+            code: "\nasync function foo() {\n\treturn (await baz(), b, await 'bar');\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (await baz(), b, 'bar');\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (baz() ? await bar() : b);\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (baz() ? bar() : b);\n}\n" })
+            code: "\nasync function foo() {\n\treturn (baz() ? await 'bar' : b);\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (baz() ? 'bar' : b);\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (baz() ? a : await bar());\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (baz() ? a : bar());\n}\n" })
+            code: "\nasync function foo() {\n\treturn (baz() ? a : await 'bar');\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (baz() ? a : 'bar');\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (baz() ? (a, await bar()) : b);\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (baz() ? (a, bar()) : b);\n}\n" })
+            code: "\nasync function foo() {\n\treturn (baz() ? (a, await 'bar') : b);\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (baz() ? (a, 'bar') : b);\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (baz() ? a : (b, await bar()));\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (baz() ? a : (b, bar()));\n}\n" })
+            code: "\nasync function foo() {\n\treturn (baz() ? a : (b, await 'bar'));\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (baz() ? a : (b, 'bar'));\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (baz() ? (a && await bar()) : b);\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (baz() ? (a && bar()) : b);\n}\n" })
+            code: "\nasync function foo() {\n\treturn (baz() ? (a && await 'bar') : b);\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (baz() ? (a && 'bar') : b);\n}\n" })
         },
         {
-            code: "\nasync function foo() {\n\treturn (baz() ? a : (b && await bar()));\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (baz() ? a : (b && bar()));\n}\n" })
+            code: "\nasync function foo() {\n\treturn (baz() ? a : (b && await 'bar'));\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\n\treturn (baz() ? a : (b && 'bar'));\n}\n" })
         },
         {
-            code: "\nasync () => { return await bar(); }\n",
-            errors: createErrorList({ suggestionOutput: "\nasync () => { return bar(); }\n" })
+            code: "\nasync () => { return await 'bar'; }\n",
+            errors: createErrorList({ suggestionOutput: "\nasync () => { return 'bar'; }\n" })
         },
         {
-            code: "\nasync () => await bar()\n",
-            errors: createErrorList({ suggestionOutput: "\nasync () => bar()\n" })
+            code: "\nasync () => await 'bar'\n",
+            errors: createErrorList({ suggestionOutput: "\nasync () => 'bar'\n" })
         },
         {
-            code: "\nasync () => (a, b, await bar())\n",
-            errors: createErrorList({ suggestionOutput: "\nasync () => (a, b, bar())\n" })
+            code: "\nasync () => (a, b, await 'bar')\n",
+            errors: createErrorList({ suggestionOutput: "\nasync () => (a, b, 'bar')\n" })
         },
         {
-            code: "\nasync () => (a && await bar())\n",
-            errors: createErrorList({ suggestionOutput: "\nasync () => (a && bar())\n" })
+            code: "\nasync () => (a && await 'bar')\n",
+            errors: createErrorList({ suggestionOutput: "\nasync () => (a && 'bar')\n" })
         },
         {
-            code: "\nasync () => (baz() ? await bar() : b)\n",
-            errors: createErrorList({ suggestionOutput: "\nasync () => (baz() ? bar() : b)\n" })
+            code: "\nasync () => (baz() ? await 'bar' : b)\n",
+            errors: createErrorList({ suggestionOutput: "\nasync () => (baz() ? 'bar' : b)\n" })
         },
         {
-            code: "\nasync () => (baz() ? a : (b, await bar()))\n",
-            errors: createErrorList({ suggestionOutput: "\nasync () => (baz() ? a : (b, bar()))\n" })
+            code: "\nasync () => (baz() ? a : (b, await 'bar'))\n",
+            errors: createErrorList({ suggestionOutput: "\nasync () => (baz() ? a : (b, 'bar'))\n" })
         },
         {
-            code: "\nasync () => (baz() ? a : (b && await bar()))\n",
-            errors: createErrorList({ suggestionOutput: "\nasync () => (baz() ? a : (b && bar()))\n" })
+            code: "\nasync () => (baz() ? a : (b && await 'bar'))\n",
+            errors: createErrorList({ suggestionOutput: "\nasync () => (baz() ? a : (b && 'bar'))\n" })
         },
         {
-            code: "\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn await bar();\n\t\t}\n\t}\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n" })
+            code: "\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn await 'bar';\n\t\t}\n\t}\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn 'bar';\n\t\t}\n\t}\n}\n" })
         },
         {
-            code: "\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn await bar();\n\t\t}\n\t}\n}\n",
-            errors: createErrorList({ suggestionOutput: "\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n" })
+            code: "\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn await 'bar';\n\t\t}\n\t}\n}\n",
+            errors: createErrorList({ suggestionOutput: "\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn 'bar';\n\t\t}\n\t}\n}\n" })
         },
         {
             code: `
               async function foo() {
                 try {}
                 finally {
-                  return await bar();
+                  return await 'bar';
                 }
               }
             `,
@@ -266,7 +290,7 @@ ruleTester.run("no-return-await", rule, {
               async function foo() {
                 try {}
                 finally {
-                  return bar();
+                  return 'bar';
                 }
               }
             `
@@ -277,7 +301,7 @@ ruleTester.run("no-return-await", rule, {
               async function foo() {
                 try {}
                 catch (e) {
-                  return await bar();
+                  return await 'bar';
                 }
               }
             `,
@@ -286,7 +310,7 @@ ruleTester.run("no-return-await", rule, {
               async function foo() {
                 try {}
                 catch (e) {
-                  return bar();
+                  return 'bar';
                 }
               }
             `
@@ -296,7 +320,7 @@ ruleTester.run("no-return-await", rule, {
             code: `
               try {
                 async function foo() {
-                  return await bar();
+                  return await 'bar';
                 }
               } catch (e) {}
             `,
@@ -304,7 +328,7 @@ ruleTester.run("no-return-await", rule, {
                 suggestionOutput: `
               try {
                 async function foo() {
-                  return bar();
+                  return 'bar';
                 }
               } catch (e) {}
             `
@@ -313,13 +337,13 @@ ruleTester.run("no-return-await", rule, {
         {
             code: `
               try {
-                async () => await bar();
+                async () => await 'bar';
               } catch (e) {}
             `,
             errors: createErrorList({
                 suggestionOutput: `
               try {
-                async () => bar();
+                async () => 'bar';
               } catch (e) {}
             `
             })
@@ -331,7 +355,7 @@ ruleTester.run("no-return-await", rule, {
                 catch (e) {
                   try {}
                   catch (e) {
-                    return await bar();
+                    return await 'bar';
                   }
                 }
               }
@@ -343,7 +367,7 @@ ruleTester.run("no-return-await", rule, {
                 catch (e) {
                   try {}
                   catch (e) {
-                    return bar();
+                    return 'bar';
                   }
                 }
               }
@@ -353,38 +377,10 @@ ruleTester.run("no-return-await", rule, {
         {
             code: `
               async function foo() {
-                return await new Promise(resolve => {
-                  resolve(5);
-                });
+                return await (true ? true : bar());
               }
             `,
-            errors: createErrorList({
-                suggestionOutput: `
-              async function foo() {
-                return new Promise(resolve => {
-                  resolve(5);
-                });
-              }
-            `
-            })
-        },
-        {
-            code: `
-              async () => {
-                return await (
-                  foo()
-                )
-              };
-            `,
-            errors: createErrorList({
-                suggestionOutput: `
-              async () => {
-                return (
-                  foo()
-                )
-              };
-            `
-            })
+            errors: createErrorList()
         },
         {
             code: `


### PR DESCRIPTION
In async functions, returning awaited promises no longer has any performance penalty and is now faster than returning promises directly.

Because we cannot detect what the result type of a `CallExpression` or the type of a `MemberExpression`, or the type of an `Identifier`, warnings related to whether an actual Promise is being returned cannot be processed. Strictly from at an AST level, we can detect `Literal` node types and `undefined`.

* Detect await being used on `Literal` node type
* Detect await being used on an `Identifier` named `undefined`
* Detect await being used on a `ConditionalExpression` that returns either a `Literal` type or `undefined`.
* Detect await being used on a void operation (results in `undefined`)

Futher changes can be made to detect syntaxes where a `Literal` type would be returned, such as

* await (4 + 3)
* await ('foo' + 'bar')

Future changes may also, suggest rewriting awaited `CondtionExpression` nodes such as:

* async function foo(value) { return await (value ? true : bar()) }

This would require more extensive testing.

Fixes #17345

See: https://v8.dev/blog/fast-async

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

(see commit message)

#### Is there anything you'd like reviewers to focus on?

It's impossible to properly assess the return type, but we can *at least* check for `Literal` nodes and `undefined`.

This keeps the rule being a suggestion, but relaxes type-related checks.

<!-- markdownlint-disable-file MD004 -->
