### PR TITLE
docs: show `NEXT` in version selectors

### DIFF
--- a/docs/src/_data/config.json
+++ b/docs/src/_data/config.json
@@ -1,5 +1,5 @@
 {
     "lang": "en",
-    "version": "7.26.0",
-    "showNextVersion": false
+    "version": "8.56.0",
+    "showNextVersion": true
 }

--- a/docs/src/_data/eslintVersion.js
+++ b/docs/src/_data/eslintVersion.js
@@ -16,6 +16,7 @@ const path = require("path");
 
 const pkgPath = path.resolve(__dirname, "../../package.json");
 const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+const config = JSON.parse(fs.readFileSync(path.resolve(__dirname, "./config.json"), "utf8"));
 const { ESLINT_VERSION } = process.env;
 
 //-----------------------------------------------------------------------------
@@ -31,4 +32,4 @@ const { ESLINT_VERSION } = process.env;
  * GitHub. Otherwise, we will use the version from package.json.
  */
 
-module.exports = ESLINT_VERSION ?? pkg.version;
+module.exports = ESLINT_VERSION ?? config.version ?? pkg.version;

--- a/docs/tools/validate-links.js
+++ b/docs/tools/validate-links.js
@@ -18,6 +18,7 @@ const skipPatterns = [
     "/team",
     "/donate",
     "/docs/latest",
+    "/docs/next",
     'src="null"'
 ];
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Enables `NEXT` in version selectors.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Set `config.showNextVersion` to `true` to enable `NEXT` in version selectors (see https://github.com/eslint/eslint/commit/66694136b67277c050bd27f60050779687a88c9f).
* Updated `eslintVersion` to read from `config.version`, because `pkg.version` will soon become `9.0.0-alpha.0`.

#### Is there anything you'd like reviewers to focus on?

* If we merge this now, `NEXT` will appear in the lists on https://eslint.org/docs/head before the release. Is that okay? 
* When this is merged, I'll sync the `next` branch.
* I'll send a separate PR targeting the `latest` branch to set `"showNextVersion": true` there.
* `eslintVersion` also reads from `ESLINT_VERSION` environment variable, so we could just set this variable on Netlify instead of hardcoding the latest version in the config file. However, this is a temporary solution anyway, and this will make it more clear where the `8.56.0` value is coming from when we start working on a long-term solution.

<!-- markdownlint-disable-file MD004 -->
