### PR TITLE
feat: flat-rule-tester make sure default config always matches

### DIFF
--- a/lib/rule-tester/flat-rule-tester.js
+++ b/lib/rule-tester/flat-rule-tester.js
@@ -84,13 +84,15 @@ const { ConfigArraySymbol } = require("@humanwhocodes/config-array");
  * testerDefaultConfig must not be modified as it allows to reset the tester to
  * the initial default configuration
  */
-const testerDefaultConfig = { rules: {} };
+const testerDefaultConfig = { files: ["**/*.*"], rules: {} };
 
 /*
  * RuleTester uses this config as its default. This can be overwritten via
  * setDefaultConfig().
+ * Files is required to also match non-JavaScript files when
+ * a test case defines a "filename".
  */
-let sharedDefaultConfig = { rules: {} };
+let sharedDefaultConfig = { ...testerDefaultConfig };
 
 /*
  * List every parameters possible on a test case that are not related to eslint
@@ -368,7 +370,10 @@ class FlatRuleTester {
         sharedDefaultConfig = config;
 
         // Make sure the rules object exists since it is assumed to exist later
-        sharedDefaultConfig.rules = sharedDefaultConfig.rules || {};
+        sharedDefaultConfig.rules = sharedDefaultConfig.rules || testerDefaultConfig.rules;
+
+        // Make sure the config is always matching if no files are specified
+        sharedDefaultConfig.files = sharedDefaultConfig.files || testerDefaultConfig.files;
     }
 
     /**
@@ -386,9 +391,7 @@ class FlatRuleTester {
      */
     static resetDefaultConfig() {
         sharedDefaultConfig = {
-            rules: {
-                ...testerDefaultConfig.rules
-            }
+            ...testerDefaultConfig
         };
     }
 

--- a/lib/rule-tester/flat-rule-tester.js
+++ b/lib/rule-tester/flat-rule-tester.js
@@ -84,7 +84,7 @@ const { ConfigArraySymbol } = require("@humanwhocodes/config-array");
  * testerDefaultConfig must not be modified as it allows to reset the tester to
  * the initial default configuration
  */
-const testerDefaultConfig = { files: ["**/*.*"], rules: {} };
+const testerDefaultConfig = { files: ["**"], rules: {} };
 
 /*
  * RuleTester uses this config as its default. This can be overwritten via

--- a/lib/rule-tester/flat-rule-tester.js
+++ b/lib/rule-tester/flat-rule-tester.js
@@ -84,15 +84,13 @@ const { ConfigArraySymbol } = require("@humanwhocodes/config-array");
  * testerDefaultConfig must not be modified as it allows to reset the tester to
  * the initial default configuration
  */
-const testerDefaultConfig = { files: ["**"], rules: {} };
+const testerDefaultConfig = { rules: {} };
 
 /*
  * RuleTester uses this config as its default. This can be overwritten via
  * setDefaultConfig().
- * Files is required to also match non-JavaScript files when
- * a test case defines a "filename".
  */
-let sharedDefaultConfig = { ...testerDefaultConfig };
+let sharedDefaultConfig = { rules: {} };
 
 /*
  * List every parameters possible on a test case that are not related to eslint
@@ -370,10 +368,7 @@ class FlatRuleTester {
         sharedDefaultConfig = config;
 
         // Make sure the rules object exists since it is assumed to exist later
-        sharedDefaultConfig.rules = sharedDefaultConfig.rules || testerDefaultConfig.rules;
-
-        // Make sure the config is always matching if no files are specified
-        sharedDefaultConfig.files = sharedDefaultConfig.files || testerDefaultConfig.files;
+        sharedDefaultConfig.rules = sharedDefaultConfig.rules || {};
     }
 
     /**
@@ -391,7 +386,9 @@ class FlatRuleTester {
      */
     static resetDefaultConfig() {
         sharedDefaultConfig = {
-            ...testerDefaultConfig
+            rules: {
+                ...testerDefaultConfig.rules
+            }
         };
     }
 
@@ -501,6 +498,7 @@ class FlatRuleTester {
         }
 
         const baseConfig = [
+            { files: ["**"] }, // Make sure the default config matches for all files
             {
                 plugins: {
 

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -124,7 +124,7 @@ describe("FlatRuleTester", () => {
             FlatRuleTester.resetDefaultConfig();
             assert.deepStrictEqual(
                 FlatRuleTester.getDefaultConfig(),
-                { rules: {} },
+                { rules: {}, files: ["**/*.*"] },
                 "The default configuration has not reset correctly"
             );
         });
@@ -1114,6 +1114,32 @@ describe("FlatRuleTester", () => {
                 ]
             });
         }());
