### PR TITLE
fix: Allow specifying arbitrarily named processors in configs

### DIFF
--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -189,18 +189,6 @@ function assertIsRuleSeverity(ruleId, value) {
 }
 
 /**
- * Validates that a given string is the form pluginName/objectName.
- * @param {string} value The string to check.
- * @returns {void}
- * @throws {TypeError} If the string isn't in the correct format.
- */
-function assertIsPluginMemberName(value) {
-    if (!/[@a-z0-9-_$]+(?:\/(?:[a-z0-9-_$]+))+$/iu.test(value)) {
-        throw new TypeError(`Expected string in the form "pluginName/objectName" but found "${value}".`);
-    }
-}
-
-/**
  * Validates that a value is an object.
  * @param {any} value The value to check.
  * @returns {void}
@@ -323,7 +311,9 @@ const processorSchema = {
     merge: "replace",
     validate(value) {
         if (typeof value === "string") {
-            assertIsPluginMemberName(value);
+            if (!value.includes("/")) {
+                throw new TypeError(`Expected string in the form "pluginName/processorName" but found "${value}".`);
+            }
         } else if (value && typeof value === "object") {
             if (typeof value.preprocess !== "function" || typeof value.postprocess !== "function") {
                 throw new TypeError("Object must have a preprocess() and a postprocess() method.");

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -128,6 +128,20 @@ async function assertInvalidConfig(values, message) {
 }
 
 /**
+ * Asserts that a given set of configs results is a valid config.
+ * @param {*[]} values An array of configs to use in the config array.
+ * @returns {void}
+ * @throws {Error} If the config is invalid.
+ */
+async function assertValidConfig(values) {
+    const configs = createFlatConfigArray(values);
+
+    await configs.normalize();
+
+    configs.getConfig("foo.js"); // should not throw error
+}
+
+/**
  * Normalizes the rule configs to an array with severity to match
  * how Flat Config merges rule options.
  * @param {Object} rulesConfig The rules config portion of a config.
@@ -908,13 +922,34 @@ describe("FlatConfigArray", () => {
                 });
             });
 
+            it("should not error when an extension-named processor string is used", async () => {
+
+                await assertValidConfig([
+                    {
+                        plugins: {
+                            foo: {
+                                processors: {
+                                    ".yaml": {
+                                        preprocess() {},
+                                        postprocess() {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        processor: "foo/.yaml"
+                    }
+                ]);
+            });
+
             it("should error when an invalid string is used", async () => {
 
                 await assertInvalidConfig([
                     {
                         processor: "foo"
                     }
-                ], "pluginName/objectName");
+                ], "pluginName/processorName");
             });
 
             it("should error when an empty string is used", async () => {
@@ -923,7 +958,7 @@ describe("FlatConfigArray", () => {
                     {
                         processor: ""
                     }
-                ], "pluginName/objectName");
+                ], "pluginName/processorName");
             });
 
             it("should error when an invalid processor is used", async () => {


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v18.16.0
npm version: v9.5.1
Local ESLint version: v8.45.0 (Currently used)
Global ESLint version: Not found
Operating System: win32 10.0.23493

**What parser are you using (place an "X" next to just one item)?**

[X] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
const customPlugin = { 
    name: "custom",
    processors: {
        ".js": {
            preprocess: function(text, filename) { console.log('preprocess'); return [{ text: text, filename: "_" + filename }]; },
            postprocess: function(messages) { console.log('postprocess'); return messages[0]; }
        }
    }
};

module.exports = [
    {
        plugins: { customPlugin },
		processor: "customPlugin/.js"
        //processor: customPlugin.processors[".js"]
    }
];
```

</details>

**What did you do? Please include the actual source code causing the issue.**
N/a

**What did you expect to happen?**
The processor to be successfully loaded, and the console output to be:
```
preprocess
postprocess
```


**What actually happened? Please include the actual, raw output from ESLint.**
```

Oops! Something went wrong! :(

ESLint: 8.45.0

TypeError: Key "processor": Expected string in the form "pluginName/objectName" but found "customPlugin/.js".
    at assertIsPluginMemberName (C:\Code\eslint-repro - Copy (2)\node_modules\eslint\lib\config\flat-config-schema.js:199:15)
    at Object.validate (C:\Code\eslint-repro - Copy (2)\node_modules\eslint\lib\config\flat-config-schema.js:326:13)
    at ObjectSchema.validate (C:\Code\eslint-repro - Copy (2)\node_modules\@humanwhocodes\object-schema\src\object-schema.js:218:35)
    at C:\Code\eslint-repro - Copy (2)\node_modules\@humanwhocodes\object-schema\src\object-schema.js:171:18
    at Array.reduce (<anonymous>)
    at ObjectSchema.merge (C:\Code\eslint-repro - Copy (2)\node_modules\@humanwhocodes\object-schema\src\object-schema.js:169:24)
    at C:\Code\eslint-repro - Copy (2)\node_modules\@humanwhocodes\config-array\api.js:916:42
    at Array.reduce (<anonymous>)
    at FlatConfigArray.getConfig (C:\Code\eslint-repro - Copy (2)\node_modules\@humanwhocodes\config-array\api.js:915:39)
    at FlatConfigArray.isFileIgnored (C:\Code\eslint-repro - Copy (2)\node_modules\@humanwhocodes\config-array\api.js:943:15)
```

#### What changes did you make? (Give an overview)

Since both rules and processors can be arbitrarily named (any string that can be a property key), I've loosened the processor name validation to simply check if there is a `/` present in the ID, since that's the only part of the ID that is required to be present. Both plugin and processor names can have `/`'s in them, but there will always be at least one required to separate the plugin/processor parts.

There is a follow on problem with converting object IDs to plugin/object pairs that this highlights, because it assumes certain forms, but doesn't check that the form actually maps to a defined processor/rule. I'm preparing a separate PR to address that problem.