### PR TITLE
docs: update `no-promise-executor-return` examples

### DIFF
--- a/docs/src/rules/no-promise-executor-return.md
+++ b/docs/src/rules/no-promise-executor-return.md
@@ -75,6 +75,7 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-promise-executor-return: "error"*/
+/*eslint-env es6*/
 
 // Turn return inline into two lines
 new Promise((resolve, reject) => {
@@ -123,6 +124,7 @@ Examples of **correct** code for this rule with the `{ "allowVoid": true }` opti
 
 ```js
 /*eslint no-promise-executor-return: ["error", { allowVoid: true }]*/
+/*eslint-env es6*/
 
 new Promise((resolve, reject) => {
     if (someCondition) {

--- a/docs/src/rules/no-promise-executor-return.md
+++ b/docs/src/rules/no-promise-executor-return.md
@@ -38,6 +38,7 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-promise-executor-return: "error"*/
+/*eslint-env es6*/
 
 new Promise((resolve, reject) => {
     if (someCondition) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Add `/*eslint-env es6*/` to examples so that ESLint can report errors on ES6 syntax.

Without this, the playground doesn't show any errors on the incorrect code example when we click on `Open in Playground` button.

- [Before Demo](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tcHJvbWlzZS1leGVjdXRvci1yZXR1cm46IFwiZXJyb3JcIiovXG5cbm5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICBpZiAoc29tZUNvbmRpdGlvbikge1xuICAgICAgICByZXR1cm4gZGVmYXVsdFJlc3VsdDtcbiAgICB9XG4gICAgZ2V0U29tZXRoaW5nKChlcnIsIHJlc3VsdCkgPT4ge1xuICAgICAgICBpZiAoZXJyKSB7XG4gICAgICAgICAgICByZWplY3QoZXJyKTtcbiAgICAgICAgfSBlbHNlIHtcbiAgICAgICAgICAgIHJlc29sdmUocmVzdWx0KTtcbiAgICAgICAgfVxuICAgIH0pO1xufSk7XG5cbm5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IGdldFNvbWV0aGluZygoZXJyLCBkYXRhKSA9PiB7XG4gICAgaWYgKGVycikge1xuICAgICAgICByZWplY3QoZXJyKTtcbiAgICB9IGVsc2Uge1xuICAgICAgICByZXNvbHZlKGRhdGEpO1xuICAgIH1cbn0pKTtcblxubmV3IFByb21pc2UoKCkgPT4ge1xuICAgIHJldHVybiAxO1xufSk7XG5cbm5ldyBQcm9taXNlKHIgPT4gcigxKSk7XG4ifQ==)
- [After Demo](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tcHJvbWlzZS1leGVjdXRvci1yZXR1cm46IFwiZXJyb3JcIiovXG4vKmVzbGludC1lbnYgZXM2Ki9cblxubmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgIGlmIChzb21lQ29uZGl0aW9uKSB7XG4gICAgICAgIHJldHVybiBkZWZhdWx0UmVzdWx0O1xuICAgIH1cbiAgICBnZXRTb21ldGhpbmcoKGVyciwgcmVzdWx0KSA9PiB7XG4gICAgICAgIGlmIChlcnIpIHtcbiAgICAgICAgICAgIHJlamVjdChlcnIpO1xuICAgICAgICB9IGVsc2Uge1xuICAgICAgICAgICAgcmVzb2x2ZShyZXN1bHQpO1xuICAgICAgICB9XG4gICAgfSk7XG59KTtcblxubmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4gZ2V0U29tZXRoaW5nKChlcnIsIGRhdGEpID0+IHtcbiAgICBpZiAoZXJyKSB7XG4gICAgICAgIHJlamVjdChlcnIpO1xuICAgIH0gZWxzZSB7XG4gICAgICAgIHJlc29sdmUoZGF0YSk7XG4gICAgfVxufSkpO1xuXG5uZXcgUHJvbWlzZSgoKSA9PiB7XG4gICAgcmV0dXJuIDE7XG59KTtcblxubmV3IFByb21pc2UociA9PiByKDEpKTtcbiIsIm9wdGlvbnMiOnsiZW52Ijp7fSwicnVsZXMiOnt9LCJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e30sImVjbWFWZXJzaW9uIjoibGF0ZXN0Iiwic291cmNlVHlwZSI6InNjcmlwdCJ9fX0=)

#### Is there anything you'd like reviewers to focus on?
No
<!-- markdownlint-disable-file MD004 -->
