### PR TITLE
docs: explained rule fixers and suggestions

### DIFF
--- a/docs/src/_includes/components/rule-categories.macro.html
+++ b/docs/src/_includes/components/rule-categories.macro.html
@@ -21,7 +21,7 @@
     <div class="rule-category">
         <span class="rule-category__icon">💡 <span class="visually-hidden">hasSuggestions</span></span>
         <p class="rule-category__description">
-            Some problems reported by this rule are manually fixable by editor <a href="../extend/custom-rules#providing-suggestions">suggestions</a>
+            Some problems reported by this rule are manually fixable by editor <a href="../use/core-concepts#report-suggestions">suggestions</a>
         </p>
     </div>
     {%- endif -%}

--- a/docs/src/_includes/components/rule-categories.macro.html
+++ b/docs/src/_includes/components/rule-categories.macro.html
@@ -21,7 +21,7 @@
     <div class="rule-category">
         <span class="rule-category__icon">💡 <span class="visually-hidden">hasSuggestions</span></span>
         <p class="rule-category__description">
-            Some problems reported by this rule are manually fixable by editor <a href="../use/core-concepts#report-suggestions">suggestions</a>
+            Some problems reported by this rule are manually fixable by editor <a href="../use/core-concepts#rule-suggestions">suggestions</a>
         </p>
     </div>
     {%- endif -%}

--- a/docs/src/use/core-concepts.md
+++ b/docs/src/use/core-concepts.md
@@ -23,17 +23,20 @@ ESLint contains hundreds of built-in rules that you can use. You can also create
 
 For more information, refer to [Rules](../rules/).
 
-### Report Fixers
+### Rule Fixes
 
-Rule reports may optionally provide "fixes" that safely correct the reported issue without changing application logic.
+Rules may optionally provide fixes for violations that they find. Fixes safely correct the violation without changing application logic.
+
 Fixes may be applied automatically with the [`--fix` command line option](https://eslint.org/docs/latest/use/command-line-interface#--fix) and via editor extensions.
 
-Rules that may provide fixers are marked with 🔧 in [Rules](../rules/).
+Rules that may provide fixes are marked with 🔧 in [Rules](../rules/).
 
-### Report Suggestions
+### Rule Suggestions
 
-Rule reports may optionally provide "suggestions" that correct the reported issue but also change application logic.
-Suggestions cannot be applied automatically, but may be applied manually via editor extensions.
+Rules may optionally provide suggestions in addition to or instead of providing fixes. Suggestions differ from fixes in two ways:
+
+1. Suggestions may change application logic and so cannot be automatically applied.
+1. Suggestions cannot be applied through the ESLint CLI and are only available through editor integrations.
 
 Rules that may provide suggestions are marked with 💡 in [Rules](../rules/).
 

--- a/docs/src/use/core-concepts.md
+++ b/docs/src/use/core-concepts.md
@@ -23,6 +23,20 @@ ESLint contains hundreds of built-in rules that you can use. You can also create
 
 For more information, refer to [Rules](../rules/).
 
+### Report Fixers
+
+Rule reports may optionally provide "fixes" that safely correct the reported issue without changing application logic.
+Fixes may be applied automatically with the [`--fix` command line option](https://eslint.org/docs/latest/use/command-line-interface#--fix) and via editor extensions.
+
+Rules that may provide fixers are marked with 🔧 in [Rules](../rules/).
+
+### Report Suggestions
+
+Rule reports may optionally provide "suggestions" that correct the reported issue but also change application logic.
+Suggestions cannot be applied automatically, but may be applied manually via editor extensions.
+
+Rules that may provide suggestions are marked with 💡 in [Rules](../rules/).
+
 ## Configuration Files
 
 An ESLint configuration file is a place where you put the configuration for ESLint in your project. You can include built-in rules, how you want them enforced, plugins with custom rules, shareable configurations, which files you want rules to apply to, and more.


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Per the issue, added _Report Fixers_ and _Report Suggestions_ as sections in the _Core Concepts_ page. Also switched the _Rules_ page link about suggestions to point to the new core conception subheading instead of the custom rules docs.

Fixes https://github.com/eslint/eslint.org/issues/479.

#### Is there anything you'd like reviewers to focus on?

I personally call them rule "reports" as that's what the `context.report` API refers to them as. But nowhere else in the _Core Concepts_ page are they referred to by that name. What's the standard nomenclature we should use here?