### PR TITLE
ci: pin Node.js 21.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [21.x, 20.x, 19.x, 18.x, 17.x, 16.x, 14.x, 12.x, "12.22.0"]
+        node: ["21.2.0", 20.x, 19.x, 18.x, 17.x, 16.x, 14.x, 12.x, "12.22.0"]
         include:
         - os: windows-latest
           node: "lts/*"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Temporarily pins Node 21 to 21.2.0 in CI.

Currently, our checks fail in the recently released Node.js 21.3.0 because `fs.writeFileSync` throws an `ENOENT` error when called from `shelljs`. This is a problem either in `shelljs` or in Node.js 21.3.0 (possibly caused by https://github.com/nodejs/node/pull/49884).

Since the published eslint package doesn't use `shelljs`, seems fine to skip testing in Node > 21.2 for now, until the problem is fixed. 

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed `21.x` to `"21.2.0"` in the workflow file.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
