### PR TITLE
feat: `no-useless-escape` support `v` flag

### DIFF
--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -206,8 +206,22 @@ module.exports = {
                     const reportedIndex = characterNode.start + 1;
 
                     if (characterClassStack.length) {
+                        const characterClassNode = characterClassStack[0];
+
+                        if (escapedChar === "^") {
+
+                            /*
+                             * The '^' character is also a special case; it must always be escaped outside of character classes, but
+                             * it only needs to be escaped in character classes if it's at the beginning of the character class. To
+                             * account for this, consider it to be a valid escape character outside of character classes, and filter
+                             * out '^' characters that appear at the start of a character class.
+                             */
+                            if (characterClassNode.start + 1 === characterNode.start) {
+
+                                return;
+                            }
+                        }
                         if (!unicodeSets) {
-                            const characterClassNode = characterClassStack[0];
 
                             if (characterClassNode.type === "CharacterClass") {
                                 if (escapedChar === "-") {
@@ -219,19 +233,6 @@ module.exports = {
                                      * character class.
                                      */
                                     if (characterClassNode.start + 1 !== characterNode.start && characterNode.end !== characterClassNode.end - 1) {
-
-                                        return;
-                                    }
-                                }
-                                if (escapedChar === "^") {
-
-                                    /*
-                                     * The '^' character is also a special case; it must always be escaped outside of character classes, but
-                                     * it only needs to be escaped in character classes if it's at the beginning of the character class. To
-                                     * account for this, consider it to be a valid escape character outside of character classes, and filter
-                                     * out '^' characters that appear at the start of a character class.
-                                     */
-                                    if (characterClassNode.start + 1 === characterNode.start) {
 
                                         return;
                                     }
@@ -250,8 +251,6 @@ module.exports = {
                                     }
 
                                     // If the previous character is a `negate` caret(`^`), escape to caret is unnecessary.
-
-                                    const characterClassNode = characterClassStack[0];
 
                                     if (!characterClassNode.negate) {
                                         return;

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -6,7 +6,12 @@
 "use strict";
 
 const astUtils = require("./utils/ast-utils");
+const { RegExpParser, visitRegExpAST } = require("@eslint-community/regexpp");
 
+/**
+ * @typedef {import('@eslint-community/regexpp').AST.CharacterClass} CharacterClass
+ * @typedef {import('@eslint-community/regexpp').AST.ExpressionCharacterClass} ExpressionCharacterClass
+ */
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -28,55 +33,17 @@ const VALID_STRING_ESCAPES = union(new Set("\\nrvtbfux"), astUtils.LINEBREAKS);
 const REGEX_GENERAL_ESCAPES = new Set("\\bcdDfnpPrsStvwWxu0123456789]");
 const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("^/.$*+?[{}|()Bk"));
 
-/**
- * Parses a regular expression into a list of characters with character class info.
- * @param {string} regExpText The raw text used to create the regular expression
- * @returns {Object[]} A list of characters, each with info on escaping and whether they're in a character class.
- * @example
- *
- * parseRegExp("a\\b[cd-]");
- *
- * // returns:
- * [
- *     { text: "a", index: 0, escaped: false, inCharClass: false, startsCharClass: false, endsCharClass: false },
- *     { text: "b", index: 2, escaped: true, inCharClass: false, startsCharClass: false, endsCharClass: false },
- *     { text: "c", index: 4, escaped: false, inCharClass: true, startsCharClass: true, endsCharClass: false },
- *     { text: "d", index: 5, escaped: false, inCharClass: true, startsCharClass: false, endsCharClass: false },
- *     { text: "-", index: 6, escaped: false, inCharClass: true, startsCharClass: false, endsCharClass: false }
- * ];
- *
+/*
+ * Set of characters that require escaping in character classes in `unicodeSets` mode.
+ * ( ) [ ] { } / - \ | are ClassSetSyntaxCharacter
  */
-function parseRegExp(regExpText) {
-    const charList = [];
+const REGEX_CLASSSET_CHARACTER_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("q/[{}|()-"));
 
-    regExpText.split("").reduce((state, char, index) => {
-        if (!state.escapeNextChar) {
-            if (char === "\\") {
-                return Object.assign(state, { escapeNextChar: true });
-            }
-            if (char === "[" && !state.inCharClass) {
-                return Object.assign(state, { inCharClass: true, startingCharClass: true });
-            }
-            if (char === "]" && state.inCharClass) {
-                if (charList.length && charList[charList.length - 1].inCharClass) {
-                    charList[charList.length - 1].endsCharClass = true;
-                }
-                return Object.assign(state, { inCharClass: false, startingCharClass: false });
-            }
-        }
-        charList.push({
-            text: char,
-            index,
-            escaped: state.escapeNextChar,
-            inCharClass: state.inCharClass,
-            startsCharClass: state.startingCharClass,
-            endsCharClass: false
-        });
-        return Object.assign(state, { escapeNextChar: false, startingCharClass: false });
-    }, { escapeNextChar: false, inCharClass: false, startingCharClass: false });
-
-    return charList;
-}
+/*
+ * A single character set of ClassSetReservedDoublePunctuator.
+ * && !! ## $$ %% ** ++ ,, .. :: ;; << == >> ?? @@ ^^ `` ~~ are ClassSetReservedDoublePunctuator
+ */
+const REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR = new Set("!#$%&*+,.:;<=>?@^`~");
 
 /** @type {import('../shared/types').Rule} */
 module.exports = {
@@ -103,6 +70,7 @@ module.exports = {
 
     create(context) {
         const sourceCode = context.sourceCode;
+        const parser = new RegExpParser();
 
         /**
          * Reports a node
@@ -183,6 +151,131 @@ module.exports = {
         }
 
         /**
+         * Checks if the escape character in given regexp is unnecessary.
+         * @private
+         * @param {ASTNode} node node to validate.
+         * @returns {void}
+         */
+        function validateRegExp(node) {
+            const { pattern, flags } = node.regex;
+            let patternNode;
+            const unicode = flags.includes("u");
+            const unicodeSets = flags.includes("v");
+
+            try {
+                patternNode = parser.parsePattern(pattern, 0, pattern.length, { unicode, unicodeSets });
+            } catch {
+
+                // Ignore regular expressions with syntax errors
+                return;
+            }
+
+            /** @type {(CharacterClass | ExpressionCharacterClass)[]} */
+            const characterClassStack = [];
+
+            visitRegExpAST(patternNode, {
+                onCharacterClassEnter: characterClassNode => characterClassStack.unshift(characterClassNode),
+                onCharacterClassLeave: () => characterClassStack.shift(),
+                onExpressionCharacterClassEnter: characterClassNode => characterClassStack.unshift(characterClassNode),
+                onExpressionCharacterClassLeave: () => characterClassStack.shift(),
+                onCharacterEnter(characterNode) {
+                    if (!characterNode.raw.startsWith("\\")) {
+
+                        // It's not an escaped character.
+                        return;
+                    }
+
+                    const escapedChar = characterNode.raw.slice(1);
+
+                    if (escapedChar !== String.fromCodePoint(characterNode.value)) {
+
+                        // It's a valid escape.
+                        return;
+                    }
+                    let allowedEscapes;
+
+                    if (characterClassStack.length) {
+                        allowedEscapes = unicodeSets ? REGEX_CLASSSET_CHARACTER_ESCAPES : REGEX_GENERAL_ESCAPES;
+                    } else {
+                        allowedEscapes = REGEX_NON_CHARCLASS_ESCAPES;
+                    }
+                    if (allowedEscapes.has(escapedChar)) {
+                        return;
+                    }
+
+                    const reportedIndex = characterNode.start + 1;
+
+                    if (characterClassStack.length) {
+                        if (!unicodeSets) {
+                            const characterClassNode = characterClassStack[0];
+
+                            if (characterClassNode.type === "CharacterClass") {
+                                if (escapedChar === "-") {
+
+                                    /*
+                                     * The '-' character is a special case, because it's only valid to escape it if it's in a character
+                                     * class, and is not at either edge of the character class. To account for this, don't consider '-'
+                                     * characters to be valid in general, and filter out '-' characters that appear in the middle of a
+                                     * character class.
+                                     */
+                                    if (characterClassNode.start + 1 !== characterNode.start && characterNode.end !== characterClassNode.end - 1) {
+
+                                        return;
+                                    }
+                                }
+                                if (escapedChar === "^") {
+
+                                    /*
+                                     * The '^' character is also a special case; it must always be escaped outside of character classes, but
+                                     * it only needs to be escaped in character classes if it's at the beginning of the character class. To
+                                     * account for this, consider it to be a valid escape character outside of character classes, and filter
+                                     * out '^' characters that appear at the start of a character class.
+                                     */
+                                    if (characterClassNode.start + 1 === characterNode.start) {
+
+                                        return;
+                                    }
+                                }
+                            }
+                        } else { // unicodeSets mode
+                            if (REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR.has(escapedChar)) {
+
+                                // Escaping is valid if it is a ClassSetReservedDoublePunctuator.
+                                if (pattern[characterNode.end] === escapedChar) {
+                                    return;
+                                }
+                                if (pattern[characterNode.start - 1] === escapedChar) {
+                                    if (escapedChar !== "^") {
+                                        return;
+                                    }
+
+                                    // If the previous character is a `negate` caret(`^`), escape to caret is unnecessary.
+
+                                    const characterClassNode = characterClassStack[0];
+
+                                    if (!characterClassNode.negate) {
+                                        return;
+                                    }
+                                    const negateCaretIndex = characterClassNode.start + 1;
+
+                                    if (negateCaretIndex < characterNode.start - 1) {
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    report(
+                        node,
+                        reportedIndex,
+                        escapedChar
+                    );
+                }
+            });
+        }
+
+        /**
          * Checks if a node has an escape.
          * @param {ASTNode} node node to check.
          * @returns {void}
@@ -220,32 +313,7 @@ module.exports = {
                     validateString(node, match);
                 }
             } else if (node.regex) {
-                parseRegExp(node.regex.pattern)
-
-                    /*
-                     * The '-' character is a special case, because it's only valid to escape it if it's in a character
-                     * class, and is not at either edge of the character class. To account for this, don't consider '-'
-                     * characters to be valid in general, and filter out '-' characters that appear in the middle of a
-                     * character class.
-                     */
-                    .filter(charInfo => !(charInfo.text === "-" && charInfo.inCharClass && !charInfo.startsCharClass && !charInfo.endsCharClass))
-
-                    /*
-                     * The '^' character is also a special case; it must always be escaped outside of character classes, but
-                     * it only needs to be escaped in character classes if it's at the beginning of the character class. To
-                     * account for this, consider it to be a valid escape character outside of character classes, and filter
-                     * out '^' characters that appear at the start of a character class.
-                     */
-                    .filter(charInfo => !(charInfo.text === "^" && charInfo.startsCharClass))
-
-                    // Filter out characters that aren't escaped.
-                    .filter(charInfo => charInfo.escaped)
-
-                    // Filter out characters that are valid to escape, based on their position in the regular expression.
-                    .filter(charInfo => !(charInfo.inCharClass ? REGEX_GENERAL_ESCAPES : REGEX_NON_CHARCLASS_ESCAPES).has(charInfo.text))
-
-                    // Report all the remaining characters.
-                    .forEach(charInfo => report(node, charInfo.index, charInfo.text));
+                validateRegExp(node);
             }
 
         }

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -222,20 +222,17 @@ module.exports = {
                             }
                         }
                         if (!unicodeSets) {
+                            if (escapedChar === "-") {
 
-                            if (characterClassNode.type === "CharacterClass") {
-                                if (escapedChar === "-") {
+                                /*
+                                 * The '-' character is a special case, because it's only valid to escape it if it's in a character
+                                 * class, and is not at either edge of the character class. To account for this, don't consider '-'
+                                 * characters to be valid in general, and filter out '-' characters that appear in the middle of a
+                                 * character class.
+                                 */
+                                if (characterClassNode.start + 1 !== characterNode.start && characterNode.end !== characterClassNode.end - 1) {
 
-                                    /*
-                                     * The '-' character is a special case, because it's only valid to escape it if it's in a character
-                                     * class, and is not at either edge of the character class. To account for this, don't consider '-'
-                                     * characters to be valid in general, and filter out '-' characters that appear in the middle of a
-                                     * character class.
-                                     */
-                                    if (characterClassNode.start + 1 !== characterNode.start && characterNode.end !== characterClassNode.end - 1) {
-
-                                        return;
-                                    }
+                                    return;
                                 }
                             }
                         } else { // unicodeSets mode

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -77,9 +77,10 @@ module.exports = {
          * @param {ASTNode} node The node to report
          * @param {number} startOffset The backslash's offset from the start of the node
          * @param {string} character The uselessly escaped character (not including the backslash)
+         * @param {boolean} [disableEscapeBackslashSuggest] `true` if escapeBackslash suggestion should be turned off.
          * @returns {void}
          */
-        function report(node, startOffset, character) {
+        function report(node, startOffset, character, disableEscapeBackslashSuggest) {
             const rangeStart = node.range[0] + startOffset;
             const range = [rangeStart, rangeStart + 1];
             const start = sourceCode.getLocFromIndex(rangeStart);
@@ -102,12 +103,16 @@ module.exports = {
                             return fixer.removeRange(range);
                         }
                     },
-                    {
-                        messageId: "escapeBackslash",
-                        fix(fixer) {
-                            return fixer.insertTextBeforeRange(range, "\\");
-                        }
-                    }
+                    ...disableEscapeBackslashSuggest
+                        ? []
+                        : [
+                            {
+                                messageId: "escapeBackslash",
+                                fix(fixer) {
+                                    return fixer.insertTextBeforeRange(range, "\\");
+                                }
+                            }
+                        ]
                 ]
             });
         }
@@ -204,6 +209,7 @@ module.exports = {
                     }
 
                     const reportedIndex = characterNode.start + 1;
+                    let disableEscapeBackslashSuggest = false;
 
                     if (characterClassStack.length) {
                         const characterClassNode = characterClassStack[0];
@@ -259,13 +265,18 @@ module.exports = {
                                     }
                                 }
                             }
+
+                            if (characterNode.parent.type === "ClassIntersection" || characterNode.parent.type === "ClassSubtraction") {
+                                disableEscapeBackslashSuggest = true;
+                            }
                         }
                     }
 
                     report(
                         node,
                         reportedIndex,
-                        escapedChar
+                        escapedChar,
+                        disableEscapeBackslashSuggest
                     );
                 }
             });

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -1625,6 +1625,216 @@ ruleTester.run("no-useless-escape", rule, {
                     }
                 ]
             }]
+        },
+        {
+            code: String.raw`/[\p{ASCII}--\.]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 14,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[\p{ASCII}--.]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\p{ASCII}&&\.]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 14,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[\p{ASCII}&&.]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\.--[.&]]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[.--[.&]]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\.&&[.&]]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[.&&[.&]]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\.--\.--\.]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[.--\.--\.]/v`
+                    }
+                ]
+            }, {
+                line: 1,
+                column: 7,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[\.--.--\.]/v`
+                    }
+                ]
+            }, {
+                line: 1,
+                column: 11,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[\.--\.--.]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\.&&\.&&\.]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[.&&\.&&\.]/v`
+                    }
+                ]
+            }, {
+                line: 1,
+                column: 7,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[\.&&.&&\.]/v`
+                    }
+                ]
+            }, {
+                line: 1,
+                column: 11,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[\.&&\.&&.]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[[\.&]--[\.&]]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 4,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[[.&]--[\.&]]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[[\\.&]--[\.&]]/v`
+                    }
+                ]
+            }, {
+                line: 1,
+                column: 11,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[[\.&]--[.&]]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[[\.&]--[\\.&]]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[[\.&]&&[\.&]]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 4,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[[.&]&&[\.&]]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[[\\.&]&&[\.&]]/v`
+                    }
+                ]
+            }, {
+                line: 1,
+                column: 11,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[[\.&]&&[.&]]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[[\.&]&&[\\.&]]/v`
+                    }
+                ]
+            }]
         }
     ]
 });

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -127,7 +127,64 @@ ruleTester.run("no-useless-escape", rule, {
         { code: String.raw`var foo = /\p{ASCII}/u`, parserOptions: { ecmaVersion: 2018 } },
         { code: String.raw`var foo = /\P{ASCII}/u`, parserOptions: { ecmaVersion: 2018 } },
         { code: String.raw`var foo = /[\p{ASCII}]/u`, parserOptions: { ecmaVersion: 2018 } },
-        { code: String.raw`var foo = /[\P{ASCII}]/u`, parserOptions: { ecmaVersion: 2018 } }
+        { code: String.raw`var foo = /[\P{ASCII}]/u`, parserOptions: { ecmaVersion: 2018 } },
+
+        // Carets
+        String.raw`/[^^]/`,
+        { code: String.raw`/[^^]/u`, parserOptions: { ecmaVersion: 2015 } },
+
+        // ES2024
+        { code: String.raw`/[\q{abc}]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\(]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\)]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\{]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\]]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\}]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\/]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\-]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\|]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\$$]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\&&]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\!!]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\##]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\%%]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\**]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\++]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\,,]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\..]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\::]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\;;]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\<<]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\==]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\>>]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\??]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\@@]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: "/[\\``]/v", parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\~~]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[^\^^]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[_\^^]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[$\$]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[&\&]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[!\!]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[#\#]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[%\%]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[*\*]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[+\+]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[,\,]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[.\.]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[:\:]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[;\;]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[<\<]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[=\=]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[>\>]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[?\?]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[@\@]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: "/[`\\`]/v", parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[~\~]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[^^\^]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[_^\^]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\&&&\&]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[[\-]\-]/v`, parserOptions: { ecmaVersion: 2024 } }
     ],
 
     invalid: [
@@ -1102,6 +1159,470 @@ ruleTester.run("no-useless-escape", rule, {
                     messageId: "escapeBackslash",
                     output: String.raw`({ foo() { "foo"; "bar"; "ba\\z" } })`
                 }]
+            }]
+        },
+
+        // Carets
+        {
+            code: String.raw`/[^\^]/`,
+            errors: [{
+                line: 1,
+                column: 4,
+                message: "Unnecessary escape character: \\^.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: "/[^^]/"
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[^\\^]/`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[^\^]/u`,
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                line: 1,
+                column: 4,
+                message: "Unnecessary escape character: \\^.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: "/[^^]/u"
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[^\\^]/u`
+                    }
+                ]
+            }]
+        },
+
+        // ES2024
+        {
+            code: String.raw`/[\$]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                endColumn: 4,
+                message: "Unnecessary escape character: \\$.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: "/[$]/v"
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\$]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\&\&]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\&.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[&\&]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\&\&]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\!\!]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\!.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[!\!]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\!\!]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\#\#]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\#.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[#\#]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\#\#]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\%\%]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\%.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[%\%]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\%\%]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\*\*]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\*.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[*\*]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\*\*]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\+\+]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\+.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[+\+]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\+\+]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\,\,]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\,.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[,\,]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\,\,]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\.\.]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\..",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[.\.]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\.\.]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\:\:]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\:.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[:\:]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\:\:]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\;\;]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\;.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[;\;]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\;\;]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\<\<]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\<.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[<\<]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\<\<]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\=\=]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\=.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[=\=]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\=\=]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\>\>]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\>.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[>\>]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\>\>]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\?\?]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\?.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[?\?]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\?\?]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\@\@]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\@.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[@\@]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\@\@]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: "/[\\`\\`]/v",
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\`.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: "/[`\\`]/v"
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: "/[\\\\`\\`]/v"
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\~\~]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\~.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[~\~]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\~\~]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[^\^\^]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 4,
+                message: "Unnecessary escape character: \\^.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[^^\^]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[^\\^\^]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[_\^\^]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 4,
+                message: "Unnecessary escape character: \\^.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[_^\^]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[_\\^\^]/v`
+                    }
+                ]
+            }]
+        },
+        {
+            code: String.raw`/[\&\&&\&]/v`,
+            parserOptions: { ecmaVersion: 2024 },
+            errors: [{
+                line: 1,
+                column: 3,
+                message: "Unnecessary escape character: \\&.",
+                type: "Literal",
+                suggestions: [
+                    {
+                        messageId: "removeEscape",
+                        output: String.raw`/[&\&&\&]/v`
+                    },
+                    {
+                        messageId: "escapeBackslash",
+                        output: String.raw`/[\\&\&&\&]/v`
+                    }
+                ]
             }]
         }
     ]

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -184,7 +184,8 @@ ruleTester.run("no-useless-escape", rule, {
         { code: String.raw`/[^^\^]/v`, parserOptions: { ecmaVersion: 2024 } },
         { code: String.raw`/[_^\^]/v`, parserOptions: { ecmaVersion: 2024 } },
         { code: String.raw`/[\&&&\&]/v`, parserOptions: { ecmaVersion: 2024 } },
-        { code: String.raw`/[[\-]\-]/v`, parserOptions: { ecmaVersion: 2024 } }
+        { code: String.raw`/[[\-]\-]/v`, parserOptions: { ecmaVersion: 2024 } },
+        { code: String.raw`/[\^]/v`, parserOptions: { ecmaVersion: 2024 } }
     ],
 
     invalid: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refs #17223

This PR modifies the `no-useless-escape` rule and adds support for regexp `v` flag.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
