### PR TITLE
docs: remove "Open in Playground" buttons for removed rules

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -195,7 +195,12 @@ module.exports = function(eleventyConfig) {
 
     // markdown-it plugin options for playground-linked code blocks in rule examples.
     const ruleExampleOptions = markdownItRuleExample({
-        open(type, code, parserOptions) {
+        open({ type, code, parserOptions, env }) {
+            const isRuleRemoved = !Object.prototype.hasOwnProperty.call(env.rules_meta, env.title);
+
+            if (isRuleRemoved) {
+                return `<div class="${type}">`;
+            }
 
             // See https://github.com/eslint/eslint.org/blob/ac38ab41f99b89a8798d374f74e2cce01171be8b/src/playground/App.js#L44
             const state = encodeToBase64(

--- a/docs/src/assets/scss/docs.scss
+++ b/docs/src/assets/scss/docs.scss
@@ -113,7 +113,8 @@ div.incorrect {
         offset-block-start: -22px;
     }
 
-    pre.line-numbers-mode {
+    // Add space to the bottom if there is a Playground button.
+    .c-btn.c-btn--playground ~ pre.line-numbers-mode {
         padding-bottom: 4.5rem;
     }
 }

--- a/docs/tools/markdown-it-rule-example.js
+++ b/docs/tools/markdown-it-rule-example.js
@@ -5,10 +5,12 @@
 /**
  * A callback function to handle the opening of container blocks.
  * @callback OpenHandler
- * @param {"correct" | "incorrect"} type The type of the example.
- * @param {string} code The example code.
- * @param {ParserOptions} parserOptions The parser options to be passed to the Playground.
- * @param {Object} codeBlockToken The `markdown-it` token for the code block inside the container.
+ * @param {Object} data Callback data.
+ * @param {"correct" | "incorrect"} data.type The type of the example.
+ * @param {string} data.code The example code.
+ * @param {ParserOptions} data.parserOptions The parser options to be passed to the Playground.
+ * @param {Object} data.codeBlockToken The `markdown-it` token for the code block inside the container.
+ * @param {Object} data.env Additional Eleventy metadata, if available.
  * @returns {string | undefined} If a text is returned, it will be appended to the rendered output
  * of `markdown-it`.
  */
@@ -43,7 +45,7 @@
  *
  * markdownIt()
  *     .use(markdownItContainer, "rule-example", markdownItRuleExample({
- *         open(type, code, parserOptions, codeBlockToken) {
+ *         open({ type, code, parserOptions, codeBlockToken, env }) {
  *             // do something
  *         }
  *         close() {
@@ -58,7 +60,7 @@ function markdownItRuleExample({ open, close }) {
         validate(info) {
             return /^\s*(?:in)?correct(?!\S)/u.test(info);
         },
-        render(tokens, index) {
+        render(tokens, index, options, env) {
             const tagToken = tokens[index];
 
             if (tagToken.nesting < 0) {
@@ -77,7 +79,7 @@ function markdownItRuleExample({ open, close }) {
                 .replace(/\n$/u, "")
                 .replace(/⏎(?=\n)/gu, "");
 
-            const text = open(type, code, parserOptions, codeBlockToken);
+            const text = open({ type, code, parserOptions, codeBlockToken, env });
 
             // Return an empty string to avoid appending unexpected text to the output.
             return typeof text === "string" ? text : "";

--- a/tools/check-rule-examples.js
+++ b/tools/check-rule-examples.js
@@ -50,7 +50,7 @@ async function findProblems(filename) {
     const text = await readFile(filename, "UTF-8");
     const problems = [];
     const ruleExampleOptions = markdownItRuleExample({
-        open(type, code, parserOptions, codeBlockToken) {
+        open({ code, parserOptions, codeBlockToken }) {
             const languageTag = codeBlockToken.info;
 
             if (!STANDARD_LANGUAGE_TAGS.has(languageTag)) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Closes #17602

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR removes the "Open in Playground" buttons from examples code blocks in the docs of removed rules. Removed rules cannot be tested in the Playground.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
