### PR TITLE
fix!: no-unused-vars `varsIgnorePattern` behavior with catch arguments

### DIFF
--- a/docs/src/rules/no-unused-vars.md
+++ b/docs/src/rules/no-unused-vars.md
@@ -135,7 +135,7 @@ By default this rule is enabled with `all` option for variables and `after-used`
 ```json
 {
     "rules": {
-        "no-unused-vars": ["error", { "vars": "all", "args": "after-used", "ignoreRestSiblings": false }]
+        "no-unused-vars": ["error", { "vars": "all", "args": "after-used", "caughtErrors": "none", "ignoreRestSiblings": false }]
     }
 }
 ```
@@ -144,7 +144,7 @@ By default this rule is enabled with `all` option for variables and `after-used`
 
 The `vars` option has two settings:
 
-* `all` checks all variables for usage, including those in the global scope (except the variables those are allowed by the ignore pattern). This is the default setting.
+* `all` checks all variables for usage, including those in the global scope. However, it excludes variables targeted by other options like `args` and `caughtErrors`. This is the default setting.
 * `local` checks only that locally-declared variables are used but will allow global variables to be unused.
 
 #### vars: local
@@ -164,7 +164,7 @@ some_unused_var = 42;
 
 ### varsIgnorePattern
 
-The `varsIgnorePattern` option specifies exceptions not to check for usage: variables whose names match a regexp pattern. For example, variables whose names contain `ignored` or `Ignored`. Pattern specify in this option does not ignore the `function` and `catch` arguments.
+The `varsIgnorePattern` option specifies exceptions not to check for usage: variables whose names match a regexp pattern. For example, variables whose names contain `ignored` or `Ignored`. However, it excludes variables targeted by other options like `argsIgnorePattern` and `caughtErrorsIgnorePattern`.
 
 Examples of **correct** code for the `{ "varsIgnorePattern": "[iI]gnored" }` option:
 
@@ -265,7 +265,7 @@ Examples of **correct** code for the `{ "argsIgnorePattern": "^_" }` option:
 ::: correct
 
 ```js
-/*eslint no-unused-vars: ["error", { "args": "all", "argsIgnorePattern": "^_" }]*/
+/*eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }]*/
 
 function foo(x, _y) {
     return x + 1;

--- a/docs/src/rules/no-unused-vars.md
+++ b/docs/src/rules/no-unused-vars.md
@@ -144,7 +144,7 @@ By default this rule is enabled with `all` option for variables and `after-used`
 
 The `vars` option has two settings:
 
-* `all` checks all variables for usage, including those in the global scope. This is the default setting.
+* `all` checks all variables for usage, including those in the global scope (except the variables those are allowed by the ignore pattern). This is the default setting.
 * `local` checks only that locally-declared variables are used but will allow global variables to be unused.
 
 #### vars: local
@@ -164,7 +164,7 @@ some_unused_var = 42;
 
 ### varsIgnorePattern
 
-The `varsIgnorePattern` option specifies exceptions not to check for usage: variables whose names match a regexp pattern. For example, variables whose names contain `ignored` or `Ignored`.
+The `varsIgnorePattern` option specifies exceptions not to check for usage: variables whose names match a regexp pattern. For example, variables whose names contain `ignored` or `Ignored`. Pattern specify in this option does not ignore the `function` and `catch` arguments.
 
 Examples of **correct** code for the `{ "varsIgnorePattern": "[iI]gnored" }` option:
 
@@ -265,7 +265,7 @@ Examples of **correct** code for the `{ "argsIgnorePattern": "^_" }` option:
 ::: correct
 
 ```js
