### PR TITLE
feat: add ignoreCallProperties option to camelcase rule

### DIFF
--- a/docs/src/rules/camelcase.md
+++ b/docs/src/rules/camelcase.md
@@ -22,6 +22,8 @@ This rule has an object option:
 * `"ignoreImports": true` does not check ES2015 imports (but still checks any use of the imports later in the code except function arguments)
 * `"ignoreGlobals": false` (default) enforces camelcase style for global variables
 * `"ignoreGlobals": true` does not enforce camelcase style for global variables
+* `"ignoreCallProperties": flase` (default) enforce camelcase style for function and class properties
+* `"ignoreCallProperties": true` does not enforce camelcase style for function and class properties
 * `allow` (`string[]`) list of properties to accept. Accept regex.
 
 ### properties: "always"
@@ -299,6 +301,21 @@ Examples of **correct** code for this rule with the `{ "ignoreGlobals": true }` 
 /* global no_camelcased */
 
 const foo = no_camelcased;
+```
+
+:::
+
+### ignoreCallProperties
+
+Examples of **correct** code for this rule with the `{ "ignoreCallProperties": true }` option:
+
+:::correct
+
+```js
+/*eslint camelcase: ["error", {ignoreCallProperties: true}]*/
+
+fn({ some_property: 1 });
+new C({ some_property: 1 });
 ```
 
 :::

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -186,6 +186,17 @@ module.exports = {
         }
 
         /**
+         * Checks if a given identifier is used in Call.
+         * @param {ASTNode} node The `Identifier` node to check.
+         * @returns {boolean} `true` if the identifier is used in Call.
+         */
+        function isCallProperty(node) {
+            return node.parent.parent.parent.type === "CallExpression" ||
+                node.parent.parent.parent.type === "NewExpression";
+        }
+
+
+        /**
          * Reports an AST node as a rule violation.
          * @param {ASTNode} node The node to report.
          * @returns {void}
@@ -333,7 +344,7 @@ module.exports = {
                 "MethodDefinition > PrivateIdentifier.key",
                 "PropertyDefinition > PrivateIdentifier.key"
             ]](node) {
-                if (properties === "never" || isGoodName(node.name) || ignoreCallProperties) {
+                if (properties === "never" || isGoodName(node.name) || (ignoreCallProperties && isCallProperty(node))) {
                     return;
                 }
                 report(node);

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -42,6 +42,10 @@ module.exports = {
                         type: "boolean",
                         default: false
                     },
+                    ignoreCallProperties: {
+                        type: "boolean",
+                        default: false
+                    },
                     properties: {
                         enum: ["always", "never"]
                     },
@@ -72,6 +76,7 @@ module.exports = {
         const ignoreDestructuring = options.ignoreDestructuring;
         const ignoreImports = options.ignoreImports;
         const ignoreGlobals = options.ignoreGlobals;
+        const ignoreCallProperties = options.ignoreCallProperties;
         const allow = options.allow || [];
         const sourceCode = context.sourceCode;
 
@@ -328,7 +333,7 @@ module.exports = {
                 "MethodDefinition > PrivateIdentifier.key",
                 "PropertyDefinition > PrivateIdentifier.key"
             ]](node) {
-                if (properties === "never" || isGoodName(node.name)) {
+                if (properties === "never" || isGoodName(node.name) || ignoreCallProperties) {
                     return;
                 }
                 report(node);

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -1535,6 +1535,17 @@ ruleTester.run("camelcase", rule, {
                     column: 27
                 }
             ]
+        },
+        {
+            code: "var o = {bar_baz: 1}",
+            options: [{ ignoreCallProperties: true }],
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "bar_baz" },
+                    type: "Identifier"
+                }
+            ]
         }
     ]
 });

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -428,6 +428,24 @@ ruleTester.run("camelcase", rule, {
             parserOptions: { ecmaVersion: 2022 }
         },
 
+        {
+            code: `
+            fn({ some_property: 1 });
+            new C({ some_property: 1 });
+            `,
+            options: [{ properties: "always", ignoreCallProperties: true }],
+            parserOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: `
+            fn({ some_property });
+            new C({ some_property });
+            `,
+            options: [{ properties: "always", ignoreCallProperties: true, ignoreGlobals: true }],
+            parserOptions: { ecmaVersion: 2022 },
+            globals: { some_property: "readonly" } // eslint-disable-line camelcase -- Testing non-CamelCase
+        },
+
         // https://github.com/eslint/eslint/issues/15572
         {
             code: `


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added new option `ignoreCallProperties` to suppress camelcase checks for properties in functions and classes.

This is because whether the function is defined internally or externally, it cannot modify the naming of the properties at the place where it is called. This error is simply reporting an error.

If it's defined internally, then it's enough to report the error where the function is created. If it's defined externally, then obviously there's nothing we can do about it.

**What rule do you want to change?**

[`camelcase`](https://github.com/eslint/eslint/blob/main/lib/rules/camelcase.js)

**What change do you want to make (place an "X" next to just one item)?**

[ ] Generate more warnings
[x] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[x] A new option
[ ] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
/*eslint camelcase: ["error", {ignoreCallProperties: true}]*/

fn({ some_property: 1 });
new C({ some_property: 1 });
```

**What does the rule currently do for this code?**

It will report errors

```
Identifier 'do_something' is not in camel case.
```

**What will the rule do after it's changed?**

It will no longer report errors

#### Is there anything you'd like reviewers to focus on?

- Are the two additional test cases enough?
- Are all situations covered? Are there situations that should not be covered?

<!-- markdownlint-disable-file MD004 -->
