### PR TITLE
feat: for-direction rule add check for condition in reverse order

### DIFF
--- a/docs/src/rules/for-direction.md
+++ b/docs/src/rules/for-direction.md
@@ -24,6 +24,9 @@ for (var i = 10; i >= 0; i++) {
 for (var i = 0; i > 10; i++) {
 }
 
+for (var i = 0; 10 > i; i--) {
+}
+
 const n = -2;
 for (let i = 0; i < 10; i += n) {
 }
@@ -38,6 +41,9 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint for-direction: "error"*/
 for (var i = 0; i < 10; i++) {
+}
+
+for (var i = 0; 10 > i; i++) { // with counter "i" on the right
 }
 
 for (let i = 10; i >= 0; i += this.step) { // direction unknown

--- a/tests/lib/rules/for-direction.js
+++ b/tests/lib/rules/for-direction.js
@@ -28,6 +28,12 @@ ruleTester.run("for-direction", rule, {
         "for(var i = 10; i > 0; i--){}",
         "for(var i = 10; i >= 0; i--){}",
 
+        // test if '++', '--' with counter 'i' on the right side of test condition
+        "for(var i = 0; 10 > i; i++){}",
+        "for(var i = 0; 10 >= i; i++){}",
+        "for(var i = 10; 0 < i; i--){}",
+        "for(var i = 10; 0 <= i; i--){}",
+
         // test if '+=', '-=',
         "for(var i = 0; i < 10; i+=1){}",
         "for(var i = 0; i <= 10; i+=1){}",
@@ -43,6 +49,9 @@ ruleTester.run("for-direction", rule, {
         "for(var i = 0; i < 10; i+=+5e-7){}",
         "for(var i = 0; i < MAX; i -= ~2);",
         "for(var i = 0, n = -1; i < MAX; i += -n);",
+
+        // test if '+=', '-=' with counter 'i' on the right side of test condition
+        "for(var i = 0; 10 > i; i+=1){}",
 
         // test if no update.
         "for(var i = 10; i > 0;){}",
@@ -82,6 +91,12 @@ ruleTester.run("for-direction", rule, {
         { code: "for(var i = 10; i > 10; i++){}", errors: [incorrectDirection] },
         { code: "for(var i = 10; i >= 0; i++){}", errors: [incorrectDirection] },
 
+        // test if '++', '--' with counter 'i' on the right side of test condition
+        { code: "for(var i = 0; 10 > i; i--){}", errors: [incorrectDirection] },
+        { code: "for(var i = 0; 10 >= i; i--){}", errors: [incorrectDirection] },
+        { code: "for(var i = 10; 10 < i; i++){}", errors: [incorrectDirection] },
+        { code: "for(var i = 10; 0 <= i; i++){}", errors: [incorrectDirection] },
+
         // test if '+=', '-='
         { code: "for(var i = 0; i < 10; i-=1){}", errors: [incorrectDirection] },
         { code: "for(var i = 0; i <= 10; i-=1){}", errors: [incorrectDirection] },
@@ -96,6 +111,9 @@ ruleTester.run("for-direction", rule, {
         { code: "for(var i = MIN; i <= MAX; i-=true){}", errors: [incorrectDirection] },
         { code: "for(var i = 0; i < 10; i-=+5e-7){}", errors: [incorrectDirection] },
         { code: "for(var i = 0; i < MAX; i += (2 - 3));", errors: [incorrectDirection] },
-        { code: "var n = -2; for(var i = 0; i < 10; i += n);", errors: [incorrectDirection] }
+        { code: "var n = -2; for(var i = 0; i < 10; i += n);", errors: [incorrectDirection] },
+
+        // test if '+=', '-=' with counter 'i' on the right side of test condition
+        { code: "for(var i = 0; 10 > i; i-=1){}", errors: [incorrectDirection] }
     ]
 });


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

**What rule do you want to change?**
- [for-direction rule](https://eslint.org/docs/latest/rules/for-direction)

**What change do you want to make (place an "X" next to just one item)?**

- [x] Generate more warnings
- [ ] Generate fewer warnings
- [ ] Implement autofix
- [ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

- [ ] A new option
- [x] A new default behaviour
- [ ] Other

**Please provide some example code that this change will affect:**

```js
for (var i = 0; 10 > i; i--) {
}

for (var i = 0; 10 >= i; i--) {
}

for (var i = 10; 10 < i; i++) {
}

for (var i = 10; 0 <= i; i++) {
}
```

**What does the rule currently do for this code?**

The `for-direction` rule checks **only** for the condition with the counter i.e. `i` on the **_left side_** of the binary expression `i < 10` like:
```js
for (var i = 0; i < 10; i++) {
}
``` 

**What will the rule do after it's changed?**

The rule adds more warnings for code like this with the counter i.e. `i` on the **_right side_** of the test condition `10 > i`
```js
for (var i = 0; 10 > i; i++) {
}
```
