### PR TITLE
fix: Ensure correct code path for && followed by ??

### DIFF
--- a/lib/linter/code-path-analysis/code-path-state.js
+++ b/lib/linter/code-path-analysis/code-path-state.js
@@ -1217,7 +1217,7 @@ class CodePathState {
                     prevForkContext = currentChoiceContext.falseForkContext;
                     break;
                 case "??": // Both true/false can short-circuit, so needs the third path to go to the right-hand side. That's qqForkContext.
-                    prevForkContext = currentChoiceContext.nullishForkContext; // s1_1->s1_4
+                    prevForkContext = currentChoiceContext.nullishForkContext;
                     break;
                 default:
                     throw new Error("unreachable");

--- a/lib/linter/code-path-analysis/code-path-state.js
+++ b/lib/linter/code-path-analysis/code-path-state.js
@@ -121,7 +121,7 @@ class ChainContext {
  * true go one way and if false go the other (tracked by `trueForkContext` and
  * `falseForkContext`). The `??` operator doesn't operate on true/false because
  * the left expression is evaluated to be nullish or not, so only if nullish do
- * we fork to the right expression (tracked by `qqForkcontext`).
+ * we fork to the right expression (tracked by `nullishForkContext`).
  */
 class ChoiceContext {
 
@@ -177,7 +177,7 @@ class ChoiceContext {
 
         /**
          * Indicates if any of `trueForkContext`, `falseForkContext`, or
-         * `qqForkContext` have been updated with segments from a child context.
+         * `nullishForkContext` have been updated with segments from a child context.
          * @type {boolean}
          */
         this.processed = false;
@@ -1216,7 +1216,7 @@ class CodePathState {
                 case "||": // if false then go to the right-hand side.
                     prevForkContext = currentChoiceContext.falseForkContext;
                     break;
-                case "??": // Both true/false can short-circuit, so needs the third path to go to the right-hand side. That's qqForkContext.
+                case "??": // Both true/false can short-circuit, so needs the third path to go to the right-hand side. That's nullishForkContext.
                     prevForkContext = currentChoiceContext.nullishForkContext;
                     break;
                 default:

--- a/lib/linter/code-path-analysis/code-path-state.js
+++ b/lib/linter/code-path-analysis/code-path-state.js
@@ -170,10 +170,10 @@ class ChoiceContext {
         this.falseForkContext = ForkContext.newEmpty(forkContext);
 
         /**
-         * The fork context for the right side of the `??` path of the choice.
+         * The fork context for when the choice result is `null` or `undefined`.
          * @type {ForkContext}
          */
-        this.qqForkContext = ForkContext.newEmpty(forkContext);
+        this.nullishForkContext = ForkContext.newEmpty(forkContext);
 
         /**
          * Indicates if any of `trueForkContext`, `falseForkContext`, or
@@ -849,7 +849,7 @@ function finalizeTestSegmentsOfFor(context, choiceContext, head) {
     if (!choiceContext.processed) {
         choiceContext.trueForkContext.add(head);
         choiceContext.falseForkContext.add(head);
-        choiceContext.qqForkContext.add(head);
+        choiceContext.nullishForkContext.add(head);
     }
 
     /*
@@ -1095,31 +1095,31 @@ class CodePathState {
 
     /**
      * Pops the last choice context and finalizes it.
+     * This is called upon leaving a node that represents a choice.
      * @throws {Error} (Unreachable.)
      * @returns {ChoiceContext} The popped context.
      */
     popChoiceContext() {
-        const context = this.choiceContext;
-
-        this.choiceContext = context.upper;
-
+        const poppedChoiceContext = this.choiceContext;
         const forkContext = this.forkContext;
-        const headSegments = forkContext.head;
+        const head = forkContext.head;
 
-        switch (context.kind) {
+        this.choiceContext = poppedChoiceContext.upper;
+
+        switch (poppedChoiceContext.kind) {
             case "&&":
             case "||":
             case "??":
 
                 /*
-                 * The `headSegments` are the path of the right-hand operand.
+                 * The `head` are the path of the right-hand operand.
                  * If we haven't previously added segments from child contexts,
                  * then we add these segments to all possible forks.
                  */
-                if (!context.processed) {
-                    context.trueForkContext.add(headSegments);
-                    context.falseForkContext.add(headSegments);
-                    context.qqForkContext.add(headSegments);
+                if (!poppedChoiceContext.processed) {
+                    poppedChoiceContext.trueForkContext.add(head);
+                    poppedChoiceContext.falseForkContext.add(head);
+                    poppedChoiceContext.nullishForkContext.add(head);
                 }
 
                 /*
@@ -1128,29 +1128,29 @@ class CodePathState {
                  * then we take the segments for this context and move them up
                  * to the parent context.
                  */
-                if (context.isForkingAsResult) {
+                if (poppedChoiceContext.isForkingAsResult) {
                     const parentContext = this.choiceContext;
 
-                    parentContext.trueForkContext.addAll(context.trueForkContext);
-                    parentContext.falseForkContext.addAll(context.falseForkContext);
-                    parentContext.qqForkContext.addAll(context.qqForkContext);
+                    parentContext.trueForkContext.addAll(poppedChoiceContext.trueForkContext);
+                    parentContext.falseForkContext.addAll(poppedChoiceContext.falseForkContext);
+                    parentContext.nullishForkContext.addAll(poppedChoiceContext.nullishForkContext);
                     parentContext.processed = true;
 
                     // Exit early so we don't collapse all paths into one.
-                    return context;
+                    return poppedChoiceContext;
                 }
 
                 break;
 
             case "test":
-                if (!context.processed) {
+                if (!poppedChoiceContext.processed) {
 
                     /*
                      * The head segments are the path of the `if` block here.
                      * Updates the `true` path with the end of the `if` block.
                      */
-                    context.trueForkContext.clear();
-                    context.trueForkContext.add(headSegments);
+                    poppedChoiceContext.trueForkContext.clear();
+                    poppedChoiceContext.trueForkContext.add(head);
                 } else {
 
                     /*
@@ -1158,8 +1158,8 @@ class CodePathState {
                      * Updates the `false` path with the end of the `else`
                      * block.
                      */
-                    context.falseForkContext.clear();
-                    context.falseForkContext.add(headSegments);
+                    poppedChoiceContext.falseForkContext.clear();
+                    poppedChoiceContext.falseForkContext.add(head);
                 }
 
                 break;
@@ -1170,7 +1170,7 @@ class CodePathState {
                  * Loops are addressed in `popLoopContext()` so just return
                  * the context without modification.
                  */
-                return context;
+                return poppedChoiceContext;
 
             /* c8 ignore next */
             default:
@@ -1180,71 +1180,116 @@ class CodePathState {
         /*
          * Merge the true path with the false path to create a single path.
          */
-        const combinedForkContext = context.trueForkContext;
+        const combinedForkContext = poppedChoiceContext.trueForkContext;
 
-        combinedForkContext.addAll(context.falseForkContext);
+        combinedForkContext.addAll(poppedChoiceContext.falseForkContext);
         forkContext.replaceHead(combinedForkContext.makeNext(0, -1));
 
-        return context;
+        return poppedChoiceContext;
     }
 
     /**
-     * Makes a code path segment of the right-hand operand of a logical
+     * Creates a code path segment to represent right-hand operand of a logical
      * expression.
+     * This is called in the preprocessing phase when entering a node.
      * @throws {Error} (Unreachable.)
      * @returns {void}
      */
     makeLogicalRight() {
-        const context = this.choiceContext;
+        const currentChoiceContext = this.choiceContext;
         const forkContext = this.forkContext;
 
-        if (context.processed) {
+        if (currentChoiceContext.processed) {
 
             /*
-             * This got segments already from the child choice context.
-             * Creates the next path from own true/false fork context.
+             * This context was already assigned segments from a child
+             * choice context. In this case, we are concerned only about
+             * the path that does not short-circuit and so ends up on the
+             * right-hand operand of the logical expression.
              */
             let prevForkContext;
 
-            switch (context.kind) {
+            switch (currentChoiceContext.kind) {
                 case "&&": // if true then go to the right-hand side.
-                    prevForkContext = context.trueForkContext;
+                    prevForkContext = currentChoiceContext.trueForkContext;
                     break;
                 case "||": // if false then go to the right-hand side.
-                    prevForkContext = context.falseForkContext;
+                    prevForkContext = currentChoiceContext.falseForkContext;
                     break;
                 case "??": // Both true/false can short-circuit, so needs the third path to go to the right-hand side. That's qqForkContext.
-                    prevForkContext = context.qqForkContext;
+                    prevForkContext = currentChoiceContext.nullishForkContext; // s1_1->s1_4
                     break;
                 default:
                     throw new Error("unreachable");
             }
 
+            /*
+             * Create the segment for the right-hand operand of the logical expression
+             * and adjust the fork context pointer to point there. The right-hand segment
+             * is added at the end of all segments in `prevForkContext`.
+             */
             forkContext.replaceHead(prevForkContext.makeNext(0, -1));
+
+            /*
+             * We no longer need this list of segments.
+             *
+             * Reset `processed` because we've removed the segments from the child
+             * choice context. This allows `popChoiceContext()` to continue adding
+             * segments later.
+             */
             prevForkContext.clear();
-            context.processed = false;
+            currentChoiceContext.processed = false;
+
         } else {
 
             /*
-             * This did not get segments from the child choice context.
-             * So addresses the head segments.
-             * The head segments are the path of the left-hand operand.
+             * This choice context was not assigned segments from a child
+             * choice context, which means that it's a terminal logical
+             * expression.
+             *
+             * `head` is the segments for the left-hand operand of the
+             * logical expression.
+             *
+             * Each of the fork contexts below are empty at this point. We choose
+             * the path(s) that will short-circuit and add the segment for the
+             * left-hand operand to it. Ultimately, this will be the only segment
+             * in that path due to the short-circuting, so we are just seeding
+             * these paths to start.
              */
-            switch (context.kind) {
-                case "&&": // the false path can short-circuit.
-                    context.falseForkContext.add(forkContext.head);
+            switch (currentChoiceContext.kind) {
+                case "&&":
+
+                    /*
+                     * In most contexts, when a && expression evaluates to false,
+                     * it short circuits, so we need to account for that by setting
+                     * the `falseForkContext` to the left operand.
+                     *
+                     * When a && expression is the left-hand operand for a ??
+                     * expression, such as `(a && b) ?? c`, a nullish value will
+                     * also short-circuit in a different way than a false value,
+                     * so we also set the `nullishForkContext` to the left operand.
+                     * This path is only used with a ?? expression and is thrown
+                     * away for any other type of logical expression, so it's safe
+                     * to always add.
+                     */
+                    currentChoiceContext.falseForkContext.add(forkContext.head);
+                    currentChoiceContext.nullishForkContext.add(forkContext.head);
                     break;
                 case "||": // the true path can short-circuit.
-                    context.trueForkContext.add(forkContext.head);
+                    currentChoiceContext.trueForkContext.add(forkContext.head);
                     break;
                 case "??": // both can short-circuit.
-                    context.trueForkContext.add(forkContext.head);
-                    context.falseForkContext.add(forkContext.head);
+                    currentChoiceContext.trueForkContext.add(forkContext.head);
+                    currentChoiceContext.falseForkContext.add(forkContext.head);
                     break;
                 default:
                     throw new Error("unreachable");
             }
 
+            /*
+             * Create the segment for the right-hand operand of the logical expression
+             * and adjust the fork context pointer to point there.
+             */
             forkContext.replaceHead(forkContext.makeNext(-1, -1));
         }
     }
@@ -1265,7 +1310,7 @@ class CodePathState {
         if (!context.processed) {
             context.trueForkContext.add(forkContext.head);
             context.falseForkContext.add(forkContext.head);
-            context.qqForkContext.add(forkContext.head);
+            context.nullishForkContext.add(forkContext.head);
         }
 
         context.processed = false;

--- a/tests/fixtures/code-path-analysis/logical--and-qq.js
+++ b/tests/fixtures/code-path-analysis/logical--and-qq.js
@@ -4,20 +4,19 @@ s1_1->s1_3;
 s1_2->s1_4;
 s1_1->s1_4->final;
 */
-(a &&= b) ?? c;
+(a && b) ?? c;
 
 /*DOT
 digraph {
     node[shape=box,style="rounded,filled",fillcolor=white];
     initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
     final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
-    s1_1[label="Program:enter\nExpressionStatement:enter\nLogicalExpression:enter\nAssignmentExpression:enter\nIdentifier (a)"];
-    s1_2[label="Identifier (b)\nAssignmentExpression:exit"];
+    s1_1[label="Program:enter\nExpressionStatement:enter\nLogicalExpression:enter\nLogicalExpression:enter\nIdentifier (a)"];
+    s1_2[label="Identifier (b)\nLogicalExpression:exit"];
     s1_3[label="Identifier (c)"];
     s1_4[label="LogicalExpression:exit\nExpressionStatement:exit\nProgram:exit"];
     initial->s1_1->s1_2->s1_3->s1_4;
     s1_1->s1_3;
     s1_2->s1_4;
     s1_1->s1_4->final;
-}
-*/
+}*/

--- a/tests/fixtures/code-path-analysis/logical--if-mix-and-qq-1.js
+++ b/tests/fixtures/code-path-analysis/logical--if-mix-and-qq-1.js
@@ -1,8 +1,9 @@
 /*expected
 initial->s1_1->s1_2->s1_3->s1_4->s1_6;
-s1_1->s1_5->s1_6;
+s1_1->s1_3;
 s1_2->s1_4;
-s1_3->s1_5;
+s1_3->s1_5->s1_6;
+s1_1->s1_5;
 s1_2->s1_5;
 s1_6->final;
 */
@@ -24,9 +25,10 @@ digraph {
     s1_6[label="IfStatement:exit\nProgram:exit"];
     s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)\nIdentifier:exit (bar)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
     initial->s1_1->s1_2->s1_3->s1_4->s1_6;
-    s1_1->s1_5->s1_6;
+    s1_1->s1_3;
     s1_2->s1_4;
-    s1_3->s1_5;
+    s1_3->s1_5->s1_6;
+    s1_1->s1_5;
     s1_2->s1_5;
     s1_6->final;
 }

--- a/tests/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -725,7 +725,7 @@ describe("CodePathAnalyzer", () => {
         });
     });
 
-    describe.only("completed code paths are correct", () => {
+    describe("completed code paths are correct", () => {
         const testDataDir = path.join(__dirname, "../../../fixtures/code-path-analysis/");
         const testDataFiles = fs.readdirSync(testDataDir);
 

--- a/tests/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -725,11 +725,13 @@ describe("CodePathAnalyzer", () => {
         });
     });
 
-    describe("completed code paths are correct", () => {
+    describe.only("completed code paths are correct", () => {
         const testDataDir = path.join(__dirname, "../../../fixtures/code-path-analysis/");
         const testDataFiles = fs.readdirSync(testDataDir);
 
         testDataFiles.forEach(file => {
+
+            // if (!file.includes("--and-qq")) return;
             it(file, () => {
                 const source = fs.readFileSync(path.join(testDataDir, file), { encoding: "utf8" });
                 const expected = getExpectedDotArrows(source);

--- a/tests/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -730,8 +730,6 @@ describe("CodePathAnalyzer", () => {
         const testDataFiles = fs.readdirSync(testDataDir);
 
         testDataFiles.forEach(file => {
-
-            // if (!file.includes("--and-qq")) return;
             it(file, () => {
                 const source = fs.readFileSync(path.join(testDataDir, file), { encoding: "utf8" });
                 const expected = getExpectedDotArrows(source);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I changed the generated code path for `&&` expressions that are the left-hand operand of `??` expressions so that they show the short-circuiting of nullish values. I updated old tests that were producing incorrect results, as well.

I also did some more refactoring and added more comments with my understanding of what is happening.

Fixes #13614 

<details>
<summary>logical--and-qq</summary>

**Before:**

[GraphViz](https://dreampuf.github.io/GraphvizOnline/#digraph%20%7B%0A%20%20%20%20node%5Bshape%3Dbox%2Cstyle%3D%22rounded%2Cfilled%22%2Cfillcolor%3Dwhite%5D%3B%0A%20%20%20%20initial%5Blabel%3D%22%22%2Cshape%3Dcircle%2Cstyle%3Dfilled%2Cfillcolor%3Dblack%2Cwidth%3D0.25%2Cheight%3D0.25%5D%3B%0A%20%20%20%20final%5Blabel%3D%22%22%2Cshape%3Ddoublecircle%2Cstyle%3Dfilled%2Cfillcolor%3Dblack%2Cwidth%3D0.25%2Cheight%3D0.25%5D%3B%0A%20%20%20%20s1_1%5Blabel%3D%22Program%3Aenter%5CnExpressionStatement%3Aenter%5CnLogicalExpression%3Aenter%5CnLogicalExpression%3Aenter%5CnIdentifier%20(a)%22%5D%3B%0A%20%20%20%20s1_2%5Blabel%3D%22Identifier%20(b)%5CnLogicalExpression%3Aexit%22%5D%3B%0A%20%20%20%20s1_3%5Blabel%3D%22Identifier%20(c)%22%5D%3B%0A%20%20%20%20s1_4%5Blabel%3D%22LogicalExpression%3Aexit%5CnExpressionStatement%3Aexit%5CnProgram%3Aexit%22%5D%3B%0A%20%20%20%20initial-%3Es1_1-%3Es1_2-%3Es1_3-%3Es1_4%3B%0A%20%20%20%20s1_1-%3Es1_4%3B%0A%20%20%20%20s1_2-%3Es1_4-%3Efinal%3B%0A%7D)

![graphviz(5)](https://github.com/eslint/eslint/assets/38546/9d299f05-6d81-4b30-9410-00eec07c4c49)


**After:**

[GraphViz](https://dreampuf.github.io/GraphvizOnline/#digraph%20%7B%0A%20%20%20%20node%5Bshape%3Dbox%2Cstyle%3D%22rounded%2Cfilled%22%2Cfillcolor%3Dwhite%5D%3B%0A%20%20%20%20initial%5Blabel%3D%22%22%2Cshape%3Dcircle%2Cstyle%3Dfilled%2Cfillcolor%3Dblack%2Cwidth%3D0.25%2Cheight%3D0.25%5D%3B%0A%20%20%20%20final%5Blabel%3D%22%22%2Cshape%3Ddoublecircle%2Cstyle%3Dfilled%2Cfillcolor%3Dblack%2Cwidth%3D0.25%2Cheight%3D0.25%5D%3B%0A%20%20%20%20s1_1%5Blabel%3D%22Program%3Aenter%5CnExpressionStatement%3Aenter%5CnLogicalExpression%3Aenter%5CnLogicalExpression%3Aenter%5CnIdentifier%20(a)%22%5D%3B%0A%20%20%20%20s1_2%5Blabel%3D%22Identifier%20(b)%5CnLogicalExpression%3Aexit%22%5D%3B%0A%20%20%20%20s1_3%5Blabel%3D%22Identifier%20(c)%22%5D%3B%0A%20%20%20%20s1_4%5Blabel%3D%22LogicalExpression%3Aexit%5CnExpressionStatement%3Aexit%5CnProgram%3Aexit%22%5D%3B%0A%20%20%20%20initial-%3Es1_1-%3Es1_2-%3Es1_3-%3Es1_4%3B%0A%20%20%20%20s1_1-%3Es1_3%3B%0A%20%20%20%20s1_1-%3Es1_4%3B%0A%20%20%20%20s1_2-%3Es1_4-%3Efinal%3B%0A%7D)


![graphviz(6)](https://github.com/eslint/eslint/assets/38546/17f6dea8-edf3-48f5-b45b-81290988097b)
</details>


<details>
<summary>logical--if-mix-and-qq-1</summary>

**Before:**

[GraphViz](https://dreampuf.github.io/GraphvizOnline/#digraph%20%7B%0A%20%20%20%20node%5Bshape%3Dbox%2Cstyle%3D%22rounded%2Cfilled%22%2Cfillcolor%3Dwhite%5D%3B%0A%20%20%20%20initial%5Blabel%3D%22%22%2Cshape%3Dcircle%2Cstyle%3Dfilled%2Cfillcolor%3Dblack%2Cwidth%3D0.25%2Cheight%3D0.25%5D%3B%0A%20%20%20%20final%5Blabel%3D%22%22%2Cshape%3Ddoublecircle%2Cstyle%3Dfilled%2Cfillcolor%3Dblack%2Cwidth%3D0.25%2Cheight%3D0.25%5D%3B%0A%20%20%20%20s1_1%5Blabel%3D%22Program%5CnIfStatement%5CnLogicalExpression%5CnLogicalExpression%5CnIdentifier%20(a)%5CnIdentifier%3Aexit%20(a)%22%5D%3B%0A%20%20%20%20s1_2%5Blabel%3D%22Identifier%20(b)%5CnIdentifier%3Aexit%20(b)%5CnLogicalExpression%3Aexit%22%5D%3B%0A%20%20%20%20s1_3%5Blabel%3D%22Identifier%20(c)%5CnIdentifier%3Aexit%20(c)%5CnLogicalExpression%3Aexit%22%5D%3B%0A%20%20%20%20s1_4%5Blabel%3D%22BlockStatement%5CnExpressionStatement%5CnCallExpression%5CnIdentifier%20(foo)%5CnIdentifier%3Aexit%20(foo)%5CnCallExpression%3Aexit%5CnExpressionStatement%3Aexit%5CnBlockStatement%3Aexit%22%5D%3B%0A%20%20%20%20s1_6%5Blabel%3D%22IfStatement%3Aexit%5CnProgram%3Aexit%22%5D%3B%0A%20%20%20%20s1_5%5Blabel%3D%22BlockStatement%5CnExpressionStatement%5CnCallExpression%5CnIdentifier%20(bar)%5CnIdentifier%3Aexit%20(bar)%5CnCallExpression%3Aexit%5CnExpressionStatement%3Aexit%5CnBlockStatement%3Aexit%22%5D%3B%0A%20%20%20%20initial-%3Es1_1-%3Es1_2-%3Es1_3-%3Es1_4-%3Es1_6%3B%0A%20%20%20%20s1_1-%3Es1_5-%3Es1_6%3B%0A%20%20%20%20s1_2-%3Es1_4%3B%0A%20%20%20%20s1_3-%3Es1_5%3B%0A%20%20%20%20s1_2-%3Es1_5%3B%0A%20%20%20%20s1_6-%3Efinal%3B%0A%7D)

![graphviz(7)](https://github.com/eslint/eslint/assets/38546/742d1d81-11c6-4c38-afd5-5e6ac3358cae)



**After:**

[GraphViz](https://dreampuf.github.io/GraphvizOnline/#digraph%20%7B%0A%20%20%20%20node%5Bshape%3Dbox%2Cstyle%3D%22rounded%2Cfilled%22%2Cfillcolor%3Dwhite%5D%3B%0A%20%20%20%20initial%5Blabel%3D%22%22%2Cshape%3Dcircle%2Cstyle%3Dfilled%2Cfillcolor%3Dblack%2Cwidth%3D0.25%2Cheight%3D0.25%5D%3B%0A%20%20%20%20final%5Blabel%3D%22%22%2Cshape%3Ddoublecircle%2Cstyle%3Dfilled%2Cfillcolor%3Dblack%2Cwidth%3D0.25%2Cheight%3D0.25%5D%3B%0A%20%20%20%20s1_1%5Blabel%3D%22Program%5CnIfStatement%5CnLogicalExpression%5CnLogicalExpression%5CnIdentifier%20(a)%5CnIdentifier%3Aexit%20(a)%22%5D%3B%0A%20%20%20%20s1_2%5Blabel%3D%22Identifier%20(b)%5CnIdentifier%3Aexit%20(b)%5CnLogicalExpression%3Aexit%22%5D%3B%0A%20%20%20%20s1_3%5Blabel%3D%22Identifier%20(c)%5CnIdentifier%3Aexit%20(c)%5CnLogicalExpression%3Aexit%22%5D%3B%0A%20%20%20%20s1_4%5Blabel%3D%22BlockStatement%5CnExpressionStatement%5CnCallExpression%5CnIdentifier%20(foo)%5CnIdentifier%3Aexit%20(foo)%5CnCallExpression%3Aexit%5CnExpressionStatement%3Aexit%5CnBlockStatement%3Aexit%22%5D%3B%0A%20%20%20%20s1_6%5Blabel%3D%22IfStatement%3Aexit%5CnProgram%3Aexit%22%5D%3B%0A%20%20%20%20s1_5%5Blabel%3D%22BlockStatement%5CnExpressionStatement%5CnCallExpression%5CnIdentifier%20(bar)%5CnIdentifier%3Aexit%20(bar)%5CnCallExpression%3Aexit%5CnExpressionStatement%3Aexit%5CnBlockStatement%3Aexit%22%5D%3B%0A%20%20%20%20initial-%3Es1_1-%3Es1_2-%3Es1_3-%3Es1_4-%3Es1_6%3B%0A%20%20%20%20s1_1-%3Es1_3%3B%0A%20%20%20%20s1_3-%3Es1_5-%3Es1_6%3B%0A%20%20%20%20s1_2-%3Es1_4%3B%0A%20%20%20%20s1_1-%3Es1_5%3B%0A%20%20%20%20s1_2-%3Es1_5%3B%0A%20%20%20%20s1_6-%3Efinal%3B%0A%7D)

![graphviz(8)](https://github.com/eslint/eslint/assets/38546/08aa091b-8ee9-497e-a0dd-a5e7b9b59ebb)


</details>

<details>
<summary>assignment--nested-and-qq</summary>

**Before:**

[GraphViz](https://dreampuf.github.io/GraphvizOnline/#digraph%20%7B%0A%20%20%20%20node%5Bshape%3Dbox%2Cstyle%3D%22rounded%2Cfilled%22%2Cfillcolor%3Dwhite%5D%3B%0A%20%20%20%20initial%5Blabel%3D%22%22%2Cshape%3Dcircle%2Cstyle%3Dfilled%2Cfillcolor%3Dblack%2Cwidth%3D0.25%2Cheight%3D0.25%5D%3B%0A%20%20%20%20final%5Blabel%3D%22%22%2Cshape%3Ddoublecircle%2Cstyle%3Dfilled%2Cfillcolor%3Dblack%2Cwidth%3D0.25%2Cheight%3D0.25%5D%3B%0A%20%20%20%20s1_1%5Blabel%3D%22Program%3Aenter%5CnExpressionStatement%3Aenter%5CnLogicalExpression%3Aenter%5CnAssignmentExpression%3Aenter%5CnIdentifier%20(a)%22%5D%3B%0A%20%20%20%20s1_2%5Blabel%3D%22Identifier%20(b)%5CnAssignmentExpression%3Aexit%22%5D%3B%0A%20%20%20%20s1_3%5Blabel%3D%22Identifier%20(c)%22%5D%3B%0A%20%20%20%20s1_4%5Blabel%3D%22LogicalExpression%3Aexit%5CnExpressionStatement%3Aexit%5CnProgram%3Aexit%22%5D%3B%0A%20%20%20%20initial-%3Es1_1-%3Es1_2-%3Es1_3-%3Es1_4%3B%0A%20%20%20%20s1_1-%3Es1_4%3B%0A%20%20%20%20s1_2-%3Es1_4-%3Efinal%3B%0A%7D)

![graphviz(10)](https://github.com/eslint/eslint/assets/38546/4683cdc9-9477-476c-bcd2-698edc94d7d1)



**After:**

[GraphViz](https://dreampuf.github.io/GraphvizOnline/#digraph%20%7B%0A%20%20%20%20node%5Bshape%3Dbox%2Cstyle%3D%22rounded%2Cfilled%22%2Cfillcolor%3Dwhite%5D%3B%0A%20%20%20%20initial%5Blabel%3D%22%22%2Cshape%3Dcircle%2Cstyle%3Dfilled%2Cfillcolor%3Dblack%2Cwidth%3D0.25%2Cheight%3D0.25%5D%3B%0A%20%20%20%20final%5Blabel%3D%22%22%2Cshape%3Ddoublecircle%2Cstyle%3Dfilled%2Cfillcolor%3Dblack%2Cwidth%3D0.25%2Cheight%3D0.25%5D%3B%0A%20%20%20%20s1_1%5Blabel%3D%22Program%3Aenter%5CnExpressionStatement%3Aenter%5CnLogicalExpression%3Aenter%5CnAssignmentExpression%3Aenter%5CnIdentifier%20(a)%22%5D%3B%0A%20%20%20%20s1_2%5Blabel%3D%22Identifier%20(b)%5CnAssignmentExpression%3Aexit%22%5D%3B%0A%20%20%20%20s1_3%5Blabel%3D%22Identifier%20(c)%22%5D%3B%0A%20%20%20%20s1_4%5Blabel%3D%22LogicalExpression%3Aexit%5CnExpressionStatement%3Aexit%5CnProgram%3Aexit%22%5D%3B%0A%20%20%20%20initial-%3Es1_1-%3Es1_2-%3Es1_3-%3Es1_4%3B%0A%20%20%20%20s1_1-%3Es1_3%3B%0A%20%20%20%20s1_2-%3Es1_4%3B%0A%20%20%20%20s1_1-%3Es1_4-%3Efinal%3B%0A%7D)

![graphviz(9)](https://github.com/eslint/eslint/assets/38546/595ee684-2000-41c9-91cc-ed504536a044)


</details>

#### Is there anything you'd like reviewers to focus on?

Please double-check the digraphs on the updated tests to make sure they make sense. 

<!-- markdownlint-disable-file MD004 -->
