### PR TITLE
feat: Add `reportUsedIgnorePattern` option to `no-unused-vars` rule

### DIFF
--- a/docs/src/rules/no-unused-vars.md
+++ b/docs/src/rules/no-unused-vars.md
@@ -137,7 +137,13 @@ By default this rule is enabled with `all` option for caught errors and variable
 ```json
 {
     "rules": {
-        "no-unused-vars": ["error", { "vars": "all", "args": "after-used", "caughtErrors": "all", "ignoreRestSiblings": false }]
+        "no-unused-vars": ["error", {
+            "vars": "all",
+            "args": "after-used",
+            "caughtErrors": "all",
+            "ignoreRestSiblings": false,
+            "reportUsedIgnorePattern": false
+        }]
     }
 }
 ```
@@ -435,8 +441,6 @@ class Bar {
 }
 ```
 
-:::
-
 Examples of **correct** code for the `{ "ignoreClassWithStaticInitBlock": true }` option
 
 ::: correct
@@ -451,6 +455,39 @@ class Foo {
         console.log(bar);
     }
 }
+```
+
+### reportUsedIgnorePattern
+
+The `reportUsedIgnorePattern` option is a boolean (default: `false`).
+Using this option will report variables that match any of the valid ignore
+pattern options (`varsIgnorePattern`, `argsIgnorePattern`, `caughtErrorsIgnorePattern`, or
+`destructuredArrayIgnorePattern`) if they have been used.
+
+Examples of **incorrect** code for the `{ "reportUsedIgnorePattern": true }` option:
+
+::: incorrect
+
+```js
+/*eslint no-unused-vars: ["error", { "reportUsedIgnorePattern": true, "varsIgnorePattern": "[iI]gnored" }]*/
+
+var firstVarIgnored = 1;
+var secondVar = 2;
+console.log(firstVarIgnored, secondVar);
+```
+
+:::
+
+Examples of **correct** code for the `{ "reportUsedIgnorePattern": true }` option:
+
+::: correct
+
+```js
+/*eslint no-unused-vars: ["error", { "reportUsedIgnorePattern": true, "varsIgnorePattern": "[iI]gnored" }]*/
+
+var firstVar = 1;
+var secondVar = 2;
+console.log(firstVar, secondVar);
 ```
 
 :::

--- a/docs/src/rules/no-unused-vars.md
+++ b/docs/src/rules/no-unused-vars.md
@@ -441,6 +441,8 @@ class Bar {
 }
 ```
 
+:::
+
 Examples of **correct** code for the `{ "ignoreClassWithStaticInitBlock": true }` option
 
 ::: correct
@@ -456,6 +458,8 @@ class Foo {
     }
 }
 ```
