### PR TITLE
ci: use `--force` flag when installing eslint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         node-version: 'lts/*'
     - name: Install Packages
-      run: npm install
+      run: npm install --force
     - name: Lint Files
       run: node Makefile lint
     - name: Check Rule Files
@@ -60,7 +60,7 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
     - name: Install Packages
-      run: npm install
+      run: npm install --force
     - name: Test
       run: node Makefile mocha
     - name: Fuzz Test
@@ -75,7 +75,7 @@ jobs:
       with:
         node-version: '16'
     - name: Install Packages
-      run: npm install
+      run: npm install --force
     - name: Test
       run: node Makefile wdio
     - name: Fuzz Test

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-node@v4
 
     - name: Install npm packages
-      run: npm install
+      run: npm install --force
 
     - name: Update README with latest team and sponsor data
       run: npm run build:readme
@@ -26,7 +26,7 @@ jobs:
       run: |
         git config user.name "GitHub Actions Bot"
         git config user.email "<eslint@googlegroups.com>"
-    
+
     - name: Save updated files
       run: |
         chmod +x ./tools/commit-readme.sh


### PR DESCRIPTION
Temporary solution for prerelease versions

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Prerelease versions of `eslint` will likely need to be installed using `npm install --force`, because some of the dependencies and dev dependencies have `eslint` as a peer dependency, and prereleases most likely won't satisfy those range constraints.

I prepared this so that we can quickly fix the CI after today's v9.0.0-alpha.0 release. Do not merge yet.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated ci workflows to use the `--force` flag when installing eslint.

#### Is there anything you'd like reviewers to focus on?

Did I miss some places?

<!-- markdownlint-disable-file MD004 -->
