### PR TITLE
docs: Fix and standardize JSX code examples

### DIFF
--- a/docs/src/rules/jsx-quotes.md
+++ b/docs/src/rules/jsx-quotes.md
@@ -37,9 +37,9 @@ This rule has a string option:
 
 Examples of **incorrect** code for this rule with the default `"prefer-double"` option:
 
-:::incorrect
+:::incorrect { "ecmaFeatures": { "jsx": true } }
 
-```xml
+```jsx
 /*eslint jsx-quotes: ["error", "prefer-double"]*/
 
 <a b='c' />
@@ -49,9 +49,9 @@ Examples of **incorrect** code for this rule with the default `"prefer-double"` 
 
 Examples of **correct** code for this rule with the default `"prefer-double"` option:
 
-:::correct
+:::correct { "ecmaFeatures": { "jsx": true } }
 
-```xml
+```jsx
 /*eslint jsx-quotes: ["error", "prefer-double"]*/
 
 <a b="c" />
@@ -64,9 +64,9 @@ Examples of **correct** code for this rule with the default `"prefer-double"` op
 
 Examples of **incorrect** code for this rule with the `"prefer-single"` option:
 
-:::incorrect
+:::incorrect { "ecmaFeatures": { "jsx": true } }
 
-```xml
+```jsx
 /*eslint jsx-quotes: ["error", "prefer-single"]*/
 
 <a b="c" />
@@ -76,9 +76,9 @@ Examples of **incorrect** code for this rule with the `"prefer-single"` option:
 
 Examples of **correct** code for this rule with the `"prefer-single"` option:
 
-:::correct
+:::correct { "ecmaFeatures": { "jsx": true } }
 
-```xml
+```jsx
 /*eslint jsx-quotes: ["error", "prefer-single"]*/
 
 <a b='c' />

--- a/docs/src/rules/keyword-spacing.md
+++ b/docs/src/rules/keyword-spacing.md
@@ -58,9 +58,9 @@ if (foo) {
 
 Examples of **correct** code for this rule with the default `{ "before": true }` option:
 
-::: correct
+::: correct { "ecmaFeatures": { "jsx": true } }
 
-```js
+```jsx
 /*eslint keyword-spacing: ["error", { "before": true }]*/
 /*eslint-env es6*/
 
@@ -173,9 +173,9 @@ if(foo) {
 
 Examples of **correct** code for this rule with the default `{ "after": true }` option:
 
-::: correct
+::: correct { "ecmaFeatures": { "jsx": true } }
 
-```js
+```jsx
 /*eslint keyword-spacing: ["error", { "after": true }]*/
 
 if (foo) {

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -214,9 +214,9 @@ foo ? bar : (baz || qux);
 
 Examples of **correct** code for this rule with the `all` and `{ "ignoreJSX": "all" }` options:
 
-::: correct
+::: correct { "ecmaFeatures": { "jsx": true } }
 
-```js
+```jsx
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "all" }] */
 const Component = (<div />)
 const Component = (
@@ -230,9 +230,9 @@ const Component = (
 
 Examples of **incorrect** code for this rule with the `all` and `{ "ignoreJSX": "multi-line" }` options:
 
-::: incorrect
+::: incorrect { "ecmaFeatures": { "jsx": true } }
 
-```js
+```jsx
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "multi-line" }] */
 const Component = (<div />)
 const Component = (<div><p /></div>)
@@ -242,9 +242,9 @@ const Component = (<div><p /></div>)
 
 Examples of **correct** code for this rule with the `all` and `{ "ignoreJSX": "multi-line" }` options:
 
-::: correct
+::: correct { "ecmaFeatures": { "jsx": true } }
 
-```js
+```jsx
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "multi-line" }] */
 const Component = (
     <div>
@@ -262,9 +262,9 @@ const Component = (
 
 Examples of **incorrect** code for this rule with the `all` and `{ "ignoreJSX": "single-line" }` options:
 
-::: incorrect
+::: incorrect { "ecmaFeatures": { "jsx": true } }
 
-```js
+```jsx
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "single-line" }] */
 const Component = (
     <div>
@@ -282,9 +282,9 @@ const Component = (
 
 Examples of **correct** code for this rule with the `all` and `{ "ignoreJSX": "single-line" }` options:
 
-::: correct
+::: correct { "ecmaFeatures": { "jsx": true } }
 
-```js
+```jsx
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "single-line" }] */
 const Component = (<div />)
 const Component = (<div><p /></div>)

