### PR TITLE
feat: `no-empty-character-class` support `v` flag

### DIFF
--- a/docs/src/rules/no-empty-character-class.md
+++ b/docs/src/rules/no-empty-character-class.md
@@ -24,6 +24,23 @@ Examples of **incorrect** code for this rule:
 
 /^abc[]/.test("abcdefg"); // false
 "abcdefg".match(/^abc[]/); // null
+
+/^abc[[]]/v.test("abcdefg"); // false
+"abcdefg".match(/^abc[[]]/v); // null
+
+/^abc[[]--[x]]/v.test("abcdefg"); // false
+"abcdefg".match(/^abc[[]--[x]]/v); // null
+
+/^abc[[d]&&[]]/v.test("abcdefg"); // false
+"abcdefg".match(/^abc[[d]&&[]]/v); // null
+
+const regex = /^abc[d[]]/v;
+regex.test("abcdefg"); // true, the nested `[]` has no effect
+"abcdefg".match(regex); // ["abcd"]
+regex.test("abcefg"); // false, the nested `[]` has no effect
+"abcefg".match(regex); // null
+regex.test("abc"); // false, the nested `[]` has no effect
+"abc".match(regex); // null
 ```
 
 :::
@@ -40,6 +57,9 @@ Examples of **correct** code for this rule:
 
 /^abc[a-z]/.test("abcdefg"); // true
 "abcdefg".match(/^abc[a-z]/); // ["abcd"]
+
+/^abc[^]/.test("abcdefg"); // true
+"abcdefg".match(/^abc[^]/); // ["abcd"]
 ```
 
 :::

