### PR TITLE
fix: add preceding semicolon in suggestions of `no-object-constructor`

### DIFF
--- a/lib/rules/no-object-constructor.js
+++ b/lib/rules/no-object-constructor.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const { getVariableByName, isArrowToken } = require("./utils/ast-utils");
+const { getVariableByName, isArrowToken, isClosingBraceToken, isClosingParenToken } = require("./utils/ast-utils");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -53,7 +53,8 @@ module.exports = {
 
         messages: {
             preferLiteral: "The object literal notation {} is preferable.",
-            useLiteral: "Replace with '{{replacement}}'."
+            useLiteral: "Replace with '{{replacement}}'.",
+            useLiteralAfterSemicolon: "Replace with '{{replacement}}', add implicit semicolon."
         }
     },
 
@@ -81,6 +82,74 @@ module.exports = {
         }
 
         /**
+         * Determines whether a parenthesized object literal that replaces a specified node needs to be preceded by a semicolon.
+         * @param {ASTNode} node The node to be replaced.
+         * @returns {boolean} Whether a semicolon is required before the parenthesized object literal.
+         */
+        function needsSemicolon(node) {
+            const prevToken = sourceCode.getTokenBefore(node);
+
+            if (
+                !prevToken ||
+                prevToken.type === "Punctuator" && [":", ";", ">", "{", "=>", "++", "--"].includes(prevToken.value)
+            ) {
+                return false;
+            }
+
+            const prevNode = sourceCode.getNodeByRangeIndex(prevToken.range[0]);
+
+            if (isClosingParenToken(prevToken)) {
+                return ![
+                    "DoWhileStatement",
+                    "ForInStatement",
+                    "ForOfStatement",
+                    "ForStatement",
+                    "IfStatement",
+                    "WhileStatement",
+                    "WithStatement"
+                ].includes(prevNode.type);
+            }
+
+            if (isClosingBraceToken(prevToken)) {
+                return (
+                    prevNode.type === "BlockStatement" && prevNode.parent.type === "FunctionExpression" ||
+                    prevNode.type === "ClassBody" && prevNode.parent.type === "ClassExpression" ||
+                    prevNode.type === "ObjectExpression"
+                );
+            }
+
+            if (prevToken.type === "Identifier") {
+                return !["BreakStatement", "ContinueStatement"].includes(prevNode.parent.type);
+            }
+
+            if (prevToken.type === "Keyword") {
+
+                // Keywords that can immediately precede an ExpressionStatement node, mapped to the their node types.
+                const nodeTypesByKeyword = {
+                    __proto__: null,
+                    break: "BreakStatement",
+                    continue: "ContinueStatement",
+                    debugger: "DebuggerStatement",
+                    do: "DoWhileStatement",
+                    else: "IfStatement",
+                    return: "ReturnStatement",
+                    while: "WhileStatement",
+                    yield: "YieldExpression"
+                };
+                const keyword = prevToken.value;
+                const nodeType = nodeTypesByKeyword[keyword];
+
+                return prevNode.type !== nodeType;
+            }
+
+            if (prevToken.type === "String") {
+                return !["ExportAllDeclaration", "ExportNamedDeclaration", "ImportDeclaration"].includes(prevNode.parent.type);
+            }
+
+            return true;
+        }
+
+        /**
          * Reports on nodes where the `Object` constructor is called without arguments.
          * @param {ASTNode} node The node to evaluate.
          * @returns {void}
@@ -93,16 +162,32 @@ module.exports = {
             const variable = getVariableByName(sourceCode.getScope(node), "Object");
 
             if (variable && variable.identifiers.length === 0) {
-                const replacement = needsParentheses(node) ? "({})" : "{}";
+                let replacement;
+                let fixText;
+                let messageId;
+
+                if (needsParentheses(node)) {
+                    replacement = "({})";
+                    if (needsSemicolon(node)) {
+                        fixText = ";({})";
+                        messageId = "useLiteralAfterSemicolon";
+                    } else {
+                        fixText = "({})";
+                        messageId = "useLiteral";
+                    }
+                } else {
+                    replacement = fixText = "{}";
+                    messageId = "useLiteral";
+                }
 
                 context.report({
                     node,
                     messageId: "preferLiteral",
                     suggest: [
                         {
-                            messageId: "useLiteral",
+                            messageId,
                             data: { replacement },
-                            fix: fixer => fixer.replaceText(node, replacement)
+                            fix: fixer => fixer.replaceText(node, fixText)
                         }
                     ]
                 });

--- a/lib/rules/no-object-constructor.js
+++ b/lib/rules/no-object-constructor.js
@@ -15,6 +15,45 @@ const { getVariableByName, isArrowToken, isClosingBraceToken, isClosingParenToke
 // Helpers
 //------------------------------------------------------------------------------
 
+const BREAK_OR_CONTINUE = new Set(["BreakStatement", "ContinueStatement"]);
+
+// Declaration types that must contain a string Literal node at the end.
+const DECLARATIONS = new Set(["ExportAllDeclaration", "ExportNamedDeclaration", "ImportDeclaration"]);
+
+const IDENTIFIER_OR_KEYWORD = new Set(["Identifier", "Keyword"]);
+
+// Keywords that can immediately precede an ExpressionStatement node, mapped to the their node types.
+const NODE_TYPES_BY_KEYWORD = {
+    __proto__: null,
+    break: "BreakStatement",
+    continue: "ContinueStatement",
+    debugger: "DebuggerStatement",
+    do: "DoWhileStatement",
+    else: "IfStatement",
+    return: "ReturnStatement",
+    yield: "YieldExpression"
+};
+
+/*
+ * Before an opening parenthesis, `>` (for JSX), and postfix `++` and `--` always trigger ASI;
+ * the tokens `:`, `;`, `{` and `=>` don't expect a semicolon, as that would count as an empty statement.
+ */
+const PUNCTUATORS = new Set([":", ";", ">", "{", "=>", "++", "--"]);
+
+/*
+ * Statements that can contain an `ExpressionStatement` after a closing parenthesis.
+ * DoWhileStatement is an exception in that it always triggers ASI after the closing parenthesis.
+ */
+const STATEMENTS = new Set([
+    "DoWhileStatement",
+    "ForInStatement",
+    "ForOfStatement",
+    "ForStatement",
+    "IfStatement",
+    "WhileStatement",
+    "WithStatement"
+]);
+
 /**
  * Tests if a node appears at the beginning of an ancestor ExpressionStatement node.
  * @param {ASTNode} node The node to check.
@@ -89,25 +128,14 @@ module.exports = {
         function needsSemicolon(node) {
             const prevToken = sourceCode.getTokenBefore(node);
 
-            if (
-                !prevToken ||
-                prevToken.type === "Punctuator" && [":", ";", ">", "{", "=>", "++", "--"].includes(prevToken.value)
-            ) {
+            if (!prevToken || prevToken.type === "Punctuator" && PUNCTUATORS.has(prevToken.value)) {
                 return false;
             }
 
             const prevNode = sourceCode.getNodeByRangeIndex(prevToken.range[0]);
 
             if (isClosingParenToken(prevToken)) {
-                return ![
-                    "DoWhileStatement",
-                    "ForInStatement",
-                    "ForOfStatement",
-                    "ForStatement",
-                    "IfStatement",
-                    "WhileStatement",
-                    "WithStatement"
-                ].includes(prevNode.type);
+                return !STATEMENTS.has(prevNode.type);
             }
 
             if (isClosingBraceToken(prevToken)) {
@@ -118,30 +146,19 @@ module.exports = {
                 );
             }
 
-            if (["Identifier", "Keyword"].includes(prevToken.type)) {
-                if (["BreakStatement", "ContinueStatement"].includes(prevNode.parent.type)) {
+            if (IDENTIFIER_OR_KEYWORD.has(prevToken.type)) {
+                if (BREAK_OR_CONTINUE.has(prevNode.parent.type)) {
                     return false;
                 }
 
-                // Keywords that can immediately precede an ExpressionStatement node, mapped to the their node types.
-                const nodeTypesByKeyword = {
-                    __proto__: null,
-                    break: "BreakStatement",
-                    continue: "ContinueStatement",
-                    debugger: "DebuggerStatement",
-                    do: "DoWhileStatement",
-                    else: "IfStatement",
-                    return: "ReturnStatement",
-                    yield: "YieldExpression"
-                };
                 const keyword = prevToken.value;
-                const nodeType = nodeTypesByKeyword[keyword];
+                const nodeType = NODE_TYPES_BY_KEYWORD[keyword];
 
                 return prevNode.type !== nodeType;
             }
 
             if (prevToken.type === "String") {
-                return !["ExportAllDeclaration", "ExportNamedDeclaration", "ImportDeclaration"].includes(prevNode.parent.type);
+                return !DECLARATIONS.has(prevNode.parent.type);
             }
 
             return true;
@@ -162,7 +179,7 @@ module.exports = {
             if (variable && variable.identifiers.length === 0) {
                 let replacement;
                 let fixText;
-                let messageId;
+                let messageId = "useLiteral";
 
                 if (needsParentheses(node)) {
                     replacement = "({})";
@@ -171,11 +188,9 @@ module.exports = {
                         messageId = "useLiteralAfterSemicolon";
                     } else {
                         fixText = "({})";
-                        messageId = "useLiteral";
                     }
                 } else {
                     replacement = fixText = "{}";
-                    messageId = "useLiteral";
                 }
 
                 context.report({

--- a/lib/rules/no-object-constructor.js
+++ b/lib/rules/no-object-constructor.js
@@ -54,7 +54,7 @@ module.exports = {
         messages: {
             preferLiteral: "The object literal notation {} is preferable.",
             useLiteral: "Replace with '{{replacement}}'.",
-            useLiteralAfterSemicolon: "Replace with '{{replacement}}', add implicit semicolon."
+            useLiteralAfterSemicolon: "Replace with '{{replacement}}', add preceding semicolon."
         }
     },
 
@@ -83,7 +83,7 @@ module.exports = {
 
         /**
          * Determines whether a parenthesized object literal that replaces a specified node needs to be preceded by a semicolon.
-         * @param {ASTNode} node The node to be replaced.
+         * @param {ASTNode} node The node to be replaced. This node should be at the start of an `ExpressionStatement` or at the start of the body of an `ArrowFunctionExpression`.
          * @returns {boolean} Whether a semicolon is required before the parenthesized object literal.
          */
         function needsSemicolon(node) {
@@ -118,11 +118,10 @@ module.exports = {
                 );
             }
 
