### PR TITLE
fix: add `;` after JSX nodes in  `no-object-constructor` autofix

### DIFF
--- a/lib/rules/no-object-constructor.js
+++ b/lib/rules/no-object-constructor.js
@@ -35,10 +35,10 @@ const NODE_TYPES_BY_KEYWORD = {
 };
 
 /*
- * Before an opening parenthesis, `>` (for JSX), and postfix `++` and `--` always trigger ASI;
+ * Before an opening parenthesis, postfix `++` and `--` always trigger ASI;
  * the tokens `:`, `;`, `{` and `=>` don't expect a semicolon, as that would count as an empty statement.
  */
-const PUNCTUATORS = new Set([":", ";", ">", "{", "=>", "++", "--"]);
+const PUNCTUATORS = new Set([":", ";", "{", "=>", "++", "--"]);
 
 /*
  * Statements that can contain an `ExpressionStatement` after a closing parenthesis.

--- a/tests/lib/rules/no-object-constructor.js
+++ b/tests/lib/rules/no-object-constructor.js
@@ -168,6 +168,20 @@ ruleTester.run("no-object-constructor", rule, {
                 var foo = { bar: baz }
                 Object()
                 `
+            },
+            {
+                code: `
+                <foo />
+                Object()
+                `,
+                parserOptions: { ecmaFeatures: { jsx: true } }
+            },
+            {
+                code: `
+                <foo></foo>
+                Object()
+                `,
+                parserOptions: { ecmaFeatures: { jsx: true } }
             }
         ].map(props => ({
             ...props,
@@ -295,20 +309,6 @@ ruleTester.run("no-object-constructor", rule, {
                 foo: while (true) continue foo
                 Object()
                 `
-            },
-            {
-                code: `
-                <foo />
-                Object()
-                `,
-                parserOptions: { ecmaFeatures: { jsx: true } }
-            },
-            {
-                code: `
-                <foo></foo>
-                Object()
-                `,
-                parserOptions: { ecmaFeatures: { jsx: true } }
             },
             {
                 code: `


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**Tell us about your environment (`npx eslint --env-info`):**

Node version: v21.0.0
npm version: v10.2.0
Local ESLint version: v8.52.0 (Currently used)
Global ESLint version: v8.52.0
Operating System: darwin 23.0.0

**What parser are you using (place an "X" next to just one item)?**

[X] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
{
    "parserOptions": {
        "ecmaFeatures": {
            "jsx": true
        },
        "ecmaVersion": "latest"
    }
}
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```jsx
/* eslint no-object-constructor: error */

const a = <foo />
Object()

const b = <bar></bar>
Object()
```

[**Playground demo**](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLW9iamVjdC1jb25zdHJ1Y3RvcjogZXJyb3IgKi9cblxuY29uc3QgYSA9IDxmb28gLz5cbk9iamVjdCgpXG5cbmNvbnN0IGIgPSA8YmFyPjwvYmFyPlxuT2JqZWN0KCkiLCJvcHRpb25zIjp7ImVudiI6e30sInJ1bGVzIjp7fSwicGFyc2VyT3B0aW9ucyI6eyJlY21hRmVhdHVyZXMiOnsianN4Ijp0cnVlfSwiZWNtYVZlcnNpb24iOiJsYXRlc3QiLCJzb3VyY2VUeXBlIjoibW9kdWxlIn19fQ==)

**What did you expect to happen?**

Autofixing `no-object-constructor` should add a semicolon after the closing token `>` of a JSX node, because ASI no longer happens when `Object()` is replaced with a parenthesized expression.

**What actually happened? Please include the actual, raw output from ESLint.**

The autofix is wrong. While rechecking [these changes](https://github.com/eslint/eslint/pull/17649) in the Playground after the last release, I noticed that I had misplaced the JSX unit tests. My apologies for the mistake.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the autofix logic and moved the JSX unit tests into the right block, where autofix is expected to add a semicolon.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
