### PR TITLE
feat: ignore IIFE's for no-loop-func rule

### DIFF
--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+const astUtils = require("./utils/ast-utils");
+
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -144,6 +146,18 @@ function isSafe(loopNode, reference) {
     return Boolean(variable) && variable.references.every(isSafeReference);
 }
 
+/**
+ * Determines if a given expression node is an IIFE
+ * @param {ASTNode} node The node to check
+ * @returns {boolean} `true` if the given node is an IIFE
+ */
+function isIIFE(node) {
+    const maybeCallNode = astUtils.skipChainExpression(node);
+
+    return maybeCallNode.type === "CallExpression" && (maybeCallNode.callee.type === "FunctionExpression" ||
+        maybeCallNode.callee.type === "ArrowFunctionExpression");
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -182,6 +196,10 @@ module.exports = {
             const loopNode = getContainingLoopNode(node);
 
             if (!loopNode) {
+                return;
+            }
+
+            if (!node.async && !node.generator && isIIFE(node.parent)) {
                 return;
             }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
The change proposes to ignore IIFE's inside the loop's block. However, if the function inside the loop is an async or a generator function, the rule still continues to report error.

Fixes: #16902 

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
