### PR TITLE
fix: Ensure deprecated context.parserServices warns

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -402,8 +402,8 @@ function emitCodePathCurrentSegmentsWarning(ruleName) {
  * @returns {void}
  */
 function emitParserServicesWarning(ruleName) {
-    if (!emitParserServicesWarning.warned) {
-        emitParserServicesWarning.warned = true;
+    if (!emitParserServicesWarning[`warned-${ruleName}`]) {
+        emitParserServicesWarning[`warned-${ruleName}`] = true;
         process.emitWarning(
             `"${ruleName}" rule is using \`context.parserServices\`, which is deprecated and will be removed in ESLint v9. Please use \`sourceCode.parserServices\` instead.`,
             "DeprecationWarning"

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -396,6 +396,22 @@ function emitCodePathCurrentSegmentsWarning(ruleName) {
     }
 }
 
+/**
+ * Emit a deprecation warning if `context.parserServices` is used..
+ * @param {string} ruleName Name of the rule.
+ * @returns {void}
+ */
+function emitParserServicesWarning(ruleName) {
+    if (!emitParserServicesWarning.warned) {
+        emitParserServicesWarning.warned = true;
+        process.emitWarning(
+            `"${ruleName}" rule is using \`context.parserServices\`, which is deprecated and will be removed in ESLint v9. Please use \`sourceCode.parserServices\` instead.`,
+            "DeprecationWarning"
+        );
+    }
+}
+
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -627,25 +643,36 @@ class RuleTester {
                 freezeDeeply(context.settings);
                 freezeDeeply(context.parserOptions);
 
-                const newContext = Object.freeze(
-                    Object.create(
-                        context,
-                        Object.fromEntries(Object.keys(DEPRECATED_SOURCECODE_PASSTHROUGHS).map(methodName => [
-                            methodName,
-                            {
-                                value(...args) {
+                // wrap all deprecated methods
+                const newContext = Object.create(
+                    context,
+                    Object.fromEntries(Object.keys(DEPRECATED_SOURCECODE_PASSTHROUGHS).map(methodName => [
+                        methodName,
+                        {
+                            value(...args) {
 
-                                    // emit deprecation warning
-                                    emitDeprecatedContextMethodWarning(ruleName, methodName);
+                                // emit deprecation warning
+                                emitDeprecatedContextMethodWarning(ruleName, methodName);
 
-                                    // call the original method
-                                    return context[methodName].call(this, ...args);
-                                },
-                                enumerable: true
-                            }
-                        ]))
-                    )
+                                // call the original method
+                                return context[methodName].call(this, ...args);
+                            },
+                            enumerable: true
+                        }
+                    ]))
                 );
+
+                // emit warning about context.parserServices
+                const parserServices = context.parserServices;
+
+                Object.defineProperty(newContext, "parserServices", {
+                    get() {
+                        emitParserServicesWarning(ruleName);
+                        return parserServices;
+                    }
+                });
+
+                Object.freeze(newContext);
 
                 return (typeof rule === "function" ? rule : rule.create)(newContext);
             }

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -397,7 +397,7 @@ function emitCodePathCurrentSegmentsWarning(ruleName) {
 }
 
 /**
- * Emit a deprecation warning if `context.parserServices` is used..
+ * Emit a deprecation warning if `context.parserServices` is used.
  * @param {string} ruleName Name of the rule.
  * @returns {void}
  */


### PR DESCRIPTION
Updated RuleTester to emit a deprecation warning whenever `context.parserServices` is used.

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The `context.parserServices` property has been deprecated but we weren't warning about it with `RuleTester`, so I added that check.

#### Is there anything you'd like reviewers to focus on?

Because there was already a test using `context.parserServices`, I modified that test to check for the deprecation warning. This was the easiest way to implement the test without outputting duplicate messages to the console. Because `emitParserServicesWarning` is reused by all tests, the existing test was triggering the deprecation message and any new test would not. Please double-check that this approach is okay.


<!-- markdownlint-disable-file MD004 -->
