### PR TITLE
feat: Add suggestions for no-prototype-builtins

### DIFF
--- a/lib/rules/no-prototype-builtins.js
+++ b/lib/rules/no-prototype-builtins.js
@@ -119,11 +119,16 @@ module.exports = {
                                     return null;
                                 }
 
+                                let objectText = sourceCode.getText(callee.object);
+
+                                if (astUtils.getPrecedence(callee.object) <= astUtils.getPrecedence({ type: "SequenceExpression" })) {
+                                    objectText = `(${objectText})`;
+                                }
+
                                 const openParenToken = sourceCode.getTokenAfter(
                                     node.callee,
                                     astUtils.isOpeningParenToken
                                 );
-                                const objectText = sourceCode.getText(callee.object);
                                 const isEmptyParameters = node.arguments.length === 0;
                                 const delim = isEmptyParameters ? "" : ", ";
                                 const fixes = [

--- a/lib/rules/no-prototype-builtins.js
+++ b/lib/rules/no-prototype-builtins.js
@@ -11,6 +11,37 @@
 const astUtils = require("./utils/ast-utils");
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Returns true if the node or any of the objects
+ * to the left of it in the member/call chain is optional.
+ *
+ * e.g. `a?.b`, `a?.b.c`, `a?.()`, `a()?.()`
+ * @param {ASTNode} node The expression to check
+ * @returns {boolean} `true` if there is a short-circuiting optional `?.`
+ * in the same option chain to the left of this call or member expression,
+ * or the node itself is an optional call or member `?.`.
+ */
+function isAfterOptional(node) {
+    let leftNode;
+
+    if (node.type === "MemberExpression") {
+        leftNode = node.object;
+    } else if (node.type === "CallExpression") {
+        leftNode = node.callee;
+    } else {
+        return false;
+    }
+    if (node.optional) {
+        return true;
+    }
+    return isAfterOptional(leftNode);
+}
+
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -25,10 +56,13 @@ module.exports = {
             url: "https://eslint.org/docs/latest/rules/no-prototype-builtins"
         },
 
+        hasSuggestions: true,
+
         schema: [],
 
         messages: {
-            prototypeBuildIn: "Do not access Object.prototype method '{{prop}}' from target object."
+            prototypeBuildIn: "Do not access Object.prototype method '{{prop}}' from target object.",
+            callObjectPrototype: "Call Object.prototype.{{prop}} explicitly."
         }
     },
 
@@ -59,7 +93,38 @@ module.exports = {
                     messageId: "prototypeBuildIn",
                     loc: callee.property.loc,
                     data: { prop: propName },
-                    node
+                    node,
+                    suggest: [
+                        {
+                            messageId: "callObjectPrototype",
+                            data: { prop: propName },
+                            fix(fixer) {
+
+                                /*
+                                 * a call after an optional chain (e.g. a?.b.hasOwnProperty(c))
+                                 * must be fixed manually because the call can be short-circuited
+                                 */
+                                if (isAfterOptional(node)) {
+                                    return null;
+                                }
+
+                                const sourceCode = context.sourceCode;
+                                const openParenToken = sourceCode.getTokenAfter(
+                                    node.callee,
+                                    astUtils.isOpeningParenToken
+                                );
+                                const objectText = sourceCode.getText(callee.object);
+                                const isEmptyParameters = node.arguments.length === 0;
+                                const delim = isEmptyParameters ? "" : ", ";
+                                const fixes = [
+                                    fixer.replaceText(callee, `Object.prototype.${propName}.call`),
+                                    fixer.insertTextAfter(openParenToken, objectText + delim)
+                                ];
+
+                                return fixes;
+                            }
+                        }
+                    ]
                 });
             }
         }

