### PR TITLE
docs: Fix examples in `unicode-bom`

### DIFF
--- a/docs/src/rules/unicode-bom.md
+++ b/docs/src/rules/unicode-bom.md
@@ -31,9 +31,10 @@ Example of **correct** code for this rule with the `"always"` option:
 ::: correct
 
 ```js
+﻿// U+FEFF at the beginning
+
 /*eslint unicode-bom: ["error", "always"]*/
 
-U+FEFF
 var abc;
 ```
 
@@ -70,9 +71,10 @@ Example of **incorrect** code for this rule with the `"never"` option:
 ::: incorrect
 
 ```js
+﻿// U+FEFF at the beginning
+
 /*eslint unicode-bom: ["error", "never"]*/
 
-U+FEFF
 var abc;
 ```
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated some code examples of the `unicode-bom` rule to include a real BOM character where required. This is necessary to make the these examples correct or incorrect as expected, with respect to the rule reporting a problem or not.

#### Is there anything you'd like reviewers to focus on?

The only minor inconvenience I see with change is that it introduces a visible character at the beginning of the code blocks in the Playground ([like here](https://eslint.org/play/#eyJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsic291cmNlVHlwZSI6Im1vZHVsZSJ9fSwidGV4dCI6Iu+7vy8vIFUrRkVGRiBhdCB0aGUgYmVnaW5uaW5nXG5cbi8qZXNsaW50IHVuaWNvZGUtYm9tOiBbXCJlcnJvclwiLCBcImFsd2F5c1wiXSovXG5cbnZhciBhYmM7XG4ifQ==)), whereas a BOM character at the beginning of a file is conventionally not rendered. Let me know if you have a better idea.

<!-- markdownlint-disable-file MD004 -->
