### PR TITLE
fix: Use `cwd` constructor option as config `basePath` in Linter

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1422,7 +1422,7 @@ class Linter {
     verify(textOrSourceCode, config, filenameOrOptions) {
         debug("Verify");
 
-        const { configType } = internalSlotsMap.get(this);
+        const { configType, cwd } = internalSlotsMap.get(this);
 
         const options = typeof filenameOrOptions === "string"
             ? { filename: filenameOrOptions }
@@ -1441,7 +1441,7 @@ class Linter {
                 let configArray = config;
 
                 if (!Array.isArray(config) || typeof config.getConfig !== "function") {
-                    configArray = new FlatConfigArray(config);
+                    configArray = new FlatConfigArray(config, { basePath: cwd });
                     configArray.normalizeSync();
                 }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs https://github.com/eslint/eslint/issues/17669

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `Linter` to pass `cwd` constructor option as config's `basePath` when creating a new `FlatConfigArray`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