--- a/lib/rules/no-empty-character-class.js
+++ b/lib/rules/no-empty-character-class.js
@@ -6,19 +6,17 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { RegExpParser, visitRegExpAST } = require("@eslint-community/regexpp");
+
+//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
-/*
- * plain-English description of the following regexp:
- * 0. `^` fix the match at the beginning of the string
- * 1. `([^\\[]|\\.|\[([^\\\]]|\\.)+\])*`: regexp contents; 0 or more of the following
- * 1.0. `[^\\[]`: any character that's not a `\` or a `[` (anything but escape sequences and character classes)
- * 1.1. `\\.`: an escape sequence
- * 1.2. `\[([^\\\]]|\\.)+\]`: a character class that isn't empty
- * 2. `$`: fix the match at the end of the string
- */
-const regex = /^([^\\[]|\\.|\[([^\\\]]|\\.)+\])*$/u;
+const parser = new RegExpParser();
+const QUICK_TEST_REGEX = /\[\]/u;
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -45,9 +43,32 @@ module.exports = {
     create(context) {
         return {
             "Literal[regex]"(node) {
-                if (!regex.test(node.regex.pattern)) {
-                    context.report({ node, messageId: "unexpected" });
+                const { pattern, flags } = node.regex;
+
+                if (!QUICK_TEST_REGEX.test(pattern)) {
+                    return;
                 }
+
+                let regExpAST;
+
+                try {
+                    regExpAST = parser.parsePattern(pattern, 0, pattern.length, {
+                        unicode: flags.includes("u"),
+                        unicodeSets: flags.includes("v")
+                    });
+                } catch {
+
+                    // Ignore regular expressions that regexpp cannot parse
+                    return;
+                }
+
+                visitRegExpAST(regExpAST, {
+                    onCharacterClassEnter(characterClass) {
+                        if (!characterClass.negate && characterClass.elements.length === 0) {
+                            context.report({ node, messageId: "unexpected" });
+                        }
+                    }
+                });
             }
         };
 

--- a/tests/lib/rules/no-empty-character-class.js
+++ b/tests/lib/rules/no-empty-character-class.js
@@ -25,15 +25,26 @@ ruleTester.run("no-empty-character-class", rule, {
         "var foo = /^abc/;",
         "var foo = /[\\[]/;",
         "var foo = /[\\]]/;",
+        "var foo = /\\[][\\]]/;",
         "var foo = /[a-zA-Z\\[]/;",
         "var foo = /[[]/;",
         "var foo = /[\\[a-z[]]/;",
         "var foo = /[\\-\\[\\]\\/\\{\\}\\(\\)\\*\\+\\?\\.\\\\^\\$\\|]/g;",
         "var foo = /\\s*:\\s*/gim;",
+        "var foo = /[^]/;", // this rule allows negated empty character classes
+        "var foo = /\\[][^]/;",
         { code: "var foo = /[\\]]/uy;", parserOptions: { ecmaVersion: 6 } },
         { code: "var foo = /[\\]]/s;", parserOptions: { ecmaVersion: 2018 } },
         { code: "var foo = /[\\]]/d;", parserOptions: { ecmaVersion: 2022 } },
-        "var foo = /\\[]/"
+        "var foo = /\\[]/",
+        { code: "var foo = /[[^]]/v;", parserOptions: { ecmaVersion: 2024 } },
+        { code: "var foo = /[[\\]]]/v;", parserOptions: { ecmaVersion: 2024 } },
+        { code: "var foo = /[[\\[]]/v;", parserOptions: { ecmaVersion: 2024 } },
+        { code: "var foo = /[a--b]/v;", parserOptions: { ecmaVersion: 2024 } },
+        { code: "var foo = /[a&&b]/v;", parserOptions: { ecmaVersion: 2024 } },
+        { code: "var foo = /[[a][b]]/v;", parserOptions: { ecmaVersion: 2024 } },
+        { code: "var foo = /[\\q{}]/v;", parserOptions: { ecmaVersion: 2024 } },
+        { code: "var foo = /[[^]--\\p{ASCII}]/v;", parserOptions: { ecmaVersion: 2024 } }
     ],
     invalid: [
         { code: "var foo = /^abc[]/;", errors: [{ messageId: "unexpected", type: "Literal" }] },
@@ -43,6 +54,15 @@ ruleTester.run("no-empty-character-class", rule, {
         { code: "var foo = /[]]/;", errors: [{ messageId: "unexpected", type: "Literal" }] },
         { code: "var foo = /\\[[]/;", errors: [{ messageId: "unexpected", type: "Literal" }] },
         { code: "var foo = /\\[\\[\\]a-z[]/;", errors: [{ messageId: "unexpected", type: "Literal" }] },
-        { code: "var foo = /[]]/d;", parserOptions: { ecmaVersion: 2022 }, errors: [{ messageId: "unexpected", type: "Literal" }] }
+        { code: "var foo = /[]]/d;", parserOptions: { ecmaVersion: 2022 }, errors: [{ messageId: "unexpected", type: "Literal" }] },
+        { code: "var foo = /[(]\\u{0}*[]/u;", parserOptions: { ecmaVersion: 2015 }, errors: [{ messageId: "unexpected", type: "Literal" }] },
+        { code: "var foo = /[]/v;", parserOptions: { ecmaVersion: 2024 }, errors: [{ messageId: "unexpected", type: "Literal" }] },
+        { code: "var foo = /[[]]/v;", parserOptions: { ecmaVersion: 2024 }, errors: [{ messageId: "unexpected", type: "Literal" }] },
+        { code: "var foo = /[[a][]]/v;", parserOptions: { ecmaVersion: 2024 }, errors: [{ messageId: "unexpected", type: "Literal" }] },
+        { code: "var foo = /[a[[b[]c]]d]/v;", parserOptions: { ecmaVersion: 2024 }, errors: [{ messageId: "unexpected", type: "Literal" }] },
+        { code: "var foo = /[a--[]]/v;", parserOptions: { ecmaVersion: 2024 }, errors: [{ messageId: "unexpected", type: "Literal" }] },
+        { code: "var foo = /[[]--b]/v;", parserOptions: { ecmaVersion: 2024 }, errors: [{ messageId: "unexpected", type: "Literal" }] },
+        { code: "var foo = /[a&&[]]/v;", parserOptions: { ecmaVersion: 2024 }, errors: [{ messageId: "unexpected", type: "Literal" }] },
+        { code: "var foo = /[[]&&b]/v;", parserOptions: { ecmaVersion: 2024 }, errors: [{ messageId: "unexpected", type: "Literal" }] }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #17223

Updates `no-empty-character-class` to report nested empty character classes.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Before this change, this rule was reporting _some_  but not all empty nested character classes, depending on how its own parsing happened to work with the new syntax. Since the syntax becomes too complicated for analyzing patterns with a regex, I switched the rule to use `regexpp`. For performance reasons, I also added a quick search for `[]` to exit early and avoid parsing.

#### Is there anything you'd like reviewers to focus on?

Does reporting nested character classes makes sense for this rule? I don't think there's a case where an empty nested character class can be useful.

Note: Allowing empty `[^]` is existing behavior, it was just undocumented and untested.

<!-- markdownlint-disable-file MD004 -->
