### PR TITLE
fix: ensure that exit code for fatal errors is not overwritten

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -97,8 +97,9 @@ function getErrorMessage(error) {
  * same message once.
  * @type {Set<string>}
  */
-
 const displayedErrors = new Set();
+
+let hadFatalError = false;
 
 /**
  * Catch and report unexpected error.
@@ -107,6 +108,7 @@ const displayedErrors = new Set();
  */
 function onFatalError(error) {
     process.exitCode = 2;
+    hadFatalError = true;
 
     const { version } = require("../package.json");
     const message = `
@@ -143,9 +145,13 @@ ${getErrorMessage(error)}`;
     }
 
     // Otherwise, call the CLI.
-    process.exitCode = await require("../lib/cli").execute(
+    const exitCode = await require("../lib/cli").execute(
         process.argv,
         process.argv.includes("--stdin") ? await readStdin() : null,
         true
     );
+
+    if (!hadFatalError) {
+        process.exitCode = exitCode;
+    }
 }()).catch(onFatalError);

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -99,6 +99,10 @@ function getErrorMessage(error) {
  */
 const displayedErrors = new Set();
 
+/**
+ * Tracks whether an unexpected error was caught
+ * @type {boolean}
+ */
 let hadFatalError = false;
 
 /**
@@ -151,6 +155,18 @@ ${getErrorMessage(error)}`;
         true
     );
 
+    /*
+     * If an uncaught exception or unhandled rejection was detected in the meantime,
+     * keep the fatal exit code 2 that is already assigned to `process.exitCode`.
+     * Without this condition, exit code 2 (unsuccessful execution) could be overwritten with
+     * 1 (successful execution, lint problems found) or even 0 (successful execution, no lint problems found).
+     * This ensures that unexpected errors that seemingly don't affect the success
+     * of the execution will still cause a non-zero exit code, as it's a common
+     * practice and the default behavior of Node.js to exit with non-zero
+     * in case of an uncaught exception or unhandled rejection.
+     *
+     * Otherwise, assign the exit code returned from CLI.
+     */
     if (!hadFatalError) {
         process.exitCode = exitCode;
     }

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -387,6 +387,24 @@ describe("bin/eslint.js", () => {
             return Promise.all([exitCodeAssertion, outputAssertion]);
         });
 
+        it("does not exit with zero when there is an error in the next tick", () => {
+            const config = path.join(__dirname, "../fixtures/bin/eslint.config-promise-tick-throws.js");
+            const file = path.join(__dirname, "../fixtures/bin/empty.js");
+            const child = runESLint(["--config", config, file]);
+            const exitCodeAssertion = assertExitCode(child, 2);
+            const outputAssertion = getOutput(child).then(output => {
+
+                // ensure the expected error was printed
+                assert.include(output.stderr, "test_error_stack");
+
+                // ensure that linting the file did not cause an error
+                assert.notInclude(output.stderr, "empty.js");
+                assert.notInclude(output.stdout, "empty.js");
+            });
+
+            return Promise.all([exitCodeAssertion, outputAssertion]);
+        });
+
         // https://github.com/eslint/eslint/issues/17560
         describe("does not print duplicate errors in the event of a crash", () => {
 

--- a/tests/fixtures/bin/eslint.config-promise-tick-throws.js
+++ b/tests/fixtures/bin/eslint.config-promise-tick-throws.js
@@ -1,0 +1,13 @@
+function throwError() {
+    const error = new Error();
+    error.stack = "test_error_stack";
+    throw error;
+}
+
+process.nextTick(throwError);
+
+/*
+ * Promise ensures that this config must be await-ed and therefore
+ * the error in next tick will be thrown before any linting is done
+ */
+module.exports = Promise.resolve([{}]);

--- a/tests/fixtures/bin/eslint.config-promise-tick-throws.js
+++ b/tests/fixtures/bin/eslint.config-promise-tick-throws.js
@@ -6,8 +6,17 @@ function throwError() {
 
 process.nextTick(throwError);
 
+function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function getConfig() {
+    await delay(100);
+    return [];
+}
+
 /*
- * Promise ensures that this config must be await-ed and therefore
+ * Exporting the config as an initially unsettled Promise should ensure that
  * the error in next tick will be thrown before any linting is done
  */
-module.exports = Promise.resolve([{}]);
+module.exports = getConfig();


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Currently, when an unhandled exception happens before the main task is completed, the main task overwrites the exit code, so there can be a scenario where eslint exits with zero (i.e., success) although there was an unhandled exception. 

Reproduction is [this test](https://github.com/eslint/eslint/blob/3aec1c55ba2c6d2833e1c0afe0a58f0cc6bbc0a4/tests/bin/eslint.js#L406-L417) that is currently failing in CI, though only on Node 21.1.0. 


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `bin/eslint.js` to not change the exit code if `onFatalError` was called.

I also added another test that should be failing without this change in all Node versions (at least it does for me locally on Node 20.7.0).

#### Is there anything you'd like reviewers to focus on?


<!-- markdownlint-disable-file MD004 -->
