### PR TITLE
chore: add .github/renovate.json5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,7 +52,7 @@
         }
     ],
 
-    // By default renovate will auto-rebase whenever the dep branch falls behind main.
+    // By default Renovate will auto-rebase whenever the dep branch falls behind main.
     // This is annoying as it spams notifications and creates unnecessary action runs.
     // Instead only auto-rebase when conflicted, and we can trigger a manual rebase if required.
     "rebaseWhen": "conflicted"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,10 +50,5 @@
             "groupName": "metascraper",
             "matchPackagePrefixes": ["metascraper"]
         }
-    ],
-
-    // By default Renovate will auto-rebase whenever the dep branch falls behind main.
-    // This is annoying as it spams notifications and creates unnecessary action runs.
-    // Instead only auto-rebase when conflicted, and we can trigger a manual rebase if required.
-    "rebaseWhen": "conflicted"
+    ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,7 +15,7 @@
         // Enable major version updates, but don't auto-merge them
         {
             "automerge": false,
-            "matchUpdateTypes": ["minor"]
+            "matchUpdateTypes": ["major"]
         },
 
         // Enable minor version updates with auto-merging
@@ -32,11 +32,11 @@
 
         // Label PRs appropriately per their manager
         {
-            "addLabels": ["javascript"],
+            "addLabels": ["deps:npm"],
             "matchManagers": ["npm"]
         },
         {
-            "addLabels": ["github-actions"],
+            "addLabels": ["deps:actions"],
             "matchManagers": ["github-actions"]
         },
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,66 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended",
+        ":dependencyDashboardApproval",
+        ":semanticCommitTypeAll(ci)"
+    ],
+    "dependencyDashboard": true,
+    "dependencyDashboardLabels": ["dependencies", "repo maintenance"],
+    "enabledManagers": ["github-actions", "npm"],
+    "internalChecksFilter": "strict",
+    "labels": ["dependencies"],
+
+    // Wait a few days for any new package, as a precaution against malicious publishes
+    "minimumReleaseAge": "3 days",
+
+    "packageRules": [
+        // Enable major version updates, but don't auto-merge them
+        {
+            "automerge": false,
+            "matchUpdateTypes": ["minor"]
+        },
+
+        // Enable minor version updates with auto-merging
+        {
+            "automerge": true,
+            "automergeStrategy": "squash",
+            "matchUpdateTypes": ["minor"]
+        },
+
+        // Ignore patch versions to reduce noise
+        {
+            "enabled": false,
+            "matchUpdateTypes": ["patch"]
+        },
+
+        // Label PRs appropriately per their manager
+        {
+            "addLabels": ["javascript"],
+            "matchManagers": ["npm"]
+        },
+        {
+            "addLabels": ["github-actions"],
+            "matchManagers": ["github-actions"]
+        },
+
+        // Batch package sets together
+        {
+            "groupName": "babel",
+            "matchPackagePrefixes": ["@babel", "babel-"]
+        },
+        {
+            "groupName": "wdio",
+            "matchPackagePrefixes": ["@wdio"]
+        },
+        {
+            "groupName": "metascraper",
+            "matchPackagePrefixes": ["metascraper"]
+        }
+    ],
+
+    // By default renovate will auto-rebase whenever the dep branch falls behind main.
+    // This is annoying as it spams notifications and creates unnecessary action runs.
+    // Instead only auto-rebase when conflicted, and we can trigger a manual rebase if required.
+    "rebaseWhen": "conflicted"
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,9 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended",
+        ":dependencyDashboardApproval"
+    ],
     "internalChecksFilter": "strict",
     "labels": ["dependencies"],
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:recommended",
-        ":dependencyDashboardApproval",
+        ":approveMajorUpdates",
         ":semanticCommitScopeDisabled"
     ],
     "internalChecksFilter": "strict",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,12 +12,8 @@
     "minimumReleaseAge": "7 days",
 
     "packageRules": [
-        // Enable major version updates, but don't auto-merge them
-        {
-            "matchUpdateTypes": ["major"]
-        },
-
         // Enable minor version updates with auto-merging
+        // (Major versions will need to be triggered from the dashboard issue)
         {
             "automerge": true,
             "matchUpdateTypes": ["minor"]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,11 +1,5 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:recommended",
-        ":dependencyDashboardApproval"
-    ],
-    "dependencyDashboard": true,
-    "dependencyDashboardLabels": ["dependencies", "repo maintenance"],
     "enabledManagers": ["github-actions", "npm"],
     "internalChecksFilter": "strict",
     "labels": ["dependencies"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,8 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:recommended",
-        ":dependencyDashboardApproval",
-        ":semanticCommitTypeAll(ci)"
+        ":dependencyDashboardApproval"
     ],
     "dependencyDashboard": true,
     "dependencyDashboardLabels": ["dependencies", "repo maintenance"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,7 +16,6 @@
         // Enable minor version updates with auto-merging
         {
             "automerge": true,
-            "automergeStrategy": "squash",
             "matchUpdateTypes": ["minor"]
         },
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,8 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:recommended",
-        ":dependencyDashboardApproval"
+        ":dependencyDashboardApproval",
+        ":semanticCommitScopeDisabled"
     ],
     "internalChecksFilter": "strict",
     "labels": ["dependencies"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,7 @@
     "labels": ["dependencies"],
 
     // Wait a few days for any new package, as a precaution against malicious publishes
-    "minimumReleaseAge": "3 days",
+    "minimumReleaseAge": "7 days",
 
     "packageRules": [
         // Enable major version updates, but don't auto-merge them

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,5 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "enabledManagers": ["github-actions", "npm"],
     "internalChecksFilter": "strict",
     "labels": ["dependencies"],
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,6 @@
     "packageRules": [
         // Enable major version updates, but don't auto-merge them
         {
-            "automerge": false,
             "matchUpdateTypes": ["major"]
         },
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,32 +5,23 @@
         ":approveMajorUpdates",
         ":semanticCommitScopeDisabled"
     ],
+    "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
     "internalChecksFilter": "strict",
     "labels": ["dependencies"],
 
-    // Wait a few days for any new package, as a precaution against malicious publishes
+    // Wait well over three days for any new package as a precaution against malicious publishes
     "minimumReleaseAge": "7 days",
 
     "packageRules": [
         {
-            "description": "Automerge minor version updates. Major versions must be approved from the Dependency Dashboard issue, because we use the :approveMajorUpdates preset.",
-            "automerge": true,
-            "matchUpdateTypes": ["minor"]
-        },
-        {
-            "description": "Ignore patch versions to reduce noise.",
-            "enabled": false,
-            "matchUpdateTypes": ["patch"]
+            "description": "Use the deps:actions label for github-action manager updates (this means Renovate's github-action manager).",
+            "addLabels": ["deps:actions"],
+            "matchManagers": ["github-actions"]
         },
         {
             "description": "Use the deps:npm label for npm manager packages (this means Renovate's npm manager).",
             "addLabels": ["deps:npm"],
             "matchManagers": ["npm"]
-        },
-        {
-            "description": "Use the deps:actions label for github-action manager updates (this means Renovate's github-action manager).",
-            "addLabels": ["deps:actions"],
-            "matchManagers": ["github-actions"]
         },
         {
             "description": "Group Babel packages into a single PR.",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,6 @@
         ":semanticCommitScopeDisabled"
     ],
     "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
-    "internalChecksFilter": "strict",
     "labels": ["dependencies"],
 
     // Wait well over three days for any new package as a precaution against malicious publishes

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,39 +12,38 @@
     "minimumReleaseAge": "7 days",
 
     "packageRules": [
-        // Enable minor version updates with auto-merging
-        // (Major versions will need to be triggered from the dashboard issue)
         {
+            "description": "Automerge minor version updates. Major versions must be approved from the Dependency Dashboard issue, because we use the :approveMajorUpdates preset.",
             "automerge": true,
             "matchUpdateTypes": ["minor"]
         },
-
-        // Ignore patch versions to reduce noise
         {
+            "description": "Ignore patch versions to reduce noise.",
             "enabled": false,
             "matchUpdateTypes": ["patch"]
         },
-
-        // Label PRs appropriately per their manager
         {
+            "description": "Use the deps:npm label for npm manager packages (this means Renovate's npm manager).",
             "addLabels": ["deps:npm"],
             "matchManagers": ["npm"]
         },
         {
+            "description": "Use the deps:actions label for github-action manager updates (this means Renovate's github-action manager).",
             "addLabels": ["deps:actions"],
             "matchManagers": ["github-actions"]
         },
-
-        // Batch package sets together
         {
+            "description": "Group Babel packages into a single PR.",
             "groupName": "babel",
             "matchPackagePrefixes": ["@babel", "babel-"]
         },
         {
+            "description": "Group wdio packages into a single PR.",
             "groupName": "wdio",
             "matchPackagePrefixes": ["@wdio"]
         },
         {
+            "description": "Group metascraper packages into a single PR.",
             "groupName": "metascraper",
             "matchPackagePrefixes": ["metascraper"]
         }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,8 @@
     "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
     "labels": ["dependencies"],
 
-    // Wait well over three days for any new package as a precaution against malicious publishes
+    // Wait well over npm's three day window for any new package as a precaution against malicious publishes
+    // https://docs.npmjs.com/policies/unpublish/#packages-published-less-than-72-hours-ago
     "minimumReleaseAge": "7 days",
 
     "packageRules": [


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: GitHub automation

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make?

Creates a `.github/renovate.json5` file based on:

* Discussion in https://github.com/eslint/eslint/issues/15726
* Docs in https://docs.renovatebot.com/configuration-options/#packagerules
* The existing typescript-eslint file at https://github.com/typescript-eslint/typescript-eslint/blob/7826910d8c6ba4d2d40b8d55fcf7fd39fe290d88/.github/renovate.json5

#### Is there anything you'd like reviewers to focus on?

* If & when this config creates update PRs, we'll be able to see which packages are blocked from upgrading. Those can be added to an `ignoreDeps` field. Are there any we already know should be?
* I removed any configuration around semantic commit titles in the hope that it'll auto-detect based on the Git history. If it doesn't, I suspect we'd want to report that as a bug to Renovate.
* I set it to create majors, create and auto-merge minors, and ignore patches to reduce. An alternative could be to create and auto-merge patches to be more up-to-date. Thoughts? 
* Are there any other package groups that I missed?