### PR TITLE
feat: adds option for allowing empty object patterns as parameter

### DIFF
--- a/lib/rules/no-empty-pattern.js
+++ b/lib/rules/no-empty-pattern.js
@@ -19,7 +19,18 @@ module.exports = {
             url: "https://eslint.org/docs/latest/rules/no-empty-pattern"
         },
 
-        schema: [],
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    allowObjectPatternsAsParameters: {
+                        type: "boolean",
+                        default: false
+                    }
+                },
+                additionalProperties: false
+            }
+        ],
 
         messages: {
             unexpected: "Unexpected empty {{type}} pattern."
@@ -27,10 +38,38 @@ module.exports = {
     },
 
     create(context) {
+        const options = context.options[0] || {},
+            allowObjectPatternsAsParameters = options.allowObjectPatternsAsParameters || false;
+
         return {
             ObjectPattern(node) {
-                if (node.properties.length === 0) {
-                    context.report({ node, messageId: "unexpected", data: { type: "object" } });
+
+                // Allow {} empty object patterns in Arrow functions as parameters when allowObjectPatternsAsParameters is true
+                if (node.parent.type === "ArrowFunctionExpression" &&
+                allowObjectPatternsAsParameters === true &&
+                node.properties.length === 0) {
+                    return;
+                }
+
+                // Allow {} = {} empty object patterns in Arrow functions as parameters when allowObjectPatternsAsParameters is true
+                if (node.parent.type === "AssignmentPattern" &&
+                node.parent.parent.type === "ArrowFunctionExpression" &&
+                node.parent.right.type === "ObjectExpression" &&
+                node.parent.right.properties.length === 0 &&
+                allowObjectPatternsAsParameters === true &&
+                node.properties.length === 0) {
+                    return;
+                }
+
+                if ((node.parent.type === "ArrowFunctionExpression" &&
+                allowObjectPatternsAsParameters === false &&
+                node.properties.length === 0) ||
+                node.properties.length === 0) {
+                    context.report({
+                        node,
+                        messageId: "unexpected",
+                        data: { type: "object" }
+                    });
                 }
             },
             ArrayPattern(node) {

--- a/tests/lib/rules/no-empty-pattern.js
+++ b/tests/lib/rules/no-empty-pattern.js
@@ -26,7 +26,9 @@ ruleTester.run("no-empty-pattern", rule, {
         { code: "var {a = []} = foo;", parserOptions: { ecmaVersion: 6 } },
         { code: "function foo({a = {}}) {}", parserOptions: { ecmaVersion: 6 } },
         { code: "function foo({a = []}) {}", parserOptions: { ecmaVersion: 6 } },
-        { code: "var [a] = foo", parserOptions: { ecmaVersion: 6 } }
+        { code: "var [a] = foo", parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = ({}) => {}", options: [{ allowObjectPatternsAsParameters: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = ({} = {}) => {}", options: [{ allowObjectPatternsAsParameters: true }], parserOptions: { ecmaVersion: 6 } }
     ],
 
     // Examples of code that should trigger the rule
@@ -105,6 +107,46 @@ ruleTester.run("no-empty-pattern", rule, {
         },
         {
             code: "function foo({a: []}) {}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unexpected",
+                data: { type: "array" },
+                type: "ArrayPattern"
+            }]
+        },
+        {
+            code: "var foo = ({}) => {}",
+            options: [{ allowObjectPatternsAsParameters: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unexpected",
+                data: { type: "object" },
+                type: "ObjectPattern"
+            }]
+        },
+        {
+            code: "var foo = ({} = {}) => {}",
+            options: [{ allowObjectPatternsAsParameters: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unexpected",
+                data: { type: "object" },
+                type: "ObjectPattern"
+            }]
+        },
+        {
+            code: "var foo = ({a: {}}) => {}",
+            options: [{ allowObjectPatternsAsParameters: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "unexpected",
+                data: { type: "object" },
+                type: "ObjectPattern"
+            }]
+        },
+        {
+            code: "var foo = ([]) => {}",
+            options: [{ allowObjectPatternsAsParameters: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 messageId: "unexpected",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added a new option called `allowObjectPatternsAsParameters` in rule `no-empty-pattern` for allowing the empty object pattern in function parameters. Now `var foo = ({}) => {}` or `var foo = ({} = {}) => {}` will not give an error when option `allowObjectPatternsAsParameters: true` is applied.

#### Is there anything you'd like reviewers to focus on?
related to issue #16931 

<!-- markdownlint-disable-file MD004 -->