--- a/lib/rules/no-prototype-builtins.js
+++ b/lib/rules/no-prototype-builtins.js
@@ -99,6 +99,7 @@ module.exports = {
                             messageId: "callObjectPrototype",
                             data: { prop: propName },
                             fix(fixer) {
+                                const sourceCode = context.sourceCode;
 
                                 /*
                                  * a call after an optional chain (e.g. a?.b.hasOwnProperty(c))
@@ -108,7 +109,16 @@ module.exports = {
                                     return null;
                                 }
 
-                                const sourceCode = context.sourceCode;
+                                const objectVariable = astUtils.getVariableByName(sourceCode.getScope(node), "Object");
+
+                                /*
+                                 * We can't use Object if the global Object was shadowed,
+                                 * or Object does not exist in the global scope for some reason
+                                 */
+                                if (!objectVariable || objectVariable.scope.type !== "global" || objectVariable.defs.length > 0) {
+                                    return null;
+                                }
+
                                 const openParenToken = sourceCode.getTokenAfter(
                                     node.callee,
                                     astUtils.isOpeningParenToken

--- a/lib/rules/no-prototype-builtins.js
+++ b/lib/rules/no-prototype-builtins.js
@@ -102,10 +102,18 @@ module.exports = {
                                 const sourceCode = context.sourceCode;
 
                                 /*
-                                 * a call after an optional chain (e.g. a?.b.hasOwnProperty(c))
+                                 * A call after an optional chain (e.g. a?.b.hasOwnProperty(c))
                                  * must be fixed manually because the call can be short-circuited
                                  */
                                 if (isAfterOptional(node)) {
+                                    return null;
+                                }
+
+                                /*
+                                 * A call on a ChainExpression (e.g. (a?.hasOwnProperty)(c)) will trigger
+                                 * no-unsafe-optional-chaining which should be fixed before this suggestion
+                                 */
+                                if (node.callee.type === "ChainExpression") {
                                     return null;
                                 }
 

--- a/tests/lib/rules/no-prototype-builtins.js
+++ b/tests/lib/rules/no-prototype-builtins.js
@@ -257,6 +257,23 @@ ruleTester.run("no-prototype-builtins", rule, {
             }]
         },
         {
+
+            code: "(a,b).hasOwnProperty('bar')",
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{
+                messageId: "prototypeBuildIn",
+                data: { prop: "hasOwnProperty" },
+                suggestions: [
+
+                    // Make sure the SequenceExpression has parentheses before other arguments
+                    {
+                        messageId: "callObjectPrototype",
+                        output: "Object.prototype.hasOwnProperty.call((a,b), 'bar')"
+                    }
+                ]
+            }]
+        },
+        {
             code: "(foo?.hasOwnProperty)('bar')",
             parserOptions: { ecmaVersion: 2020 },
             errors: [{

--- a/tests/lib/rules/no-prototype-builtins.js
+++ b/tests/lib/rules/no-prototype-builtins.js
@@ -230,7 +230,7 @@ ruleTester.run("no-prototype-builtins", rule, {
         {
 
             /*
-             * if hasOwnProperty is part of a ChainExpresion
+             * If hasOwnProperty is part of a ChainExpresion
              * and the optional part is before it, then don't suggest the fix
              */
             code: "foo?.hasOwnProperty('bar').baz",
@@ -240,7 +240,7 @@ ruleTester.run("no-prototype-builtins", rule, {
         {
 
             /*
-             * if hasOwnProperty is part of a ChainExpresion
+             * If hasOwnProperty is part of a ChainExpresion
              * but the optional part is after it, then the fix is safe
              */
             code: "foo.hasOwnProperty('bar')?.baz",
@@ -274,23 +274,12 @@ ruleTester.run("no-prototype-builtins", rule, {
             }]
         },
         {
+
+            // No suggestion where no-unsafe-optional-chaining is reported on the call
             code: "(foo?.hasOwnProperty)('bar')",
             parserOptions: { ecmaVersion: 2020 },
-            errors: [{
-                messageId: "prototypeBuildIn",
-                data: { prop: "hasOwnProperty" },
-                suggestions: [
-                    {
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" }, suggestions: [] }]
 
-                        /*
-                         * Note that the original may throw TypeError: (intermediate value) is not a function
-                         * whereas the replacement may throw TypeError: Cannot convert undefined or null to object
-                         */
-                        messageId: "callObjectPrototype",
-                        output: "(Object.prototype.hasOwnProperty.call)(foo, 'bar')"
-                    }
-                ]
-            }]
         },
         {
             code: "(foo?.hasOwnProperty)?.('bar')",
@@ -303,24 +292,11 @@ ruleTester.run("no-prototype-builtins", rule, {
             errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" }, suggestions: [] }]
         },
         {
+
+            // No suggestion where no-unsafe-optional-chaining is reported on the call
             code: "(foo?.[`hasOwnProperty`])('bar')",
             parserOptions: { ecmaVersion: 2020 },
-            errors: [{
-                messageId: "prototypeBuildIn",
-                data: { prop: "hasOwnProperty" },
-                suggestions: [
-                    {
-
-                        /*
-                         * Note that the original may throw TypeError: (intermediate value) is not a function
-                         * whereas the replacement may throw TypeError: Cannot convert undefined or null to object
-                         */
-                        messageId: "callObjectPrototype",
-                        output: "(Object.prototype.hasOwnProperty.call)(foo, 'bar')"
-                    }
-                ]
-
-            }]
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" }, suggestions: [] }]
         }
     ]
 });

--- a/tests/lib/rules/no-prototype-builtins.js
+++ b/tests/lib/rules/no-prototype-builtins.js
@@ -196,6 +196,20 @@ ruleTester.run("no-prototype-builtins", rule, {
                 type: "CallExpression"
             }]
         },
+        {
+
+            // Can't suggest Object.prototype when Object is shadowed
+            code: "(function(Object) {return foo.hasOwnProperty('bar');})",
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" }, suggestions: [] }]
+        },
+        {
+            code: "foo.hasOwnProperty('bar')",
+            globals: {
+                Object: "off"
+            },
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" }, suggestions: [] }],
+            name: "Can't suggest Object.prototype when there is no Object global variable"
+        },
 
         // Optional chaining
         {

--- a/tests/lib/rules/no-prototype-builtins.js
+++ b/tests/lib/rules/no-prototype-builtins.js
@@ -61,6 +61,12 @@ ruleTester.run("no-prototype-builtins", rule, {
                 endColumn: 19,
                 messageId: "prototypeBuildIn",
                 data: { prop: "hasOwnProperty" },
+                suggestions: [
+                    {
+                        messageId: "callObjectPrototype",
+                        output: "Object.prototype.hasOwnProperty.call(foo, 'bar')"
+                    }
+                ],
                 type: "CallExpression"
             }]
         },
@@ -73,6 +79,12 @@ ruleTester.run("no-prototype-builtins", rule, {
                 endColumn: 18,
                 messageId: "prototypeBuildIn",
                 data: { prop: "isPrototypeOf" },
+                suggestions: [
+                    {
+                        messageId: "callObjectPrototype",
+                        output: "Object.prototype.isPrototypeOf.call(foo, 'bar')"
+                    }
+                ],
                 type: "CallExpression"
             }]
         },
@@ -84,6 +96,12 @@ ruleTester.run("no-prototype-builtins", rule, {
                 endLine: 1,
                 endColumn: 25,
                 messageId: "prototypeBuildIn",
+                suggestions: [
+                    {
+                        messageId: "callObjectPrototype",
+                        output: "Object.prototype.propertyIsEnumerable.call(foo, 'bar')"
+                    }
+                ],
                 data: { prop: "propertyIsEnumerable" }
             }]
         },
@@ -96,6 +114,12 @@ ruleTester.run("no-prototype-builtins", rule, {
                 endColumn: 23,
                 messageId: "prototypeBuildIn",
                 data: { prop: "hasOwnProperty" },
+                suggestions: [
+                    {
+                        messageId: "callObjectPrototype",
+                        output: "Object.prototype.hasOwnProperty.call(foo.bar, 'bar')"
+                    }
+                ],
                 type: "CallExpression"
             }]
         },
@@ -108,6 +132,12 @@ ruleTester.run("no-prototype-builtins", rule, {
                 endColumn: 26,
                 messageId: "prototypeBuildIn",
                 data: { prop: "isPrototypeOf" },
+                suggestions: [
+                    {
+                        messageId: "callObjectPrototype",
+                        output: "Object.prototype.isPrototypeOf.call(foo.bar.baz, 'bar')"
+                    }
+                ],
                 type: "CallExpression"
             }]
         },
@@ -120,6 +150,12 @@ ruleTester.run("no-prototype-builtins", rule, {
                 endColumn: 21,
                 messageId: "prototypeBuildIn",
                 data: { prop: "hasOwnProperty" },
+                suggestions: [
+                    {
+                        messageId: "callObjectPrototype",
+                        output: "Object.prototype.hasOwnProperty.call(foo, 'bar')"
+                    }
+                ],
                 type: "CallExpression"
             }]
         },
@@ -133,6 +169,12 @@ ruleTester.run("no-prototype-builtins", rule, {
                 endColumn: 20,
                 messageId: "prototypeBuildIn",
                 data: { prop: "isPrototypeOf" },
+                suggestions: [
+                    {
+                        messageId: "callObjectPrototype",
+                        output: "Object.prototype.isPrototypeOf.call(foo, 'bar').baz"
+                    }
+                ],
                 type: "CallExpression"
             }]
         },
@@ -145,6 +187,12 @@ ruleTester.run("no-prototype-builtins", rule, {
                 endColumn: 31,
                 messageId: "prototypeBuildIn",
                 data: { prop: "propertyIsEnumerable" },
+                suggestions: [
+                    {
+                        messageId: "callObjectPrototype",
+                        output: String.raw`Object.prototype.propertyIsEnumerable.call(foo.bar, 'baz')`
+                    }
+                ],
                 type: "CallExpression"
             }]
         },
@@ -153,22 +201,95 @@ ruleTester.run("no-prototype-builtins", rule, {
         {
             code: "foo?.hasOwnProperty('bar')",
             parserOptions: { ecmaVersion: 2020 },
-            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" } }]
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" }, suggestions: [] }]
+        },
+        {
+            code: "foo?.bar.hasOwnProperty('baz')",
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" }, suggestions: [] }]
+        },
+        {
+            code: "foo.hasOwnProperty?.('bar')",
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" }, suggestions: [] }]
+        },
+        {
+
+            /*
+             * if hasOwnProperty is part of a ChainExpresion
+             * and the optional part is before it, then don't suggest the fix
+             */
+            code: "foo?.hasOwnProperty('bar').baz",
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" }, suggestions: [] }]
+        },
+        {
+
+            /*
+             * if hasOwnProperty is part of a ChainExpresion
+             * but the optional part is after it, then the fix is safe
+             */
+            code: "foo.hasOwnProperty('bar')?.baz",
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{
+                messageId: "prototypeBuildIn",
+                data: { prop: "hasOwnProperty" },
+                suggestions: [
+                    {
+                        messageId: "callObjectPrototype",
+                        output: "Object.prototype.hasOwnProperty.call(foo, 'bar')?.baz"
+                    }
+                ]
+            }]
         },
         {
             code: "(foo?.hasOwnProperty)('bar')",
             parserOptions: { ecmaVersion: 2020 },
-            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" } }]
+            errors: [{
+                messageId: "prototypeBuildIn",
+                data: { prop: "hasOwnProperty" },
+                suggestions: [
+                    {
+
+                        /*
+                         * Note that the original may throw TypeError: (intermediate value) is not a function
+                         * whereas the replacement may throw TypeError: Cannot convert undefined or null to object
+                         */
+                        messageId: "callObjectPrototype",
+                        output: "(Object.prototype.hasOwnProperty.call)(foo, 'bar')"
+                    }
+                ]
+            }]
+        },
+        {
+            code: "(foo?.hasOwnProperty)?.('bar')",
+            parserOptions: { ecmaVersion: 2020 },
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" }, suggestions: [] }]
         },
         {
             code: "foo?.['hasOwnProperty']('bar')",
             parserOptions: { ecmaVersion: 2020 },
-            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" } }]
+            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" }, suggestions: [] }]
         },
         {
             code: "(foo?.[`hasOwnProperty`])('bar')",
             parserOptions: { ecmaVersion: 2020 },
-            errors: [{ messageId: "prototypeBuildIn", data: { prop: "hasOwnProperty" } }]
+            errors: [{
+                messageId: "prototypeBuildIn",
+                data: { prop: "hasOwnProperty" },
+                suggestions: [
+                    {
+
+                        /*
+                         * Note that the original may throw TypeError: (intermediate value) is not a function
+                         * whereas the replacement may throw TypeError: Cannot convert undefined or null to object
+                         */
+                        messageId: "callObjectPrototype",
+                        output: "(Object.prototype.hasOwnProperty.call)(foo, 'bar')"
+                    }
+                ]
+
+            }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule proposal.md))
[ ] Changes an existing rule ([template (https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[x] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Suggest a fix e.g. `a.hasOwnProperty(b) -> Object.prototype.hasOwnProperty.call(a, b)` according to the [`no-prototype-builtins` documentation](https://eslint.org/docs/latest/rules/no-prototype-builtins):

> To avoid subtle bugs like this, it’s better to always call these methods from `Object.prototype`. For example, `foo.hasOwnProperty("bar")` should be replaced with `Object.prototype.hasOwnProperty.call(foo, "bar")`.

However, if the method is called using an optional chain, then no fix is suggested because the optional chain undefined?.{hasOwnProperty,isPrototypeOf,propertyIsEnumerable}() evaluates to undefined whereas Object.prototype.{hasOwnProperty,isPrototypeOf,propertyIsEnumerable}.call(undefined) evaluates to throw TypeError, false, and throw TypeError, respectively.



#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

