### PR TITLE
fix: do not report on shadowed constructors in `no-new-wrappers`

### DIFF
--- a/lib/rules/no-new-wrappers.js
+++ b/lib/rules/no-new-wrappers.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { getVariableByName } = require("./utils/ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -28,18 +34,24 @@ module.exports = {
     },
 
     create(context) {
+        const { sourceCode } = context;
 
         return {
 
             NewExpression(node) {
                 const wrapperObjects = ["String", "Number", "Boolean"];
+                const { name } = node.callee;
 
-                if (wrapperObjects.includes(node.callee.name)) {
-                    context.report({
-                        node,
-                        messageId: "noConstructor",
-                        data: { fn: node.callee.name }
-                    });
+                if (wrapperObjects.includes(name)) {
+                    const variable = getVariableByName(sourceCode.getScope(node), name);
+
+                    if (variable && variable.identifiers.length === 0) {
+                        context.report({
+                            node,
+                            messageId: "noConstructor",
+                            data: { fn: name }
+                        });
+                    }
                 }
             }
         };

--- a/tests/lib/rules/no-new-wrappers.js
+++ b/tests/lib/rules/no-new-wrappers.js
@@ -21,7 +21,26 @@ const ruleTester = new RuleTester();
 ruleTester.run("no-new-wrappers", rule, {
     valid: [
         "var a = new Object();",
-        "var a = String('test'), b = String.fromCharCode(32);"
+        "var a = String('test'), b = String.fromCharCode(32);",
+        `
+        function test(Number) {
+            return new Number;
+        }
+        `,
+        {
+            code: `
+            import String from "./string";
+            const str = new String(42);
+            `,
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        `
+        if (foo) {
+            result = new Boolean(bar);
+        } else {
+            var Boolean = CustomBoolean;
+        }
+        `
     ],
     invalid: [
         {
@@ -52,6 +71,24 @@ ruleTester.run("no-new-wrappers", rule, {
                     fn: "Boolean"
                 },
                 type: "NewExpression"
+            }]
+        },
+        {
+            code: `
+            const a = new String('bar');
+            {
+                const String = CustomString;
+                const b = new String('foo');
+            }
+            `,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "noConstructor",
+                data: {
+                    fn: "String"
+                },
+                type: "NewExpression",
+                line: 2
             }]
         }
     ]

--- a/tests/lib/rules/no-new-wrappers.js
+++ b/tests/lib/rules/no-new-wrappers.js
@@ -40,6 +40,16 @@ ruleTester.run("no-new-wrappers", rule, {
         } else {
             var Boolean = CustomBoolean;
         }
+        `,
+        {
+            code: "new String()",
+            globals: {
+                String: "off"
+            }
+        },
+        `
+        /* global Boolean:off */
+        assert(new Boolean);
         `
     ],
     invalid: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v20.5.0
npm version: v9.8.0
Local ESLint version: v8.46.0 (Currently used)
Global ESLint version: Not found
Operating System: darwin 22.5.0

**What parser are you using (place an "X" next to just one item)?**

[X] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
        ecmaVersion: "latest",
        sourceType: "module"
    },
    rules: { "no-new-wrappers": "error" }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint no-new-wrappers: error */

import String from "./string";
const str = new String(42);

function test(Number) {
  return new Number;
}

if (foo) {
  result = new Boolean(bar);
} else {
  var Boolean = CustomBoolean;
}
```

**[Playground Link](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLW5ldy13cmFwcGVyczogZXJyb3IgKi9cblxuaW1wb3J0IFN0cmluZyBmcm9tIFwiLi9zdHJpbmdcIjtcbmNvbnN0IHN0ciA9IG5ldyBTdHJpbmcoNDIpO1xuXG5mdW5jdGlvbiB0ZXN0KE51bWJlcikge1xuICByZXR1cm4gbmV3IE51bWJlcjtcbn1cblxuaWYgKGZvbykge1xuICByZXN1bHQgPSBuZXcgQm9vbGVhbihiYXIpO1xufSBlbHNlIHtcbiAgdmFyIEJvb2xlYW4gPSBDdXN0b21Cb29sZWFuO1xufSIsIm9wdGlvbnMiOnsiZW52Ijp7ImVzNiI6dHJ1ZX0sInJ1bGVzIjp7fSwicGFyc2VyT3B0aW9ucyI6eyJlY21hRmVhdHVyZXMiOnt9LCJlY21hVmVyc2lvbiI6ImxhdGVzdCIsInNvdXJjZVR5cGUiOiJtb2R1bGUifX19)**

**What did you expect to happen?**

The `no-new-wrappers` rule should not report any problems because `String`, `Number` and `Boolean` are all shadowed in the above code.

**What actually happened? Please include the actual, raw output from ESLint.**

Each new-expression is reporting an error:

> 4:13 Do not use String as a constructor.  ([no-new-wrappers](https://eslint.org/docs/rules/no-new-wrappers))
> 7:10 Do not use Number as a constructor.  ([no-new-wrappers](https://eslint.org/docs/rules/no-new-wrappers))
> 11:12 Do not use Boolean as a constructor.  ([no-new-wrappers](https://eslint.org/docs/rules/no-new-wrappers))

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I've added a check to the `no-new-wrappers` rule to make sure that shadowed or undefined constructor names no longer trigger a report.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
