### PR TITLE
docs: fix correct/incorrect examples of rules

### DIFF
--- a/docs/src/rules/capitalized-comments.md
+++ b/docs/src/rules/capitalized-comments.md
@@ -236,6 +236,7 @@ Examples of **incorrect** code with `ignoreConsecutiveComments` set to `true`:
 ```js
 /* eslint capitalized-comments: ["error", "always", { "ignoreConsecutiveComments": true }] */
 
+foo();
 // this comment is invalid, but only on this line.
 // this comment does NOT get reported, since it is a consecutive comment.
 ```

--- a/docs/src/rules/dot-notation.md
+++ b/docs/src/rules/dot-notation.md
@@ -84,22 +84,27 @@ class C {
 
 For example, when preparing data to be sent to an external API, it is often required to use property names that include underscores.  If the `camelcase` rule is in effect, these [snake case](https://en.wikipedia.org/wiki/Snake_case) properties would not be allowed.  By providing an `allowPattern` to the `dot-notation` rule, these snake case properties can be accessed with bracket notation.
 
-Examples of **correct** code for the sample `{ "allowPattern": "^[a-z]+(_[a-z]+)+$" }` option:
+Examples of **incorrect** code for the sample `{ "allowPattern": "^[a-z]+(_[a-z]+)+$" }` (pattern to find snake case named properties) option:
+
+:::incorrect
+
+```js
+/*eslint dot-notation: ["error", { "allowPattern": "^[a-z]+(_[a-z]+)+$" }]*/
+
+var data = {};
+data["fooBar"] = 42;
+```
+
+:::
+Examples of **correct** code for the sample `{ "allowPattern": "^[a-z]+(_[a-z]+)+$" }` (pattern to find snake case named properties) option:
 
 :::correct
 
 ```js
-/*eslint camelcase: "error"*/
 /*eslint dot-notation: ["error", { "allowPattern": "^[a-z]+(_[a-z]+)+$" }]*/
 
 var data = {};
-data.foo_bar = 42;
-
-var data = {};
-data["fooBar"] = 42;
-
-var data = {};
-data["foo_bar"] = 42; // no warning
+data["foo_bar"] = 42;
 ```
 
 :::

--- a/docs/src/rules/max-lines-per-function.md
+++ b/docs/src/rules/max-lines-per-function.md
@@ -72,7 +72,7 @@ is equivalent to
 
 ### code
 
-Examples of **incorrect** code for this rule with a max value of `2`:
+Examples of **incorrect** code for this rule with a perticular max value:
 
 ::: incorrect
 
@@ -88,7 +88,7 @@ function foo() {
 ::: incorrect
 
 ```js
-/*eslint max-lines-per-function: ["error", 2]*/
+/*eslint max-lines-per-function: ["error", 3]*/
 function foo() {
     // a comment
     var x = 0;
@@ -100,7 +100,7 @@ function foo() {
 ::: incorrect
 
 ```js
-/*eslint max-lines-per-function: ["error", 2]*/
+/*eslint max-lines-per-function: ["error", 4]*/
 function foo() {
     // a comment followed by a blank line
 
@@ -110,7 +110,7 @@ function foo() {
 
 :::
 
-Examples of **correct** code for this rule with a max value of `3`:
+Examples of **correct** code for this rule with a perticular max value:
 
 ::: correct
 
@@ -126,7 +126,7 @@ function foo() {
 ::: correct
 
 ```js
-/*eslint max-lines-per-function: ["error", 3]*/
+/*eslint max-lines-per-function: ["error", 4]*/
 function foo() {
     // a comment
     var x = 0;
@@ -138,7 +138,7 @@ function foo() {
 ::: correct
 
 ```js
-/*eslint max-lines-per-function: ["error", 3]*/
+/*eslint max-lines-per-function: ["error", 5]*/
 function foo() {
     // a comment followed by a blank line
 

--- a/docs/src/rules/no-async-promise-executor.md
+++ b/docs/src/rules/no-async-promise-executor.md
@@ -33,6 +33,8 @@ Examples of **incorrect** code for this rule:
 ::: incorrect
 
 ```js
+/*eslint no-async-promise-executor: "error"*/
+
 const foo = new Promise(async (resolve, reject) => {
   readFile('foo.txt', function(err, result) {
     if (err) {
@@ -55,6 +57,8 @@ Examples of **correct** code for this rule:
 ::: correct
 
 ```js
+/*eslint no-async-promise-executor: "error"*/
+
 const foo = new Promise((resolve, reject) => {
   readFile('foo.txt', function(err, result) {
     if (err) {

--- a/docs/src/rules/no-else-return.md
+++ b/docs/src/rules/no-else-return.md
@@ -28,7 +28,7 @@ This rule has an object option:
 * `allowElseIf: true` (default) allows `else if` blocks after a return
 * `allowElseIf: false` disallows `else if` blocks after a return
 
-### `allowElseIf: true`
+## allowElseIf: true
 
 Examples of **incorrect** code for this rule:
 
@@ -137,7 +137,7 @@ function foo4() {
 
 :::
 
-### `allowElseIf: false`
+## allowElseIf: false
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/src/rules/no-eval.md
+++ b/docs/src/rules/no-eval.md
@@ -104,6 +104,8 @@ class A {
 
 ## Options
 
+### allowIndirect
+
 This rule has an option to allow indirect calls to `eval`.
 Indirect calls to `eval` are less dangerous than direct calls to `eval` because they cannot dynamically change the scope. Because of this, they also will not negatively impact performance to the degree of direct `eval`.
 
@@ -118,7 +120,7 @@ Example of **incorrect** code for this rule with the `{"allowIndirect": true}` o
 ::: incorrect
 
 ```js
-/*eslint no-eval: "error"*/
+/*eslint no-eval: ["error", {"allowIndirect": true} ]*/
 
 var obj = { x: "foo" },
     key = "x",
@@ -132,7 +134,7 @@ Examples of **correct** code for this rule with the `{"allowIndirect": true}` op
 ::: correct
 
 ```js
-/*eslint no-eval: "error"*/
+/*eslint no-eval: ["error", {"allowIndirect": true} ]*/
 
 (0, eval)("var a = 0");
 
@@ -147,7 +149,7 @@ this.eval("var a = 0");
 ::: correct
 
 ```js
-/*eslint no-eval: "error"*/
+/*eslint no-eval: ["error", {"allowIndirect": true} ]*/
 /*eslint-env browser*/
 
 window.eval("var a = 0");
@@ -158,7 +160,7 @@ window.eval("var a = 0");
 ::: correct
 
 ```js
-/*eslint no-eval: "error"*/
+/*eslint no-eval: ["error", {"allowIndirect": true} ]*/
 /*eslint-env node*/
 
 global.eval("var a = 0");

--- a/docs/src/rules/no-implicit-globals.md
+++ b/docs/src/rules/no-implicit-globals.md
@@ -79,7 +79,7 @@ window.bar = function() {};
 
 Examples of **correct** code for this rule with `"parserOptions": { "sourceType": "module" }` in the ESLint configuration:
 
-::: correct { "sourceType": "script" }
+::: correct { "sourceType": "module" }
 
 ```js
 /*eslint no-implicit-globals: "error"*/

--- a/docs/src/rules/no-implied-eval.md
+++ b/docs/src/rules/no-implied-eval.md
@@ -35,6 +35,7 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-implied-eval: "error"*/
+/*eslint-env browser*/
 
 setTimeout("alert('Hi!');", 100);
 

--- a/docs/src/rules/no-loop-func.md
+++ b/docs/src/rules/no-loop-func.md
@@ -48,15 +48,21 @@ for (var i=10; i; i--) {
     (function() { return i; })();
 }
 
-while(i) {
+var i = 0;
+while(i < 5) {
     var a = function() { return i; };
     a();
+
+    i++;
 }
 
+var i = 0;
 do {
     function a() { return i; };
     a();
-} while (i);
+
+    i++
+} while (i < 5);
 
 let foo = 0;
 for (let i = 0; i < 10; ++i) {

--- a/docs/src/rules/no-redeclare.md
+++ b/docs/src/rules/no-redeclare.md
@@ -77,7 +77,7 @@ The `"builtinGlobals"` option will check for redeclaration of built-in globals i
 
 Examples of **incorrect** code for the `{ "builtinGlobals": true }` option:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-redeclare: ["error", { "builtinGlobals": true }]*/
@@ -89,7 +89,7 @@ var Object = 0;
 
 Examples of **incorrect** code for the `{ "builtinGlobals": true }` option and the `browser` environment:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint no-redeclare: ["error", { "builtinGlobals": true }]*/

--- a/docs/src/rules/no-undef-init.md
+++ b/docs/src/rules/no-undef-init.md
@@ -87,6 +87,8 @@ Example of **incorrect** code for this rule:
 ::: incorrect
 
 ```js
+/*eslint no-undef-init: "error"*/
+
 for (i = 0; i < 10; i++) {
     var x = undefined;
     console.log(x);

--- a/docs/src/rules/no-unmodified-loop-condition.md
+++ b/docs/src/rules/no-unmodified-loop-condition.md
@@ -44,8 +44,8 @@ while (node) {
 }
 node = other;
 
-for (var j = 0; j < items.length; ++i) {
-    doSomething(items[j]);
+for (var j = 0; j < 5;) {
+    doSomething(j);
 }
 
 while (node !== root) {

--- a/docs/src/rules/no-unused-expressions.md
+++ b/docs/src/rules/no-unused-expressions.md
@@ -79,8 +79,6 @@ Examples of **correct** code for the default `{ "allowShortCircuit": false, "all
 
 {} // In this context, this is a block statement, not an object literal
 
-{myLabel: someVar} // In this context, this is a block statement with a label and expression, not an object literal
-
 function namedFunctionDeclaration () {}
 
 (function aGenuineIIFE () {}());

--- a/docs/src/rules/object-shorthand.md
+++ b/docs/src/rules/object-shorthand.md
@@ -116,7 +116,7 @@ Additionally, the rule takes an optional object configuration:
 * `"methodsIgnorePattern"` (`string`) for methods whose names match this regex pattern, the method shorthand will not be enforced. Note that this option can only be used when the string option is set to `"always"` or `"methods"`.
 * `"avoidExplicitReturnArrows": true` indicates that methods are preferred over explicit-return arrow functions for function properties. (By default, the rule allows either of these.) Note that this option can only be enabled when the string option is set to `"always"` or `"methods"`.
 
-### `avoidQuotes`
+### avoidQuotes
 
 ```json
 {
@@ -155,7 +155,7 @@ var foo = {
 
 :::
 
-### `ignoreConstructors`
+### ignoreConstructors
 
 ```json
 {
@@ -178,7 +178,7 @@ var foo = {
 
 :::
 
-### `methodsIgnorePattern`
+### methodsIgnorePattern
 
 Example of **correct** code for this rule with the `"always", { "methodsIgnorePattern": "^bar$" }` option:
 
@@ -194,7 +194,7 @@ var foo = {
 
 :::
 
-### `avoidExplicitReturnArrows`
+### avoidExplicitReturnArrows
 
 ```json
 {

--- a/docs/src/rules/one-var.md
+++ b/docs/src/rules/one-var.md
@@ -462,6 +462,9 @@ var bar = "bar";
 ::: correct
 
 ```js
+/*eslint one-var: ["error", { separateRequires: true, var: "always" }]*/
+/*eslint-env node*/
+
 var foo = require("foo"),
     bar = require("bar");
 ```

--- a/docs/src/rules/prefer-regex-literals.md
+++ b/docs/src/rules/prefer-regex-literals.md
@@ -110,11 +110,13 @@ This rule has an object option:
 
 * `disallowRedundantWrapping` set to `true` additionally checks for unnecessarily wrapped regex literals (Default `false`).
 
-### `disallowRedundantWrapping`
+### disallowRedundantWrapping
 
 By default, this rule doesn’t check when a regex literal is unnecessarily wrapped in a `RegExp` constructor call. When the option `disallowRedundantWrapping` is set to `true`, the rule will also disallow such unnecessary patterns.
 
 Examples of `incorrect` code for `{ "disallowRedundantWrapping": true }`
+
+::: incorrect
 
 ```js
 /*eslint prefer-regex-literals: ["error", {"disallowRedundantWrapping": true}]*/
@@ -124,7 +126,11 @@ new RegExp(/abc/);
 new RegExp(/abc/, 'u');
 ```
 
+:::
+
 Examples of `correct` code for `{ "disallowRedundantWrapping": true }`
+
+::: correct
 
 ```js
 /*eslint prefer-regex-literals: ["error", {"disallowRedundantWrapping": true}]*/
@@ -135,3 +141,5 @@ Examples of `correct` code for `{ "disallowRedundantWrapping": true }`
 
 new RegExp(/abc/, flags);
 ```
+
+:::


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
code examples inside the `correct` or `incorrect` tag of some rules are not reporting error properly (as expected), so as a fix i added some relevant code and minor updates in those docs file.

#### Is there anything you'd like reviewers to focus on?
the rule examples that are changed

`capitalized-comments` - [example in playground](https://eslint.org/play/#eyJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsic291cmNlVHlwZSI6Im1vZHVsZSJ9fSwidGV4dCI6Ii8qIGVzbGludCBjYXBpdGFsaXplZC1jb21tZW50czogW1wiZXJyb3JcIiwgXCJhbHdheXNcIiwgeyBcImlnbm9yZUNvbnNlY3V0aXZlQ29tbWVudHNcIjogdHJ1ZSB9XSAqL1xuXG4vLyB0aGlzIGNvbW1lbnQgaXMgaW52YWxpZCwgYnV0IG9ubHkgb24gdGhpcyBsaW5lLlxuLy8gdGhpcyBjb21tZW50IGRvZXMgTk9UIGdldCByZXBvcnRlZCwgc2luY2UgaXQgaXMgYSBjb25zZWN1dGl2ZSBjb21tZW50LiJ9)
`dot-notation` - [example in rule docs](https://eslint.org/docs/latest/rules/dot-notation#allowpattern)
`max-lines-per-function` - [examples in rule docs](https://eslint.org/docs/latest/rules/max-lines-per-function#code)
`no-async-pormise-executor` - [examples in rule docs](https://eslint.org/docs/latest/rules/no-async-promise-executor#rule-details)
`no-else-return` - [example in rule docs](https://eslint.org/docs/latest/rules/no-else-return#allowelseif-true)
`no-eval` - [examples in rule -docs](https://eslint.org/docs/latest/rules/no-eval#options)
`no-implicit-global` - [example in playground](https://eslint.org/play/#eyJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsic291cmNlVHlwZSI6InNjcmlwdCJ9fSwidGV4dCI6Ii8qZXNsaW50IG5vLWltcGxpY2l0LWdsb2JhbHM6IFwiZXJyb3JcIiovXG5cbi8vIGZvbyBhbmQgYmFyIGFyZSBsb2NhbCB0byBtb2R1bGVcbnZhciBmb28gPSAxO1xuZnVuY3Rpb24gYmFyKCkge30ifQ==)
`no-loop-func` - [example in playground](https://eslint.org/play/#eyJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsic291cmNlVHlwZSI6Im1vZHVsZSJ9fSwidGV4dCI6Ii8qZXNsaW50IG5vLWxvb3AtZnVuYzogXCJlcnJvclwiKi9cbi8qZXNsaW50LWVudiBlczYqL1xuXG5mb3IgKHZhciBpPTEwOyBpOyBpLS0pIHtcbiAgICAoZnVuY3Rpb24oKSB7IHJldHVybiBpOyB9KSgpO1xufVxuXG53aGlsZShpKSB7XG4gICAgdmFyIGEgPSBmdW5jdGlvbigpIHsgcmV0dXJuIGk7IH07XG4gICAgYSgpO1xufVxuXG5kbyB7XG4gICAgZnVuY3Rpb24gYSgpIHsgcmV0dXJuIGk7IH07XG4gICAgYSgpO1xufSB3aGlsZSAoaSk7XG5cbmxldCBmb28gPSAwO1xuZm9yIChsZXQgaSA9IDA7IGkgPCAxMDsgKytpKSB7XG4gICAgLy9CYWQsIGBmb29gIGlzIG5vdCBpbiB0aGUgbG9vcC1ibG9jaydzIHNjb3BlIGFuZCBgZm9vYCBpcyBtb2RpZmllZCBpbi9hZnRlciB0aGUgbG9vcFxuICAgIHNldFRpbWVvdXQoKCkgPT4gY29uc29sZS5sb2coZm9vKSk7XG4gICAgZm9vICs9IDE7XG59XG5cbmZvciAobGV0IGkgPSAwOyBpIDwgMTA7ICsraSkge1xuICAgIC8vQmFkLCBgZm9vYCBpcyBub3QgaW4gdGhlIGxvb3AtYmxvY2sncyBzY29wZSBhbmQgYGZvb2AgaXMgbW9kaWZpZWQgaW4vYWZ0ZXIgdGhlIGxvb3BcbiAgICBzZXRUaW1lb3V0KCgpID0+IGNvbnNvbGUubG9nKGZvbykpO1xufVxuZm9vID0gMTAwOyJ9)
`no-redeclare` - [example in playground](https://eslint.org/play/#eyJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsic291cmNlVHlwZSI6Im1vZHVsZSJ9fSwidGV4dCI6Ii8qZXNsaW50IG5vLXJlZGVjbGFyZTogW1wiZXJyb3JcIiwgeyBcImJ1aWx0aW5HbG9iYWxzXCI6IHRydWUgfV0qL1xuXG52YXIgT2JqZWN0ID0gMDsifQ==)
`no-undef-init`
`no-unmodified-loop-condition` - [example in playground](https://eslint.org/play/#eyJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsic291cmNlVHlwZSI6Im1vZHVsZSJ9fSwidGV4dCI6Ii8qZXNsaW50IG5vLXVubW9kaWZpZWQtbG9vcC1jb25kaXRpb246IFwiZXJyb3JcIiovXG5cbnZhciBub2RlID0gc29tZXRoaW5nO1xuXG53aGlsZSAobm9kZSkge1xuICAgIGRvU29tZXRoaW5nKG5vZGUpO1xufVxubm9kZSA9IG90aGVyO1xuXG5mb3IgKHZhciBqID0gMDsgaiA8IGl0ZW1zLmxlbmd0aDsgKytpKSB7XG4gICAgZG9Tb21ldGhpbmcoaXRlbXNbal0pO1xufVxuXG53aGlsZSAobm9kZSAhPT0gcm9vdCkge1xuICAgIGRvU29tZXRoaW5nKG5vZGUpO1xufSJ9)
`no-unused-expression` - [example in playground](https://eslint.org/play/#eyJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsic291cmNlVHlwZSI6Im1vZHVsZSJ9fSwidGV4dCI6Ii8qZXNsaW50IG5vLXVudXNlZC1leHByZXNzaW9uczogXCJlcnJvclwiKi9cblxue30gLy8gSW4gdGhpcyBjb250ZXh0LCB0aGlzIGlzIGEgYmxvY2sgc3RhdGVtZW50LCBub3QgYW4gb2JqZWN0IGxpdGVyYWxcblxue215TGFiZWw6IHNvbWVWYXJ9IC8vIEluIHRoaXMgY29udGV4dCwgdGhpcyBpcyBhIGJsb2NrIHN0YXRlbWVudCB3aXRoIGEgbGFiZWwgYW5kIGV4cHJlc3Npb24sIG5vdCBhbiBvYmplY3QgbGl0ZXJhbFxuXG5mdW5jdGlvbiBuYW1lZEZ1bmN0aW9uRGVjbGFyYXRpb24gKCkge31cblxuKGZ1bmN0aW9uIGFHZW51aW5lSUlGRSAoKSB7fSgpKTtcblxuZigpXG5cbmEgPSAwXG5cbm5ldyBDXG5cbmRlbGV0ZSBhLmJcblxudm9pZCBhIn0=)
`object-shorthand` - [titles in rule docs](https://eslint.org/docs/latest/rules/object-shorthand#avoidquotes)
`one-var` 
`prefer-regex-literals` - [examples in rule docs](https://eslint.org/docs/latest/rules/prefer-regex-literals#disallowredundantwrapping)

<!-- markdownlint-disable-file MD004 -->