-            if (prevToken.type === "Identifier") {
-                return !["BreakStatement", "ContinueStatement"].includes(prevNode.parent.type);
-            }
-
-            if (prevToken.type === "Keyword") {
+            if (["Identifier", "Keyword"].includes(prevToken.type)) {
+                if (["BreakStatement", "ContinueStatement"].includes(prevNode.parent.type)) {
+                    return false;
+                }
 
                 // Keywords that can immediately precede an ExpressionStatement node, mapped to the their node types.
                 const nodeTypesByKeyword = {
@@ -133,7 +132,6 @@ module.exports = {
                     do: "DoWhileStatement",
                     else: "IfStatement",
                     return: "ReturnStatement",
-                    while: "WhileStatement",
                     yield: "YieldExpression"
                 };
                 const keyword = prevToken.value;

--- a/tests/lib/rules/no-object-constructor.js
+++ b/tests/lib/rules/no-object-constructor.js
@@ -104,6 +104,249 @@ ruleTester.run("no-object-constructor", rule, {
                     output: "({} instanceof Object);"
                 }]
             }]
-        }
+        },
+
+        ...[
+
+            // Semicolon required before `({})` to compensate for ASI
+            {
+                code: `
+                foo
+                Object()
+                `
+            },
+            {
+                code: `
+                foo()
+                Object()
+                `
+            },
+            {
+                code: `
+                new foo
+                Object()
+                `
+            },
+            {
+                code: `
+                (a++)
+                Object()
+                `
+            },
+            {
+                code: `
+                ++a
+                Object()
+                `
+            },
+            {
+                code: `
+                const foo = function() {}
+                Object()
+                `
+            },
+            {
+                code: `
+                const foo = class {}
+                Object()
+                `
+            },
+            {
+                code: `
+                foo = this.return
+                Object()
+                `
+            },
+            {
+                code: `
+                var yield = bar.yield
+                Object()
+                `
+            },
+            {
+                code: `
+                var foo = { bar: baz }
+                Object()
+                `
+            }
+        ].map(props => ({
+            ...props,
+            errors: [{
+                messageId: "preferLiteral",
+                suggestions: [{
+                    desc: "Replace with '({})', add implicit semicolon.",
+                    messageId: "useLiteralAfterSemicolon"
+                }]
+            }]
+        })),
+
+        ...[
+
+            // No semicolon required before `({})` because ASI does not occur
+            { code: "Object()" },
+            {
+                code: `
+                {}
+                Object()
+                `
+            },
+            {
+                code: `
+                function foo() {}
+                Object()
+                `
+            },
+            {
+                code: `
+                class Foo {}
+                Object()
+                `
+            },
+            { code: "foo: Object();" },
+            { code: "foo();Object();" },
+            { code: "{ Object(); }" },
+            { code: "if (a) Object();" },
+            { code: "if (a); else Object();" },
+            { code: "while (a) Object();" },
+            {
+                code: `
+                do Object();
+                while (a);
+                `
+            },
+            { code: "for (let i = 0; i < 10; i++) Object();" },
+            { code: "for (const prop in obj) Object();" },
+            { code: "for (const element of iterable) Object();" },
+            { code: "with (obj) Object();" },
+
+            // No semicolon required before `({})` because ASI still occurs
+            {
+                code: `
+                const foo = () => {}
+                Object()
+                `
+            },
+            {
+                code: `
+                a++
+                Object()
+                `
+            },
+            {
+                code: `
+                a--
+                Object()
+                `
+            },
+            {
+                code: `
+                function foo() {
+                    return
+                    Object();
+                }
+                `
+            },
+            {
+                code: `
+                function * foo() {
+                    yield
+                    Object();
+                }
+                `
+            },
+            {
+                code: `
+                do {}
+                while (a)
+                Object()
+                `
+            },
+            {
+                code: `
+                debugger
+                Object()
+                `
+            },
+            {
+                code: `
+                for (;;) {
+                    break
+                    Object()
+                }
+                `
+            },
+            {
+                code: `
+                for (;;) {
+                    continue
+                    Object()
+                }
+                `
+            },
+            {
+                code: `
+                foo: break foo
+                Object()
+                `
+            },
+            {
+                code: `
+                foo: while (true) continue foo
+                Object()
+                `
+            },
+            {
+                code: `
+                <foo />
+                Object()
+                `,
+                parserOptions: { ecmaFeatures: { jsx: true } }
+            },
+            {
+                code: `
+                <foo></foo>
+                Object()
+                `,
+                parserOptions: { ecmaFeatures: { jsx: true } }
+            },
+            {
+                code: `
+                const foo = bar
+                export { foo }
+                Object()
+                `,
+                parserOptions: { sourceType: "module" }
+            },
+            {
+                code: `
+                export { foo } from 'bar'
+                Object()
+                `,
+                parserOptions: { sourceType: "module" }
+            },
+            {
+                code: `
+                export * as foo from 'bar'
+                Object()
+                `,
+                parserOptions: { sourceType: "module" }
+            },
+            {
+                code: `
+                import foo from 'bar'
+                Object()
+                `,
+                parserOptions: { sourceType: "module" }
+            }
+        ].map(props => ({
+            ...props,
+            errors: [{
+                messageId: "preferLiteral",
+                suggestions: [{
+                    desc: "Replace with '({})'.",
+                    messageId: "useLiteral"
+                }]
+            }]
+        }))
     ]
 });

