### PR TITLE
feat: importNamePattern option in no-restricted-imports

### DIFF
--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -129,8 +129,6 @@ Regex patterns can also be used to restrict specific import Name:
 }]
 ```
 
-**Note:** If `importNames` and `importNamePattern` are used together, it initially reviews the value specified in `importNames`. Afterward, it focuses on assessing the value specified in `importNamePattern`.
-
 To restrict the use of all Node.js core imports (via <https://github.com/nodejs/node/tree/master/lib>):
 
 ```json

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -118,6 +118,19 @@ Pattern matches can restrict specific import names only, similar to the `paths` 
 }]
 ```
 
+Regex patterns can also be used to restrict specific import Name:
+
+```json
+"no-restricted-imports": ["error", {
+    "patterns": [{
+      "group": ["import-foo/*"],
+      "importNamePatterns": "^foo",
+    }]
+}]
+```
+
+**Note:** In patterns array `importNames` and `importNamePatterns` can not be used together. If they are used together then the `importNames` will be considered.
+
 To restrict the use of all Node.js core imports (via <https://github.com/nodejs/node/tree/master/lib>):
 
 ```json
@@ -264,6 +277,18 @@ import pick from 'fooBar';
 import { isEmpty } from 'utils/collection-utils';
 ```
 
+::: incorrect { "sourceType": "module" }
+
+```js
+/*eslint no-restricted-imports: ["error", { patterns: [{
+    group: ["utils/*"],
+    importNamePatterns: '^is',
+    message: "Use 'isEmpty' from lodash instead."
+}]}]*/
+
+import { isEmpty } from 'utils/collection-utils';
+```
+
 :::
 
 Examples of **correct** code for this rule:
@@ -351,6 +376,20 @@ import pick from 'food';
 }]}]*/
 
 import { hasValues } from 'utils/collection-utils';
+```
+
+:::
+
+::: correct { "sourceType": "module" }
+
+```js
+/*eslint no-restricted-imports: ["error", { patterns: [{
+    group: ["utils/*"],
+    importNamePatterns: '^is',
+    message: "Use 'isEmpty' from lodash instead."
+}]}]*/
+
+import isEmpty, { hasValue } from 'utils/collection-utils';
 ```
 
 :::

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -295,12 +295,12 @@ import { isEmpty } from 'utils/collection-utils';
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
-    group: ["bar/*"],
+    group: ["foo/*"],
     importNamePattern: '^(is|bar)',
-    message: "Use 'isBar' from foo/bar instead"
+    message: "Use 'isBar' from baz/bar instead"
 }]}]*/
 
-import bar { isBar } from 'bar/*';
+import bar, { isBar } from 'foo/bar';
 ```
 
 :::
@@ -310,11 +310,11 @@ import bar { isBar } from 'bar/*';
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
     importNames: ["foo"],
-    group: ["bar/*"],
+    group: ["foo/*"],
     importNamePattern: '^bar',
 }]}]*/
 
-import { bar } from 'bar/*';
+import { bar } from 'foo/bar';
 ```
 
 :::

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -124,12 +124,12 @@ Regex patterns can also be used to restrict specific import Name:
 "no-restricted-imports": ["error", {
     "patterns": [{
       "group": ["import-foo/*"],
-      "importNamePatterns": "^foo",
+      "importNamePattern": "^foo",
     }]
 }]
 ```
 
-**Note:** In patterns array `importNames` and `importNamePatterns` can not be used together. If they are used together then the `importNames` will be considered.
+**Note:** If `importNames` and `importNamePattern` are used together then the `importNames` will be first considered.
 
 To restrict the use of all Node.js core imports (via <https://github.com/nodejs/node/tree/master/lib>):
 
@@ -282,11 +282,25 @@ import { isEmpty } from 'utils/collection-utils';
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
     group: ["utils/*"],
-    importNamePatterns: '^is',
+    importNamePattern: '^is',
     message: "Use 'isEmpty' from lodash instead."
 }]}]*/
 
 import { isEmpty } from 'utils/collection-utils';
+```
+
+:::
+
+::: incorrect { "sourceType": "module" }
+
+```js
+/*eslint no-restricted-imports: ["error", { patterns: [{
+    importNames: ["foo"],
+    group: ["bar/*"],
+    importNamePattern: '^bar',
+}]}]*/
+
+import { bar } from 'bar/*';
 ```
 
 :::
@@ -385,7 +399,7 @@ import { hasValues } from 'utils/collection-utils';
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
     group: ["utils/*"],
