### PR TITLE
feat: add constructorMax option for max-params rule

### DIFF
--- a/docs/src/rules/max-params.md
+++ b/docs/src/rules/max-params.md
@@ -30,6 +30,8 @@ This rule has a number or object option:
 
 * `"max"` (default `3`) enforces a maximum number of parameters in function definitions
 
+* `"constructorMax"`  enforces a maximum number of parameters in constructor definitions, default is the value set by `max`
+
 **Deprecated:** The object property `maximum` is deprecated; please use the object property `max` instead.
 
 ### max

--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -44,6 +44,10 @@ module.exports = {
                             max: {
                                 type: "integer",
                                 minimum: 0
+                            },
+                            constructorMax: {
+                                type: "integer",
+                                minimum: 0
                             }
                         },
                         additionalProperties: false
@@ -71,6 +75,15 @@ module.exports = {
             numParams = option;
         }
 
+        let constructorNumParams = numParams;
+
+        if (
+            typeof option === "object" &&
+            Object.prototype.hasOwnProperty.call(option, "constructorMax")
+        ) {
+            constructorNumParams = option.constructorMax;
+        }
+
         /**
          * Checks a function to see if it has too many parameters.
          * @param {ASTNode} node The node to check.
@@ -78,7 +91,10 @@ module.exports = {
          * @private
          */
         function checkFunction(node) {
-            if (node.params.length > numParams) {
+            const functionName = astUtils.getFunctionNameWithKind(node);
+            const validNumParams = functionName === "constructor" ? constructorNumParams : numParams;
+
+            if (node.params.length > validNumParams) {
                 context.report({
                     loc: astUtils.getFunctionHeadLoc(node, sourceCode),
                     node,

--- a/tests/lib/rules/max-params.js
+++ b/tests/lib/rules/max-params.js
@@ -26,7 +26,8 @@ ruleTester.run("max-params", rule, {
         { code: "var test = function test(a, b, c) {};", options: [3] },
 
         // object property options
-        { code: "var test = function(a, b, c) {};", options: [{ max: 3 }] }
+        { code: "var test = function(a, b, c) {};", options: [{ max: 3 }] },
+        { code: "class x { constructor(a, b, c, d, e) {} }", options: [{ max: 3, constructorMax: 5 }], parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         {

--- a/tests/lib/rules/max-params.js
+++ b/tests/lib/rules/max-params.js
@@ -124,6 +124,14 @@ ruleTester.run("max-params", rule, {
                 endLine: 1,
                 endColumn: 14
             }]
+        },
+        {
+            code: "class x { constructor(a, b, c, d, e) {} }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "exceed",
+                data: { name: "Constructor", count: 5, max: 3 }
+            }]
         }
     ]
 });


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


#### What changes did you make? (Give an overview)

add `constructorMax` option for max-params rule

Projects that use dependency injection usually have a large number of parameters in the constructor and should not have the same verification conditions as normal functions.

`constructorMax` default value is same as set by `max`

