### PR TITLE
feat: `no-invalid-regexp` support `v` flag

### DIFF
--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -133,10 +133,19 @@ module.exports = {
             }
             try {
                 validator.validateFlags(flags);
-                return null;
             } catch {
                 return `Invalid flags supplied to RegExp constructor '${flags}'`;
             }
+
+            /*
+             * `regexpp` checks the combination of `u` and `v` flags when parsing `Pattern` according to `ecma262`,
+             * but this rule may check only the flag when the pattern is unidentifiable, so check it here.
+             * https://tc39.es/ecma262/multipage/text-processing.html#sec-parsepattern
+             */
+            if (flags.includes("u") && flags.includes("v")) {
+                return "Regex 'u' and 'v' flags cannot be used together";
+            }
+            return null;
         }
 
         return {

--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -10,7 +10,7 @@
 
 const RegExpValidator = require("@eslint-community/regexpp").RegExpValidator;
 const validator = new RegExpValidator();
-const validFlags = /[dgimsuy]/gu;
+const validFlags = /[dgimsuvy]/gu;
 const undefined1 = void 0;
 
 //------------------------------------------------------------------------------
@@ -108,12 +108,14 @@ module.exports = {
         /**
          * Check syntax error in a given pattern.
          * @param {string} pattern The RegExp pattern to validate.
-         * @param {boolean} uFlag The Unicode flag.
+         * @param {Object} flags The RegExp flags to validate.
+         * @param {boolean} [flags.unicode] The Unicode flag.
+         * @param {boolean} [flags.unicodeSets] The UnicodeSets flag.
          * @returns {string|null} The syntax error.
          */
-        function validateRegExpPattern(pattern, uFlag) {
+        function validateRegExpPattern(pattern, flags) {
             try {
-                validator.validatePattern(pattern, undefined1, undefined1, uFlag);
+                validator.validatePattern(pattern, undefined1, undefined1, flags);
                 return null;
             } catch (err) {
                 return err.message;
@@ -166,8 +168,12 @@ module.exports = {
 
                     // If flags are unknown, report the regex only if its pattern is invalid both with and without the "u" flag
                     flags === null
-                        ? validateRegExpPattern(pattern, true) && validateRegExpPattern(pattern, false)
-                        : validateRegExpPattern(pattern, flags.includes("u"))
+                        ? (
+                            validateRegExpPattern(pattern, { unicode: true, unicodeSets: false }) &&
+                            validateRegExpPattern(pattern, { unicode: false, unicodeSets: true }) &&
+                            validateRegExpPattern(pattern, { unicode: false, unicodeSets: false })
+                        )
+                        : validateRegExpPattern(pattern, { unicode: flags.includes("u"), unicodeSets: flags.includes("v") })
                 );
 
                 if (message) {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.2.0",
-    "@eslint-community/regexpp": "^4.4.0",
+    "@eslint-community/regexpp": "^4.6.0",
     "@eslint/eslintrc": "^2.1.0",
     "@eslint/js": "8.44.0",
     "@humanwhocodes/config-array": "^0.11.10",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.2.0",
-    "@eslint-community/regexpp": "^4.6.0",
+    "@eslint-community/regexpp": "^4.6.1",
     "@eslint/eslintrc": "^2.1.0",
     "@eslint/js": "8.44.0",
     "@humanwhocodes/config-array": "^0.11.10",

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -81,6 +81,12 @@ ruleTester.run("no-invalid-regexp", rule, {
         "new RegExp('\\\\p{Script=Vith}', 'u')",
         "new RegExp('\\\\p{Script=Vithkuqi}', 'u')",
 
+        // ES2024
+        "new RegExp('[A--B]', 'v')",
+        "new RegExp('[A&&B]', 'v')",
+        "new RegExp('[A--[0-9]]', 'v')",
+        "new RegExp('[\\\\p{Basic_Emoji}--\\\\q{a|bc|def}]', 'v')",
+
         // allowConstructorFlags
         {
             code: "new RegExp('.', 'g')",

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -86,6 +86,8 @@ ruleTester.run("no-invalid-regexp", rule, {
         "new RegExp('[A&&B]', 'v')",
         "new RegExp('[A--[0-9]]', 'v')",
         "new RegExp('[\\\\p{Basic_Emoji}--\\\\q{a|bc|def}]', 'v')",
+        "new RegExp('[A--B]', flags)", // valid only with `v` flag
+        "new RegExp('[[]\\\\u{0}*', flags)", // valid only with `u` flag
 
         // allowConstructorFlags
         {
@@ -298,6 +300,14 @@ ruleTester.run("no-invalid-regexp", rule, {
 
         // ES2024
         {
+            code: "new RegExp('[[]', 'v');",
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid regular expression: /[[]/u: Unterminated character class" },
+                type: "NewExpression"
+            }]
+        },
+        {
             code: "new RegExp('.', 'uv');",
             errors: [{
                 messageId: "regexMessage",
@@ -310,6 +320,22 @@ ruleTester.run("no-invalid-regexp", rule, {
             errors: [{
                 messageId: "regexMessage",
                 data: { message: "Regex 'u' and 'v' flags cannot be used together" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "new RegExp('[A--B]' /* valid only with `v` flag */, 'u')",
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid regular expression: /[A--B]/u: Range out of order in character class" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "new RegExp('[[]\\\\u{0}*' /* valid only with `u` flag */, 'v')",
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid regular expression: /[[]\\u{0}*/u: Unterminated character class" },
                 type: "NewExpression"
             }]
         }

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -294,6 +294,24 @@ ruleTester.run("no-invalid-regexp", rule, {
                 data: { message: "Invalid flags supplied to RegExp constructor 'z'" },
                 type: "NewExpression"
             }]
+        },
+
+        // ES2024
+        {
+            code: "new RegExp('.', 'uv');",
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Regex 'u' and 'v' flags cannot be used together" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "new RegExp(pattern, 'uv');",
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Regex 'u' and 'v' flags cannot be used together" },
+                type: "NewExpression"
+            }]
         }
     ]
 });

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -303,7 +303,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             code: "new RegExp('[[]', 'v');",
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid regular expression: /[[]/u: Unterminated character class" },
+                data: { message: "Invalid regular expression: /[[]/v: Unterminated character class" },
                 type: "NewExpression"
             }]
         },
@@ -335,7 +335,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             code: "new RegExp('[[]\\\\u{0}*' /* valid only with `u` flag */, 'v')",
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid regular expression: /[[]\\u{0}*/u: Unterminated character class" },
+                data: { message: "Invalid regular expression: /[[]\\u{0}*/v: Unterminated character class" },
                 type: "NewExpression"
             }]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[X] Other, please explain:

Update `@eslint-community/regexpp` to v4.6.0

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refs #17223

This PR modifies the `no-invalid-regexp` rule and adds support for regexp `v` flag.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
