### PR TITLE
docs: fix incorrect tag's place

### DIFF
--- a/docs/src/rules/logical-assignment-operators.md
+++ b/docs/src/rules/logical-assignment-operators.md
@@ -96,9 +96,9 @@ a = a ?? b
 
 This option checks for additional patterns with if statements which could be expressed with the logical assignment operator.
 
-::: incorrect
-
 Examples of **incorrect** code for this rule with the `["always", { enforceForIfStatements: true }]` option:
+
+::: incorrect
 
 ```js
 /*eslint logical-assignment-operators: ["error", "always", { enforceForIfStatements: true }]*/


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
In `logical-assignment-operator` rule [page](https://eslint.org/docs/latest/rules/logical-assignment-operators#enforceforifstatements) an `incorrect` tag is placed wrong. because of that code within the tag isn't opening in the playground.

![Screenshot 2023-09-17 at 21-00-55 logical-assignment-operators - ESLint - Pluggable JavaScript Linter](https://github.com/eslint/eslint/assets/86398394/54d08f97-b98f-47b6-b1f8-2210675f1833)

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
