### PR TITLE
docs: Add more removed `context` methods to migrate to v9 guide

### DIFF
--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -312,9 +312,9 @@ In addition to the methods in the above table, there are several other methods t
 
 |**Removed on `context`**|**Replacement(s) on `SourceCode`**|
 |-----------------------|--------------------------|
-|`context.getAncestors()`|`sourceCode.getAncestors()`|
-|`context.getScope()`|`sourceCode.getScope()`|
-|`context.markVariableAsUsed()`|`sourceCode.markVariableAsUsed()`|
+|`context.getAncestors()`|`sourceCode.getAncestors(node)`|
+|`context.getScope()`|`sourceCode.getScope(node)`|
+|`context.markVariableAsUsed(name)`|`sourceCode.markVariableAsUsed(name, node)`|
 
 **To address:** Following the recommendations in the [blog post](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#from-context-to-sourcecode).
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -306,6 +306,15 @@ ESLint v9.0.0 removes multiple deprecated methods from the `context` object and 
 |`context.getTokensBefore()`|`sourceCode.getTokensBefore()`|
 |`context.getTokensBetween()`|`sourceCode.getTokensBetween()`|
 |`context.parserServices`|`sourceCode.parserServices`|
+|`context.getDeclaredVariables()`|`sourceCode.getDeclaredVariables()`|
+
+In addition to the methods in the above table, there are several other methods that are also moved but required different method signatures:
+
+|**Removed on `context`**|**Replacement(s) on `SourceCode`**|
+|-----------------------|--------------------------|
+|`context.getAncestors()`|`sourceCode.getAncestors()`|
+|`context.getScope()`|`sourceCode.getScope()`|
+|`context.markVariableAsUsed()`|`sourceCode.markVariableAsUsed()`|
 
 **To address:** Following the recommendations in the [blog post](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#from-context-to-sourcecode).
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Adds `context.getAncestors()`, `context.getDeclaredVariables()`, `context.getScope()`, and `context.markVariableAsUsed()` to the  v9 migration guide in the "Removed multiple context methods" section.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated v9 migration guide.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
