### PR TITLE
fix: syntax error in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ insert_final_newline = true
 [docs/rules/linebreak-style.md]
 end_of_line = disabled
 
-[{docs/rules/{indent.md,no-mixed-spaces-and-tabs.md}]
+[docs/rules/{indent.md,no-mixed-spaces-and-tabs.md}]
 indent_style = disabled
 indent_size = disabled
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))

#### What changes did you make? (Give an overview)

Fix syntax error in `.editorconfig` as seen when opening any file with [editorconfig-vim](https://github.com/editorconfig/editorconfig-vim) installed in nvim:

```
editorconfig: Error occurred while parsing glob pattern "/Users/silverwind/git/eslint/{docs/rules/{indent.md,no-mix
ed-spaces-and-tabs.md}": Vim:E220: Missing }.
```

#### Is there anything you'd like reviewers to focus on?

No
