### PR TITLE
fix: ESLint stops linting on first error with flat config

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -117,4 +117,7 @@ let hadFatalError = false;
     if (!hadFatalError) {
         process.exitCode = exitCode;
     }
-}()).catch(onFatalError);
+}()).catch(error => {
+    hadFatalError = true;
+    onFatalError(error);
+});

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -16,6 +16,7 @@ const path = require("path");
 const findUp = require("find-up");
 const { version } = require("../../package.json");
 const { Linter } = require("../linter");
+const { onFatalError } = require("../shared/error-utils");
 const { getRuleFromConfig } = require("../config/flat-config-helpers");
 const {
     Legacy: {
@@ -919,8 +920,12 @@ class ESLint {
                         }
 
                         return result;
-                    });
+                    }).catch(error => {
+                        onFatalError(error);
 
+                        // eslint-disable-next-line n/no-process-exit -- Intentionally exit to avoid running the process further.
+                        process.exit();
+                    });
             })
         );
 

--- a/lib/shared/error-utils.js
+++ b/lib/shared/error-utils.js
@@ -1,0 +1,76 @@
+/**
+ * @fileoverview Utilities for error handling in ESLint CLI and Node.js API.
+ * @author Nitin Kumar
+ */
+"use strict";
+
+/**
+ * Get the error message of a given value.
+ * @param {any} error The value to get.
+ * @returns {string} The error message.
+ */
+function getErrorMessage(error) {
+
+    // Lazy loading because this is used only if an error happened.
+    const util = require("util");
+
+    // Foolproof -- third-party module might throw non-object.
+    if (typeof error !== "object" || error === null) {
+        return String(error);
+    }
+
+    // Use templates if `error.messageTemplate` is present.
+    if (typeof error.messageTemplate === "string") {
+        try {
+            const template = require(`../messages/${error.messageTemplate}.js`);
+
+            return template(error.messageData || {});
+        } catch {
+
+            // Ignore template error then fallback to use `error.stack`.
+        }
+    }
+
+    // Use the stacktrace if it's an error object.
+    if (typeof error.stack === "string") {
+        return error.stack;
+    }
+
+    // Otherwise, dump the object.
+    return util.format("%o", error);
+}
+
+/**
+ * Tracks error messages that are shown to the user so we only ever show the
+ * same message once.
+ * @type {Set<string>}
+ */
+const displayedErrors = new Set();
+
+/**
+ * Catch and report unexpected error.
+ * @param {any} error The thrown error object.
+ * @returns {void}
+ */
+function onFatalError(error) {
+    process.exitCode = 2;
+
+    const { version } = require("../../package.json");
+    const message = `
+Oops! Something went wrong! :(
+
+ESLint: ${version}
+
+${getErrorMessage(error)}`;
+
+    if (!displayedErrors.has(message)) {
+        // eslint-disable-next-line no-console -- We need to print the error message
+        console.error(message);
+        displayedErrors.add(message);
+    }
+}
+
+module.exports = {
+    onFatalError,
+    getErrorMessage
+};

--- a/lib/shared/error-utils.js
+++ b/lib/shared/error-utils.js
@@ -22,7 +22,7 @@ function getErrorMessage(error) {
     // Use templates if `error.messageTemplate` is present.
     if (typeof error.messageTemplate === "string") {
         try {
-            const template = require(`../messages/${error.messageTemplate}.js`);
+            const template = require(`../../messages/${error.messageTemplate}.js`);
 
             return template(error.messageData || {});
         } catch {

--- a/tests/fixtures/eslint.config-rule-throws.js
+++ b/tests/fixtures/eslint.config-rule-throws.js
@@ -4,8 +4,17 @@ module.exports = [
             foo: {
                 rules: {
                     bar: {
-                        create() {
-                            throw new Error("Rule created");
+                        create(context) {
+                            // Rule was executed if this is logged
+                            console.log("Rule Created.");
+                            return {
+                                Program(node) {
+                                    context.report({
+                                        node,
+                                        message: "Rule created",
+                                    });
+                                },
+                            };
                         }
                     }
                 }

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -640,20 +640,29 @@ describe("cli", () => {
                         const filePath = getFixturePath("single-quoted.js");
                         const configPath = getFixturePath("eslint.config-rule-throws.js");
                         const cliArgs = `--quiet --config ${configPath}' ${filePath}`;
+                        const consoleStub = sinon.stub(console, "log");
 
                         const exit = await cli.execute(cliArgs, null, useFlatConfig);
 
                         assert.strictEqual(exit, 0);
+                        assert.strictEqual(consoleStub.callCount, 0, "shouldn't call `console.log()`");
+
+                        consoleStub.restore();
                     });
 
                     it(`should run rules set to 'warn' while maxWarnings is set with configType:${configType}`, async () => {
                         const filePath = getFixturePath("single-quoted.js");
                         const configPath = getFixturePath("eslint.config-rule-throws.js");
                         const cliArgs = `--quiet --max-warnings=1 --config ${configPath}' ${filePath}`;
+                        const consoleStub = sinon.stub(console, "log");
 
-                        await stdAssert.rejects(async () => {
-                            await cli.execute(cliArgs, null, useFlatConfig);
-                        });
+                        const exit = await cli.execute(cliArgs, null, useFlatConfig);
+
+                        assert.strictEqual(exit, 0);
+                        assert.strictEqual(consoleStub.callCount, 1, "calls `console.log()` once");
+                        assert.strictEqual(consoleStub.getCall(0).args[0], "Rule Created.");
+
+                        consoleStub.restore();
                     });
                 }
             });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixes #17621

- Use `process.exit()` to ensure that no further processing or asynchronous operations are attempted.
- Move `onFatalError` and `getErrorMessage` to `lib/shared/error-utils`.


#### Is there anything you'd like reviewers to focus on?
I'm not sure how to add tests for this behavior.
<!-- markdownlint-disable-file MD004 -->
