### PR TITLE
docs: add metadata for parser/processor

### DIFF
--- a/docs/src/extend/custom-parsers.md
+++ b/docs/src/extend/custom-parsers.md
@@ -12,22 +12,6 @@ ESLint custom parsers let you extend ESLint to support linting new non-standard 
 
 ## Creating a Custom Parser
 
-### Meta Data in Custom Parsers
-
-For easier debugging and more effective caching of custom parsers, it's recommended to provide a name and version in a `meta` object at the root of your custom parsers, like this:
-
-```js
-// preferred location of name and version
-module.exports = {
-    meta: {
-        name: "eslint-parser-custom",
-        version: "1.2.3"
-    }
-};
-```
-
-The `meta.name` property should match the npm package name for your custom parser and the `meta.version` property should match the npm package version for your custom parser. The easiest way to accomplish this is by reading this information from your `package.json`.
-
 ### Methods in Custom Parsers
 
 A custom parser is a JavaScript object with either a `parse` or `parseForESLint` method. The `parse` method only returns the AST, whereas `parseForESLint` also returns additional values that let the parser customize the behavior of ESLint even more.
@@ -65,6 +49,22 @@ The `parseForESLint` method should return an object that contains the required p
     * Support for `scopeManager` was added in ESLint v4.14.0. ESLint versions that support `scopeManager` will provide an `eslintScopeManager: true` property in `parserOptions`, which can be used for feature detection.
 * `visitorKeys` can be an object to customize AST traversal. The keys of the object are the type of AST nodes. Each value is an array of the property names which should be traversed. The default is [KEYS of `eslint-visitor-keys`](https://github.com/eslint/eslint-visitor-keys#evkkeys).
     * Support for `visitorKeys` was added in ESLint v4.14.0. ESLint versions that support `visitorKeys` will provide an `eslintVisitorKeys: true` property in `parserOptions`, which can be used for feature detection.
+
+### Meta Data in Custom Parsers
+
+For easier debugging and more effective caching of custom parsers, it's recommended to provide a name and version in a `meta` object at the root of your custom parsers, like this:
+
+```js
+// preferred location of name and version
+module.exports = {
+    meta: {
+        name: "eslint-parser-custom",
+        version: "1.2.3"
+    }
+};
+```
+
+The `meta.name` property should match the npm package name for your custom parser and the `meta.version` property should match the npm package version for your custom parser. The easiest way to accomplish this is by reading this information from your `package.json`.
 
 ## AST Specification
 

--- a/docs/src/extend/custom-parsers.md
+++ b/docs/src/extend/custom-parsers.md
@@ -12,6 +12,24 @@ ESLint custom parsers let you extend ESLint to support linting new non-standard 
 
 ## Creating a Custom Parser
 
+### Metadata in Custom Parsers
+
+For easier debugging and more effective caching of custom parsers, it's recommended to provide a name and version in a `meta` object at the root of your custom parsers, like this:
+
+```js
+// preferred location of name and version
+module.exports = {
+    meta: {
+        name: "eslint-parser-custom",
+        version: "1.2.3"
+    }
+};
+```
+
+The `meta.name` property should match the npm package name for your custom parser and the `meta.version` property should match the npm package version for your custom parser. The easiest way to accomplish this is by reading this information from your `package.json`.
+
+### Methods in Custom Parsers
+
 A custom parser is a JavaScript object with either a `parse` or `parseForESLint` method. The `parse` method only returns the AST, whereas `parseForESLint` also returns additional values that let the parser customize the behavior of ESLint even more.
 
 Both methods should take in the source code as the first argument, and an optional configuration object as the second argument, which is provided as [`parserOptions`](../use/configure/language-options#specifying-parser-options) in a configuration file.
@@ -33,11 +51,11 @@ function parse(code, options) {
 module.exports = { parse };
 ```
 
-## `parse` Return Object
+### `parse` Return Object
 
 The `parse` method should simply return the [AST](#ast-specification) object.
 
-## `parseForESLint` Return Object
+### `parseForESLint` Return Object
 
 The `parseForESLint` method should return an object that contains the required property `ast` and optional properties `services`, `scopeManager`, and `visitorKeys`.
 

--- a/docs/src/extend/custom-parsers.md
+++ b/docs/src/extend/custom-parsers.md
@@ -12,7 +12,7 @@ ESLint custom parsers let you extend ESLint to support linting new non-standard 
 
 ## Creating a Custom Parser
 
-### Metadata in Custom Parsers
+### Meta Data in Custom Parsers
 
 For easier debugging and more effective caching of custom parsers, it's recommended to provide a name and version in a `meta` object at the root of your custom parsers, like this:
 

--- a/docs/src/extend/custom-processors.md
+++ b/docs/src/extend/custom-processors.md
@@ -18,6 +18,10 @@ In order to create a custom processor, the object exported from your module has 
 module.exports = {
     processors: {
         "processor-name": {
+            meta: {
+                name: "eslint-processor-name",
+                version: "1.2.3"
+            },
             // takes text of the file and filename
             preprocess: function(text, filename) {
                 // here, you can strip out any non-JS content
@@ -44,6 +48,8 @@ module.exports = {
     }
 };
 ```
+
+**The `meta` object** helps ESLint cache the processor and provide more friendly debug message. The `meta.name` property should match the processor name and the `meta.version` property should match the npm package version for your processors. The easiest way to accomplish this is by reading this information from your `package.json`.
 
 **The `preprocess` method** takes the file contents and filename as arguments, and returns an array of code blocks to lint. The code blocks will be linted separately but still be registered to the filename.
 

--- a/docs/src/extend/custom-processors.md
+++ b/docs/src/extend/custom-processors.md
@@ -49,8 +49,6 @@ module.exports = {
 };
 ```
 
-**The `meta` object** helps ESLint cache the processor and provide more friendly debug message. The `meta.name` property should match the processor name and the `meta.version` property should match the npm package version for your processors. The easiest way to accomplish this is by reading this information from your `package.json`.
-
 **The `preprocess` method** takes the file contents and filename as arguments, and returns an array of code blocks to lint. The code blocks will be linted separately but still be registered to the filename.
 
 A code block has two properties `text` and `filename`. The `text` property is the content of the block and the `filename` property is the name of the block. The name of the block can be anything, but should include the file extension, which tells the linter how to process the current block. The linter checks the [`--ext` CLI option](../use/command-line-interface#--ext) to see if the current block should be linted and resolves `overrides` configs to check how to process the current block.
@@ -126,6 +124,8 @@ By default, ESLint does not perform autofixes when a custom processor is used, e
 2. Add a `supportsAutofix: true` property to the processor.
 
 You can have both rules and custom processors in a single plugin. You can also have multiple processors in one plugin. To support multiple extensions, add each one to the `processors` element and point them to the same object.
+
+**The `meta` object** helps ESLint cache the processor and provide more friendly debug message. The `meta.name` property should match the processor name and the `meta.version` property should match the npm package version for your processors. The easiest way to accomplish this is by reading this information from your `package.json`.
 
 ## Specifying Processor in Config Files
 

--- a/docs/src/extend/plugins.md
+++ b/docs/src/extend/plugins.md
@@ -18,34 +18,6 @@ Each plugin is an npm module with a name in the format of `eslint-plugin-<plugin
 
 The easiest way to start creating a plugin is to use the [Yeoman generator](https://www.npmjs.com/package/generator-eslint). The generator will guide you through setting up the skeleton of a plugin.
 
-### Metadata in Plugins
-
-For easier debugging and more effective caching of plugins, it's recommended to provide a name and version in a `meta` object at the root of your plugin, like this:
-
-```js
-// preferred location of name and version
-module.exports = {
-    meta: {
-        name: "eslint-plugin-custom",
-        version: "1.2.3"
-    }
-};
-```
-
-The `meta.name` property should match the npm package name for your plugin and the `meta.version` property should match the npm package version for your plugin. The easiest way to accomplish this is by reading this information from your `package.json`.
-
-As an alternative, you can also expose `name` and `version` properties at the root of your plugin, such as:
-
-```js
-// alternate location of name and version
-module.exports = {
-    name: "eslint-plugin-custom",
-    version: "1.2.3"
-};
-```
-
-While the `meta` object is the preferred way to provide the plugin name and version, this format is also acceptable and is provided for backward compatibility.
-
 ### Rules in Plugins
 
 Plugins can expose custom rules for use in ESLint. To do so, the plugin must export a `rules` object containing a key-value mapping of rule ID to rule. The rule ID does not have to follow any naming convention (so it can just be `dollar-sign`, for instance). To learn more about creating custom rules in plugins, refer to [Custom Rules](custom-rules).
@@ -162,6 +134,34 @@ If the example plugin above were called `eslint-plugin-myPlugin`, the `myConfig`
 }
 
 ```
+
+### Meta Data in Plugins
+
+For easier debugging and more effective caching of plugins, it's recommended to provide a name and version in a `meta` object at the root of your plugin, like this:
+
+```js
+// preferred location of name and version
+module.exports = {
+    meta: {
+        name: "eslint-plugin-custom",
+        version: "1.2.3"
+    }
+};
+```
+
+The `meta.name` property should match the npm package name for your plugin and the `meta.version` property should match the npm package version for your plugin. The easiest way to accomplish this is by reading this information from your `package.json`.
+
+As an alternative, you can also expose `name` and `version` properties at the root of your plugin, such as:
+
+```js
+// alternate location of name and version
+module.exports = {
+    name: "eslint-plugin-custom",
+    version: "1.2.3"
+};
+```
+
+While the `meta` object is the preferred way to provide the plugin name and version, this format is also acceptable and is provided for backward compatibility.
 
 ### Peer Dependency
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added `metadata` descriptions to `custom-parsers.md` and `custom-processors.md`. I don't know if `metadata` object is also implemented for formatters, if so I am happy to add a section covering that, too.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
The current `meta` sections are mostly copied from `plugins.md`. Frankly I don't know if `meta` object helps ESLint cache the parsers/processors. If not please correct me.