### PR TITLE
test: ensure that CLI tests run with FlatESLint

### DIFF
--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -340,6 +340,17 @@ describe("cli", () => {
             });
 
             describe("when given an invalid built-in formatter name", () => {
+
+                const originalCwd = process.cwd;
+
+                beforeEach(() => {
+                    process.cwd = () => getFixturePath();
+                });
+
+                afterEach(() => {
+                    process.cwd = originalCwd;
+                });
+
                 it(`should execute with error: with configType:${configType}`, async () => {
                     const filePath = getFixturePath("passing.js");
                     const exit = await cli.execute(`-f fakeformatter ${filePath} ${flag}`, null, useFlatConfig);
@@ -349,6 +360,17 @@ describe("cli", () => {
             });
 
             describe("when given a valid formatter path", () => {
+
+                const originalCwd = process.cwd;
+
+                beforeEach(() => {
+                    process.cwd = () => getFixturePath();
+                });
+
+                afterEach(() => {
+                    process.cwd = originalCwd;
+                });
+
                 it(`should execute without any errors with configType:${configType}`, async () => {
                     const formatterPath = getFixturePath("formatters", "simple.js");
                     const filePath = getFixturePath("passing.js");
@@ -380,6 +402,17 @@ describe("cli", () => {
             });
 
             describe("when given an async formatter path", () => {
+
+                const originalCwd = process.cwd;
+
+                beforeEach(() => {
+                    process.cwd = () => getFixturePath();
+                });
+
+                afterEach(() => {
+                    process.cwd = originalCwd;
+                });
+
                 it(`should execute without any errors with configType:${configType}`, async () => {
                     const formatterPath = getFixturePath("formatters", "async.js");
                     const filePath = getFixturePath("passing.js");

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -16,7 +16,7 @@
 
 const assert = require("chai").assert,
     stdAssert = require("assert"),
-    { ESLint } = require("../../lib/eslint"),
+    { ESLint, FlatESLint } = require("../../lib/eslint"),
     BuiltinRules = require("../../lib/rules"),
     path = require("path"),
     sinon = require("sinon"),
@@ -54,10 +54,12 @@ describe("cli", () => {
      */
     async function verifyESLintOpts(cmd, opts, configType) {
 
+        const ActiveESLint = configType === "flat" ? FlatESLint : ESLint;
+
         // create a fake ESLint class to test with
         const fakeESLint = sinon.mock().withExactArgs(sinon.match(opts));
 
-        Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ESLint.prototype));
+        Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ActiveESLint.prototype));
         sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
         sinon.stub(fakeESLint.prototype, "loadFormatter").returns({ format: sinon.spy() });
 
@@ -110,6 +112,7 @@ describe("cli", () => {
     ["eslintrc", "flat"].forEach(configType => {
 
         const useFlatConfig = configType === "flat";
+        const ActiveESLint = configType === "flat" ? FlatESLint : ESLint;
 
         describe("execute()", () => {
 
@@ -555,7 +558,7 @@ describe("cli", () => {
 
                 it(`should allow defining variables with multiple flags with configType:${configType}`, async () => {
                     const filePath = getFixturePath("undef.js");
-                    const exit = await cli.execute(`--global baz --global bat:true --no-ignore ${filePath}`);
+                    const exit = await cli.execute(`--global baz --global bat:true --no-ignore ${filePath}`, null, useFlatConfig);
 
                     assert.isTrue(log.info.notCalled);
                     assert.strictEqual(exit, 0);
@@ -980,7 +983,7 @@ describe("cli", () => {
                 // create a fake ESLint class to test with
                 const fakeESLint = sinon.mock().withExactArgs(sinon.match({ allowInlineConfig: false }));
 
-                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ESLint.prototype));
+                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ActiveESLint.prototype));
                 sinon.stub(fakeESLint.prototype, "lintFiles").returns([{
                     filePath: "./foo.js",
                     output: "bar",
@@ -1010,7 +1013,7 @@ describe("cli", () => {
                 // create a fake ESLint class to test with
                 const fakeESLint = sinon.mock().withExactArgs(sinon.match({ allowInlineConfig: true }));
 
-                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ESLint.prototype));
+                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ActiveESLint.prototype));
                 sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
                 sinon.stub(fakeESLint.prototype, "loadFormatter").returns({ format: () => "done" });
                 fakeESLint.outputFixes = sinon.stub();
@@ -1041,7 +1044,7 @@ describe("cli", () => {
                 // create a fake ESLint class to test with
                 const fakeESLint = sinon.mock().withExactArgs(sinon.match({ fix: true }));
 
-                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ESLint.prototype));
+                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ActiveESLint.prototype));
                 sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
                 sinon.stub(fakeESLint.prototype, "loadFormatter").returns({ format: () => "done" });
                 fakeESLint.outputFixes = sinon.mock().once();
@@ -1077,7 +1080,7 @@ describe("cli", () => {
                 // create a fake ESLint class to test with
                 const fakeESLint = sinon.mock().withExactArgs(sinon.match({ fix: true }));
 
-                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ESLint.prototype));
+                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ActiveESLint.prototype));
                 sinon.stub(fakeESLint.prototype, "lintFiles").returns(report);
                 sinon.stub(fakeESLint.prototype, "loadFormatter").returns({ format: () => "done" });
                 fakeESLint.outputFixes = sinon.mock().withExactArgs(report);
@@ -1113,7 +1116,7 @@ describe("cli", () => {
                 // create a fake ESLint class to test with
                 const fakeESLint = sinon.mock().withExactArgs(sinon.match({ fix: sinon.match.func }));
 
-                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ESLint.prototype));
+                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ActiveESLint.prototype));
                 sinon.stub(fakeESLint.prototype, "lintFiles").returns(report);
                 sinon.stub(fakeESLint.prototype, "loadFormatter").returns({ format: () => "done" });
                 fakeESLint.getErrorResults = sinon.stub().returns([]);
@@ -1163,7 +1166,7 @@ describe("cli", () => {
                 // create a fake ESLint class to test with
                 const fakeESLint = sinon.mock().withExactArgs(sinon.match({ fix: true }));
 
-                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ESLint.prototype));
+                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ActiveESLint.prototype));
                 sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
                 sinon.stub(fakeESLint.prototype, "loadFormatter").returns({ format: () => "done" });
                 fakeESLint.outputFixes = sinon.mock().never();
@@ -1191,7 +1194,7 @@ describe("cli", () => {
                 // create a fake ESLint class to test with
                 const fakeESLint = sinon.mock().withExactArgs(sinon.match(expectedESLintOptions));
 
-                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ESLint.prototype));
+                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ActiveESLint.prototype));
                 sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
                 sinon.stub(fakeESLint.prototype, "loadFormatter").returns({ format: () => "done" });
                 fakeESLint.outputFixes = sinon.stub();
@@ -1226,7 +1229,7 @@ describe("cli", () => {
                 // create a fake ESLint class to test with
                 const fakeESLint = sinon.mock().withExactArgs(sinon.match({ fix: true }));
 
-                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ESLint.prototype));
+                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ActiveESLint.prototype));
                 sinon.stub(fakeESLint.prototype, "lintFiles").returns(report);
                 sinon.stub(fakeESLint.prototype, "loadFormatter").returns({ format: () => "done" });
                 fakeESLint.outputFixes = sinon.mock().never();
@@ -1262,7 +1265,7 @@ describe("cli", () => {
                 // create a fake ESLint class to test with
                 const fakeESLint = sinon.mock().withExactArgs(sinon.match({ fix: sinon.match.func }));
 
-                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ESLint.prototype));
+                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ActiveESLint.prototype));
                 sinon.stub(fakeESLint.prototype, "lintFiles").returns(report);
                 sinon.stub(fakeESLint.prototype, "loadFormatter").returns({ format: () => "done" });
                 fakeESLint.getErrorResults = sinon.stub().returns([]);
@@ -1299,7 +1302,7 @@ describe("cli", () => {
                 // create a fake ESLint class to test with
                 const fakeESLint = sinon.mock().withExactArgs(sinon.match({ fix: true }));
 
-                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ESLint.prototype));
+                Object.defineProperties(fakeESLint.prototype, Object.getOwnPropertyDescriptors(ActiveESLint.prototype));
                 sinon.stub(fakeESLint.prototype, "lintText").returns(report);
                 sinon.stub(fakeESLint.prototype, "loadFormatter").returns({ format: () => "done" });
                 fakeESLint.outputFixes = sinon.mock().never();


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Fix unit tests.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The test suite for `cli.execute` in  `tests/lib/cli.js` is defined twice, once for eslintrc and once for flat config:

https://github.com/eslint/eslint/blob/0dd9704c4751e1cd02039f7d6485fee09bbccbf6/tests/lib/cli.js#L110

This PR updates the test logic so that when the tests run in flat config mode, `FlatESLint` is used instead of `ESLint` consistently, and the `useFlatConfig` parameter is passed to `cli.execute`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
