### PR TITLE
docs: update with TypeScript info

### DIFF
--- a/docs/src/rules/constructor-super.md
+++ b/docs/src/rules/constructor-super.md
@@ -70,4 +70,4 @@ class A extends B {
 
 If you don't want to be notified about invalid/missing `super()` callings in constructors, you can safely disable this rule.
 
-It is safe to disable this rule when using TypeScript because [TypeScript's compiler enforces this check (`ts(2335) & ts(2377)`)](https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json).
+It is safe to disable this rule when using TypeScript because TypeScript's compiler enforces this check (`ts(2335) & ts(2377)`).

--- a/docs/src/rules/constructor-super.md
+++ b/docs/src/rules/constructor-super.md
@@ -70,4 +70,4 @@ class A extends B {
 
 If you don't want to be notified about invalid/missing `super()` callings in constructors, you can safely disable this rule.
 
-It is safe to disable this rule when using TypeScript because [TypeScript's compiler enforces this check (`ts(2377)`)](https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json).
+It is safe to disable this rule when using TypeScript because [TypeScript's compiler enforces this check (`ts(2335) & ts(2377)`)](https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json).

--- a/docs/src/rules/constructor-super.md
+++ b/docs/src/rules/constructor-super.md
@@ -69,3 +69,5 @@ class A extends B {
 ## When Not To Use It
 
 If you don't want to be notified about invalid/missing `super()` callings in constructors, you can safely disable this rule.
+
+It's also safe to disable this rule when using TypeScript because [TypeScript's compiler enforces this check (`ts(2377)`)](https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json).

--- a/docs/src/rules/constructor-super.md
+++ b/docs/src/rules/constructor-super.md
@@ -70,4 +70,4 @@ class A extends B {
 
 If you don't want to be notified about invalid/missing `super()` callings in constructors, you can safely disable this rule.
 
-It's also safe to disable this rule when using TypeScript because [TypeScript's compiler enforces this check (`ts(2377)`)](https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json).
+It is safe to disable this rule when using TypeScript because [TypeScript's compiler enforces this check (`ts(2377)`)](https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json).

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -102,4 +102,4 @@ This rule should not be used in ES3/5 environments.
 
 In ES2015 (ES6) or later, if you don't want to be notified about duplicate names in class members, you can safely disable this rule.
 
-It's also safe to disable this rule when using TypeScript because [TypeScript's compiler enforces this check (`ts(2393)`)](https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json).
+It is safe to disable this rule when using TypeScript because [TypeScript's compiler enforces this check (`ts(2393)`)](https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json).

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -102,4 +102,4 @@ This rule should not be used in ES3/5 environments.
 
 In ES2015 (ES6) or later, if you don't want to be notified about duplicate names in class members, you can safely disable this rule.
 
-It is safe to disable this rule when using TypeScript because [TypeScript's compiler enforces this check (`ts(2393)`)](https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json).
+It is safe to disable this rule when using TypeScript because [TypeScript's compiler enforces this check (`ts(2300) & ts(2393)`)](https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json).

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -102,4 +102,4 @@ This rule should not be used in ES3/5 environments.
 
 In ES2015 (ES6) or later, if you don't want to be notified about duplicate names in class members, you can safely disable this rule.
 
-It is safe to disable this rule when using TypeScript because [TypeScript's compiler enforces this check (`ts(2300) & ts(2393)`)](https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json).
+It is safe to disable this rule when using TypeScript because TypeScript's compiler enforces this check (`ts(2300) & ts(2393)`).

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -102,4 +102,4 @@ This rule should not be used in ES3/5 environments.
 
 In ES2015 (ES6) or later, if you don't want to be notified about duplicate names in class members, you can safely disable this rule.
 
-It's also safe to disable this rule when using TypeScript because TypeScript's compiler already checks for duplicate function implementations.
+It's also safe to disable this rule when using TypeScript because [TypeScript's compiler enforces this check (`ts(2393)`)](https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json).


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update

#### What changes did you make? (Give an overview)

I added TypeScript information to the docs.

#### Is there anything you'd like reviewers to focus on?

No.

#### Motivation

The `no-dupe-class-members` rule helpfully documents that if you are using TypeScript, then you don't have to enable the rule. This is fantastic! However, there are many other ESLint rules that are also pointless if you are using TypeScript, but they are not documented. So this is the first step in solving that problem.

#### Other Discussion

I want to document all rules that are covered by the TypeScript compiler, and this PR is the first step in doing so.
In my next PR I would like to reduce the text duplication that I am introducing with this PR by using some kind of auto-filled template. I envision something like:

```
{{ TypeScript 2377 }}
```

Which would output the following text during the actual website build:

```
It is safe to disable this rule when using TypeScript because [TypeScript's compiler enforces this check (`ts(2377)`)](https://github.com/Microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json).
```

I don't know if the docs already contains anything like this, so I would like a contributor to work with me to find the cleanest way to accomplish this.

Furthermore, I also want to include a TypeScript icon next to these kinds of texts to make it easier to see at a glance that the rule is covered already by TypeScript, which is another idea for a future PR.