### PR TITLE
docs: change position of return to top button

### DIFF
--- a/docs/src/assets/scss/docs.scss
+++ b/docs/src/assets/scss/docs.scss
@@ -166,7 +166,7 @@ pre[class*="language-"] {
     height: 50px;
     display: none;
     position: fixed;
-    right: 50px;
+    right: 19.8vw;
     bottom: 35px;
     z-index: 1;
     font-size: 1.5rem;
@@ -177,7 +177,35 @@ pre[class*="language-"] {
     align-items: center;
     background-color: var(--link-color);
 
-    @media (max-width: 800px) {
+    @media (max-width: 1299px) {
+        right: 18.99vw;
+    }
+
+    @media (max-width: 1100px) {
+        right: 19.4vw;
+    }
+
+    @media (max-width: 1060px) {
+        right: 19.9vw;
+    }
+
+    @media (max-width: 1024px) {
+        right: 22vw;
+    }
+
+    @media (max-width: 860px) {
+        right: 22.2vw;
+    }
+
+    @media (max-width: 850px) {
+        right: 22.6vw;
+    }
+
+    @media (max-width: 820px) {
+        right: 23.4vw;
+    }
+
+    @media (max-width: 799px) {
         right: 35px;
     }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
changed the position of return to top button in content page to avoid the overlapping of link buttons or other functional components of docs page.
for mobile or tab screen size the position is not changed.

#### Is there anything you'd like reviewers to focus on?
Fixes #17646

<!-- markdownlint-disable-file MD004 -->
