### PR TITLE
fix: `eslint-disable` to be able to parse quoted rule names

### DIFF
--- a/lib/linter/apply-disable-directives.js
+++ b/lib/linter/apply-disable-directives.js
@@ -87,7 +87,7 @@ function createIndividualDirectivesRemoval(directives, commentToken) {
     return directives.map(directive => {
         const { ruleId } = directive;
 
-        const regex = new RegExp(String.raw`(?:^|\s*,\s*)${escapeRegExp(ruleId)}(?:\s*,\s*|$)`, "u");
+        const regex = new RegExp(String.raw`(?:^|\s*,\s*)(?<quote>['"]?)${escapeRegExp(ruleId)}\k<quote>(?:\s*,\s*|$)`, "u");
         const match = regex.exec(listText);
         const matchedText = match[0];
         const matchStartOffset = listStartOffset + match.index;

--- a/lib/linter/config-comment-parser.js
+++ b/lib/linter/config-comment-parser.js
@@ -139,7 +139,7 @@ module.exports = class ConfigCommentParser {
         const items = {};
 
         string.split(",").forEach(name => {
-            const trimmedName = name.replace(/^\s*(?<quote>['"]?)(?<ruleId>\S*)\k<quote>\s*$/u, "$<ruleId>");
+            const trimmedName = name.trim().replace(/^(?<quote>['"]?)(?<ruleId>.*)\k<quote>$/us, "$<ruleId>");
 
             if (trimmedName) {
                 items[trimmedName] = true;

--- a/lib/linter/config-comment-parser.js
+++ b/lib/linter/config-comment-parser.js
@@ -139,7 +139,7 @@ module.exports = class ConfigCommentParser {
         const items = {};
 
         string.split(",").forEach(name => {
-            const trimmedName = name.trim();
+            const trimmedName = name.replace(/^\s*(?<quote>['"]?)(?<ruleId>\S*)\k<quote>\s*$/u, "$<ruleId>");
 
             if (trimmedName) {
                 items[trimmedName] = true;

--- a/tests/lib/linter/config-comment-parser.js
+++ b/tests/lib/linter/config-comment-parser.js
@@ -236,6 +236,16 @@ describe("ConfigCommentParser", () => {
                 "'c\"": true // This result is correct because used mismatched quotes.
             });
         });
+        it("should parse list config with spaced items", () => {
+            const code = " a b , 'c d' , \"e f\" ";
+            const result = commentParser.parseListConfig(code);
+
+            assert.deepStrictEqual(result, {
+                "a b": true,
+                "c d": true,
+                "e f": true
+            });
+        });
     });
 
 });

--- a/tests/lib/linter/config-comment-parser.js
+++ b/tests/lib/linter/config-comment-parser.js
@@ -224,6 +224,18 @@ describe("ConfigCommentParser", () => {
                 b: true
             });
         });
+
+        it("should parse list config with literal items", () => {
+            const code = "'a', \"b\", 'c\", \"d'";
+            const result = commentParser.parseListConfig(code);
+
+            assert.deepStrictEqual(result, {
+                a: true,
+                b: true,
+                "\"d'": true, // This result is correct because used mismatched quotes.
+                "'c\"": true // This result is correct because used mismatched quotes.
+            });
+        });
     });
 
 });

--- a/tests/lib/linter/config-comment-parser.js
+++ b/tests/lib/linter/config-comment-parser.js
@@ -225,7 +225,7 @@ describe("ConfigCommentParser", () => {
             });
         });
 
-        it("should parse list config with literal items", () => {
+        it("should parse list config with quoted items", () => {
             const code = "'a', \"b\", 'c\", \"d'";
             const result = commentParser.parseListConfig(code);
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -15473,15 +15473,15 @@ var a = "test2";
                         });
 
                         // Test for literals
-                        for (const testcaseForliteral of [
+                        for (const testcaseForLiteral of [
                             { code: code.replace(/(test\/[\w-]+)/gu, '"$1"'), output: output.replace(/(test\/[\w-]+)/gu, '"$1"') },
                             { code: code.replace(/(test\/[\w-]+)/gu, "'$1'"), output: output.replace(/(test\/[\w-]+)/gu, "'$1'") }
                         ]) {
                             // eslint-disable-next-line no-loop-func -- `linter` is getting updated in beforeEach()
-                            it(testcaseForliteral.code, () => {
+                            it(testcaseForLiteral.code, () => {
                                 assert.strictEqual(
-                                    linter.verifyAndFix(testcaseForliteral.code, config).output,
-                                    testcaseForliteral.output
+                                    linter.verifyAndFix(testcaseForLiteral.code, config).output,
+                                    testcaseForLiteral.output
                                 );
                             });
                         }

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -4949,8 +4949,8 @@ var a = "test2";
 
                 // Test for quoted rule names
                 for (const testcaseForLiteral of [
-                    { code: code.replace(/(test\/[\w-]+)/gu, '"$1"'), output: output.replace(/(test\/[\w-]+)/gu, '"$1"') },
-                    { code: code.replace(/(test\/[\w-]+)/gu, "'$1'"), output: output.replace(/(test\/[\w-]+)/gu, "'$1'") }
+                    { code: code.replace(/((?:un)?used[\w-]*)/gu, '"$1"'), output: output.replace(/((?:un)?used[\w-]*)/gu, '"$1"') },
+                    { code: code.replace(/((?:un)?used[\w-]*)/gu, "'$1'"), output: output.replace(/((?:un)?used[\w-]*)/gu, "'$1'") }
                 ]) {
                     // eslint-disable-next-line no-loop-func -- `linter` is getting updated in beforeEach()
                     it(testcaseForLiteral.code, () => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -13060,7 +13060,7 @@ var a = "test2";
                     assert.strictEqual(suppressedMessages[1].line, 3);
                 });
 
-                it("should report a violation with literals", () => {
+                it("should report a violation with literals in eslint-disable", () => {
                     const code = [
                         "/*eslint-disable 'no-alert' */",
                         "alert('test');",
@@ -13084,7 +13084,7 @@ var a = "test2";
                     assert.strictEqual(suppressedMessages[1].ruleId, "no-console");
                 });
 
-                it("should report a violation with literals", () => {
+                it("should report a violation with literals in eslint-enable", () => {
                     const code = [
                         "/*eslint-disable no-alert, no-console */",
                         "alert('test');",
@@ -13347,7 +13347,7 @@ var a = "test2";
                     assert.strictEqual(suppressedMessages.length, 5);
                 });
 
-                it("should report a violation with literals", () => {
+                it("should report a violation with literals in eslint-disable-line", () => {
                     const code = [
                         "alert('test'); // eslint-disable-line 'no-alert'",
                         "console.log('test');", // here


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR fixes the suppression directive comment so that it can parse rule names like string literals using quotes.

fixes #17598

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
