### PR TITLE
[Reference] feat!: factor in schema defaults for rule options

### DIFF
--- a/lib/linter/getRuleOptions.js
+++ b/lib/linter/getRuleOptions.js
@@ -1,0 +1,165 @@
+/* eslint-disable no-undefined -- `null` and `undefined` are different in options */
+/**
+ * @fileoverview Applies default rule options
+ * @author JoshuaKGoldberg
+ */
+
+"use strict";
+
+/**
+ * Creates a "shallow" copy of an array or object's properties.
+ * Other objects are returned directly.
+ * @template Value
+ * @param {Value} value Value to be copied.
+ * @returns {Value} The shallow copied value.
+ */
+function cloneShallow(value) {
+    if (Array.isArray(value)) {
+        return [...value];
+    }
+
+    if (value && typeof value === "object") {
+        return { ...value };
+    }
+
+    return value;
+}
+
+/**
+ * Returns either a value, or the fallback if the value was undefined.
+ * @template T Type of value or fallback.
+ * @param {T | undefined} value Result to use by default.
+ * @param {T} fallback Fallback if value was undefined.
+ * @returns {T} value, or fallback if value was undefined.
+ */
+function valueOrFallback(value, fallback) {
+    return value === undefined ? fallback : value;
+}
+
+/**
+ * Finds the first defined value, or undefined.
+ * @template T Types of values.
+ * @param  {...(T | undefined)[]} values Values to choose from.
+ * @returns {T | undefined} First defined value in values, or undefined.
+ */
+function firstDefined(...values) {
+    for (const value of values) {
+        if (value !== undefined) {
+            return value;
+        }
+    }
+
+    return undefined;
+}
+
+/**
+ * Finds the last index in a schema that will need a recursive defaulting pass.
+ * @param {Array} schema Schema for a rule.
+ * @param {number} startIndex Start index to search after.
+ * @returns {number} Last index of a schema with default or properties, or -1.
+ */
+function findSchemaSliceEnd(schema, startIndex) {
+    for (let i = schema.length - 1; i >= startIndex; i -= 1) {
+        if (
+            Object.hasOwn(schema[i], "default") ||
+            Object.hasOwn(schema[i], "properties")
+        ) {
+            return i + 1;
+        }
+    }
+
+    return -1;
+}
+
+/**
+ * Recursive worker to parse a rule config.
+ * @param {Array|Object|null} ruleConfig Config for a rule.
+ * @param {Array|Object|null} schema Option schema of the rule.
+ * @returns {Array|Object|null} Resolved option(s) for the rule.
+ */
+function getRuleOptionsWorker(ruleConfig, schema) {
+    if (ruleConfig === null || !schema) {
+        return ruleConfig;
+    }
+
+    if (Array.isArray(schema)) {
+        // eslint-disable-next-line no-use-before-define -- Recursive functions calling each other
+        return getRuleOptionsArray(ruleConfig, schema);
+    }
+
+    const options = cloneShallow(
+        valueOrFallback(
+            firstDefined(ruleConfig, schema.default),
+            schema.properties ? {} : undefined
+        )
+    );
+
+    if (options && schema.properties) {
+        for (const [key, value] of Object.entries(schema.properties)) {
+            if (
+                Object.hasOwn(value, "default") &&
+                !Object.hasOwn(options, key)
+            ) {
+                if (value.type === "object") {
+                    options[key] = getRuleOptionsWorker(
+                        { ...value.default },
+                        value
+                    );
+                } else {
+                    options[key] = cloneShallow(value.default);
+                }
+            }
+
+            if (value.type === "object") {
+                options[key] = getRuleOptionsWorker({ ...options[key] }, value);
+            }
+        }
+    }
+
+    return options;
+}
+
+/**
+ * Gets the resolved options of a rule's array config based on its schema array.
+ * @param {Array} ruleConfig Rule config options array.
+ * @param {Object} schema Schema elements for the rule.
+ * @returns {Array} Resolved options for the rule.
+ */
+function getRuleOptionsArray(ruleConfig, schema) {
+    const options = [];
+
+    for (let i = 0; i < Math.min(ruleConfig.length, schema.length); i += 1) {
+        options.push(getRuleOptionsWorker(ruleConfig[i], schema[i]));
+    }
+
+    if (ruleConfig.length > schema.length) {
+        return [...options, ...ruleConfig.slice(schema.length)];
+    }
+
+    const schemaSliceEnd = findSchemaSliceEnd(schema, ruleConfig.length);
+
+    return schemaSliceEnd === -1
+        ? options
+        : [
+            ...options,
+            ...schema
+                .slice(ruleConfig.length, schemaSliceEnd)
+                .map(item => getRuleOptionsWorker(undefined, item))
+        ];
+}
+
+/**
+ * Get the options for a rule (not including severity), if any.
+ * @param {Array|number} ruleConfig Config for a rule.
+ * @param {Object|undefined} schema Schema for a rule.
+ * @returns {Array} Resolve option(s) for the rule, factoring in schema defaults.
+ */
+function getRuleOptions(ruleConfig, schema) {
+    return Array.isArray(ruleConfig)
+        ? getRuleOptionsWorker(ruleConfig.slice(1), schema)
+        : getRuleOptionsWorker([], schema);
+}
+
+exports.getRuleOptions = getRuleOptions;
+
+/* eslint-enable no-undefined -- `null` and `undefined` are different in options */

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -33,6 +33,7 @@ const
     CodePathAnalyzer = require("./code-path-analysis/code-path-analyzer"),
     applyDisableDirectives = require("./apply-disable-directives"),
     ConfigCommentParser = require("./config-comment-parser"),
