### PR TITLE
fix: Ensure all RuleTester tests all deprecated context methods

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -186,7 +186,12 @@ const DEPRECATED_SOURCECODE_PASSTHROUGHS = {
     getTokens: "getTokens",
     getTokensAfter: "getTokensAfter",
     getTokensBefore: "getTokensBefore",
-    getTokensBetween: "getTokensBetween"
+    getTokensBetween: "getTokensBetween",
+
+    getScope: "getScope",
+    getAncestors: "getAncestors",
+    getDeclaredVariables: "getDeclaredVariables",
+    markVariableAsUsed: "markVariableAsUsed"
 };
 
 /**

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2534,9 +2534,12 @@ describe("RuleTester", () => {
             getTokens: "getTokens",
             getTokensAfter: "getTokensAfter",
             getTokensBefore: "getTokensBefore",
-            getTokensBetween: "getTokensBetween"
+            getTokensBetween: "getTokensBetween",
+            getScope: "getScope",
+            getAncestors: "getAncestors",
+            getDeclaredVariables: "getDeclaredVariables",
+            markVariableAsUsed: "markVariableAsUsed"
         }).forEach(([methodName, replacementName]) => {
-
 
             it(`should log a deprecation warning when calling \`context.${methodName}\``, () => {
                 const ruleToCheckDeprecation = {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

When I initially added deprecation warnings to `RuleTester` for `context` methods that have been moved to `SourceCode`, I missed the newest ones. This PR adds the remaining four deprecated methods.

#### Is there anything you'd like reviewers to focus on?

We also have deprecated methods like `getCwd()`, `getSourceCode()`, `getFilename()` and `getPhysicalFilename()`, and I wasn't sure if we wanted to strictly remove those in v9 because they don't interfere with the language plugins changes as they don't interact with `sourceCode`. So two questions:

1. do we want to check for these in `RuleTester`? 
2. do we want to remove these in v9?

<!-- markdownlint-disable-file MD004 -->