+
+:::
 
 ### reportUsedIgnorePattern
 

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -228,52 +228,51 @@ module.exports = {
         /**
          * Generate the warning message about a variable being used even though
          * it is marked as being ignored.
-         * @param {Variable} usedIgnoredVar eslint-scope variable object
+         * @param {Variable} variable eslint-scope variable object
+         * @param {"catch-clause" | "args" | "array-destructure" | "vars"} variableType
+         *  the type of the unused variable
+         * @throws {Error} (Unreachable)
          * @returns {UsedIgnoredVarMessageData} The message data to be used with
          * this used ignored variable.
          */
-        function getUsedIgnoredMessageData(usedIgnoredVar) {
-            const def = usedIgnoredVar.defs && usedIgnoredVar.defs[0];
-            let additional = "";
+        function getUsedIgnoredMessageData(variable, variableType) {
+            let pattern;
+            let variableDescription;
 
-            if (def) {
-                let type;
-                let pattern;
+            switch (variableType) {
+                case "catch-clause":
+                    pattern = config.caughtErrorsIgnorePattern;
+                    variableDescription = "args";
+                    break;
 
-                switch (def.type) {
-                    case "CatchClause":
-                        if (config.caughtErrorsIgnorePattern) {
-                            type = "args";
-                            pattern = config.caughtErrorsIgnorePattern;
-                        }
-                        break;
+                case "args":
+                    pattern = config.argsIgnorePattern;
+                    variableDescription = "args";
+                    break;
 
-                    case "Parameter":
-                        if (config.argsIgnorePattern) {
-                            type = "args";
-                            pattern = config.argsIgnorePattern;
-                        }
-                        break;
+                case "array-destructure":
+                    pattern = config.destructuredArrayIgnorePattern;
+                    variableDescription = "elements of array destructuring";
+                    break;
 
-                    default:
-                        if (def.name.parent.type === "ArrayPattern" && config.destructuredArrayIgnorePattern) {
-                            type = "elements of array destructuring";
-                            pattern = config.destructuredArrayIgnorePattern;
-                        } else if (config.varsIgnorePattern) {
-                            type = "vars";
-                            pattern = config.varsIgnorePattern;
-                        }
-                        break;
-                }
+                case "vars":
+                    pattern = config.varsIgnorePattern;
+                    variableDescription = "vars";
+                    break;
 
-                if (type) {
-                    additional = `. Used ${type} must not match ${pattern.toString()}`;
-                }
+                default:
+                    throw new Error(`Unexpected variable type: ${variableType}`);
+            }
+
+            let additionalMessageData = "";
+
+            if (pattern && variableDescription) {
+                additionalMessageData = `. Used ${variableDescription} must not match ${pattern.toString()}`;
             }
 
             return {
-                varName: usedIgnoredVar.name,
-                additional
+                varName: variable.name,
+                additional: additionalMessageData
             };
         }
 
@@ -671,13 +670,12 @@ module.exports = {
          * Gets an array of variables without read references.
          * @param {Scope} scope an eslint-scope Scope object.
          * @param {Variable[]} unusedVars an array containing unused variables that should be reported
-         * @param {Variable[]} usedIgnoredVars an array containing used variables that match an ignore pattern
          * @returns {[Variable[], Variable[]]} an array containing
          *   1. unused variables of the scope and descendant scopes.
          *   2. used variables that match an ignore pattern of the scope and descendant scope
          * @private
          */
-        function collectUnusedVariables(scope, unusedVars, usedIgnoredVars) {
+        function collectUnusedVariables(scope, unusedVars) {
             const variables = scope.variables;
             const childScopes = scope.childScopes;
             let i, l;
@@ -723,7 +721,11 @@ module.exports = {
                             config.destructuredArrayIgnorePattern.test(def.name.name)
                         ) {
                             if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
-                                usedIgnoredVars.push(variable);
+                                context.report({
+                                    node: def.name,
+                                    messageId: "usedIgnoredVar",
+                                    data: getUsedIgnoredMessageData(variable, "array-destructure")
+                                });
                             }
 
                             continue;
@@ -746,7 +748,11 @@ module.exports = {
                             // skip ignored parameters
                             if (config.caughtErrorsIgnorePattern && config.caughtErrorsIgnorePattern.test(def.name.name)) {
                                 if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
-                                    usedIgnoredVars.push(variable);
+                                    context.report({
+                                        node: def.name,
+                                        messageId: "usedIgnoredVar",
+                                        data: getUsedIgnoredMessageData(variable, "catch-clause")
+                                    });
                                 }
 
                                 continue;
@@ -766,7 +772,11 @@ module.exports = {
                             // skip ignored parameters
                             if (config.argsIgnorePattern && config.argsIgnorePattern.test(def.name.name)) {
                                 if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
-                                    usedIgnoredVars.push(variable);
+                                    context.report({
+                                        node: def.name,
+                                        messageId: "usedIgnoredVar",
+                                        data: getUsedIgnoredMessageData(variable, "args")
+                                    });
                                 }
 
                                 continue;
@@ -781,7 +791,11 @@ module.exports = {
                             // skip ignored variables
                             if (config.varsIgnorePattern && config.varsIgnorePattern.test(def.name.name)) {
                                 if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
-                                    usedIgnoredVars.push(variable);
+                                    context.report({
+                                        node: def.name,
+                                        messageId: "usedIgnoredVar",
+                                        data: getUsedIgnoredMessageData(variable, "vars")
+                                    });
                                 }
 
                                 continue;
@@ -796,10 +810,10 @@ module.exports = {
             }
 
             for (i = 0, l = childScopes.length; i < l; ++i) {
-                collectUnusedVariables(childScopes[i], unusedVars, usedIgnoredVars);
+                collectUnusedVariables(childScopes[i], unusedVars);
             }
 
-            return [unusedVars, usedIgnoredVars];
+            return unusedVars;
         }
 
         //--------------------------------------------------------------------------
@@ -808,7 +822,7 @@ module.exports = {
 
         return {
             "Program:exit"(programNode) {
-                const [unusedVars, usedIgnoredVars] = collectUnusedVariables(sourceCode.getScope(programNode), [], []);
+                const unusedVars = collectUnusedVariables(sourceCode.getScope(programNode), []);
 
                 for (let i = 0, l = unusedVars.length; i < l; ++i) {
                     const unusedVar = unusedVars[i];
@@ -843,18 +857,6 @@ module.exports = {
                             messageId: "unusedVar",
                             data: getDefinedMessageData(unusedVar)
                         });
-                    }
-                }
-
-                if (config.reportUsedIgnorePattern) {
-                    for (const usedIgnoredVar of usedIgnoredVars) {
-                        for (const definition of usedIgnoredVar.defs) {
-                            context.report({
-                                node: definition.name,
-                                messageId: "usedIgnoredVar",
-                                data: getUsedIgnoredMessageData(usedIgnoredVar)
-                            });
-                        }
                     }
                 }
             }

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -670,9 +670,7 @@ module.exports = {
          * Gets an array of variables without read references.
          * @param {Scope} scope an eslint-scope Scope object.
          * @param {Variable[]} unusedVars an array containing unused variables that should be reported
-         * @returns {[Variable[], Variable[]]} an array containing
-         *   1. unused variables of the scope and descendant scopes.
-         *   2. used variables that match an ignore pattern of the scope and descendant scope
+         * @returns {Variable[]} an array containing unused variables of the scope and descendant scopes.
          * @private
          */
         function collectUnusedVariables(scope, unusedVars) {

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -16,6 +16,11 @@ const astUtils = require("./utils/ast-utils");
 //------------------------------------------------------------------------------
 
 /**
+ * A colloquial name for type of variables that this rule handles
+ * @typedef {'array-destructure'|'catch-clause'|'parameter'|'variable'} VariableType
+ */
+
+/**
  * Bag of data used for formatting the `unusedVar` lint message.
  * @typedef {Object} UnusedVarMessageData
  * @property {string} varName The name of the unused var.
@@ -143,6 +148,51 @@ module.exports = {
         }
 
         /**
+         * Gets a given variable's description and configured ignore pattern
+         * based on the provided variableType
+         * @param {VariableType} variableType a colloquial name for type of variables that this rule handles
+         * @throws {Error} (Unreachable)
+         * @returns {[string | undefined, string | undefined]} the given variable's description and
+         * ignore pattern
+         */
+        function getVariableDescription(variableType) {
+            let pattern;
+            let variableDescription;
+
+            switch (variableType) {
+
+                case "array-destructure":
+                    pattern = config.destructuredArrayIgnorePattern;
+                    variableDescription = "elements of array destructuring";
+                    break;
+
+                case "catch-clause":
+                    pattern = config.caughtErrorsIgnorePattern;
+                    variableDescription = "args";
+                    break;
+
+                case "parameter":
+                    pattern = config.argsIgnorePattern;
+                    variableDescription = "args";
+                    break;
+
+                case "variable":
+                    pattern = config.varsIgnorePattern;
+                    variableDescription = "vars";
+                    break;
+
+                default:
+                    throw new Error(`Unexpected variable type: ${variableType}`);
+            }
+
+            if (pattern) {
+                pattern = pattern.toString();
+            }
+
+            return [variableDescription, pattern];
+        }
+
+        /**
          * Generates the message data about the variable being defined and unused,
          * including the ignore pattern if configured.
          * @param {Variable} unusedVar eslint-scope variable object.
@@ -150,44 +200,41 @@ module.exports = {
          */
         function getDefinedMessageData(unusedVar) {
             const def = unusedVar.defs && unusedVar.defs[0];
-            let additional = "";
+            let additionalMessageData = "";
 
             if (def) {
-                let type;
                 let pattern;
+                let variableDescription;
 
                 switch (def.type) {
                     case "CatchClause":
                         if (config.caughtErrorsIgnorePattern) {
-                            type = "args";
-                            pattern = config.caughtErrorsIgnorePattern;
+                            [variableDescription, pattern] = getVariableDescription("catch-clause");
                         }
                         break;
 
                     case "Parameter":
                         if (config.argsIgnorePattern) {
-                            type = "args";
-                            pattern = config.argsIgnorePattern;
+                            [variableDescription, pattern] = getVariableDescription("parameter");
                         }
                         break;
 
                     default:
                         if (config.varsIgnorePattern) {
-                            type = "vars";
-                            pattern = config.varsIgnorePattern;
+                            [variableDescription, pattern] = getVariableDescription("variable");
                         }
                         break;
                 }
 
-                if (type) {
-                    additional = `. Allowed unused ${type} must match ${pattern.toString()}`;
+                if (pattern && variableDescription) {
+                    additionalMessageData = `. Allowed unused ${variableDescription} must match ${pattern}`;
                 }
             }
 
             return {
                 varName: unusedVar.name,
                 action: "defined",
-                additional
+                additional: additionalMessageData
             };
         }
 
@@ -199,29 +246,27 @@ module.exports = {
          */
         function getAssignedMessageData(unusedVar) {
             const def = unusedVar.defs && unusedVar.defs[0];
-            let additional = "";
+            let additionalMessageData = "";
 
             if (def) {
-                let type;
                 let pattern;
+                let variableDescription;
 
                 if (def.name.parent.type === "ArrayPattern" && config.destructuredArrayIgnorePattern) {
-                    type = "elements of array destructuring";
-                    pattern = config.destructuredArrayIgnorePattern;
+                    [variableDescription, pattern] = getVariableDescription("array-destructure");
                 } else if (config.varsIgnorePattern) {
-                    type = "vars";
-                    pattern = config.varsIgnorePattern;
+                    [variableDescription, pattern] = getVariableDescription("variable");
                 }
 
-                if (type) {
-                    additional = `. Allowed unused ${type} must match ${pattern.toString()}`;
+                if (pattern && variableDescription) {
+                    additionalMessageData = `. Allowed unused ${variableDescription} must match ${pattern}`;
                 }
             }
 
             return {
                 varName: unusedVar.name,
                 action: "assigned a value",
-                additional
+                additional: additionalMessageData
             };
         }
 
@@ -229,45 +274,17 @@ module.exports = {
          * Generate the warning message about a variable being used even though
          * it is marked as being ignored.
          * @param {Variable} variable eslint-scope variable object
-         * @param {"catch-clause" | "args" | "array-destructure" | "vars"} variableType
-         *  the type of the unused variable
-         * @throws {Error} (Unreachable)
+         * @param {VariableType} variableType a colloquial name for type of variables that this rule handles
          * @returns {UsedIgnoredVarMessageData} The message data to be used with
          * this used ignored variable.
          */
         function getUsedIgnoredMessageData(variable, variableType) {
-            let pattern;
-            let variableDescription;
-
-            switch (variableType) {
-                case "catch-clause":
-                    pattern = config.caughtErrorsIgnorePattern;
-                    variableDescription = "args";
-                    break;
-
-                case "args":
-                    pattern = config.argsIgnorePattern;
-                    variableDescription = "args";
-                    break;
-
-                case "array-destructure":
-                    pattern = config.destructuredArrayIgnorePattern;
-                    variableDescription = "elements of array destructuring";
-                    break;
-
-                case "vars":
-                    pattern = config.varsIgnorePattern;
-                    variableDescription = "vars";
-                    break;
-
-                default:
-                    throw new Error(`Unexpected variable type: ${variableType}`);
-            }
+            const [variableDescription, pattern] = getVariableDescription(variableType);
 
             let additionalMessageData = "";
 
             if (pattern && variableDescription) {
-                additionalMessageData = `. Used ${variableDescription} must not match ${pattern.toString()}`;
+                additionalMessageData = `. Used ${variableDescription} must not match ${pattern}`;
             }
 
             return {
@@ -773,7 +790,7 @@ module.exports = {
                                     context.report({
                                         node: def.name,
                                         messageId: "usedIgnoredVar",
-                                        data: getUsedIgnoredMessageData(variable, "args")
+                                        data: getUsedIgnoredMessageData(variable, "parameter")
                                     });
                                 }
 
@@ -792,7 +809,7 @@ module.exports = {
                                     context.report({
                                         node: def.name,
                                         messageId: "usedIgnoredVar",
-                                        data: getUsedIgnoredMessageData(variable, "vars")
+                                        data: getUsedIgnoredMessageData(variable, "variable")
                                     });
                                 }
 

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -16,7 +16,7 @@ const astUtils = require("./utils/ast-utils");
 //------------------------------------------------------------------------------
 
 /**
- * A colloquial name for type of variables that this rule handles
+ * A colloquial name for the type of variables that this rule can handle
  * @typedef {'array-destructure'|'catch-clause'|'parameter'|'variable'} VariableType
  */
 
@@ -97,15 +97,18 @@ module.exports = {
         ],
 
         messages: {
-            unusedVar: "'{{varName}}' is {{action}} but never used{{additional}}.",
-            usedIgnoredVar: "'{{varName}}' is marked as ignored but is used{{additional}}."
+            unusedVar:
+                "'{{varName}}' is {{action}} but never used{{additional}}.",
+            usedIgnoredVar:
+                "'{{varName}}' is marked as ignored but is used{{additional}}."
         }
     },
 
     create(context) {
         const sourceCode = context.sourceCode;
 
-        const REST_PROPERTY_TYPE = /^(?:RestElement|(?:Experimental)?RestProperty)$/u;
+        const REST_PROPERTY_TYPE =
+            /^(?:RestElement|(?:Experimental)?RestProperty)$/u;
 
         const config = {
             vars: "all",
@@ -124,25 +127,43 @@ module.exports = {
             } else {
                 config.vars = firstOption.vars || config.vars;
                 config.args = firstOption.args || config.args;
-                config.ignoreRestSiblings = firstOption.ignoreRestSiblings || config.ignoreRestSiblings;
-                config.caughtErrors = firstOption.caughtErrors || config.caughtErrors;
-                config.ignoreClassWithStaticInitBlock = firstOption.ignoreClassWithStaticInitBlock || config.ignoreClassWithStaticInitBlock;
-                config.reportUsedIgnorePattern = firstOption.reportUsedIgnorePattern || config.reportUsedIgnorePattern;
+                config.ignoreRestSiblings =
+                    firstOption.ignoreRestSiblings || config.ignoreRestSiblings;
+                config.caughtErrors =
+                    firstOption.caughtErrors || config.caughtErrors;
+                config.ignoreClassWithStaticInitBlock =
+                    firstOption.ignoreClassWithStaticInitBlock ||
+                    config.ignoreClassWithStaticInitBlock;
+                config.reportUsedIgnorePattern =
+                    firstOption.reportUsedIgnorePattern ||
+                    config.reportUsedIgnorePattern;
 
                 if (firstOption.varsIgnorePattern) {
-                    config.varsIgnorePattern = new RegExp(firstOption.varsIgnorePattern, "u");
+                    config.varsIgnorePattern = new RegExp(
+                        firstOption.varsIgnorePattern,
+                        "u"
+                    );
                 }
 
                 if (firstOption.argsIgnorePattern) {
-                    config.argsIgnorePattern = new RegExp(firstOption.argsIgnorePattern, "u");
+                    config.argsIgnorePattern = new RegExp(
+                        firstOption.argsIgnorePattern,
+                        "u"
+                    );
                 }
 
                 if (firstOption.caughtErrorsIgnorePattern) {
-                    config.caughtErrorsIgnorePattern = new RegExp(firstOption.caughtErrorsIgnorePattern, "u");
+                    config.caughtErrorsIgnorePattern = new RegExp(
+                        firstOption.caughtErrorsIgnorePattern,
+                        "u"
+                    );
                 }
 
                 if (firstOption.destructuredArrayIgnorePattern) {
-                    config.destructuredArrayIgnorePattern = new RegExp(firstOption.destructuredArrayIgnorePattern, "u");
+                    config.destructuredArrayIgnorePattern = new RegExp(
+                        firstOption.destructuredArrayIgnorePattern,
+                        "u"
+                    );
                 }
             }
         }
@@ -160,7 +181,6 @@ module.exports = {
             let variableDescription;
 
             switch (variableType) {
-
                 case "array-destructure":
                     pattern = config.destructuredArrayIgnorePattern;
                     variableDescription = "elements of array destructuring";
@@ -182,7 +202,9 @@ module.exports = {
                     break;
 
                 default:
-                    throw new Error(`Unexpected variable type: ${variableType}`);
+                    throw new Error(
+                        `Unexpected variable type: ${variableType}`
+                    );
             }
 
             if (pattern) {
@@ -209,19 +231,22 @@ module.exports = {
                 switch (def.type) {
                     case "CatchClause":
                         if (config.caughtErrorsIgnorePattern) {
-                            [variableDescription, pattern] = getVariableDescription("catch-clause");
+                            [variableDescription, pattern] =
+                                getVariableDescription("catch-clause");
                         }
                         break;
 
                     case "Parameter":
                         if (config.argsIgnorePattern) {
-                            [variableDescription, pattern] = getVariableDescription("parameter");
+                            [variableDescription, pattern] =
+                                getVariableDescription("parameter");
                         }
                         break;
 
                     default:
                         if (config.varsIgnorePattern) {
-                            [variableDescription, pattern] = getVariableDescription("variable");
+                            [variableDescription, pattern] =
+                                getVariableDescription("variable");
                         }
                         break;
                 }
@@ -252,10 +277,15 @@ module.exports = {
                 let pattern;
                 let variableDescription;
 
-                if (def.name.parent.type === "ArrayPattern" && config.destructuredArrayIgnorePattern) {
-                    [variableDescription, pattern] = getVariableDescription("array-destructure");
+                if (
+                    def.name.parent.type === "ArrayPattern" &&
+                    config.destructuredArrayIgnorePattern
+                ) {
+                    [variableDescription, pattern] =
+                        getVariableDescription("array-destructure");
                 } else if (config.varsIgnorePattern) {
-                    [variableDescription, pattern] = getVariableDescription("variable");
+                    [variableDescription, pattern] =
+                        getVariableDescription("variable");
                 }
 
                 if (pattern && variableDescription) {
@@ -279,7 +309,8 @@ module.exports = {
          * this used ignored variable.
          */
         function getUsedIgnoredMessageData(variable, variableType) {
-            const [variableDescription, pattern] = getVariableDescription(variableType);
+            const [variableDescription, pattern] =
+                getVariableDescription(variableType);
 
             let additionalMessageData = "";
 
@@ -306,11 +337,9 @@ module.exports = {
          * @private
          */
         function isExported(variable) {
-
             const definition = variable.defs[0];
 
             if (definition) {
-
                 let node = definition.node;
 
                 if (node.type === "VariableDeclarator") {
@@ -322,7 +351,6 @@ module.exports = {
                 return node.parent.type.indexOf("Export") === 0;
             }
             return false;
-
         }
 
         /**
@@ -331,9 +359,11 @@ module.exports = {
          * @returns {boolean} True if the node is a sibling of the rest property, otherwise false.
          */
         function hasRestSibling(node) {
-            return node.type === "Property" &&
+            return (
+                node.type === "Property" &&
                 node.parent.type === "ObjectPattern" &&
-                REST_PROPERTY_TYPE.test(node.parent.properties.at(-1).type);
+                REST_PROPERTY_TYPE.test(node.parent.properties.at(-1).type)
+            );
         }
 
         /**
@@ -344,8 +374,11 @@ module.exports = {
          */
         function hasRestSpreadSibling(variable) {
             if (config.ignoreRestSiblings) {
-                const hasRestSiblingDefinition = variable.defs.some(def => hasRestSibling(def.name.parent));
-                const hasRestSiblingReference = variable.references.some(ref => hasRestSibling(ref.identifier.parent));
+                const hasRestSiblingDefinition = variable.defs.some(def =>
+                    hasRestSibling(def.name.parent));
+                const hasRestSiblingReference = variable.references.some(
+                    ref => hasRestSibling(ref.identifier.parent)
+                );
 
                 return hasRestSiblingDefinition || hasRestSiblingReference;
             }
@@ -402,8 +435,12 @@ module.exports = {
                 }
 
                 // FunctionExpressions
-                if (type === "Variable" && node.init &&
-                    (node.init.type === "FunctionExpression" || node.init.type === "ArrowFunctionExpression")) {
+                if (
+                    type === "Variable" &&
+                    node.init &&
+                    (node.init.type === "FunctionExpression" ||
+                        node.init.type === "ArrowFunctionExpression")
+                ) {
                     functionDefinitions.push(node.init);
                 }
             });
@@ -469,7 +506,8 @@ module.exports = {
             const parent = id.parent;
             const refScope = ref.from.variableScope;
             const varScope = ref.resolved.scope.variableScope;
-            const canBeUsedLater = refScope !== varScope || astUtils.isInLoop(id);
+            const canBeUsedLater =
+                refScope !== varScope || astUtils.isInLoop(id);
 
             /*
              * Inherits the previous node if this reference is in the node.
@@ -479,7 +517,8 @@ module.exports = {
                 return prevRhsNode;
             }
 
-            if (parent.type === "AssignmentExpression" &&
+            if (
+                parent.type === "AssignmentExpression" &&
                 isUnusedExpression(parent) &&
                 id === parent.left &&
                 !canBeUsedLater
@@ -574,28 +613,21 @@ module.exports = {
             const id = ref.identifier;
             const parent = id.parent;
 
-            return ref.isRead() && (
+            return (
+                ref.isRead() &&
 
                 // self update. e.g. `a += 1`, `a++`
-                (
-                    (
-                        parent.type === "AssignmentExpression" &&
-                        parent.left === id &&
-                        isUnusedExpression(parent) &&
-                        !astUtils.isLogicalAssignmentOperator(parent.operator)
-                    ) ||
-                    (
-                        parent.type === "UpdateExpression" &&
-                        isUnusedExpression(parent)
-                    )
-                ) ||
+                ((parent.type === "AssignmentExpression" &&
+                    parent.left === id &&
+                    isUnusedExpression(parent) &&
+                    !astUtils.isLogicalAssignmentOperator(parent.operator)) ||
+                    (parent.type === "UpdateExpression" &&
+                        isUnusedExpression(parent)) ||
 
-                // in RHS of an assignment for itself. e.g. `a = a + 1`
-                (
-                    rhsNode &&
-                    isInside(id, rhsNode) &&
-                    !isInsideOfStorableFunction(id, rhsNode)
-                )
+                    // in RHS of an assignment for itself. e.g. `a = a + 1`
+                    (rhsNode &&
+                        isInside(id, rhsNode) &&
+                        !isInsideOfStorableFunction(id, rhsNode)))
             );
         }
 
@@ -608,13 +640,15 @@ module.exports = {
         function isForInOfRef(ref) {
             let target = ref.identifier.parent;
 
-
             // "for (var ...) { return; }"
             if (target.type === "VariableDeclarator") {
                 target = target.parent.parent;
             }
 
-            if (target.type !== "ForInStatement" && target.type !== "ForOfStatement") {
+            if (
+                target.type !== "ForInStatement" &&
+                target.type !== "ForOfStatement"
+            ) {
                 return false;
             }
 
@@ -622,7 +656,7 @@ module.exports = {
             if (target.body.type === "BlockStatement") {
                 target = target.body.body[0];
 
-            // "for (...) return;"
+                // "for (...) return;"
             } else {
                 target = target.body;
             }
@@ -663,7 +697,10 @@ module.exports = {
                 return (
                     isReadRef(ref) &&
                     !forItself &&
-                    !(isFunctionDefinition && isSelfReference(ref, functionNodes))
+                    !(
+                        isFunctionDefinition &&
+                        isSelfReference(ref, functionNodes)
+                    )
                 );
             });
         }
@@ -680,7 +717,9 @@ module.exports = {
             const posteriorParams = params.slice(params.indexOf(variable) + 1);
 
             // If any used parameters occur after this parameter, do not report.
-            return !posteriorParams.some(v => v.references.length > 0 || v.eslintUsed);
+            return !posteriorParams.some(
+                v => v.references.length > 0 || v.eslintUsed
+            );
         }
 
         /**
@@ -700,7 +739,10 @@ module.exports = {
                     const variable = variables[i];
 
                     // skip a variable of class itself name in the class scope
-                    if (scope.type === "class" && scope.block.id === variable.identifiers[0]) {
+                    if (
+                        scope.type === "class" &&
+                        scope.block.id === variable.identifiers[0]
+                    ) {
                         continue;
                     }
 
@@ -710,12 +752,19 @@ module.exports = {
                     }
 
                     // skip variables marked with markVariableAsUsed()
-                    if (!config.reportUsedIgnorePattern && variable.eslintUsed) {
+                    if (
+                        !config.reportUsedIgnorePattern &&
+                        variable.eslintUsed
+                    ) {
                         continue;
                     }
 
                     // skip implicit "arguments" variable
-                    if (scope.type === "function" && variable.name === "arguments" && variable.identifiers.length === 0) {
+                    if (
+                        scope.type === "function" &&
+                        variable.name === "arguments" &&
+                        variable.identifiers.length === 0
+                    ) {
                         continue;
                     }
 
@@ -724,22 +773,31 @@ module.exports = {
 
                     if (def) {
                         const type = def.type;
-                        const refUsedInArrayPatterns = variable.references.some(ref => ref.identifier.parent.type === "ArrayPattern");
+                        const refUsedInArrayPatterns = variable.references.some(
+                            ref =>
+                                ref.identifier.parent.type === "ArrayPattern"
+                        );
 
                         // skip elements of array destructuring patterns
                         if (
-                            (
-                                def.name.parent.type === "ArrayPattern" ||
-                                refUsedInArrayPatterns
-                            ) &&
+                            (def.name.parent.type === "ArrayPattern" ||
+                                refUsedInArrayPatterns) &&
                             config.destructuredArrayIgnorePattern &&
-                            config.destructuredArrayIgnorePattern.test(def.name.name)
+                            config.destructuredArrayIgnorePattern.test(
+                                def.name.name
+                            )
                         ) {
-                            if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
+                            if (
+                                config.reportUsedIgnorePattern &&
+                                isUsedVariable(variable)
+                            ) {
                                 context.report({
                                     node: def.name,
                                     messageId: "usedIgnoredVar",
-                                    data: getUsedIgnoredMessageData(variable, "array-destructure")
+                                    data: getUsedIgnoredMessageData(
+                                        variable,
+                                        "array-destructure"
+                                    )
                                 });
                             }
 
@@ -747,9 +805,14 @@ module.exports = {
                         }
 
                         if (type === "ClassName") {
-                            const hasStaticBlock = def.node.body.body.some(node => node.type === "StaticBlock");
+                            const hasStaticBlock = def.node.body.body.some(
+                                node => node.type === "StaticBlock"
+                            );
 
-                            if (config.ignoreClassWithStaticInitBlock && hasStaticBlock) {
+                            if (
+                                config.ignoreClassWithStaticInitBlock &&
+                                hasStaticBlock
+                            ) {
                                 continue;
                             }
                         }
@@ -761,12 +824,23 @@ module.exports = {
                             }
 
                             // skip ignored parameters
-                            if (config.caughtErrorsIgnorePattern && config.caughtErrorsIgnorePattern.test(def.name.name)) {
-                                if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
+                            if (
+                                config.caughtErrorsIgnorePattern &&
+                                config.caughtErrorsIgnorePattern.test(
+                                    def.name.name
+                                )
+                            ) {
+                                if (
+                                    config.reportUsedIgnorePattern &&
+                                    isUsedVariable(variable)
+                                ) {
                                     context.report({
                                         node: def.name,
                                         messageId: "usedIgnoredVar",
-                                        data: getUsedIgnoredMessageData(variable, "catch-clause")
+                                        data: getUsedIgnoredMessageData(
+                                            variable,
+                                            "catch-clause"
+                                        )
                                     });
                                 }
 
@@ -775,7 +849,12 @@ module.exports = {
                         } else if (type === "Parameter") {
 
                             // skip any setter argument
-                            if ((def.node.parent.type === "Property" || def.node.parent.type === "MethodDefinition") && def.node.parent.kind === "set") {
+                            if (
+                                (def.node.parent.type === "Property" ||
+                                    def.node.parent.type ===
+                                        "MethodDefinition") &&
+                                def.node.parent.kind === "set"
+                            ) {
                                 continue;
                             }
 
@@ -785,12 +864,21 @@ module.exports = {
                             }
 
                             // skip ignored parameters
-                            if (config.argsIgnorePattern && config.argsIgnorePattern.test(def.name.name)) {
-                                if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
+                            if (
+                                config.argsIgnorePattern &&
+                                config.argsIgnorePattern.test(def.name.name)
+                            ) {
+                                if (
+                                    config.reportUsedIgnorePattern &&
+                                    isUsedVariable(variable)
+                                ) {
                                     context.report({
                                         node: def.name,
                                         messageId: "usedIgnoredVar",
-                                        data: getUsedIgnoredMessageData(variable, "parameter")
+                                        data: getUsedIgnoredMessageData(
+                                            variable,
+                                            "parameter"
+                                        )
                                     });
                                 }
 
@@ -798,18 +886,31 @@ module.exports = {
                             }
 
                             // if "args" option is "after-used", skip used variables
-                            if (config.args === "after-used" && astUtils.isFunction(def.name.parent) && !isAfterLastUsedArg(variable)) {
+                            if (
+                                config.args === "after-used" &&
+                                astUtils.isFunction(def.name.parent) &&
+                                !isAfterLastUsedArg(variable)
+                            ) {
                                 continue;
                             }
                         } else {
 
                             // skip ignored variables
-                            if (config.varsIgnorePattern && config.varsIgnorePattern.test(def.name.name)) {
-                                if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
+                            if (
+                                config.varsIgnorePattern &&
+                                config.varsIgnorePattern.test(def.name.name)
+                            ) {
+                                if (
+                                    config.reportUsedIgnorePattern &&
+                                    isUsedVariable(variable)
+                                ) {
                                     context.report({
                                         node: def.name,
                                         messageId: "usedIgnoredVar",
-                                        data: getUsedIgnoredMessageData(variable, "variable")
+                                        data: getUsedIgnoredMessageData(
+                                            variable,
+                                            "variable"
+                                        )
                                     });
                                 }
 
@@ -818,7 +919,11 @@ module.exports = {
                         }
                     }
 
-                    if (!isUsedVariable(variable) && !isExported(variable) && !hasRestSpreadSibling(variable)) {
+                    if (
+                        !isUsedVariable(variable) &&
+                        !isExported(variable) &&
+                        !hasRestSpreadSibling(variable)
+                    ) {
                         unusedVars.push(variable);
                     }
                 }
@@ -837,7 +942,10 @@ module.exports = {
 
         return {
             "Program:exit"(programNode) {
-                const unusedVars = collectUnusedVariables(sourceCode.getScope(programNode), []);
+                const unusedVars = collectUnusedVariables(
+                    sourceCode.getScope(programNode),
+                    []
+                );
 
                 for (let i = 0, l = unusedVars.length; i < l; ++i) {
                     const unusedVar = unusedVars[i];
@@ -846,7 +954,12 @@ module.exports = {
                     if (unusedVar.defs.length > 0) {
 
                         // report last write reference, https://github.com/eslint/eslint/issues/14324
-                        const writeReferences = unusedVar.references.filter(ref => ref.isWrite() && ref.from.variableScope === unusedVar.scope.variableScope);
+                        const writeReferences = unusedVar.references.filter(
+                            ref =>
+                                ref.isWrite() &&
+                                ref.from.variableScope ===
+                                    unusedVar.scope.variableScope
+                        );
 
                         let referenceToReport;
 
@@ -855,20 +968,28 @@ module.exports = {
                         }
 
                         context.report({
-                            node: referenceToReport ? referenceToReport.identifier : unusedVar.identifiers[0],
+                            node: referenceToReport
+                                ? referenceToReport.identifier
+                                : unusedVar.identifiers[0],
                             messageId: "unusedVar",
-                            data: unusedVar.references.some(ref => ref.isWrite())
+                            data: unusedVar.references.some(ref =>
+                                ref.isWrite())
                                 ? getAssignedMessageData(unusedVar)
                                 : getDefinedMessageData(unusedVar)
                         });
 
-                    // If there are no regular declaration, report the first `/*globals*/` comment directive.
+                        // If there are no regular declaration, report the first `/*globals*/` comment directive.
                     } else if (unusedVar.eslintExplicitGlobalComments) {
-                        const directiveComment = unusedVar.eslintExplicitGlobalComments[0];
+                        const directiveComment =
+                            unusedVar.eslintExplicitGlobalComments[0];
 
                         context.report({
                             node: programNode,
-                            loc: astUtils.getNameLocationInGlobalDirectiveComment(sourceCode, directiveComment, unusedVar.name),
+                            loc: astUtils.getNameLocationInGlobalDirectiveComment(
+                                sourceCode,
+                                directiveComment,
+                                unusedVar.name
+                            ),
                             messageId: "unusedVar",
                             data: getDefinedMessageData(unusedVar)
                         });

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -669,8 +669,8 @@ module.exports = {
         /**
          * Gets an array of variables without read references.
          * @param {Scope} scope an eslint-scope Scope object.
-         * @param {Variable[]} unusedVars an array containing unused variables that should be reported
-         * @returns {Variable[]} an array containing unused variables of the scope and descendant scopes.
+         * @param {Variable[]} unusedVars an array that saving result.
+         * @returns {Variable[]} unused variables of the scope and descendant scopes.
          * @private
          */
         function collectUnusedVariables(scope, unusedVars) {

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -23,6 +23,13 @@ const astUtils = require("./utils/ast-utils");
  * @property {string} additional Any additional info to be appended at the end.
  */
 
+/**
+ * Bag of data used for formatting the `usedIgnoredVar` lint message.
+ * @typedef {Object} UsedIgnoredVarMessageData
+ * @property {string} varName The name of the unused var.
+ * @property {string} additional Any additional info to be appended at the end.
+ */
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -73,6 +80,9 @@ module.exports = {
                             },
                             ignoreClassWithStaticInitBlock: {
                                 type: "boolean"
+                            },
+                            reportUsedIgnorePattern: {
+                                type: "boolean"
                             }
                         },
                         additionalProperties: false
@@ -82,7 +92,8 @@ module.exports = {
         ],
 
         messages: {
-            unusedVar: "'{{varName}}' is {{action}} but never used{{additional}}."
+            unusedVar: "'{{varName}}' is {{action}} but never used{{additional}}.",
+            usedIgnoredVar: "'{{varName}}' is marked as ignored but is used{{additional}}."
         }
     },
 
@@ -96,7 +107,8 @@ module.exports = {
             args: "after-used",
             ignoreRestSiblings: false,
             caughtErrors: "all",
-            ignoreClassWithStaticInitBlock: false
+            ignoreClassWithStaticInitBlock: false,
+            reportUsedIgnorePattern: false
         };
 
         const firstOption = context.options[0];
@@ -110,6 +122,7 @@ module.exports = {
                 config.ignoreRestSiblings = firstOption.ignoreRestSiblings || config.ignoreRestSiblings;
                 config.caughtErrors = firstOption.caughtErrors || config.caughtErrors;
                 config.ignoreClassWithStaticInitBlock = firstOption.ignoreClassWithStaticInitBlock || config.ignoreClassWithStaticInitBlock;
+                config.reportUsedIgnorePattern = firstOption.reportUsedIgnorePattern || config.reportUsedIgnorePattern;
 
                 if (firstOption.varsIgnorePattern) {
                     config.varsIgnorePattern = new RegExp(firstOption.varsIgnorePattern, "u");
@@ -136,22 +149,40 @@ module.exports = {
          * @returns {UnusedVarMessageData} The message data to be used with this unused variable.
          */
         function getDefinedMessageData(unusedVar) {
-            const defType = unusedVar.defs && unusedVar.defs[0] && unusedVar.defs[0].type;
-            let type;
-            let pattern;
+            const def = unusedVar.defs && unusedVar.defs[0];
+            let additional = "";
 
-            if (defType === "CatchClause" && config.caughtErrorsIgnorePattern) {
-                type = "args";
-                pattern = config.caughtErrorsIgnorePattern.toString();
-            } else if (defType === "Parameter" && config.argsIgnorePattern) {
-                type = "args";
-                pattern = config.argsIgnorePattern.toString();
-            } else if (defType !== "Parameter" && defType !== "CatchClause" && config.varsIgnorePattern) {
-                type = "vars";
-                pattern = config.varsIgnorePattern.toString();
+            if (def) {
+                let type;
+                let pattern;
+
+                switch (def.type) {
+                    case "CatchClause":
+                        if (config.caughtErrorsIgnorePattern) {
+                            type = "args";
+                            pattern = config.caughtErrorsIgnorePattern;
+                        }
+                        break;
+
+                    case "Parameter":
+                        if (config.argsIgnorePattern) {
+                            type = "args";
+                            pattern = config.argsIgnorePattern;
+                        }
+                        break;
+
+                    default:
+                        if (config.varsIgnorePattern) {
+                            type = "vars";
+                            pattern = config.varsIgnorePattern;
+                        }
+                        break;
+                }
+
+                if (type) {
+                    additional = `. Allowed unused ${type} must match ${pattern.toString()}`;
+                }
             }
-
-            const additional = type ? `. Allowed unused ${type} must match ${pattern}` : "";
 
             return {
                 varName: unusedVar.name,
@@ -167,18 +198,81 @@ module.exports = {
          * @returns {UnusedVarMessageData} The message data to be used with this unused variable.
          */
         function getAssignedMessageData(unusedVar) {
-            const def = unusedVar.defs[0];
+            const def = unusedVar.defs && unusedVar.defs[0];
             let additional = "";
 
-            if (config.destructuredArrayIgnorePattern && def && def.name.parent.type === "ArrayPattern") {
-                additional = `. Allowed unused elements of array destructuring patterns must match ${config.destructuredArrayIgnorePattern.toString()}`;
-            } else if (config.varsIgnorePattern) {
-                additional = `. Allowed unused vars must match ${config.varsIgnorePattern.toString()}`;
+            if (def) {
+                let type;
+                let pattern;
+
+                if (def.name.parent.type === "ArrayPattern" && config.destructuredArrayIgnorePattern) {
+                    type = "elements of array destructuring";
+                    pattern = config.destructuredArrayIgnorePattern;
+                } else if (config.varsIgnorePattern) {
+                    type = "vars";
+                    pattern = config.varsIgnorePattern;
+                }
+
+                if (type) {
+                    additional = `. Allowed unused ${type} must match ${pattern.toString()}`;
+                }
             }
 
             return {
                 varName: unusedVar.name,
                 action: "assigned a value",
+                additional
+            };
+        }
+
+        /**
+         * Generate the warning message about a variable being used even though
+         * it is marked as being ignored.
+         * @param {Variable} usedIgnoredVar eslint-scope variable object
+         * @returns {UsedIgnoredVarMessageData} The message data to be used with
+         * this used ignored variable.
+         */
+        function getUsedIgnoredMessageData(usedIgnoredVar) {
+            const def = usedIgnoredVar.defs && usedIgnoredVar.defs[0];
+            let additional = "";
+
+            if (def) {
+                let type;
+                let pattern;
+
+                switch (def.type) {
+                    case "CatchClause":
+                        if (config.caughtErrorsIgnorePattern) {
+                            type = "args";
+                            pattern = config.caughtErrorsIgnorePattern;
+                        }
+                        break;
+
+                    case "Parameter":
+                        if (config.argsIgnorePattern) {
+                            type = "args";
+                            pattern = config.argsIgnorePattern;
+                        }
+                        break;
+
+                    default:
+                        if (def.name.parent.type === "ArrayPattern" && config.destructuredArrayIgnorePattern) {
+                            type = "elements of array destructuring";
+                            pattern = config.destructuredArrayIgnorePattern;
+                        } else if (config.varsIgnorePattern) {
+                            type = "vars";
+                            pattern = config.varsIgnorePattern;
+                        }
+                        break;
+                }
+
+                if (type) {
+                    additional = `. Used ${type} must not match ${pattern.toString()}`;
+                }
+            }
+
+            return {
+                varName: usedIgnoredVar.name,
                 additional
             };
         }
@@ -532,8 +626,13 @@ module.exports = {
          * @private
          */
         function isUsedVariable(variable) {
-            const functionNodes = getFunctionDefinitions(variable),
-                isFunctionDefinition = functionNodes.length > 0;
+            if (variable.eslintUsed) {
+                return true;
+            }
+
+            const functionNodes = getFunctionDefinitions(variable);
+            const isFunctionDefinition = functionNodes.length > 0;
+
             let rhsNode = null;
 
             return variable.references.some(ref => {
@@ -571,11 +670,14 @@ module.exports = {
         /**
          * Gets an array of variables without read references.
          * @param {Scope} scope an eslint-scope Scope object.
-         * @param {Variable[]} unusedVars an array that saving result.
-         * @returns {Variable[]} unused variables of the scope and descendant scopes.
+         * @param {Variable[]} unusedVars an array containing unused variables that should be reported
+         * @param {Variable[]} usedIgnoredVars an array containing used variables that match an ignore pattern
+         * @returns {[Variable[], Variable[]]} an array containing
+         *   1. unused variables of the scope and descendant scopes.
+         *   2. used variables that match an ignore pattern of the scope and descendant scope
          * @private
          */
-        function collectUnusedVariables(scope, unusedVars) {
+        function collectUnusedVariables(scope, unusedVars, usedIgnoredVars) {
             const variables = scope.variables;
             const childScopes = scope.childScopes;
             let i, l;
@@ -589,8 +691,13 @@ module.exports = {
                         continue;
                     }
 
-                    // skip function expression names and variables marked with markVariableAsUsed()
-                    if (scope.functionExpressionScope || variable.eslintUsed) {
+                    // skip function expression names
+                    if (scope.functionExpressionScope) {
+                        continue;
+                    }
+
+                    // skip variables marked with markVariableAsUsed()
+                    if (!config.reportUsedIgnorePattern && variable.eslintUsed) {
                         continue;
                     }
 
@@ -615,6 +722,10 @@ module.exports = {
                             config.destructuredArrayIgnorePattern &&
                             config.destructuredArrayIgnorePattern.test(def.name.name)
                         ) {
+                            if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
+                                usedIgnoredVars.push(variable);
+                            }
+
                             continue;
                         }
 
@@ -634,6 +745,10 @@ module.exports = {
 
                             // skip ignored parameters
                             if (config.caughtErrorsIgnorePattern && config.caughtErrorsIgnorePattern.test(def.name.name)) {
+                                if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
+                                    usedIgnoredVars.push(variable);
+                                }
+
                                 continue;
                             }
                         } else if (type === "Parameter") {
@@ -650,6 +765,10 @@ module.exports = {
 
                             // skip ignored parameters
                             if (config.argsIgnorePattern && config.argsIgnorePattern.test(def.name.name)) {
+                                if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
+                                    usedIgnoredVars.push(variable);
+                                }
+
                                 continue;
                             }
 
@@ -661,6 +780,10 @@ module.exports = {
 
                             // skip ignored variables
                             if (config.varsIgnorePattern && config.varsIgnorePattern.test(def.name.name)) {
+                                if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
+                                    usedIgnoredVars.push(variable);
+                                }
+
                                 continue;
                             }
                         }
@@ -673,10 +796,10 @@ module.exports = {
             }
 
             for (i = 0, l = childScopes.length; i < l; ++i) {
-                collectUnusedVariables(childScopes[i], unusedVars);
+                collectUnusedVariables(childScopes[i], unusedVars, usedIgnoredVars);
             }
 
-            return unusedVars;
+            return [unusedVars, usedIgnoredVars];
         }
 
         //--------------------------------------------------------------------------
@@ -685,7 +808,7 @@ module.exports = {
 
         return {
             "Program:exit"(programNode) {
-                const unusedVars = collectUnusedVariables(sourceCode.getScope(programNode), []);
+                const [unusedVars, usedIgnoredVars] = collectUnusedVariables(sourceCode.getScope(programNode), [], []);
 
                 for (let i = 0, l = unusedVars.length; i < l; ++i) {
                     const unusedVar = unusedVars[i];
@@ -722,8 +845,19 @@ module.exports = {
                         });
                     }
                 }
+
+                if (config.reportUsedIgnorePattern) {
+                    for (const usedIgnoredVar of usedIgnoredVars) {
+                        for (const definition of usedIgnoredVar.defs) {
+                            context.report({
+                                node: definition.name,
+                                messageId: "usedIgnoredVar",
+                                data: getUsedIgnoredMessageData(usedIgnoredVar)
+                            });
+                        }
+                    }
+                }
             }
         };
-
     }
 };

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -97,18 +97,15 @@ module.exports = {
         ],
 
         messages: {
-            unusedVar:
-                "'{{varName}}' is {{action}} but never used{{additional}}.",
-            usedIgnoredVar:
-                "'{{varName}}' is marked as ignored but is used{{additional}}."
+            unusedVar: "'{{varName}}' is {{action}} but never used{{additional}}.",
+            usedIgnoredVar: "'{{varName}}' is marked as ignored but is used{{additional}}."
         }
     },
 
     create(context) {
         const sourceCode = context.sourceCode;
 
-        const REST_PROPERTY_TYPE =
-            /^(?:RestElement|(?:Experimental)?RestProperty)$/u;
+        const REST_PROPERTY_TYPE = /^(?:RestElement|(?:Experimental)?RestProperty)$/u;
 
         const config = {
             vars: "all",
@@ -127,43 +124,25 @@ module.exports = {
             } else {
                 config.vars = firstOption.vars || config.vars;
                 config.args = firstOption.args || config.args;
-                config.ignoreRestSiblings =
-                    firstOption.ignoreRestSiblings || config.ignoreRestSiblings;
-                config.caughtErrors =
-                    firstOption.caughtErrors || config.caughtErrors;
-                config.ignoreClassWithStaticInitBlock =
-                    firstOption.ignoreClassWithStaticInitBlock ||
-                    config.ignoreClassWithStaticInitBlock;
-                config.reportUsedIgnorePattern =
-                    firstOption.reportUsedIgnorePattern ||
-                    config.reportUsedIgnorePattern;
+                config.ignoreRestSiblings = firstOption.ignoreRestSiblings || config.ignoreRestSiblings;
+                config.caughtErrors = firstOption.caughtErrors || config.caughtErrors;
+                config.ignoreClassWithStaticInitBlock = firstOption.ignoreClassWithStaticInitBlock || config.ignoreClassWithStaticInitBlock;
+                config.reportUsedIgnorePattern = firstOption.reportUsedIgnorePattern || config.reportUsedIgnorePattern;
 
                 if (firstOption.varsIgnorePattern) {
-                    config.varsIgnorePattern = new RegExp(
-                        firstOption.varsIgnorePattern,
-                        "u"
-                    );
+                    config.varsIgnorePattern = new RegExp(firstOption.varsIgnorePattern, "u");
                 }
 
                 if (firstOption.argsIgnorePattern) {
-                    config.argsIgnorePattern = new RegExp(
-                        firstOption.argsIgnorePattern,
-                        "u"
-                    );
+                    config.argsIgnorePattern = new RegExp(firstOption.argsIgnorePattern, "u");
                 }
 
                 if (firstOption.caughtErrorsIgnorePattern) {
-                    config.caughtErrorsIgnorePattern = new RegExp(
-                        firstOption.caughtErrorsIgnorePattern,
-                        "u"
-                    );
+                    config.caughtErrorsIgnorePattern = new RegExp(firstOption.caughtErrorsIgnorePattern, "u");
                 }
 
                 if (firstOption.destructuredArrayIgnorePattern) {
-                    config.destructuredArrayIgnorePattern = new RegExp(
-                        firstOption.destructuredArrayIgnorePattern,
-                        "u"
-                    );
+                    config.destructuredArrayIgnorePattern = new RegExp(firstOption.destructuredArrayIgnorePattern, "u");
                 }
             }
         }
@@ -202,9 +181,7 @@ module.exports = {
                     break;
 
                 default:
-                    throw new Error(
-                        `Unexpected variable type: ${variableType}`
-                    );
+                    throw new Error(`Unexpected variable type: ${variableType}`);
             }
 
             if (pattern) {
@@ -231,22 +208,19 @@ module.exports = {
                 switch (def.type) {
                     case "CatchClause":
                         if (config.caughtErrorsIgnorePattern) {
-                            [variableDescription, pattern] =
-                                getVariableDescription("catch-clause");
+                            [variableDescription, pattern] = getVariableDescription("catch-clause");
                         }
                         break;
 
                     case "Parameter":
                         if (config.argsIgnorePattern) {
-                            [variableDescription, pattern] =
-                                getVariableDescription("parameter");
+                            [variableDescription, pattern] = getVariableDescription("parameter");
                         }
                         break;
 
                     default:
                         if (config.varsIgnorePattern) {
-                            [variableDescription, pattern] =
-                                getVariableDescription("variable");
+                            [variableDescription, pattern] = getVariableDescription("variable");
                         }
                         break;
                 }
@@ -277,15 +251,10 @@ module.exports = {
                 let pattern;
                 let variableDescription;
 
-                if (
-                    def.name.parent.type === "ArrayPattern" &&
-                    config.destructuredArrayIgnorePattern
-                ) {
-                    [variableDescription, pattern] =
-                        getVariableDescription("array-destructure");
+                if (def.name.parent.type === "ArrayPattern" && config.destructuredArrayIgnorePattern) {
+                    [variableDescription, pattern] = getVariableDescription("array-destructure");
                 } else if (config.varsIgnorePattern) {
-                    [variableDescription, pattern] =
-                        getVariableDescription("variable");
+                    [variableDescription, pattern] = getVariableDescription("variable");
                 }
 
                 if (pattern && variableDescription) {
@@ -309,8 +278,7 @@ module.exports = {
          * this used ignored variable.
          */
         function getUsedIgnoredMessageData(variable, variableType) {
-            const [variableDescription, pattern] =
-                getVariableDescription(variableType);
+            const [variableDescription, pattern] = getVariableDescription(variableType);
 
             let additionalMessageData = "";
 
@@ -337,9 +305,11 @@ module.exports = {
          * @private
          */
         function isExported(variable) {
+
             const definition = variable.defs[0];
 
             if (definition) {
+
                 let node = definition.node;
 
                 if (node.type === "VariableDeclarator") {
@@ -351,6 +321,7 @@ module.exports = {
                 return node.parent.type.indexOf("Export") === 0;
             }
             return false;
+
         }
 
         /**
@@ -359,11 +330,9 @@ module.exports = {
          * @returns {boolean} True if the node is a sibling of the rest property, otherwise false.
          */
         function hasRestSibling(node) {
-            return (
-                node.type === "Property" &&
+            return node.type === "Property" &&
                 node.parent.type === "ObjectPattern" &&
-                REST_PROPERTY_TYPE.test(node.parent.properties.at(-1).type)
-            );
+                REST_PROPERTY_TYPE.test(node.parent.properties.at(-1).type);
         }
 
         /**
@@ -374,11 +343,8 @@ module.exports = {
          */
         function hasRestSpreadSibling(variable) {
             if (config.ignoreRestSiblings) {
-                const hasRestSiblingDefinition = variable.defs.some(def =>
-                    hasRestSibling(def.name.parent));
-                const hasRestSiblingReference = variable.references.some(
-                    ref => hasRestSibling(ref.identifier.parent)
-                );
+                const hasRestSiblingDefinition = variable.defs.some(def => hasRestSibling(def.name.parent));
+                const hasRestSiblingReference = variable.references.some(ref => hasRestSibling(ref.identifier.parent));
 
                 return hasRestSiblingDefinition || hasRestSiblingReference;
             }
@@ -435,12 +401,8 @@ module.exports = {
                 }
 
                 // FunctionExpressions
-                if (
-                    type === "Variable" &&
-                    node.init &&
-                    (node.init.type === "FunctionExpression" ||
-                        node.init.type === "ArrowFunctionExpression")
-                ) {
+                if (type === "Variable" && node.init &&
+                    (node.init.type === "FunctionExpression" || node.init.type === "ArrowFunctionExpression")) {
                     functionDefinitions.push(node.init);
                 }
             });
@@ -506,8 +468,7 @@ module.exports = {
             const parent = id.parent;
             const refScope = ref.from.variableScope;
             const varScope = ref.resolved.scope.variableScope;
-            const canBeUsedLater =
-                refScope !== varScope || astUtils.isInLoop(id);
+            const canBeUsedLater = refScope !== varScope || astUtils.isInLoop(id);
 
             /*
              * Inherits the previous node if this reference is in the node.
@@ -517,8 +478,7 @@ module.exports = {
                 return prevRhsNode;
             }
 
-            if (
-                parent.type === "AssignmentExpression" &&
+            if (parent.type === "AssignmentExpression" &&
                 isUnusedExpression(parent) &&
                 id === parent.left &&
                 !canBeUsedLater
@@ -613,21 +573,28 @@ module.exports = {
             const id = ref.identifier;
             const parent = id.parent;
 
-            return (
-                ref.isRead() &&
+            return ref.isRead() && (
 
                 // self update. e.g. `a += 1`, `a++`
-                ((parent.type === "AssignmentExpression" &&
-                    parent.left === id &&
-                    isUnusedExpression(parent) &&
-                    !astUtils.isLogicalAssignmentOperator(parent.operator)) ||
-                    (parent.type === "UpdateExpression" &&
-                        isUnusedExpression(parent)) ||
+                (
+                    (
+                        parent.type === "AssignmentExpression" &&
+                        parent.left === id &&
+                        isUnusedExpression(parent) &&
+                        !astUtils.isLogicalAssignmentOperator(parent.operator)
+                    ) ||
+                    (
+                        parent.type === "UpdateExpression" &&
+                        isUnusedExpression(parent)
+                    )
+                ) ||
 
-                    // in RHS of an assignment for itself. e.g. `a = a + 1`
-                    (rhsNode &&
-                        isInside(id, rhsNode) &&
-                        !isInsideOfStorableFunction(id, rhsNode)))
+                // in RHS of an assignment for itself. e.g. `a = a + 1`
+                (
+                    rhsNode &&
+                    isInside(id, rhsNode) &&
+                    !isInsideOfStorableFunction(id, rhsNode)
+                )
             );
         }
 
@@ -640,15 +607,13 @@ module.exports = {
         function isForInOfRef(ref) {
             let target = ref.identifier.parent;
 
+
             // "for (var ...) { return; }"
             if (target.type === "VariableDeclarator") {
                 target = target.parent.parent;
             }
 
-            if (
-                target.type !== "ForInStatement" &&
-                target.type !== "ForOfStatement"
-            ) {
+            if (target.type !== "ForInStatement" && target.type !== "ForOfStatement") {
                 return false;
             }
 
@@ -656,7 +621,7 @@ module.exports = {
             if (target.body.type === "BlockStatement") {
                 target = target.body.body[0];
 
-                // "for (...) return;"
+            // "for (...) return;"
             } else {
                 target = target.body;
             }
@@ -697,10 +662,7 @@ module.exports = {
                 return (
                     isReadRef(ref) &&
                     !forItself &&
-                    !(
-                        isFunctionDefinition &&
-                        isSelfReference(ref, functionNodes)
-                    )
+                    !(isFunctionDefinition && isSelfReference(ref, functionNodes))
                 );
             });
         }
@@ -717,9 +679,7 @@ module.exports = {
             const posteriorParams = params.slice(params.indexOf(variable) + 1);
 
             // If any used parameters occur after this parameter, do not report.
-            return !posteriorParams.some(
-                v => v.references.length > 0 || v.eslintUsed
-            );
+            return !posteriorParams.some(v => v.references.length > 0 || v.eslintUsed);
         }
 
         /**
@@ -739,10 +699,7 @@ module.exports = {
                     const variable = variables[i];
 
                     // skip a variable of class itself name in the class scope
-                    if (
-                        scope.type === "class" &&
-                        scope.block.id === variable.identifiers[0]
-                    ) {
+                    if (scope.type === "class" && scope.block.id === variable.identifiers[0]) {
                         continue;
                     }
 
@@ -752,19 +709,12 @@ module.exports = {
                     }
 
                     // skip variables marked with markVariableAsUsed()
-                    if (
-                        !config.reportUsedIgnorePattern &&
-                        variable.eslintUsed
-                    ) {
+                    if (!config.reportUsedIgnorePattern && variable.eslintUsed) {
                         continue;
                     }
 
                     // skip implicit "arguments" variable
-                    if (
-                        scope.type === "function" &&
-                        variable.name === "arguments" &&
-                        variable.identifiers.length === 0
-                    ) {
+                    if (scope.type === "function" && variable.name === "arguments" && variable.identifiers.length === 0) {
                         continue;
                     }
 
@@ -773,31 +723,22 @@ module.exports = {
 
                     if (def) {
                         const type = def.type;
-                        const refUsedInArrayPatterns = variable.references.some(
-                            ref =>
-                                ref.identifier.parent.type === "ArrayPattern"
-                        );
+                        const refUsedInArrayPatterns = variable.references.some(ref => ref.identifier.parent.type === "ArrayPattern");
 
                         // skip elements of array destructuring patterns
                         if (
-                            (def.name.parent.type === "ArrayPattern" ||
-                                refUsedInArrayPatterns) &&
+                            (
+                                def.name.parent.type === "ArrayPattern" ||
+                                refUsedInArrayPatterns
+                            ) &&
                             config.destructuredArrayIgnorePattern &&
-                            config.destructuredArrayIgnorePattern.test(
-                                def.name.name
-                            )
+                            config.destructuredArrayIgnorePattern.test(def.name.name)
                         ) {
-                            if (
-                                config.reportUsedIgnorePattern &&
-                                isUsedVariable(variable)
-                            ) {
+                            if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
                                 context.report({
                                     node: def.name,
                                     messageId: "usedIgnoredVar",
-                                    data: getUsedIgnoredMessageData(
-                                        variable,
-                                        "array-destructure"
-                                    )
+                                    data: getUsedIgnoredMessageData(variable, "array-destructure")
                                 });
                             }
 
@@ -805,14 +746,9 @@ module.exports = {
                         }
 
                         if (type === "ClassName") {
-                            const hasStaticBlock = def.node.body.body.some(
-                                node => node.type === "StaticBlock"
-                            );
+                            const hasStaticBlock = def.node.body.body.some(node => node.type === "StaticBlock");
 
-                            if (
-                                config.ignoreClassWithStaticInitBlock &&
-                                hasStaticBlock
-                            ) {
+                            if (config.ignoreClassWithStaticInitBlock && hasStaticBlock) {
                                 continue;
                             }
                         }
@@ -824,23 +760,12 @@ module.exports = {
                             }
 
                             // skip ignored parameters
-                            if (
-                                config.caughtErrorsIgnorePattern &&
-                                config.caughtErrorsIgnorePattern.test(
-                                    def.name.name
-                                )
-                            ) {
-                                if (
-                                    config.reportUsedIgnorePattern &&
-                                    isUsedVariable(variable)
-                                ) {
+                            if (config.caughtErrorsIgnorePattern && config.caughtErrorsIgnorePattern.test(def.name.name)) {
+                                if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
                                     context.report({
                                         node: def.name,
                                         messageId: "usedIgnoredVar",
-                                        data: getUsedIgnoredMessageData(
-                                            variable,
-                                            "catch-clause"
-                                        )
+                                        data: getUsedIgnoredMessageData(variable, "catch-clause")
                                     });
                                 }
 
@@ -849,12 +774,7 @@ module.exports = {
                         } else if (type === "Parameter") {
 
                             // skip any setter argument
-                            if (
-                                (def.node.parent.type === "Property" ||
-                                    def.node.parent.type ===
-                                        "MethodDefinition") &&
-                                def.node.parent.kind === "set"
-                            ) {
+                            if ((def.node.parent.type === "Property" || def.node.parent.type === "MethodDefinition") && def.node.parent.kind === "set") {
                                 continue;
                             }
 
@@ -864,21 +784,12 @@ module.exports = {
                             }
 
                             // skip ignored parameters
-                            if (
-                                config.argsIgnorePattern &&
-                                config.argsIgnorePattern.test(def.name.name)
-                            ) {
-                                if (
-                                    config.reportUsedIgnorePattern &&
-                                    isUsedVariable(variable)
-                                ) {
+                            if (config.argsIgnorePattern && config.argsIgnorePattern.test(def.name.name)) {
+                                if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
                                     context.report({
                                         node: def.name,
                                         messageId: "usedIgnoredVar",
-                                        data: getUsedIgnoredMessageData(
-                                            variable,
-                                            "parameter"
-                                        )
+                                        data: getUsedIgnoredMessageData(variable, "parameter")
                                     });
                                 }
 
@@ -886,31 +797,18 @@ module.exports = {
                             }
 
                             // if "args" option is "after-used", skip used variables
-                            if (
-                                config.args === "after-used" &&
-                                astUtils.isFunction(def.name.parent) &&
-                                !isAfterLastUsedArg(variable)
-                            ) {
+                            if (config.args === "after-used" && astUtils.isFunction(def.name.parent) && !isAfterLastUsedArg(variable)) {
                                 continue;
                             }
                         } else {
 
                             // skip ignored variables
-                            if (
-                                config.varsIgnorePattern &&
-                                config.varsIgnorePattern.test(def.name.name)
-                            ) {
-                                if (
-                                    config.reportUsedIgnorePattern &&
-                                    isUsedVariable(variable)
-                                ) {
+                            if (config.varsIgnorePattern && config.varsIgnorePattern.test(def.name.name)) {
+                                if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
                                     context.report({
                                         node: def.name,
                                         messageId: "usedIgnoredVar",
-                                        data: getUsedIgnoredMessageData(
-                                            variable,
-                                            "variable"
-                                        )
+                                        data: getUsedIgnoredMessageData(variable, "variable")
                                     });
                                 }
 
@@ -919,11 +817,7 @@ module.exports = {
                         }
                     }
 
-                    if (
-                        !isUsedVariable(variable) &&
-                        !isExported(variable) &&
-                        !hasRestSpreadSibling(variable)
-                    ) {
+                    if (!isUsedVariable(variable) && !isExported(variable) && !hasRestSpreadSibling(variable)) {
                         unusedVars.push(variable);
                     }
                 }
@@ -942,10 +836,7 @@ module.exports = {
 
         return {
             "Program:exit"(programNode) {
-                const unusedVars = collectUnusedVariables(
-                    sourceCode.getScope(programNode),
-                    []
-                );
+                const unusedVars = collectUnusedVariables(sourceCode.getScope(programNode), []);
 
                 for (let i = 0, l = unusedVars.length; i < l; ++i) {
                     const unusedVar = unusedVars[i];
@@ -954,12 +845,7 @@ module.exports = {
                     if (unusedVar.defs.length > 0) {
 
                         // report last write reference, https://github.com/eslint/eslint/issues/14324
-                        const writeReferences = unusedVar.references.filter(
-                            ref =>
-                                ref.isWrite() &&
-                                ref.from.variableScope ===
-                                    unusedVar.scope.variableScope
-                        );
+                        const writeReferences = unusedVar.references.filter(ref => ref.isWrite() && ref.from.variableScope === unusedVar.scope.variableScope);
 
                         let referenceToReport;
 
@@ -968,28 +854,20 @@ module.exports = {
                         }
 
                         context.report({
-                            node: referenceToReport
-                                ? referenceToReport.identifier
-                                : unusedVar.identifiers[0],
+                            node: referenceToReport ? referenceToReport.identifier : unusedVar.identifiers[0],
                             messageId: "unusedVar",
-                            data: unusedVar.references.some(ref =>
-                                ref.isWrite())
+                            data: unusedVar.references.some(ref => ref.isWrite())
                                 ? getAssignedMessageData(unusedVar)
                                 : getDefinedMessageData(unusedVar)
                         });
 
-                        // If there are no regular declaration, report the first `/*globals*/` comment directive.
+                    // If there are no regular declaration, report the first `/*globals*/` comment directive.
                     } else if (unusedVar.eslintExplicitGlobalComments) {
-                        const directiveComment =
-                            unusedVar.eslintExplicitGlobalComments[0];
+                        const directiveComment = unusedVar.eslintExplicitGlobalComments[0];
 
                         context.report({
                             node: programNode,
-                            loc: astUtils.getNameLocationInGlobalDirectiveComment(
-                                sourceCode,
-                                directiveComment,
-                                unusedVar.name
-                            ),
+                            loc: astUtils.getNameLocationInGlobalDirectiveComment(sourceCode, directiveComment, unusedVar.name),
                             messageId: "unusedVar",
                             data: getDefinedMessageData(unusedVar)
                         });

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -16,7 +16,7 @@ const astUtils = require("./utils/ast-utils");
 //------------------------------------------------------------------------------
 
 /**
- * A colloquial name for the type of variables that this rule can handle
+ * A simple name for the types of variables that this rule supports
  * @typedef {'array-destructure'|'catch-clause'|'parameter'|'variable'} VariableType
  */
 
@@ -171,7 +171,7 @@ module.exports = {
         /**
          * Gets a given variable's description and configured ignore pattern
          * based on the provided variableType
-         * @param {VariableType} variableType a colloquial name for type of variables that this rule handles
+         * @param {VariableType} variableType a simple name for the types of variables that this rule supports
          * @throws {Error} (Unreachable)
          * @returns {[string | undefined, string | undefined]} the given variable's description and
          * ignore pattern
@@ -304,7 +304,7 @@ module.exports = {
          * Generate the warning message about a variable being used even though
          * it is marked as being ignored.
          * @param {Variable} variable eslint-scope variable object
-         * @param {VariableType} variableType a colloquial name for type of variables that this rule handles
+         * @param {VariableType} variableType a simple name for the types of variables that this rule supports
          * @returns {UsedIgnoredVarMessageData} The message data to be used with
          * this used ignored variable.
          */

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -481,6 +481,7 @@ ruleTester.run("no-unused-vars", rule, {
             options: [{ ignoreClassWithStaticInitBlock: false, varsIgnorePattern: "^Foo" }],
             languageOptions: { ecmaVersion: 2022 }
         },
+
         // https://github.com/eslint/eslint/issues/17568
         {
             code: "const a = 5; const _c = a + 5;",
@@ -1645,6 +1646,7 @@ c = foo1`,
             languageOptions: { ecmaVersion: 2022 },
             errors: [{ ...definedError("Foo"), line: 1, column: 7 }]
         },
+
         // https://github.com/eslint/eslint/issues/17568
         {
             code: "const _a = 5;const _b = _a + 5",
@@ -1672,6 +1674,18 @@ c = foo1`,
             errors: [
                 usedIgnoredError("_b", ". Used elements of array destructuring must not match /^_/u")
             ]
+        },
+        {
+            code: "let _x;\n[_x] = arr;\nfoo(_x);",
+            options: [{ destructuredArrayIgnorePattern: "^_", reportUsedIgnorePattern: true, varsIgnorePattern: "[iI]gnored" }],
+            languageOptions: { ecmaVersion: 6 },
+            errors: [usedIgnoredError("_x", ". Used elements of array destructuring must not match /^_/u")]
+        },
+        {
+            code: "const [ignored] = arr;\nfoo(ignored);",
+            options: [{ destructuredArrayIgnorePattern: "^_", reportUsedIgnorePattern: true, varsIgnorePattern: "[iI]gnored" }],
+            languageOptions: { ecmaVersion: 6 },
+            errors: [usedIgnoredError("ignored", ". Used vars must not match /[iI]gnored/u")]
         },
         {
             code: "try{}catch(_err){console.error(_err)}",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

- [x] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
- [x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
- [ ] Add autofix to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

`no-unused-vars`

**What change do you want to make (place an "X" next to just one item)?**

- [x] Generate more warnings
- [ ] Generate fewer warnings
- [ ] Implement autofix
- [ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

- [x] A new option
- [ ] A new default behavior
- [ ] Other

**Please provide some example code that this change will affect:**

Example 1:
```js
/* eslint no-unused-vars: ["error", { "varsIgnorePattern": "^_" }] */

const _a = 5;
const _b = _a + 5
```

Example 2:
```js
/* eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }] */

function foo(_a) {
  return _a + 5
}
```

Example 3:
```js
/* eslint no-unused-vars: ["error", { "destructuredArrayIgnorePattern": "^_" }] */

const [ a, _b ] = items;
console.log(a + _b);
```

Example 4:
```js
/* eslint no-unused-vars: ["error", { "caughtErrorsIgnorePattern": "^_" }] */

try {}
catch(_err) {
  console.error(_err);
}
```

**What does the rule currently do for this code?**

In all examples, no warnings are reported.

**What will the rule do after it's changed?**

When the new option `reportUsedIgnorePattern` is enabled, each of the examples above will report; indicating that a variable that has been marked as an ignored unused variable is being used.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This change adds a new option `reportUsedIgnorePattern` to the `no-unused-vars` rule. When enabled, the rule will report any instances of variables that match any of the valid ignore pattern options when that variable is actually being used. 

Resolves: #17568

#### Is there anything you'd like reviewers to focus on?

When finding all references in order to report on the correct nodes, it is also finding the variable declaration. So a question for the team would be which nodes should this option report on:
* Should all references including the declaration be reported?
* Should only the variable declaration be reported? 
* Should only references not including the declaration be reported

<!-- markdownlint-disable-file MD004 -->
