### PR TITLE
fix: `TypeError: fs.exists is not a function` on read-only file system

### DIFF
--- a/lib/eslint/flat-eslint.js
+++ b/lib/eslint/flat-eslint.js
@@ -11,6 +11,7 @@
 
 // Note: Node.js 12 does not support fs/promises.
 const fs = require("fs").promises;
+const { existsSync } = require("fs");
 const path = require("path");
 const findUp = require("find-up");
 const { version } = require("../../package.json");
@@ -766,7 +767,7 @@ class FlatESLint {
                 const errorCode = error && error.code;
 
                 // Ignore errors when no such file exists or file system is read only (and cache file does not exist)
-                if (errorCode !== "ENOENT" && !(errorCode === "EROFS" && !(await fs.exists(cacheFilePath)))) {
+                if (errorCode !== "ENOENT" && !(errorCode === "EROFS" && !existsSync(cacheFilePath))) {
                     throw error;
                 }
             }

--- a/tests/lib/eslint/flat-eslint.js
+++ b/tests/lib/eslint/flat-eslint.js
@@ -2601,6 +2601,40 @@ describe("FlatESLint", () => {
                 assert(!shell.test("-f", cacheFilePath), "the cache for eslint should have been deleted since last run did not use the cache");
             });
 
+            it("should not throw an error if the cache file to be deleted does not exist on a read-only file system", async () => {
+                cacheFilePath = getFixturePath(".eslintcache");
+                doDelete(cacheFilePath);
+                assert(!shell.test("-f", cacheFilePath), "the cache file already exists and wasn't successfully deleted");
+
+                // Simulate a read-only file system.
+                sinon.stub(fsp, "unlink").rejects(
+                    Object.assign(new Error("read-only file system"), { code: "EROFS" })
+                );
+
+                const eslintOptions = {
+                    overrideConfigFile: true,
+
+                    // specifying cache false the cache will be deleted
+                    cache: false,
+                    cacheLocation: cacheFilePath,
+                    overrideConfig: {
+                        rules: {
+                            "no-console": 0,
+                            "no-unused-vars": 2
+                        }
+                    },
+                    cwd: path.join(fixtureDir, "..")
+                };
+
+                eslint = new FlatESLint(eslintOptions);
+
+                const file = getFixturePath("cache/src", "test-file.js");
+
+                await eslint.lintFiles([file]);
+
+                assert(fsp.unlink.calledWithExactly(cacheFilePath), "Expected attempt to delete the cache was not made.");
+            });
+
             it("should store in the cache a file that has lint messages and a file that doesn't have lint messages", async () => {
                 cacheFilePath = getFixturePath(".eslintcache");
                 doDelete(cacheFilePath);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v20.10.0
npm version: v10.2.3
Local ESLint version: Not found
Global ESLint version: v8.55.0
Operating System: linux 6.1.0-10-arm64

**What parser are you using (place an "X" next to just one item)?**

[X] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

No configuration.

**What did you do? Please include the actual source code causing the issue.**

On Linux, I ran ESLint using flat config on a read-only file system.

Specifically, I mounted a read-only file system at an empty directory and launched ESLint with `ESLINT_USE_FLAT_CONFIG` set to `true` in that directory.

Here are the commands I entered in the bash terminal:

```shell
sudo mkdir /media/rofs
sudo mount -r -t tmpfs tmpfs /media/rofs
cd /media/rofs
ESLINT_USE_FLAT_CONFIG=true npx eslint@8.55.0 --no-config-lookup --no-error-on-unmatched-pattern .
```

**What did you expect to happen?**

No output, like in eslintrc.

**What actually happened? Please include the actual, raw output from ESLint.**

ESLint printed an error and failed with exit code 2.

```console
Oops! Something went wrong! :(

ESLint: 8.55.0

TypeError: fs.exists is not a function
    at FlatESLint.lintFiles (/home/runner/.npm/_npx/25d11f2eb00e99cc/node_modules/eslint/lib/eslint/flat-eslint.js:769:85)
    at async Object.execute (/home/runner/.npm/_npx/25d11f2eb00e99cc/node_modules/eslint/lib/cli.js:402:23)
    at async main (/home/runner/.npm/_npx/25d11f2eb00e99cc/node_modules/eslint/bin/eslint.js:152:22)
```

Here is a repro inside GitHub Actions: https://github.com/fasttime/ESLint-Repro/actions/runs/7186527166/job/19572109911

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In `FlatESLint`, in the `lintFiles` method, I replaced a call to the nonexisting (undefined) import `fs.promises.exists` with `fs.existsSync`.

Node.js only ships two variations of the "exists" function: [`fs.existsSync`](https://nodejs.org/api/fs.html#fsexistssyncpath) and the deprecated [`fs.exists`](https://nodejs.org/api/fs.html#fsexistspath-callback). There are no "exists" functions in `fs.promises`. A possible workaround to avoid synchronous I/O operations is calling [`fs.promises.stat`](https://nodejs.org/api/fs.html#fspromisesstatpath-options) in a `try`-with-`catch` block.

#### Is there anything you'd like reviewers to focus on?

In the unit tests, I am mocking a file system call to produce the desired EROFS error. Let me know if you can figure out an efficient way to reproduce the error in the unit tests that doesn't use mocks.

<!-- markdownlint-disable-file MD004 -->
