### PR TITLE
feat!: assert suggestion messages are unique in rule testers

### DIFF
--- a/lib/rule-tester/flat-rule-tester.js
+++ b/lib/rule-tester/flat-rule-tester.js
@@ -770,6 +770,26 @@ class FlatRuleTester {
         }
 
         /**
+         * Hydrates a suggestion's message from its desc or messageId.
+         * @param {Object} suggestion Rule suggestion.
+         * @returns {string} The suggestion's equivalent message.
+         * @private
+         */
+        function getSuggestionMessage(suggestion) {
+            if (hasOwnProperty(suggestion, "desc")) {
+                return suggestion.desc;
+            }
+
+            if (!hasOwnProperty(suggestion, "data")) {
+                return suggestion.messageId;
+            }
+
+            const unformattedMetaMessage = rule.meta.messages[suggestion.messageId];
+
+            return interpolate(unformattedMetaMessage, suggestion.data);
+        }
+
+        /**
          * Check if the template is invalid or not
          * all invalid cases go through this.
          * @param {string|Object} item Item to run the rule against
@@ -793,6 +813,22 @@ class FlatRuleTester {
 
             const result = runRuleForItem(item);
             const messages = result.messages;
+
+            for (const message of messages) {
+                if (hasOwnProperty(message, "suggestions")) {
+
+                    /** @type {Map<string, number>} */
+                    const seenMessageIndices = new Map();
+
+                    for (let i = 0; i < message.suggestions.length; i += 1) {
+                        const suggestionMessage = getSuggestionMessage(message.suggestions[i]);
+                        const previous = seenMessageIndices.get(suggestionMessage);
+
+                        assert.ok(!seenMessageIndices.has(suggestionMessage), `Suggestion message '${suggestionMessage}' reported from suggestion ${i} was previously reported by suggestion ${previous}. Suggestion messages should be unique within an error.`);
+                        seenMessageIndices.set(suggestionMessage, i);
+                    }
+                }
+            }
 
             if (typeof item.errors === "number") {
 

--- a/lib/rule-tester/flat-rule-tester.js
+++ b/lib/rule-tester/flat-rule-tester.js
@@ -821,7 +821,7 @@ class FlatRuleTester {
                     const seenMessageIndices = new Map();
 
                     for (let i = 0; i < message.suggestions.length; i += 1) {
-                        const suggestionMessage = getSuggestionMessage(message.suggestions[i]);
+                        const suggestionMessage = message.suggestions[i].desc;
                         const previous = seenMessageIndices.get(suggestionMessage);
 
                         assert.ok(!seenMessageIndices.has(suggestionMessage), `Suggestion message '${suggestionMessage}' reported from suggestion ${i} was previously reported by suggestion ${previous}. Suggestion messages should be unique within an error.`);

--- a/lib/rule-tester/flat-rule-tester.js
+++ b/lib/rule-tester/flat-rule-tester.js
@@ -770,26 +770,6 @@ class FlatRuleTester {
         }
 
         /**
-         * Hydrates a suggestion's message from its desc or messageId.
-         * @param {Object} suggestion Rule suggestion.
-         * @returns {string} The suggestion's equivalent message.
-         * @private
-         */
-        function getSuggestionMessage(suggestion) {
-            if (hasOwnProperty(suggestion, "desc")) {
-                return suggestion.desc;
-            }
-
-            if (!hasOwnProperty(suggestion, "data")) {
-                return suggestion.messageId;
-            }
-
-            const unformattedMetaMessage = rule.meta.messages[suggestion.messageId];
-
-            return interpolate(unformattedMetaMessage, suggestion.data);
-        }
-
-        /**
          * Check if the template is invalid or not
          * all invalid cases go through this.
          * @param {string|Object} item Item to run the rule against

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -843,6 +843,26 @@ class RuleTester {
         }
 
         /**
+         * Hydrates a suggestion's message from its desc or messageId.
+         * @param {Object} suggestion Rule suggestion.
+         * @returns {string} The suggestion's equivalent message.
+         * @private
+         */
+        function getSuggestionMessage(suggestion) {
+            if (hasOwnProperty(suggestion, "desc")) {
+                return suggestion.desc;
+            }
+
+            if (!hasOwnProperty(suggestion, "data")) {
+                return suggestion.messageId;
+            }
+
+            const unformattedMetaMessage = rule.meta.messages[suggestion.messageId];
+
+            return interpolate(unformattedMetaMessage, suggestion.data);
+        }
+
+        /**
          * Check if the template is invalid or not
          * all invalid cases go through this.
          * @param {string|Object} item Item to run the rule against
@@ -866,6 +886,22 @@ class RuleTester {
 
             const result = runRuleForItem(item);
             const messages = result.messages;
+
+            for (const message of messages) {
+                if (hasOwnProperty(message, "suggestions")) {
+
+                    /** @type {Map<string, number>} */
+                    const seenMessageIndices = new Map();
+
+                    for (let i = 0; i < message.suggestions.length; i += 1) {
+                        const suggestionMessage = getSuggestionMessage(message.suggestions[i]);
+                        const previous = seenMessageIndices.get(suggestionMessage);
+
+                        assert.ok(!seenMessageIndices.has(suggestionMessage), `Suggestion message '${suggestionMessage}' reported from suggestion ${i} was previously reported by suggestion ${previous}. Suggestion messages should be unique within an error.`);
+                        seenMessageIndices.set(suggestionMessage, i);
+                    }
+                }
+            }
 
             if (typeof item.errors === "number") {
 

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -843,26 +843,6 @@ class RuleTester {
         }
 
         /**
-         * Hydrates a suggestion's message from its desc or messageId.
-         * @param {Object} suggestion Rule suggestion.
-         * @returns {string} The suggestion's equivalent message.
-         * @private
-         */
-        function getSuggestionMessage(suggestion) {
-            if (hasOwnProperty(suggestion, "desc")) {
-                return suggestion.desc;
-            }
-
-            if (!hasOwnProperty(suggestion, "data")) {
-                return suggestion.messageId;
-            }
-
-            const unformattedMetaMessage = rule.meta.messages[suggestion.messageId];
-
-            return interpolate(unformattedMetaMessage, suggestion.data);
-        }
-
-        /**
          * Check if the template is invalid or not
          * all invalid cases go through this.
          * @param {string|Object} item Item to run the rule against

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -894,7 +894,7 @@ class RuleTester {
                     const seenMessageIndices = new Map();
 
                     for (let i = 0; i < message.suggestions.length; i += 1) {
-                        const suggestionMessage = getSuggestionMessage(message.suggestions[i]);
+                        const suggestionMessage = message.suggestions[i].desc;
                         const previous = seenMessageIndices.get(suggestionMessage);
 
                         assert.ok(!seenMessageIndices.has(suggestionMessage), `Suggestion message '${suggestionMessage}' reported from suggestion ${i} was previously reported by suggestion ${previous}. Suggestion messages should be unique within an error.`);

--- a/tests/fixtures/testers/rule-tester/suggestions.js
+++ b/tests/fixtures/testers/rule-tester/suggestions.js
@@ -59,6 +59,101 @@ module.exports.withMessageIds = {
     }
 };
 
+module.exports.withDuplicateDescriptions = {
+    meta: {
+        hasSuggestions: true
+    },
+    create(context) {
+        return {
+            Identifier(node) {
+                if (node.name === "foo") {
+                    context.report({
+                        node,
+                        message: "Avoid using identifiers name 'foo'.",
+                        suggest: [{
+                            desc: "Rename 'foo' to 'bar'",
+                            fix: fixer => fixer.replaceText(node, "bar")
+                        }, {
+                            desc: "Rename 'foo' to 'bar'",
+                            fix: fixer => fixer.replaceText(node, "baz")
+                        }]
+                    });
+                }
+            }
+        };
+    }
+};
+
+module.exports.withDuplicateMessageIdsNoData = {
+    meta: {
+        messages: {
+            avoidFoo: "Avoid using identifiers named '{{ name }}'.",
+            renameFoo: "Rename identifier"
+        },
+        hasSuggestions: true
+    },
+    create(context) {
+        return {
+            Identifier(node) {
+                if (node.name === "foo") {
+                    context.report({
+                        node,
+                        messageId: "avoidFoo",
+                        data: {
+                            name: "foo"
+                        },
+                        suggest: [{
+                            messageId: "renameFoo",
+                            fix: fixer => fixer.replaceText(node, "bar")
+                        }, {
+                            messageId: "renameFoo",
+                            fix: fixer => fixer.replaceText(node, "baz")
+                        }]
+                    });
+                }
+            }
+        };
+    }
+};
+
+module.exports.withDuplicateMessageIdsWithData = {
+    meta: {
+        messages: {
+            avoidFoo: "Avoid using identifiers named foo.",
+            renameFoo: "Rename identifier 'foo' to '{{ newName }}'"
+        },
+        hasSuggestions: true
+    },
+    create(context) {
+        return {
+            Identifier(node) {
+                if (node.name === "foo") {
+                    context.report({
+                        node,
+                        messageId: "avoidFoo",
+                        data: {
+                            name: "foo"
+                        },
+                        suggest: [{
+                            messageId: "renameFoo",
+                            data: {
+                                newName: "bar"
+                            },
+                            fix: fixer => fixer.replaceText(node, "bar")
+                        }, {
+                            messageId: "renameFoo",
+                            data: {
+                                newName: "bar"
+                            },
+                            fix: fixer => fixer.replaceText(node, "baz")
+                        }]
+                    });
+                }
+            }
+        };
+    }
+};
+
 module.exports.withoutHasSuggestionsProperty = {
     create(context) {
         return {

--- a/tests/fixtures/testers/rule-tester/suggestions.js
+++ b/tests/fixtures/testers/rule-tester/suggestions.js
@@ -131,9 +131,6 @@ module.exports.withDuplicateMessageIdsWithData = {
                     context.report({
                         node,
                         messageId: "avoidFoo",
-                        data: {
-                            name: "foo"
-                        },
                         suggest: [{
                             messageId: "renameFoo",
                             data: {

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -2236,6 +2236,39 @@ describe("FlatRuleTester", () => {
             }, /Invalid suggestion property name 'outpt'/u);
         });
 
+        it("should fail if a rule produces two suggestions with the same description", () => {
+            assert.throws(() => {
+                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateDescriptions, {
+                    valid: [],
+                    invalid: [
+                        { code: "var foo = bar;", output: "5", errors: 1 }
+                    ]
+                });
+            }, "Suggestion message 'Rename 'foo' to 'bar'' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");
+        });
+
+        it("should fail if a rule produces two suggestions with the same messageId without data", () => {
+            assert.throws(() => {
+                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateMessageIdsNoData, {
+                    valid: [],
+                    invalid: [
+                        { code: "var foo = bar;", output: "5", errors: 1 }
+                    ]
+                });
+            }, "Suggestion message 'Rename identifier' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");
+        });
+
+        it("should fail if a rule produces two suggestions with the same messageId without data", () => {
+            assert.throws(() => {
+                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateMessageIdsWithData, {
+                    valid: [],
+                    invalid: [
+                        { code: "var foo = bar;", output: "5", errors: 1 }
+                    ]
+                });
+            }, "Suggestion message 'Rename identifier 'foo' to 'bar'' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");
+        });
+
         it("should throw an error if a rule that doesn't have `meta.hasSuggestions` enabled produces suggestions", () => {
             assert.throws(() => {
                 ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withoutHasSuggestionsProperty, {

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -2249,7 +2249,7 @@ describe("FlatRuleTester", () => {
 
         it("should fail if a rule produces two suggestions with the same messageId without data", () => {
             assert.throws(() => {
-                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateMessageIdsNoData, {
+                ruleTester.run("suggestions-with-duplicate-messageids-no-data", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateMessageIdsNoData, {
                     valid: [],
                     invalid: [
                         { code: "var foo = bar;", errors: 1 }

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -2238,10 +2238,10 @@ describe("FlatRuleTester", () => {
 
         it("should fail if a rule produces two suggestions with the same description", () => {
             assert.throws(() => {
-                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateDescriptions, {
+                ruleTester.run("suggestions-with-duplicate-descriptions", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateDescriptions, {
                     valid: [],
                     invalid: [
-                        { code: "var foo = bar;", output: "5", errors: 1 }
+                        { code: "var foo = bar;", errors: 1 }
                     ]
                 });
             }, "Suggestion message 'Rename 'foo' to 'bar'' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");
@@ -2252,18 +2252,18 @@ describe("FlatRuleTester", () => {
                 ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateMessageIdsNoData, {
                     valid: [],
                     invalid: [
-                        { code: "var foo = bar;", output: "5", errors: 1 }
+                        { code: "var foo = bar;", errors: 1 }
                     ]
                 });
             }, "Suggestion message 'Rename identifier' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");
         });
 
-        it("should fail if a rule produces two suggestions with the same messageId without data", () => {
+        it("should fail if a rule produces two suggestions with the same messageId with data", () => {
             assert.throws(() => {
-                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateMessageIdsWithData, {
+                ruleTester.run("suggestions-with-duplicate-messageids-with-data", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateMessageIdsWithData, {
                     valid: [],
                     invalid: [
-                        { code: "var foo = bar;", output: "5", errors: 1 }
+                        { code: "var foo = bar;", errors: 1 }
                     ]
                 });
             }, "Suggestion message 'Rename identifier 'foo' to 'bar'' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2220,6 +2220,39 @@ describe("RuleTester", () => {
             }, /Invalid suggestion property name 'outpt'/u);
         });
 
+        it("should fail if a rule produces two suggestions with the same description", () => {
+            assert.throws(() => {
+                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateDescriptions, {
+                    valid: [],
+                    invalid: [
+                        { code: "var foo = bar;", output: "5", errors: 1 }
+                    ]
+                });
+            }, "Suggestion message 'Rename 'foo' to 'bar'' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");
+        });
+
+        it("should fail if a rule produces two suggestions with the same messageId without data", () => {
+            assert.throws(() => {
+                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateMessageIdsNoData, {
+                    valid: [],
+                    invalid: [
+                        { code: "var foo = bar;", output: "5", errors: 1 }
+                    ]
+                });
+            }, "Suggestion message 'Rename identifier' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");
+        });
+
+        it("should fail if a rule produces two suggestions with the same messageId without data", () => {
+            assert.throws(() => {
+                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateMessageIdsWithData, {
+                    valid: [],
+                    invalid: [
+                        { code: "var foo = bar;", output: "5", errors: 1 }
+                    ]
+                });
+            }, "Suggestion message 'Rename identifier 'foo' to 'bar'' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");
+        });
+
         it("should throw an error if a rule that doesn't have `meta.hasSuggestions` enabled produces suggestions", () => {
             assert.throws(() => {
                 ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withoutHasSuggestionsProperty, {
@@ -2228,7 +2261,7 @@ describe("RuleTester", () => {
                         { code: "var foo = bar;", output: "5", errors: 1 }
                     ]
                 });
-            }, "Rules with suggestions must set the `meta.hasSuggestions` property to `true`.");
+            }, "Rules with suggestions must set the `meta.hasSuggestions` property to `true`");
         });
     });
 

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2261,7 +2261,7 @@ describe("RuleTester", () => {
                         { code: "var foo = bar;", output: "5", errors: 1 }
                     ]
                 });
-            }, "Rules with suggestions must set the `meta.hasSuggestions` property to `true`");
+            }, "Rules with suggestions must set the `meta.hasSuggestions` property to `true`.");
         });
     });
 

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2222,10 +2222,10 @@ describe("RuleTester", () => {
 
         it("should fail if a rule produces two suggestions with the same description", () => {
             assert.throws(() => {
-                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateDescriptions, {
+                ruleTester.run("suggestions-with-duplicate-descriptions", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateDescriptions, {
                     valid: [],
                     invalid: [
-                        { code: "var foo = bar;", output: "5", errors: 1 }
+                        { code: "var foo = bar;", errors: 1 }
                     ]
                 });
             }, "Suggestion message 'Rename 'foo' to 'bar'' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");
@@ -2233,21 +2233,21 @@ describe("RuleTester", () => {
 
         it("should fail if a rule produces two suggestions with the same messageId without data", () => {
             assert.throws(() => {
-                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateMessageIdsNoData, {
+                ruleTester.run("suggestions-with-duplicate-messageids-no-data", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateMessageIdsNoData, {
                     valid: [],
                     invalid: [
-                        { code: "var foo = bar;", output: "5", errors: 1 }
+                        { code: "var foo = bar;", errors: 1 }
                     ]
                 });
             }, "Suggestion message 'Rename identifier' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");
         });
 
-        it("should fail if a rule produces two suggestions with the same messageId without data", () => {
+        it("should fail if a rule produces two suggestions with the same messageId with data", () => {
             assert.throws(() => {
-                ruleTester.run("suggestions-missing-hasSuggestions-property", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateMessageIdsWithData, {
+                ruleTester.run("suggestions-with-duplicate-messageids-with-data", require("../../fixtures/testers/rule-tester/suggestions").withDuplicateMessageIdsWithData, {
                     valid: [],
                     invalid: [
-                        { code: "var foo = bar;", output: "5", errors: 1 }
+                        { code: "var foo = bar;", errors: 1 }
                     ]
                 });
             }, "Suggestion message 'Rename identifier 'foo' to 'bar'' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Added logic to the two rule tester classes to assert that no suggestion contains the same hydrated description as a previous suggestion in the same error. 

#### Is there anything you'd like reviewers to focus on?

Was the consensus for asserting on the rule's _actual_ reported suggestions or _expected_? I went with _actual_ to start because that feels more comprehensive. Relevant: #15104

Fixes #16908.