### PR TITLE
docs: Remove trailing newline from the code of Playground links

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -207,7 +207,9 @@ module.exports = function(eleventyConfig) {
                     // See https://github.com/eslint/eslint.org/blob/ac38ab41f99b89a8798d374f74e2cce01171be8b/src/playground/App.js#L44
                     const parserOptionsJSON = tokens[index].info?.split("correct ")[1]?.trim();
                     const parserOptions = { sourceType: "module", ...(parserOptionsJSON && JSON.parse(parserOptionsJSON)) };
-                    const { content } = tokens[index + 1];
+
+                    // Remove the trailing newline (https://github.com/eslint/eslint/issues/17627):
+                    const content = tokens[index + 1].content.replace(/\n$/u, "");
                     const state = encodeToBase64(
                         JSON.stringify({
                             options: { parserOptions },

--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -208,8 +208,10 @@ module.exports = function(eleventyConfig) {
                     const parserOptionsJSON = tokens[index].info?.split("correct ")[1]?.trim();
                     const parserOptions = { sourceType: "module", ...(parserOptionsJSON && JSON.parse(parserOptionsJSON)) };
 
-                    // Remove the trailing newline (https://github.com/eslint/eslint/issues/17627):
-                    const content = tokens[index + 1].content.replace(/\n$/u, "");
+                    // Remove trailing newline and presentational `⏎` characters (https://github.com/eslint/eslint/issues/17627):
+                    const content = tokens[index + 1].content
+                        .replace(/\n$/u, "")
+                        .replace(/⏎(?=\n)/gu, "");
                     const state = encodeToBase64(
                         JSON.stringify({
                             options: { parserOptions },

--- a/docs/src/rules/eol-last.md
+++ b/docs/src/rules/eol-last.md
@@ -42,7 +42,8 @@ Examples of **correct** code for this rule:
 
 function doSomething() {
   var foo = 2;
-}\n
+}
+
 ```
 
 :::

--- a/docs/src/rules/no-multiple-empty-lines.md
+++ b/docs/src/rules/no-multiple-empty-lines.md
@@ -59,13 +59,13 @@ Examples of **incorrect** code for this rule with the `{ max: 2, maxEOF: 0 }` op
 ::: incorrect
 
 ```js
-/*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/
-
-var foo = 5;
-
-
-var bar = 3;
-
+/*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/⏎
+⏎
+var foo = 5;⏎
+⏎
+⏎
+var bar = 3;⏎
+⏎
 
 ```
 
@@ -76,11 +76,11 @@ Examples of **correct** code for this rule with the `{ max: 2, maxEOF: 0 }` opti
 ::: correct
 
 ```js
-/*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/
-
-var foo = 5;
-
-
+/*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/⏎
+⏎
+var foo = 5;⏎
+⏎
+⏎
 var bar = 3;
 ```
 
@@ -93,12 +93,12 @@ var bar = 3;
 ::: correct
 
 ```js
-/*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/
-
-var foo = 5;
-
-
-var bar = 3;
+/*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/⏎
+⏎
+var foo = 5;⏎
+⏎
+⏎
+var bar = 3;⏎
 
 ```
 
@@ -111,9 +111,8 @@ Examples of **incorrect** code for this rule with the `{ max: 2, maxBOF: 1 }` op
 ::: incorrect
 
 ```js
-
-
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxBOF": 1 }]*/
+
 
 var foo = 5;
 
@@ -128,7 +127,6 @@ Examples of **correct** code for this rule with the `{ max: 2, maxBOF: 1 }` opti
 ::: correct
 
 ```js
-
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxBOF": 1}]*/
 
 var foo = 5;

--- a/docs/src/rules/no-multiple-empty-lines.md
+++ b/docs/src/rules/no-multiple-empty-lines.md
@@ -88,34 +88,17 @@ var bar = 3;
 
 **Note**: Although this ensures zero empty lines at the EOF, most editors will still show one empty line at the end if the file ends with a line break, as illustrated below. There is no empty line at the end of a file after the last `\n`, although editors may show an additional line. A true additional line would be represented by `\n\n`.
 
-**Incorrect**:
-
-::: incorrect
-
-```js
-/*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/⏎
-⏎
-var foo = 5;⏎
-⏎
-⏎
-var bar = 3;⏎
-⏎
-
-```
-
-:::
-
 **Correct**:
 
 ::: correct
 
 ```js
-/*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/⏎
-⏎
-var foo = 5;⏎
-⏎
-⏎
-var bar = 3;⏎
+/*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxEOF": 0 }]*/
+
+var foo = 5;
+
+
+var bar = 3;
 
 ```
 
@@ -128,8 +111,9 @@ Examples of **incorrect** code for this rule with the `{ max: 2, maxBOF: 1 }` op
 ::: incorrect
 
 ```js
-/*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxBOF": 1 }]*/
 
+
+/*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxBOF": 1 }]*/
 
 var foo = 5;
 
@@ -144,6 +128,7 @@ Examples of **correct** code for this rule with the `{ max: 2, maxBOF: 1 }` opti
 ::: correct
 
 ```js
+
 /*eslint no-multiple-empty-lines: ["error", { "max": 2, "maxBOF": 1}]*/
 
 var foo = 5;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #17627

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed the last newline character from the code of Playground links in rule examples.

Fixed examples of the rules `eol-last` and `no-multiple-empty-lines`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
