### PR TITLE
fix: no-lone-blocks wont flag blocks followed by break in switch-case

### DIFF
--- a/lib/rules/no-lone-blocks.js
+++ b/lib/rules/no-lone-blocks.js
@@ -62,7 +62,10 @@ module.exports = {
                 node.parent.type === "Program" ||
 
                 // Don't report blocks in switch cases if the block is the only statement of the case.
-                node.parent.type === "SwitchCase" && !(node.parent.consequent[0] === node && node.parent.consequent.length === 1);
+                node.parent.type === "SwitchCase" &&
+                !(node.parent.consequent[0] === node && node.parent.consequent.length === 1) &&
+                !(node.parent.consequent.length === 2 && node.parent.consequent[0] === node &&
+                  node.parent.consequent[1].type === "BreakStatement");
         }
 
         /**

--- a/tests/lib/rules/no-lone-blocks.js
+++ b/tests/lib/rules/no-lone-blocks.js
@@ -57,6 +57,15 @@ ruleTester.run("no-lone-blocks", rule, {
             }
           }
         `,
+        `
+          switch (foo) {
+            case bar: {
+              boop;
+            }
+            break;
+            default: break;
+          }
+        `,
         { code: "function foo() { { const x = 4 } const x = 3 }", parserOptions: { ecmaVersion: 6 } },
 
         { code: "class C { static {} }", parserOptions: { ecmaVersion: 2022 } },


### PR DESCRIPTION
…that are followed by a break

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))

**Tell us about your environment (`npx eslint --env-info`):**

* **Node version:** v18.14.0
* **npm version:** v9.3.1
* **Local ESLint version:** v8.47.0
* **Global ESLint version:** Not found
* **Operating System:**  darwin 22.5.0

**What parser are you using (place an "X" next to just one item)?**

`Default (Espree)`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
{
  rules: { "no-lone-blocks": "error" }
}
```

</details>

**What did you do? Please include the actual source code causing the issue.**

Wrote a switch case like so:

```js
switch (foo) {
  case "bar":
    {
      const one = 1;
      console.log(one);
      // ... 
    }
    break;
    default: break;
}
```

**What did you expect to happen?**

The rule `no-lone-blocks` should **not** have been reported on the `BlockStatement` inside the switch case.

Yes, it's possible to move the `break` inside the block and leave the behavior untouched, but I think that the linter should identify and ignore this particular case since it's a common pattern.

**What actually happened? Please include the actual, raw output from ESLint.**

The `no-lone-blocks` lint was raised here:

<img width="460" alt="Screenshot 2023-08-16 at 2 28 30 PM" src="https://github.com/eslint/eslint/assets/50487716/5ad2211f-ca2e-40b1-908d-e85ad1d3e66c">

#### What changes did you make? (Give an overview)

Add a check in the rule that confirms if the block-statement inside a switch-case is followed by a single break statement, and nothing else

#### Is there anything you'd like reviewers to focus on?

Nothing in particular, since it's a small change.
Though, I'd like to be wary of any edge cases that I might have left out.

<!-- markdownlint-disable-file MD004 -->
