### PR TITLE
fix: remove duplicated comparison

### DIFF
--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -77,8 +77,7 @@ module.exports = {
          * @returns {boolean} Whether or not the node is first "!" in "!!"
          */
         function isFirstBangInBangBangExpression(node) {
-            return node && node.type === "UnaryExpression" && node.argument.operator === "!" &&
-                node.argument && node.argument.type === "UnaryExpression" && node.argument.operator === "!";
+            return node && node.type === "UnaryExpression" && node.argument && node.argument.type === "UnaryExpression" && node.argument.operator === "!";
         }
 
         /**


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
- [ ] Add autofix to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed a duplicated and maybe unsafe expression in rule `space-unary-ops`, but changed nothing.

#### Is there anything you'd like reviewers to focus on?

`node.argument.operator === "!"` is duplicated and we should keep the last one.

<!-- markdownlint-disable-file MD004 -->