--- a/tests/lib/rules/no-object-constructor.js
+++ b/tests/lib/rules/no-object-constructor.js
@@ -174,7 +174,7 @@ ruleTester.run("no-object-constructor", rule, {
             errors: [{
                 messageId: "preferLiteral",
                 suggestions: [{
-                    desc: "Replace with '({})', add implicit semicolon.",
+                    desc: "Replace with '({})', add preceding semicolon.",
                     messageId: "useLiteralAfterSemicolon"
                 }]
             }]
@@ -337,6 +337,17 @@ ruleTester.run("no-object-constructor", rule, {
                 Object()
                 `,
                 parserOptions: { sourceType: "module" }
+            },
+            {
+                code: `
+                var yield = 5;
+
+                yield: while (foo) {
+                    if (bar)
+                        break yield
+                    new Object();
+                }
+                `
             }
         ].map(props => ({
             ...props,

--- a/tests/lib/rules/no-object-constructor.js
+++ b/tests/lib/rules/no-object-constructor.js
@@ -175,7 +175,8 @@ ruleTester.run("no-object-constructor", rule, {
                 messageId: "preferLiteral",
                 suggestions: [{
                     desc: "Replace with '({})', add preceding semicolon.",
-                    messageId: "useLiteralAfterSemicolon"
+                    messageId: "useLiteralAfterSemicolon",
+                    output: props.code.replace(/(new )?Object\(\)/u, ";({})")
                 }]
             }]
         })),
@@ -355,7 +356,8 @@ ruleTester.run("no-object-constructor", rule, {
                 messageId: "preferLiteral",
                 suggestions: [{
                     desc: "Replace with '({})'.",
-                    messageId: "useLiteral"
+                    messageId: "useLiteral",
+                    output: props.code.replace(/(new )?Object\(\)/u, "({})")
                 }]
             }]
         }))


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v20.8.0
npm version: v10.1.0
Local ESLint version: v8.51.0 (Currently used)
Global ESLint version: v8.51.0
Operating System: darwin 23.0.0

**What parser are you using (place an "X" next to just one item)?**

[X] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<!-- Paste your configuration below: -->
```js
export default {};
```

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint no-object-constructor: error */

++index
Object()
```

[**Playground Link**](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLW9iamVjdC1jb25zdHJ1Y3RvcjogZXJyb3IgKi9cblxuKytpbmRleFxuT2JqZWN0KCkiLCJvcHRpb25zIjp7ImVudiI6e30sInJ1bGVzIjp7fSwicGFyc2VyT3B0aW9ucyI6eyJlY21hRmVhdHVyZXMiOnt9LCJlY21hVmVyc2lvbiI6ImxhdGVzdCIsInNvdXJjZVR5cGUiOiJzY3JpcHQifX19)

**What did you expect to happen?**

The autofix of `no-object-constructor` should not change the semantics of the code.

**What actually happened? Please include the actual, raw output from ESLint.**

The autofix introduces a syntax error:

```js
/* eslint no-object-constructor: error */

++index
({})
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR changes the autofix behavior of `no-object-constructor` to account for the fact that when `Object()` is replaced with `({})`, automatic semicolon insertion may no longer occur.

The autofix will now insert an explicit semicolon (`;`) before a replaced `({})` when it is necessary to preserve the structure of the previous node.

#### Is there anything you'd like reviewers to focus on?

I had to consider a large number of special cases for this change, so let me know if I've missed something.

For simplicity, the autofix will now add a semicolon right before the replaced token if necessary, e.g.:

```js
++index
;({})
```

We could also add the semicolon after the previous token since that's more common, but there's the rule `semi-style` to fix that.

<!-- markdownlint-disable-file MD004 -->
