### PR TITLE
fix: make rule severity case-sensitive in flat config

### DIFF
--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -179,9 +179,7 @@ class InvalidRuleSeverityError extends Error {
  * @throws {InvalidRuleSeverityError} If the value isn't a valid rule severity.
  */
 function assertIsRuleSeverity(ruleId, value) {
-    const severity = typeof value === "string"
-        ? ruleSeverities.get(value.toLowerCase())
-        : ruleSeverities.get(value);
+    const severity = ruleSeverities.get(value);
 
     if (typeof severity === "undefined") {
         throw new InvalidRuleSeverityError(ruleId, value);

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -1726,6 +1726,17 @@ describe("FlatConfigArray", () => {
                 ], "Key \"rules\": Key \"foo\": Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
             });
 
+            it("should error when a string rule severity is not in lowercase", async () => {
+
+                await assertInvalidConfig([
+                    {
+                        rules: {
+                            foo: "Error"
+                        }
+                    }
+                ], "Key \"rules\": Key \"foo\": Expected severity of \"off\", 0, \"warn\", 1, \"error\", or 2.");
+            });
+
             it("should error when an invalid rule severity is set in an array", async () => {
 
                 await assertInvalidConfig([

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -1906,6 +1906,22 @@ describe("Linter", () => {
             assert.strictEqual(suppressedMessages.length, 0);
         });
 
+        it("should enable rule configured using a string severity that contains uppercase letters", () => {
+            const code = "/*eslint no-alert: \"Error\"*/ alert('test');";
+            const config = { rules: {} };
+
+            const messages = linter.verify(code, config, filename);
+            const suppressedMessages = linter.getSuppressedMessages();
+
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].severity, 2);
+            assert.strictEqual(messages[0].message, "Unexpected alert.");
+            assert.include(messages[0].nodeType, "CallExpression");
+
+            assert.strictEqual(suppressedMessages.length, 0);
+        });
+
         it("rules should not change initial config", () => {
             const config = { rules: { strict: 2 } };
             const codeA = "/*eslint strict: 0*/ function bar() { return 2; }";
@@ -12198,6 +12214,29 @@ describe("Linter with FlatConfigArray", () => {
                                     column: 1,
                                     endLine: 1,
                                     endColumn: 25,
+                                    nodeType: null
+                                }
+                            ]
+                        );
+
+                        assert.strictEqual(suppressedMessages.length, 0);
+                    });
+
+                    it("should report a violation when a rule is configured using a string severity that contains uppercase letters", () => {
+                        const messages = linter.verify("/*eslint no-alert: \"Error\"*/ alert('test');", {});
+                        const suppressedMessages = linter.getSuppressedMessages();
+
+                        assert.deepStrictEqual(
+                            messages,
+                            [
+                                {
+                                    severity: 2,
+                                    ruleId: "no-alert",
+                                    message: "Inline configuration for rule \"no-alert\" is invalid:\n\tExpected severity of \"off\", 0, \"warn\", 1, \"error\", or 2. You passed \"Error\".\n",
+                                    line: 1,
+                                    column: 1,
+                                    endLine: 1,
+                                    endColumn: 29,
                                     nodeType: null
                                 }
                             ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes https://github.com/eslint/eslint/issues/17570


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->



#### What changes did you make? (Give an overview)

Updated `function assertIsRuleSeverity` to ensure that rule severities are case-sensitive in flat config.

This means that configurations such as `"no-alert": "Off"` or `"no-alert": ["Error"]` will be invalid.

This also applies to inline configuration comments. For example, `/* no-alert: "Error" */` will be invalid in the flat config mode after this change. It remains valid in the eslintrc mode (I added a test to verify).

#### Is there anything you'd like reviewers to focus on?

Currently (before this change), in the flat config mode, uppercase severities are effectively already not allowed in configuration files even though they pass the initial validation, because they turn into `undefined` while merging config objects, but they are allowed in inline configuration comments.

<!-- markdownlint-disable-file MD004 -->