-    importNamePatterns: '^is',
+    importNamePattern: '^is',
     message: "Use 'isEmpty' from lodash instead."
 }]}]*/
 

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -275,6 +275,8 @@ import pick from 'fooBar';
 import { isEmpty } from 'utils/collection-utils';
 ```
 
+:::
+
 ::: incorrect { "sourceType": "module" }
 
 ```js

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -129,7 +129,7 @@ Regex patterns can also be used to restrict specific import Name:
 }]
 ```
 
-**Note:** If `importNames` and `importNamePattern` are used together then the `importNames` will be first considered.
+**Note:** If `importNames` and `importNamePattern` are used together, it initially reviews the value specified in `importNames`. Afterward, it focuses on assessing the value specified in `importNamePattern`.
 
 To restrict the use of all Node.js core imports (via <https://github.com/nodejs/node/tree/master/lib>):
 
@@ -287,6 +287,20 @@ import { isEmpty } from 'utils/collection-utils';
 }]}]*/
 
 import { isEmpty } from 'utils/collection-utils';
+```
+
+:::
+
+::: incorrect { "sourceType": "module" }
+
+```js
+/*eslint no-restricted-imports: ["error", { patterns: [{
+    group: ["bar/*"],
+    importNamePattern: '^(is|bar)',
+    message: "Use 'isBar' from foo/bar instead"
+}]}]*/
+
+import bar { isBar } from 'bar/*';
 ```
 
 :::

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -281,7 +281,7 @@ import { isEmpty } from 'utils/collection-utils';
 /*eslint no-restricted-imports: ["error", { patterns: [{
     group: ["utils/*"],
     importNamePattern: '^is',
-    message: "Use 'isEmpty' from lodash instead."
+    message: "Use 'is*' functions from lodash instead."
 }]}]*/
 
 import { isEmpty } from 'utils/collection-utils';
@@ -294,11 +294,11 @@ import { isEmpty } from 'utils/collection-utils';
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
     group: ["foo/*"],
-    importNamePattern: '^(is|bar)',
-    message: "Use 'isBar' from baz/bar instead"
+    importNamePattern: '^(is|has)',
+    message: "Use 'is*' and 'has*' functions from baz/bar instead"
 }]}]*/
 
-import bar, { isBar } from 'foo/bar';
+import { isSomething, hasSomething } from 'foo/bar';
 ```
 
 :::
@@ -307,12 +307,12 @@ import bar, { isBar } from 'foo/bar';
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
-    importNames: ["foo"],
     group: ["foo/*"],
-    importNamePattern: '^bar',
+    importNames: ["bar"],
+    importNamePattern: '^baz',
 }]}]*/
 
-import { bar } from 'foo/bar';
+import { bar, bazQux } from 'foo/quux';
 ```
 
 :::
