### PR TITLE
docs: fix overlapping of `open in playground` button

### DIFF
--- a/docs/src/assets/scss/docs.scss
+++ b/docs/src/assets/scss/docs.scss
@@ -166,6 +166,7 @@ pre[class*="language-"] {
     position: fixed;
     right: 50px;
     bottom: 35px;
+    z-index: 1;
     font-size: 1.5rem;
     border-radius: 50%;
     color: var(--body-background-color);

--- a/docs/src/assets/scss/syntax-highlighter.scss
+++ b/docs/src/assets/scss/syntax-highlighter.scss
@@ -120,3 +120,12 @@ pre[class*="language-"] {
         width: 1.2em;
     }
 }
+
+.incorrect,
+.correct {
+    @media all and (min-width: 768px) {
+        pre.line-numbers-mode {
+            padding-bottom: 65px;
+        }
+    }
+}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
The `open in Playground` button is overlapping the code in PC size.

|current | after this PR |
| :--------- | :----------|
| ![Screenshot 2023-07-22 195236](https://github.com/eslint/eslint/assets/86398394/2ec27b3f-7b2e-45a7-917f-731ffb980fe9) | ![Screenshot 2023-07-22 195203](https://github.com/eslint/eslint/assets/86398394/5e949770-4e8a-4971-ba83-837e2062db1b) |
| ![Screenshot 2023-07-22 195427](https://github.com/eslint/eslint/assets/86398394/f9b5cafc-11bc-4f65-a2d2-ac9bb84668a8) | ![Screenshot 2023-07-22 195452](https://github.com/eslint/eslint/assets/86398394/74162e42-b01a-4aea-92a2-ae1d749102bc) |

And also overlapping the back to top arrow button.

![Screenshot 2023-07-22 202619](https://github.com/eslint/eslint/assets/86398394/05dacf39-2da6-434a-be6a-48a04bd4d896)


So as a fix some padding is added to the code part. 
And added `z-index: 1` property to scroll up button.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
