### PR TITLE
fix: import also applies ignore destruction

### DIFF
--- a/lib/rules/id-match.js
+++ b/lib/rules/id-match.js
@@ -262,7 +262,10 @@ module.exports = {
 
                 // Check if it's an import specifier
                 } else if (IMPORT_TYPES.has(parent.type)) {
-
+                    // import also applies ignore destruction
+                    if (ignoreDestructuring && parent.type === "ImportSpecifier") {
+                        return;
+                    }
                     // Report only if the local imported identifier is invalid
                     if (parent.local && parent.local.name === node.name && isInvalid(name)) {
                         report(node);

--- a/tests/lib/rules/id-match.js
+++ b/tests/lib/rules/id-match.js
@@ -276,8 +276,16 @@ ruleTester.run("id-match", rule, {
                 classFields: false
             }],
             parserOptions: { ecmaVersion: 2022 }
-        }
+        },
 
+        // import also applies ignore destruction
+        {
+            code: "import { no_camelcased } from \"external-module\";",
+            options: ["^[^_]+$", {
+                ignoreDestructuring: true
+            }],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
     ],
     invalid: [
         {
@@ -914,6 +922,21 @@ ruleTester.run("id-match", rule, {
                     type: "Identifier"
                 }
             ]
-        }
+        },
+
+        // import also applies ignore destruction
+        {
+            code: "import * as no_camelcased from \"external-module\";",
+            options: ["^[^_]+$", {
+                ignoreDestructuring: true
+            }],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    message: "Identifier 'no_camelcased' does not match the pattern '^[^_]+$'.",
+                    type: "Identifier"
+                }
+            ]
+        },
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

- [X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))

**What rule do you want to change?**
`id-match`
**What change do you want to make (place an "X" next to just one item)?**

- [X] Generate fewer warnings

**How will the change be implemented (place an "X" next to just one item)?**

- [X] Other

**Please provide some example code that this change will affect:**
```
            "id-match": ["error", "^[^_]+$", {
                ignoreDestructuring: true
            }]
```
```js
// Changed to prevent errors when setting up `ignoreDestructuring`
import { no_camelcased } from "external-module"
```

**What does the rule currently do for this code?**
Error Occurred
**What will the rule do after it's changed?**
None
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Early return in `Identifier(node)` when `ignoreDestructuring && parent.type === "ImportSpecifier"`

#### Is there anything you'd like reviewers to focus on?
[#14005](https://github.com/eslint/eslint/issues/14005) is already closed, but fixes uncomfortable behavior that is close to a bug without adding options.
<!-- markdownlint-disable-file MD004 -->
