### PR TITLE
docs: add typescript template

### DIFF
--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -27,7 +27,7 @@ layout: base.html
             </p>
             {% if extra_typescript_info %}
                 <p>
-                    {{ extra_typescript_info | markdown }}
+                    {{ extra_typescript_info | markdown | safe }}
                 </p>
             {% endif %}
         {% endset %}

--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -27,7 +27,7 @@ layout: base.html
             </p>
             {% if extra_typescript_info %}
                 <p>
-                    {{ extra_typescript_info }}
+                    {{ extra_typescript_info | markdown }}
                 </p>
             {% endif %}
         {% endset %}

--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -22,11 +22,14 @@ layout: base.html
     {% if handled_by_typescript %}
         {% set handled_by_typescript_content %}
             <h2 id="handled_by_typescript">Handled by TypeScript</h2>
-            It is safe to disable this rule when using TypeScript because TypeScript's compiler enforces this check (
-            {%- for code in handled_by_typescript -%}
-                <code>ts({{ code }})</code>{% if not loop.last %} & {% endif %}
-            {%- endfor -%}
-            ).
+            <p>
+                It is safe to disable this rule when using TypeScript because TypeScript's compiler enforces this check.
+            </p>
+            {% if extra_typescript_info %}
+                <p>
+                    {{ extra_typescript_info }}
+                </p>
+            {% endif %}
         {% endset %}
 
         {% set all_content = [all_content, handled_by_typescript_content] | join %}

--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -19,6 +19,19 @@ layout: base.html
     {% set added_version = rule_versions.added[title] %}
     {% set removed_version = rule_versions.removed[title] %}
 
+    {% if handled_by_typescript %}
+        {% set handled_by_typescript_content %}
+            <h2 id="handled_by_typescript">Handled by TypeScript</h2>
+            It is safe to disable this rule when using TypeScript because TypeScript's compiler enforces this check (
+            {%- for code in handled_by_typescript -%}
+                <code>ts({{ code }})</code>{% if not loop.last %} & {% endif %}
+            {%- endfor -%}
+            ).
+        {% endset %}
+
+        {% set all_content = [all_content, handled_by_typescript_content] | join %}
+    {% endif %}
+
     {% if related_rules %}
         {% set related_rules_content %}
             <h2 id="related-rules">Related Rules</h2>
@@ -48,7 +61,7 @@ layout: base.html
 
         {% set all_content = [all_content, further_reading_content] | join %}
     {% endif %}
-        
+
     {% if rule_meta %}
         {% set resources_content %}
             <h2 id="resources">Resources</h2>
@@ -76,7 +89,7 @@ layout: base.html
                 {% endif %}
 
                 {% include 'components/docs-toc.html' %}
-                
+
                 {{ all_content | safe }}
             </div>
 
@@ -102,6 +115,7 @@ layout: base.html
             {% include "partials/docs-footer.html" %}
         </div>
     </div>
+
     <a id="scroll-up-btn" href="#site_top">
         <svg fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="24"><line x1="12" x2="12" y1="19" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
     </a>

--- a/docs/src/rules/constructor-super.md
+++ b/docs/src/rules/constructor-super.md
@@ -1,9 +1,7 @@
 ---
 title: constructor-super
 rule_type: problem
-handled_by_typescript:
-- 2335
-- 2377
+handled_by_typescript: true
 ---
 
 Constructors of derived classes must call `super()`.

--- a/docs/src/rules/constructor-super.md
+++ b/docs/src/rules/constructor-super.md
@@ -1,7 +1,12 @@
 ---
 title: constructor-super
 rule_type: problem
+handled_by_typescript:
+- 2335
+- 2377
 ---
+
+
 
 Constructors of derived classes must call `super()`.
 Constructors of non derived classes must not call `super()`.
