### PR TITLE
feat: rule tester do not create empty valid or invalid test suites

### DIFF
--- a/lib/rule-tester/flat-rule-tester.js
+++ b/lib/rule-tester/flat-rule-tester.js
@@ -1011,29 +1011,35 @@ class FlatRuleTester {
         /*
          * This creates a mocha test suite and pipes all supplied info through
          * one of the templates above.
+         * The test suites for valid/invalid are created conditionally as
+         * test runners (eg. vitest) fail for empty test suites.
          */
         this.constructor.describe(ruleName, () => {
-            this.constructor.describe("valid", () => {
-                test.valid.forEach(valid => {
-                    this.constructor[valid.only ? "itOnly" : "it"](
-                        sanitize(typeof valid === "object" ? valid.name || valid.code : valid),
-                        () => {
-                            testValidTemplate(valid);
-                        }
-                    );
+            if (test.valid.length > 0) {
+                this.constructor.describe("valid", () => {
+                    test.valid.forEach(valid => {
+                        this.constructor[valid.only ? "itOnly" : "it"](
+                            sanitize(typeof valid === "object" ? valid.name || valid.code : valid),
+                            () => {
+                                testValidTemplate(valid);
+                            }
+                        );
+                    });
                 });
-            });
+            }
 
-            this.constructor.describe("invalid", () => {
-                test.invalid.forEach(invalid => {
-                    this.constructor[invalid.only ? "itOnly" : "it"](
-                        sanitize(invalid.name || invalid.code),
-                        () => {
-                            testInvalidTemplate(invalid);
-                        }
-                    );
+            if (test.invalid.length > 0) {
+                this.constructor.describe("invalid", () => {
+                    test.invalid.forEach(invalid => {
+                        this.constructor[invalid.only ? "itOnly" : "it"](
+                            sanitize(invalid.name || invalid.code),
+                            () => {
+                                testInvalidTemplate(invalid);
+                            }
+                        );
+                    });
                 });
-            });
+            }
         });
     }
 }

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -1021,29 +1021,35 @@ class RuleTester {
         /*
          * This creates a mocha test suite and pipes all supplied info through
          * one of the templates above.
+         * The test suites for valid/invalid are created conditionally as
+         * test runners (eg. vitest) fail for empty test suites.
          */
         this.constructor.describe(ruleName, () => {
-            this.constructor.describe("valid", () => {
-                test.valid.forEach(valid => {
-                    this.constructor[valid.only ? "itOnly" : "it"](
-                        sanitize(typeof valid === "object" ? valid.name || valid.code : valid),
-                        () => {
-                            testValidTemplate(valid);
-                        }
-                    );
+            if (test.valid.length > 0) {
+                this.constructor.describe("valid", () => {
+                    test.valid.forEach(valid => {
+                        this.constructor[valid.only ? "itOnly" : "it"](
+                            sanitize(typeof valid === "object" ? valid.name || valid.code : valid),
+                            () => {
+                                testValidTemplate(valid);
+                            }
+                        );
+                    });
                 });
-            });
+            }
 
-            this.constructor.describe("invalid", () => {
-                test.invalid.forEach(invalid => {
-                    this.constructor[invalid.only ? "itOnly" : "it"](
-                        sanitize(invalid.name || invalid.code),
-                        () => {
-                            testInvalidTemplate(invalid);
-                        }
-                    );
+            if (test.invalid.length > 0) {
+                this.constructor.describe("invalid", () => {
+                    test.invalid.forEach(invalid => {
+                        this.constructor[invalid.only ? "itOnly" : "it"](
+                            sanitize(invalid.name || invalid.code),
+                            () => {
+                                testInvalidTemplate(invalid);
+                            }
+                        );
+                    });
                 });
-            });
+            }
         });
     }
 }

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -2651,7 +2651,7 @@ describe("FlatRuleTester", () => {
             sinon.assert.calledWith(spyRuleTesterDescribe, "no-var");
         });
 
-        it("should create a valid test suite if there are is a valid test cases", () => {
+        it("should create a valid test suite if there is a valid test case", () => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: ["value = 0;"],
                 invalid: []
@@ -2667,7 +2667,7 @@ describe("FlatRuleTester", () => {
             sinon.assert.neverCalledWith(spyRuleTesterDescribe, "valid");
         });
 
-        it("should create a valid test suite if there is an invalid test cases", () => {
+        it("should create a valid test suite if there is an invalid test case", () => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: ["value = 0;"],
                 invalid: [
@@ -2681,7 +2681,7 @@ describe("FlatRuleTester", () => {
             sinon.assert.calledWith(spyRuleTesterDescribe, "invalid");
         });
 
-        it("should not create a invalid test suite if there are no invalid test cases", () => {
+        it("should not create an invalid test suite if there are no invalid test cases", () => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: ["value = 0;"],
                 invalid: []

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -2673,9 +2673,9 @@ describe("FlatRuleTester", () => {
             sinon.assert.neverCalledWith(spyRuleTesterDescribe, "valid");
         });
 
-        it("should create a valid test suite if there is an invalid test case", () => {
+        it("should create an invalid test suite if there is an invalid test case", () => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
-                valid: ["value = 0;"],
+                valid: [],
                 invalid: [
                     {
                         code: "var value = 0;",

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -2626,4 +2626,67 @@ describe("FlatRuleTester", () => {
 
     });
 
+    describe("Optional Test Suites", () => {
+        let originalRuleTesterDescribe;
+        let spyRuleTesterDescribe;
+
+        before(() => {
+            originalRuleTesterDescribe = FlatRuleTester.describe;
+            spyRuleTesterDescribe = sinon.spy((title, callback) => callback());
+            FlatRuleTester.describe = spyRuleTesterDescribe;
+        });
+        after(() => {
+            FlatRuleTester.describe = originalRuleTesterDescribe;
+        });
+        beforeEach(() => {
+            spyRuleTesterDescribe.resetHistory();
+            ruleTester = new FlatRuleTester();
+        });
+
+        it("should create a test suite with the rule name even if there are no test cases", () => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [],
+                invalid: []
+            });
+            sinon.assert.calledWith(spyRuleTesterDescribe, "no-var");
+        });
+
+        it("should create a valid test suite if there are is a valid test cases", () => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: ["value = 0;"],
+                invalid: []
+            });
+            sinon.assert.calledWith(spyRuleTesterDescribe, "valid");
+        });
+
+        it("should not create a valid test suite if there are no valid test cases", () => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [],
+                invalid: []
+            });
+            sinon.assert.neverCalledWith(spyRuleTesterDescribe, "valid");
+        });
+
+        it("should create a valid test suite if there is an invalid test cases", () => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: ["value = 0;"],
+                invalid: [
+                    {
+                        code: "var value = 0;",
+                        errors: [/^Bad var/u],
+                        output: " value = 0;"
+                    }
+                ]
+            });
+            sinon.assert.calledWith(spyRuleTesterDescribe, "invalid");
+        });
+
+        it("should not create a invalid test suite if there are no invalid test cases", () => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: ["value = 0;"],
+                invalid: []
+            });
+            sinon.assert.neverCalledWith(spyRuleTesterDescribe, "invalid");
+        });
+    });
 });

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -2662,7 +2662,13 @@ describe("FlatRuleTester", () => {
         it("should not create a valid test suite if there are no valid test cases", () => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
-                invalid: []
+                invalid: [
+                    {
+                        code: "var value = 0;",
+                        errors: [/^Bad var/u],
+                        output: " value = 0;"
+                    }
+                ]
             });
             sinon.assert.neverCalledWith(spyRuleTesterDescribe, "valid");
         });

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2917,16 +2917,10 @@ describe("RuleTester", () => {
             sinon.assert.neverCalledWith(spyRuleTesterDescribe, "valid");
         });
 
-        it("should create a valid test suite if there is an invalid test case", () => {
+        it("should create an invalid test suite if there is an invalid test case", () => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: ["value = 0;"],
-                invalid: [
-                    {
-                        code: "var value = 0;",
-                        errors: [/^Bad var/u],
-                        output: " value = 0;"
-                    }
-                ]
+                invalid: []
             });
             sinon.assert.calledWith(spyRuleTesterDescribe, "invalid");
         });

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2906,7 +2906,13 @@ describe("RuleTester", () => {
         it("should not create a valid test suite if there are no valid test cases", () => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [],
-                invalid: []
+                invalid: [
+                    {
+                        code: "var value = 0;",
+                        errors: [/^Bad var/u],
+                        output: " value = 0;"
+                    }
+                ]
             });
             sinon.assert.neverCalledWith(spyRuleTesterDescribe, "valid");
         });

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2919,8 +2919,14 @@ describe("RuleTester", () => {
 
         it("should create an invalid test suite if there is an invalid test case", () => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
-                valid: ["value = 0;"],
-                invalid: []
+                valid: [],
+                invalid: [
+                    {
+                        code: "var value = 0;",
+                        errors: [/^Bad var/u],
+                        output: " value = 0;"
+                    }
+                ]
             });
             sinon.assert.calledWith(spyRuleTesterDescribe, "invalid");
         });

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2895,7 +2895,7 @@ describe("RuleTester", () => {
             sinon.assert.calledWith(spyRuleTesterDescribe, "no-var");
         });
 