@@ -412,7 +412,7 @@ import { hasValues } from 'utils/collection-utils';
 /*eslint no-restricted-imports: ["error", { patterns: [{
     group: ["utils/*"],
     importNamePattern: '^is',
-    message: "Use 'isEmpty' from lodash instead."
+    message: "Use 'is*' functions from lodash instead."
 }]}]*/
 
 import isEmpty, { hasValue } from 'utils/collection-utils';

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -270,7 +270,7 @@ module.exports = {
 
             const customMessage = group.customMessage;
             const restrictedImportNames = group.importNames;
-            const restrictedImportNamePattern = !group.importNamePattern ? null : new RegExp(group.importNamePattern, "u");
+            const restrictedImportNamePattern = group.importNamePattern ? new RegExp(group.importNamePattern, "u") : null;
 
             /*
              * If we are not restricting to any specific import names and just the pattern itself,

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -119,11 +119,11 @@ module.exports = {
 
             patternAndEverything: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted from being used by a pattern.",
 
-            patternAndEverythingWithRegexImportName: "* import is invalid because import name with '{{importNames}}' regex pattern from '{{importSource}}' is restricted from being used by a pattern.",
+            patternAndEverythingWithRegexImportName: "* import is invalid because import name matching '{{importNames}}' pattern from '{{importSource}}' is restricted from being used.",
             // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
             patternAndEverythingWithCustomMessage: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted from being used by a pattern. {{customMessage}}",
             // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
-            patternAndEverythingWithRegexImportNameAndCustomMessage: "* import is invalid because import name with '{{importNames}}' regex pattern from '{{importSource}}' is restricted from being used by a pattern. {{customMessage}}",
+            patternAndEverythingWithRegexImportNameAndCustomMessage: "* import is invalid because import name matching '{{importNames}}' pattern from '{{importSource}}' is restricted from being used. {{customMessage}}",
 
             everything: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted.",
             // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -259,29 +259,6 @@ module.exports = {
         /**
          * Report a restricted path specifically for patterns.
          * @param {node} node representing the restricted path reference
-         * @param {string} importSource representing the restricted import pattern
-         * @param {string} importName representing restricted import name
-         * @param {Object} specifier contains location of the node
-         * @param {string} customMessage contains message related to the restricted import name or pattern
-         * @returns {void}
-         * @private
-         */
-        function reportPatternAndImportName(node, importSource, importName, specifier, customMessage) {
-            context.report({
-                node,
-                messageId: customMessage ? "patternAndImportNameWithCustomMessage" : "patternAndImportName",
-                loc: specifier.loc,
-                data: {
-                    importSource,
-                    customMessage,
-                    importName
-                }
-            });
-        }
-
-        /**
-         * Report a restricted path specifically for patterns.
-         * @param {node} node representing the restricted path reference
          * @param {Object} group contains an Ignore instance for paths, the customMessage to show on failure,
          * and any restricted import names that have been specified in the config
          * @param {Map<string,Object[]>} importNames Map of import names that are being imported
@@ -299,85 +276,67 @@ module.exports = {
              * If we are not restricting to any specific import names and just the pattern itself,
              * report the error and move on
              */
-            if (!restrictedImportNames) {
-                if (restrictedImportNamePattern) {
-                    importNames.forEach((specifiers, importName) => {
-                        specifiers.forEach(specifier => {
-                            if (!restrictedImportNamePattern.test(importName)) {
-                                if (importName === "*") {
-                                    context.report({
-                                        node,
-                                        messageId: customMessage ? "patternAndEverythingWithRegexImportNameAndCustomMessage" : "patternAndEverythingWithRegexImportName",
-                                        loc: specifier.loc,
-                                        data: {
-                                            importSource,
-                                            importNames: restrictedImportNamePattern,
-                                            customMessage
-                                        }
-                                    });
-                                }
-
-                                return;
-                            }
-
-                            reportPatternAndImportName(node, importSource, importName, specifier, customMessage);
-                        });
-                    });
-                } else {
-                    context.report({
-                        node,
-                        messageId: customMessage ? "patternWithCustomMessage" : "patterns",
-                        data: {
-                            importSource,
-                            customMessage
-                        }
-                    });
-                }
-                return;
-            }
-
-            if (importNames.has("*")) {
-                const specifierData = importNames.get("*")[0];
-
+            if (!restrictedImportNames && !restrictedImportNamePattern) {
                 context.report({
                     node,
-                    messageId: customMessage ? "patternAndEverythingWithCustomMessage" : "patternAndEverything",
-                    loc: specifierData.loc,
+                    messageId: customMessage ? "patternWithCustomMessage" : "patterns",
                     data: {
                         importSource,
-                        importNames: restrictedImportNames,
                         customMessage
                     }
                 });
+                return;
             }
 
-            if (restrictedImportNamePattern) {
-                importNames.forEach((specifiers, importName) => {
-                    specifiers.forEach(specifier => {
-                        if (restrictedImportNames.includes(importName)) {
-                            reportPatternAndImportName(node, importSource, importName, specifier, customMessage);
-                        } else {
-                            if (!restrictedImportNamePattern.test(importName)) {
-                                return;
-                            }
+            importNames.forEach((specifiers, importName) => {
+                if (importName === "*") {
+                    const [specifier] = specifiers;
 
-                            reportPatternAndImportName(node, importSource, importName, specifier, customMessage);
-                        }
-                    });
-                });
-            } else {
-                restrictedImportNames.forEach(importName => {
-                    if (!importNames.has(importName)) {
-                        return;
+                    if (restrictedImportNames) {
+                        context.report({
+                            node,
+                            messageId: customMessage ? "patternAndEverythingWithCustomMessage" : "patternAndEverything",
+                            loc: specifier.loc,
+                            data: {
+                                importSource,
+                                importNames: restrictedImportNames,
+                                customMessage
+                            }
+                        });
+                    } else {
+                        context.report({
+                            node,
+                            messageId: customMessage ? "patternAndEverythingWithRegexImportNameAndCustomMessage" : "patternAndEverythingWithRegexImportName",
+                            loc: specifier.loc,
+                            data: {
+                                importSource,
+                                importNames: restrictedImportNamePattern,
+                                customMessage
+                            }
+                        });
                     }
 
-                    const specifiers = importNames.get(importName);
+                    return;
+                }
 
+                if (
+                    (restrictedImportNames && restrictedImportNames.includes(importName)) ||
+                    (restrictedImportNamePattern && restrictedImportNamePattern.test(importName))
+                ) {
                     specifiers.forEach(specifier => {
-                        reportPatternAndImportName(node, importSource, importName, specifier, customMessage);
+                        context.report({
+                            node,
+                            messageId: customMessage ? "patternAndImportNameWithCustomMessage" : "patternAndImportName",
+                            loc: specifier.loc,
+                            data: {
+                                importSource,
+                                customMessage,
+                                importName
+                            }
+                        });
                     });
-                });
-            }
+                }
+            });
         }
 
         /**

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -74,7 +74,7 @@ const arrayOfStringsOrObjectPatterns = {
                         minItems: 1,
                         uniqueItems: true
                     },
-                    importNamePatterns: {
+                    importNamePattern: {
                         type: "string"
                     },
                     message: {
@@ -182,11 +182,11 @@ module.exports = {
         }
 
         // relative paths are supported for this rule
-        const restrictedPatternGroups = restrictedPatterns.map(({ group, message, caseSensitive, importNames, importNamePatterns }) => ({
+        const restrictedPatternGroups = restrictedPatterns.map(({ group, message, caseSensitive, importNames, importNamePattern }) => ({
             matcher: ignore({ allowRelativePaths: true, ignorecase: !caseSensitive }).add(group),
             customMessage: message,
             importNames,
-            importNamePattern: new RegExp(importNamePatterns, "u")
+            importNamePattern
         }));
 
         // if no imports are restricted we don't need to check
@@ -259,6 +259,29 @@ module.exports = {
         /**
          * Report a restricted path specifically for patterns.
          * @param {node} node representing the restricted path reference
+         * @param {string} importSource representing the restricted import pattern
+         * @param {string} importName representing restricted import name
+         * @param {Object} specifier contains location of the node
+         * @param {string} customMessage contains message related to the restricted import name or pattern
+         * @returns {void}
+         * @private
+         */
+        function reportPatternAndImportName(node, importSource, importName, specifier, customMessage) {
+            context.report({
+                node,
+                messageId: customMessage ? "patternAndImportNameWithCustomMessage" : "patternAndImportName",
+                loc: specifier.loc,
+                data: {
+                    importSource,
+                    customMessage,
+                    importName
+                }
+            });
+        }
+
+        /**
+         * Report a restricted path specifically for patterns.
+         * @param {node} node representing the restricted path reference
          * @param {Object} group contains an Ignore instance for paths, the customMessage to show on failure,
          * and any restricted import names that have been specified in the config
          * @param {Map<string,Object[]>} importNames Map of import names that are being imported
@@ -270,14 +293,14 @@ module.exports = {
 
             const customMessage = group.customMessage;
             const restrictedImportNames = group.importNames;
-            const restrictedImportNamePattern = group.importNamePattern;
+            const restrictedImportNamePattern = !group.importNamePattern ? null : new RegExp(group.importNamePattern, "u");
 
             /*
              * If we are not restricting to any specific import names and just the pattern itself,
              * report the error and move on
              */
             if (!restrictedImportNames) {
-                if (!restrictedImportNamePattern.test("")) {
+                if (restrictedImportNamePattern) {
                     importNames.forEach((specifiers, importName) => {
                         specifiers.forEach(specifier => {
                             if (!restrictedImportNamePattern.test(importName)) {
@@ -297,16 +320,7 @@ module.exports = {
                                 return;
                             }
 
-                            context.report({
-                                node,
-                                messageId: customMessage ? "patternAndImportNameWithCustomMessage" : "patternAndImportName",
-                                loc: specifier.loc,
-                                data: {
-                                    importSource,
-                                    importName,
-                                    customMessage
-                                }
-                            });
+                            reportPatternAndImportName(node, importSource, importName, specifier, customMessage);
                         });
                     });
                 } else {
@@ -337,26 +351,33 @@ module.exports = {
                 });
             }
 
-            restrictedImportNames.forEach(importName => {
-                if (!importNames.has(importName)) {
-                    return;
-                }
+            if (restrictedImportNamePattern) {
+                importNames.forEach((specifiers, importName) => {
+                    specifiers.forEach(specifier => {
+                        if (restrictedImportNames.includes(importName)) {
+                            reportPatternAndImportName(node, importSource, importName, specifier, customMessage);
+                        } else {
+                            if (!restrictedImportNamePattern.test(importName)) {
+                                return;
+                            }
 
-                const specifiers = importNames.get(importName);
-
-                specifiers.forEach(specifier => {
-                    context.report({
-                        node,
-                        messageId: customMessage ? "patternAndImportNameWithCustomMessage" : "patternAndImportName",
-                        loc: specifier.loc,
-                        data: {
-                            importSource,
-                            customMessage,
-                            importName
+                            reportPatternAndImportName(node, importSource, importName, specifier, customMessage);
                         }
                     });
                 });
-            });
+            } else {
+                restrictedImportNames.forEach(importName => {
+                    if (!importNames.has(importName)) {
+                        return;
+                    }
+
+                    const specifiers = importNames.get(importName);
+
+                    specifiers.forEach(specifier => {
+                        reportPatternAndImportName(node, importSource, importName, specifier, customMessage);
+                    });
+                });
+            }
         }
 
         /**

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -74,6 +74,9 @@ const arrayOfStringsOrObjectPatterns = {
                         minItems: 1,
                         uniqueItems: true
                     },
+                    importNamePatterns: {
+                        type: "string"
+                    },
                     message: {
                         type: "string",
                         minLength: 1
@@ -115,8 +118,12 @@ module.exports = {
             patternAndImportNameWithCustomMessage: "'{{importName}}' import from '{{importSource}}' is restricted from being used by a pattern. {{customMessage}}",
 
             patternAndEverything: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted from being used by a pattern.",
+
+            patternAndEverythingWithRegexImportName: "* import is invalid because import name with '{{importNames}}' regex pattern from '{{importSource}}' is restricted from being used by a pattern.",
             // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
             patternAndEverythingWithCustomMessage: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted from being used by a pattern. {{customMessage}}",
+            // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
+            patternAndEverythingWithRegexImportNameAndCustomMessage: "* import is invalid because import name with '{{importNames}}' regex pattern from '{{importSource}}' is restricted from being used by a pattern. {{customMessage}}",
 
             everything: "* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted.",
             // eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
@@ -175,10 +182,11 @@ module.exports = {
         }
 
         // relative paths are supported for this rule
-        const restrictedPatternGroups = restrictedPatterns.map(({ group, message, caseSensitive, importNames }) => ({
+        const restrictedPatternGroups = restrictedPatterns.map(({ group, message, caseSensitive, importNames, importNamePatterns }) => ({
             matcher: ignore({ allowRelativePaths: true, ignorecase: !caseSensitive }).add(group),
             customMessage: message,
-            importNames
+            importNames,
+            importNamePattern: new RegExp(importNamePatterns, "u")
         }));
 
         // if no imports are restricted we don't need to check
@@ -262,20 +270,55 @@ module.exports = {
 
             const customMessage = group.customMessage;
             const restrictedImportNames = group.importNames;
+            const restrictedImportNamePattern = group.importNamePattern;
 
             /*
              * If we are not restricting to any specific import names and just the pattern itself,
              * report the error and move on
              */
             if (!restrictedImportNames) {
-                context.report({
-                    node,
-                    messageId: customMessage ? "patternWithCustomMessage" : "patterns",
-                    data: {
-                        importSource,
-                        customMessage
-                    }
-                });
+                if (!restrictedImportNamePattern.test("")) {
+                    importNames.forEach((specifiers, importName) => {
+                        specifiers.forEach(specifier => {
+                            if (!restrictedImportNamePattern.test(importName)) {
+                                if (importName === "*") {
+                                    context.report({
+                                        node,
+                                        messageId: customMessage ? "patternAndEverythingWithRegexImportNameAndCustomMessage" : "patternAndEverythingWithRegexImportName",
+                                        loc: specifier.loc,
+                                        data: {
+                                            importSource,
+                                            importNames: restrictedImportNamePattern,
+                                            customMessage
+                                        }
+                                    });
+                                }
+
+                                return;
+                            }
+
+                            context.report({
+                                node,
+                                messageId: customMessage ? "patternAndImportNameWithCustomMessage" : "patternAndImportName",
+                                loc: specifier.loc,
+                                data: {
+                                    importSource,
+                                    importName,
+                                    customMessage
+                                }
+                            });
+                        });
+                    });
+                } else {
+                    context.report({
+                        node,
+                        messageId: customMessage ? "patternWithCustomMessage" : "patterns",
+                        data: {
+                            importSource,
+                            customMessage
+                        }
+                    });
+                }
                 return;
             }
 

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -282,6 +282,15 @@ ruleTester.run("no-restricted-imports", rule, {
                     importNames: ["Foo"]
                 }]
             }]
+        },
+        {
+            code: "import Foo from '../../my/relative-module';",
+            options: [{
+                patterns: [{
+                    group: ["**/my/relative-module"],
+                    importNamePatterns: "^Foo"
+                }]
+            }]
         }
     ],
     invalid: [{
@@ -1234,6 +1243,112 @@ ruleTester.run("no-restricted-imports", rule, {
             column: 8,
             endColumn: 11,
             message: "'default' import from 'mod' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "import { Foo } from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                group: ["**/my/relative-module"],
+                importNamePatterns: "^Foo"
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 13,
+            message: "'Foo' import from '../../my/relative-module' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "import { FooBar } from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                group: ["**/my/relative-module"],
+                importNamePatterns: "^Foo"
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 16,
+            message: "'FooBar' import from '../../my/relative-module' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "import Foo, { Bar } from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                group: ["**/my/relative-module"],
+                importNamePatterns: "^Foo|^Bar"
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 15,
+            endColumn: 18,
+            message: "'Bar' import from '../../my/relative-module' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "import { Foo, Bar } from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                group: ["**/my/relative-module"],
+                importNamePatterns: "^Foo|^Bar"
+            }]
+        }],
+        errors: [
+            {
+                type: "ImportDeclaration",
+                line: 1,
+                column: 10,
+                endColumn: 13,
+                message: "'Foo' import from '../../my/relative-module' is restricted from being used by a pattern."
+            },
+            {
+                type: "ImportDeclaration",
+                line: 1,
+                column: 15,
+                endColumn: 18,
+                message: "'Bar' import from '../../my/relative-module' is restricted from being used by a pattern."
+            }
+        ]
+    },
+    {
+        code: "import * as All from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                group: ["**/my/relative-module"],
+                importNamePatterns: "^Foo"
+            }]
+        }],
+        errors: [{
+            message: "* import is invalid because import name with '/^Foo/u' regex pattern from '../../my/relative-module' is restricted from being used by a pattern.",
+            type: "ImportDeclaration",
+            line: 1,
+            column: 8,
+            endColumn: 16
+        }]
+    },
+    {
+        code: "import * as AllWithCustomMessage from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                group: ["**/my/relative-module"],
+                importNamePatterns: "^Foo",
+                message: "Import from @/utils instead."
+            }]
+        }],
+        errors: [{
+            message: "* import is invalid because import name with '/^Foo/u' regex pattern from '../../my/relative-module' is restricted from being used by a pattern. Import from @/utils instead.",
+            type: "ImportDeclaration",
+            line: 1,
+            column: 8,
+            endColumn: 33
         }]
     }
     ]

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -288,7 +288,7 @@ ruleTester.run("no-restricted-imports", rule, {
             options: [{
                 patterns: [{
                     group: ["**/my/relative-module"],
-                    importNamePatterns: "^Foo"
+                    importNamePattern: "^Foo"
                 }]
             }]
         }
@@ -1250,7 +1250,7 @@ ruleTester.run("no-restricted-imports", rule, {
         options: [{
             patterns: [{
                 group: ["**/my/relative-module"],
-                importNamePatterns: "^Foo"
+                importNamePattern: "^Foo"
             }]
         }],
         errors: [{
@@ -1266,7 +1266,7 @@ ruleTester.run("no-restricted-imports", rule, {
         options: [{
             patterns: [{
                 group: ["**/my/relative-module"],
-                importNamePatterns: "^Foo"
+                importNamePattern: "^Foo"
             }]
         }],
         errors: [{
@@ -1282,7 +1282,7 @@ ruleTester.run("no-restricted-imports", rule, {
         options: [{
             patterns: [{
                 group: ["**/my/relative-module"],
-                importNamePatterns: "^Foo|^Bar"
+                importNamePattern: "^Foo|^Bar"
             }]
         }],
         errors: [{
@@ -1298,7 +1298,7 @@ ruleTester.run("no-restricted-imports", rule, {
         options: [{
             patterns: [{
                 group: ["**/my/relative-module"],
-                importNamePatterns: "^Foo|^Bar"
+                importNamePattern: "^Foo|^Bar"
             }]
         }],
         errors: [
@@ -1323,7 +1323,7 @@ ruleTester.run("no-restricted-imports", rule, {
         options: [{
             patterns: [{
                 group: ["**/my/relative-module"],
-                importNamePatterns: "^Foo"
+                importNamePattern: "^Foo"
             }]
         }],
         errors: [{
@@ -1339,7 +1339,7 @@ ruleTester.run("no-restricted-imports", rule, {
         options: [{
             patterns: [{
                 group: ["**/my/relative-module"],
-                importNamePatterns: "^Foo",
+                importNamePattern: "^Foo",
                 message: "Import from @/utils instead."
             }]
         }],
@@ -1350,6 +1350,118 @@ ruleTester.run("no-restricted-imports", rule, {
             column: 8,
             endColumn: 33
         }]
+    },
+    {
+        code: "import * as AllWithCustomMessage from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                importNames: ["Foo"],
+                group: ["**/my/relative-module"],
+                importNamePattern: "^Foo",
+                message: "Import from @/utils instead."
+            }]
+        }],
+        errors: [{
+            message: "* import is invalid because 'Foo' from '../../my/relative-module' is restricted from being used by a pattern. Import from @/utils instead.",
+            type: "ImportDeclaration",
+            line: 1,
+            column: 8,
+            endColumn: 33
+        }]
+    },
+    {
+        code: "import { Foo } from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                importNames: ["Foo"],
+                group: ["**/my/relative-module"],
+                importNamePattern: "^Foo"
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 13,
+            message: "'Foo' import from '../../my/relative-module' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "import { Foo } from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                importNames: ["Foo", "Bar"],
+                group: ["**/my/relative-module"],
+                importNamePattern: "^Foo"
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 13,
+            message: "'Foo' import from '../../my/relative-module' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "import { Foo } from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                importNames: ["Bar"],
+                group: ["**/my/relative-module"],
+                importNamePattern: "^Foo"
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 13,
+            message: "'Foo' import from '../../my/relative-module' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "import { Foo } from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                importNames: ["Foo"],
+                group: ["**/my/relative-module"],
+                importNamePattern: "^Bar"
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 13,
+            message: "'Foo' import from '../../my/relative-module' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "import { Foo, Bar } from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                importNames: ["Foo"],
+                group: ["**/my/relative-module"],
+                importNamePattern: "^Bar"
+            }]
+        }],
+        errors: [
+            {
+                type: "ImportDeclaration",
+                line: 1,
+                column: 10,
+                endColumn: 13,
+                message: "'Foo' import from '../../my/relative-module' is restricted from being used by a pattern."
+            },
+            {
+                type: "ImportDeclaration",
+                line: 1,
+                column: 15,
+                endColumn: 18,
+                message: "'Bar' import from '../../my/relative-module' is restricted from being used by a pattern."
+            }
+        ]
     }
     ]
 });

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -1430,7 +1430,7 @@ ruleTester.run("no-restricted-imports", rule, {
         options: [{
             patterns: [{
                 group: ["**/my/relative-module"],
-                importNamePattern: "^Foo|^Bar"
+                importNamePattern: "^(Foo|Bar)"
             }]
         }],
         errors: [
@@ -1459,7 +1459,7 @@ ruleTester.run("no-restricted-imports", rule, {
             }]
         }],
         errors: [{
-            message: "* import is invalid because import name with '/^Foo/u' regex pattern from 'foo' is restricted from being used by a pattern.",
+            message: "* import is invalid because import name matching '/^Foo/u' pattern from 'foo' is restricted from being used.",
             type: "ImportDeclaration",
             line: 1,
             column: 8,
@@ -1475,7 +1475,7 @@ ruleTester.run("no-restricted-imports", rule, {
             }]
         }],
         errors: [{
-            message: "* import is invalid because import name with '/^Foo/u' regex pattern from '../../my/relative-module' is restricted from being used by a pattern.",
+            message: "* import is invalid because import name matching '/^Foo/u' pattern from '../../my/relative-module' is restricted from being used.",
             type: "ImportDeclaration",
             line: 1,
             column: 8,
@@ -1492,7 +1492,7 @@ ruleTester.run("no-restricted-imports", rule, {
             }]
         }],
         errors: [{
-            message: "* import is invalid because import name with '/^Foo/u' regex pattern from '../../my/relative-module' is restricted from being used by a pattern. Import from @/utils instead.",
+            message: "* import is invalid because import name matching '/^Foo/u' pattern from '../../my/relative-module' is restricted from being used. Import from @/utils instead.",
             type: "ImportDeclaration",
             line: 1,
             column: 8,
@@ -1673,7 +1673,7 @@ ruleTester.run("no-restricted-imports", rule, {
             line: 1,
             column: 8,
             endColumn: 9,
-            message: "* import is invalid because import name with '/^Foo/u' regex pattern from 'foo' is restricted from being used by a pattern."
+            message: "* import is invalid because import name matching '/^Foo/u' pattern from 'foo' is restricted from being used."
         }]
     }
     ]

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -284,10 +284,94 @@ ruleTester.run("no-restricted-imports", rule, {
             }]
         },
         {
+            code: "import Foo from 'foo';",
+            options: [{
+                patterns: [{
+                    group: ["foo"],
+                    importNamePattern: "^Foo"
+                }]
+            }]
+        },
+        {
+            code: "import Foo from 'foo';",
+            options: [{
+                patterns: [{
+                    importNames: ["Foo"],
+                    group: ["foo"],
+                    importNamePattern: "^Foo"
+                }]
+            }]
+        },
+        {
             code: "import Foo from '../../my/relative-module';",
             options: [{
                 patterns: [{
                     group: ["**/my/relative-module"],
+                    importNamePattern: "^Foo"
+                }]
+            }]
+        },
+        {
+            code: "import { Bar } from '../../my/relative-module';",
+            options: [{
+                patterns: [{
+                    group: ["**/my/relative-module"],
+                    importNamePattern: "^Foo"
+                }]
+            }]
+        },
+        {
+            code: "import { Bar as Foo } from '../../my/relative-module';",
+            options: [{
+                patterns: [{
+                    group: ["**/my/relative-module"],
+                    importNamePattern: "^Foo"
+                }]
+            }]
+        },
+        {
+            code: "import { Bar as Foo } from '../../my/relative-module';",
+            options: [{
+                patterns: [{
+                    importNames: ["Foo"],
+                    group: ["**/my/relative-module"],
+                    importNamePattern: "^Foo"
+                }]
+            }]
+        },
+        {
+            code: "import Foo, { Baz as Bar } from '../../my/relative-module';",
+            options: [{
+                patterns: [{
+                    group: ["**/my/relative-module"],
+                    importNamePattern: "^(Foo|Bar)"
+                }]
+            }]
+        },
+        {
+            code: "import Foo, { Baz as Bar } from '../../my/relative-module';",
+            options: [{
+                patterns: [{
+                    importNames: ["Foo"],
+                    group: ["**/my/relative-module"],
+                    importNamePattern: "^Bar"
+                }]
+            }]
+        },
+        {
+            code: "export { Bar } from 'foo';",
+            options: [{
+                patterns: [{
+                    group: ["foo"],
+                    importNamePattern: "^Foo"
+                }]
+            }]
+        },
+        {
+            code: "export { Bar as Foo } from 'foo';",
+            options: [{
+                patterns: [{
+                    group: ["foo"],
                     importNamePattern: "^Foo"
                 }]
             }]
@@ -1246,6 +1330,54 @@ ruleTester.run("no-restricted-imports", rule, {
         }]
     },
     {
+        code: "import { Foo } from 'foo';",
+        options: [{
+            patterns: [{
+                group: ["foo"],
+                importNamePattern: "^Foo"
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 13,
+            message: "'Foo' import from 'foo' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "import { Foo as Bar } from 'foo';",
+        options: [{
+            patterns: [{
+                group: ["foo"],
+                importNamePattern: "^Foo"
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 20,
+            message: "'Foo' import from 'foo' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "import Foo, { Bar } from 'foo';",
+        options: [{
+            patterns: [{
+                group: ["foo"],
+                importNamePattern: "^(Foo|Bar)"
+            }]
+        }],
+        errors: [{
+            type: "ImportDeclaration",
+            line: 1,
+            column: 15,
+            endColumn: 18,
+            message: "'Bar' import from 'foo' is restricted from being used by a pattern."
+        }]
+    },
+    {
         code: "import { Foo } from '../../my/relative-module';",
         options: [{
             patterns: [{
@@ -1317,6 +1449,22 @@ ruleTester.run("no-restricted-imports", rule, {
                 message: "'Bar' import from '../../my/relative-module' is restricted from being used by a pattern."
             }
         ]
+    },
+    {
+        code: "import * as Foo from 'foo';",
+        options: [{
+            patterns: [{
+                group: ["foo"],
+                importNamePattern: "^Foo"
+            }]
+        }],
+        errors: [{
+            message: "* import is invalid because import name with '/^Foo/u' regex pattern from 'foo' is restricted from being used by a pattern.",
+            type: "ImportDeclaration",
+            line: 1,
+            column: 8,
+            endColumn: 16
+        }]
     },
     {
         code: "import * as All from '../../my/relative-module';",
@@ -1462,6 +1610,71 @@ ruleTester.run("no-restricted-imports", rule, {
                 message: "'Bar' import from '../../my/relative-module' is restricted from being used by a pattern."
             }
         ]
+    },
+    {
+        code: "export { Foo } from 'foo';",
+        options: [{
+            patterns: [{
+                group: ["foo"],
+                importNamePattern: "^Foo"
+            }]
+        }],
+        errors: [{
+            type: "ExportNamedDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 13,
+            message: "'Foo' import from 'foo' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "export { Foo as Bar } from 'foo';",
+        options: [{
+            patterns: [{
+                group: ["foo"],
+                importNamePattern: "^Foo"
+            }]
+        }],
+        errors: [{
+            type: "ExportNamedDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 20,
+            message: "'Foo' import from 'foo' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "export { Foo } from 'foo';",
+        options: [{
+            patterns: [{
+                importNames: ["Bar"],
+                group: ["foo"],
+                importNamePattern: "^Foo"
+            }]
+        }],
+        errors: [{
+            type: "ExportNamedDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 13,
+            message: "'Foo' import from 'foo' is restricted from being used by a pattern."
+        }]
+    },
+    {
+        code: "export * from 'foo';",
+        options: [{
+            patterns: [{
+                group: ["foo"],
+                importNamePattern: "^Foo"
+            }]
+        }],
+        errors: [{
+            type: "ExportAllDeclaration",
+            line: 1,
+            column: 8,
+            endColumn: 9,
+            message: "* import is invalid because import name with '/^Foo/u' regex pattern from 'foo' is restricted from being used by a pattern."
+        }]
     }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added a new option in `no-restricted-imports` rule that enable to use regex pattern to restrict a particular import name that matches a given regex pattern.

#### Is there anything you'd like reviewers to focus on?
Fixes #17303 

<!-- markdownlint-disable-file MD004 -->
