### PR TITLE
test: fix flat config linter tests to use Linter in flat config mode

### DIFF
--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -15627,7 +15627,7 @@ var a = "test2";
                 const code = BROKEN_TEST_CODE;
 
                 it("should report a violation with a useful parse error prefix", () => {
-                    const messages = linter.verify(code);
+                    const messages = linter.verify(code, {});
                     const suppressedMessages = linter.getSuppressedMessages();
 
                     assert.strictEqual(messages.length, 1);
@@ -15648,7 +15648,7 @@ var a = "test2";
                         "    x++;",
                         "}"
                     ];
-                    const messages = linter.verify(inValidCode.join("\n"));
+                    const messages = linter.verify(inValidCode.join("\n"), {});
                     const suppressedMessages = linter.getSuppressedMessages();
 
                     assert.strictEqual(messages.length, 1);
@@ -16584,7 +16584,7 @@ var a = "test2";
         });
 
         it("should not crash when invalid parentheses syntax is encountered", () => {
-            linter.verify("left = (aSize.width/2) - ()");
+            linter.verify("left = (aSize.width/2) - ()", {});
         });
 
         it("should not crash when let is used inside of switch case", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Fixes several Linter tests under `"Linter with FlatConfigArray"` to really use Linter in the flat config mode.

`Linter#verify()` needs `configType: "flat"` constructor option AND the second, `config` argument to trigger the flat config mode. Without the `config` argument, `Linter#verify()` still works in the eslintrc mode regardless of `configType`. 

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added an empty config as the config argument in tests that were unintentionally using Linter in the eslintrc mode.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
