### PR TITLE
docs: Add real whitespace to `no-trailing-spaces` examples

### DIFF
--- a/docs/src/rules/no-trailing-spaces.md
+++ b/docs/src/rules/no-trailing-spaces.md
@@ -58,7 +58,8 @@ Examples of **correct** code for this rule with the `{ "skipBlankLines": true }`
 
 var foo = 0;
 var baz = 5;
-// trailing whitespace →     
+// ↓ a line with whitespace only ↓
+     
 ```
 
 :::

--- a/docs/src/rules/no-trailing-spaces.md
+++ b/docs/src/rules/no-trailing-spaces.md
@@ -18,9 +18,9 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-trailing-spaces: "error"*/
 
-var foo = 0;//•••••
-var baz = 5;//••
-//•••••
+var foo = 0;/* trailing whitespace */     
+var baz = 5;/* trailing whitespace */  
+/* trailing whitespace */     
 ```
 
 :::
@@ -58,7 +58,7 @@ Examples of **correct** code for this rule with the `{ "skipBlankLines": true }`
 
 var foo = 0;
 var baz = 5;
-//•••••
+// trailing whitespace →     
 ```
 
 :::
@@ -72,12 +72,12 @@ Examples of **correct** code for this rule with the `{ "ignoreComments": true }`
 ```js
 /*eslint no-trailing-spaces: ["error", { "ignoreComments": true }]*/
 
-//foo•
-//•••••
+// ↓ these comments have trailing whitespace → 
+//     
 /**
- *•baz
- *••
- *•bar
+ * baz
+ *  
+ * bar
  */
 ```
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated code examples of the `no-trailing-spaces` rule to include real whitespace rather than placeholders where expected. This is especially necessary to make the invalid code example really invalid.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