@@ -69,5 +74,3 @@ class A extends B {
 ## When Not To Use It
 
 If you don't want to be notified about invalid/missing `super()` callings in constructors, you can safely disable this rule.
-
-It is safe to disable this rule when using TypeScript because TypeScript's compiler enforces this check (`ts(2335) & ts(2377)`).

--- a/docs/src/rules/constructor-super.md
+++ b/docs/src/rules/constructor-super.md
@@ -6,8 +6,6 @@ handled_by_typescript:
 - 2377
 ---
 
-
-
 Constructors of derived classes must call `super()`.
 Constructors of non derived classes must not call `super()`.
 If this is not observed, the JavaScript engine will raise a runtime error.

--- a/docs/src/rules/getter-return.md
+++ b/docs/src/rules/getter-return.md
@@ -1,8 +1,7 @@
 ---
 title: getter-return
 rule_type: problem
-handled_by_typescript:
-- 2378
+handled_by_typescript: true
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get
 - https://leanpub.com/understandinges6/read/#leanpub-auto-accessor-properties

--- a/docs/src/rules/getter-return.md
+++ b/docs/src/rules/getter-return.md
@@ -1,6 +1,8 @@
 ---
 title: getter-return
 rule_type: problem
+handled_by_typescript:
+- 2378
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get
 - https://leanpub.com/understandinges6/read/#leanpub-auto-accessor-properties

--- a/docs/src/rules/no-const-assign.md
+++ b/docs/src/rules/no-const-assign.md
@@ -1,8 +1,7 @@
 ---
 title: no-const-assign
 rule_type: problem
-handled_by_typescript:
-- 2588
+handled_by_typescript: true
 ---
 
 

--- a/docs/src/rules/no-const-assign.md
+++ b/docs/src/rules/no-const-assign.md
@@ -1,6 +1,8 @@
 ---
 title: no-const-assign
 rule_type: problem
+handled_by_typescript:
+- 2588
 ---
 
 

--- a/docs/src/rules/no-dupe-args.md
+++ b/docs/src/rules/no-dupe-args.md
@@ -1,6 +1,8 @@
 ---
 title: no-dupe-args
 rule_type: problem
+handled_by_typescript:
+- 2300
 ---
 
 

--- a/docs/src/rules/no-dupe-args.md
+++ b/docs/src/rules/no-dupe-args.md
@@ -1,8 +1,7 @@
 ---
 title: no-dupe-args
 rule_type: problem
-handled_by_typescript:
-- 2300
+handled_by_typescript: true
 ---
 
 

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -6,6 +6,8 @@ handled_by_typescript:
 - 2393
 ---
 
+
+
 If there are declarations of the same name in class members, the last declaration overwrites other declarations silently.
 It can cause unexpected behaviors.
 

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -1,9 +1,7 @@
 ---
 title: no-dupe-class-members
 rule_type: problem
-handled_by_typescript:
-- 2300
-- 2393
+handled_by_typescript: true
 ---
 
 

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -1,9 +1,10 @@
 ---
 title: no-dupe-class-members
 rule_type: problem
+handled_by_typescript:
+- 2300
+- 2393
 ---
-
-
 
 If there are declarations of the same name in class members, the last declaration overwrites other declarations silently.
 It can cause unexpected behaviors.
@@ -101,5 +102,3 @@ class Foo {
 This rule should not be used in ES3/5 environments.
 
 In ES2015 (ES6) or later, if you don't want to be notified about duplicate names in class members, you can safely disable this rule.
-
-It is safe to disable this rule when using TypeScript because TypeScript's compiler enforces this check (`ts(2300) & ts(2393)`).

--- a/docs/src/rules/no-dupe-keys.md
+++ b/docs/src/rules/no-dupe-keys.md
@@ -1,6 +1,8 @@
 ---
 title: no-dupe-keys
 rule_type: problem
+handled_by_typescript:
+- 1117
 ---
 
 

--- a/docs/src/rules/no-dupe-keys.md
+++ b/docs/src/rules/no-dupe-keys.md
@@ -1,8 +1,7 @@
 ---
 title: no-dupe-keys
 rule_type: problem
-handled_by_typescript:
-- 1117
+handled_by_typescript: true
 ---
 
 

--- a/docs/src/rules/no-func-assign.md
+++ b/docs/src/rules/no-func-assign.md
@@ -1,8 +1,7 @@
 ---
 title: no-func-assign
 rule_type: problem
-handled_by_typescript:
-- 2630
+handled_by_typescript: true
 ---
 
 

--- a/docs/src/rules/no-func-assign.md
+++ b/docs/src/rules/no-func-assign.md
@@ -2,7 +2,7 @@
 title: no-func-assign
 rule_type: problem
 handled_by_typescript:
-- 2539
+- 2630
 ---
 
 

--- a/docs/src/rules/no-func-assign.md
+++ b/docs/src/rules/no-func-assign.md
@@ -1,6 +1,8 @@
 ---
 title: no-func-assign
 rule_type: problem
+handled_by_typescript:
+- 2539
 ---
 
 

--- a/docs/src/rules/no-import-assign.md
+++ b/docs/src/rules/no-import-assign.md
@@ -1,6 +1,8 @@
 ---
 title: no-import-assign
 rule_type: problem
+handled_by_typescript: true
+extra_typescript_info: However, note that the compiler will not catch the "Object.assign" case. Thus, if you use "Object.assign" in your codebase, this rule will still provide some miniscule value.
 ---
 
 
@@ -57,5 +59,3 @@ test(mod_ns) // Not errored because it doesn't know that 'test' updates the memb
 ## When Not To Use It
 
 If you don't want to be notified about modifying imported bindings, you can disable this rule.
-
-If you use TypeScript, it is not recommended to use this rule, since the compiler will mostly catch this error (`ts(2632)`). However, note that the compiler does not catch the `Object.assign` case, so this rule still provides some miniscule value.

--- a/docs/src/rules/no-import-assign.md
+++ b/docs/src/rules/no-import-assign.md
@@ -1,6 +1,9 @@
 ---
 title: no-import-assign
 rule_type: problem
+handled_by_typescript:
+- 2539
+- 2540
 ---
 
 

--- a/docs/src/rules/no-import-assign.md
+++ b/docs/src/rules/no-import-assign.md
@@ -2,7 +2,7 @@
 title: no-import-assign
 rule_type: problem
 handled_by_typescript: true
-extra_typescript_info: However, note that the compiler will not catch the "Object.assign" case. Thus, if you use "Object.assign" in your codebase, this rule will still provide some miniscule value.
+extra_typescript_info: Note that the compiler will not catch the `Object.assign()` case. Thus, if you use `Object.assign()` in your codebase, this rule will still provide some value.
 ---
 
 

--- a/docs/src/rules/no-import-assign.md
+++ b/docs/src/rules/no-import-assign.md
@@ -58,4 +58,4 @@ test(mod_ns) // Not errored because it doesn't know that 'test' updates the memb
 
 If you don't want to be notified about modifying imported bindings, you can disable this rule.
 
-Note that if you are using TypeScript, the compiler will partially catch this error (`ts(2539)` & `ts(2540)`). However, it does not catch the `Object.assign` case, so this rule still provides some value to TypeScript users.
+If you use TypeScript, it is not recommended to use this rule, since the compiler will mostly catch this error (`ts(2539)` & `ts(2540)`). However, note that the compiler does not catch the `Object.assign` case, so this rule still provides some miniscule value.

--- a/docs/src/rules/no-import-assign.md
+++ b/docs/src/rules/no-import-assign.md
@@ -58,4 +58,4 @@ test(mod_ns) // Not errored because it doesn't know that 'test' updates the memb
 
 If you don't want to be notified about modifying imported bindings, you can disable this rule.
 
-If you use TypeScript, it is not recommended to use this rule, since the compiler will mostly catch this error (`ts(2539)` & `ts(2540)`). However, note that the compiler does not catch the `Object.assign` case, so this rule still provides some miniscule value.
+If you use TypeScript, it is not recommended to use this rule, since the compiler will mostly catch this error (`ts(2632)`). However, note that the compiler does not catch the `Object.assign` case, so this rule still provides some miniscule value.

--- a/docs/src/rules/no-import-assign.md
+++ b/docs/src/rules/no-import-assign.md
@@ -1,9 +1,6 @@
 ---
 title: no-import-assign
 rule_type: problem
-handled_by_typescript:
-- 2539
-- 2540
 ---
 
 
@@ -60,3 +57,5 @@ test(mod_ns) // Not errored because it doesn't know that 'test' updates the memb
 ## When Not To Use It
 
 If you don't want to be notified about modifying imported bindings, you can disable this rule.
+
+Note that if you are using TypeScript, the compiler will partially catch this error (`ts(2539)` & `ts(2540)`). However, it does not catch the `Object.assign` case, so this rule still provides some value to TypeScript users.

--- a/docs/src/rules/no-invalid-this.md
+++ b/docs/src/rules/no-invalid-this.md
@@ -2,7 +2,7 @@
 title: no-invalid-this
 rule_type: suggestion
 handled_by_typescript: true
-extra_typescript_info: Note that technically, TypeScript will only catch this if you have the "strict" or "noImplicitThis" flags enabled. These are enabled in most TypeScript projects, since they are considered to be best practice.
+extra_typescript_info: Note that, technically, TypeScript will only catch this if you have the `strict` or `noImplicitThis` flags enabled. These are enabled in most TypeScript projects, since they are considered to be best practice.
 ---
 
 

--- a/docs/src/rules/no-invalid-this.md
+++ b/docs/src/rules/no-invalid-this.md
@@ -1,6 +1,8 @@
 ---
 title: no-invalid-this
 rule_type: suggestion
+handled_by_typescript: true
+extra_typescript_info: Note that technically, TypeScript will only catch this if you have the "strict" or "noImplicitThis" flags enabled. These are enabled in most TypeScript projects, since they are considered to be best practice.
 ---
 
 

--- a/docs/src/rules/no-new-symbol.md
+++ b/docs/src/rules/no-new-symbol.md
@@ -1,6 +1,8 @@
 ---
 title: no-new-symbol
 rule_type: problem
+handled_by_typescript:
+- 7009
 further_reading:
 - https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects
 ---

--- a/docs/src/rules/no-new-symbol.md
+++ b/docs/src/rules/no-new-symbol.md
@@ -1,8 +1,7 @@
 ---
 title: no-new-symbol
 rule_type: problem
-handled_by_typescript:
-- 7009
+handled_by_typescript: true
 further_reading:
 - https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects
 ---

--- a/docs/src/rules/no-obj-calls.md
+++ b/docs/src/rules/no-obj-calls.md
@@ -1,8 +1,7 @@
 ---
 title: no-obj-calls
 rule_type: problem
-handled_by_typescript:
-- 2349
+handled_by_typescript: true
 further_reading:
 - https://es5.github.io/#x15.8
 ---

--- a/docs/src/rules/no-obj-calls.md
+++ b/docs/src/rules/no-obj-calls.md
@@ -1,6 +1,8 @@
 ---
 title: no-obj-calls
 rule_type: problem
+handled_by_typescript:
+- 2349
 further_reading:
 - https://es5.github.io/#x15.8
 ---

--- a/docs/src/rules/no-redeclare.md
+++ b/docs/src/rules/no-redeclare.md
@@ -1,6 +1,8 @@
 ---
 title: no-redeclare
 rule_type: suggestion
+handled_by_typescript:
+- 2451
 related_rules:
 - no-shadow
 ---

--- a/docs/src/rules/no-redeclare.md
+++ b/docs/src/rules/no-redeclare.md
@@ -2,7 +2,7 @@
 title: no-redeclare
 rule_type: suggestion
 handled_by_typescript: true
-extra_typescript_info: However, note that while TypeScript will catch `let` redeclares and `const` redeclares, it will not catch `var` redeclares. Thus, if you use the legacy `var` keyword in your TypeScript codebase, this rule will still provide some miniscule value.
+extra_typescript_info: Note that while TypeScript will catch `let` redeclares and `const` redeclares, it will not catch `var` redeclares. Thus, if you use the legacy `var` keyword in your TypeScript codebase, this rule will still provide some value.
 related_rules:
 - no-shadow
 ---

--- a/docs/src/rules/no-redeclare.md
+++ b/docs/src/rules/no-redeclare.md
@@ -1,8 +1,6 @@
 ---
 title: no-redeclare
 rule_type: suggestion
-handled_by_typescript:
-- 2451
 related_rules:
 - no-shadow
 ---

--- a/docs/src/rules/no-redeclare.md
+++ b/docs/src/rules/no-redeclare.md
@@ -101,3 +101,7 @@ var top = 0;
 The `browser` environment has many built-in global variables (for example, `top`). Some of built-in global variables cannot be redeclared.
 
 Note that when using the `node` or `commonjs` environments (or `ecmaFeatures.globalReturn`, if using the default parser), the top scope of a program is not actually the global scope, but rather a "module" scope. When this is the case, declaring a variable named after a builtin global is not a redeclaration, but rather a shadowing of the global variable. In that case, the [`no-shadow`](no-shadow) rule with the `"builtinGlobals"` option should be used.
+
+## When Not To Use It
+
+If you use TypeScript, it is not recommended to use this rule, since the compiler will mostly catch this error (`ts(2451)`). However, note that while the compiler will catch `let` redeclares and `const` redeclares, it will not catch `var` redeclares. Thus, if you use the legacy `var` keyword in your TypeScript codebase, this rule still provides some miniscule value.

--- a/docs/src/rules/no-redeclare.md
+++ b/docs/src/rules/no-redeclare.md
@@ -1,6 +1,8 @@
 ---
 title: no-redeclare
 rule_type: suggestion
+handled_by_typescript: true
+extra_typescript_info: However, note that while TypeScript will catch `let` redeclares and `const` redeclares, it will not catch `var` redeclares. Thus, if you use the legacy `var` keyword in your TypeScript codebase, this rule will still provide some miniscule value.
 related_rules:
 - no-shadow
 ---
@@ -101,7 +103,3 @@ var top = 0;
 The `browser` environment has many built-in global variables (for example, `top`). Some of built-in global variables cannot be redeclared.
 
 Note that when using the `node` or `commonjs` environments (or `ecmaFeatures.globalReturn`, if using the default parser), the top scope of a program is not actually the global scope, but rather a "module" scope. When this is the case, declaring a variable named after a builtin global is not a redeclaration, but rather a shadowing of the global variable. In that case, the [`no-shadow`](no-shadow) rule with the `"builtinGlobals"` option should be used.
-
-## When Not To Use It
-
-If you use TypeScript, it is not recommended to use this rule, since the compiler will mostly catch this error (`ts(2451)`). However, note that while the compiler will catch `let` redeclares and `const` redeclares, it will not catch `var` redeclares. Thus, if you use the legacy `var` keyword in your TypeScript codebase, this rule still provides some miniscule value.

--- a/docs/src/rules/no-setter-return.md
+++ b/docs/src/rules/no-setter-return.md
@@ -1,8 +1,7 @@
 ---
 title: no-setter-return
 rule_type: problem
-handled_by_typescript:
-- 2408
+handled_by_typescript: true
 related_rules:
 - getter-return
 further_reading:

--- a/docs/src/rules/no-setter-return.md
+++ b/docs/src/rules/no-setter-return.md
@@ -1,6 +1,8 @@
 ---
 title: no-setter-return
 rule_type: problem
+handled_by_typescript:
+- 2408
 related_rules:
 - getter-return
 further_reading:

--- a/docs/src/rules/no-this-before-super.md
+++ b/docs/src/rules/no-this-before-super.md
@@ -1,9 +1,7 @@
 ---
 title: no-this-before-super
 rule_type: problem
-handled_by_typescript:
-- 2376
-- 17009
+handled_by_typescript: true
 ---
 
 

--- a/docs/src/rules/no-this-before-super.md
+++ b/docs/src/rules/no-this-before-super.md
@@ -3,6 +3,7 @@ title: no-this-before-super
 rule_type: problem
 handled_by_typescript:
 - 2376
+- 17009
 ---
 
 

--- a/docs/src/rules/no-this-before-super.md
+++ b/docs/src/rules/no-this-before-super.md
@@ -1,6 +1,8 @@
 ---
 title: no-this-before-super
 rule_type: problem
+handled_by_typescript:
+- 2376
 ---
 
 

--- a/docs/src/rules/no-undef.md
+++ b/docs/src/rules/no-undef.md
@@ -1,8 +1,7 @@
 ---
 title: no-undef
 rule_type: problem
-handled_by_typescript:
-- 2552
+handled_by_typescript: true
 related_rules:
 - no-global-assign
 - no-redeclare

--- a/docs/src/rules/no-undef.md
+++ b/docs/src/rules/no-undef.md
@@ -2,7 +2,7 @@
 title: no-undef
 rule_type: problem
 handled_by_typescript:
-- 2304
+- 2552
 related_rules:
 - no-global-assign
 - no-redeclare

--- a/docs/src/rules/no-undef.md
+++ b/docs/src/rules/no-undef.md
@@ -1,6 +1,8 @@
 ---
 title: no-undef
 rule_type: problem
+handled_by_typescript:
+- 2304
 related_rules:
 - no-global-assign
 - no-redeclare

--- a/docs/src/rules/no-unreachable.md
+++ b/docs/src/rules/no-unreachable.md
@@ -1,6 +1,8 @@
 ---
 title: no-unreachable
 rule_type: problem
+handled_by_typescript:
+- 7027
 ---
 
 

--- a/docs/src/rules/no-unreachable.md
+++ b/docs/src/rules/no-unreachable.md
@@ -1,8 +1,7 @@
 ---
 title: no-unreachable
 rule_type: problem
-handled_by_typescript:
-- 7027
+handled_by_typescript: true
 ---
 
 

--- a/docs/src/rules/no-unsafe-negation.md
+++ b/docs/src/rules/no-unsafe-negation.md
@@ -1,6 +1,10 @@
 ---
 title: no-unsafe-negation
 rule_type: problem
+handled_by_typescript:
+- 2358
+- 2360
+- 2365
 ---
 
 

--- a/docs/src/rules/no-unsafe-negation.md
+++ b/docs/src/rules/no-unsafe-negation.md
@@ -2,9 +2,8 @@
 title: no-unsafe-negation
 rule_type: problem
 handled_by_typescript:
+- 2322
 - 2358
-- 2360
-- 2365
 ---
 
 

--- a/docs/src/rules/no-unsafe-negation.md
+++ b/docs/src/rules/no-unsafe-negation.md
@@ -1,9 +1,7 @@
 ---
 title: no-unsafe-negation
 rule_type: problem
-handled_by_typescript:
-- 2322
-- 2358
+handled_by_typescript: true
 ---
 
 


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update

#### What changes did you make? (Give an overview)

This is a follow-up on my last PR, #17423.

@nzakas mentioned in the ESLint Discord server that we should move forward with reducing the duplication introduced with my last PR by using a frontmatter template, which this PR includes.

Additionally, I also documented the remaining known ESLint core rules that conflict with the TypeScript compiler.

#### Additional Discussion

When doing this PR, I noticed that the rules pages have inconsistent formatting.
Rules randomly have either 1, 2, 3, or 5 newlines after the frontmatter.
This kind of thing makes it difficult for people to contribute, as it makes finding the proper style non-trivial.
I propose that docs should be formatted using Prettier (or dprint), in the same way that the @typescript-eslint project does.