--- a/docs/src/rules/no-inline-comments.md
+++ b/docs/src/rules/no-inline-comments.md
@@ -54,9 +54,9 @@ Comments inside the curly braces in JSX are allowed to be on the same line as th
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "ecmaFeatures": { "jsx": true } }
 
-```js
+```jsx
 /*eslint no-inline-comments: "error"*/
 
 var foo = <div>{ /* On the same line with other code */ }<h1>Some heading</h1></div>;
@@ -74,9 +74,9 @@ var bar = (
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "ecmaFeatures": { "jsx": true } }
 
-```js
+```jsx
 /*eslint no-inline-comments: "error"*/
 
 var foo = (

--- a/docs/src/rules/no-irregular-whitespace.md
+++ b/docs/src/rules/no-irregular-whitespace.md
@@ -197,9 +197,9 @@ function thing() {
 
 Examples of additional **correct** code for this rule with the `{ "skipJSXText": true }` option:
 
-::: correct
+::: correct { "ecmaFeatures": { "jsx": true } }
 
-```js
+```jsx
 /*eslint no-irregular-whitespace: ["error", { "skipJSXText": true }]*/
 /*eslint-env es6*/
 

--- a/docs/src/rules/no-unused-expressions.md
+++ b/docs/src/rules/no-unused-expressions.md
@@ -251,7 +251,7 @@ JSX is most-commonly used in the React ecosystem, where it is compiled to `React
 
 Examples of **incorrect** code for the `{ "enforceForJSX": true }` option:
 
-::: incorrect
+::: incorrect { "ecmaFeatures": { "jsx": true } }
 
 ```jsx
 /*eslint no-unused-expressions: ["error", { "enforceForJSX": true }]*/
@@ -265,7 +265,7 @@ Examples of **incorrect** code for the `{ "enforceForJSX": true }` option:
 
 Examples of **correct** code for the `{ "enforceForJSX": true }` option:
 
-::: correct
+::: correct { "ecmaFeatures": { "jsx": true } }
 
 ```jsx
 /*eslint no-unused-expressions: ["error", { "enforceForJSX": true }]*/


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR aims to make JSX code examples in rule docs loaded with the correct parser options in the playground. Opening any of these code examples in the playground results currently in a parser error, because JSX is not enabled by default.

* Added `{ "ecmaFeatures": { "jsx": true } }` to the parser options of examples that contain JSX.
* Unified all markdown language tags to `jsx`. Currently, the variants `js`, `jsx`, and `xml` are in use.

From what I know, language tags in markdown code fences are only used for visual formatting, they don't affect the parsing in the playground, so the language tags change is just cosmetic.

Note that the correct parser options alone don't guarantee that a code block is parsable: for example, the JSX examples in [`no-extra-parens`](https://eslint.org/docs/latest/rules/no-extra-parens#ignorejsx) will be still unparsable after the fix because of the duplicate `Component` declarations. Same thing for the JSX example in [`keyword-spacing`](https://eslint.org/docs/latest/rules/keyword-spacing) with repeated identifiers. This is a quite common problem that needs additional discussion. I am testing a script to detect unparsable code examples automatically and will show the results in a separate issue.

 #### Is there anything you'd like reviewers to focus on?

Did I miss any examples?

<!-- markdownlint-disable-file MD004 -->
