### PR TITLE
docs: default to `sourceType: "module"` in rule examples

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -205,11 +205,12 @@ module.exports = function(eleventyConfig) {
                     }
 
                     // See https://github.com/eslint/eslint.org/blob/ac38ab41f99b89a8798d374f74e2cce01171be8b/src/playground/App.js#L44
-                    const parserOptions = tokens[index].info?.split("correct ")[1]?.trim();
+                    const parserOptionsJSON = tokens[index].info?.split("correct ")[1]?.trim();
+                    const parserOptions = { sourceType: "module", ...(parserOptionsJSON && JSON.parse(parserOptionsJSON)) };
                     const { content } = tokens[index + 1];
                     const state = encodeToBase64(
                         JSON.stringify({
-                            ...(parserOptions && { options: { parserOptions: JSON.parse(parserOptions) } }),
+                            options: { parserOptions },
                             text: content
                         })
                     );

--- a/docs/src/rules/camelcase.md
+++ b/docs/src/rules/camelcase.md
@@ -319,7 +319,7 @@ function UNSAFE_componentWillMount() {
 
 :::
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint camelcase: ["error", {allow: ["^UNSAFE_"]}]*/
@@ -328,7 +328,7 @@ function UNSAFE_componentWillMount() {
     // ...
 }
 
-function UNSAFE_componentWillMount() {
+function UNSAFE_componentWillReceiveProps() {
     // ...
 }
 ```

--- a/docs/src/rules/camelcase.md
+++ b/docs/src/rules/camelcase.md
@@ -319,7 +319,7 @@ function UNSAFE_componentWillMount() {
 
 :::
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint camelcase: ["error", {allow: ["^UNSAFE_"]}]*/

--- a/docs/src/rules/comma-spacing.md
+++ b/docs/src/rules/comma-spacing.md
@@ -50,7 +50,7 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule with the default `{ "before": false, "after": true }` options:
 
-:::incorrect
+:::incorrect { "sourceType": "script" }
 
 ```js
 /*eslint comma-spacing: ["error", { "before": false, "after": true }]*/
@@ -68,7 +68,7 @@ a ,b
 
 Examples of **correct** code for this rule with the default `{ "before": false, "after": true }` options:
 
-:::correct
+:::correct { "sourceType": "script" }
 
 ```js
 /*eslint comma-spacing: ["error", { "before": false, "after": true }]*/
@@ -122,7 +122,7 @@ foo(a, b,)
 
 Examples of **incorrect** code for this rule with the `{ "before": true, "after": false }` options:
 
-:::incorrect
+:::incorrect { "sourceType": "script" }
 
 ```js
 /*eslint comma-spacing: ["error", { "before": true, "after": false }]*/
@@ -139,7 +139,7 @@ a, b
 
 Examples of **correct** code for this rule with the `{ "before": true, "after": false }` options:
 
-:::correct
+:::correct { "sourceType": "script" }
 
 ```js
 /*eslint comma-spacing: ["error", { "before": true, "after": false }]*/

--- a/docs/src/rules/comma-spacing.md
+++ b/docs/src/rules/comma-spacing.md
@@ -50,7 +50,7 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule with the default `{ "before": false, "after": true }` options:
 
-:::incorrect { "sourceType": "script" }
+:::incorrect
 
 ```js
 /*eslint comma-spacing: ["error", { "before": false, "after": true }]*/
@@ -60,7 +60,7 @@ var arr = [1 , 2];
 var obj = {"foo": "bar" ,"baz": "qur"};
 foo(a ,b);
 new Foo(a ,b);
-function foo(a ,b){}
+function baz(a ,b){}
 a ,b
 ```
 
@@ -68,7 +68,7 @@ a ,b
 
 Examples of **correct** code for this rule with the default `{ "before": false, "after": true }` options:
 
-:::correct { "sourceType": "script" }
+:::correct
 
 ```js
 /*eslint comma-spacing: ["error", { "before": false, "after": true }]*/
@@ -80,7 +80,7 @@ var arr = [1,, 3]
 var obj = {"foo": "bar", "baz": "qur"};
 foo(a, b);
 new Foo(a, b);
-function foo(a, b){}
+function qur(a, b){}
 a, b
 ```
 
@@ -122,7 +122,7 @@ foo(a, b,)
 
 Examples of **incorrect** code for this rule with the `{ "before": true, "after": false }` options:
 
-:::incorrect { "sourceType": "script" }
+:::incorrect
 
 ```js
 /*eslint comma-spacing: ["error", { "before": true, "after": false }]*/
@@ -131,7 +131,7 @@ var foo = 1, bar = 2;
 var arr = [1 , 2];
 var obj = {"foo": "bar", "baz": "qur"};
 new Foo(a,b);
-function foo(a,b){}
+function baz(a,b){}
 a, b
 ```
 
@@ -139,7 +139,7 @@ a, b
 
 Examples of **correct** code for this rule with the `{ "before": true, "after": false }` options:
 
-:::correct { "sourceType": "script" }
+:::correct
 
 ```js
 /*eslint comma-spacing: ["error", { "before": true, "after": false }]*/
@@ -151,7 +151,7 @@ var arr = [1 ,,3]
 var obj = {"foo": "bar" ,"baz": "qur"};
 foo(a ,b);
 new Foo(a ,b);
-function foo(a ,b){}
+function qur(a ,b){}
 a ,b
 ```
 

--- a/docs/src/rules/comma-style.md
+++ b/docs/src/rules/comma-style.md
@@ -54,7 +54,7 @@ A way to determine the node types as defined by [ESTree](https://github.com/estr
 
 Examples of **incorrect** code for this rule with the default `"last"` option:
 
-:::incorrect { "sourceType": "script" }
+:::incorrect
 
 ```js
 /*eslint comma-style: ["error", "last"]*/
@@ -69,7 +69,7 @@ var foo = 1
 var foo = ["apples"
            , "oranges"];
 
-function bar() {
+function baz() {
     return {
         "a": 1
         ,"b:": 2
@@ -81,7 +81,7 @@ function bar() {
 
 Examples of **correct** code for this rule with the default `"last"` option:
 
-:::correct { "sourceType": "script" }
+:::correct
 
 ```js
 /*eslint comma-style: ["error", "last"]*/
@@ -94,7 +94,7 @@ var foo = 1,
 var foo = ["apples",
            "oranges"];
 
-function bar() {
+function baz() {
     return {
         "a": 1,
         "b:": 2
@@ -108,7 +108,7 @@ function bar() {
 
 Examples of **incorrect** code for this rule with the `"first"` option:
 
-:::incorrect { "sourceType": "script" }
+:::incorrect
 
 ```js
 /*eslint comma-style: ["error", "first"]*/
@@ -119,7 +119,7 @@ var foo = 1,
 var foo = ["apples",
            "oranges"];
 
-function bar() {
+function baz() {
     return {
         "a": 1,
         "b:": 2
@@ -131,7 +131,7 @@ function bar() {
 
 Examples of **correct** code for this rule with the `"first"` option:
 
-:::correct { "sourceType": "script" }
+:::correct
 
 ```js
 /*eslint comma-style: ["error", "first"]*/
@@ -144,7 +144,7 @@ var foo = 1
 var foo = ["apples"
           ,"oranges"];
 
-function bar() {
+function baz() {
     return {
         "a": 1
         ,"b:": 2

--- a/docs/src/rules/comma-style.md
+++ b/docs/src/rules/comma-style.md
@@ -54,7 +54,7 @@ A way to determine the node types as defined by [ESTree](https://github.com/estr
 
 Examples of **incorrect** code for this rule with the default `"last"` option:
 
-:::incorrect
+:::incorrect { "sourceType": "script" }
 
 ```js
 /*eslint comma-style: ["error", "last"]*/
@@ -81,7 +81,7 @@ function bar() {
 
 Examples of **correct** code for this rule with the default `"last"` option:
 
-:::correct
+:::correct { "sourceType": "script" }
 
 ```js
 /*eslint comma-style: ["error", "last"]*/
@@ -108,7 +108,7 @@ function bar() {
 
 Examples of **incorrect** code for this rule with the `"first"` option:
 
-:::incorrect
+:::incorrect { "sourceType": "script" }
 
 ```js
 /*eslint comma-style: ["error", "first"]*/
@@ -131,7 +131,7 @@ function bar() {
 
 Examples of **correct** code for this rule with the `"first"` option:
 
-:::correct
+:::correct { "sourceType": "script" }
 
 ```js
 /*eslint comma-style: ["error", "first"]*/

--- a/docs/src/rules/consistent-return.md
+++ b/docs/src/rules/consistent-return.md
@@ -35,7 +35,7 @@ This rule requires `return` statements to either always or never specify values.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint consistent-return: "error"*/
@@ -48,7 +48,7 @@ function doSomething(condition) {
     }
 }
 
-function doSomething(condition) {
+function doSomethingElse(condition) {
     if (condition) {
         return true;
     }

--- a/docs/src/rules/consistent-return.md
+++ b/docs/src/rules/consistent-return.md
@@ -35,7 +35,7 @@ This rule requires `return` statements to either always or never specify values.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint consistent-return: "error"*/

--- a/docs/src/rules/default-param-last.md
+++ b/docs/src/rules/default-param-last.md
@@ -21,7 +21,7 @@ This rule enforces default parameters to be the last of parameters.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /* eslint default-param-last: ["error"] */

--- a/docs/src/rules/default-param-last.md
+++ b/docs/src/rules/default-param-last.md
@@ -21,14 +21,14 @@ This rule enforces default parameters to be the last of parameters.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /* eslint default-param-last: ["error"] */
 
 function f(a = 0, b) {}
 
-function f(a, b = 0, c) {}
+function g(a, b = 0, c) {}
 ```
 
 :::

--- a/docs/src/rules/function-paren-newline.md
+++ b/docs/src/rules/function-paren-newline.md
@@ -42,7 +42,7 @@ Example configurations:
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /* eslint function-paren-newline: ["error", "always"] */
@@ -60,7 +60,7 @@ foo(bar, baz);
 
 Examples of **correct** code for this rule with the `"always"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /* eslint function-paren-newline: ["error", "always"] */
@@ -89,7 +89,7 @@ foo(
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /* eslint function-paren-newline: ["error", "never"] */
@@ -118,7 +118,7 @@ foo(
 
 Examples of **correct** code for this rule with the `"never"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /* eslint function-paren-newline: ["error", "never"] */
@@ -142,7 +142,7 @@ foo(bar,
 
 Examples of **incorrect** code for this rule with the default `"multiline"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /* eslint function-paren-newline: ["error", "multiline"] */
@@ -173,7 +173,7 @@ foo(
 
 Examples of **correct** code for this rule with the default `"multiline"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /* eslint function-paren-newline: ["error", "multiline"] */
@@ -204,7 +204,7 @@ foo(function() {
 
 Examples of **incorrect** code for this rule with the `"consistent"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /* eslint function-paren-newline: ["error", "consistent"] */
@@ -235,7 +235,7 @@ foo(
 
 Examples of **correct** code for this rule with the `"consistent"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /* eslint function-paren-newline: ["error", "consistent"] */
@@ -265,7 +265,7 @@ foo(
 
 Examples of **incorrect** code for this rule with the `"multiline-arguments"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /* eslint function-paren-newline: ["error", "multiline-arguments"] */
@@ -296,7 +296,7 @@ foo(
 
 Examples of **correct** code for this rule with the consistent `"multiline-arguments"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /* eslint function-paren-newline: ["error", "multiline-arguments"] */
@@ -323,7 +323,7 @@ foo(
 
 Examples of **incorrect** code for this rule with the `{ "minItems": 3 }` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /* eslint function-paren-newline: ["error", { "minItems": 3 }] */
@@ -350,7 +350,7 @@ foo(bar,
 
 Examples of **correct** code for this rule with the `{ "minItems": 3 }` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /* eslint function-paren-newline: ["error", { "minItems": 3 }] */

--- a/docs/src/rules/function-paren-newline.md
+++ b/docs/src/rules/function-paren-newline.md
@@ -42,16 +42,16 @@ Example configurations:
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /* eslint function-paren-newline: ["error", "always"] */
 
 function foo(bar, baz) {}
 
-var foo = function(bar, baz) {};
+var qux = function(bar, baz) {};
 
-var foo = (bar, baz) => {};
+var qux = (bar, baz) => {};
 
 foo(bar, baz);
 ```
@@ -60,7 +60,7 @@ foo(bar, baz);
 
 Examples of **correct** code for this rule with the `"always"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /* eslint function-paren-newline: ["error", "always"] */
@@ -70,11 +70,11 @@ function foo(
   baz
 ) {}
 
-var foo = function(
+var qux = function(
   bar, baz
 ) {};
 
-var foo = (
+var qux = (
   bar,
   baz
 ) => {};
@@ -89,7 +89,7 @@ foo(
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /* eslint function-paren-newline: ["error", "never"] */
@@ -99,11 +99,11 @@ function foo(
   baz
 ) {}
 
-var foo = function(
+var qux = function(
   bar, baz
 ) {};
 
-var foo = (
+var qux = (
   bar,
   baz
 ) => {};
@@ -118,19 +118,19 @@ foo(
 
 Examples of **correct** code for this rule with the `"never"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /* eslint function-paren-newline: ["error", "never"] */
 
 function foo(bar, baz) {}
 
-function foo(bar,
+function qux(bar,
              baz) {}
 
-var foo = function(bar, baz) {};
+var foobar = function(bar, baz) {};
 
-var foo = (bar, baz) => {};
+var foobar = (bar, baz) => {};
 
 foo(bar, baz);
 
@@ -142,7 +142,7 @@ foo(bar,
 
 Examples of **incorrect** code for this rule with the default `"multiline"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /* eslint function-paren-newline: ["error", "multiline"] */
@@ -151,11 +151,11 @@ function foo(bar,
   baz
 ) {}
 
-var foo = function(
+var qux = function(
   bar, baz
 ) {};
 
-var foo = (
+var qux = (
   bar,
   baz) => {};
 
@@ -173,19 +173,19 @@ foo(
 
 Examples of **correct** code for this rule with the default `"multiline"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /* eslint function-paren-newline: ["error", "multiline"] */
 
 function foo(bar, baz) {}
 
-var foo = function(
+var foobar = function(
   bar,
   baz
 ) {};
 
-var foo = (bar, baz) => {};
+var foobar = (bar, baz) => {};
 
 foo(bar, baz, qux);
 
@@ -204,7 +204,7 @@ foo(function() {
 
 Examples of **incorrect** code for this rule with the `"consistent"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /* eslint function-paren-newline: ["error", "consistent"] */
@@ -213,11 +213,11 @@ function foo(bar,
   baz
 ) {}
 
-var foo = function(bar,
+var qux = function(bar,
   baz
 ) {};
 
-var foo = (
+var qux = (
   bar,
   baz) => {};
 
@@ -235,7 +235,7 @@ foo(
 
 Examples of **correct** code for this rule with the `"consistent"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /* eslint function-paren-newline: ["error", "consistent"] */
@@ -243,9 +243,9 @@ Examples of **correct** code for this rule with the `"consistent"` option:
 function foo(bar,
   baz) {}
 
-var foo = function(bar, baz) {};
+var qux = function(bar, baz) {};
 
-var foo = (
+var qux = (
   bar,
   baz
 ) => {};
@@ -265,7 +265,7 @@ foo(
 
 Examples of **incorrect** code for this rule with the `"multiline-arguments"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /* eslint function-paren-newline: ["error", "multiline-arguments"] */
@@ -274,11 +274,11 @@ function foo(bar,
   baz
 ) {}
 
-var foo = function(bar,
+var foobar = function(bar,
   baz
 ) {};
 
-var foo = (
+var foobar = (
   bar,
   baz) => {};
 
@@ -296,7 +296,7 @@ foo(
 
 Examples of **correct** code for this rule with the consistent `"multiline-arguments"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /* eslint function-paren-newline: ["error", "multiline-arguments"] */
@@ -306,9 +306,9 @@ function foo(
   baz
 ) {}
 
-var foo = function(bar, baz) {};
+var qux = function(bar, baz) {};
 
-var foo = (
+var qux = (
   bar
 ) => {};
 
@@ -323,7 +323,7 @@ foo(
 
 Examples of **incorrect** code for this rule with the `{ "minItems": 3 }` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /* eslint function-paren-newline: ["error", { "minItems": 3 }] */
@@ -333,13 +333,13 @@ function foo(
   baz
 ) {}
 
-function foo(bar, baz, qux) {}
+function foobar(bar, baz, qux) {}
 
-var foo = function(
+var barbaz = function(
   bar, baz
 ) {};
 
-var foo = (bar,
+var barbaz = (bar,
   baz) => {};
 
 foo(bar,
@@ -350,20 +350,20 @@ foo(bar,
 
 Examples of **correct** code for this rule with the `{ "minItems": 3 }` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /* eslint function-paren-newline: ["error", { "minItems": 3 }] */
 
 function foo(bar, baz) {}
 
-var foo = function(
+var foobar = function(
   bar,
   baz,
   qux
 ) {};
 
-var foo = (
+var foobar = (
   bar, baz, qux
 ) => {};
 

--- a/docs/src/rules/global-require.md
+++ b/docs/src/rules/global-require.md
@@ -32,7 +32,7 @@ This rule requires all calls to `require()` to be at the top level of the module
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint global-require: "error"*/
@@ -76,7 +76,7 @@ try {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint global-require: "error"*/

--- a/docs/src/rules/id-length.md
+++ b/docs/src/rules/id-length.md
@@ -143,7 +143,7 @@ var { prop: [x]} = {};
 
 Examples of **correct** code for this rule with the `{ "min": 4 }` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint id-length: ["error", { "min": 4 }]*/

--- a/docs/src/rules/id-length.md
+++ b/docs/src/rules/id-length.md
@@ -143,7 +143,7 @@ var { prop: [x]} = {};
 
 Examples of **correct** code for this rule with the `{ "min": 4 }` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint id-length: ["error", { "min": 4 }]*/
@@ -160,10 +160,10 @@ try {
 }
 var myObj = { apple: 1 };
 (value) => { value * value };
-function foobar(value = 0) { }
+function foobaz(value = 0) { }
 class MyClass { }
 class Foobar { method() {} }
-function foobar(...args) { }
+function barbaz(...args) { }
 var { prop } = {};
 var [longName] = foo;
 var { a: [prop] } = {};

--- a/docs/src/rules/lines-around-directive.md
+++ b/docs/src/rules/lines-around-directive.md
@@ -60,7 +60,7 @@ This is the default option.
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /* eslint lines-around-directive: ["error", "always"] */
@@ -92,7 +92,7 @@ function foo() {
 
 Examples of **correct** code for this rule with the `"always"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /* eslint lines-around-directive: ["error", "always"] */
@@ -132,7 +132,7 @@ function foo() {
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /* eslint lines-around-directive: ["error", "never"] */
@@ -171,7 +171,7 @@ function foo() {
 
 Examples of **correct** code for this rule with the `"never"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /* eslint lines-around-directive: ["error", "never"] */
@@ -205,7 +205,7 @@ function foo() {
 
 Examples of **incorrect** code for this rule with the `{ "before": "never", "after": "always" }` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /* eslint lines-around-directive: ["error", { "before": "never", "after": "always" }] */
@@ -240,7 +240,7 @@ function foo() {
 
 Examples of **correct** code for this rule with the `{ "before": "never", "after": "always" }`  option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /* eslint lines-around-directive: ["error", { "before": "never", "after": "always" }] */
@@ -276,7 +276,7 @@ function foo() {
 
 Examples of **incorrect** code for this rule with the `{ "before": "always", "after": "never" }` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /* eslint lines-around-directive: ["error", { "before": "always", "after": "never" }] */
@@ -312,7 +312,7 @@ function foo() {
 
 Examples of **correct** code for this rule with the `{ "before": "always", "after": "never" }` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /* eslint lines-around-directive: ["error", { "before": "always", "after": "never" }] */

--- a/docs/src/rules/max-statements-per-line.md
+++ b/docs/src/rules/max-statements-per-line.md
@@ -30,7 +30,7 @@ The "max" object property is optional (default: 1).
 
 Examples of **incorrect** code for this rule with the default `{ "max": 1 }` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint max-statements-per-line: ["error", { "max": 1 }]*/
@@ -40,7 +40,7 @@ if (condition) { bar = 1; }
 for (var i = 0; i < length; ++i) { bar = 1; }
 switch (discriminant) { default: break; }
 function foo() { bar = 1; }
-var foo = function foo() { bar = 1; };
+var qux = function qux() { bar = 1; };
 (function foo() { bar = 1; })();
 ```
 
@@ -48,7 +48,7 @@ var foo = function foo() { bar = 1; };
 
 Examples of **correct** code for this rule with the default `{ "max": 1 }` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint max-statements-per-line: ["error", { "max": 1 }]*/
@@ -58,7 +58,7 @@ if (condition) bar = 1;
 for (var i = 0; i < length; ++i);
 switch (discriminant) { default: }
 function foo() { }
-var foo = function foo() { };
+var qux = function qux() { };
 (function foo() { })();
 ```
 
@@ -66,7 +66,7 @@ var foo = function foo() { };
 
 Examples of **incorrect** code for this rule with the `{ "max": 2 }` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint max-statements-per-line: ["error", { "max": 2 }]*/
@@ -76,7 +76,7 @@ if (condition) { bar = 1; } else { baz = 2; }
 for (var i = 0; i < length; ++i) { bar = 1; baz = 2; }
 switch (discriminant) { case 'test': break; default: break; }
 function foo() { bar = 1; baz = 2; }
-var foo = function foo() { bar = 1; };
+var qux = function qux() { bar = 1; };
 (function foo() { bar = 1; baz = 2; })();
 ```
 
@@ -84,7 +84,7 @@ var foo = function foo() { bar = 1; };
 
 Examples of **correct** code for this rule with the `{ "max": 2 }` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint max-statements-per-line: ["error", { "max": 2 }]*/
@@ -94,7 +94,7 @@ if (condition) bar = 1; if (condition) baz = 2;
 for (var i = 0; i < length; ++i) { bar = 1; }
 switch (discriminant) { default: break; }
 function foo() { bar = 1; }
-var foo = function foo() { bar = 1; };
+var qux = function qux() { bar = 1; };
 (function foo() { var bar = 1; })();
 ```
 

--- a/docs/src/rules/max-statements-per-line.md
+++ b/docs/src/rules/max-statements-per-line.md
@@ -30,7 +30,7 @@ The "max" object property is optional (default: 1).
 
 Examples of **incorrect** code for this rule with the default `{ "max": 1 }` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint max-statements-per-line: ["error", { "max": 1 }]*/
@@ -48,7 +48,7 @@ var foo = function foo() { bar = 1; };
 
 Examples of **correct** code for this rule with the default `{ "max": 1 }` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint max-statements-per-line: ["error", { "max": 1 }]*/
@@ -66,7 +66,7 @@ var foo = function foo() { };
 
 Examples of **incorrect** code for this rule with the `{ "max": 2 }` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint max-statements-per-line: ["error", { "max": 2 }]*/
@@ -84,7 +84,7 @@ var foo = function foo() { bar = 1; };
 
 Examples of **correct** code for this rule with the `{ "max": 2 }` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint max-statements-per-line: ["error", { "max": 2 }]*/

--- a/docs/src/rules/newline-before-return.md
+++ b/docs/src/rules/newline-before-return.md
@@ -44,19 +44,19 @@ This rule requires an empty line before `return` statements to increase code cla
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint newline-before-return: "error"*/
 
-function foo(bar) {
+function foo1(bar) {
     if (!bar) {
         return;
     }
     return bar;
 }
 
-function foo(bar) {
+function foo2(bar) {
     if (!bar) {
         return;
     }
@@ -70,35 +70,35 @@ function foo(bar) {
 
 Examples of **correct** code for this rule:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint newline-before-return: "error"*/
 
-function foo() {
+function foo1() {
     return;
 }
 
-function foo() {
+function foo2() {
 
     return;
 }
 
-function foo(bar) {
+function foo3(bar) {
     if (!bar) return;
 }
 
-function foo(bar) {
+function foo4(bar) {
     if (!bar) { return };
 }
 
-function foo(bar) {
+function foo5(bar) {
     if (!bar) {
         return;
     }
 }
 
-function foo(bar) {
+function foo6(bar) {
     if (!bar) {
         return;
     }
@@ -106,14 +106,14 @@ function foo(bar) {
     return bar;
 }
 
-function foo(bar) {
+function foo7(bar) {
     if (!bar) {
 
         return;
     }
 }
 
-function foo() {
+function foo8() {
 
     // comment
     return;

--- a/docs/src/rules/newline-before-return.md
+++ b/docs/src/rules/newline-before-return.md
@@ -44,7 +44,7 @@ This rule requires an empty line before `return` statements to increase code cla
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint newline-before-return: "error"*/
@@ -70,7 +70,7 @@ function foo(bar) {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint newline-before-return: "error"*/

--- a/docs/src/rules/no-catch-shadow.md
+++ b/docs/src/rules/no-catch-shadow.md
@@ -26,7 +26,7 @@ This rule is aimed at preventing unexpected behavior in your program that may ar
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-catch-shadow: "error"*/
@@ -39,13 +39,13 @@ try {
 
 }
 
-function err() {
+function error() {
     // ...
 };
 
 try {
     throw "problem";
-} catch (err) {
+} catch (error) {
 
 }
 ```
@@ -54,7 +54,7 @@ try {
 
 Examples of **correct** code for this rule:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-catch-shadow: "error"*/
@@ -67,7 +67,7 @@ try {
 
 }
 
-function err() {
+function error() {
     // ...
 };
 

--- a/docs/src/rules/no-catch-shadow.md
+++ b/docs/src/rules/no-catch-shadow.md
@@ -26,7 +26,7 @@ This rule is aimed at preventing unexpected behavior in your program that may ar
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-catch-shadow: "error"*/
@@ -54,7 +54,7 @@ try {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-catch-shadow: "error"*/

--- a/docs/src/rules/no-cond-assign.md
+++ b/docs/src/rules/no-cond-assign.md
@@ -45,8 +45,7 @@ if (x = 0) {
 }
 
 // Practical example that is similar to an error
-function setHeight(someNode) {
-    "use strict";
+var setHeight = function (someNode) {
     do {
         someNode.height = "100px";
     } while (someNode = someNode.parentNode);
@@ -57,7 +56,7 @@ function setHeight(someNode) {
 
 Examples of **correct** code for this rule with the default `"except-parens"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-cond-assign: "error"*/
@@ -69,16 +68,14 @@ if (x === 0) {
 }
 
 // Practical example that wraps the assignment in parentheses
-function setHeight(someNode) {
-    "use strict";
+var setHeight = function (someNode) {
     do {
         someNode.height = "100px";
     } while ((someNode = someNode.parentNode));
 }
 
 // Practical example that wraps the assignment and tests for 'null'
-function setHeight(someNode) {
-    "use strict";
+var setHeight = function (someNode) {
     do {
         someNode.height = "100px";
     } while ((someNode = someNode.parentNode) !== null);
@@ -91,7 +88,7 @@ function setHeight(someNode) {
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-cond-assign: ["error", "always"]*/
@@ -103,24 +100,21 @@ if (x = 0) {
 }
 
 // Practical example that is similar to an error
-function setHeight(someNode) {
-    "use strict";
+var setHeight = function (someNode) {
     do {
         someNode.height = "100px";
     } while (someNode = someNode.parentNode);
 }
 
 // Practical example that wraps the assignment in parentheses
-function setHeight(someNode) {
-    "use strict";
+var setHeight = function (someNode) {
     do {
         someNode.height = "100px";
     } while ((someNode = someNode.parentNode));
 }
 
 // Practical example that wraps the assignment and tests for 'null'
-function setHeight(someNode) {
-    "use strict";
+var setHeight = function (someNode) {
     do {
         someNode.height = "100px";
     } while ((someNode = someNode.parentNode) !== null);

--- a/docs/src/rules/no-cond-assign.md
+++ b/docs/src/rules/no-cond-assign.md
@@ -57,7 +57,7 @@ function setHeight(someNode) {
 
 Examples of **correct** code for this rule with the default `"except-parens"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-cond-assign: "error"*/
@@ -91,7 +91,7 @@ function setHeight(someNode) {
 
 Examples of **incorrect** code for this rule with the `"always"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-cond-assign: ["error", "always"]*/

--- a/docs/src/rules/no-delete-var.md
+++ b/docs/src/rules/no-delete-var.md
@@ -15,7 +15,7 @@ If ESLint parses code in strict mode, the parser (instead of this rule) reports 
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-delete-var: "error"*/

--- a/docs/src/rules/no-dupe-args.md
+++ b/docs/src/rules/no-dupe-args.md
@@ -16,7 +16,7 @@ If ESLint parses code in strict mode, the parser (instead of this rule) reports 
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-dupe-args: "error"*/
@@ -34,7 +34,7 @@ var bar = function (a, b, a) {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-dupe-args: "error"*/

--- a/docs/src/rules/no-else-return.md
+++ b/docs/src/rules/no-else-return.md
@@ -32,7 +32,7 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-else-return: "error"*/
@@ -93,7 +93,7 @@ function foo() {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-else-return: "error"*/

--- a/docs/src/rules/no-else-return.md
+++ b/docs/src/rules/no-else-return.md
@@ -32,12 +32,12 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-else-return: "error"*/
 
-function foo() {
+function foo1() {
     if (x) {
         return y;
     } else {
@@ -45,7 +45,7 @@ function foo() {
     }
 }
 
-function foo() {
+function foo2() {
     if (x) {
         return y;
     } else if (z) {
@@ -55,7 +55,7 @@ function foo() {
     }
 }
 
-function foo() {
+function foo3() {
     if (x) {
         return y;
     } else {
@@ -65,7 +65,7 @@ function foo() {
     return t;
 }
 
-function foo() {
+function foo4() {
     if (error) {
         return 'It failed';
     } else {
@@ -76,7 +76,7 @@ function foo() {
 }
 
 // Two warnings for nested occurrences
-function foo() {
+function foo5() {
     if (x) {
         if (y) {
             return y;
@@ -93,12 +93,12 @@ function foo() {
 
 Examples of **correct** code for this rule:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-else-return: "error"*/
 
-function foo() {
+function foo1() {
     if (x) {
         return y;
     }
@@ -106,7 +106,7 @@ function foo() {
     return z;
 }
 
-function foo() {
+function foo2() {
     if (x) {
         return y;
     } else if (z) {
@@ -116,7 +116,7 @@ function foo() {
     }
 }
 
-function foo() {
+function foo3() {
     if (x) {
         if (z) {
             return y;
@@ -126,7 +126,7 @@ function foo() {
     }
 }
 
-function foo() {
+function foo4() {
     if (error) {
         return 'It failed';
     } else if (loading) {

--- a/docs/src/rules/no-empty-function.md
+++ b/docs/src/rules/no-empty-function.md
@@ -30,7 +30,7 @@ A function will not be considered a problem if it contains a comment.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-empty-function: "error"*/
@@ -85,7 +85,7 @@ class A {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-empty-function: "error"*/
@@ -198,7 +198,7 @@ This rule has an option to allow specific kinds of functions to be empty.
 
 Examples of **correct** code for the `{ "allow": ["functions"] }` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["functions"] }]*/
@@ -233,7 +233,7 @@ var foo = () => {};
 
 Examples of **correct** code for the `{ "allow": ["generatorFunctions"] }` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["generatorFunctions"] }]*/

--- a/docs/src/rules/no-empty-function.md
+++ b/docs/src/rules/no-empty-function.md
@@ -30,7 +30,7 @@ A function will not be considered a problem if it contains a comment.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-empty-function: "error"*/
@@ -38,13 +38,13 @@ Examples of **incorrect** code for this rule:
 
 function foo() {}
 
-var foo = function() {};
+var bar = function() {};
 
-var foo = () => {};
+var bar = () => {};
 
-function* foo() {}
+function* baz() {}
 
-var foo = function*() {};
+var bar = function*() {};
 
 var obj = {
     foo: function() {},
@@ -85,7 +85,7 @@ class A {
 
 Examples of **correct** code for this rule:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-empty-function: "error"*/
@@ -95,19 +95,19 @@ function foo() {
     // do nothing.
 }
 
-var foo = function() {
+var baz = function() {
     // any clear comments.
 };
 
-var foo = () => {
+var baz = () => {
     bar();
 };
 
-function* foo() {
+function* foobar() {
     // do nothing.
 }
 
-var foo = function*() {
+var baz = function*() {
     // do nothing.
 };
 
@@ -198,14 +198,14 @@ This rule has an option to allow specific kinds of functions to be empty.
 
 Examples of **correct** code for the `{ "allow": ["functions"] }` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["functions"] }]*/
 
 function foo() {}
 
-var foo = function() {};
+var bar = function() {};
 
 var obj = {
     foo: function() {}
@@ -233,7 +233,7 @@ var foo = () => {};
 
 Examples of **correct** code for the `{ "allow": ["generatorFunctions"] }` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["generatorFunctions"] }]*/
@@ -241,7 +241,7 @@ Examples of **correct** code for the `{ "allow": ["generatorFunctions"] }` optio
 
 function* foo() {}
 
-var foo = function*() {};
+var bar = function*() {};
 
 var obj = {
     foo: function*() {}

--- a/docs/src/rules/no-empty-pattern.md
+++ b/docs/src/rules/no-empty-pattern.md
@@ -34,7 +34,7 @@ This rule aims to flag any empty patterns in destructured objects and arrays, an
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-empty-pattern: "error"*/
@@ -53,7 +53,7 @@ function foo({a: []}) {}
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-empty-pattern: "error"*/
@@ -78,7 +78,7 @@ Set to `false` by default. Setting this option to `true` allows empty object pat
 
 Examples of **incorrect** code for this rule with the `{"allowObjectPatternsAsParameters": true}` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-empty-pattern: ["error", { "allowObjectPatternsAsParameters": true }]*/
@@ -96,7 +96,7 @@ function foo([]) {}
 
 Examples of **correct** code for this rule with the `{"allowObjectPatternsAsParameters": true}` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-empty-pattern: ["error", { "allowObjectPatternsAsParameters": true }]*/

--- a/docs/src/rules/no-empty-pattern.md
+++ b/docs/src/rules/no-empty-pattern.md
@@ -34,7 +34,7 @@ This rule aims to flag any empty patterns in destructured objects and arrays, an
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-empty-pattern: "error"*/
@@ -44,16 +44,16 @@ var [] = foo;
 var {a: {}} = foo;
 var {a: []} = foo;
 function foo({}) {}
-function foo([]) {}
-function foo({a: {}}) {}
-function foo({a: []}) {}
+function bar([]) {}
+function baz({a: {}}) {}
+function qux({a: []}) {}
 ```
 
 :::
 
 Examples of **correct** code for this rule:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-empty-pattern: "error"*/
@@ -61,7 +61,7 @@ Examples of **correct** code for this rule:
 var {a = {}} = foo;
 var {a = []} = foo;
 function foo({a = {}}) {}
-function foo({a = []}) {}
+function bar({a = []}) {}
 ```
 
 :::
@@ -78,34 +78,34 @@ Set to `false` by default. Setting this option to `true` allows empty object pat
 
 Examples of **incorrect** code for this rule with the `{"allowObjectPatternsAsParameters": true}` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-empty-pattern: ["error", { "allowObjectPatternsAsParameters": true }]*/
 
 function foo({a: {}}) {}
-var foo = function({a: {}}) {};
-var foo = ({a: {}}) => {};
-var foo = ({} = bar) => {};
-var foo = ({} = { bar: 1 }) => {};
+var bar = function({a: {}}) {};
+var bar = ({a: {}}) => {};
+var bar = ({} = bar) => {};
+var bar = ({} = { bar: 1 }) => {};
 
-function foo([]) {}
+function baz([]) {}
 ```
 
 :::
 
 Examples of **correct** code for this rule with the `{"allowObjectPatternsAsParameters": true}` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-empty-pattern: ["error", { "allowObjectPatternsAsParameters": true }]*/
 
 function foo({}) {}
-var foo = function({}) {};
-var foo = ({}) => {};
+var bar = function({}) {};
+var bar = ({}) => {};
 
-function foo({} = {}) {}
+function baz({} = {}) {}
 ```
 
 :::

--- a/docs/src/rules/no-extra-boolean-cast.md
+++ b/docs/src/rules/no-extra-boolean-cast.md
@@ -67,7 +67,7 @@ for (; !!foo; ) {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-extra-boolean-cast: "error"*/

--- a/docs/src/rules/no-extra-boolean-cast.md
+++ b/docs/src/rules/no-extra-boolean-cast.md
@@ -67,7 +67,7 @@ for (; !!foo; ) {
 
 Examples of **correct** code for this rule:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-extra-boolean-cast: "error"*/
@@ -75,7 +75,7 @@ Examples of **correct** code for this rule:
 var foo = !!bar;
 var foo = Boolean(bar);
 
-function foo() {
+function qux() {
     return !!bar;
 }
 

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -154,16 +154,16 @@ for (;(a = b););
 
 Examples of **correct** code for this rule with the `"all"` and `{ "returnAssign": false }` options:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /* eslint no-extra-parens: ["error", "all", { "returnAssign": false }] */
 
-function a(b) {
+function a1(b) {
   return (b = 1);
 }
 
-function a(b) {
+function a2(b) {
   return b ? (c = d) : (c = e);
 }
 

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -154,7 +154,7 @@ for (;(a = b););
 
 Examples of **correct** code for this rule with the `"all"` and `{ "returnAssign": false }` options:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /* eslint no-extra-parens: ["error", "all", { "returnAssign": false }] */

--- a/docs/src/rules/no-extra-strict.md
+++ b/docs/src/rules/no-extra-strict.md
@@ -26,7 +26,7 @@ This rule is aimed at preventing unnecessary `"use strict";` directives. As such
 
 Example of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 "use strict";
@@ -41,7 +41,7 @@ Example of **incorrect** code for this rule:
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 "use strict";
@@ -53,7 +53,7 @@ Examples of **correct** code for this rule:
 
 :::
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 (function () {

--- a/docs/src/rules/no-extra-strict.md
+++ b/docs/src/rules/no-extra-strict.md
@@ -26,7 +26,7 @@ This rule is aimed at preventing unnecessary `"use strict";` directives. As such
 
 Example of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 "use strict";
@@ -41,7 +41,7 @@ Example of **incorrect** code for this rule:
 
 Examples of **correct** code for this rule:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 "use strict";
@@ -53,7 +53,7 @@ Examples of **correct** code for this rule:
 
 :::
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 (function () {

--- a/docs/src/rules/no-func-assign.md
+++ b/docs/src/rules/no-func-assign.md
@@ -19,7 +19,7 @@ This rule disallows reassigning `function` declarations.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-func-assign: "error"*/
@@ -53,7 +53,7 @@ function foo() {}
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-func-assign: "error"*/

--- a/docs/src/rules/no-func-assign.md
+++ b/docs/src/rules/no-func-assign.md
@@ -19,7 +19,7 @@ This rule disallows reassigning `function` declarations.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-func-assign: "error"*/
@@ -27,8 +27,8 @@ Examples of **incorrect** code for this rule:
 function foo() {}
 foo = bar;
 
-function foo() {
-    foo = bar;
+function baz() {
+    baz = bar;
 }
 
 var a = function hello() {
@@ -53,7 +53,7 @@ function foo() {}
 
 Examples of **correct** code for this rule:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-func-assign: "error"*/
@@ -61,12 +61,12 @@ Examples of **correct** code for this rule:
 var foo = function () {}
 foo = bar;
 
-function foo(foo) { // `foo` is shadowed.
-    foo = bar;
+function baz(baz) { // `baz` is shadowed.
+    baz = bar;
 }
 
-function foo() {
-    var foo = bar;  // `foo` is shadowed.
+function qux() {
+    var qux = bar;  // `qux` is shadowed.
 }
 ```
 

--- a/docs/src/rules/no-inner-declarations.md
+++ b/docs/src/rules/no-inner-declarations.md
@@ -74,7 +74,7 @@ This rule has a string option:
 
 Examples of **incorrect** code for this rule with the default `"functions"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-inner-declarations: "error"*/
@@ -104,7 +104,7 @@ class C {
 
 Examples of **correct** code for this rule with the default `"functions"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-inner-declarations: "error"*/
@@ -139,7 +139,7 @@ if (foo) var a;
 
 Examples of **incorrect** code for this rule with the `"both"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-inner-declarations: ["error", "both"]*/
@@ -171,7 +171,7 @@ class C {
 
 Examples of **correct** code for this rule with the `"both"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-inner-declarations: ["error", "both"]*/

--- a/docs/src/rules/no-invalid-this.md
+++ b/docs/src/rules/no-invalid-this.md
@@ -49,7 +49,7 @@ With `"parserOptions": { "sourceType": "module" }` in the ESLint configuration, 
 
 Examples of **incorrect** code for this rule in strict mode:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-invalid-this: "error"*/
@@ -97,7 +97,7 @@ foo.forEach(function() {
 
 Examples of **correct** code for this rule in strict mode:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-invalid-this: "error"*/
@@ -243,7 +243,7 @@ Set `"capIsConstructor"` to `false` if you want those functions to be treated as
 
 Examples of **incorrect** code for this rule with `"capIsConstructor"` option set to `false`:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-invalid-this: ["error", { "capIsConstructor": false }]*/
@@ -271,7 +271,7 @@ Baz = function() {
 
 Examples of **correct** code for this rule with `"capIsConstructor"` option set to `false`:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-invalid-this: ["error", { "capIsConstructor": false }]*/

--- a/docs/src/rules/no-irregular-whitespace.md
+++ b/docs/src/rules/no-irregular-whitespace.md
@@ -69,36 +69,36 @@ This rule has an object option for exceptions:
 
 Examples of **incorrect** code for this rule with the default `{ "skipStrings": true }` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-irregular-whitespace: "error"*/
 
-function thing() /*<NBSP>*/{
+var thing = function() /*<NBSP>*/{
     return 'test';
 }
 
-function thing( /*<NBSP>*/){
+var thing = function( /*<NBSP>*/){
     return 'test';
 }
 
-function thing /*<NBSP>*/(){
+var thing = function /*<NBSP>*/(){
     return 'test';
 }
 
-function thing᠎/*<MVS>*/(){
+var thing = function᠎/*<MVS>*/(){
     return 'test';
 }
 
-function thing() {
+var thing = function() {
     return 'test'; /*<ENSP>*/
 }
 
-function thing() {
+var thing = function() {
     return 'test'; /*<NBSP>*/
 }
 
-function thing() {
+var thing = function() {
     // Description <NBSP>: some descriptive text
 }
 
@@ -106,12 +106,12 @@ function thing() {
 Description <NBSP>: some descriptive text
 */
 
-function thing() {
+var thing = function() {
     return / <NBSP>regexp/;
 }
 
 /*eslint-env es6*/
-function thing() {
+var thing = function() {
     return `template <NBSP>string`;
 }
 ```
@@ -120,20 +120,20 @@ function thing() {
 
 Examples of **correct** code for this rule with the default `{ "skipStrings": true }` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-irregular-whitespace: "error"*/
 
-function thing() {
+var thing = function() {
     return ' <NBSP>thing';
 }
 
-function thing() {
+var thing = function() {
     return '​<ZWSP>thing';
 }
 
-function thing() {
+var thing = function() {
     return 'th <NBSP>ing';
 }
 ```

--- a/docs/src/rules/no-irregular-whitespace.md
+++ b/docs/src/rules/no-irregular-whitespace.md
@@ -69,7 +69,7 @@ This rule has an object option for exceptions:
 
 Examples of **incorrect** code for this rule with the default `{ "skipStrings": true }` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-irregular-whitespace: "error"*/
@@ -120,7 +120,7 @@ function thing() {
 
 Examples of **correct** code for this rule with the default `{ "skipStrings": true }` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-irregular-whitespace: "error"*/

--- a/docs/src/rules/no-nonoctal-decimal-escape.md
+++ b/docs/src/rules/no-nonoctal-decimal-escape.md
@@ -30,7 +30,7 @@ This rule disallows `\8` and `\9` escape sequences in string literals.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-nonoctal-decimal-escape: "error"*/
@@ -52,7 +52,7 @@ var quux = "\0\8";
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-nonoctal-decimal-escape: "error"*/

--- a/docs/src/rules/no-octal-escape.md
+++ b/docs/src/rules/no-octal-escape.md
@@ -18,7 +18,7 @@ If ESLint parses code in strict mode, the parser (instead of this rule) reports 
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect  { "sourceType": "script" }
 
 ```js
 /*eslint no-octal-escape: "error"*/
@@ -30,7 +30,7 @@ var foo = "Copyright \251";
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct  { "sourceType": "script" }
 
 ```js
 /*eslint no-octal-escape: "error"*/

--- a/docs/src/rules/no-octal.md
+++ b/docs/src/rules/no-octal.md
@@ -21,7 +21,7 @@ If ESLint parses code in strict mode, the parser (instead of this rule) reports 
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-octal: "error"*/
@@ -34,7 +34,7 @@ var result = 5 + 07;
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-octal: "error"*/

--- a/docs/src/rules/no-param-reassign.md
+++ b/docs/src/rules/no-param-reassign.md
@@ -16,7 +16,7 @@ This rule aims to prevent unintended behavior caused by modification or reassign
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-param-reassign: "error"*/
@@ -62,7 +62,7 @@ This rule takes one option, an object, with a boolean property `"props"`, and  a
 
 Examples of **correct** code for the default `{ "props": false }` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-param-reassign: ["error", { "props": false }]*/
@@ -92,7 +92,7 @@ function foo(bar) {
 
 Examples of **incorrect** code for the `{ "props": true }` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-param-reassign: ["error", { "props": true }]*/
@@ -122,7 +122,7 @@ function foo(bar) {
 
 Examples of **correct** code for the `{ "props": true }` option with `"ignorePropertyModificationsFor"` set:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsFor": ["bar"] }]*/
@@ -152,7 +152,7 @@ function foo(bar) {
 
 Examples of **correct** code for the `{ "props": true }` option with `"ignorePropertyModificationsForRegex"` set:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsForRegex": ["^bar"] }]*/

--- a/docs/src/rules/no-param-reassign.md
+++ b/docs/src/rules/no-param-reassign.md
@@ -16,24 +16,24 @@ This rule aims to prevent unintended behavior caused by modification or reassign
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-param-reassign: "error"*/
 
-function foo(bar) {
+var foo = function(bar) {
     bar = 13;
 }
 
-function foo(bar) {
+var foo = function(bar) {
     bar++;
 }
 
-function foo(bar) {
+var foo = function(bar) {
     for (bar in baz) {}
 }
 
-function foo(bar) {
+var foo = function(bar) {
     for (bar of baz) {}
 }
 ```
@@ -47,7 +47,7 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-param-reassign: "error"*/
 
-function foo(bar) {
+var foo = function(bar) {
     var baz = bar;
 }
 ```
@@ -62,28 +62,28 @@ This rule takes one option, an object, with a boolean property `"props"`, and  a
 
 Examples of **correct** code for the default `{ "props": false }` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-param-reassign: ["error", { "props": false }]*/
 
-function foo(bar) {
+var foo = function(bar) {
     bar.prop = "value";
 }
 
-function foo(bar) {
+var foo = function(bar) {
     delete bar.aaa;
 }
 
-function foo(bar) {
+var foo = function(bar) {
     bar.aaa++;
 }
 
-function foo(bar) {
+var foo = function(bar) {
     for (bar.aaa in baz) {}
 }
 
-function foo(bar) {
+var foo = function(bar) {
     for (bar.aaa of baz) {}
 }
 ```
@@ -92,28 +92,28 @@ function foo(bar) {
 
 Examples of **incorrect** code for the `{ "props": true }` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-param-reassign: ["error", { "props": true }]*/
 
-function foo(bar) {
+var foo = function(bar) {
     bar.prop = "value";
 }
 
-function foo(bar) {
+var foo = function(bar) {
     delete bar.aaa;
 }
 
-function foo(bar) {
+var foo = function(bar) {
     bar.aaa++;
 }
 
-function foo(bar) {
+var foo = function(bar) {
     for (bar.aaa in baz) {}
 }
 
-function foo(bar) {
+var foo = function(bar) {
     for (bar.aaa of baz) {}
 }
 ```
@@ -122,28 +122,28 @@ function foo(bar) {
 
 Examples of **correct** code for the `{ "props": true }` option with `"ignorePropertyModificationsFor"` set:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsFor": ["bar"] }]*/
 
-function foo(bar) {
+var foo = function(bar) {
     bar.prop = "value";
 }
 
-function foo(bar) {
+var foo = function(bar) {
     delete bar.aaa;
 }
 
-function foo(bar) {
+var foo = function(bar) {
     bar.aaa++;
 }
 
-function foo(bar) {
+var foo = function(bar) {
     for (bar.aaa in baz) {}
 }
 
-function foo(bar) {
+var foo = function(bar) {
     for (bar.aaa of baz) {}
 }
 ```
@@ -152,28 +152,28 @@ function foo(bar) {
 
 Examples of **correct** code for the `{ "props": true }` option with `"ignorePropertyModificationsForRegex"` set:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsForRegex": ["^bar"] }]*/
 
-function foo(barVar) {
+var foo = function(barVar) {
     barVar.prop = "value";
 }
 
-function foo(barrito) {
+var foo = function(barrito) {
     delete barrito.aaa;
 }
 
-function foo(bar_) {
+var foo = function(bar_) {
     bar_.aaa++;
 }
 
-function foo(barBaz) {
+var foo = function(barBaz) {
     for (barBaz.aaa in baz) {}
 }
 
-function foo(barBaz) {
+var foo = function(barBaz) {
     for (barBaz.aaa of baz) {}
 }
 ```

--- a/docs/src/rules/no-plusplus.md
+++ b/docs/src/rules/no-plusplus.md
@@ -31,7 +31,7 @@ This rule disallows the unary operators `++` and `--`.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "ecmaFeatures": { "globalReturn": true }, "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-plusplus: "error"*/
@@ -43,7 +43,7 @@ var bar = 42;
 bar--;
 
 for (i = 0; i < l; i++) {
-    return;
+    doSomething(i);
 }
 ```
 
@@ -51,7 +51,7 @@ for (i = 0; i < l; i++) {
 
 Examples of **correct** code for this rule:
 
-::: correct { "ecmaFeatures": { "globalReturn": true }, "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-plusplus: "error"*/
@@ -63,7 +63,7 @@ var bar = 42;
 bar -= 1;
 
 for (i = 0; i < l; i += 1) {
-    return;
+    doSomething(i);
 }
 ```
 

--- a/docs/src/rules/no-plusplus.md
+++ b/docs/src/rules/no-plusplus.md
@@ -31,7 +31,7 @@ This rule disallows the unary operators `++` and `--`.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "ecmaFeatures": { "globalReturn": true }, "sourceType": "script" }
 
 ```js
 /*eslint no-plusplus: "error"*/
@@ -51,7 +51,7 @@ for (i = 0; i < l; i++) {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "ecmaFeatures": { "globalReturn": true }, "sourceType": "script" }
 
 ```js
 /*eslint no-plusplus: "error"*/

--- a/docs/src/rules/no-restricted-syntax.md
+++ b/docs/src/rules/no-restricted-syntax.md
@@ -57,7 +57,7 @@ The string and object formats can be freely mixed in the configuration as needed
 
 Examples of **incorrect** code for this rule with the `"FunctionExpression", "WithStatement", BinaryExpression[operator='in']` options:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement", "BinaryExpression[operator='in']"] */
@@ -75,7 +75,7 @@ foo in bar;
 
 Examples of **correct** code for this rule with the `"FunctionExpression", "WithStatement", BinaryExpression[operator='in']` options:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement", "BinaryExpression[operator='in']"] */

--- a/docs/src/rules/no-return-assign.md
+++ b/docs/src/rules/no-return-assign.md
@@ -34,7 +34,7 @@ It disallows assignments unless they are enclosed in parentheses.
 
 Examples of **incorrect** code for the default `"except-parens"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-return-assign: "error"*/
@@ -60,7 +60,7 @@ function doSomething() {
 
 Examples of **correct** code for the default `"except-parens"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-return-assign: "error"*/
@@ -95,7 +95,7 @@ All assignments are treated as problems.
 
 Examples of **incorrect** code for the `"always"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-return-assign: ["error", "always"]*/
@@ -117,7 +117,7 @@ function doSomething() {
 
 Examples of **correct** code for the `"always"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-return-assign: ["error", "always"]*/

--- a/docs/src/rules/no-return-assign.md
+++ b/docs/src/rules/no-return-assign.md
@@ -34,7 +34,7 @@ It disallows assignments unless they are enclosed in parentheses.
 
 Examples of **incorrect** code for the default `"except-parens"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-return-assign: "error"*/
@@ -43,7 +43,7 @@ function doSomething() {
     return foo = bar + 2;
 }
 
-function doSomething() {
+function doSomethingElse() {
     return foo += 2;
 }
 
@@ -51,7 +51,7 @@ const foo = (a, b) => a = b
 
 const bar = (a, b, c) => (a = b, c == b)
 
-function doSomething() {
+function doSomethingMore() {
     return foo = bar && foo > 0;
 }
 ```
@@ -60,7 +60,7 @@ function doSomething() {
 
 Examples of **correct** code for the default `"except-parens"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-return-assign: "error"*/
@@ -69,11 +69,11 @@ function doSomething() {
     return foo == bar + 2;
 }
 
-function doSomething() {
+function doSomethingElse() {
     return foo === bar + 2;
 }
 
-function doSomething() {
+function doSomethingMore() {
     return (foo = bar + 2);
 }
 
@@ -81,7 +81,7 @@ const foo = (a, b) => (a = b)
 
 const bar = (a, b, c) => ((a = b), c == b)
 
-function doSomething() {
+function doAnotherThing() {
     return (foo = bar) && foo > 0;
 }
 ```
@@ -95,7 +95,7 @@ All assignments are treated as problems.
 
 Examples of **incorrect** code for the `"always"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-return-assign: ["error", "always"]*/
@@ -104,11 +104,11 @@ function doSomething() {
     return foo = bar + 2;
 }
 
-function doSomething() {
+function doSomethingElse() {
     return foo += 2;
 }
 
-function doSomething() {
+function doSomethingMore() {
     return (foo = bar + 2);
 }
 ```
@@ -117,7 +117,7 @@ function doSomething() {
 
 Examples of **correct** code for the `"always"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-return-assign: ["error", "always"]*/
@@ -126,7 +126,7 @@ function doSomething() {
     return foo == bar + 2;
 }
 
-function doSomething() {
+function doSomethingElse() {
     return foo === bar + 2;
 }
 ```

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -33,28 +33,28 @@ async function foo() {
 
 Examples of **correct** code for this rule:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-return-await: "error"*/
 
-async function foo() {
+async function foo1() {
     return bar();
 }
 
-async function foo() {
+async function foo2() {
     await bar();
     return;
 }
 
 // This is essentially the same as `return await bar();`, but the rule checks only `await` in `return` statements
-async function foo() {
+async function foo3() {
     const x = await bar();
     return x;
 }
 
 // In this example the `await` is necessary to be able to catch errors thrown from `bar()`
-async function foo() {
+async function foo4() {
     try {
         return await bar();
     } catch (error) {}

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -33,7 +33,7 @@ async function foo() {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-return-await: "error"*/

--- a/docs/src/rules/no-sequences.md
+++ b/docs/src/rules/no-sequences.md
@@ -25,7 +25,7 @@ This rule forbids the use of the comma operator, with the following exceptions:
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-sequences: "error"*/
@@ -51,7 +51,7 @@ with (doSomething(), val) {}
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-sequences: "error"*/
@@ -119,7 +119,7 @@ This rule takes one option, an object, with the following properties:
 
 Examples of **incorrect** code for this rule with the `{ "allowInParentheses": false }` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-sequences: ["error", { "allowInParentheses": false }]*/

--- a/docs/src/rules/no-shadow-restricted-names.md
+++ b/docs/src/rules/no-shadow-restricted-names.md
@@ -22,7 +22,7 @@ Then any code used within the same scope would not get the global `undefined`, b
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-shadow-restricted-names: "error"*/
@@ -40,7 +40,7 @@ try {} catch(eval){}
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-shadow-restricted-names: "error"*/

--- a/docs/src/rules/no-shadow.md
+++ b/docs/src/rules/no-shadow.md
@@ -25,7 +25,7 @@ This rule aims to eliminate shadowed variable declarations.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-shadow: "error"*/

--- a/docs/src/rules/no-shadow.md
+++ b/docs/src/rules/no-shadow.md
@@ -43,7 +43,7 @@ var c = function () {
 function d(a) {
     a = 10;
 }
-b(a);
+d(a);
 
 if (true) {
     let a = 5;

--- a/docs/src/rules/no-shadow.md
+++ b/docs/src/rules/no-shadow.md
@@ -25,7 +25,7 @@ This rule aims to eliminate shadowed variable declarations.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-shadow: "error"*/
@@ -36,11 +36,11 @@ function b() {
     var a = 10;
 }
 
-var b = function () {
+var c = function () {
     var a = 10;
 }
 
-function b(a) {
+function d(a) {
     a = 10;
 }
 b(a);

--- a/docs/src/rules/no-throw-literal.md
+++ b/docs/src/rules/no-throw-literal.md
@@ -69,7 +69,7 @@ Due to the limits of static analysis, this rule cannot guarantee that you will o
 
 Examples of **correct** code for this rule, but which do not throw an `Error` object:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-throw-literal: "error"*/

--- a/docs/src/rules/no-throw-literal.md
+++ b/docs/src/rules/no-throw-literal.md
@@ -69,7 +69,7 @@ Due to the limits of static analysis, this rule cannot guarantee that you will o
 
 Examples of **correct** code for this rule, but which do not throw an `Error` object:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint no-throw-literal: "error"*/
@@ -84,10 +84,10 @@ throw foo("error");
 
 throw new String("error");
 
-var foo = {
+var baz = {
     bar: "error"
 };
-throw foo.bar;
+throw baz.bar;
 ```
 
 :::

--- a/docs/src/rules/no-undefined.md
+++ b/docs/src/rules/no-undefined.md
@@ -41,7 +41,7 @@ This rule aims to eliminate the use of `undefined`, and as such, generates a war
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint no-undefined: "error"*/
@@ -54,7 +54,7 @@ if (foo === undefined) {
     // ...
 }
 
-function foo(undefined) {
+function baz(undefined) {
     // ...
 }
 

--- a/docs/src/rules/no-undefined.md
+++ b/docs/src/rules/no-undefined.md
@@ -41,7 +41,7 @@ This rule aims to eliminate the use of `undefined`, and as such, generates a war
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-undefined: "error"*/

--- a/docs/src/rules/no-unsafe-optional-chaining.md
+++ b/docs/src/rules/no-unsafe-optional-chaining.md
@@ -32,7 +32,7 @@ This rule aims to detect some cases where the use of optional chaining doesn't p
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-unsafe-optional-chaining: "error"*/

--- a/docs/src/rules/no-useless-escape.md
+++ b/docs/src/rules/no-useless-escape.md
@@ -43,7 +43,7 @@ Examples of **incorrect** code for this rule:
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-useless-escape: "error"*/

--- a/docs/src/rules/no-useless-return.md
+++ b/docs/src/rules/no-useless-return.md
@@ -13,19 +13,19 @@ This rule aims to report redundant `return` statements.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /* eslint no-useless-return: "error" */
 
-function foo() { return; }
+var foo = function() { return; }
 
-function foo() {
+var foo = function() {
   doSomething();
   return;
 }
 
-function foo() {
+var foo = function() {
   if (condition) {
     bar();
     return;
@@ -34,7 +34,7 @@ function foo() {
   }
 }
 
-function foo() {
+var foo = function() {
   switch (bar) {
     case 1:
       doSomething();
@@ -50,18 +50,18 @@ function foo() {
 
 Examples of **correct** code for this rule:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /* eslint no-useless-return: "error" */
 
-function foo() { return 5; }
+var foo = function() { return 5; }
 
-function foo() {
+var foo = function() {
   return doSomething();
 }
 
-function foo() {
+var foo = function() {
   if (condition) {
     bar();
     return;
@@ -71,7 +71,7 @@ function foo() {
   qux();
 }
 
-function foo() {
+var foo = function() {
   switch (bar) {
     case 1:
       doSomething();
@@ -81,7 +81,7 @@ function foo() {
   }
 }
 
-function foo() {
+var foo = function() {
   for (const foo of bar) {
     return;
   }

--- a/docs/src/rules/no-useless-return.md
+++ b/docs/src/rules/no-useless-return.md
@@ -13,7 +13,7 @@ This rule aims to report redundant `return` statements.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /* eslint no-useless-return: "error" */
@@ -50,7 +50,7 @@ function foo() {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /* eslint no-useless-return: "error" */

--- a/docs/src/rules/no-with.md
+++ b/docs/src/rules/no-with.md
@@ -17,7 +17,7 @@ If ESLint parses code in strict mode, the parser (instead of this rule) reports 
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-with: "error"*/
@@ -31,7 +31,7 @@ with (point) {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint no-with: "error"*/

--- a/docs/src/rules/one-var.md
+++ b/docs/src/rules/one-var.md
@@ -69,7 +69,7 @@ Alternate object option:
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint one-var: ["error", "always"]*/
@@ -120,7 +120,7 @@ class C {
 
 Examples of **correct** code for this rule with the default `"always"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint one-var: ["error", "always"]*/
@@ -225,7 +225,7 @@ class C {
 
 Examples of **correct** code for this rule with the `"never"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint one-var: ["error", "never"]*/
@@ -272,7 +272,7 @@ for (var i = 0, len = arr.length; i < len; i++) {
 
 Examples of **incorrect** code for this rule with the `"consecutive"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint one-var: ["error", "consecutive"]*/
@@ -306,7 +306,7 @@ class C {
 
 Examples of **correct** code for this rule with the `"consecutive"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint one-var: ["error", "consecutive"]*/
@@ -343,7 +343,7 @@ class C {
 
 Examples of **incorrect** code for this rule with the `{ var: "always", let: "never", const: "never" }` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint one-var: ["error", { var: "always", let: "never", const: "never" }]*/
@@ -368,7 +368,7 @@ function foo() {
 
 Examples of **correct** code for this rule with the `{ var: "always", let: "never", const: "never" }` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint one-var: ["error", { var: "always", let: "never", const: "never" }]*/
@@ -466,7 +466,7 @@ var foo = require("foo"),
 
 Examples of **incorrect** code for this rule with the `{ var: "never", let: "consecutive", const: "consecutive" }` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint one-var: ["error", { var: "never", let: "consecutive", const: "consecutive" }]*/
@@ -495,7 +495,7 @@ function foo() {
 
 Examples of **correct** code for this rule with the `{ var: "never", let: "consecutive", const: "consecutive" }` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint one-var: ["error", { var: "never", let: "consecutive", const: "consecutive" }]*/

--- a/docs/src/rules/one-var.md
+++ b/docs/src/rules/one-var.md
@@ -69,26 +69,26 @@ Alternate object option:
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", "always"]*/
 
-function foo() {
+function foo1() {
     var bar;
     var baz;
     let qux;
     let norf;
 }
 
-function foo(){
+function foo2(){
     const bar = false;
     const baz = true;
     let qux;
     let norf;
 }
 
-function foo() {
+function foo3() {
     var bar;
 
     if (baz) {
@@ -120,26 +120,26 @@ class C {
 
 Examples of **correct** code for this rule with the default `"always"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint one-var: ["error", "always"]*/
 
-function foo() {
+function foo1() {
     var bar,
         baz;
     let qux,
         norf;
 }
 
-function foo(){
+function foo2(){
     const bar = true,
         baz = false;
     let qux,
         norf;
 }
 
-function foo() {
+function foo3() {
     var bar,
         qux;
 
@@ -148,7 +148,7 @@ function foo() {
     }
 }
 
-function foo(){
+function foo4(){
     let bar;
 
     if (baz) {
@@ -225,17 +225,17 @@ class C {
 
 Examples of **correct** code for this rule with the `"never"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint one-var: ["error", "never"]*/
 
-function foo() {
+function foo1() {
     var bar;
     var baz;
 }
 
-function foo() {
+function foo2() {
     var bar;
 
     if (baz) {
@@ -243,7 +243,7 @@ function foo() {
     }
 }
 
-function foo() {
+function foo3() {
     let bar;
 
     if (baz) {
@@ -272,17 +272,17 @@ for (var i = 0, len = arr.length; i < len; i++) {
 
 Examples of **incorrect** code for this rule with the `"consecutive"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", "consecutive"]*/
 
-function foo() {
+function foo1() {
     var bar;
     var baz;
 }
 
-function foo(){
+function foo2(){
     var bar = 1;
     var baz = 2;
 
@@ -306,17 +306,17 @@ class C {
 
 Examples of **correct** code for this rule with the `"consecutive"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint one-var: ["error", "consecutive"]*/
 
-function foo() {
+function foo1() {
     var bar,
         baz;
 }
 
-function foo(){
+function foo2(){
     var bar = 1,
         baz = 2;
 
@@ -343,20 +343,20 @@ class C {
 
 Examples of **incorrect** code for this rule with the `{ var: "always", let: "never", const: "never" }` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", { var: "always", let: "never", const: "never" }]*/
 /*eslint-env es6*/
 
-function foo() {
+function foo1() {
     var bar;
     var baz;
     let qux,
         norf;
 }
 
-function foo() {
+function foo2() {
     const bar = 1,
           baz = 2;
     let qux,
@@ -368,20 +368,20 @@ function foo() {
 
 Examples of **correct** code for this rule with the `{ var: "always", let: "never", const: "never" }` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint one-var: ["error", { var: "always", let: "never", const: "never" }]*/
 /*eslint-env es6*/
 
-function foo() {
+function foo1() {
     var bar,
         baz;
     let qux;
     let norf;
 }
 
-function foo() {
+function foo2() {
     const bar = 1;
     const baz = 2;
     let qux;
@@ -466,13 +466,13 @@ var foo = require("foo"),
 
 Examples of **incorrect** code for this rule with the `{ var: "never", let: "consecutive", const: "consecutive" }` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint one-var: ["error", { var: "never", let: "consecutive", const: "consecutive" }]*/
 /*eslint-env es6*/
 
-function foo() {
+function foo1() {
     let a,
         b;
     let c;
@@ -481,7 +481,7 @@ function foo() {
         e;
 }
 
-function foo() {
+function foo2() {
     const a = 1,
         b = 2;
     const c = 3;
@@ -495,13 +495,13 @@ function foo() {
 
 Examples of **correct** code for this rule with the `{ var: "never", let: "consecutive", const: "consecutive" }` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint one-var: ["error", { var: "never", let: "consecutive", const: "consecutive" }]*/
 /*eslint-env es6*/
 
-function foo() {
+function foo1() {
     let a,
         b;
 
@@ -511,7 +511,7 @@ function foo() {
     let f;
 }
 
-function foo() {
+function foo2() {
     const a = 1,
           b = 2;
 

--- a/docs/src/rules/padding-line-between-statements.md
+++ b/docs/src/rules/padding-line-between-statements.md
@@ -112,7 +112,7 @@ function foo() {
 
 Examples of **correct** code for the `[{ blankLine: "always", prev: "*", next: "return" }]` configuration:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint padding-line-between-statements: [
@@ -139,7 +139,7 @@ This configuration would require blank lines after every sequence of variable de
 
 Examples of **incorrect** code for the `[{ blankLine: "always", prev: ["const", "let", "var"], next: "*"}, { blankLine: "any", prev: ["const", "let", "var"], next: ["const", "let", "var"]}]` configuration:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint padding-line-between-statements: [
@@ -175,7 +175,7 @@ class C {
 
 Examples of **correct** code for the `[{ blankLine: "always", prev: ["const", "let", "var"], next: "*"}, { blankLine: "any", prev: ["const", "let", "var"], next: ["const", "let", "var"]}]` configuration:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint padding-line-between-statements: [

--- a/docs/src/rules/padding-line-between-statements.md
+++ b/docs/src/rules/padding-line-between-statements.md
@@ -112,7 +112,7 @@ function foo() {
 
 Examples of **correct** code for the `[{ blankLine: "always", prev: "*", next: "return" }]` configuration:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint padding-line-between-statements: [
@@ -120,13 +120,13 @@ Examples of **correct** code for the `[{ blankLine: "always", prev: "*", next: "
     { blankLine: "always", prev: "*", next: "return" }
 ]*/
 
-function foo() {
+function foo1() {
     bar();
 
     return;
 }
 
-function foo() {
+function foo2() {
     return;
 }
 ```
@@ -139,7 +139,7 @@ This configuration would require blank lines after every sequence of variable de
 
 Examples of **incorrect** code for the `[{ blankLine: "always", prev: ["const", "let", "var"], next: "*"}, { blankLine: "any", prev: ["const", "let", "var"], next: ["const", "let", "var"]}]` configuration:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint padding-line-between-statements: [
@@ -148,17 +148,17 @@ Examples of **incorrect** code for the `[{ blankLine: "always", prev: ["const", 
     { blankLine: "any",    prev: ["const", "let", "var"], next: ["const", "let", "var"]}
 ]*/
 
-function foo() {
+function foo1() {
     var a = 0;
     bar();
 }
 
-function foo() {
+function foo2() {
     let a = 0;
     bar();
 }
 
-function foo() {
+function foo3() {
     const a = 0;
     bar();
 }
@@ -175,7 +175,7 @@ class C {
 
 Examples of **correct** code for the `[{ blankLine: "always", prev: ["const", "let", "var"], next: "*"}, { blankLine: "any", prev: ["const", "let", "var"], next: ["const", "let", "var"]}]` configuration:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint padding-line-between-statements: [
@@ -184,21 +184,21 @@ Examples of **correct** code for the `[{ blankLine: "always", prev: ["const", "l
     { blankLine: "any",    prev: ["const", "let", "var"], next: ["const", "let", "var"]}
 ]*/
 
-function foo() {
+function foo1() {
     var a = 0;
     var b = 0;
 
     bar();
 }
 
-function foo() {
+function foo2() {
     let a = 0;
     const b = 0;
 
     bar();
 }
 
-function foo() {
+function foo3() {
     const a = 0;
     const b = 0;
 

--- a/docs/src/rules/prefer-reflect.md
+++ b/docs/src/rules/prefer-reflect.md
@@ -380,7 +380,7 @@ delete foo.bar; // deleting object property
 
 Examples of **correct** code for this rule when used without exceptions:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -395,7 +395,7 @@ Note: For a rule preventing deletion of variables, see [no-delete-var instead](n
 
 Examples of **correct** code for this rule with the `{ "exceptions": ["delete"] }` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint prefer-reflect: ["error", { "exceptions": ["delete"] }]*/

--- a/docs/src/rules/prefer-rest-params.md
+++ b/docs/src/rules/prefer-rest-params.md
@@ -19,7 +19,7 @@ This rule is aimed to flag usage of `arguments` variables.
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint prefer-rest-params: "error"*/
@@ -43,7 +43,7 @@ function foo(action) {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint prefer-rest-params: "error"*/

--- a/docs/src/rules/require-await.md
+++ b/docs/src/rules/require-await.md
@@ -50,7 +50,7 @@ bar(async () => {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint require-await: "error"*/

--- a/docs/src/rules/require-await.md
+++ b/docs/src/rules/require-await.md
@@ -50,7 +50,7 @@ bar(async () => {
 
 Examples of **correct** code for this rule:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint require-await: "error"*/
@@ -63,7 +63,7 @@ bar(async () => {
     await doSomething();
 });
 
-function foo() {
+function baz() {
     doSomething();
 }
 

--- a/docs/src/rules/require-jsdoc.md
+++ b/docs/src/rules/require-jsdoc.md
@@ -60,7 +60,7 @@ Default option settings are:
 
 Examples of **incorrect** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": true, "FunctionExpression": true } }` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint "require-jsdoc": ["error", {
@@ -77,7 +77,7 @@ function foo() {
     return 10;
 }
 
-var foo = () => {
+var bar = () => {
     return 10;
 };
 
@@ -87,11 +87,11 @@ class Foo {
     }
 }
 
-var foo = function() {
+var bar = function() {
     return 10;
 };
 
-var foo = {
+var bar = {
     bar: function() {
         return 10;
     },
@@ -106,7 +106,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": true, "FunctionExpression": true } }` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint "require-jsdoc": ["error", {
@@ -131,21 +131,21 @@ function foo() {
  * @params {int} test - some number
  * @returns {int} sum of test and 10
  */
-var foo = (test) => {
+var bar = (test) => {
     return test + 10;
 }
 
 /**
  * It returns 10
  */
-var foo = () => {
+var bar = () => {
     return 10;
 }
 
 /**
  * It returns 10
  */
-var foo = function() {
+var bar = function() {
     return 10;
 }
 
@@ -169,11 +169,11 @@ class Foo {
 /**
  * It returns 10
  */
-var foo = function() {
+var bar = function() {
     return 10;
 };
 
-var foo = {
+var bar = {
     /**
     * It returns 10
     */

--- a/docs/src/rules/require-jsdoc.md
+++ b/docs/src/rules/require-jsdoc.md
@@ -60,7 +60,7 @@ Default option settings are:
 
 Examples of **incorrect** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": true, "FunctionExpression": true } }` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint "require-jsdoc": ["error", {
@@ -106,7 +106,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": true, "FunctionExpression": true } }` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint "require-jsdoc": ["error", {

--- a/docs/src/rules/require-yield.md
+++ b/docs/src/rules/require-yield.md
@@ -30,7 +30,7 @@ function* foo() {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint require-yield: "error"*/

--- a/docs/src/rules/require-yield.md
+++ b/docs/src/rules/require-yield.md
@@ -30,7 +30,7 @@ function* foo() {
 
 Examples of **correct** code for this rule:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint require-yield: "error"*/
@@ -41,12 +41,12 @@ function* foo() {
   return 10;
 }
 
-function foo() {
+function bar() {
   return 10;
 }
 
 // This rule does not warn on empty generator functions.
-function* foo() { }
+function* baz() { }
 ```
 
 :::

--- a/docs/src/rules/space-before-function-paren.md
+++ b/docs/src/rules/space-before-function-paren.md
@@ -61,7 +61,7 @@ Each of the following options can be set to `"always"`, `"never"`, or `"ignore"`
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint space-before-function-paren: "error"*/
@@ -98,7 +98,7 @@ var foo = async() => 1
 
 Examples of **correct** code for this rule with the default `"always"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint space-before-function-paren: "error"*/
@@ -137,7 +137,7 @@ var foo = async () => 1
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint space-before-function-paren: ["error", "never"]*/
@@ -174,7 +174,7 @@ var foo = async () => 1
 
 Examples of **correct** code for this rule with the `"never"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint space-before-function-paren: ["error", "never"]*/
@@ -213,7 +213,7 @@ var foo = async() => 1
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "always", "named": "never", "asyncArrow": "always"}` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint space-before-function-paren: ["error", {"anonymous": "always", "named": "never", "asyncArrow": "always"}]*/
@@ -246,7 +246,7 @@ var foo = async(a) => await a
 
 Examples of **correct** code for this rule with the `{"anonymous": "always", "named": "never", "asyncArrow": "always"}` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint space-before-function-paren: ["error", {"anonymous": "always", "named": "never", "asyncArrow": "always"}]*/
@@ -281,7 +281,7 @@ var foo = async (a) => await a
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
@@ -312,7 +312,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
@@ -345,7 +345,7 @@ var foo = {
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "ignore", "named": "always"}` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/
@@ -372,7 +372,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the `{"anonymous": "ignore", "named": "always"}` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/

--- a/docs/src/rules/space-before-function-paren.md
+++ b/docs/src/rules/space-before-function-paren.md
@@ -61,7 +61,7 @@ Each of the following options can be set to `"always"`, `"never"`, or `"ignore"`
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint space-before-function-paren: "error"*/
@@ -85,20 +85,20 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar() {
         // ...
     }
 };
 
-var foo = async() => 1
+var baz = async() => 1
 ```
 
 :::
 
 Examples of **correct** code for this rule with the default `"always"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint space-before-function-paren: "error"*/
@@ -122,13 +122,13 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar () {
         // ...
     }
 };
 
-var foo = async () => 1
+var baz = async () => 1
 ```
 
 :::
@@ -137,7 +137,7 @@ var foo = async () => 1
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint space-before-function-paren: ["error", "never"]*/
@@ -161,20 +161,20 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar () {
         // ...
     }
 };
 
-var foo = async () => 1
+var baz = async () => 1
 ```
 
 :::
 
 Examples of **correct** code for this rule with the `"never"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint space-before-function-paren: ["error", "never"]*/
@@ -198,13 +198,13 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar() {
         // ...
     }
 };
 
-var foo = async() => 1
+var baz = async() => 1
 ```
 
 :::
@@ -213,7 +213,7 @@ var foo = async() => 1
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "always", "named": "never", "asyncArrow": "always"}` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint space-before-function-paren: ["error", {"anonymous": "always", "named": "never", "asyncArrow": "always"}]*/
@@ -233,20 +233,20 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar () {
         // ...
     }
 };
 
-var foo = async(a) => await a
+var baz = async(a) => await a
 ```
 
 :::
 
 Examples of **correct** code for this rule with the `{"anonymous": "always", "named": "never", "asyncArrow": "always"}` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint space-before-function-paren: ["error", {"anonymous": "always", "named": "never", "asyncArrow": "always"}]*/
@@ -266,13 +266,13 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar() {
         // ...
     }
 };
 
-var foo = async (a) => await a
+var baz = async (a) => await a
 ```
 
 :::
@@ -281,7 +281,7 @@ var foo = async (a) => await a
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
@@ -301,7 +301,7 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar() {
         // ...
     }
@@ -312,7 +312,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
@@ -332,7 +332,7 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar () {
         // ...
     }
@@ -345,7 +345,7 @@ var foo = {
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "ignore", "named": "always"}` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/
@@ -361,7 +361,7 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar() {
         // ...
     }
@@ -372,7 +372,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the `{"anonymous": "ignore", "named": "always"}` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/
@@ -396,7 +396,7 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar () {
         // ...
     }

--- a/docs/src/rules/space-before-function-parentheses.md
+++ b/docs/src/rules/space-before-function-parentheses.md
@@ -36,7 +36,7 @@ This rule takes one argument. If it is `"always"`, which is the default option, 
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint-env es6*/
@@ -59,7 +59,7 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar() {
         // ...
     }
@@ -70,7 +70,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the default `"always"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint-env es6*/
@@ -93,7 +93,7 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar () {
         // ...
     }
@@ -104,7 +104,7 @@ var foo = {
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint-env es6*/
@@ -127,7 +127,7 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar () {
         // ...
     }
@@ -138,7 +138,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the `"never"` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint-env es6*/
@@ -161,7 +161,7 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar() {
         // ...
     }
@@ -172,7 +172,7 @@ var foo = {
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "always", "named": "never"}` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint-env es6*/
@@ -191,7 +191,7 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar () {
         // ...
     }
@@ -202,7 +202,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the `{"anonymous": "always", "named": "never"}` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint-env es6*/
@@ -221,7 +221,7 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar() {
         // ...
     }
@@ -232,7 +232,7 @@ var foo = {
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint-env es6*/
@@ -251,7 +251,7 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar() {
         // ...
     }
@@ -262,7 +262,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint-env es6*/
@@ -281,7 +281,7 @@ class Foo {
     }
 }
 
-var foo = {
+var baz = {
     bar () {
         // ...
     }

--- a/docs/src/rules/space-before-function-parentheses.md
+++ b/docs/src/rules/space-before-function-parentheses.md
@@ -36,7 +36,7 @@ This rule takes one argument. If it is `"always"`, which is the default option, 
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint-env es6*/
@@ -70,7 +70,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the default `"always"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint-env es6*/
@@ -104,7 +104,7 @@ var foo = {
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint-env es6*/
@@ -138,7 +138,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the `"never"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint-env es6*/
@@ -172,7 +172,7 @@ var foo = {
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "always", "named": "never"}` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint-env es6*/
@@ -202,7 +202,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the `{"anonymous": "always", "named": "never"}` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint-env es6*/
@@ -232,7 +232,7 @@ var foo = {
 
 Examples of **incorrect** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint-env es6*/
@@ -262,7 +262,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint-env es6*/

--- a/docs/src/rules/strict.md
+++ b/docs/src/rules/strict.md
@@ -82,7 +82,7 @@ Otherwise the `"safe"` option corresponds to the `"function"` option. Note that 
 
 Examples of **incorrect** code for this rule with the `"global"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint strict: ["error", "global"]*/
@@ -93,7 +93,7 @@ function foo() {
 
 :::
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint strict: ["error", "global"]*/
@@ -105,7 +105,7 @@ function foo() {
 
 :::
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint strict: ["error", "global"]*/
@@ -121,7 +121,7 @@ function foo() {
 
 Examples of **correct** code for this rule with the `"global"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint strict: ["error", "global"]*/
@@ -140,7 +140,7 @@ This option ensures that all function bodies are strict mode code, while global 
 
 Examples of **incorrect** code for this rule with the `"function"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint strict: ["error", "function"]*/
@@ -153,7 +153,7 @@ function foo() {
 
 :::
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint strict: ["error", "function"]*/
@@ -170,7 +170,7 @@ function foo() {
 
 :::
 
-::: incorrect
+::: incorrect { "ecmaVersion": 6, "sourceType": "script" }
 
 ```js
 /*eslint strict: ["error", "function"]*/
@@ -192,7 +192,7 @@ function foo(a = 1) {
 
 Examples of **correct** code for this rule with the `"function"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint strict: ["error", "function"]*/
@@ -225,7 +225,7 @@ var foo = (function() {
 
 Examples of **incorrect** code for this rule with the `"never"` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint strict: ["error", "never"]*/
@@ -238,7 +238,7 @@ function foo() {
 
 :::
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint strict: ["error", "never"]*/
@@ -252,7 +252,7 @@ function foo() {
 
 Examples of **correct** code for this rule with the `"never"` option:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint strict: ["error", "never"]*/
@@ -271,7 +271,7 @@ This option ensures that all functions are executed in strict mode. A strict mod
 
 Examples of **incorrect** code for this rule with the earlier default option which has been removed:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 // "strict": "error"
@@ -282,7 +282,7 @@ function foo() {
 
 :::
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 // "strict": "error"
@@ -298,7 +298,7 @@ function foo() {
 
 Examples of **correct** code for this rule with the earlier default option which has been removed:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 // "strict": "error"
@@ -311,7 +311,7 @@ function foo() {
 
 :::
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 // "strict": "error"
@@ -323,7 +323,7 @@ function foo() {
 
 :::
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 // "strict": "error"

--- a/docs/src/rules/vars-on-top.md
+++ b/docs/src/rules/vars-on-top.md
@@ -20,7 +20,7 @@ Allowing multiple declarations helps promote maintainability and is thus allowed
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "sourceType": "script" }
+::: incorrect
 
 ```js
 /*eslint vars-on-top: "error"*/
@@ -34,7 +34,7 @@ function doSomething() {
 }
 
 // Variable declaration in for initializer:
-function doSomething() {
+function doSomethingElse() {
     for (var i=0; i<10; i++) {}
 }
 ```
@@ -82,7 +82,7 @@ class C {
 
 Examples of **correct** code for this rule:
 
-::: correct { "sourceType": "script" }
+::: correct
 
 ```js
 /*eslint vars-on-top: "error"*/
@@ -95,7 +95,7 @@ function doSomething() {
     }
 }
 
-function doSomething() {
+function doSomethingElse() {
     var i;
     for (i=0; i<10; i++) {}
 }

--- a/docs/src/rules/vars-on-top.md
+++ b/docs/src/rules/vars-on-top.md
@@ -20,7 +20,7 @@ Allowing multiple declarations helps promote maintainability and is thus allowed
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint vars-on-top: "error"*/
@@ -82,7 +82,7 @@ class C {
 
 Examples of **correct** code for this rule:
 
-::: correct
+::: correct { "sourceType": "script" }
 
 ```js
 /*eslint vars-on-top: "error"*/


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR changes playground links in rule example links such that the `sourceType` parser option defaults to `"module"`. Currently, the Playground default `"script"` is used when `sourceType` is not explicitly specified.

I had to add `"sourceType": "script"` (and in a few cases other parser options) to a number of rule examples to make sure that their behavior doesn't change. This is necessary for different reasons:

* Some rules explicitly state that they only apply in strict mode, e.g. `no-invalid-this`.
* Some examples contain syntax that is not allowed in strict mode, such as `delete x`, duplicate parameter names, octal escape sequences, `with` statements, etc.
* In some code examples, top-level `"use strict"` directives are necessary to show how the rule works. In ES modules, these directives are of no use and could be confusing (`lines-around-directive`).
* The global `require()` API is associated to script/CommonJS code (`global-require`).

Some code examples contain syntax that is allowed in scripts but forbidden in ES modules, i.e. top-level function declarations with non-unique names.
```js
var a;
function a() {} // valid in scripts, syntax error in ES modules
```
Rather than keeping these examples as scripts, it was decided to rename the clashing identifiers in order to avoid a syntax error when parsing as ES modules.

---

This change is a first step towards implementating #17602. It will leave us with 126 syntax errors left in rule examples.

```
File docs/src/rules/arrow-body-style.md:
  - code block #2 on line 42 cannot be parsed: Identifier 'foo' has already been declared
  - code block #3 on line 60 cannot be parsed: Identifier 'foo' has already been declared
  - code block #4 on line 83 cannot be parsed: Identifier 'foo' has already been declared
  - code block #5 on line 117 cannot be parsed: Identifier 'foo' has already been declared
  - code block #6 on line 130 cannot be parsed: Identifier 'foo' has already been declared
  - code block #7 on line 146 cannot be parsed: Identifier 'foo' has already been declared
  - code block #8 on line 165 cannot be parsed: Identifier 'foo' has already been declared

File docs/src/rules/camelcase.md:
  - code block #1 on line 31 cannot be parsed: Identifier 'foo' has already been declared
  - code block #2 on line 75 cannot be parsed: Identifier 'foo' has already been declared

File docs/src/rules/class-methods-use-this.md:
  - code block #2 on line 78 cannot be parsed: Identifier 'A' has already been declared

File docs/src/rules/constructor-super.md:
  - code block #1 on line 19 cannot be parsed: super() call outside constructor of a subclass
  - code block #2 on line 51 cannot be parsed: Identifier 'A' has already been declared

File docs/src/rules/eol-last.md:
  - code block #2 on line 38 cannot be parsed: Expecting Unicode escape sequence \uXXXX

File docs/src/rules/generator-star.md:
  - no correct code blocks
  - no incorrect code blocks

File docs/src/rules/global-strict.md:
  - no correct code blocks
  - no incorrect code blocks

File docs/src/rules/id-blacklist.md:
  - no correct code blocks
  - no incorrect code blocks

File docs/src/rules/id-denylist.md:
  - code block #1 on line 44 cannot be parsed: Unexpected token }
  - code block #2 on line 84 cannot be parsed: Unexpected token }

File docs/src/rules/id-length.md:
  - code block #1 on line 28 cannot be parsed: Identifier 'x' has already been declared
  - code block #2 on line 63 cannot be parsed: Identifier 'foo' has already been declared
  - code block #3 on line 116 cannot be parsed: Identifier 'foo' has already been declared
  - code block #8 on line 247 cannot be parsed: Identifier 'x' has already been declared

File docs/src/rules/id-match.md:
  - code block #1 on line 32 cannot be parsed: Identifier 'myClass' has already been declared
  - code block #2 on line 64 cannot be parsed: Identifier 'myClass' has already been declared
  - code block #4 on line 121 cannot be parsed: Identifier 'myClass' has already been declared

File docs/src/rules/indent-legacy.md:
  - code block #7 on line 198 cannot be parsed: Identifier 'a' has already been declared
  - code block #8 on line 219 cannot be parsed: Identifier 'a' has already been declared
  - code block #9 on line 240 cannot be parsed: Identifier 'a' has already been declared
  - code block #10 on line 261 cannot be parsed: Identifier 'a' has already been declared

File docs/src/rules/indent.md:
  - code block #9 on line 242 cannot be parsed: Identifier 'a' has already been declared
  - code block #10 on line 263 cannot be parsed: Identifier 'a' has already been declared
  - code block #11 on line 284 cannot be parsed: Identifier 'a' has already been declared
  - code block #12 on line 305 cannot be parsed: Identifier 'a' has already been declared
  - code block #13 on line 326 cannot be parsed: Identifier 'a' has already been declared
  - code block #14 on line 347 cannot be parsed: Identifier 'a' has already been declared
  - code block #44 on line 852 cannot be parsed: Identifier 'foo' has already been declared

File docs/src/rules/jsx-quotes.md:
  - code block #2 on line 52 cannot be parsed: Adjacent JSX elements must be wrapped in an enclosing tag
  - code block #4 on line 79 cannot be parsed: Adjacent JSX elements must be wrapped in an enclosing tag

File docs/src/rules/keyword-spacing.md:
  - code block #2 on line 61 cannot be parsed: Identifier 'a' has already been declared
  - code block #6 on line 176 cannot be parsed: Identifier 'a' has already been declared

File docs/src/rules/lines-around-comment.md:
  - code block #29 on line 660 cannot be parsed: Unexpected token ,

File docs/src/rules/lines-between-class-members.md:
  - code block #4 on line 91 cannot be parsed: Identifier 'Foo' has already been declared
  - code block #5 on line 115 cannot be parsed: Identifier 'Foo' has already been declared

File docs/src/rules/max-len.md:
  - code block #3 on line 72 cannot be parsed: Expecting Unicode escape sequence \uXXXX
  - code block #4 on line 84 cannot be parsed: Expecting Unicode escape sequence \uXXXX

File docs/src/rules/max-params.md:
  - code block #1 on line 39 cannot be parsed: Identifier 'foo' has already been declared
  - code block #2 on line 58 cannot be parsed: Identifier 'foo' has already been declared

File docs/src/rules/max-statements.md:
  - code block #1 on line 45 cannot be parsed: Identifier 'foo' has already been declared
  - code block #2 on line 86 cannot be parsed: Identifier 'foo' has already been declared

File docs/src/rules/newline-after-var.md:
  - code block #1 on line 45 cannot be parsed: Identifier 'greet' has already been declared
  - code block #2 on line 73 cannot be parsed: Identifier 'greet' has already been declared
  - code block #3 on line 107 cannot be parsed: Identifier 'greet' has already been declared
  - code block #4 on line 139 cannot be parsed: Identifier 'greet' has already been declared

File docs/src/rules/no-arrow-condition.md:
  - no correct code blocks

File docs/src/rules/no-delete-var.md:
  - no correct code blocks

File docs/src/rules/no-dupe-class-members.md:
  - code block #1 on line 32 cannot be parsed: Identifier 'Foo' has already been declared
  - code block #2 on line 67 cannot be parsed: Identifier 'Foo' has already been declared

File docs/src/rules/no-empty-static-block.md:
  - code block #2 on line 34 cannot be parsed: Identifier 'Foo' has already been declared

File docs/src/rules/no-extra-parens.md:
  - code block #7 on line 217 cannot be parsed: Identifier 'Component' has already been declared
  - code block #8 on line 233 cannot be parsed: Identifier 'Component' has already been declared
  - code block #9 on line 245 cannot be parsed: Identifier 'Component' has already been declared
  - code block #10 on line 265 cannot be parsed: Identifier 'Component' has already been declared
  - code block #11 on line 285 cannot be parsed: Identifier 'Component' has already been declared

File docs/src/rules/no-invalid-this.md:
  - code block #2 on line 100 cannot be parsed: Identifier 'Foo' has already been declared

File docs/src/rules/no-irregular-whitespace.md:
  - code block #1 on line 72 cannot be parsed: Unexpected character '᠎'
  - code block #6 on line 200 cannot be parsed: Unexpected token `}`. Did you mean `&rbrace;` or `{"}"}`?

File docs/src/rules/no-loss-of-precision.md:
  - code block #1 on line 16 cannot be parsed: Identifier 'x' has already been declared
  - code block #2 on line 33 cannot be parsed: Identifier 'x' has already been declared

File docs/src/rules/no-misleading-character-class.md:
  - code block #1 on line 58 cannot be parsed: Unexpected token ^
  - code block #2 on line 75 cannot be parsed: Unexpected token ^

File docs/src/rules/no-multi-assign.md:
  - code block #1 on line 25 cannot be parsed: Identifier 'a' has already been declared
  - code block #2 on line 49 cannot be parsed: Identifier 'a' has already been declared

File docs/src/rules/no-multiple-empty-lines.md:
  - code block #5 on line 93 cannot be parsed: Unexpected character '⏎'
  - code block #6 on line 110 cannot be parsed: Unexpected character '⏎'

File docs/src/rules/no-restricted-exports.md:
  - code block #6 on line 141 cannot be parsed: Duplicate export 'default'
  - code block #8 on line 173 cannot be parsed: Duplicate export 'default'

File docs/src/rules/no-restricted-imports.md:
  - code block #7 on line 197 cannot be parsed: Identifier 'AllowedObject' has already been declared

File docs/src/rules/no-script-url.md:
  - no correct code blocks

File docs/src/rules/no-self-compare.md:
  - no correct code blocks

File docs/src/rules/no-sequences.md:
  - code block #3 on line 84 cannot be parsed: Identifier 'foo' has already been declared
  - code block #4 on line 99 cannot be parsed: Identifier 'foo' has already been declared

File docs/src/rules/no-tabs.md:
  - code block #1 on line 15 cannot be parsed: Expecting Unicode escape sequence \uXXXX
  - code block #3 on line 57 cannot be parsed: Expecting Unicode escape sequence \uXXXX

File docs/src/rules/no-this-before-super.md:
  - code block #1 on line 21 cannot be parsed: Identifier 'A' has already been declared
  - code block #2 on line 59 cannot be parsed: Identifier 'A' has already been declared

File docs/src/rules/no-underscore-dangle.md:
  - code block #2 on line 38 cannot be parsed: Identifier 'foo' has already been declared
  - code block #5 on line 102 cannot be parsed: 'super' keyword outside a method
  - code block #7 on line 132 cannot be parsed: Identifier 'Foo' has already been declared
  - code block #8 on line 160 cannot be parsed: Identifier 'Foo' has already been declared
  - code block #9 on line 192 cannot be parsed: Identifier '_bar' has already been declared
  - code block #10 on line 208 cannot be parsed: Identifier 'foo' has already been declared
  - code block #11 on line 221 cannot be parsed: Identifier 'foo' has already been declared
  - code block #12 on line 236 cannot be parsed: Identifier 'foo' has already been declared

File docs/src/rules/no-unexpected-multiline.md:
  - code block #1 on line 29 cannot be parsed: Identifier 'x' has already been declared

File docs/src/rules/no-unused-private-class-members.md:
  - code block #1 on line 18 cannot be parsed: Identifier 'Foo' has already been declared
  - code block #2 on line 55 cannot be parsed: Identifier 'Foo' has already been declared

File docs/src/rules/no-useless-constructor.md:
  - code block #2 on line 52 cannot be parsed: Identifier 'A' has already been declared

File docs/src/rules/no-useless-rename.md:
  - code block #1 on line 58 cannot be parsed: Identifier 'foo' has already been declared
  - code block #2 on line 79 cannot be parsed: Identifier 'foo' has already been declared
  - code block #4 on line 122 cannot be parsed: Duplicate export 'foo'
  - code block #5 on line 135 cannot be parsed: Identifier 'foo' has already been declared

File docs/src/rules/object-curly-newline.md:
  - code block #13 on line 550 cannot be parsed: Identifier 'bar' has already been declared
  - code block #14 on line 575 cannot be parsed: Identifier 'foo' has already been declared

File docs/src/rules/one-var-declaration-per-line.md:
  - code block #1 on line 41 cannot be parsed: Identifier 'a' has already been declared
  - code block #2 on line 57 cannot be parsed: Identifier 'a' has already been declared
  - code block #3 on line 78 cannot be parsed: Identifier 'a' has already been declared
  - code block #4 on line 95 cannot be parsed: Identifier 'a' has already been declared

File docs/src/rules/one-var.md:
  - code block #3 on line 190 cannot be parsed: Identifier 'bar' has already been declared
  - code block #10 on line 412 cannot be parsed: Identifier 'bar' has already been declared

File docs/src/rules/prefer-const.md:
  - code block #1 on line 21 cannot be parsed: Identifier 'a' has already been declared
  - code block #2 on line 57 cannot be parsed: Identifier 'a' has already been declared
  - code block #4 on line 162 cannot be parsed: Identifier 'a' has already been declared

File docs/src/rules/prefer-destructuring.md:
  - code block #2 on line 52 cannot be parsed: Identifier 'foo' has already been declared

File docs/src/rules/require-unicode-regexp.md:
  - code block #2 on line 78 cannot be parsed: Identifier 'f' has already been declared

File docs/src/rules/rest-spread-spacing.md:
  - code block #1 on line 83 cannot be parsed: Unexpected token ...
  - code block #2 on line 100 cannot be parsed: Unexpected token ...
  - code block #3 on line 125 cannot be parsed: Unexpected token ...
  - code block #4 on line 142 cannot be parsed: Unexpected token ...

File docs/src/rules/sort-imports.md:
  - code block #1 on line 74 cannot be parsed: Identifier 'a' has already been declared
  - code block #2 on line 106 cannot be parsed: Identifier 'a' has already been declared

File docs/src/rules/sort-keys.md:
  - code block #1 on line 18 cannot be parsed: Identifier 'obj' has already been declared
  - code block #2 on line 44 cannot be parsed: Identifier 'obj' has already been declared
  - code block #3 on line 115 cannot be parsed: Identifier 'obj' has already been declared
  - code block #4 on line 135 cannot be parsed: Identifier 'obj' has already been declared
  - code block #5 on line 157 cannot be parsed: Identifier 'obj' has already been declared
  - code block #6 on line 171 cannot be parsed: Identifier 'obj' has already been declared
  - code block #9 on line 215 cannot be parsed: Identifier 'obj' has already been declared
  - code block #10 on line 243 cannot be parsed: Identifier 'obj' has already been declared
  - code block #12 on line 315 cannot be parsed: Identifier 'obj' has already been declared

File docs/src/rules/space-before-keywords.md:
  - code block #1 on line 46 cannot be parsed: Identifier 'foo' has already been declared
  - code block #2 on line 69 cannot be parsed: Unexpected token onClick

File docs/src/rules/space-infix-ops.md:
  - code block #1 on line 44 cannot be parsed: Identifier 'a' has already been declared
  - code block #2 on line 69 cannot be parsed: Identifier 'a' has already been declared

File docs/src/rules/yield-star-spacing.md:
  - no incorrect code blocks
```

The code to generate the above report is the same I've used in #17602 except for adding `sourceType: "module"` to the default parser options.

<details>
<summary><b>check-rule-examples.js</b></summary>

```js
// Put this file into the eslint project folder and run it with `node`.

"use strict";

const { parse } = require("espree");
const { promises: { readFile } } = require("fs");
const glob = require("glob");
const { promisify } = require("util");

/**
 * Tries to parse a specified JavaScript code.
 * @param {string} code The JavaScript code to parse.
 * @param {ParserOptions} parserOptions Explicitly specified parser options.
 * @returns {string|undefined} An error message if the code cannot be parsed, or undefined.
 */
function tryParse(code, parserOptions) {
    try {
        parse(code, { ecmaVersion: "latest", sourceType: "module", ...parserOptions });
    } catch ({ message }) {
        return message;
    }
    return void 0;
}

/**
 * Checks a rule docs file for possible problems.
 * @param {string} file The path of a rule docs file to be checked.
 * @returns {Promise<string[]>} A list of warnings found for the file.
 */
async function checkFile(file) {
    const text = await readFile(file, "utf-8");
    const warnings = [];
    const blockMatches = text.matchAll(/^:::(?<heading>.*?)$\s*^(?<codeBlock>.*?)$\s*^:::$/gmsu);
    let anyCorrectMatches = false;
    let anyIncorrectMatches = false;
    let count = 0;

    for (const blockMatch of blockMatches) {
        const blockNumber = ++count;
        let currentBlock = {
            toString() {
                const lineNumber = text.slice(0, blockMatch.index).match(/\n/gu).length + 1;

                return (currentBlock = `code block #${blockNumber} on line ${lineNumber}`);
            }
        };
        const { heading, codeBlock } = blockMatch.groups;
        const { typeTag, parserOptionsJSON } =
        /^\s*(?<typeTag>\S*)(?:\s+(?<parserOptionsJSON>.*?)\s*)?$/u.exec(heading).groups;

        switch (typeTag) {
            case "correct":
                anyCorrectMatches = true;
                break;
            case "incorrect":
                anyIncorrectMatches = true;
                break;
            default:
                warnings.push(`${currentBlock} has wrong type tag '${typeTag}'`);
                break;
        }
        const codeBlockMatch = /^```(?<langTag>.*?)\n(?<code>.*)\n```$/su.exec(codeBlock);

        if (codeBlockMatch) {
            const { code, langTag } = codeBlockMatch.groups;

            if (!["javascript", "js", "jsx"].includes(langTag)) {
                warnings.push(`${currentBlock} has unexpected language tag '${langTag}'`);
            }
            const parserOptions = parserOptionsJSON ? JSON.parse(parserOptionsJSON) : { };
            const message = tryParse(code, parserOptions);

            if (message) {
                warnings.push(`${currentBlock} cannot be parsed: ${message}`);
            }
        } else {
            warnings.push(`${currentBlock} has no fenced code block`);
        }
    }
    if (!anyCorrectMatches) {
        warnings.push("no correct code blocks");
    }
    if (!anyIncorrectMatches) {
        warnings.push("no incorrect code blocks");
    }
    return warnings;
}

(async function main() {
    const files = await promisify(glob)("docs/src/rules/*.md");
    const warningsList = await Promise.all(files.map(checkFile));

    warningsList.forEach((warnings, index) => {
        if (warnings.length) {
            console.log( // eslint-disable-line no-console -- not for release
                `File ${files[index]}:\n${warnings.map(warning => `  - ${warning}\n`).join("")}`
            );
        }
    });
}());
```
</details>

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
