### PR TITLE
fix: wrong suggestion and message in `no-misleading-character-class`

### DIFF
--- a/lib/rules/no-misleading-character-class.js
+++ b/lib/rules/no-misleading-character-class.js
@@ -14,26 +14,33 @@ const { isValidWithUnicodeFlag } = require("./utils/regular-expressions");
 //------------------------------------------------------------------------------
 
 /**
+ * @typedef {import('@eslint-community/regexpp').AST.Character} Character
+ * @typedef {import('@eslint-community/regexpp').AST.CharacterClassElement} CharacterClassElement
+ */
+
+/**
  * Iterate character sequences of a given nodes.
  *
  * CharacterClassRange syntax can steal a part of character sequence,
  * so this function reverts CharacterClassRange syntax and restore the sequence.
- * @param {import('@eslint-community/regexpp').AST.CharacterClassElement[]} nodes The node list to iterate character sequences.
- * @returns {IterableIterator<number[]>} The list of character sequences.
+ * @param {CharacterClassElement[]} nodes The node list to iterate character sequences.
+ * @returns {IterableIterator<Character[]>} The list of character sequences.
  */
 function *iterateCharacterSequence(nodes) {
+
+    /** @type {Character[]} */
     let seq = [];
 
     for (const node of nodes) {
         switch (node.type) {
             case "Character":
-                seq.push(node.value);
+                seq.push(node);
                 break;
 
             case "CharacterClassRange":
-                seq.push(node.min.value);
+                seq.push(node.min);
                 yield seq;
-                seq = [node.max.value];
+                seq = [node.max];
                 break;
 
             case "CharacterSet":
@@ -55,32 +62,74 @@ function *iterateCharacterSequence(nodes) {
     }
 }
 
+
+/**
+ * Checks whether the given character node is a Unicode code point escape or not.
+ * @param {Character} char the character node to check.
+ * @returns {boolean} `true` if the character node is a Unicode code point escape.
+ */
+function isUnicodeCodePointEscape(char) {
+    return /^\\u\{[\da-f]+\}$/iu.test(char.raw);
+}
+
+/**
+ * Each function returns `true` if it detects that kind of problem.
+ * @type {Record<string, (chars: Character[]) => boolean>}
+ */
 const hasCharacterSequence = {
     surrogatePairWithoutUFlag(chars) {
-        return chars.some((c, i) => i !== 0 && isSurrogatePair(chars[i - 1], c));
+        return chars.some((c, i) => {
+            if (i === 0) {
+                return false;
+            }
+            const c1 = chars[i - 1];
+
+            return (
+                isSurrogatePair(c1.value, c.value) &&
+                !isUnicodeCodePointEscape(c1) &&
+                !isUnicodeCodePointEscape(c)
+            );
+        });
+    },
+
+    surrogatePair(chars) {
+        return chars.some((c, i) => {
+            if (i === 0) {
+                return false;
+            }
+            const c1 = chars[i - 1];
+
+            return (
+                isSurrogatePair(c1.value, c.value) &&
+                (
+                    isUnicodeCodePointEscape(c1) ||
+                    isUnicodeCodePointEscape(c)
+                )
+            );
+        });
     },
 
     combiningClass(chars) {
         return chars.some((c, i) => (
             i !== 0 &&
-            isCombiningCharacter(c) &&
-            !isCombiningCharacter(chars[i - 1])
+            isCombiningCharacter(c.value) &&
+            !isCombiningCharacter(chars[i - 1].value)
         ));
     },
 
     emojiModifier(chars) {
         return chars.some((c, i) => (
             i !== 0 &&
-            isEmojiModifier(c) &&
-            !isEmojiModifier(chars[i - 1])
+            isEmojiModifier(c.value) &&
+            !isEmojiModifier(chars[i - 1].value)
         ));
     },
 
     regionalIndicatorSymbol(chars) {
         return chars.some((c, i) => (
             i !== 0 &&
-            isRegionalIndicatorSymbol(c) &&
-            isRegionalIndicatorSymbol(chars[i - 1])
+            isRegionalIndicatorSymbol(c.value) &&
+            isRegionalIndicatorSymbol(chars[i - 1].value)
         ));
     },
 
@@ -90,9 +139,9 @@ const hasCharacterSequence = {
         return chars.some((c, i) => (
             i !== 0 &&
             i !== lastIndex &&
-            c === 0x200d &&
-            chars[i - 1] !== 0x200d &&
-            chars[i + 1] !== 0x200d
+            c.value === 0x200d &&
+            chars[i - 1].value !== 0x200d &&
+            chars[i + 1].value !== 0x200d
         ));
     }
 };
@@ -120,6 +169,7 @@ module.exports = {
 
         messages: {
             surrogatePairWithoutUFlag: "Unexpected surrogate pair in character class. Use 'u' flag.",
+            surrogatePair: "Unexpected surrogate pair in character class.",
             combiningClass: "Unexpected combined character in character class.",
             emojiModifier: "Unexpected modified Emoji in character class.",
             regionalIndicatorSymbol: "Unexpected national flag in character class.",

--- a/tests/lib/rules/no-misleading-character-class.js
+++ b/tests/lib/rules/no-misleading-character-class.js
@@ -630,7 +630,6 @@ ruleTester.run("no-misleading-character-class", rule, {
         },
         {
             code: String.raw`/[\ud83d\u{dc4d}]/u`,
-            env: { es2020: true },
             errors: [{
                 messageId: "surrogatePair",
                 suggestions: null
@@ -638,7 +637,6 @@ ruleTester.run("no-misleading-character-class", rule, {
         },
         {
             code: String.raw`/[\u{d83d}\udc4d]/u`,
-            env: { es2020: true },
             errors: [{
                 messageId: "surrogatePair",
                 suggestions: null
@@ -646,7 +644,6 @@ ruleTester.run("no-misleading-character-class", rule, {
         },
         {
             code: String.raw`/[\u{d83d}\u{dc4d}]/u`,
-            env: { es2020: true },
             errors: [{
                 messageId: "surrogatePair",
                 suggestions: null
@@ -654,7 +651,6 @@ ruleTester.run("no-misleading-character-class", rule, {
         },
         {
             code: String.raw`/[\uD83D\u{DC4d}]/u`,
-            env: { es2020: true },
             errors: [{
                 messageId: "surrogatePair",
                 suggestions: null

--- a/tests/lib/rules/no-misleading-character-class.js
+++ b/tests/lib/rules/no-misleading-character-class.js
@@ -628,6 +628,38 @@ ruleTester.run("no-misleading-character-class", rule, {
                 suggestions: null
             }]
         },
+        {
+            code: String.raw`/[\ud83d\u{dc4d}]/u`,
+            env: { es2020: true },
+            errors: [{
+                messageId: "surrogatePair",
+                suggestions: null
+            }]
+        },
+        {
+            code: String.raw`/[\u{d83d}\udc4d]/u`,
+            env: { es2020: true },
+            errors: [{
+                messageId: "surrogatePair",
+                suggestions: null
+            }]
+        },
+        {
+            code: String.raw`/[\u{d83d}\u{dc4d}]/u`,
+            env: { es2020: true },
+            errors: [{
+                messageId: "surrogatePair",
+                suggestions: null
+            }]
+        },
+        {
+            code: String.raw`/[\uD83D\u{DC4d}]/u`,
+            env: { es2020: true },
+            errors: [{
+                messageId: "surrogatePair",
+                suggestions: null
+            }]
+        },
 
 
         // ES2024


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

close #17537

Fixed incorrect message and changed to not suggest u flag, when Unicode code point escapes were included.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
