### PR TITLE
feat: `prefer-named-capture-group` support `v` flag

### DIFF
--- a/lib/rules/prefer-named-capture-group.js
+++ b/lib/rules/prefer-named-capture-group.js
@@ -112,14 +112,17 @@ module.exports = {
          * @param {string} pattern The regular expression pattern to be checked.
          * @param {ASTNode} node AST node which contains the regular expression or a call/new expression.
          * @param {ASTNode} regexNode AST node which contains the regular expression.
-         * @param {boolean} uFlag Flag indicates whether unicode mode is enabled or not.
+         * @param {string} flags The regular expression flags to be checked.
          * @returns {void}
          */
-        function checkRegex(pattern, node, regexNode, uFlag) {
+        function checkRegex(pattern, node, regexNode, flags) {
             let ast;
 
             try {
-                ast = parser.parsePattern(pattern, 0, pattern.length, uFlag);
+                ast = parser.parsePattern(pattern, 0, pattern.length, {
+                    unicode: Boolean(flags && flags.includes("u")),
+                    unicodeSets: Boolean(flags && flags.includes("v"))
+                });
             } catch {
 
                 // ignore regex syntax errors
@@ -148,7 +151,7 @@ module.exports = {
         return {
             Literal(node) {
                 if (node.regex) {
-                    checkRegex(node.regex.pattern, node, node, node.regex.flags.includes("u"));
+                    checkRegex(node.regex.pattern, node, node, node.regex.flags);
                 }
             },
             Program(node) {
@@ -166,7 +169,7 @@ module.exports = {
                     const flags = getStringIfConstant(refNode.arguments[1]);
 
                     if (regex) {
-                        checkRegex(regex, refNode, refNode.arguments[0], flags && flags.includes("u"));
+                        checkRegex(regex, refNode, refNode.arguments[0], flags);
                     }
                 }
             }

--- a/lib/rules/prefer-named-capture-group.js
+++ b/lib/rules/prefer-named-capture-group.js
@@ -112,7 +112,7 @@ module.exports = {
          * @param {string} pattern The regular expression pattern to be checked.
          * @param {ASTNode} node AST node which contains the regular expression or a call/new expression.
          * @param {ASTNode} regexNode AST node which contains the regular expression.
-         * @param {string} flags The regular expression flags to be checked.
+         * @param {string|null} flags The regular expression flags to be checked.
          * @returns {void}
          */
         function checkRegex(pattern, node, regexNode, flags) {

--- a/tests/lib/rules/prefer-named-capture-group.js
+++ b/tests/lib/rules/prefer-named-capture-group.js
@@ -74,6 +74,12 @@ ruleTester.run("prefer-named-capture-group", rule, {
 
         // ES2024
         "new RegExp('(?<c>[[A--B]])', 'v')",
+
+        /*
+         * This testcase checks if the rule understands the v flag correctly.
+         * Without the v flag, `([\q])` is considered a valid regex and the rule reports,
+         * but if the v flag is understood correctly the rule does not because of a syntax error.
+         */
         String.raw`new RegExp('([\\q])', 'v')` // SyntaxError
     ],
 

--- a/tests/lib/rules/prefer-named-capture-group.js
+++ b/tests/lib/rules/prefer-named-capture-group.js
@@ -70,7 +70,11 @@ ruleTester.run("prefer-named-capture-group", rule, {
                 }
                 `,
             env: { es2020: true }
-        }
+        },
+
+        // ES2024
+        "new RegExp('(?<c>[[A--B]])', 'v')",
+        String.raw`new RegExp('([\\q])', 'v')` // SyntaxError
     ],
 
     invalid: [
@@ -590,6 +594,27 @@ ruleTester.run("prefer-named-capture-group", rule, {
             `
                     }
                 ]
+            }]
+        },
+
+        // ES2024
+        {
+            code: "new RegExp('([[A--B]])', 'v')",
+            errors: [{
+                messageId: "required",
+                type: "NewExpression",
+                data: { group: "([[A--B]])" },
+                line: 1,
+                column: 1,
+                suggestions: [
+                    {
+                        messageId: "addGroupName",
+                        output: "new RegExp('(?<temp1>[[A--B]])', 'v')"
+                    },
+                    {
+                        messageId: "addNonCapture",
+                        output: "new RegExp('(?:[[A--B]])', 'v')"
+                    }]
             }]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refs #17223

This PR modifies the `prefer-named-capture-group` rule and adds support for regexp `v` flag.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
