### PR TITLE
feat: `prefer-regex-literals` support `v` flag

### DIFF
--- a/lib/rules/prefer-regex-literals.js
+++ b/lib/rules/prefer-regex-literals.js
@@ -241,7 +241,7 @@ module.exports = {
         /**
          * Returns a ecmaVersion compatible for regexpp.
          * @param {number} ecmaVersion The ecmaVersion to convert.
-         * @returns {import("regexpp/ecma-versions").EcmaVersion} The resulting ecmaVersion compatible for regexpp.
+         * @returns {import("@eslint-community/regexpp/ecma-versions").EcmaVersion} The resulting ecmaVersion compatible for regexpp.
          */
         function getRegexppEcmaVersion(ecmaVersion) {
             if (ecmaVersion <= 5) {
@@ -297,7 +297,10 @@ module.exports = {
             const validator = new RegExpValidator({ ecmaVersion: regexppEcmaVersion });
 
             try {
-                validator.validatePattern(pattern, 0, pattern.length, flags ? flags.includes("u") : false);
+                validator.validatePattern(pattern, 0, pattern.length, {
+                    unicode: flags ? flags.includes("u") : false,
+                    unicodeSets: flags ? flags.includes("v") : false
+                });
                 if (flags) {
                     validator.validateFlags(flags);
                 }
@@ -461,7 +464,10 @@ module.exports = {
                         if (regexContent && !noFix) {
                             let charIncrease = 0;
 
-                            const ast = new RegExpParser({ ecmaVersion: regexppEcmaVersion }).parsePattern(regexContent, 0, regexContent.length, flags ? flags.includes("u") : false);
+                            const ast = new RegExpParser({ ecmaVersion: regexppEcmaVersion }).parsePattern(regexContent, 0, regexContent.length, {
+                                unicode: flags ? flags.includes("u") : false,
+                                unicodeSets: flags ? flags.includes("v") : false
+                            });
 
                             visitRegExpAST(ast, {
                                 onCharacterEnter(characterNode) {

--- a/lib/rules/utils/regular-expressions.js
+++ b/lib/rules/utils/regular-expressions.js
@@ -8,7 +8,7 @@
 
 const { RegExpValidator } = require("@eslint-community/regexpp");
 
-const REGEXPP_LATEST_ECMA_VERSION = 2022;
+const REGEXPP_LATEST_ECMA_VERSION = 2024;
 
 /**
  * Checks if the given regular expression pattern would be valid with the `u` flag.

--- a/tests/lib/rules/prefer-regex-literals.js
+++ b/tests/lib/rules/prefer-regex-literals.js
@@ -134,7 +134,10 @@ ruleTester.run("prefer-regex-literals", rule, {
         {
             code: "class C { #RegExp; foo() { globalThis.#RegExp('a'); } }",
             env: { es2020: true }
-        }
+        },
+
+        // ES2024
+        "new RegExp('[[A--B]]' + a, 'v')"
     ],
 
     invalid: [
@@ -2802,6 +2805,43 @@ ruleTester.run("prefer-regex-literals", rule, {
         },
         {
             code: "new RegExp('mysafereg' /* comment explaining its safety */)",
+            errors: [
+                {
+                    messageId: "unexpectedRegExp",
+                    suggestions: null
+                }
+            ]
+        },
+
+        // ES2024
+        {
+            code: "new RegExp('[[A--B]]', 'v')",
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [
+                {
+                    messageId: "unexpectedRegExp",
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteral",
+                            output: "/[[A--B]]/v"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "new RegExp('[[A--B]]', 'v')",
+            parserOptions: { ecmaVersion: 2023 },
+            errors: [
+                {
+                    messageId: "unexpectedRegExp",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "new RegExp('[[A&&&]]', 'v')",
+            parserOptions: { ecmaVersion: 2024 },
             errors: [
                 {
                     messageId: "unexpectedRegExp",

--- a/tests/lib/rules/prefer-regex-literals.js
+++ b/tests/lib/rules/prefer-regex-literals.js
@@ -2848,6 +2848,146 @@ ruleTester.run("prefer-regex-literals", rule, {
                     suggestions: null
                 }
             ]
+        },
+        {
+            code: "new RegExp('a', 'uv')",
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [
+                {
+                    messageId: "unexpectedRegExp",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/a/, 'v')",
+            options: [{ disallowRedundantWrapping: true }],
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/v",
+                            data: {
+                                flags: "v"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/a/, 'v')",
+            options: [{ disallowRedundantWrapping: true }],
+            parserOptions: { ecmaVersion: 2023 },
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/a/g, 'v')",
+            options: [{ disallowRedundantWrapping: true }],
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/v",
+                            data: {
+                                flags: "v"
+                            }
+                        },
+                        {
+                            messageId: "replaceWithIntendedLiteralAndFlags",
+                            output: "/a/gv",
+                            data: {
+                                flags: "gv"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/[[A--B]]/v, 'g')",
+            options: [{ disallowRedundantWrapping: true }],
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    suggestions: [
+                        {
+                            messageId: "replaceWithIntendedLiteralAndFlags",
+                            output: "/[[A--B]]/vg",
+                            data: {
+                                flags: "vg"
+                            }
+                        }
+
+                        // suggestion with flags `g` would be invalid
+                    ]
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/a/u, 'v')",
+            options: [{ disallowRedundantWrapping: true }],
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/v",
+                            data: {
+                                flags: "v"
+                            }
+                        }
+
+                        // suggestion with merged flags `uv` would be invalid
+                    ]
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/a/v, 'u')",
+            options: [{ disallowRedundantWrapping: true }],
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    suggestions: [
+                        {
+                            messageId: "replaceWithLiteralAndFlags",
+                            output: "/a/u",
+                            data: {
+                                flags: "u"
+                            }
+                        }
+
+                        // suggestion with merged flags `vu` would be invalid
+                    ]
+                }
+            ]
+        },
+        {
+            code: "new RegExp(/[[A--B]]/v, 'u')",
+            options: [{ disallowRedundantWrapping: true }],
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [
+                {
+                    messageId: "unexpectedRedundantRegExpWithFlags",
+                    suggestions: null
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refs #17223

This PR modifies the `prefer-regex-literals` rule and adds support for regexp `v` flag.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