-        it("should create a valid test suite if there are is a valid test cases", () => {
+        it("should create a valid test suite if there is a valid test case", () => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: ["value = 0;"],
                 invalid: []
@@ -2911,7 +2911,7 @@ describe("RuleTester", () => {
             sinon.assert.neverCalledWith(spyRuleTesterDescribe, "valid");
         });
 
-        it("should create a valid test suite if there is an invalid test cases", () => {
+        it("should create a valid test suite if there is an invalid test case", () => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: ["value = 0;"],
                 invalid: [
@@ -2925,7 +2925,7 @@ describe("RuleTester", () => {
             sinon.assert.calledWith(spyRuleTesterDescribe, "invalid");
         });
 
-        it("should not create a invalid test suite if there are no invalid test cases", () => {
+        it("should not create an invalid test suite if there are no invalid test cases", () => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: ["value = 0;"],
                 invalid: []

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2870,4 +2870,67 @@ describe("RuleTester", () => {
 
     });
 
+    describe("Optional Test Suites", () => {
+        let originalRuleTesterDescribe;
+        let spyRuleTesterDescribe;
+
+        before(() => {
+            originalRuleTesterDescribe = RuleTester.describe;
+            spyRuleTesterDescribe = sinon.spy((title, callback) => callback());
+            RuleTester.describe = spyRuleTesterDescribe;
+        });
+        after(() => {
+            RuleTester.describe = originalRuleTesterDescribe;
+        });
+        beforeEach(() => {
+            spyRuleTesterDescribe.resetHistory();
+            ruleTester = new RuleTester();
+        });
+
+        it("should create a test suite with the rule name even if there are no test cases", () => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [],
+                invalid: []
+            });
+            sinon.assert.calledWith(spyRuleTesterDescribe, "no-var");
+        });
+
+        it("should create a valid test suite if there are is a valid test cases", () => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: ["value = 0;"],
+                invalid: []
+            });
+            sinon.assert.calledWith(spyRuleTesterDescribe, "valid");
+        });
+
+        it("should not create a valid test suite if there are no valid test cases", () => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [],
+                invalid: []
+            });
+            sinon.assert.neverCalledWith(spyRuleTesterDescribe, "valid");
+        });
+
+        it("should create a valid test suite if there is an invalid test cases", () => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: ["value = 0;"],
+                invalid: [
+                    {
+                        code: "var value = 0;",
+                        errors: [/^Bad var/u],
+                        output: " value = 0;"
+                    }
+                ]
+            });
+            sinon.assert.calledWith(spyRuleTesterDescribe, "invalid");
+        });
+
+        it("should not create a invalid test suite if there are no invalid test cases", () => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: ["value = 0;"],
+                invalid: []
+            });
+            sinon.assert.neverCalledWith(spyRuleTesterDescribe, "invalid");
+        });
+    });
 });


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)
[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: RuleTester no longer creates empty `valid` or `invalid` test suites

#### What changes did you make? (Give an overview)
Fix #17455 by only calling `RuleTester.describe` for `valid` and `invalid` if they have respective test cases.
The outer test suite with the rule name is always created even if there are no valid or invalid test cases as the `RuleTester#run` call is useless then.

#### Is there anything you'd like reviewers to focus on?
No

<!-- markdownlint-disable-file MD004 -->
