### PR TITLE
fix!: configuration comments with just severity should retain options

### DIFF
--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -23,7 +23,7 @@ The lists below are ordered roughly by the number of users each change is expect
 * [`eslint:recommended` has been updated](#eslint-recommended)
 * [`--quiet` no longer runs rules set to `"warn"`](#quiet-warn)
 * [Change in behavior when no patterns are passed to CLI](#cli-empty-patterns)
-* [`/* eslint */` comments with only severity retain options from the config file](#eslint-comment-options)
+* [`/* eslint */` comments with only severity now retain options from the config file](#eslint-comment-options)
 * [`no-constructor-return` and `no-sequences` rule schemas are stricter](#stricter-rule-schemas)
 * [New checks in `no-implicit-coercion` by default](#no-implicit-coercion)
 * [Case-sensitive flags in `no-invalid-regexp`](#no-invalid-regexp)
@@ -136,7 +136,7 @@ Prior to ESLint v9.0.0, running the ESLint CLI without any file or directory pat
 
 **Related issue(s):** [#14308](https://github.com/eslint/eslint/issues/14308)
 
-## <a name="eslint-comment-options"></a> `/* eslint */` comments with only severity retain options from the config file
+## <a name="eslint-comment-options"></a> `/* eslint */` comments with only severity now retain options from the config file
 
 Prior to ESLint v9.0.0, configuration comments such as `/* eslint curly: "warn" */` or `/* eslint curly: ["warn"] */` would completely override any configuration specified for the rule in the config file, and thus enforce the default options of the rule.
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -23,6 +23,7 @@ The lists below are ordered roughly by the number of users each change is expect
 * [`eslint:recommended` has been updated](#eslint-recommended)
 * [`--quiet` no longer runs rules set to `"warn"`](#quiet-warn)
 * [Change in behavior when no patterns are passed to CLI](#cli-empty-patterns)
+* [`/* eslint */` comments with only severity retain options from the config file](#eslint-comment-options)
 * [`no-constructor-return` and `no-sequences` rule schemas are stricter](#stricter-rule-schemas)
 * [New checks in `no-implicit-coercion` by default](#no-implicit-coercion)
 * [Case-sensitive flags in `no-invalid-regexp`](#no-invalid-regexp)
@@ -134,6 +135,46 @@ Prior to ESLint v9.0.0, running the ESLint CLI without any file or directory pat
 **To address:** In most cases, no change is necessary, and you may find some locations where you thought ESLint was running but it wasn't. If you'd like to keep the v8.x behavior, where passing no patterns results in ESLint exiting with code 0, add the `--pass-on-no-patterns` flag to the CLI call.
 
 **Related issue(s):** [#14308](https://github.com/eslint/eslint/issues/14308)
+
+## <a name="eslint-comment-options"></a> `/* eslint */` comments with only severity retain options from the config file
+
+Prior to ESLint v9.0.0, configuration comments such as `/* eslint curly: "warn" */` or `/* eslint curly: ["warn"] */` would completely override any configuration specified for the rule in the config file, and thus enforce the default options of the rule.
+
+In ESLint v9.0.0, the behavior of configuration comments is aligned with how rule configurations in config files are merged, meaning that a configuration comment with only severity now retains options specified in the config file and just overrides the severity.
+
+For example, if you have the following config file:
+
+```js
+// eslint.config.js
+
+export default [{
+    rules: {
+        curly: ["error", "multi"]
+    }
+}];
+```
+
+and the following configuration comment:
+
+```js
+// my-file.js
+
+/* eslint curly: "warn" */
+```
+
+the resulting configuration for the `curly` rule when linting `my-file.js` will be `curly: ["warn", "multi"]`.
+
+Note that this change only affects cases where the same rule is configured in the config file with options and using a configuration comment without options. In all other cases (e.g. the rule is only configured using a configuration comment), the behavior remains the same as prior to ESLint v9.0.0.
+
+**To address:** We expect that in most cases no change is necessary, as rules configured using configuration comments are typically not already configured in the config file. However, if you need a configuration comment to completely override configuration from the config file and enforce the default options, you'll need to specify at least one option:
+
+```js
+// my-file.js
+
+/* eslint curly: ["warn", "all"] */
+```
+
+**Related issue(s):** [#17381](https://github.com/eslint/eslint/issues/17381)
 
 ## <a name="stricter-rule-schemas"></a> `no-constructor-return` and `no-sequences` rule schemas are stricter
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1331,7 +1331,56 @@ class Linter {
             { exportedVariables: commentDirectives.exportedVariables, enabledGlobals: commentDirectives.enabledGlobals }
         );
 
+        /*
+         * Now we determine the final configurations for rules.
+         * First, let all inline rule configurations override those from the config.
+         * Then, check for a special case: if a rule is configured in both places,
+         * inline rule configuration that only has severity should retain options from
+         * the config and just override the severity.
+         *
+         * Example:
+         *
+         *   {
+         *       rules: {
+         *           curly: ["error", "multi"]
+         *       }
+         *   }
+         *
+         *   /* eslint curly: ["warn"] * /
+         *
+         *   Results in:
+         *
+         *   curly: ["warn", "multi"]
+         */
         const configuredRules = Object.assign({}, config.rules, commentDirectives.configuredRules);
+
+        if (config.rules) {
+            for (const [ruleId, ruleInlineConfig] of Object.entries(commentDirectives.configuredRules)) {
+                if (
+
+                    /*
+                     * If inline config for the rule has only severity
+                     */
+                    (!Array.isArray(ruleInlineConfig) || ruleInlineConfig.length === 1) &&
+
+                    /*
+                     * And provided config for the rule has options
+                     */
+                    Object.hasOwn(config.rules, ruleId) &&
+                    (Array.isArray(config.rules[ruleId]) && config.rules[ruleId].length > 1)
+                ) {
+
+                    /*
+                     * Then use severity from the inline config and options from the provided config
+                     */
+                    configuredRules[ruleId] = [
+                        Array.isArray(ruleInlineConfig) ? ruleInlineConfig[0] : ruleInlineConfig, // severity from the inline config
+                        ...config.rules[ruleId].slice(1) // options from the provided config
+                    ];
+                }
+            }
+        }
+
         let lintingProblems;
 
         try {
@@ -1674,7 +1723,7 @@ class Linter {
                                     [ruleId]: ruleOptions
                                 }
                             });
-                            mergedInlineConfig.rules[ruleId] = ruleValue;
+                            mergedInlineConfig.rules[ruleId] = ruleOptions;
                         } catch (err) {
 
                             /*
@@ -1713,7 +1762,58 @@ class Linter {
             )
             : { problems: [], disableDirectives: [] };
 
+        /*
+         * Now we determine the final configurations for rules.
+         * First, let all inline rule configurations override those from the config.
+         * Then, check for a special case: if a rule is configured in both places,
+         * inline rule configuration that only has severity should retain options from
+         * the config and just override the severity.
+         *
+         * Example:
+         *
+         *   {
+         *       rules: {
+         *           curly: ["error", "multi"]
+         *       }
+         *   }
+         *
+         *   /* eslint curly: ["warn"] * /
+         *
+         *   Results in:
+         *
+         *   curly: ["warn", "multi"]
+         *
+         * At this point, all rule configurations are normalized to arrays.
+         */
         const configuredRules = Object.assign({}, config.rules, mergedInlineConfig.rules);
+
+        if (config.rules) {
+            for (const [ruleId, ruleInlineConfig] of Object.entries(mergedInlineConfig.rules)) {
+                if (
+
+                    /*
+                     * If inline config for the rule has only severity
+                     */
+                    ruleInlineConfig.length === 1 &&
+
+                    /*
+                     * And provided config for the rule has options
+                     */
+                    Object.hasOwn(config.rules, ruleId) &&
+                    config.rules[ruleId].length > 1
+                ) {
+
+                    /*
+                     * Then use severity from the inline config and options from the provided config
+                     */
+                    configuredRules[ruleId] = [
+                        ruleInlineConfig[0], // severity from the inline config
+                        ...config.rules[ruleId].slice(1) // options from the provided config
+                    ];
+                }
+            }
+        }
+
         let lintingProblems;
 
         sourceCode.finalize();


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #17381

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `Linter` to align the behavior of `/* eslint */` rule configuration comments with the way rule configs are merged in the config array. In particular, a configuration comment with only severity should retain options from the config.

#### Is there anything you'd like reviewers to focus on?

I updated the v9 migration guide, but this should be also described somewhere in the documentation. However, the part that explains how rule configs are merged doesn't seem to exist in the new docs for flat config. I'll open a separate issue for this.

<!-- markdownlint-disable-file MD004 -->
