### PR TITLE
fix: Fix missing named exports from `eslint/use-at-your-own-risk`

### DIFF
--- a/lib/unsupported-api.js
+++ b/lib/unsupported-api.js
@@ -11,6 +11,7 @@
 // Requirements
 //-----------------------------------------------------------------------------
 
+const builtinRules = require("./rules");
 const { FileEnumerator } = require("./cli-engine/file-enumerator");
 const { ESLint: FlatESLint, shouldUseFlatConfig } = require("./eslint/eslint");
 const { LegacyESLint } = require("./eslint/legacy-eslint");
@@ -20,7 +21,7 @@ const { LegacyESLint } = require("./eslint/legacy-eslint");
 //-----------------------------------------------------------------------------
 
 module.exports = {
-    builtinRules: require("./rules"),
+    builtinRules,
     FlatESLint,
     shouldUseFlatConfig,
     FileEnumerator,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

* **Node version: v21.4.0**
* **npm version: 10.2.4**
* **Local ESLint version: 8.56.0**
* **Global ESLint version: 9.0.0-alpha.0**
* **Operating System: macOS 14.1.2**

**What parser are you using (place an "X" next to just one item)?**

[ ] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

No configuration.

**What did you do? Please include the actual source code causing the issue.**

I implement the tool ([eslint-interactive](https://github.com/mizdra/eslint-interactive)) using the Node.js API provided by ESLint. In that tool, I have decided to use some items exported from `eslint/use-at-your-own-risk`.

However, I found that some of the named exports from `eslint/use-at-your-own-risk` are missing.

```js
// main.mjs
const pkg = await import('eslint/use-at-your-own-risk');
console.log(pkg);
```

```console
$ node main.mjs
```

**What did you expect to happen?**

`pkg.<item_name>` is named exports.

```console
$ node main.mjs
[Module: null prototype] {
  builtinRules: LazyLoadingRuleMap(291) [Map] {
    'accessor-pairs' => { meta: [Object], create: [Function: create] },
    // ...
  },
  FlatESLint: [class FlatESLint],
  shouldUseFlatConfig: [AsyncFunction: shouldUseFlatConfig],
  FlatRuleTester: [class FlatRuleTester] {
    [Symbol(itOnly)]: null,
    [Symbol(it)]: null,
    [Symbol(describe)]: null
  },
  FileEnumerator: [class FileEnumerator],
  LegacyESLint: [class ESLint]
  default: {
    builtinRules: LazyLoadingRuleMap(291) [Map] {
      'accessor-pairs' => [Object],
      // ...
    },
    FlatESLint: [class FlatESLint],
    shouldUseFlatConfig: [AsyncFunction: shouldUseFlatConfig],
    FlatRuleTester: [class FlatRuleTester] {
      [Symbol(itOnly)]: null,
      [Symbol(it)]: null,
      [Symbol(describe)]: null
    },
    FileEnumerator: [class FileEnumerator],
    LegacyESLint: [class ESLint]
  }
}
```

**What actually happened? Please include the actual, raw output from ESLint.**

`pkg.builtinRules` is available, but `pkg.FlatESLint` and others are missing.

```console
$ node main.mjs
[Module: null prototype] {
  builtinRules: LazyLoadingRuleMap(291) [Map] {
    'accessor-pairs' => { meta: [Object], create: [Function: create] },
    // ...
  },
  default: {
    builtinRules: LazyLoadingRuleMap(291) [Map] {
      'accessor-pairs' => [Object],
      // ...
    },
    FlatESLint: [class FlatESLint],
    shouldUseFlatConfig: [AsyncFunction: shouldUseFlatConfig],
    FlatRuleTester: [class FlatRuleTester] {
      [Symbol(itOnly)]: null,
      [Symbol(it)]: null,
      [Symbol(describe)]: null
    },
    FileEnumerator: [class FileEnumerator],
    LegacyESLint: [class ESLint]
  }
}
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Rewrite the code to allow [cjs-module-lexer](https://github.com/nodejs/cjs-module-lexer) to detect named exports.

For more information on the issue, see the following repository:

- https://github.com/mizdra/esm-interop-module-exports-test

When this change is applied, the output is as follows:

```console
$ node main.mjs
[Module: null prototype] {
  FileEnumerator: [class FileEnumerator],
  FlatESLint: [class FlatESLint],
  FlatRuleTester: [class FlatRuleTester] {
    [Symbol(itOnly)]: null,
    [Symbol(it)]: null,
    [Symbol(describe)]: null
  },
  LegacyESLint: [class ESLint],
  builtinRules: LazyLoadingRuleMap(291) [Map] {
    'accessor-pairs' => { meta: [Object], create: [Function: create] },
    // ...
  },
  default: {
    builtinRules: LazyLoadingRuleMap(291) [Map] {
      'accessor-pairs' => [Object],
      // ...
    },
    FlatESLint: [class FlatESLint],
    shouldUseFlatConfig: [AsyncFunction: shouldUseFlatConfig],
    FlatRuleTester: [class FlatRuleTester] {
      [Symbol(itOnly)]: null,
      [Symbol(it)]: null,
      [Symbol(describe)]: null
    },
    FileEnumerator: [class FileEnumerator],
    LegacyESLint: [class ESLint]
  },
  shouldUseFlatConfig: [AsyncFunction: shouldUseFlatConfig]
}
```

#### Is there anything you'd like reviewers to focus on?

Nothing.

<!-- markdownlint-disable-file MD004 -->
