### PR TITLE
chore: remove formatting/stylistic rules from new rule templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-rule.yml
+++ b/.github/ISSUE_TEMPLATE/new-rule.yml
@@ -26,7 +26,6 @@ body:
     options:
       - Warns about a potential problem
       - Suggests an alternate way of doing something
-      - Enforces a formatting/stylistic preference
   validations:
     required: true
 - type: textarea

--- a/templates/rule-proposal.md
+++ b/templates/rule-proposal.md
@@ -6,7 +6,6 @@
 
 [ ] Warns about a potential problem
 [ ] Suggests an alternate way of doing something
-[ ] Enforces a formatting/stylistic preference
 
 **Please provide some example JavaScript code that this rule will warn about:**
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Change issue templates.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Now that [formatting rules are deprecated](https://eslint.org/blog/2023/10/deprecating-formatting-rules/) and [stylistic rules are frozen](https://github.com/eslint/eslint#stylistic-rule-updates), I was wondering if it would make sense to also remove the option to create those rules from the issue templates.

While the option is there, some contributors will still use it to suggest new rules even if their classification doesn't match (e.g. #17769). And if it the classification matches, probably the rule cannot be accepted because it's formatting/stylistic.

#### Is there anything you'd like reviewers to focus on?

Feel free to close if we prefer to keep the option in the templates.

<!-- markdownlint-disable-file MD004 -->
