### PR TITLE
feat!: `no-invalid-regexp` make allowConstructorFlags case-sensitive

### DIFF
--- a/docs/src/rules/no-invalid-regexp.md
+++ b/docs/src/rules/no-invalid-regexp.md
@@ -53,7 +53,7 @@ If you want to allow additional constructor flags for any reason, you can specif
 
 This rule has an object option for exceptions:
 
-* `"allowConstructorFlags"` is an array of flags
+* `"allowConstructorFlags"` is a case-sensitive array of flags
 
 ### allowConstructorFlags
 

--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -55,7 +55,7 @@ module.exports = {
             const temp = options.allowConstructorFlags.join("").replace(validFlags, "");
 
             if (temp) {
-                allowedFlags = new RegExp(`[${temp}]`, "giu");
+                allowedFlags = new RegExp(`[${temp}]`, "gu");
             }
         }
 

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -184,6 +184,24 @@ ruleTester.run("no-invalid-regexp", rule, {
             }]
         },
         {
+            code: "RegExp('.', 'a');",
+            options: [{ allowConstructorFlags: ["A"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'a'" },
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "RegExp('.', 'A');",
+            options: [{ allowConstructorFlags: ["a"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'A'" },
+                type: "CallExpression"
+            }]
+        },
+        {
             code: "new RegExp('.', 'az');",
             options: [{ allowConstructorFlags: ["z"] }],
             errors: [{


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
**What change do you want to make (place an "X" next to just one item)?**

[x] Generate more warnings
[ ] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[ ] A new option
[x] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
const ESLint = require("eslint");
console.log(
  new ESLint.Linter().verify('RegExp(".", "A");', {
    rules: { "no-invalid-regexp": [1, { allowConstructorFlags: ["a"] }] },
  })
);
```

**What does the rule currently do for this code?**

Treats all allowed constructor flags as case-insensitive.

**What will the rule do after it's changed?**

They're now case-sensitive, as per the issue.

Adds a unit test for code being lowercase vs. rule config being uppercase, and vice-versa.

Fixes #16574.