### PR TITLE
feat: deprecate no-return-await

### DIFF
--- a/docs/src/_data/further_reading_links.json
+++ b/docs/src/_data/further_reading_links.json
@@ -719,5 +719,12 @@
         "logo": "https://tc39.es/ecma262/img/favicon.ico",
         "title": "ECMAScript® 2023 Language Specification",
         "description": null
+    },
+    "https://v8.dev/blog/fast-async": {
+        "domain": "v8.dev",
+        "url": "https://v8.dev/blog/fast-async",
+        "logo": "https://v8.dev/favicon.ico",
+        "title": "Faster async functions and promises · V8",
+        "description": "Faster and easier-to-debug async functions and promises are coming to V8 v7.2 / Chrome 72."
     }
 }

--- a/docs/src/_data/rules.json
+++ b/docs/src/_data/rules.json
@@ -1063,13 +1063,6 @@
                     "hasSuggestions": false
                 },
                 {
-                    "name": "no-return-await",
-                    "description": "Disallow unnecessary `return await`",
-                    "recommended": false,
-                    "fixable": false,
-                    "hasSuggestions": true
-                },
-                {
                     "name": "no-script-url",
                     "description": "Disallow `javascript:` urls",
                     "recommended": false,
@@ -1981,6 +1974,10 @@
             },
             {
                 "name": "no-restricted-modules",
+                "replacedBy": []
+            },
+            {
+                "name": "no-return-await",
                 "replacedBy": []
             },
             {

--- a/docs/src/_data/rules_meta.json
+++ b/docs/src/_data/rules_meta.json
@@ -1578,6 +1578,8 @@
             "recommended": false,
             "url": "https://eslint.org/docs/latest/rules/no-return-await"
         },
+        "deprecated": true,
+        "replacedBy": [],
         "fixable": null
     },
     "no-script-url": {

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -7,7 +7,7 @@ further_reading:
 - https://jakearchibald.com/2017/await-vs-return-vs-return-await/
 ---
 
-This rule was **deprecated** in ESLint v8.46.0 with no replacement. The original intent of this rule no longer applies due to the fact Javascript now handles native `Promises` differently. It can now be slower to remove `await` rather than keeping it. More technical information can be found in [this](https://v8.dev/blog/fast-async) V8 blog entry.
+This rule was **deprecated** in ESLint v8.46.0 with no replacement. The original intent of this rule no longer applies due to the fact JavaScript now handles native `Promises` differently. It can now be slower to remove `await` rather than keeping it. More technical information can be found in [this V8 blog entry](https://v8.dev/blog/fast-async).
 
 Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited has resolved, at the cost of an extra microtask before resolving the outer Promise. `return await` can also be used in a try/catch statement to catch errors from another function that returns a Promise.
 

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -7,7 +7,7 @@ further_reading:
 - https://jakearchibald.com/2017/await-vs-return-vs-return-await/
 ---
 
-This rule was **deprecated** in Eslint v8.49.0 with no replacement. The original intent of this rule no longer applies due to the fact Javascript now handles native `Promises` differently. It can now be slower to remove `await` rather than keeping it. More technical information can be found in [this](https://v8.dev/blog/fast-async) V8 blog entry.
+This rule was **deprecated** in ESLint v8.46.0 with no replacement. The original intent of this rule no longer applies due to the fact Javascript now handles native `Promises` differently. It can now be slower to remove `await` rather than keeping it. More technical information can be found in [this](https://v8.dev/blog/fast-async) V8 blog entry.
 
 Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited has resolved, at the cost of an extra microtask before resolving the outer Promise. `return await` can also be used in a try/catch statement to catch errors from another function that returns a Promise.
 

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -2,10 +2,12 @@
 title: no-return-await
 rule_type: suggestion
 further_reading:
+- https://v8.dev/blog/fast-async
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function
 - https://jakearchibald.com/2017/await-vs-return-vs-return-await/
 ---
 
+This rule was **deprecated** in Eslint v8.49.0 with no replacement. The original intent of this rule no longer applies due to the fact Javascript now handles native `Promises` differently. It can now be slower to remove `await` rather than keeping it. More technical information can be found in [this](https://v8.dev/blog/fast-async) V8 blog entry.
 
 Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited has resolved, at the cost of an extra microtask before resolving the outer Promise. `return await` can also be used in a try/catch statement to catch errors from another function that returns a Promise.
 

--- a/lib/rules/no-return-await.js
+++ b/lib/rules/no-return-await.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Disallows unnecessary `return await`
  * @author Jordan Harband
+ * @deprecated
  */
 "use strict";
 
@@ -25,6 +26,10 @@ module.exports = {
         },
 
         fixable: null,
+
+        deprecated: true,
+
+        replacedBy: [],
 
         schema: [
         ],

--- a/lib/rules/no-return-await.js
+++ b/lib/rules/no-return-await.js
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Disallows unnecessary `return await`
  * @author Jordan Harband
- * @deprecated
+ * @deprecated in ESLint v8.46.0
  */
 "use strict";
 

--- a/packages/js/src/configs/eslint-all.js
+++ b/packages/js/src/configs/eslint-all.js
@@ -172,7 +172,6 @@ module.exports = Object.freeze({
         "no-restricted-properties": "error",
         "no-restricted-syntax": "error",
         "no-return-assign": "error",
-        "no-return-await": "error",
         "no-script-url": "error",
         "no-self-assign": "error",
         "no-self-compare": "error",


### PR DESCRIPTION
The original intent of this rule no longer applies due to the fact Javascript now handles native `Promises` differently. It can no be slower to remove `await` rather than keeping it.

Fixes #17345

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[] Add something to the core
[x] Other, please explain:

Deprecate `no-return-await`.


#### What changes did you make? (Give an overview)

#### Is there anything you'd like reviewers to focus on?

