### PR TITLE
docs: fix number of code-path events on custom rules page

### DIFF
--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -870,7 +870,7 @@ Here, the `myCustomVar` variable is marked as used relative to a `ReturnStatemen
 
 ### Accessing Code Paths
 
-ESLint analyzes code paths while traversing AST. You can access code path objects with five events related to code paths. For more information, refer to [Code Path Analysis](code-path-analysis).
+ESLint analyzes code paths while traversing AST. You can access code path objects with seven events related to code paths. For more information, refer to [Code Path Analysis](code-path-analysis).
 
 ### Deprecated `SourceCode` Methods
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes https://github.com/eslint/eslint/issues/17968

#### What changes did you make? (Give an overview)
In the section https://eslint.org/docs/latest/extend/custom-rules#accessing-code-paths, the number of code-path events is incorrectly stated as five. I have changed it to seven.

#### Is there anything you'd like reviewers to focus on?