### PR TITLE
feat: `no-regex-spaces` support `v` flag

### DIFF
--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -77,7 +77,7 @@ module.exports = {
             let regExpAST;
 
             try {
-                regExpAST = regExpParser.parsePattern(pattern, 0, pattern.length, flags.includes("u"));
+                regExpAST = regExpParser.parsePattern(pattern, 0, pattern.length, { unicode: flags.includes("u"), unicodeSets: flags.includes("v") });
             } catch {
 
                 // Ignore regular expressions with syntax errors

--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -155,13 +155,28 @@ module.exports = {
             const regExpVar = astUtils.getVariableByName(scope, "RegExp");
             const shadowed = regExpVar && regExpVar.defs.length > 0;
             const patternNode = node.arguments[0];
-            const flagsNode = node.arguments[1];
 
             if (node.callee.type === "Identifier" && node.callee.name === "RegExp" && isString(patternNode) && !shadowed) {
                 const pattern = patternNode.value;
                 const rawPattern = patternNode.raw.slice(1, -1);
                 const rawPatternStartRange = patternNode.range[0] + 1;
-                const flags = isString(flagsNode) ? flagsNode.value : "";
+                let flags;
+
+                if (node.arguments.length < 2) {
+
+                    // It has no flags.
+                    flags = "";
+                } else {
+                    const flagsNode = node.arguments[1];
+
+                    if (isString(flagsNode)) {
+                        flags = flagsNode.value;
+                    } else {
+
+                        // The flags cannot be determined.
+                        return;
+                    }
+                }
 
                 checkRegex(
                     node,

--- a/tests/lib/rules/no-regex-spaces.js
+++ b/tests/lib/rules/no-regex-spaces.js
@@ -69,6 +69,9 @@ ruleTester.run("no-regex-spaces", rule, {
         // don't report invalid regex
         "var foo = new RegExp('[  ');",
         "var foo = new RegExp('{  ', 'u');",
+
+        // don't report if flags cannot be determined
+        "new RegExp('  ', flags)",
         "new RegExp('[[abc]  ]', flags + 'v')",
         "new RegExp('[[abc]\\\\q{  }]', flags + 'v')"
     ],
@@ -380,6 +383,20 @@ ruleTester.run("no-regex-spaces", rule, {
         },
 
         // ES2024
+        {
+            code: "var foo = /[[    ]    ]    /v;",
+            output: "var foo = /[[    ]    ] {4}/v;",
+            parserOptions: {
+                ecmaVersion: 2024
+            },
+            errors: [
+                {
+                    messageId: "multipleSpaces",
+                    data: { length: "4" },
+                    type: "Literal"
+                }
+            ]
+        },
         {
             code: "var foo = new RegExp('[[    ]    ]    ', 'v');",
             output: "var foo = new RegExp('[[    ]    ] {4}', 'v');",

--- a/tests/lib/rules/no-regex-spaces.js
+++ b/tests/lib/rules/no-regex-spaces.js
@@ -62,6 +62,10 @@ ruleTester.run("no-regex-spaces", rule, {
         "var foo = new RegExp(' \\[   ');",
         "var foo = new RegExp(' \\[   \\] ');",
 
+        // ES2024
+        { code: "var foo = /  {2}/v;", parserOptions: { ecmaVersion: 2024 } },
+        { code: "var foo = /[\\q{    }]/v;", parserOptions: { ecmaVersion: 2024 } },
+
         // don't report invalid regex
         "var foo = new RegExp('[  ');",
         "var foo = new RegExp('{  ', 'u');"
@@ -368,6 +372,19 @@ ruleTester.run("no-regex-spaces", rule, {
                 {
                     messageId: "multipleSpaces",
                     data: { length: "2" },
+                    type: "NewExpression"
+                }
+            ]
+        },
+
+        // ES2024
+        {
+            code: "var foo = new RegExp('[[    ]    ]    ', 'v');",
+            output: "var foo = new RegExp('[[    ]    ] {4}', 'v');",
+            errors: [
+                {
+                    messageId: "multipleSpaces",
+                    data: { length: "4" },
                     type: "NewExpression"
                 }
             ]

--- a/tests/lib/rules/no-regex-spaces.js
+++ b/tests/lib/rules/no-regex-spaces.js
@@ -68,7 +68,9 @@ ruleTester.run("no-regex-spaces", rule, {
 
         // don't report invalid regex
         "var foo = new RegExp('[  ');",
-        "var foo = new RegExp('{  ', 'u');"
+        "var foo = new RegExp('{  ', 'u');",
+        "new RegExp('[[abc]  ]', flags + 'v')",
+        "new RegExp('[[abc]\\\\q{  }]', flags + 'v')"
     ],
 
     invalid: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refs #17223

This PR modifies the `no-regex-space` rule and adds support for regexp `v` flag.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
