### PR TITLE
feat: update regex for methods with `thisArg`

### DIFF
--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -26,9 +26,9 @@ const {
 
 const anyFunctionPattern = /^(?:Function(?:Declaration|Expression)|ArrowFunctionExpression)$/u;
 const anyLoopPattern = /^(?:DoWhile|For|ForIn|ForOf|While)Statement$/u;
+const arrayMethodWithThisArgPattern = /^(?:every|filter|find(?:Last)?(?:Index)?|flatMap|forEach|map|some)$/u;
 const arrayOrTypedArrayPattern = /Array$/u;
 const bindOrCallOrApplyPattern = /^(?:bind|call|apply)$/u;
-const methodWithThisArgPattern = /^(?:every|filter|find(?:Last)?(?:Index)?|flatMap|forEach|map|some)$/u;
 const thisTagPattern = /^[\s*]*@this/mu;
 
 
@@ -472,7 +472,7 @@ function isArrayFromMethod(node) {
  * @returns {boolean} Whether or not the node is a method which expects a function as a first argument, and `thisArg` as a second argument.
  */
 function isMethodWhichHasThisArg(node) {
-    return isSpecificMemberAccess(node, null, methodWithThisArgPattern);
+    return isSpecificMemberAccess(node, null, arrayMethodWithThisArgPattern);
 }
 
 /**

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -27,8 +27,8 @@ const {
 const anyFunctionPattern = /^(?:Function(?:Declaration|Expression)|ArrowFunctionExpression)$/u;
 const anyLoopPattern = /^(?:DoWhile|For|ForIn|ForOf|While)Statement$/u;
 const arrayOrTypedArrayPattern = /Array$/u;
-const arrayMethodPattern = /^(?:every|filter|find|findIndex|forEach|map|some)$/u;
 const bindOrCallOrApplyPattern = /^(?:bind|call|apply)$/u;
+const methodWithThisArgPattern = /^(?:every|filter|find(?:Last)?(?:Index)?|flatMap|forEach|map|some)$/u;
 const thisTagPattern = /^[\s*]*@this/mu;
 
 
@@ -467,12 +467,12 @@ function isArrayFromMethod(node) {
 }
 
 /**
- * Checks whether or not a node is a method which has `thisArg`.
+ * Checks whether or not a node is a method which expects a function as a first argument, and `thisArg` as a second argument.
  * @param {ASTNode} node A node to check.
- * @returns {boolean} Whether or not the node is a method which has `thisArg`.
+ * @returns {boolean} Whether or not the node is a method which expects a function as a first argument, and `thisArg` as a second argument.
  */
 function isMethodWhichHasThisArg(node) {
-    return isSpecificMemberAccess(node, null, arrayMethodPattern);
+    return isSpecificMemberAccess(node, null, methodWithThisArgPattern);
 }
 
 /**

--- a/tests/lib/rules/no-eval.js
+++ b/tests/lib/rules/no-eval.js
@@ -57,6 +57,11 @@ ruleTester.run("no-eval", rule, {
         { code: "class A { field = () => this.eval(); }", parserOptions: { ecmaVersion: 2022 } },
         { code: "class A { static { this.eval(); } }", parserOptions: { ecmaVersion: 2022 } },
 
+        // User-defined this.eval in callbacks
+        "array.findLast(function (x) { return this.eval.includes(x); }, { eval: ['foo', 'bar'] });",
+        "callbacks.findLastIndex(function (cb) { return cb(this.eval); }, this);",
+        "['1+1'].flatMap(function (str) { return this.eval(str); }, new Evaluator);",
+
         // Allows indirect eval
         { code: "(0, eval)('foo')", options: [{ allowIndirect: true }] },
         { code: "(0, window.eval)('foo')", options: [{ allowIndirect: true }], env: { browser: true } },
@@ -161,6 +166,25 @@ ruleTester.run("no-eval", rule, {
         {
             code: "function foo() { 'use strict'; this.eval(); }",
             parserOptions: { ecmaVersion: 3 },
+            errors: [{ messageId: "unexpected" }]
+        },
+
+        // this.eval in callbacks (not user-defined)
+        {
+            code: "array.findLast(x => this.eval.includes(x), { eval: 'abc' });",
+            parserOptions: { ecmaVersion: 2023 },
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "callbacks.findLastIndex(function (cb) { return cb(eval); }, this);",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "['1+1'].flatMap(function (str) { return this.eval(str); });",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "['1'].reduce(function (a, b) { return this.eval(a) ? a : b; }, '0');",
             errors: [{ messageId: "unexpected" }]
         }
     ]

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -474,103 +474,47 @@ const patterns = [
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
-    {
-        code: "foo.every(function() { console.log(this); z(x => console.log(x, this)); });",
+    ...[
+        "every",
+        "filter",
+        "find",
+        "findIndex",
+        "findLast",
+        "findLastIndex",
+        "flatMap",
+        "forEach",
+        "map",
+        "some"
+    ].map(methodName => ({
+        code: `foo.${methodName}(function() { console.log(this); z(x => console.log(x, this)); });`,
         parserOptions: { ecmaVersion: 6 },
         errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
-    },
-    {
-        code: "foo.filter(function() { console.log(this); z(x => console.log(x, this)); });",
-        parserOptions: { ecmaVersion: 6 },
-        errors,
-        valid: [NORMAL],
-        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
-    },
-    {
-        code: "foo.find(function() { console.log(this); z(x => console.log(x, this)); });",
-        parserOptions: { ecmaVersion: 6 },
-        errors,
-        valid: [NORMAL],
-        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
-    },
-    {
-        code: "foo.findIndex(function() { console.log(this); z(x => console.log(x, this)); });",
-        parserOptions: { ecmaVersion: 6 },
-        errors,
-        valid: [NORMAL],
-        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
-    },
-    {
-        code: "foo.forEach(function() { console.log(this); z(x => console.log(x, this)); });",
-        parserOptions: { ecmaVersion: 6 },
-        errors,
-        valid: [NORMAL],
-        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
-    },
-    {
-        code: "foo.map(function() { console.log(this); z(x => console.log(x, this)); });",
-        parserOptions: { ecmaVersion: 6 },
-        errors,
-        valid: [NORMAL],
-        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
-    },
-    {
-        code: "foo.some(function() { console.log(this); z(x => console.log(x, this)); });",
-        parserOptions: { ecmaVersion: 6 },
-        errors,
-        valid: [NORMAL],
-        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
-    },
+    })),
     {
         code: "Array.from([], function() { console.log(this); z(x => console.log(x, this)); }, obj);",
         parserOptions: { ecmaVersion: 6 },
         valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
         invalid: []
     },
-    {
-        code: "foo.every(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+    ...[
+        "every",
+        "filter",
+        "find",
+        "findIndex",
+        "findLast",
+        "findLastIndex",
+        "flatMap",
+        "forEach",
+        "map",
+        "some"
+    ].map(methodName => ({
+        code: `foo.${methodName}(function() { console.log(this); z(x => console.log(x, this)); }, obj);`,
         parserOptions: { ecmaVersion: 6 },
         valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
         invalid: []
-    },
-    {
-        code: "foo.filter(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
-        parserOptions: { ecmaVersion: 6 },
-        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
-        invalid: []
-    },
-    {
-        code: "foo.find(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
-        parserOptions: { ecmaVersion: 6 },
-        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
-        invalid: []
-    },
-    {
-        code: "foo.findIndex(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
-        parserOptions: { ecmaVersion: 6 },
-        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
-        invalid: []
-    },
-    {
-        code: "foo.forEach(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
-        parserOptions: { ecmaVersion: 6 },
-        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
-        invalid: []
-    },
-    {
-        code: "foo.map(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
-        parserOptions: { ecmaVersion: 6 },
-        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
-        invalid: []
-    },
-    {
-        code: "foo.some(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
-        parserOptions: { ecmaVersion: 6 },
-        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
-        invalid: []
-    },
+    })),
     {
         code: "foo.forEach(function() { console.log(this); z(x => console.log(x, this)); }, null);",
         parserOptions: { ecmaVersion: 6 },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

`no-eval` and `no-invalid-this`

**What change do you want to make (place an "X" next to just one item)?**

[ ] Generate more warnings
[X] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[ ] A new option
[X] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
/* eslint no-eval: error */
array.findLast(function (x) { return this.eval.includes(x); }, { eval: ['foo', 'bar'] });

/* eslint no-invalid-this: error */
array.flatMap(function(value) { "use strict"; return this.doSomething(value); }, obj);
```

[**Playground Link**](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWV2YWw6IGVycm9yICovXG5hcnJheS5maW5kTGFzdChmdW5jdGlvbiAoeCkgeyByZXR1cm4gdGhpcy5ldmFsLmluY2x1ZGVzKHgpOyB9LCB7IGV2YWw6IFsnZm9vJywgJ2JhciddIH0pO1xuXG4vKiBlc2xpbnQgbm8taW52YWxpZC10aGlzOiBlcnJvciAqL1xuYXJyYXkuZmxhdE1hcChmdW5jdGlvbih2YWx1ZSkgeyBcInVzZSBzdHJpY3RcIjsgcmV0dXJuIHRoaXMuZG9Tb21ldGhpbmcodmFsdWUpOyB9LCBvYmopOyIsIm9wdGlvbnMiOnsiZW52Ijp7ImVzNiI6dHJ1ZX0sInJ1bGVzIjp7fSwicGFyc2VyT3B0aW9ucyI6eyJlY21hRmVhdHVyZXMiOnt9LCJlY21hVmVyc2lvbiI6ImxhdGVzdCIsInNvdXJjZVR5cGUiOiJzY3JpcHQifX19)

Find more examples in the [updated unit tests](https://github.com/eslint/eslint/pull/17439/files).

**What does the rule currently do for this code?**

Report an error for each rule.

**What will the rule do after it's changed?**

Report no error.

#### What changes did you make? (Give an overview)

This PR updates a shared regex in `ast-utils.js` to add support for method names that were added to the spec since ES2019.

The regex is used in the rules `no-eval` and `no-invalid-this` to avoid flagging some special cases, trivially relying on the name of a method being called.
So the net effect of this PR will be less problems reported by those two rules.

The updated regex is intended to match names of built-in methods that expect a callback function as a first argument, and the value bound to `this` in calls to the callback as a second argument.
These are mostly methods of arrays and typed arrays, although `forEach` is also defined on sets and maps.

The new method names in this PR are:

* `findLast` (added in ES2023 to [`Array.prototype`](https://262.ecma-international.org/14.0/#sec-array.prototype.findlast) and [`TypedArray.prototype`](https://262.ecma-international.org/14.0/#sec-%typedarray%.prototype.findlast))
* `findLastIndex` (added in ES2023 to [`Array.prototype`](https://262.ecma-international.org/14.0/#sec-array.prototype.findlastindex) and [`TypedArray.prototype`](https://262.ecma-international.org/14.0/#sec-%typedarray%.prototype.findlastindex))
* `flatMap` (added in ES2019 to [`Array.prototype`](https://262.ecma-international.org/10.0/#sec-array.prototype.flatmap))

I've also renamed the regex for more clarity and added unit tests for the `no-eval` rule and extended the tests for `no-invalid-this`.

#### Is there anything you'd like reviewers to focus on?

* Should this be tagged `fix` or `feat`?
* The shared function `astUtils.isDefaultThisBinding` is currently only tested indirectly. Do we need any specific unit tests?