### PR TITLE
fix: suggestion with invalid syntax in no-promise-executor-return rule

### DIFF
--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -209,12 +209,15 @@ module.exports = {
                         });
                     }
 
-                    suggest.push({
-                        messageId: "wrapBraces",
-                        fix(fixer) {
-                            return curlyWrapFixer(sourceCode, node, fixer);
-                        }
-                    });
+                    // Do not suggest wrapping an unnamed FunctionExpression in braces as that would be invalid syntax.
+                    if (!(node.body.type === "FunctionExpression" && !node.body.id)) {
+                        suggest.push({
+                            messageId: "wrapBraces",
+                            fix(fixer) {
+                                return curlyWrapFixer(sourceCode, node, fixer);
+                            }
+                        });
+                    }
 
                     context.report({
                         node: node.body,

--- a/tests/lib/rules/no-promise-executor-return.js
+++ b/tests/lib/rules/no-promise-executor-return.js
@@ -891,17 +891,14 @@ ruleTester.run("no-promise-executor-return", rule, {
             }]
         },
         {
+
+            // No suggestion since an unnamed FunctionExpression inside braces is invalid syntax.
             code: "() => new Promise(() => function () {});",
             errors: [{
                 messageId: "returnsValue",
                 type: "FunctionExpression",
                 column: 25,
-                suggestions: [
-                    {
-                        messageId: "wrapBraces",
-                        output: "() => new Promise(() => {function () {}});"
-                    }
-                ]
+                suggestions: []
             }]
         },
         {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Avoid producing the suggestion that is known to be invalid syntax, as invalid syntax in suggestions will no longer be allowed as a result of:

* https://github.com/eslint/eslint/pull/16639

Original code (flagged by rule):

```js
() => new Promise(() => function () {});
```

Suggestion (invalid syntax):

```js
() => new Promise(() => {function () {}});
```

As an alternate fix, we could add `void` in front of the function expression to fix the syntax, if desired:

```js
() => new Promise(() => {void function () {}});
```

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
