### PR TITLE
feat: `no-control-regex` support `v` flag

### DIFF
--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -32,10 +32,11 @@ const collector = new (class {
 
     collectControlChars(regexpStr, flags) {
         const uFlag = typeof flags === "string" && flags.includes("u");
+        const vFlag = typeof flags === "string" && flags.includes("v");
 
         try {
             this._source = regexpStr;
-            this._validator.validatePattern(regexpStr, void 0, void 0, uFlag); // Call onCharacter hook
+            this._validator.validatePattern(regexpStr, void 0, void 0, { unicode: uFlag, unicodeSets: vFlag }); // Call onCharacter hook
         } catch {
 
             // Ignore syntax errors in RegExp.

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -14,6 +14,16 @@ const collector = new (class {
     }
 
     onPatternEnter() {
+
+        /*
+         * `RegExpValidator` may parse the pattern twice in one `validatePattern`.
+         * So `this._controlChars` should be cleared here as well.
+         *
+         * For example, the `/(?<a>\x1f)/` regex will parse the pattern twice.
+         * This is based on the content described in Annex B.
+         * If the regex contains a `GroupName` and the `u` flag is not used, `ParseText` will be called twice.
+         * See https://tc39.es/ecma262/2023/multipage/additional-ecmascript-features-for-web-browsers.html#sec-parsepattern-annexb
+         */
         this._controlChars = [];
     }
 
@@ -34,8 +44,10 @@ const collector = new (class {
         const uFlag = typeof flags === "string" && flags.includes("u");
         const vFlag = typeof flags === "string" && flags.includes("v");
 
+        this._controlChars = [];
+        this._source = regexpStr;
+
         try {
-            this._source = regexpStr;
             this._validator.validatePattern(regexpStr, void 0, void 0, { unicode: uFlag, unicodeSets: vFlag }); // Call onCharacter hook
         } catch {
 

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -33,7 +33,8 @@ ruleTester.run("no-control-regex", rule, {
         String.raw`new RegExp("\\u{20}", "u")`,
         String.raw`new RegExp("\\u{1F}")`,
         String.raw`new RegExp("\\u{1F}", "g")`,
-        String.raw`new RegExp("\\u{1F}", flags)` // when flags are unknown, this rule assumes there's no `u` flag
+        String.raw`new RegExp("\\u{1F}", flags)`, // when flags are unknown, this rule assumes there's no `u` flag
+        String.raw`new RegExp("[\\q{\\u{20}}]", "v")`
     ],
     invalid: [
         { code: String.raw`var regex = /\x1f/`, errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }] },
@@ -84,6 +85,10 @@ ruleTester.run("no-control-regex", rule, {
         },
         {
             code: String.raw`new RegExp("\\u{1F}", "gui")`,
+            errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
+        },
+        {
+            code: String.raw`new RegExp("[\\q{\\u{1F}}]", "v")`,
             errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
         }
     ]

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -97,6 +97,11 @@ ruleTester.run("no-control-regex", rule, {
             code: String.raw`/[\u{1F}--B]/v`,
             parserOptions: { ecmaVersion: 2024 },
             errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
+        },
+        {
+            code: String.raw`/\x11/; RegExp("foo", "uv");`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{ messageId: "unexpected", data: { controlChars: "\\x11" }, type: "Literal", column: 1 }]
         }
     ]
 });

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -34,7 +34,9 @@ ruleTester.run("no-control-regex", rule, {
         String.raw`new RegExp("\\u{1F}")`,
         String.raw`new RegExp("\\u{1F}", "g")`,
         String.raw`new RegExp("\\u{1F}", flags)`, // when flags are unknown, this rule assumes there's no `u` flag
-        String.raw`new RegExp("[\\q{\\u{20}}]", "v")`
+        String.raw`new RegExp("[\\q{\\u{20}}]", "v")`,
+        { code: String.raw`/[\u{20}--B]/v`, parserOptions: { ecmaVersion: 2024 } }
+
     ],
     invalid: [
         { code: String.raw`var regex = /\x1f/`, errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }] },
@@ -89,6 +91,11 @@ ruleTester.run("no-control-regex", rule, {
         },
         {
             code: String.raw`new RegExp("[\\q{\\u{1F}}]", "v")`,
+            errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
+        },
+        {
+            code: String.raw`/[\u{1F}--B]/v`,
+            parserOptions: { ecmaVersion: 2024 },
             errors: [{ messageId: "unexpected", data: { controlChars: "\\x1f" }, type: "Literal" }]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refs #17223

This PR modifies the `no-control-regex` rule and adds support for regexp `v` flag.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
