### PR TITLE
docs: Add exported and string config notes to migrate to v9 guide

### DIFF
--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -24,7 +24,7 @@ The lists below are ordered roughly by the number of users each change is expect
 * [New checks in `no-implicit-coercion` by default](#no-implicit-coercion)
 * [Case-sensitive flags in `no-invalid-regexp`](#no-invalid-regexp)
 * [Stricter `/* exported */` parsing](#exported-parsing)
-* [`"eslint:recommended"` and `"eslint:all"` invalid in flat config](#string-config)
+* [`"eslint:recommended"` and `"eslint:all"`strings no longer accepted in flat config](#string-config)
 
 ### Breaking changes for plugin developers
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -23,6 +23,8 @@ The lists below are ordered roughly by the number of users each change is expect
 * [`no-constructor-return` and `no-sequences` rule schemas are stricter](#stricter-rule-schemas)
 * [New checks in `no-implicit-coercion` by default](#no-implicit-coercion)
 * [Case-sensitive flags in `no-invalid-regexp`](#no-invalid-regexp)
+* [Stricter `/* exported */` parsing](#exported-parsing)
+* [`"eslint:recommended"` and `"eslint:all"` invalid in flat config](#string-config)
 
 ### Breaking changes for plugin developers
 
@@ -149,6 +151,50 @@ In ESLint v9.0.0, the option `allowConstructorFlags` is now case-sensitive.
 **To address:** Update your configuration if needed.
 
 **Related issue(s):** [#16574](https://github.com/eslint/eslint/issues/16574)
+
+## <a name="exported-parsing"></a> Stricter `/* exported */` parsing
+
+Prior to ESLint v9.0.0, the `/* exported */` directive incorrectly allowed the following syntax:
+
+```js
+/* exported foo: true, bar: false */
+```
+
+The `true` and `false` in this example had no effect on ESLint's behavior, and in fact, was a parsing bug.
+
+In ESLint v9.0.0, any `/* exported */` variables followed by a colon and value will be ignored as invalid.
+
+**To address:** Update any `/* exported */` directives to eliminate the colons and subsequent values.
+
+**Related issue(s):** [#17622](https://github.com/eslint/eslint/issues/17622)
+
+## <a name="string-config"></a> `"eslint:recommended"` and `"eslint:all"` invalid in flat config
+
+In ESLint v8.x, `eslint.config.js` could refer to `"eslint:recommended"` and `"eslint:all"` configurations by inserting a string into the config array, as in this example:
+
+```js
+// eslint.config.js
+export default [
+    "eslint:recommended",
+    "eslint:all"
+];
+```
+
+In ESLint v9.0.0, this format is no longer supported and will result in an error.
+
+**To address:** Use the `@eslint/js` package instead:
+
+```js
+// eslint.config.js
+import js from "@eslint/js";
+
+export default [
+    js.configs.recommended,
+    js.configs.all
+];
+```
+
+**Related issue(s):** [#17488](https://github.com/eslint/eslint/issues/17488)
 
 ## <a name="removed-context-methods"></a> Removed multiple `context` methods
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -24,7 +24,7 @@ The lists below are ordered roughly by the number of users each change is expect
 * [New checks in `no-implicit-coercion` by default](#no-implicit-coercion)
 * [Case-sensitive flags in `no-invalid-regexp`](#no-invalid-regexp)
 * [Stricter `/* exported */` parsing](#exported-parsing)
-* [`"eslint:recommended"` and `"eslint:all"`strings no longer accepted in flat config](#string-config)
+* [`"eslint:recommended"` and `"eslint:all"` strings no longer accepted in flat config](#string-config)
 
 ### Breaking changes for plugin developers
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -158,17 +158,25 @@ Prior to ESLint v9.0.0, the `/* exported */` directive incorrectly allowed the f
 
 ```js
 /* exported foo: true, bar: false */
+
+// and
+
+/* exported foo bar */
 ```
 
 The `true` and `false` in this example had no effect on ESLint's behavior, and in fact, was a parsing bug.
 
 In ESLint v9.0.0, any `/* exported */` variables followed by a colon and value will be ignored as invalid.
 
-**To address:** Update any `/* exported */` directives to eliminate the colons and subsequent values.
+**To address:** Update any `/* exported */` directives to eliminate the colons and subsequent values, and ensure there are commas between variable names such as:
+
+```js
+/* exported foo, bar */
+```
 
 **Related issue(s):** [#17622](https://github.com/eslint/eslint/issues/17622)
 
-## <a name="string-config"></a> `"eslint:recommended"` and `"eslint:all"` invalid in flat config
+## <a name="string-config"></a> `"eslint:recommended"` and `"eslint:all"` no longer accepted in flat config
 
 In ESLint v8.x, `eslint.config.js` could refer to `"eslint:recommended"` and `"eslint:all"` configurations by inserting a string into the config array, as in this example:
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added sections to the migration guide for:

- `/* exported */` parsing
- dropping support for string configs in flat config


#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