+    { getRuleOptions } = require("./getRuleOptions"),
     NodeEventGenerator = require("./node-event-generator"),
     createReportTranslator = require("./report-translator"),
     Rules = require("./rules"),
@@ -733,11 +734,11 @@ function stripUnicodeBOM(text) {
 }
 
 /**
- * Get the options for a rule (not including severity), if any
+ * Get the raw (non-defaulted) options for a rule (not including severity), if any
  * @param {Array|number} ruleConfig rule configuration
  * @returns {Array} of rule options, empty Array if none
  */
-function getRuleOptions(ruleConfig) {
+function getRuleOptionsRaw(ruleConfig) {
     if (Array.isArray(ruleConfig)) {
         return ruleConfig.slice(1);
     }
@@ -997,7 +998,8 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
                 Object.create(sharedTraversalContext),
                 {
                     id: ruleId,
-                    options: getRuleOptions(configuredRules[ruleId]),
+                    options: getRuleOptions(configuredRules[ruleId], rule.meta && rule.meta.schema),
+                    optionsRaw: getRuleOptionsRaw(configuredRules[ruleId]),
                     report(...args) {
 
                         /*

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -669,17 +669,17 @@ module.exports = {
             ignoreComments: false
         };
 
-        if (context.options.length) {
-            if (context.options[0] === "tab") {
+        if (context.optionsRaw.length) {
+            if (context.optionsRaw[0] === "tab") {
                 indentSize = 1;
                 indentType = "tab";
             } else {
-                indentSize = context.options[0];
+                indentSize = context.optionsRaw[0];
                 indentType = "space";
             }
 
-            if (context.options[1]) {
-                Object.assign(options, context.options[1]);
+            if (context.optionsRaw[1]) {
+                Object.assign(options, context.optionsRaw[1]);
 
                 if (typeof options.VariableDeclarator === "number" || options.VariableDeclarator === "first") {
                     options.VariableDeclarator = {

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -121,16 +121,16 @@ module.exports = {
         }
 
         // The options object must be the last option specified…
-        const options = Object.assign({}, context.options[context.options.length - 1]);
+        const options = Object.assign({}, context.optionsRaw[context.optionsRaw.length - 1]);
 
         // …but max code length…
-        if (typeof context.options[0] === "number") {
-            options.code = context.options[0];
+        if (typeof context.optionsRaw[0] === "number") {
+            options.code = context.optionsRaw[0];
         }
 
         // …and tabWidth can be optionally specified directly as integers.
-        if (typeof context.options[1] === "number") {
-            options.tabWidth = context.options[1];
+        if (typeof context.optionsRaw[1] === "number") {
+            options.tabWidth = context.optionsRaw[1];
         }
 
         const maxLength = typeof options.code === "number" ? options.code : 80,

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -58,10 +58,10 @@ module.exports = {
             maxEOF = max,
             maxBOF = max;
 
-        if (context.options.length) {
-            max = context.options[0].max;
-            maxEOF = typeof context.options[0].maxEOF !== "undefined" ? context.options[0].maxEOF : max;
-            maxBOF = typeof context.options[0].maxBOF !== "undefined" ? context.options[0].maxBOF : max;
+        if (context.optionsRaw.length) {
+            max = context.optionsRaw[0].max;
+            maxEOF = typeof context.optionsRaw[0].maxEOF !== "undefined" ? context.optionsRaw[0].maxEOF : max;
+            maxBOF = typeof context.optionsRaw[0].maxBOF !== "undefined" ? context.optionsRaw[0].maxBOF : max;
         }
 
         const sourceCode = context.sourceCode;

--- a/tests/lib/linter/getRuleOptions.js
+++ b/tests/lib/linter/getRuleOptions.js
@@ -1,0 +1,471 @@
+/**
+ * @fileoverview Tests for getRuleOptions.
+ * @author JoshuaKGoldberg
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { getRuleOptions } = require("../../../lib/linter/getRuleOptions");
+const assert = require("assert");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const schemaArrayWithStringItems = {
+    items: { type: "string" },
+    type: "array"
+};
+
+const schemaArrayWithStringItemsAndDefault = {
+    ...schemaArrayWithStringItems,
+    default: ["abc"]
+};
+
+const schemaEnum = {
+    enum: ["first", "second"]
+};
+
+const schemaEnumWithDefault = {
+    ...schemaEnum,
+    default: "first"
+};
+
+const schemaObjectWithShallowDefault = {
+    default: {
+        first: 2
+    },
+    properties: {
+        first: {
+            type: "number"
+        }
+    }
+};
+
+const schemaObjectWithNestedDefault = {
+    additionalProperties: false,
+    properties: {
+        first: {
+            default: 2
+        }
+    }
+};
+
+const schemaObjectWithNestedDefaultAndDefault = {
+    ...schemaObjectWithNestedDefault,
+    default: {
+        first: 1
+    }
+};
+
+describe("getRuleOptions", () => {
+    for (const [name, ruleConfig, schema, expected] of [
+        [
+            "No schema or options",
+            ["error"],
+            [],
+            []
+        ],
+        [
+            "No schema with null option",
+            ["error", null],
+            [],
+            [null]
+        ],
+        [
+            "No schema with options",
+            ["error", "a", "b", "c"],
+            [],
+            ["a", "b", "c"]
+        ],
+        [
+            "Empty object schema",
+            ["error"],
+            [{}],
+            []
+        ],
+        [
+            "Config extending beyond schema",
+            ["error", "a", "b", "c"],
+            [{ default: 1 }],
+            ["a", "b", "c"]
+        ],
+        [
+            "Rule severity without options and schema default",
+            "error",
+            [{ default: 1 }],
+            [1]
+        ],
+        [
+            "Array schema without default value and no config",
+            ["error"],
+            [schemaArrayWithStringItems],
+            []
+        ],
+        [
+            "Array schema without default value and null config",
+            ["error", null],
+            [schemaArrayWithStringItems],
+            [null]
+        ],
+        [
+            "Array schema without default value and empty array config",
+            ["error", []],
+            [schemaArrayWithStringItems],
+            [[]]
+        ],
+        [
+            "Array schema without default value and populated array config",
+            ["error", ["def"]],
+            [schemaArrayWithStringItems],
+            [["def"]]
+        ],
+        [
+            "Array schema with default value and no config",
+            ["error"],
+            [schemaArrayWithStringItemsAndDefault],
+            [["abc"]]
+        ],
+        [
+            "Array schema with default value and null config",
+            ["error", null],
+            [schemaArrayWithStringItemsAndDefault],
+            [null]
+        ],
+        [
+            "Array schema with default value and empty array config",
+            ["error", []],
+            [schemaArrayWithStringItemsAndDefault],
+            [[]]
+        ],
+        [
+            "Array schema with default value and populated array config",
+            ["error", ["def"]],
+            [schemaArrayWithStringItemsAndDefault],
+            [["def"]]
+        ],
+        [
+            "Enum schema without default value and no config",
+            ["error"],
+            [schemaEnum],
+            []
+        ],
+        [
+            "Enum schema without default value with value config",
+            ["error", null],
+            [schemaEnum],
+            [null]
+        ],
+        [
+            "Enum schema with default value and no config",
+            ["error"],
+            [schemaEnumWithDefault],
+            [schemaEnumWithDefault.default]
+        ],
+        [
+            "Enum schema with default value with value config",
+            ["error", null],
+            [schemaEnumWithDefault],
+            [null]
+        ],
+        [
+            "Object schema with shallow default value and no config",
+            ["error"],
+            [schemaObjectWithShallowDefault],
+            [{ first: 2 }]
+        ],
+        [
+            "Object schema with shallow default value and null config",
+            ["error", null],
+            [schemaObjectWithShallowDefault],
+            [null]
+        ],
+        [
+            "Object schema with shallow default value and empty object config",
+            ["error", {}],
+            [schemaObjectWithShallowDefault],
+            [{}]
+        ],
+        [
+            "Object schema with shallow default value and populated object config",
+            ["error", { first: 3 }],
+            [schemaObjectWithShallowDefault],
+            [{ first: 3 }]
+        ],
+        [
+            "Object schema with nested default value and no config",
+            ["error"],
+            [schemaObjectWithNestedDefault],
+            [{ first: 2 }]
+        ],
+        [
+            "Object schema with nested default value and null config",
+            ["error", null],
+            [schemaObjectWithNestedDefault],
+            [null]
+        ],
+        [
+            "Object schema with nested default value and empty object config",
+            ["error", {}],
+            [schemaObjectWithNestedDefault],
+            [{ first: 2 }]
+        ],
+        [
+            "Object schema with nested default value and populated object config",
+            ["error", { first: 3 }],
+            [schemaObjectWithNestedDefault],
+            [{ first: 3 }]
+        ],
+        [
+            "Object schema with default value and no config",
+            ["error"],
+            [schemaObjectWithNestedDefaultAndDefault],
+            [{ first: 1 }]
+        ],
+        [
+            "Object schema with default value and null config",
+            ["error", null],
+            [schemaObjectWithNestedDefaultAndDefault],
+            [null]
+        ],
+        [
+            "Object schema with default value and empty object config",
+            ["error", {}],
+            [schemaObjectWithNestedDefaultAndDefault],
+            [{ first: 2 }]
+        ],
+        [
+            "Object schema with default value and populated object config",
+            ["error", { first: 3 }],
+            [schemaObjectWithNestedDefaultAndDefault],
+            [{ first: 3 }]
+        ],
+        [
+            "Object schema with anyOf and no config",
+            ["error"],
+            [{
+                anyOf: [
+                    {
+                        properties: {
+                            first: {
+                                type: "number"
+                            }
+                        }
+                    },
+                    {
+                        type: "string"
+                    }
+                ]
+            }],
+            []
+        ],
+        [
+            "Object schema with anyOf and populated object config config",
+            ["error", { first: 3 }],
+            [{
+                anyOf: [
+                    {
+                        properties: {
+                            first: {
+                                type: "number"
+                            }
+                        }
+                    },
+                    {
+                        type: "string"
+                    }
+                ]
+            }],
+            [{ first: 3 }]
+        ],
+        [
+            "Real-world: class-methods-use-this and no config",
+            ["error"],
+            [
+                {
+                    type: "object",
+                    properties: {
+                        exceptMethods: {
+                            type: "array",
+                            items: {
+                                type: "string"
+                            }
+                        },
+                        enforceForClassFields: {
+                            type: "boolean",
+                            default: true
+                        }
+                    },
+                    additionalProperties: false
+                }
+            ],
+            [
+                {
+                    enforceForClassFields: true
+                }
+            ]
+        ],
+        [
+            "Real-world: class-methods-use-this and null config",
+            ["error", null],
+            [
+                {
+                    type: "object",
+                    properties: {
+                        exceptMethods: {
+                            type: "array",
+                            items: {
+                                type: "string"
+                            }
+                        },
+                        enforceForClassFields: {
+                            type: "boolean",
+                            default: true
+                        }
+                    },
+                    additionalProperties: false
+                }
+            ],
+            [null]
+        ],
+        [
+            "Real-world: class-methods-use-this and empty object config",
+            ["error", {}],
+            [
+                {
+                    type: "object",
+                    properties: {
+                        exceptMethods: {
+                            type: "array",
+                            items: {
+                                type: "string"
+                            }
+                        },
+                        enforceForClassFields: {
+                            type: "boolean",
+                            default: true
+                        }
+                    },
+                    additionalProperties: false
+                }
+            ],
+            [{ enforceForClassFields: true }]
+        ],
+        [
+            "Real-world: require-jsdoc and no config",
+            ["error"],
+            [
+                {
+                    type: "object",
+                    properties: {
+                        require: {
+                            type: "object",
+                            properties: {
+                                ClassDeclaration: {
+                                    type: "boolean",
+                                    default: false
+                                },
+                                MethodDefinition: {
+                                    type: "boolean",
+                                    default: false
+                                },
+                                FunctionDeclaration: {
+                                    type: "boolean",
+                                    default: true
+                                },
+                                ArrowFunctionExpression: {
+                                    type: "boolean",
+                                    default: false
+                                },
+                                FunctionExpression: {
+                                    type: "boolean",
+                                    default: false
+                                }
+                            },
+                            additionalProperties: false,
+                            default: {}
+                        }
+                    },
+                    additionalProperties: false
+                }
+            ],
+            [
+                {
+                    require: {
+                        ClassDeclaration: false,
+                        MethodDefinition: false,
+                        FunctionDeclaration: true,
+                        ArrowFunctionExpression: false,
+                        FunctionExpression: false
+                    }
+                }
+            ]
+        ],
+        [
+            "Real-world: require-jsdoc and partially filled object config",
+            [
+                "error",
+                {
+                    require: {
+                        MethodDefinition: true,
+                        FunctionDeclaration: false
+                    }
+                }
+            ],
+            [
+                {
+                    type: "object",
+                    properties: {
+                        require: {
+                            type: "object",
+                            properties: {
+                                ClassDeclaration: {
+                                    type: "boolean",
+                                    default: false
+                                },
+                                MethodDefinition: {
+                                    type: "boolean",
+                                    default: false
+                                },
+                                FunctionDeclaration: {
+                                    type: "boolean",
+                                    default: true
+                                },
+                                ArrowFunctionExpression: {
+                                    type: "boolean",
+                                    default: false
+                                },
+                                FunctionExpression: {
+                                    type: "boolean",
+                                    default: false
+                                }
+                            },
+                            additionalProperties: false,
+                            default: {}
+                        }
+                    },
+                    additionalProperties: false
+                }
+            ],
+            [
+                {
+                    require: {
+                        ClassDeclaration: false,
+                        MethodDefinition: true,
+                        FunctionDeclaration: false,
+                        ArrowFunctionExpression: false,
+                        FunctionExpression: false
+                    }
+                }
+            ]
+        ]
+    ]) {
+        it(name, () => {
+            assert.deepStrictEqual(getRuleOptions(ruleConfig, schema), expected);
+        });
+    }
+});

--- a/tests/lib/linter/getRuleOptions.js
+++ b/tests/lib/linter/getRuleOptions.js
@@ -16,6 +16,15 @@ const assert = require("assert");
 // Tests
 //------------------------------------------------------------------------------
 
+const schemaString = {
+    type: "string"
+};
+
+const schemaStringWithDefault = {
+    ...schemaString,
+    default: "implicit"
+};
+
 const schemaArrayWithStringItems = {
     items: { type: "string" },
     type: "array"
@@ -99,6 +108,42 @@ describe("getRuleOptions", () => {
             "error",
             [{ default: 1 }],
             [1]
+        ],
+        [
+            "String schema without default value and no config",
+            ["error"],
+            [schemaString],
+            []
+        ],
+        [
+            "String schema without default value and null config",
+            ["error", null],
+            [schemaString],
+            [null]
+        ],
+        [
+            "String schema without default value and explicit config",
+            ["error", "explicit"],
+            [schemaString],
+            ["explicit"]
+        ],
+        [
+            "String schema with default value and no config",
+            ["error"],
+            [schemaStringWithDefault],
+            ["implicit"]
+        ],
+        [
+            "String schema with default value and null config",
+            ["error", null],
+            [schemaStringWithDefault],
+            [null]
+        ],
+        [
+            "String schema with default value and explicit config",
+            ["error", "explicit"],
+            [schemaStringWithDefault],
+            ["explicit"]
         ],
         [
             "Array schema without default value and no config",


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Augments `getRuleOptions` to factor in the rule's `schema`. Specifically, it:

* Defaults `undefined` options to the schema's `.default` value 
* Recursively creates `{}` objects

#### Is there anything you'd like reviewers to focus on?

Sending an RFC momentarily.

* Issue: https://github.com/eslint/eslint/issues/17448
* RFC: https://github.com/eslint/rfcs/pull/113

<!-- markdownlint-disable-file MD004 -->
