### PR TITLE
fix: deep merge behavior in flat config

### DIFF
--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -54,6 +54,15 @@ function isNonNullObject(value) {
 }
 
 /**
+ * Check if a value is a non-null non-array object.
+ * @param {any} value The value to check.
+ * @returns {boolean} `true` if the value is a non-null non-array object.
+ */
+function isNonArrayObject(value) {
+    return isNonNullObject(value) && !Array.isArray(value);
+}
+
+/**
  * Check if a value is undefined.
  * @param {any} value The value to check.
  * @returns {boolean} `true` if the value is undefined.
@@ -63,7 +72,7 @@ function isUndefined(value) {
 }
 
 /**
- * Deeply merges two objects.
+ * Deeply merges two non-array objects.
  * @param {Object} first The base object.
  * @param {Object} second The overrides object.
  * @param {Map<string, Map<string, Object>>} [mergeMap] Maps the combination of first and second arguments to a merged result.
@@ -115,7 +124,7 @@ function deepMerge(first, second, mergeMap = new Map()) {
         const firstValue = first[key];
         const secondValue = second[key];
 
-        if (isNonNullObject(firstValue) && isNonNullObject(secondValue)) {
+        if (isNonArrayObject(firstValue) && isNonArrayObject(secondValue)) {
             result[key] = deepMerge(firstValue, secondValue, mergeMap);
         } else if (isUndefined(secondValue)) {
             result[key] = firstValue;

--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -101,15 +101,12 @@ function deepMerge(first, second, mergeMap = new Map()) {
      * later rather than needing to inspect and change every property
      * individually.
      */
