### PR TITLE
feat: `no-misleading-character-class` support `v` flag

### DIFF
--- a/docs/src/rules/no-misleading-character-class.md
+++ b/docs/src/rules/no-misleading-character-class.md
@@ -79,6 +79,7 @@ Examples of **correct** code for this rule:
 
 /^[abc]$/
 /^[👍]$/u
+/^[\q{👶🏻}]$/v
 ```
 
 :::

--- a/lib/rules/no-misleading-character-class.js
+++ b/lib/rules/no-misleading-character-class.js
@@ -18,7 +18,7 @@ const { isValidWithUnicodeFlag } = require("./utils/regular-expressions");
  *
  * CharacterClassRange syntax can steal a part of character sequence,
  * so this function reverts CharacterClassRange syntax and restore the sequence.
- * @param {regexpp.AST.CharacterClassElement[]} nodes The node list to iterate character sequences.
+ * @param {import('@eslint-community/regexpp').AST.CharacterClassElement[]} nodes The node list to iterate character sequences.
  * @returns {IterableIterator<number[]>} The list of character sequences.
  */
 function *iterateCharacterSequence(nodes) {
@@ -37,6 +37,9 @@ function *iterateCharacterSequence(nodes) {
                 break;
 
             case "CharacterSet":
+            case "CharacterClass": // [[]] nesting character class
+            case "ClassStringDisjunction": // \q{...}
+            case "ExpressionCharacterClass": // [A--B]
                 if (seq.length > 0) {
                     yield seq;
                     seq = [];

--- a/lib/rules/no-misleading-character-class.js
+++ b/lib/rules/no-misleading-character-class.js
@@ -144,7 +144,10 @@ module.exports = {
                     pattern,
                     0,
                     pattern.length,
-                    flags.includes("u")
+                    {
+                        unicode: flags.includes("u"),
+                        unicodeSets: flags.includes("v")
+                    }
                 );
             } catch {
 

--- a/lib/rules/utils/regular-expressions.js
+++ b/lib/rules/utils/regular-expressions.js
@@ -28,7 +28,7 @@ function isValidWithUnicodeFlag(ecmaVersion, pattern) {
     });
 
     try {
-        validator.validatePattern(pattern, void 0, void 0, /* uFlag = */ true);
+        validator.validatePattern(pattern, void 0, void 0, { unicode: /* uFlag = */ true });
     } catch {
         return false;
     }

--- a/tests/lib/rules/no-misleading-character-class.js
+++ b/tests/lib/rules/no-misleading-character-class.js
@@ -70,7 +70,11 @@ ruleTester.run("no-misleading-character-class", rule, {
         "var r = new RegExp('[Á] [ ');",
         "var r = RegExp('{ [Á]', 'u');",
         { code: "var r = new globalThis.RegExp('[Á] [ ');", env: { es2020: true } },
-        { code: "var r = globalThis.RegExp('{ [Á]', 'u');", env: { es2020: true } }
+        { code: "var r = globalThis.RegExp('{ [Á]', 'u');", env: { es2020: true } },
+
+        // ES2024
+        { code: "var r = /[👍]/v", parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`var r = /^[\q{👶🏻}]$/v`, parserOptions: { ecmaVersion: 2024 } }
     ],
     invalid: [
 
@@ -618,6 +622,17 @@ ruleTester.run("no-misleading-character-class", rule, {
             env: { es2020: true },
             errors: [{
                 messageId: "zwj",
+                suggestions: null
+            }]
+        },
+
+
+        // ES2024
+        {
+            code: "var r = /[[👶🏻]]/v",
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                messageId: "emojiModifier",
                 suggestions: null
             }]
         }

--- a/tests/lib/rules/no-misleading-character-class.js
+++ b/tests/lib/rules/no-misleading-character-class.js
@@ -74,7 +74,10 @@ ruleTester.run("no-misleading-character-class", rule, {
 
         // ES2024
         { code: "var r = /[👍]/v", parserOptions: { ecmaVersion: 2024 } },
-        { code: String.raw`var r = /^[\q{👶🏻}]$/v`, parserOptions: { ecmaVersion: 2024 } }
+        { code: String.raw`var r = /^[\q{👶🏻}]$/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`var r = /[🇯\q{abc}🇵]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: "var r = /[🇯[A]🇵]/v", parserOptions: { ecmaVersion: 2024 } },
+        { code: "var r = /[🇯[A--B]🇵]/v", parserOptions: { ecmaVersion: 2024 } }
     ],
     invalid: [
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refs #17223

This PR modifies the `no-misleading-character-class` rule and adds support for regexp `v` flag.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
