### PR TITLE
feat: `no-useless-backreference` support `v` flag

### DIFF
--- a/lib/rules/no-useless-backreference.js
+++ b/lib/rules/no-useless-backreference.js
@@ -95,7 +95,7 @@ module.exports = {
             let regExpAST;
 
             try {
-                regExpAST = parser.parsePattern(pattern, 0, pattern.length, flags.includes("u"));
+                regExpAST = parser.parsePattern(pattern, 0, pattern.length, { unicode: flags.includes("u"), unicodeSets: flags.includes("v") });
             } catch {
 
                 // Ignore regular expressions with syntax errors

--- a/tests/lib/rules/no-useless-backreference.js
+++ b/tests/lib/rules/no-useless-backreference.js
@@ -142,7 +142,11 @@ ruleTester.run("no-useless-backreference", rule, {
         String.raw`new RegExp('\\1(a)\\2', 'ug')`, // \1 would be an error, but \2 is syntax error because of the 'u' flag
         String.raw`const flags = 'gus'; RegExp('\\1(a){', flags);`, // \1 would be an error, but the rule is aware of the 'u' flag so this is a syntax error
         String.raw`RegExp('\\1(a)\\k<foo>', 'u')`, // \1 would be an error, but \k<foo> produces syntax error because of the u flag
-        String.raw`new RegExp('\\k<foo>(?<foo>a)\\k<bar>')` // \k<foo> would be an error, but \k<bar> produces syntax error because group <bar> doesn't exist
+        String.raw`new RegExp('\\k<foo>(?<foo>a)\\k<bar>')`, // \k<foo> would be an error, but \k<bar> produces syntax error because group <bar> doesn't exist
+
+        // ES2024
+        String.raw`new RegExp('([\\q{a}])\\1', 'v')`,
+        String.raw`new RegExp('[[]\\1](a)', 'v')` // SyntaxError
     ],
 
     invalid: [
@@ -508,6 +512,13 @@ ruleTester.run("no-useless-backreference", rule, {
         {
             code: String.raw`const r = RegExp, p = '\\1', s = '(a)'; new r(p + s);`,
             errors: [{ messageId: "forward", data: { bref: String.raw`\1`, group: String.raw`(a)` }, type: "NewExpression" }]
+        },
+
+
+        // ES2024
+        {
+            code: String.raw`new RegExp('\\1([[a]])', 'v')`,
+            errors: [{ messageId: "forward", data: { bref: String.raw`\1`, group: String.raw`([[a]])` }, type: "NewExpression" }]
         }
     ]
 });

--- a/tests/lib/rules/no-useless-backreference.js
+++ b/tests/lib/rules/no-useless-backreference.js
@@ -145,7 +145,7 @@ ruleTester.run("no-useless-backreference", rule, {
         String.raw`new RegExp('\\k<foo>(?<foo>a)\\k<bar>')`, // \k<foo> would be an error, but \k<bar> produces syntax error because group <bar> doesn't exist
 
         // ES2024
-        String.raw`new RegExp('([\\q{a}])\\1', 'v')`,
+        String.raw`new RegExp('([[A--B]])\\1', 'v')`,
         String.raw`new RegExp('[[]\\1](a)', 'v')` // SyntaxError
     ],
 
@@ -517,8 +517,8 @@ ruleTester.run("no-useless-backreference", rule, {
 
         // ES2024
         {
-            code: String.raw`new RegExp('\\1([[a]])', 'v')`,
-            errors: [{ messageId: "forward", data: { bref: String.raw`\1`, group: String.raw`([[a]])` }, type: "NewExpression" }]
+            code: String.raw`new RegExp('\\1([[A--B]])', 'v')`,
+            errors: [{ messageId: "forward", data: { bref: String.raw`\1`, group: String.raw`([[A--B]])` }, type: "NewExpression" }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refs #17223

This PR modifies the `no-useless-backreference` rule and adds support for regexp `v` flag.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
