### PR TITLE
feat: public FlatESLint nodejs API

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -9,7 +9,7 @@
 // Requirements
 //-----------------------------------------------------------------------------
 
-const { ESLint } = require("./eslint");
+const { ESLint, FlatESLint } = require("./eslint");
 const { Linter } = require("./linter");
 const { RuleTester } = require("./rule-tester");
 const { SourceCode } = require("./source-code");
@@ -21,6 +21,7 @@ const { SourceCode } = require("./source-code");
 module.exports = {
     Linter,
     ESLint,
+    FlatESLint,
     RuleTester,
     SourceCode
 };


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other: Flat config is being public and being easy to migrate to for about a year. But there is an issue: when you opt in flat config, you cannot use nodejs API anymore.


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make?
Just a single line of code making some part of API public. Flat config is being public in CLI, docs and probably other parts for a long time, but not in NodeJS API.

#### Is there anything you'd like reviewers to focus on?

My usecase: https://stackoverflow.com/a/73818629/11858171
```
import { FlatESLint } from "eslint";

async function removeIgnoredFiles(files) {
	const eslint = new FlatESLint();
	const ignoredFiles = await Promise.all(
		files.map((file) => eslint.isPathIgnored(file)),
	);
	const filteredFiles = files.filter((_, i) => !ignoredFiles[i]);
	return filteredFiles.join(" ");
}

function buildEslintCommand(commandToRun) {
	return async (stagedFiles) => {
		const stagedAndNotIgnoredFiles = await removeIgnoredFiles(stagedFiles);
		return `${commandToRun} ${stagedAndNotIgnoredFiles}`;
	};
}

export default {
	"*.{svelte,?(m|c)(j|t)s}": [buildEslintCommand("pnpm lint:_eslint")],
};
```

<!-- markdownlint-disable-file MD004 -->