-/*eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }]*/
+/*eslint no-unused-vars: ["error", { "args": "all", "argsIgnorePattern": "^_" }]*/
 
 function foo(x, _y) {
     return x + 1;
@@ -333,7 +333,7 @@ Examples of **correct** code for the `{ "caughtErrorsIgnorePattern": "^ignore" }
 ::: correct
 
 ```js
-/*eslint no-unused-vars: ["error", { "caughtErrorsIgnorePattern": "^ignore" }]*/
+/*eslint no-unused-vars: ["error", { "caughtErrors": "all", "caughtErrorsIgnorePattern": "^ignore" }]*/
 
 try {
     //...

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -28,6 +28,7 @@ The lists below are ordered roughly by the number of users each change is expect
 * [Case-sensitive flags in `no-invalid-regexp`](#no-invalid-regexp)
 * [Stricter `/* exported */` parsing](#exported-parsing)
 * [`"eslint:recommended"` and `"eslint:all"` strings no longer accepted in flat config](#string-config)
+* [Behavior of `varsIgnorePattern` option of `no-unused-vars` rule with catch arguments](#vars-ignore-pattern)
 
 ### Breaking changes for plugin developers
 
@@ -235,6 +236,25 @@ export default [
 ```
 
 **Related issue(s):** [#17488](https://github.com/eslint/eslint/issues/17488)
+
+## <a name="vars-ignore-pattern"></a> Behavior of `varsIgnorePattern` option of `no-unused-vars` rule with catch arguments
+
+In previous versions of ESLint, `varsIgnorePattern` option of `no-unused-vars`, that is used to restrict some specified variable to be reported, used to ignore all variables that machtes the specified pattern except `function` arguments because there is a seperate option to ignore them called `argsIgnorePattern` and same was expected for `caughtErrorsIgnorePattern` option but `varsIgnorePattern` was also ignoring `catch` block arguments.
+
+This behavior has been fixed in ESLint v9.0.0, that means `varsIgnorePattern` option don't get applied to both `function` and `catch` block arguments.
+
+```js
+/*eslint no-unused-vars: ["error", { "caughtErrors": "all", "varsIgnorePattern": "^err" }]*/
+
+try {
+    //...
+} catch (err) { // 'err' will be reported.
+    console.error("errors");
+}
+
+```
+
+**Related issue(s):** [#17540](https://github.com/eslint/eslint/issues/17540)
 
 ## <a name="removed-context-methods"></a> Removed multiple `context` methods
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -28,7 +28,7 @@ The lists below are ordered roughly by the number of users each change is expect
 * [Case-sensitive flags in `no-invalid-regexp`](#no-invalid-regexp)
 * [Stricter `/* exported */` parsing](#exported-parsing)
 * [`"eslint:recommended"` and `"eslint:all"` strings no longer accepted in flat config](#string-config)
-* [Behavior of `varsIgnorePattern` option of `no-unused-vars` rule with catch arguments](#vars-ignore-pattern)
+* [`varsIgnorePattern` option of `no-unused-vars` no longer applies to catch arguments](#vars-ignore-pattern)
 
 ### Breaking changes for plugin developers
 
@@ -237,11 +237,9 @@ export default [
 
 **Related issue(s):** [#17488](https://github.com/eslint/eslint/issues/17488)
 
-## <a name="vars-ignore-pattern"></a> Behavior of `varsIgnorePattern` option of `no-unused-vars` rule with catch arguments
+## <a name="vars-ignore-pattern"></a> `varsIgnorePattern` option of `no-unused-vars` no longer applies to catch arguments
 
-In previous versions of ESLint, `varsIgnorePattern` option of `no-unused-vars`, that is used to restrict some specified variable to be reported, used to ignore all variables that machtes the specified pattern except `function` arguments because there is a seperate option to ignore them called `argsIgnorePattern` and same was expected for `caughtErrorsIgnorePattern` option but `varsIgnorePattern` was also ignoring `catch` block arguments.
-
-This behavior has been fixed in ESLint v9.0.0, that means `varsIgnorePattern` option don't get applied to both `function` and `catch` block arguments.
+In previous versions of ESLint, the `varsIgnorePattern` option of `no-unused-vars` incorrectly ignored errors specified in a `catch` clause. In ESLint v9.0.0, `varsIgnorePattern` no longer applies to errors in `catch` clauses. For example:
 
 ```js
 /*eslint no-unused-vars: ["error", { "caughtErrors": "all", "varsIgnorePattern": "^err" }]*/
@@ -253,6 +251,8 @@ try {
 }
 
 ```
+
+**To address:** If you want to specify ignore patterns for `catch` clause variable names, use the `caughtErrorsIgnorePattern` option in addition to `varsIgnorePattern`.
 
 **Related issue(s):** [#17540](https://github.com/eslint/eslint/issues/17540)
 

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -141,7 +141,7 @@ module.exports = {
             } else if (defType === "Parameter" && config.argsIgnorePattern) {
                 type = "args";
                 pattern = config.argsIgnorePattern.toString();
-            } else if (defType !== "Parameter" && config.varsIgnorePattern) {
+            } else if (defType !== "Parameter" && defType !== "CatchClause" && config.varsIgnorePattern) {
                 type = "vars";
                 pattern = config.varsIgnorePattern.toString();
             }

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -623,9 +623,7 @@ module.exports = {
                             if (config.caughtErrorsIgnorePattern && config.caughtErrorsIgnorePattern.test(def.name.name)) {
                                 continue;
                             }
-                        }
-
-                        if (type === "Parameter") {
+                        } else if (type === "Parameter") {
 
                             // skip any setter argument
                             if ((def.node.parent.type === "Property" || def.node.parent.type === "MethodDefinition") && def.node.parent.kind === "set") {

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -1137,6 +1137,11 @@ ruleTester.run("no-unused-vars", rule, {
             options: [{ caughtErrors: "all", varsIgnorePattern: "^err" }],
             errors: [definedError("err")]
         },
+        {
+            code: "try{}catch(err){};",
+            options: [{ caughtErrors: "all", varsIgnorePattern: "^." }],
+            errors: [definedError("err")]
+        },
 
         // multiple try catch with one success
         {

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -1132,6 +1132,11 @@ ruleTester.run("no-unused-vars", rule, {
             options: [{ caughtErrors: "all", caughtErrorsIgnorePattern: "^ignore" }],
             errors: [definedError("err", ". Allowed unused args must match /^ignore/u")]
         },
+        {
+            code: "try{}catch(err){};",
+            options: [{ caughtErrors: "all", varsIgnorePattern: "^err" }],
+            errors: [definedError("err", ". Allowed unused vars must match /^err/u")]
+        },
 
         // multiple try catch with one success
         {

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -1135,7 +1135,7 @@ ruleTester.run("no-unused-vars", rule, {
         {
             code: "try{}catch(err){};",
             options: [{ caughtErrors: "all", varsIgnorePattern: "^err" }],
-            errors: [definedError("err", ". Allowed unused vars must match /^err/u")]
+            errors: [definedError("err")]
         },
 
         // multiple try catch with one success


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

* **Node version: 21.1.0**
* **npm version: 10.2.0**
* **Local ESLint version: latest**
* **Global ESLint version: latest**
* **Operating System: windows**

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
'@typescript-eslint/no-unused-vars': [
      'error',
      {
        varsIgnorePattern: '^err',
        caughtErrors: 'all'
      }
    ]
```

</details>

**What did you do? Please include the actual source code causing the issue.**
```js
try {
  // ...
} catch (err) { // <== unused variable
  console.error(process.env)
}
```

**What did you expect to happen?**
eslint won't ignore the `err` argument.
**What actually happened? Please include the actual, raw output from ESLint.**
eslint ignored the `err` argument by following the `varsIgnorePattern`.

Fixes: #17540
