### PR TITLE
fix: RuleTester JSDoc and deprecations

### DIFF
--- a/lib/rule-tester/flat-rule-tester.js
+++ b/lib/rule-tester/flat-rule-tester.js
@@ -32,7 +32,7 @@ const { ConfigArraySymbol } = require("@humanwhocodes/config-array");
 
 /** @typedef {import("../shared/types").Parser} Parser */
 /** @typedef {import("../shared/types").LanguageOptions} LanguageOptions */
-/** @typedef {import("../shared/types").Rule} Parser */
+/** @typedef {import("../shared/types").Rule} Rule */
 
 
 /**

--- a/lib/rule-tester/flat-rule-tester.js
+++ b/lib/rule-tester/flat-rule-tester.js
@@ -32,6 +32,7 @@ const { ConfigArraySymbol } = require("@humanwhocodes/config-array");
 
 /** @typedef {import("../shared/types").Parser} Parser */
 /** @typedef {import("../shared/types").LanguageOptions} LanguageOptions */
+/** @typedef {import("../shared/types").Rule} Parser */
 
 
 /**
@@ -446,7 +447,7 @@ class FlatRuleTester {
     /**
      * Adds a new rule test to execute.
      * @param {string} ruleName The name of the rule to run.
-     * @param {Function} rule The rule to test.
+     * @param {Function | Rule} rule The rule to test.
      * @param {{
      *   valid: (ValidTestCase | string)[],
      *   invalid: InvalidTestCase[]

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -514,6 +514,9 @@ class RuleTester {
      * @returns {void}
      */
     defineRule(name, rule) {
+        if (typeof rule === "function") {
+            emitLegacyRuleAPIWarning(name);
+        }
         this.rules[name] = rule;
     }
 

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -109,6 +109,8 @@ const { SourceCode } = require("../source-code");
  * @property {number} [endColumn] The 1-based column number of the reported end location.
  */
 
+/** @typedef {import("../shared/types").Rule} Rule */
+
 //------------------------------------------------------------------------------
 // Private Members
 //------------------------------------------------------------------------------
@@ -508,7 +510,7 @@ class RuleTester {
     /**
      * Define a rule for one particular run of tests.
      * @param {string} name The name of the rule to define.
-     * @param {Function} rule The rule definition.
+     * @param {Function | Rule} rule The rule definition.
      * @returns {void}
      */
     defineRule(name, rule) {
@@ -518,7 +520,7 @@ class RuleTester {
     /**
      * Adds a new rule test to execute.
      * @param {string} ruleName The name of the rule to run.
-     * @param {Function} rule The rule to test.
+     * @param {Function | Rule} rule The rule to test.
      * @param {{
      *   valid: (ValidTestCase | string)[],
      *   invalid: InvalidTestCase[]

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -62,6 +62,7 @@ const { SourceCode } = require("../source-code");
 //------------------------------------------------------------------------------
 
 /** @typedef {import("../shared/types").Parser} Parser */
+/** @typedef {import("../shared/types").Rule} Rule */
 
 
 /**
@@ -108,8 +109,6 @@ const { SourceCode } = require("../source-code");
  * @property {number} [endLine] The 1-based line number of the reported end location.
  * @property {number} [endColumn] The 1-based column number of the reported end location.
  */
-
-/** @typedef {import("../shared/types").Rule} Rule */
 
 //------------------------------------------------------------------------------
 // Private Members


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

Without this fix, I get a misguided warning in IntelliJ IDEA that the "new-style" rule defintition on line 14 from [this example in the documentation](https://eslint.org/docs/latest/extend/custom-rule-tutorial#step-6-write-the-test) does not match the type `Function`  — it should accept both the legacy `Function` and new style, object-based `Rule` definitions.

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**Tell us about your environment (`npx eslint --env-info`):**
* Node version: v18.13.0
* npm version: v8.19.3
* Local ESLint version: v8.47.0 (Currently used)
* Global ESLint version: Not found
* Operating System: linux 6.4.11-100.fc37.x86_64

**What parser are you using (place an "X" next to just one item)?**

[X] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>
See https://eslint.org/docs/latest/extend/custom-rule-tutorial
</details>

**What did you do? Please include the actual source code causing the issue.**

See https://eslint.org/docs/latest/extend/custom-rule-tutorial

**What did you expect to happen?**

The example code should not generate this kind of warning in IntelliJ IDEA.

**What actually happened? Please include the actual, raw output from ESLint.**

IntelliJ IDEA (and other JSDoc-supporting source code editors) warns about an incorrect function argument when the JSDoc definition actually only allows the deprecated old-style rule definition.

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the JSDoc to support the new-style rule definition as well. Also updated a neighbouring function the same way and copy-pasted the check for legacy rule definitions from the run() function source code.

#### Is there anything you'd like reviewers to focus on?

I have not checked any other files than the one I modified for similar issues.
<!-- markdownlint-disable-file MD004 -->
