### PR TITLE
fix: Behavior of CLI when no arguments are passed

### DIFF
--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -36,6 +36,15 @@ Please note that when passing a glob as a parameter, it is expanded by your shel
 npx eslint "lib/**"
 ```
 
+If you are using a [flat configuration file](./configure/configuration-files-new) (`eslint.config.js`), you can also omit the file arguments and ESLint will use `.`. For instance, these two lines perform the same operation:
+
+```shell
+npx eslint .
+npx eslint
+```
+
+If you are not using a flat configuration file, running ESLint without file arguments results in an error.
+
 **Note:** You can also use alternative package managers such as [Yarn](https://yarnpkg.com/) or [pnpm](https://pnpm.io/) to run ESLint. Please refer to your package manager's documentation for the correct syntax.
 
 ## Pass Multiple Values to an Option

--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -105,20 +105,20 @@ class AllFilesIgnoredError extends Error {
 
 /**
  * Check if a given value is a non-empty string or not.
- * @param {any} x The value to check.
- * @returns {boolean} `true` if `x` is a non-empty string.
+ * @param {any} value The value to check.
+ * @returns {boolean} `true` if `value` is a non-empty string.
  */
-function isNonEmptyString(x) {
-    return typeof x === "string" && x.trim() !== "";
+function isNonEmptyString(value) {
+    return typeof value === "string" && value.trim() !== "";
 }
 
 /**
  * Check if a given value is an array of non-empty strings or not.
- * @param {any} x The value to check.
- * @returns {boolean} `true` if `x` is an array of non-empty strings.
+ * @param {any} value The value to check.
+ * @returns {boolean} `true` if `value` is an array of non-empty strings.
  */
-function isArrayOfNonEmptyString(x) {
-    return Array.isArray(x) && x.every(isNonEmptyString);
+function isArrayOfNonEmptyString(value) {
+    return Array.isArray(value) && value.length && value.every(isNonEmptyString);
 }
 
 //-----------------------------------------------------------------------------

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -97,35 +97,45 @@ const privateMembersMap = new WeakMap();
 
 /**
  * Check if a given value is a non-empty string or not.
- * @param {any} x The value to check.
- * @returns {boolean} `true` if `x` is a non-empty string.
+ * @param {any} value The value to check.
+ * @returns {boolean} `true` if `value` is a non-empty string.
  */
-function isNonEmptyString(x) {
-    return typeof x === "string" && x.trim() !== "";
+function isNonEmptyString(value) {
+    return typeof value === "string" && value.trim() !== "";
 }
 
 /**
  * Check if a given value is an array of non-empty strings or not.
- * @param {any} x The value to check.
- * @returns {boolean} `true` if `x` is an array of non-empty strings.
+ * @param {any} value The value to check.
+ * @returns {boolean} `true` if `value` is an array of non-empty strings.
  */
-function isArrayOfNonEmptyString(x) {
-    return Array.isArray(x) && x.every(isNonEmptyString);
+function isArrayOfNonEmptyString(value) {
+    return Array.isArray(value) && value.length && value.every(isNonEmptyString);
+}
+
+/**
+ * Check if a given value is an empty array or an array of non-empty strings.
+ * @param {any} value The value to check.
+ * @returns {boolean} `true` if `value` is an empty array or an array of non-empty
+ *      strings.
+ */
+function isEmptyArrayOrArrayOfNonEmptyString(value) {
+    return Array.isArray(value) && value.every(isNonEmptyString);
 }
 
 /**
  * Check if a given value is a valid fix type or not.
- * @param {any} x The value to check.
- * @returns {boolean} `true` if `x` is valid fix type.
+ * @param {any} value The value to check.
+ * @returns {boolean} `true` if `value` is valid fix type.
  */
-function isFixType(x) {
-    return x === "directive" || x === "problem" || x === "suggestion" || x === "layout";
+function isFixType(value) {
+    return value === "directive" || value === "problem" || value === "suggestion" || value === "layout";
 }
 
 /**
  * Check if a given value is an array of fix types or not.
  * @param {any} x The value to check.
- * @returns {boolean} `true` if `x` is an array of fix types.
+ * @returns {boolean} `true` if `value` is an array of fix types.
  */
 function isFixTypeArray(x) {
     return Array.isArray(x) && x.every(isFixType);
@@ -225,7 +235,7 @@ function processOptions({
     if (typeof errorOnUnmatchedPattern !== "boolean") {
         errors.push("'errorOnUnmatchedPattern' must be a boolean.");
     }
-    if (!isArrayOfNonEmptyString(extensions) && extensions !== null) {
+    if (!isEmptyArrayOrArrayOfNonEmptyString(extensions) && extensions !== null) {
         errors.push("'extensions' must be an array of non-empty strings or null.");
     }
     if (typeof fix !== "boolean" && typeof fix !== "function") {
@@ -271,7 +281,7 @@ function processOptions({
     ) {
         errors.push("'resolvePluginsRelativeTo' must be a non-empty string or null.");
     }
-    if (!isArrayOfNonEmptyString(rulePaths)) {
+    if (!isEmptyArrayOrArrayOfNonEmptyString(rulePaths)) {
         errors.push("'rulePaths' must be an array of non-empty strings.");
     }
     if (typeof useEslintrc !== "boolean") {

--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -731,7 +731,21 @@ class FlatESLint {
      * @returns {Promise<LintResult[]>} The results of linting the file patterns given.
      */
     async lintFiles(patterns) {
-        if (!isNonEmptyString(patterns) && !isArrayOfNonEmptyString(patterns)) {
+
+        let normalizedPatterns = patterns;
+
+        /*
+         * Special cases:
+         * 1. `patterns` is an empty string
+         * 2. `patterns` is an empty array
+         *
+         * In both cases, we use the cwd as the directory to lint.
+         */
+        if (patterns === "" || Array.isArray(patterns) && patterns.length === 0) {
+            normalizedPatterns = ["."];
+        } else if (typeof patterns === "string") {
+            normalizedPatterns = [patterns];
+        } else if (!isNonEmptyString(patterns) && !isArrayOfNonEmptyString(patterns)) {
             throw new Error("'patterns' must be a non-empty string or an array of non-empty strings");
         }
 
@@ -773,7 +787,7 @@ class FlatESLint {
         }
 
         const filePaths = await findFiles({
-            patterns: typeof patterns === "string" ? [patterns] : patterns,
+            patterns: normalizedPatterns,
             cwd,
             globInputPaths,
             configs,

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -1067,6 +1067,27 @@ describe("ESLint", () => {
             await assert.rejects(async () => await eslint.lintFiles(["lib/cli.js"]), /Cannot find module 'test11'/u);
         });
 
+        describe("Invalid inputs", () => {
+
+            [
+                ["an empty string", ""],
+                ["an empty array", []],
+                ["an array with one empty string", [""]],
+                ["an array with two empty strings", ["", ""]]
+
+            ].forEach(([name, value]) => {
+
+                it(`should throw an error when passed ${name}`, async () => {
+                    eslint = new ESLint({
+                        useEslintrc: false
+                    });
+
+                    await assert.rejects(async () => await eslint.lintFiles(value), /'patterns' must be a non-empty string or an array of non-empty strings/u);
+                });
+            });
+
+        });
+
         it("should report zero messages when given a directory with a .js2 file", async () => {
             eslint = new ESLint({
                 cwd: path.join(fixtureDir, ".."),

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -951,6 +951,53 @@ describe("FlatESLint", () => {
             await assert.rejects(async () => await eslint.lintFiles(["lib/cli.js"]), /Expected object with parse\(\) or parseForESLint\(\) method/u);
         });
 
+        describe("Invalid inputs", () => {
+
+            [
+                ["an array with one empty string", [""]],
+                ["an array with two empty strings", ["", ""]]
+
+            ].forEach(([name, value]) => {
+
+                it(`should throw an error when passed ${name}`, async () => {
+                    eslint = new FlatESLint({
+                        overrideConfigFile: true
+                    });
+
+                    await assert.rejects(async () => await eslint.lintFiles(value), /'patterns' must be a non-empty string or an array of non-empty strings/u);
+                });
+            });
+
+        });
+
+        describe("Normalized inputs", () => {
+
+            [
+                ["an empty string", ""],
+                ["an empty array", []]
+
+            ].forEach(([name, value]) => {
+
+                it(`should normalize to '.' when ${name} is passed`, async () => {
+                    eslint = new FlatESLint({
+                        ignore: false,
+                        cwd: getFixturePath("files"),
+                        overrideConfig: { files: ["**/*.js"] },
+                        overrideConfigFile: getFixturePath("eslint.config.js")
+                    });
+                    const results = await eslint.lintFiles(value);
+
+                    assert.strictEqual(results.length, 2);
+                    assert.strictEqual(results[0].filePath, getFixturePath("files/.bar.js"));
+                    assert.strictEqual(results[0].messages.length, 0);
+                    assert.strictEqual(results[1].filePath, getFixturePath("files/foo.js"));
+                    assert.strictEqual(results[1].messages.length, 0);
+                    assert.strictEqual(results[0].suppressedMessages.length, 0);
+                });
+            });
+
+        });
+
         it("should report zero messages when given a directory with a .js2 file", async () => {
             eslint = new FlatESLint({
                 cwd: path.join(fixtureDir, ".."),


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

When running the CLI without file arguments it silently fails right now. This PR makes the following changes:

* When running the CLI in eslintrc mode, failing to use file arguments throws an error.
* When running the CLI in flat config mode, failing to use file arguments means that it runs on the current working directory.

Fixes #14308



#### Is there anything you'd like reviewers to focus on?

To make this work, I changed how `lintFiles()` works in both `ESLint` and `FlatESLint`. In `FlatESLint`, I decided that an empty string and an empty array are the same and should be treated as `.`. I'm not sure if that's the right decision, so I'd like to hear some opinions on that.

<!-- markdownlint-disable-file MD004 -->
