### PR TITLE
chore: fix getting scope in tests

### DIFF
--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -824,8 +824,8 @@ describe("Linter", () => {
 
             linter.defineRule("checker", {
                 create(context) {
-                    spy = sinon.spy(() => {
-                        const scope = context.getScope(),
+                    spy = sinon.spy(node => {
+                        const scope = context.sourceCode.getScope(node),
                             horse = getVariable(scope, "horse");
 
                         assert.isTrue(horse.eslintUsed);
@@ -846,8 +846,8 @@ describe("Linter", () => {
 
             linter.defineRule("checker", {
                 create(context) {
-                    spy = sinon.spy(() => {
-                        const scope = context.getScope(),
+                    spy = sinon.spy(node => {
+                        const scope = context.sourceCode.getScope(node),
                             horse = getVariable(scope, "horse");
 
                         assert.notOk(horse.eslintUsed);
@@ -868,8 +868,8 @@ describe("Linter", () => {
 
             linter.defineRule("checker", {
                 create(context) {
-                    spy = sinon.spy(() => {
-                        const scope = context.getScope();
+                    spy = sinon.spy(node => {
+                        const scope = context.sourceCode.getScope(node);
 
                         ["horse", "dog"].forEach(name => {
                             assert.isTrue(getVariable(scope, name).eslintUsed);
@@ -891,8 +891,8 @@ describe("Linter", () => {
 
             linter.defineRule("checker", {
                 create(context) {
-                    spy = sinon.spy(() => {
-                        const scope = context.getScope();
+                    spy = sinon.spy(node => {
+                        const scope = context.sourceCode.getScope(node);
 
                         ["horse", "dog"].forEach(name => {
                             assert.notOk(getVariable(scope, name).eslintUsed);
@@ -9932,8 +9932,8 @@ describe("Linter with FlatConfigArray", () => {
                                 rules: {
                                     checker: {
                                         create(context) {
-                                            spy = sinon.spy(() => {
-                                                const scope = context.getScope(),
+                                            spy = sinon.spy(node => {
+                                                const scope = context.sourceCode.getScope(node),
                                                     horse = getVariable(scope, "horse");
 
                                                 assert.isTrue(horse.eslintUsed);
@@ -9964,8 +9964,8 @@ describe("Linter with FlatConfigArray", () => {
                                 rules: {
                                     checker: {
                                         create(context) {
-                                            spy = sinon.spy(() => {
-                                                const scope = context.getScope(),
+                                            spy = sinon.spy(node => {
+                                                const scope = context.sourceCode.getScope(node),
                                                     horse = getVariable(scope, "horse");
 
                                                 assert.notOk(horse.eslintUsed);
@@ -9996,8 +9996,8 @@ describe("Linter with FlatConfigArray", () => {
                                 rules: {
                                     checker: {
                                         create(context) {
-                                            spy = sinon.spy(() => {
-                                                const scope = context.getScope();
+                                            spy = sinon.spy(node => {
+                                                const scope = context.sourceCode.getScope(node);
 
                                                 ["horse", "dog"].forEach(name => {
                                                     assert.isTrue(getVariable(scope, name).eslintUsed);
@@ -10029,8 +10029,8 @@ describe("Linter with FlatConfigArray", () => {
                                 rules: {
                                     checker: {
                                         create(context) {
-                                            spy = sinon.spy(() => {
-                                                const scope = context.getScope();
+                                            spy = sinon.spy(node => {
+                                                const scope = context.sourceCode.getScope(node);
 
                                                 ["horse", "dog"].forEach(name => {
                                                     assert.notOk(getVariable(scope, name).eslintUsed);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Fixes recently committed tests that were still using now-removed `context.getScope()`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`context.getScope` -> `context.sourceCode.getScope`

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
