### PR TITLE
feat!: `no-useless-computed-key` consider template literals

### DIFF
--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -37,7 +37,7 @@ const astUtils = require("./utils/ast-utils");
  *     class C { static "prototype"() {} } produces a parsing error (breaks the whole script)
  * @param {ASTNode} node The node to check. It can be `Property`, `PropertyDefinition` or `MethodDefinition`.
  * @throws {Error} (Unreachable.)
- * @returns {void} `true` if the node has useless computed key.
+ * @returns {boolean} `true` if the node has useless computed key.
  */
 function hasUselessComputedKey(node) {
     if (!node.computed) {
@@ -46,11 +46,18 @@ function hasUselessComputedKey(node) {
 
     const { key } = node;
 
-    if (key.type !== "Literal") {
+    if (key.type !== "Literal" && key.type !== "TemplateLiteral") {
         return false;
     }
 
-    const { value } = key;
+    if (key.expressions && key.expressions.length) {
+
+        // a TemplateLiteral with expressions can't be simplified
+        return false;
+    }
+
+    const value =
+        key.type === "TemplateLiteral" ? key.quasis[0].value.raw : key.value;
 
     if (typeof value !== "number" && typeof value !== "string") {
         return false;
@@ -78,7 +85,6 @@ function hasUselessComputedKey(node) {
         default:
             throw new Error(`Unexpected node type: ${node.type}`);
     }
-
 }
 
 //------------------------------------------------------------------------------
@@ -144,7 +150,12 @@ module.exports = {
                         const needsSpaceBeforeKey = tokenBeforeLeftBracket.range[1] === leftSquareBracket.range[0] &&
                             !astUtils.canTokensBeAdjacent(tokenBeforeLeftBracket, sourceCode.getFirstToken(key));
 
-                        const replacementKey = (needsSpaceBeforeKey ? " " : "") + key.raw;
+                        const rawProperty =
+                            key.type === "TemplateLiteral"
+                                ? `'${key.quasis[0].value.raw}'`
+                                : key.raw;
+
+                        const replacementKey = (needsSpaceBeforeKey ? " " : "") + rawProperty;
 
                         return fixer.replaceTextRange([leftSquareBracket.range[0], rightSquareBracket.range[1]], replacementKey);
                     }

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -45,6 +45,12 @@ ruleTester.run("no-useless-computed-key", rule, {
         { code: "class Foo { ['constructor'] }", options: [{ enforceForClassMembers: true }] },
         { code: "class Foo { static ['constructor'] }", options: [{ enforceForClassMembers: true }] },
         { code: "class Foo { static ['prototype'] }", options: [{ enforceForClassMembers: true }] },
+        "({ [tag``]: 1 })",
+        "({ [tag` abc `]: 1 })",
+        "({ [`abc ${1}`]: 1 })",
+        "({ [`abc ${'xyz'}`]: 1 })",
+        "({ [`${x}`]: 1 })",
+        "({ [`${'abc'}`]: 1 })",
 
         /*
          * Well-known browsers throw syntax error bigint literals on property names,
@@ -578,6 +584,30 @@ ruleTester.run("no-useless-computed-key", rule, {
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'prototype'" },
                 type: "PropertyDefinition"
+            }]
+        }, {
+            code: "({ [`x`]: 123 })",
+            output: "({ 'x': 123 })",
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "`x`" },
+                type: "Property"
+            }]
+        }, {
+            code: "({ [`multi word`]: 123 })",
+            output: "({ 'multi word': 123 })",
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "`multi word`" },
+                type: "Property"
+            }]
+        }, {
+            code: "({ *[`test`]() {} })",
+            output: "({ *'test'() {} })",
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "`test`" },
+                type: "Property"
             }]
         }
     ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

`no-useless-computed-key`

**What change do you want to make (place an "X" next to just one item)?**

[x] Generate more warnings
[ ] Generate fewer warnings
[x] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[ ] A new option
[x] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**


```js
// (assuming the `quote-props` rule is also on)

obj = { ["x"]: 1 } // -> { x: 1 } // ✅ already works
obj = { ['x']: 1 } // -> { x: 1 } // ✅ already works
obj = { [`x`]: 1 } // -> { x: 1 } // 🆕 works now, did not use to work

obj = { [`x y`]: 1 } // -> { 'x y': 1 } // 🆕

// unchanged:
obj = { [tagged`abc`]: 1 }
obj = { [`abc ${1} ${x}`]: 1 }
obj = { [`abc ${"xyz"}`]: 1 }
obj = { [`${"abc"}`]: 1 }
```

**What does the rule currently do for this code?**

The rule does nothing 

**What will the rule do after it's changed?**

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Emit an error with an autofix suggestion.

#### What changes did you make? (Give an overview)

Handle `type=TemplateLiteral` in addition to `type=Literal`

#### Is there anything you'd like reviewers to focus on?


- I assume this counts as a breaking change?
- This PR does not try to simply \`&shy;`abc ${"xyz"}`&shy;\` -> \`&shy;`abc xyz`&shy;\`, I think that logic belongs in a future rule
- This PR does not try to simply other weird computed keys that are currently allowed, such as `x = { [['abc']]: 123 }`

<!-- markdownlint-disable-file MD004 -->