+    });
+
+    it("should allow setting the filename to a non-JavaScript file", () => {
+        ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
+            valid: [
+                {
+                    code: "var foo = 'bar'",
+                    filename: "somefile.ts"
+                }
+            ],
+            invalid: []
+        });
+    });
+
+    it("should keep allowing non-JavaScript files if the default config does not specify files", () => {
+        FlatRuleTester.setDefaultConfig({ rules: {} });
+        ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
+            valid: [
+                {
+                    code: "var foo = 'bar'",
+                    filename: "somefile.ts"
+                }
+            ],
+            invalid: []
+        });
+        FlatRuleTester.resetDefaultConfig();
     });
 
     it("should pass-through the options to the rule", () => {

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -1167,7 +1167,14 @@ describe("FlatRuleTester", () => {
     it("should allow setting the filename to a file path without extension", () => {
         ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
             valid: [
-
+                {
+                    code: "var foo = 'bar'",
+                    filename: "path/to/somefile"
+                },
+                {
+                    code: "var foo = 'bar'",
+                    filename: "src/somefile"
+                }
             ],
             invalid: []
         });

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -1140,12 +1140,24 @@ describe("FlatRuleTester", () => {
         });
     });
 
-    it("should allow setting the filename to a file path without extension", () => {
+    it("should allow setting the filename to a file path with extension", () => {
         ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
             valid: [
                 {
                     code: "var foo = 'bar'",
                     filename: "path/to/somefile.js"
+                }
+            ],
+            invalid: []
+        });
+    });
+
+    it("should allow setting the filename to a file path without extension", () => {
+        ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
+            valid: [
+                {
+                    code: "var foo = 'bar'",
+                    filename: "path/to/somefile"
                 }
             ],
             invalid: []

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -124,7 +124,7 @@ describe("FlatRuleTester", () => {
             FlatRuleTester.resetDefaultConfig();
             assert.deepStrictEqual(
                 FlatRuleTester.getDefaultConfig(),
-                { rules: {}, files: ["**"] },
+                { rules: {} },
                 "The default configuration has not reset correctly"
             );
         });
@@ -1128,12 +1128,16 @@ describe("FlatRuleTester", () => {
         });
     });
 
-    it("should allow setting the filename to a file name without extension", () => {
+    it("should allow setting the filename to a file path without extension", () => {
         ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
             valid: [
                 {
                     code: "var foo = 'bar'",
                     filename: "somefile"
+                },
+                {
+                    code: "var foo = 'bar'",
+                    filename: "path/to/somefile"
                 }
             ],
             invalid: []
@@ -1146,6 +1150,14 @@ describe("FlatRuleTester", () => {
                 {
                     code: "var foo = 'bar'",
                     filename: "path/to/somefile.js"
+                },
+                {
+                    code: "var foo = 'bar'",
+                    filename: "src/somefile.ts"
+                },
+                {
+                    code: "var foo = 'bar'",
+                    filename: "components/Component.vue"
                 }
             ],
             invalid: []
@@ -1155,10 +1167,7 @@ describe("FlatRuleTester", () => {
     it("should allow setting the filename to a file path without extension", () => {
         ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
             valid: [
-                {
-                    code: "var foo = 'bar'",
-                    filename: "path/to/somefile"
-                }
+
             ],
             invalid: []
         });

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -124,7 +124,7 @@ describe("FlatRuleTester", () => {
             FlatRuleTester.resetDefaultConfig();
             assert.deepStrictEqual(
                 FlatRuleTester.getDefaultConfig(),
-                { rules: {}, files: ["**/*.*"] },
+                { rules: {}, files: ["**"] },
                 "The default configuration has not reset correctly"
             );
         });
@@ -1122,6 +1122,30 @@ describe("FlatRuleTester", () => {
                 {
                     code: "var foo = 'bar'",
                     filename: "somefile.ts"
+                }
+            ],
+            invalid: []
+        });
+    });
+
+    it("should allow setting the filename to a file name without extension", () => {
+        ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
+            valid: [
+                {
+                    code: "var foo = 'bar'",
+                    filename: "somefile"
+                }
+            ],
+            invalid: []
+        });
+    });
+
+    it("should allow setting the filename to a file path without extension", () => {
+        ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
+            valid: [
+                {
+                    code: "var foo = 'bar'",
+                    filename: "path/to/somefile.js"
                 }
             ],
             invalid: []


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

Fixes #17577

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Flat Rule Tester bug fix

#### What changes did you make? (Give an overview)
Add `files: ["**/*.*"]` to the default shared config of the flat rule tester.
Adjusted the static methods `setDefaultConfig` to make sure `files` is always set and `resetDefaultConfig`.


#### Is there anything you'd like reviewers to focus on?
I decided to use object spread rather than defining the same properties because of the file pattern which may get out of sync.

<!-- markdownlint-disable-file MD004 -->