-    let result = {
+    const result = {
         ...first,
         ...second
     };
 
     delete result.__proto__; // eslint-disable-line no-proto -- don't merge own property "__proto__"
-    if (Array.isArray(second)) {
-        result = Object.assign([], result);
-    }
 
     // Store the pending result for this combination of first and second arguments.
     secondMergeMap.set(second, result);

--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -62,25 +62,14 @@ function isUndefined(value) {
     return typeof value === "undefined";
 }
 
-// A unique empty object to be used internally as a mapping key in `deepMerge`.
-const EMPTY_OBJECT = {};
-
 /**
  * Deeply merges two objects.
  * @param {Object} first The base object.
- * @param {any} second The overrides value.
+ * @param {Object} second The overrides object.
  * @param {Map<string, Map<string, Object>>} [mergeMap] Maps the combination of first and second arguments to a merged result.
  * @returns {Object} An object with properties from both first and second.
  */
-function deepMerge(first, second = {}, mergeMap = new Map()) {
-
-    /*
-     * If the second value is an array, just return it. We don't merge
-     * arrays because order matters and we can't know the correct order.
-     */
-    if (Array.isArray(second)) {
-        return second;
-    }
+function deepMerge(first, second, mergeMap = new Map()) {
 
     let secondMergeMap = mergeMap.get(first);
 
@@ -98,15 +87,20 @@ function deepMerge(first, second = {}, mergeMap = new Map()) {
     }
 
     /*
-     * First create a result object where properties from the second value
+     * First create a result object where properties from the second object
      * overwrite properties from the first. This sets up a baseline to use
      * later rather than needing to inspect and change every property
      * individually.
      */
-    const result = {
+    let result = {
         ...first,
         ...second
     };
+
+    delete result.__proto__; // eslint-disable-line no-proto -- don't merge own property "__proto__"
+    if (Array.isArray(second)) {
+        result = Object.assign([], result);
+    }
 
     // Store the pending result for this combination of first and second arguments.
     secondMergeMap.set(second, result);
@@ -121,14 +115,10 @@ function deepMerge(first, second = {}, mergeMap = new Map()) {
         const firstValue = first[key];
         const secondValue = second[key];
 
-        if (isNonNullObject(firstValue)) {
+        if (isNonNullObject(firstValue) && isNonNullObject(secondValue)) {
             result[key] = deepMerge(firstValue, secondValue, mergeMap);
-        } else if (isUndefined(firstValue)) {
-            if (isNonNullObject(secondValue)) {
-                result[key] = deepMerge(EMPTY_OBJECT, secondValue, mergeMap);
-            } else if (!isUndefined(secondValue)) {
-                result[key] = secondValue;
-            }
+        } else if (isUndefined(secondValue)) {
+            result[key] = firstValue;
         }
     }
 

--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -114,7 +114,7 @@ function deepMerge(first, second, mergeMap = new Map()) {
     for (const key of Object.keys(second)) {
 
         // avoid hairy edge case
-        if (key === "__proto__") {
+        if (key === "__proto__" || !Object.prototype.propertyIsEnumerable.call(first, key)) {
             continue;
         }
 

--- a/tests/lib/config/flat-config-schema.js
+++ b/tests/lib/config/flat-config-schema.js
@@ -7,6 +7,28 @@
 
 const { flatConfigSchema } = require("../../../lib/config/flat-config-schema");
 const { assert } = require("chai");
+const { Legacy: { ConfigArray } } = require("@eslint/eslintrc");
+
+/**
+ * This function checks the result of merging two values in eslintrc config.
+ * It uses deep strict equality to compare the actual and the expected results.
+ * This is useful to ensure that the flat config merge logic behaves similarly to the old logic.
+ * When eslintrc is removed, this function and its invocations can be also removed.
+ * @param {Object} [first] The base object.
+ * @param {Object} [second] The overrides object.
+ * @param {Object} [expectedResult] The expected reults of merging first and second values.
+ * @returns {void}
+ */
+function confirmLegacyMergeResult(first, second, expectedResult) {
+    const configArray = new ConfigArray(
+        { settings: first },
+        { settings: second }
+    );
+    const config = configArray.extractConfig("/file");
+    const actualResult = config.settings;
+
+    assert.deepStrictEqual(actualResult, expectedResult);
+}
 
 describe("merge", () => {
 
@@ -18,36 +40,14 @@ describe("merge", () => {
         const result = merge(first, second);
 
         assert.deepStrictEqual(result, { ...first, ...second });
-    });
-
-    it("overrides an object with an array", () => {
-        const first = { foo: 42 };
-        const second = ["bar", "baz"];
-        const result = merge(first, second);
-
-        assert.strictEqual(result, second);
-    });
-
-    it("merges an array with an object", () => {
-        const first = ["foo", "bar"];
-        const second = { baz: 42 };
-        const result = merge(first, second);
-
-        assert.deepStrictEqual(result, { 0: "foo", 1: "bar", baz: 42 });
-    });
-
-    it("overrides an array with another array", () => {
-        const first = ["foo", "bar"];
-        const second = ["baz", "qux"];
-        const result = merge(first, second);
-
-        assert.strictEqual(result, second);
+        confirmLegacyMergeResult(first, second, result);
     });
 
     it("returns an emtpy object if both values are undefined", () => {
         const result = merge(void 0, void 0);
 
         assert.deepStrictEqual(result, {});
+        confirmLegacyMergeResult(void 0, void 0, result);
     });
 
     it("returns an object equal to the first one if the second one is undefined", () => {
@@ -56,6 +56,7 @@ describe("merge", () => {
 
         assert.deepStrictEqual(result, first);
         assert.notStrictEqual(result, first);
+        confirmLegacyMergeResult(first, void 0, result);
     });
 
     it("returns an object equal to the second one if the first one is undefined", () => {
@@ -64,6 +65,16 @@ describe("merge", () => {
 
         assert.deepStrictEqual(result, second);
         assert.notStrictEqual(result, second);
+        confirmLegacyMergeResult(void 0, second, result);
+    });
+
+    it("does not preserve the type of merged objects", () => {
+        const first = new Set(["foo", "bar"]);
+        const second = new Set(["baz"]);
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, {});
+        confirmLegacyMergeResult(first, second, result);
     });
 
     it("merges two objects in a property", () => {
@@ -72,6 +83,39 @@ describe("merge", () => {
         const result = merge(first, second);
 
         assert.deepStrictEqual(result, { foo: { bar: "baz", qux: 42 } });
+        confirmLegacyMergeResult(first, second, result);
+    });
+
+    it("merges an object in a property with an array", () => {
+        const first = { someProperty: { 1: "foo", bar: "baz" } };
+        const second = { someProperty: ["qux"] };
+        const result = merge(first, second);
+
+        /*
+         * When comparing two arrays, chai's deepStrictEqual does not consider non-index properties.
+         * So we have to use an additional assertion:
+         */
+        assert.deepStrictEqual(result, { someProperty: ["qux", "foo"] });
+        assert.propertyVal(result.someProperty, "bar", "baz");
+        confirmLegacyMergeResult(first, second, result);
+    });
+
+    it("merges two arrays in a property", () => {
+        const first = { someProperty: ["foo", "bar", void 0, "baz"] };
+        const second = { someProperty: ["qux", void 0, 42] };
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, { someProperty: ["qux", "bar", 42, "baz"] });
+        confirmLegacyMergeResult(first, second, result);
+    });
+
+    it("merges an array in a property with an object", () => {
+        const first = { foo: ["foobar"] };
+        const second = { foo: { 1: "qux", bar: "baz" } };
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, { foo: { 0: "foobar", 1: "qux", bar: "baz" } });
+        confirmLegacyMergeResult(first, second, result);
     });
 
     it("does not override a value in a property with undefined", () => {
@@ -81,6 +125,7 @@ describe("merge", () => {
 
         assert.deepStrictEqual(result, first);
         assert.notStrictEqual(result, first);
+        confirmLegacyMergeResult(first, second, result);
     });
 
     it("does not change the prototype of a merged object", () => {
@@ -89,6 +134,7 @@ describe("merge", () => {
         const result = merge(first, second);
 
         assert.strictEqual(Object.getPrototypeOf(result), Object.prototype);
+        confirmLegacyMergeResult(first, second, result);
     });
 
     it("does not merge the '__proto__' property", () => {
@@ -96,32 +142,58 @@ describe("merge", () => {
         const second = { ["__proto__"]: { bar: "baz" } };
         const result = merge(first, second);
 
-        assert.deepStrictEqual(result, second);
-        assert.notStrictEqual(result, second);
+        assert.deepStrictEqual(result, {});
+        confirmLegacyMergeResult(first, second, result);
     });
 
-    it("throws an error if a value in a property is overriden with null", () => {
+    it("overrides a value in a property with null", () => {
         const first = { foo: { bar: "baz" } };
         const second = { foo: null };
+        const result = merge(first, second);
 
-        assert.throws(() => merge(first, second), TypeError);
+        assert.deepStrictEqual(result, second);
+        assert.notStrictEqual(result, second);
+        confirmLegacyMergeResult(first, second, result);
     });
 
-    it("does not override a value in a property with a primitive", () => {
+    it("overrides a value in a property with a non-nullish primitive", () => {
         const first = { foo: { bar: "baz" } };
         const second = { foo: 42 };
         const result = merge(first, second);
 
-        assert.deepStrictEqual(result, first);
-        assert.notStrictEqual(result, first);
+        assert.deepStrictEqual(result, second);
+        assert.notStrictEqual(result, second);
+        confirmLegacyMergeResult(first, second, result);
     });
 
-    it("merges an object in a property with a string", () => {
+    it("overrides an object in a property with a string", () => {
         const first = { foo: { bar: "baz" } };
         const second = { foo: "qux" };
         const result = merge(first, second);
 
-        assert.deepStrictEqual(result, { foo: { 0: "q", 1: "u", 2: "x", bar: "baz" } });
+        assert.deepStrictEqual(result, second);
+        assert.notStrictEqual(result, first);
+        confirmLegacyMergeResult(first, second, result);
+    });
+
+    it("overrides a value in a property with a function", () => {
+        const first = { someProperty: { foo: 42 } };
+        const second = { someProperty() {} };
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, second);
+        assert.notProperty(result.someProperty, "foo");
+        confirmLegacyMergeResult(first, second, result);
+    });
+
+    it("overrides a function in a property with an object", () => {
+        const first = { someProperty: Object.assign(() => {}, { foo: "bar" }) };
+        const second = { someProperty: { baz: "qux" } };
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, second);
+        assert.notProperty(result.someProperty, "foo");
+        confirmLegacyMergeResult(first, second, result);
     });
 
     it("merges objects with self-references", () => {

--- a/tests/lib/config/flat-config-schema.js
+++ b/tests/lib/config/flat-config-schema.js
@@ -191,6 +191,14 @@ describe("merge", () => {
         confirmLegacyMergeResult(first, second, result);
     });
 
+    it("sets properties to undefined", () => {
+        const first = { foo: void 0, bar: void 0 };
+        const second = { foo: void 0, baz: void 0 };
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(result, { foo: void 0, bar: void 0, baz: void 0 });
+    });
+
     it("merges objects with self-references", () => {
         const first = { foo: 42 };
 

--- a/tests/lib/config/flat-config-schema.js
+++ b/tests/lib/config/flat-config-schema.js
@@ -199,6 +199,36 @@ describe("merge", () => {
         assert.deepStrictEqual(result, { foo: void 0, bar: void 0, baz: void 0 });
     });
 
+    it("considers only own enumerable properties", () => {
+        const first = {
+            __proto__: { inherited1: "A" }, // non-own properties are not considered
+            included1: "B",
+            notMerged1: { first: true }
+        };
+        const second = {
+            __proto__: { inherited2: "C" }, // non-own properties are not considered
+            included2: "D",
+            notMerged2: { second: true }
+        };
+
+        // non-enumerable properties are not considered
+        Object.defineProperty(first, "notMerged2", { enumerable: false, value: { first: true } });
+        Object.defineProperty(second, "notMerged1", { enumerable: false, value: { second: true } });
+
+        const result = merge(first, second);
+
+        assert.deepStrictEqual(
+            result,
+            {
+                included1: "B",
+                included2: "D",
+                notMerged1: { first: true },
+                notMerged2: { second: true }
+            }
+        );
+        confirmLegacyMergeResult(first, second, result);
+    });
+
     it("merges objects with self-references", () => {
         const first = { foo: 42 };
 

--- a/tests/lib/config/flat-config-schema.js
+++ b/tests/lib/config/flat-config-schema.js
@@ -86,36 +86,31 @@ describe("merge", () => {
         confirmLegacyMergeResult(first, second, result);
     });
 
-    it("merges an object in a property with an array", () => {
+    it("overwrites an object in a property with an array", () => {
         const first = { someProperty: { 1: "foo", bar: "baz" } };
         const second = { someProperty: ["qux"] };
         const result = merge(first, second);
 
-        /*
-         * When comparing two arrays, chai's deepStrictEqual does not consider non-index properties.
-         * So we have to use an additional assertion:
-         */
-        assert.deepStrictEqual(result, { someProperty: ["qux", "foo"] });
-        assert.propertyVal(result.someProperty, "bar", "baz");
-        confirmLegacyMergeResult(first, second, result);
+        assert.deepStrictEqual(result, second);
+        assert.strictEqual(result.someProperty, second.someProperty);
     });
 
-    it("merges two arrays in a property", () => {
+    it("overwrites an array in a property with another array", () => {
         const first = { someProperty: ["foo", "bar", void 0, "baz"] };
         const second = { someProperty: ["qux", void 0, 42] };
         const result = merge(first, second);
 
-        assert.deepStrictEqual(result, { someProperty: ["qux", "bar", 42, "baz"] });
-        confirmLegacyMergeResult(first, second, result);
+        assert.deepStrictEqual(result, second);
+        assert.strictEqual(result.someProperty, second.someProperty);
     });
 
-    it("merges an array in a property with an object", () => {
+    it("overwrites an array in a property with an object", () => {
         const first = { foo: ["foobar"] };
         const second = { foo: { 1: "qux", bar: "baz" } };
         const result = merge(first, second);
 
-        assert.deepStrictEqual(result, { foo: { 0: "foobar", 1: "qux", bar: "baz" } });
-        confirmLegacyMergeResult(first, second, result);
+        assert.deepStrictEqual(result, second);
+        assert.strictEqual(result.foo, second.foo);
     });
 
     it("does not override a value in a property with undefined", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #17820

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v21.5.0
npm version: v10.2.4
Local ESLint version: v8.56.0 (Currently used)
Global ESLint version: Not found
Operating System: darwin 23.1.0

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

No config file.

**What did you do? Please include the actual source code causing the issue.**

I compared the merge behavior in flat config against eslintrc in different cases.

```js
// test1.js
const { default: { FlatESLint } } = await import("eslint/use-at-your-own-risk");

const eslint = new FlatESLint({
    overrideConfigFile: true,
    baseConfig: [
        {
            languageOptions: {
                parserOptions: {
                    foo: {}
                }
            },
        },
        {
            languageOptions: {
                parserOptions: {
                    // null overwrites other values in eslintrc.
                    foo: null
                }
            },
        },
    ]
});
const { languageOptions: { parserOptions } } = await eslint.calculateConfigForFile("file.js");
console.log(parserOptions);
```

```js
// test2.js
const { default: { FlatESLint } } = await import("eslint/use-at-your-own-risk");

const eslint = new FlatESLint({
    overrideConfigFile: true,
    baseConfig: [
        {
            languageOptions: {
                parserOptions: {
                    prop1: {},
                    prop2: {},
                    prop3: { 1: "one" },
                    prop4: ["a", "b", "c"],
                    prop5: { ["__proto__"]: 1 }
                }
            },
        },
        {
            languageOptions: {
                parserOptions: {
                    // In eslintrc, primitives overwrite other values.
                    prop1: 123,

                    // In eslintrc, strings are not spread.
                    prop2: "foo",

                    // In eslintrc, it is possible to merge an object or an array with another array.
                    // Properties in the second array override properties in the first value.
                    prop3: ["zero"],
                    prop4: ["d", "e"],

                    // An own property "__proto__" is not merged in eslintrc.
                    prop5: { ["__proto__"]: 2 }
                }
            },
        },
    ]
});
const { languageOptions: { parserOptions } } = await eslint.calculateConfigForFile("file.js");
console.log(parserOptions);
```

**What did you expect to happen?**

The merge behavior in flat config should be the same as in eslintrc.

```console
❯ node test1.js
{ foo: null }
```

```console
❯ node test2.js
{
  prop1: 123,
  prop2: 'foo',
  prop3: [ 'zero', 'one' ],
  prop4: [ 'd', 'e', 'c' ],
  prop5: {}
}
```

**What actually happened? Please include the actual, raw output from ESLint.**

There are some differences in the merge behavior, all addressed in this PR.

```console
❯ node test1.js
Error: Key "languageOptions": Key "parserOptions": Cannot convert undefined or null to object
```

```console
❯ node test2.js
{
  prop1: {},
  prop2: { '0': 'f', '1': 'o', '2': 'o' },
  prop3: [ 'zero' ],
  prop4: [ 'd', 'e' ],
  prop5: { ['__proto__']: 2 }
}
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**Repro**: https://stackblitz.com/edit/stackblitz-starters-7ta5nx

#### What changes did you make? (Give an overview)

Updated the `deepMerge` algorithm in lib/config/flat-config-schema.js to make it more similar to eslintrc's [`mergeWithoutOverwrite`](https://github.com/eslint/eslintrc/blob/bdce01aad747393d13cd1ae17d8280e54c9c5191/lib/config-array/config-array.js#L126-L156). I think this was requested in https://github.com/eslint/eslint/issues/17820#issuecomment-1843181566.

The new changes affect the way properties are merged: we could keep all of them or revert some to the current behavior.

* Primitive property values in the second object will always overwrite properties of the first object. Currently, if the first property value is an object and the second one is a primitive, the algorithm will try to merge the values, producing a new object that is mostly, but not always, a clone of the first one.
* `null` property values in the second object will no longer result in a runtime error but instead behave like other primitives and overwrite properties of the first object. This is the original bug reported in #17820.
* String property values in the second object will behave like other primitives and no longer spread over their characters.
* When merging two objects with an own `__proto__` property, the `__proto__` property will no longer be merged. In the current merge implementation, the result will contain an own `__proto__` property if the first object does.
* <strike>Arrays can merge with arrays and other objects like in eslintrc. The resulting value will be an array or a plain object, depending on the type of the second value. Currently, merging only occurs when the second value is not an array (although the first value may be any object). I'm not 100% sure of this change because of [this comment](https://github.com/eslint/eslint/blob/v8.56.0/lib/config/flat-config-schema.js#L73-L76).</strike> There is agreement that in the new config system arrays should not merge with other arrays or objects like in eslintrc.

#### Is there anything you'd like reviewers to focus on?

All of the above points.

As a hint, you may find it helpful to play with the [repro](https://stackblitz.com/edit/stackblitz-starters-7ta5nx) when not sure about how things work in the current implementation or in eslintrc.

<!-- markdownlint-disable-file MD004 -->
