### PR TITLE
build: update docs files when publishing prereleases

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -274,15 +274,17 @@ function publishSite() {
 /**
  * Updates the changelog, bumps the version number in package.json, creates a local git commit and tag,
  * and generates the site in an adjacent `website` folder.
+ * @param {string} [prereleaseId] The prerelease identifier (alpha, beta, etc.). If `undefined`, this is
+ *      a regular release.
  * @returns {void}
  */
-function generateRelease() {
-    ReleaseOps.generateRelease();
+function generateRelease(prereleaseId) {
+    ReleaseOps.generateRelease(prereleaseId);
     const releaseInfo = JSON.parse(cat(".eslint-release-info.json"));
 
     echo("Generating site");
     target.gensite();
-    generateBlogPost(releaseInfo);
+    generateBlogPost(releaseInfo, prereleaseId ? semver.inc(releaseInfo.version, "major") : void 0);
     commitSiteToGit(`v${releaseInfo.version}`);
 
     echo("Updating version in docs package");
@@ -295,44 +297,6 @@ function generateRelease() {
     echo("Updating commit with docs data");
     exec("git add docs/ && git commit --amend --no-edit");
     exec(`git tag -a -f v${releaseInfo.version} -m ${releaseInfo.version}`);
-}
-
-/**
- * Updates the changelog, bumps the version number in package.json, creates a local git commit and tag,
- * and generates the site in an adjacent `website` folder.
- * @param {string} prereleaseId The prerelease identifier (alpha, beta, etc.)
- * @returns {void}
- */
-function generatePrerelease(prereleaseId) {
-    ReleaseOps.generateRelease(prereleaseId);
-    const releaseInfo = JSON.parse(cat(".eslint-release-info.json"));
-    const nextMajor = semver.inc(releaseInfo.version, "major");
-
-    echo("Generating site");
-
-    // always write docs into the next major directory (so 2.0.0-alpha.0 writes to 2.0.0)
-    target.gensite(nextMajor);
-
-    /*
-     * Premajor release should have identical "next major version".
-     * Preminor and prepatch release will not.
-     * 5.0.0-alpha.0 --> next major = 5, current major = 5
-     * 4.4.0-alpha.0 --> next major = 5, current major = 4
-     * 4.0.1-alpha.0 --> next major = 5, current major = 4
-     */
-    if (semver.major(releaseInfo.version) === semver.major(nextMajor)) {
-
-        /*
-         * This prerelease is for a major release (not preminor/prepatch).
-         * Blog post generation logic needs to be aware of this (as well as
-         * know what the next major version is actually supposed to be).
-         */
-        generateBlogPost(releaseInfo, nextMajor);
-    } else {
-        generateBlogPost(releaseInfo);
-    }
-
-    commitSiteToGit(`v${releaseInfo.version}`);
 }
 
 /**
@@ -1105,6 +1069,6 @@ target.perf = function() {
     });
 };
 
-target.generateRelease = generateRelease;
-target.generatePrerelease = ([prereleaseType]) => generatePrerelease(prereleaseType);
+target.generateRelease = () => generateRelease();
+target.generatePrerelease = ([prereleaseType]) => generateRelease(prereleaseType);
 target.publishRelease = publishRelease;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Fixes our release process to update docs files when publishing prereleases, the same as when publishing regular releases.

https://github.com/eslint/eslint/issues/17883#issuecomment-1872420068 

https://github.com/eslint/eslint/issues/17893#issuecomment-1873327372

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Merged prerelease-specific logic from `function generatePrerelease` into `function generateRelease` so that `function generateRelease` now handles both releases and prereleases.

#### Is there anything you'd like reviewers to focus on?

It seems that `function generatePrerelease` was also supporting prereleases of minor versions. I didn't copy that logic, it was probably needed for `0.x` prereleases only.

<!-- markdownlint-disable-file MD004 -->
