### PR TITLE
fix: allow circular references in config

### DIFF
--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -61,20 +61,23 @@ function isUndefined(value) {
     return typeof value === "undefined";
 }
 
+// A unique empty object to be used internally as a mapping key in `deepMerge`.
+const EMPTY_OBJECT = {};
+
 /**
  * Deeply merges two objects.
  * @param {Object} first The base object.
- * @param {Object} second The overrides object.
+ * @param {any} second The overrides value.
  * @param {Map<string, Map<string, Object>>} [mergeMap] Maps the combination of first and second arguments to a merged result.
  * @returns {Object} An object with properties from both first and second.
  */
-function deepMerge(first, second, mergeMap = new Map()) {
+function deepMerge(first, second = {}, mergeMap = new Map()) {
 
     /*
-     * If either argument is an array, just return the second one. We don't merge
+     * If the second value is an array, just return it. We don't merge
      * arrays because order matters and we can't know the correct order.
      */
-    if (Array.isArray(first) || Array.isArray(second)) {
+    if (Array.isArray(second)) {
         return second;
     }
 
@@ -94,7 +97,7 @@ function deepMerge(first, second, mergeMap = new Map()) {
     }
 
     /*
-     * First create a result object where properties from the second object
+     * First create a result object where properties from the second value
      * overwrite properties from the first. This sets up a baseline to use
      * later rather than needing to inspect and change every property
      * individually.
@@ -117,10 +120,14 @@ function deepMerge(first, second, mergeMap = new Map()) {
         const firstValue = first[key];
         const secondValue = second[key];
 
-        if (isNonNullObject(firstValue) && isNonNullObject(secondValue)) {
+        if (isNonNullObject(firstValue)) {
             result[key] = deepMerge(firstValue, secondValue, mergeMap);
-        } else if (isUndefined(secondValue)) {
-            result[key] = firstValue;
+        } else if (isUndefined(firstValue)) {
+            if (isNonNullObject(secondValue)) {
+                result[key] = deepMerge(EMPTY_OBJECT, secondValue, mergeMap);
+            } else if (!isUndefined(secondValue)) {
+                result[key] = secondValue;
+            }
         }
     }
 

--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -65,16 +65,32 @@ function isUndefined(value) {
  * Deeply merges two objects.
  * @param {Object} first The base object.
  * @param {Object} second The overrides object.
+ * @param {Map<string, Map<string, Object>>} [mergeMap] Maps the combination of first and second arguments to a merged result.
  * @returns {Object} An object with properties from both first and second.
  */
-function deepMerge(first = {}, second = {}) {
+function deepMerge(first, second, mergeMap = new Map()) {
 
     /*
-     * If the second value is an array, just return it. We don't merge
+     * If either argument is an array, just return the second one. We don't merge
      * arrays because order matters and we can't know the correct order.
      */
-    if (Array.isArray(second)) {
+    if (Array.isArray(first) || Array.isArray(second)) {
         return second;
+    }
+
+    let secondMergeMap = mergeMap.get(first);
+
+    if (secondMergeMap) {
+        const result = secondMergeMap.get(second);
+
+        if (result) {
+
+            // If this combination of first and second arguments has been already visited, return the previously created result.
+            return result;
+        }
+    } else {
+        secondMergeMap = new Map();
+        mergeMap.set(first, secondMergeMap);
     }
 
     /*
@@ -88,6 +104,9 @@ function deepMerge(first = {}, second = {}) {
         ...second
     };
 
+    // Store the pending result for this combination of first and second arguments.
+    secondMergeMap.set(second, result);
+
     for (const key of Object.keys(second)) {
 
         // avoid hairy edge case
@@ -98,17 +117,10 @@ function deepMerge(first = {}, second = {}) {
         const firstValue = first[key];
         const secondValue = second[key];
 
-        if (isNonNullObject(firstValue)) {
-            result[key] = deepMerge(firstValue, secondValue);
-        } else if (isUndefined(firstValue)) {
-            if (isNonNullObject(secondValue)) {
-                result[key] = deepMerge(
-                    Array.isArray(secondValue) ? [] : {},
-                    secondValue
-                );
-            } else if (!isUndefined(secondValue)) {
-                result[key] = secondValue;
-            }
+        if (isNonNullObject(firstValue) && isNonNullObject(secondValue)) {
+            result[key] = deepMerge(firstValue, secondValue, mergeMap);
+        } else if (isUndefined(secondValue)) {
+            result[key] = firstValue;
         }
     }
 

--- a/tests/lib/config/flat-config-schema.js
+++ b/tests/lib/config/flat-config-schema.js
@@ -1,0 +1,222 @@
+/**
+ * @fileoverview Tests for flatConfigSchema
+ * @author Francesco Trotta
+ */
+
+"use strict";
+
+const { flatConfigSchema } = require("../../../lib/config/flat-config-schema");
+const { assert } = require("chai");
+
+describe("merge", () => {
+
+    const { merge } = flatConfigSchema.settings;
+
+    it("merges two objects", () => {
+        const first = { foo: 42 };
+        const second = { bar: "baz" };
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, { ...first, ...second });
+    });
+
+    it("does not merge an object and an array", () => {
+        const first = { foo: 42 };
+        const second = ["bar", "baz"];
+        const result = merge(first, second);
+
+        assert.strictEqual(result, second);
+    });
+
+    it("does not merge an array with an object", () => {
+        const first = ["foo", "bar"];
+        const second = { baz: 42 };
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, second);
+    });
+
+    it("does not merge two arrays", () => {
+        const first = ["foo", "bar"];
+        const second = ["baz", "qux"];
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, second);
+    });
+
+    it("returns an emtpy object if both values are undefined", () => {
+        const result = merge(void 0, void 0);
+
+        assert.deepStrictEqual(result, {});
+    });
+
+    it("returns an object equal to the first one if the second one is undefined", () => {
+        const first = { foo: 42, bar: "baz" };
+        const result = merge(first, void 0);
+
+        assert.deepStrictEqual(result, first);
+        assert.notStrictEqual(result, first);
+    });
+
+    it("returns an object equal to the second one if the first one is undefined", () => {
+        const second = { foo: 42, bar: "baz" };
+        const result = merge(void 0, second);
+
+        assert.deepStrictEqual(result, second);
+        assert.notStrictEqual(result, second);
+    });
+
+    it("merges two objects in a property", () => {
+        const first = { foo: { bar: "baz" } };
+        const second = { foo: { qux: 42 } };
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, { foo: { bar: "baz", qux: 42 } });
+    });
+
+    it("does not overwrite a value in the first object with undefined in the second one", () => {
+        const first = { foo: { bar: "baz" } };
+        const second = { foo: void 0 };
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, first);
+        assert.notStrictEqual(result, first);
+    });
+
+    it("does not change the prototype of a merged object", () => {
+        const first = { foo: 42 };
+        const second = { bar: "baz", ["__proto__"]: { qux: true } };
+        const result = merge(first, second);
+
+        assert.strictEqual(Object.getPrototypeOf(result), Object.prototype);
+    });
+
+    it("does not merge the '__proto__' property", () => {
+        const first = { ["__proto__"]: { foo: 42 } };
+        const second = { ["__proto__"]: { bar: "baz" } };
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, second);
+        assert.notStrictEqual(result, second);
+    });
+
+    it("overwrites a value in the first object with null in the second one", () => {
+        const first = { foo: { bar: "baz" } };
+        const second = { foo: null };
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, second);
+        assert.notStrictEqual(result, second);
+    });
+
+    it("overwrites a value in the first object with a primitive in the second one", () => {
+        const first = { foo: { bar: "baz" } };
+        const second = { foo: 42 };
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, second);
+        assert.notStrictEqual(result, second);
+    });
+
+    it("merges objects with self-references", () => {
+        const first = { foo: 42 };
+
+        first.first = first;
+        const second = { bar: "baz" };
+
+        second.second = second;
+        const result = merge(first, second);
+
+        assert.strictEqual(result.first, first);
+        assert.strictEqual(result.second, second);
+
+        const expected = { foo: 42, bar: "baz" };
+
+        expected.first = first;
+        expected.second = second;
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it("merges objects with overlapping self-references", () => {
+        const first = { foo: 42 };
+
+        first.reference = first;
+        const second = { bar: "baz" };
+
+        second.reference = second;
+
+        const result = merge(first, second);
+
+        assert.strictEqual(result.reference, result);
+
+        const expected = { foo: 42, bar: "baz" };
+
+        expected.reference = expected;
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it("merges objects with cross-references", () => {
+        const first = { foo: 42 };
+        const second = { bar: "baz" };
+
+        first.second = second;
+        second.first = first;
+
+        const result = merge(first, second);
+
+        assert.strictEqual(result.first, first);
+        assert.strictEqual(result.second, second);
+
+        const expected = { foo: 42, bar: "baz" };
+
+        expected.first = first;
+        expected.second = second;
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it("merges objects with overlapping cross-references", () => {
+        const first = { foo: 42 };
+        const second = { bar: "baz" };
+
+        first.reference = second;
+        second.reference = first;
+
+        const result = merge(first, second);
+
+        assert.strictEqual(result, result.reference.reference);
+
+        const expected = { foo: 42, bar: "baz", reference: { foo: 42, bar: "baz" } };
+
+        expected.reference.reference = expected;
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it("produces the same results for the same combinations of property values", () => {
+        const firstCommon = { foo: 42 };
+        const secondCommon = { bar: "baz" };
+        const first = {
+            a: firstCommon,
+            b: firstCommon,
+            c: { foo: "different" },
+            d: firstCommon
+        };
+        const second = {
+            a: secondCommon,
+            b: { bar: "something else" },
+            c: secondCommon,
+            d: secondCommon
+        };
+        const result = merge(first, second);
+
+        assert.strictEqual(result.a, result.d);
+
+        const expected = {
+            a: { foo: 42, bar: "baz" },
+            b: { foo: 42, bar: "something else" },
+            c: { foo: "different", bar: "baz" },
+            d: { foo: 42, bar: "baz" }
+        };
+
+        assert.deepStrictEqual(result, expected);
+    });
+});

--- a/tests/lib/config/flat-config-schema.js
+++ b/tests/lib/config/flat-config-schema.js
@@ -20,7 +20,7 @@ describe("merge", () => {
         assert.deepStrictEqual(result, { ...first, ...second });
     });
 
-    it("does not merge an object and an array", () => {
+    it("overrides an object with an array", () => {
         const first = { foo: 42 };
         const second = ["bar", "baz"];
         const result = merge(first, second);
@@ -28,20 +28,20 @@ describe("merge", () => {
         assert.strictEqual(result, second);
     });
 
-    it("does not merge an array with an object", () => {
+    it("merges an array with an object", () => {
         const first = ["foo", "bar"];
         const second = { baz: 42 };
         const result = merge(first, second);
 
-        assert.deepStrictEqual(result, second);
+        assert.deepStrictEqual(result, { 0: "foo", 1: "bar", baz: 42 });
     });
 
-    it("does not merge two arrays", () => {
+    it("overrides an array with another array", () => {
         const first = ["foo", "bar"];
         const second = ["baz", "qux"];
         const result = merge(first, second);
 
-        assert.deepStrictEqual(result, second);
+        assert.strictEqual(result, second);
     });
 
     it("returns an emtpy object if both values are undefined", () => {
@@ -74,7 +74,7 @@ describe("merge", () => {
         assert.deepStrictEqual(result, { foo: { bar: "baz", qux: 42 } });
     });
 
-    it("does not overwrite a value in the first object with undefined in the second one", () => {
+    it("does not override a value in a property with undefined", () => {
         const first = { foo: { bar: "baz" } };
         const second = { foo: void 0 };
         const result = merge(first, second);
@@ -100,22 +100,28 @@ describe("merge", () => {
         assert.notStrictEqual(result, second);
     });
 
-    it("overwrites a value in the first object with null in the second one", () => {
+    it("throws an error if a value in a property is overriden with null", () => {
         const first = { foo: { bar: "baz" } };
         const second = { foo: null };
-        const result = merge(first, second);
 
-        assert.deepStrictEqual(result, second);
-        assert.notStrictEqual(result, second);
+        assert.throws(() => merge(first, second), TypeError);
     });
 
-    it("overwrites a value in the first object with a primitive in the second one", () => {
+    it("does not override a value in a property with a primitive", () => {
         const first = { foo: { bar: "baz" } };
         const second = { foo: 42 };
         const result = merge(first, second);
 
-        assert.deepStrictEqual(result, second);
-        assert.notStrictEqual(result, second);
+        assert.deepStrictEqual(result, first);
+        assert.notStrictEqual(result, first);
+    });
+
+    it("merges an object in a property with a string", () => {
+        const first = { foo: { bar: "baz" } };
+        const second = { foo: "qux" };
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, { foo: { 0: "q", 1: "u", 2: "x", bar: "baz" } });
     });
 
     it("merges objects with self-references", () => {
@@ -128,7 +134,7 @@ describe("merge", () => {
         const result = merge(first, second);
 
         assert.strictEqual(result.first, first);
-        assert.strictEqual(result.second, second);
+        assert.deepStrictEqual(result.second, second);
 
         const expected = { foo: 42, bar: "baz" };
 
@@ -164,7 +170,7 @@ describe("merge", () => {
 
         const result = merge(first, second);
 
-        assert.strictEqual(result.first, first);
+        assert.deepStrictEqual(result.first, first);
         assert.strictEqual(result.second, second);
 
         const expected = { foo: 42, bar: "baz" };
@@ -208,7 +214,7 @@ describe("merge", () => {
         };
         const result = merge(first, second);
 
-        assert.strictEqual(result.a, result.d);
+        assert.deepStrictEqual(result.a, result.d);
 
         const expected = {
             a: { foo: 42, bar: "baz" },

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -6065,7 +6065,7 @@ describe("FlatESLint", () => {
 
             await eslint.lintText("debugger;");
 
-            assert.strictEqual(resolvedSettings.sharedData, circular);
+            assert.deepStrictEqual(resolvedSettings.sharedData, circular);
         });
 
         it("in 'parserOptions'", async () => {
@@ -6093,7 +6093,7 @@ describe("FlatESLint", () => {
 
             await eslint.lintText("debugger;");
 
-            assert.strictEqual(resolvedParserOptions.testOption, circular);
+            assert.deepStrictEqual(resolvedParserOptions.testOption, circular);
         });
     });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #17665

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR fixes an issue that would cause a stack overflow when configuration `settings` or `parserOptions` contain a circular reference.

The fix uses a two-dimensional map in the `deepMerge` function to keep track of the results previously created when merging pairs of arguments. If the same pair of arguments is encountered later on while merging another property, the previous result will be returned immediately. This avoids infinite recursion.

#### Is there anything you'd like reviewers to focus on?

I have questions about two important implementation details. Would like reviewers to confirm if my approach is okay or how to change it.

##### Question 1

What is the expected result when merging an object with a primitive or a function? E.g.

```js
// current result is { a: { 0: "b", 1: "a", 2: "z", foo: "bar" } }
// new result is { a: "baz" }
merge(
    { a: { foo: "bar" } },
    { a: "baz" }
);

// currently throws TypeError
// new result is { a: null }
merge(
    { a: { foo: "bar" } },
    { a: null }
);

// current result is { a: { foo: "bar" } }
// new result is { a: () => { } }
merge(
    { a: { foo: "bar" } },
    { a: () => { } }
);
```

To me, none of the above examples seems to behave as intended in the current implementation. In my unit tests, I'm assuming that when two values cannot be merged because they are not both objects, the expectation is to just pick the second value if it's not undefined. That's how [Lodash's `merge`](https://lodash.com/docs#merge) works, for example, except that it also merges arrays while we don't.

I'm leaving this as a question for reviewers if we want to keep this behavior like that, revert it to how it was before, or change it in another way.

##### Question 2

There is still some potential to produce a stack overflow even without a circular reference, for example if a property evaluates to a different object on every access. Here's an example:

```js
// eslint.config.js

function createObject(parent, generation) {
    return {
        parent,
        generation,
        get child() {
            return createObject(this, this.generation + 1);
        }
    };
}

export default [{
    settings: {
        sharedData: createObject(null, 0)
    }
}];
```

I think this is a constructed case we don't need to care about, but if we decide to do so and handle this situation in a way or another, then we should also have a look at `normalizeRuleOptions`:

https://github.com/eslint/eslint/blob/5de9637fc925729a83d5a5e9e868a41792a184e3/lib/config/flat-config-schema.js#L132

The `structuredClone` algorithm we use there will similarly fail with an error when non-circular properties exceed the depth that fits inside the stack - but again, I don't expect this situation to happen for a reasonable config.

<!-- markdownlint-disable-file MD004 -->
