### PR TITLE
docs: Update `no-irregular-whitespace` and fix examples

### DIFF
--- a/docs/src/_data/further_reading_links.json
+++ b/docs/src/_data/further_reading_links.json
@@ -740,5 +740,12 @@
         "logo": "https://v8.dev/favicon.ico",
         "title": "RegExp v flag with set notation and properties of strings · V8",
         "description": "The new RegExp `v` flag enables `unicodeSets` mode, unlocking support for extended character classes, including Unicode properties of strings, set notation, and improved case-insensitive matching."
+    },
+    "https://codepoints.net/U+1680": {
+        "domain": "codepoints.net",
+        "url": "https://codepoints.net/U+1680",
+        "logo": "https://codepoints.net/favicon.ico",
+        "title": "U+1680 OGHAM SPACE MARK:   – Unicode – Codepoints",
+        "description": " , codepoint U+1680 OGHAM SPACE MARK in Unicode, is located in the block “Ogham”. It belongs to the Ogham script and is a Space Separator."
     }
 }

--- a/docs/src/rules/no-irregular-whitespace.md
+++ b/docs/src/rules/no-irregular-whitespace.md
@@ -4,6 +4,7 @@ rule_type: problem
 further_reading:
 - https://es5.github.io/#x7.2
 - https://web.archive.org/web/20200414142829/http://timelessrepo.com/json-isnt-a-javascript-subset
+- https://codepoints.net/U+1680
 ---
 
 
@@ -16,11 +17,17 @@ A simple fix for this problem could be to rewrite the offending line from scratc
 
 Known issues these spaces cause:
 
+* Ogham Space Mark
+    * Is a valid token separator, but is rendered as a visible glyph in most typefaces, which may be misleading in source code.
+* Mongolian Vowel Separator
+    * Is no longer considered a space separator since Unicode 6.3. It will result in a syntax error in current parsers when used in place of a regular token separator.
+* Line Separator and Paragraph Separator
+    * These have always been valid whitespace characters and line terminators, but were considered illegal in string literals prior to ECMAScript 2019.
 * Zero Width Space
-    * Is NOT considered a separator for tokens and is often parsed as an `Unexpected token ILLEGAL`
-    * Is NOT shown in modern browsers making code repository software expected to resolve the visualization
-* Line Separator
-    * Is NOT a valid character within JSON which would cause parse errors
+    * Is NOT considered a separator for tokens and is often parsed as an `Unexpected token ILLEGAL`.
+    * Is NOT shown in modern browsers making code repository software expected to resolve the visualization.
+
+In JSON, none of the characters listed as irregular whitespace by this rule may appear outside of a string.
 
 ## Rule Details
 
@@ -86,7 +93,7 @@ var thing = function /*<NBSP>*/(){
     return 'test';
 }
 
-var thing = function᠎/*<MVS>*/(){
+var thing = function /*<Ogham Space Mark>*/(){
     return 'test';
 }
 
@@ -204,7 +211,7 @@ Examples of additional **correct** code for this rule with the `{ "skipJSXText":
 /*eslint-env es6*/
 
 function Thing() {
-    return <div>text in <NBSP>JSX</div>;
+    return <div>text in JSX</div>; // <NBSP> before `JSX`
 }
 ```
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed outdated info and code examples in the `no-irregular-whitespace` rule docs.

The Mongolian Vowel Separator lost its Zs status quite a while ago [in Unicode 6.3](https://www.unicode.org/versions/Unicode6.3.0/#Database_Changes), so it can no longer be used as a token separator in JS code today. I fixed a code example that was producing a syntax error by replacing the Mongolian Vowel Separator with an equally infamous Ogham Space Mark. Added informative note about both characters and an external link.

I also updated a note about Line Separator and Paragraph Separator because of [these changes in ES2019](https://tc39.es/proposal-json-superset/). A previous note stating that the Line Separator is not a valid character within JSON actually applies to all irregular whitespace chars, so I refactored it in a more generic fashion.

Finally, I fixed another code example that was producing a syntax error because of an unescaped `<` in JSX.

Refs #17602 

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
