### PR TITLE
feat: maintain latest ecma version in ESLint

### DIFF
--- a/conf/ecma-version.js
+++ b/conf/ecma-version.js
@@ -1,0 +1,16 @@
+/**
+ * @fileoverview Configuration related to ECMAScript versions
+ * @author Milos Djermanovic
+ */
+
+"use strict";
+
+/**
+ * The latest ECMAScript version supported by ESLint.
+ * @type {number} year-based ECMAScript version
+ */
+const LATEST_ECMA_VERSION = 2024;
+
+module.exports = {
+    LATEST_ECMA_VERSION
+};

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -52,6 +52,7 @@ const DEFAULT_ECMA_VERSION = 5;
 const commentParser = new ConfigCommentParser();
 const DEFAULT_ERROR_LOC = { start: { line: 1, column: 0 }, end: { line: 1, column: 1 } };
 const parserSymbol = Symbol.for("eslint.RuleTester.parser");
+const { LATEST_ECMA_VERSION } = require("../../conf/ecma-version");
 
 //------------------------------------------------------------------------------
 // Typedefs
@@ -594,7 +595,7 @@ function normalizeEcmaVersionForLanguageOptions(ecmaVersion) {
      * that is used for a number of processes inside of ESLint. It's normally
      * safe to assume people want the latest unless otherwise specified.
      */
-    return espree.latestEcmaVersion + 2009;
+    return LATEST_ECMA_VERSION;
 }
 
 const eslintEnvPattern = /\/\*\s*eslint-env\s(.+?)(?:\*\/|$)/gsu;

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -18,6 +18,8 @@ const { assert } = require("chai"),
 const { Linter } = require("../../../lib/linter");
 const { FlatConfigArray } = require("../../../lib/config/flat-config-array");
 
+const { LATEST_ECMA_VERSION } = require("../../../conf/ecma-version");
+
 //------------------------------------------------------------------------------
 // Constants
 //------------------------------------------------------------------------------
@@ -5470,7 +5472,7 @@ var a = "test2";
                 assert.strictEqual(ecmaVersion, espree.latestEcmaVersion + 2009, "ecmaVersion should be 2022");
             });
 
-            it("the 'next' is equal to espree.latestEcmaVersion on languageOptions with custom parser", () => {
+            it("the 'next' is equal to ESLint's latest ECMA version on languageOptions with custom parser", () => {
                 let ecmaVersion = null;
                 const config = { rules: { "ecma-version": 2 }, parser: "custom-parser", parserOptions: { ecmaVersion: "next" } };
 
@@ -5483,7 +5485,7 @@ var a = "test2";
                     })
                 });
                 linter.verify("", config);
-                assert.strictEqual(ecmaVersion, espree.latestEcmaVersion + 2009, "ecmaVersion should be 2022");
+                assert.strictEqual(ecmaVersion, LATEST_ECMA_VERSION, `ecmaVersion should be ${LATEST_ECMA_VERSION}`);
             });
 
             it("missing ecmaVersion is equal to 5 on languageOptions with custom parser", () => {
@@ -7649,7 +7651,7 @@ describe("Linter with FlatConfigArray", () => {
                                     checker: {
                                         create: context => ({
                                             Program() {
-                                                assert.strictEqual(context.languageOptions.ecmaVersion, espree.latestEcmaVersion + 2009);
+                                                assert.strictEqual(context.languageOptions.ecmaVersion, LATEST_ECMA_VERSION);
                                             }
                                         })
                                     }
@@ -7694,7 +7696,7 @@ describe("Linter with FlatConfigArray", () => {
                                     checker: {
                                         create: context => ({
                                             Program() {
-                                                assert.strictEqual(context.languageOptions.ecmaVersion, espree.latestEcmaVersion + 2009);
+                                                assert.strictEqual(context.languageOptions.ecmaVersion, LATEST_ECMA_VERSION);
                                             }
                                         })
                                     }
@@ -8359,7 +8361,7 @@ describe("Linter with FlatConfigArray", () => {
                         }, "filename.js");
 
                         assert(spy.calledWithMatch(";", {
-                            ecmaVersion: espree.latestEcmaVersion + 2009,
+                            ecmaVersion: LATEST_ECMA_VERSION,
                             sourceType: "module"
                         }));
                     });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

Fixes #15366

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I added configuration for the latest ECMAScript version to ESLint and updated Linter to use it instead of `espree.latestEcmaVersion` when resolving `"latest"` value of `languageOptions.ecmaVersion`.

#### Is there anything you'd like reviewers to focus on?

I didn't change the eslintrc logic:

https://github.com/eslint/eslint/blob/95075251fb3ce35aaf7eadbd1d0a737106c13ec6/lib/linter/linter.js#L553-L559

because, in eslintrc configs, `ecmaVersion` is in `parserOptions`:

```js
// .eslintrc.js
module.exports = {
    parserOptions: {
        ecmaVersion: "latest"
    }
}
```

thus, in this case, I think it makes more sense to keep getting the version from the parser.

<!-- markdownlint-disable-file MD004 -->
