### PR TITLE
fix!: Parsing 'exported' comment using parseListConfig

### DIFF
--- a/lib/linter/config-comment-parser.js
+++ b/lib/linter/config-comment-parser.js
@@ -37,7 +37,7 @@ module.exports = class ConfigCommentParser {
 
     /**
      * Parses a list of "name:string_value" or/and "name" options divided by comma or
-     * whitespace. Used for "global" and "exported" comments.
+     * whitespace. Used for "global" comments.
      * @param {string} string The string to parse.
      * @param {Comment} comment The comment node which has the string.
      * @returns {Object} Result map object of names and string values, or null values if no value was provided

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -409,7 +409,7 @@ function getDirectiveComments(sourceCode, ruleMapper, warnInlineConfig) {
             }
 
             case "exported":
-                Object.assign(exportedVariables, commentParser.parseStringConfig(directiveValue, comment));
+                Object.assign(exportedVariables, commentParser.parseListConfig(directiveValue, comment));
                 break;
 
             case "globals":

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -984,7 +984,7 @@ class SourceCode extends TokenStore {
 
             switch (directiveText) {
                 case "exported":
-                    Object.assign(exportedVariables, commentParser.parseStringConfig(directiveValue, comment));
+                    Object.assign(exportedVariables, commentParser.parseListConfig(directiveValue, comment));
                     break;
 
                 case "globals":

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -1531,6 +1531,96 @@ describe("Linter", () => {
             linter.verify(code, config, filename, true);
         });
 
+        it("variable should be exported ", () => {
+            const code = "/* exported horse */\n\nvar horse;";
+            const config = { rules: { checker: "error" } };
+            let spy;
+
+            linter.defineRule("checker", {
+                create(context) {
+                    spy = sinon.spy(() => {
+                        const scope = context.getScope(),
+                            horse = getVariable(scope, "horse");
+
+                        assert.isTrue(horse.eslintUsed);
+                    });
+
+                    return { Program: spy };
+                }
+            });
+
+            linter.verify(code, config);
+            assert(spy && spy.calledOnce);
+        });
+
+        it("`key: value` pair variable should not be exported", () => {
+            const code = "/* exported horse: true */\n\nvar horse;";
+            const config = { rules: { checker: "error" } };
+            let spy;
+
+            linter.defineRule("checker", {
+                create(context) {
+                    spy = sinon.spy(() => {
+                        const scope = context.getScope(),
+                            horse = getVariable(scope, "horse");
+
+                        assert.notOk(horse.eslintUsed);
+                    });
+
+                    return { Program: spy };
+                }
+            });
+
+            linter.verify(code, config);
+            assert(spy && spy.calledOnce);
+        });
+
+        it("variables with comma should be exported", () => {
+            const code = "/* exported horse, dog */\n\nvar horse, dog;";
+            const config = { rules: { checker: "error" } };
+            let spy;
+
+            linter.defineRule("checker", {
+                create(context) {
+                    spy = sinon.spy(() => {
+                        const scope = context.getScope();
+
+                        ["horse", "dog"].forEach(name => {
+                            assert.isTrue(getVariable(scope, name).eslintUsed);
+                        });
+                    });
+
+                    return { Program: spy };
+                }
+            });
+
+            linter.verify(code, config);
+            assert(spy && spy.calledOnce);
+        });
+
+        it("variables without comma should not be exported", () => {
+            const code = "/* exported horse dog */\n\nvar horse, dog;";
+            const config = { rules: { checker: "error" } };
+            let spy;
+
+            linter.defineRule("checker", {
+                create(context) {
+                    spy = sinon.spy(() => {
+                        const scope = context.getScope();
+
+                        ["horse", "dog"].forEach(name => {
+                            assert.notOk(getVariable(scope, name).eslintUsed);
+                        });
+                    });
+
+                    return { Program: spy };
+                }
+            });
+
+            linter.verify(code, config);
+            assert(spy && spy.calledOnce);
+        });
+
         it("variables should be exported", () => {
             const code = "/* exported horse */\n\nvar horse = 'circus'";
             const config = { rules: { checker: "error" } };
@@ -12658,6 +12748,136 @@ describe("Linter with FlatConfigArray", () => {
                     const config = { rules: {} };
 
                     linter.verify(code, config, filename, true);
+                });
+
+                it("variable should be exported", () => {
+                    const code = "/* exported horse */\n\nvar horse;";
+                    let spy;
+                    const config = {
+                        plugins: {
+                            test: {
+                                rules: {
+                                    checker: {
+                                        create(context) {
+                                            spy = sinon.spy(() => {
+                                                const scope = context.getScope(),
+                                                    horse = getVariable(scope, "horse");
+
+                                                assert.isTrue(horse.eslintUsed);
+                                            });
+
+                                            return { Program: spy };
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        languageOptions: {
+                            sourceType: "script"
+                        },
+                        rules: { "test/checker": "error" }
+                    };
+
+                    linter.verify(code, config);
+                    assert(spy && spy.calledOnce);
+                });
+
+                it("`key: value` pair variable should not be exported", () => {
+                    const code = "/* exported horse: true */\n\nvar horse;";
+                    let spy;
+                    const config = {
+                        plugins: {
+                            test: {
+                                rules: {
+                                    checker: {
+                                        create(context) {
+                                            spy = sinon.spy(() => {
+                                                const scope = context.getScope(),
+                                                    horse = getVariable(scope, "horse");
+
+                                                assert.notOk(horse.eslintUsed);
+                                            });
+
+                                            return { Program: spy };
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        languageOptions: {
+                            sourceType: "script"
+                        },
+                        rules: { "test/checker": "error" }
+                    };
+
+                    linter.verify(code, config);
+                    assert(spy && spy.calledOnce);
+                });
+
+                it("variables with comma should be exported", () => {
+                    const code = "/* exported horse, dog */\n\nvar horse, dog;";
+                    let spy;
+                    const config = {
+                        plugins: {
+                            test: {
+                                rules: {
+                                    checker: {
+                                        create(context) {
+                                            spy = sinon.spy(() => {
+                                                const scope = context.getScope();
+
+                                                ["horse", "dog"].forEach(name => {
+                                                    assert.isTrue(getVariable(scope, name).eslintUsed);
+                                                });
+                                            });
+
+                                            return { Program: spy };
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        languageOptions: {
+                            sourceType: "script"
+                        },
+                        rules: { "test/checker": "error" }
+                    };
+
+                    linter.verify(code, config);
+                    assert(spy && spy.calledOnce);
+                });
+
+                it("variables without comma should not be exported", () => {
+                    const code = "/* exported horse dog */\n\nvar horse, dog;";
+                    let spy;
+                    const config = {
+                        plugins: {
+                            test: {
+                                rules: {
+                                    checker: {
+                                        create(context) {
+                                            spy = sinon.spy(() => {
+                                                const scope = context.getScope();
+
+                                                ["horse", "dog"].forEach(name => {
+                                                    assert.notOk(getVariable(scope, name).eslintUsed);
+                                                });
+                                            });
+
+                                            return { Program: spy };
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        languageOptions: {
+                            sourceType: "script"
+                        },
+                        rules: { "test/checker": "error" }
+                    };
+
+                    linter.verify(code, config);
+                    assert(spy && spy.calledOnce);
                 });
 
                 it("variables should be exported", () => {

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -3966,26 +3966,74 @@ describe("SourceCode", () => {
             assert.isTrue(variable.writeable);
         });
 
+        describe("exported variables", () => {
 
-        it("should mark exported variables", () => {
+            /**
+             * GlobalScope
+             * @param {string} code the code to check
+             * @returns {Scope} globalScope
+             */
+            function loadGlobalScope(code) {
+                const ast = espree.parse(code, DEFAULT_CONFIG);
+                const scopeManager = eslintScope.analyze(ast, {
+                    ignoreEval: true,
+                    ecmaVersion: 6
+                });
+                const sourceCode = new SourceCode({ text: code, ast, scopeManager });
 
-            const code = "/*exported foo */ var foo;";
-            const ast = espree.parse(code, DEFAULT_CONFIG);
-            const scopeManager = eslintScope.analyze(ast, {
-                ignoreEval: true,
-                ecmaVersion: 6
+                sourceCode.applyInlineConfig();
+                sourceCode.finalize();
+
+                const globalScope = sourceCode.scopeManager.scopes[0].set;
+
+                return globalScope;
+            }
+
+            it("should mark exported variable", () => {
+                const code = "/*exported foo */ var foo;";
+                const globalScope = loadGlobalScope(code);
+                const variable = globalScope.get("foo");
+
+                assert.isDefined(variable);
+                assert.isTrue(variable.eslintUsed);
+                assert.isTrue(variable.eslintExported);
             });
-            const sourceCode = new SourceCode({ text: code, ast, scopeManager });
 
-            sourceCode.applyInlineConfig();
-            sourceCode.finalize();
+            it("should not mark exported variable with `key: value` pair", () => {
+                const code = "/*exported foo: true */ var foo;";
+                const globalScope = loadGlobalScope(code);
+                const variable = globalScope.get("foo");
 
-            const globalScope = sourceCode.scopeManager.scopes[0];
-            const variable = globalScope.set.get("foo");
+                assert.isDefined(variable);
+                assert.notOk(variable.eslintUsed);
+                assert.notOk(variable.eslintExported);
+            });
 
-            assert.isDefined(variable);
-            assert.isTrue(variable.eslintUsed);
-            assert.isTrue(variable.eslintExported);
+            it("should mark exported variables with comma", () => {
+                const code = "/*exported foo, bar */ var foo, bar;";
+                const globalScope = loadGlobalScope(code);
+
+                ["foo", "bar"].forEach(name => {
+                    const variable = globalScope.get(name);
+
+                    assert.isDefined(variable);
+                    assert.isTrue(variable.eslintUsed);
+                    assert.isTrue(variable.eslintExported);
+                });
+            });
+
+            it("should not mark exported variables without comma", () => {
+                const code = "/*exported foo bar */ var foo, bar;";
+                const globalScope = loadGlobalScope(code);
+
+                ["foo", "bar"].forEach(name => {
+                    const variable = globalScope.get(name);
+
+                    assert.isDefined(variable);
+                    assert.notOk(variable.eslintUsed);
+                    assert.notOk(variable.eslintExported);
+                });
+            });
         });
 
         it("should extract rule configuration", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Parsing 'exported' comment using parseListConfig.
Fixes https://github.com/eslint/eslint/issues/17622.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In the [docs](https://eslint.org/docs/latest/rules/no-unused-vars#exported), only information about the name entries.
However, when processing `/* exported */` comments, Linter uses `parseStringConfig` function, making it appear as if it's checking the `name: value` entries.
So, change Linter to use the `parseListConfig` function for parsing `/* exported */` comments.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
