### PR TITLE
fix: `no-misleading-character-class` edge cases with granular errors

### DIFF
--- a/lib/rules/no-misleading-character-class.js
+++ b/lib/rules/no-misleading-character-class.js
@@ -73,119 +73,125 @@ function isUnicodeCodePointEscape(char) {
 
 /**
  * Each function returns matched characters if it detects that kind of problem.
- * @type {Record<string, (char: Character, index: number, chars: Character[]) => Character[] | null>}
+ * @type {Record<string, (chars: Character[]) => IterableIterator<Character[]>>}
  */
-const characterSequenceIndexFilters = {
-    surrogatePairWithoutUFlag(char, index, chars) {
-        if (index === 0) {
-            return null;
+const findCharacterSequences = {
+    *surrogatePairWithoutUFlag(chars) {
+        for (const [index, char] of chars.entries()) {
+            if (index === 0) {
+                continue;
+            }
+            const previous = chars[index - 1];
+
+            if (
+                isSurrogatePair(previous.value, char.value) &&
+                !isUnicodeCodePointEscape(previous) &&
+                !isUnicodeCodePointEscape(char)
+            ) {
+                yield [previous, char];
+            }
         }
-
-        const previous = chars[index - 1];
-
-        if (
-            isSurrogatePair(previous.value, char.value) &&
-            !isUnicodeCodePointEscape(previous) &&
-            !isUnicodeCodePointEscape(char)
-        ) {
-            return [previous, char];
-        }
-
-        return null;
     },
 
-    surrogatePair(char, index, chars) {
-        if (index === 0) {
-            return null;
+    *surrogatePair(chars) {
+        for (const [index, char] of chars.entries()) {
+            if (index === 0) {
+                continue;
+            }
+            const previous = chars[index - 1];
+
+            if (
+                isSurrogatePair(previous.value, char.value) &&
+                (
+                    isUnicodeCodePointEscape(previous) ||
+                    isUnicodeCodePointEscape(char)
+                )
+            ) {
+                yield [previous, char];
+            }
         }
-
-        const previous = chars[index - 1];
-
-        if (
-            isSurrogatePair(previous.value, char.value) &&
-            (
-                isUnicodeCodePointEscape(previous) ||
-                isUnicodeCodePointEscape(char)
-            )
-        ) {
-            return [previous, char];
-        }
-
-        return null;
     },
 
-    combiningClass(char, index, chars) {
-        if (
-            index !== 0 &&
-            isCombiningCharacter(char.value) &&
-            !isCombiningCharacter(chars[index - 1].value)
-        ) {
-            return [chars[index - 1], char];
-        }
+    *combiningClass(chars) {
+        for (const [index, char] of chars.entries()) {
+            if (index === 0) {
+                continue;
+            }
+            const previous = chars[index - 1];
 
-        return null;
+            if (
+                isCombiningCharacter(char.value) &&
+                !isCombiningCharacter(previous.value)
+            ) {
+                yield [previous, char];
+            }
+        }
     },
 
-    emojiModifier(char, index, chars) {
-        if (
-            index !== 0 &&
-            isEmojiModifier(char.value) &&
-            !isEmojiModifier(chars[index - 1].value)
-        ) {
-            return [chars[index - 1], char];
-        }
+    *emojiModifier(chars) {
+        for (const [index, char] of chars.entries()) {
+            if (index === 0) {
+                continue;
+            }
+            const previous = chars[index - 1];
 
-        return null;
+            if (
+                isEmojiModifier(char.value) &&
+                !isEmojiModifier(previous.value)
+            ) {
+                yield [previous, char];
+            }
+        }
     },
 
-    regionalIndicatorSymbol(char, index, chars) {
-        if (
-            index !== 0 &&
-            isRegionalIndicatorSymbol(char.value) &&
-            isRegionalIndicatorSymbol(chars[index - 1].value)
-        ) {
-            return [chars[index - 1], char];
-        }
+    *regionalIndicatorSymbol(chars) {
+        for (const [index, char] of chars.entries()) {
+            if (index === 0) {
+                continue;
+            }
+            const previous = chars[index - 1];
 
-        return null;
+            if (
+                isRegionalIndicatorSymbol(char.value) &&
+                isRegionalIndicatorSymbol(previous.value)
+            ) {
+                yield [previous, char];
+            }
+        }
     },
 
-    zwj(char, index, chars) {
-        if (
-            index !== 0 &&
-            index !== chars.length - 1 &&
-            char.value === 0x200d &&
-            chars[index - 1].value !== 0x200d &&
-            chars[index + 1].value !== 0x200d
-        ) {
-            return chars.slice(index - 1, index + 2);
+    *zwj(chars) {
+        let sequence = null;
+
+        for (const [index, char] of chars.entries()) {
+            if (index === 0 || index === chars.length - 1) {
+                continue;
+            }
+            if (
+                char.value === 0x200d &&
+                chars[index - 1].value !== 0x200d &&
+                chars[index + 1].value !== 0x200d
+            ) {
+                if (sequence) {
+                    if (sequence.at(-1) === chars[index - 1]) {
+                        sequence.push(char, chars[index + 1]); // append to the sequence
+                    } else {
+                        yield sequence;
+                        sequence = chars.slice(index - 1, index + 2);
+                    }
+                } else {
+                    sequence = chars.slice(index - 1, index + 2);
+                }
+            }
         }
 
-        return null;
+        if (sequence) {
+            yield sequence;
+        }
     }
 };
 
-const kinds = Object.keys(characterSequenceIndexFilters);
-
-/**
- * Collects the indices where the filter returns an array.
- * @param {Character[]} chars Characters to run the filter on.
- * @param {(char: Character, index: number, chars: Character[]) => Character[] | null} filter Finds matches for an index.
- * @returns {Character[][]} Indices where the filter returned true.
- */
-function accumulate(chars, filter) {
-    const matchingChars = [];
-
-    chars.forEach((char, index) => {
-        const matches = filter(char, index, chars);
-
-        if (matches) {
-            matchingChars.push(matches);
-        }
-    });
-
-    return matchingChars;
-}
+const kinds = Object.keys(findCharacterSequences);
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -232,7 +238,7 @@ module.exports = {
             // Limit to to literals and expression-less templates with raw values === their value.
             switch (node.type) {
                 case "TemplateLiteral":
-                    if (node.expressions.length || node.quasis[0].value.raw !== node.quasis[0].value.cooked) {
+                    if (node.expressions.length || sourceCode.getText(node).slice(1, -1) !== node.quasis[0].value.cooked) {
                         return null;
                     }
                     break;
@@ -309,12 +315,10 @@ module.exports = {
                 onCharacterClassEnter(ccNode) {
                     for (const chars of iterateCharacterSequence(ccNode.elements)) {
                         for (const kind of kinds) {
-                            const matches = accumulate(chars, characterSequenceIndexFilters[kind]);
-
                             if (foundKindMatches.has(kind)) {
-                                foundKindMatches.get(kind).push(...matches);
+                                foundKindMatches.get(kind).push(...findCharacterSequences[kind](chars));
                             } else {
-                                foundKindMatches.set(kind, matches);
+                                foundKindMatches.set(kind, [...findCharacterSequences[kind](chars)]);
                             }
 
                         }
@@ -334,24 +338,13 @@ module.exports = {
 
                 const locs = getNodeReportLocations(matches, node);
 
-                // Grapheme zero-width joiners (e.g. in 👨‍👩‍👦) visually show as one emoji
-                if (kind === "zwj" && locs.length > 1) {
+                for (const loc of locs) {
                     context.report({
-                        loc: {
-                            start: locs[0].start,
-                            end: locs[1].end
-                        },
+                        node,
+                        loc,
                         messageId: kind,
                         suggest
                     });
-                } else {
-                    for (const loc of locs) {
-                        context.report({
-                            loc,
-                            messageId: kind,
-                            suggest
-                        });
-                    }
                 }
             }
         }

--- a/tests/lib/rules/no-misleading-character-class.js
+++ b/tests/lib/rules/no-misleading-character-class.js
@@ -420,7 +420,7 @@ ruleTester.run("no-misleading-character-class", rule, {
                 },
                 {
                     column: 12,
-                    endColumn: 18,
+                    endColumn: 15,
                     messageId: "zwj",
                     suggestions: null
                 },
@@ -429,6 +429,12 @@ ruleTester.run("no-misleading-character-class", rule, {
                     endColumn: 16,
                     messageId: "surrogatePairWithoutUFlag",
                     suggestions: [{ messageId: "suggestUnicodeFlag", output: "var r = /[👨‍👩‍👦]/u" }]
+                },
+                {
+                    column: 15,
+                    endColumn: 18,
+                    messageId: "zwj",
+                    suggestions: null
                 },
                 {
                     column: 17,
@@ -444,6 +450,68 @@ ruleTester.run("no-misleading-character-class", rule, {
                 {
                     column: 11,
                     endColumn: 19,
+                    messageId: "zwj",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "var r = /[👩‍👦]/u",
+            errors: [
+                {
+                    column: 11,
+                    endColumn: 16,
+                    messageId: "zwj",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "var r = /[👩‍👦][👩‍👦]/u",
+            errors: [
+                {
+                    column: 11,
+                    endColumn: 16,
+                    messageId: "zwj",
+                    suggestions: null
+                },
+                {
+                    column: 18,
+                    endColumn: 23,
+                    messageId: "zwj",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "var r = /[👨‍👩‍👦]foo[👨‍👩‍👦]/u",
+            errors: [
+                {
+                    column: 11,
+                    endColumn: 19,
+                    messageId: "zwj",
+                    suggestions: null
+                },
+                {
+                    column: 24,
+                    endColumn: 32,
+                    messageId: "zwj",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "var r = /[👨‍👩‍👦👩‍👦]/u",
+            errors: [
+                {
+                    column: 11,
+                    endColumn: 19,
+                    messageId: "zwj",
+                    suggestions: null
+                },
+                {
+                    column: 19,
+                    endColumn: 24,
                     messageId: "zwj",
                     suggestions: null
                 }
@@ -466,6 +534,45 @@ ruleTester.run("no-misleading-character-class", rule, {
                 {
                     column: 11,
                     endColumn: 54,
+                    messageId: "zwj",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "var r = /[\\uD83D\\uDC68\\u200D\\uD83D\\uDC69]/u",
+            errors: [
+                {
+                    column: 11,
+                    endColumn: 41,
+                    messageId: "zwj",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "var r = /[\\u{1F468}\\u{200D}\\u{1F469}]/u",
+            errors: [
+                {
+                    column: 11,
+                    endColumn: 37,
+                    messageId: "zwj",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: "var r = /[\\u{1F468}\\u{200D}\\u{1F469}\\u{200D}\\u{1F466}]foo[\\u{1F468}\\u{200D}\\u{1F469}\\u{200D}\\u{1F466}]/u",
+            errors: [
+                {
+                    column: 11,
+                    endColumn: 54,
+                    messageId: "zwj",
+                    suggestions: null
+                },
+                {
+                    column: 59,
+                    endColumn: 102,
                     messageId: "zwj",
                     suggestions: null
                 }
@@ -521,6 +628,17 @@ ruleTester.run("no-misleading-character-class", rule, {
             errors: [{
                 column: 18,
                 endColumn: 20,
+                messageId: "combiningClass",
+                suggestions: null
+            }]
+        },
+        {
+            code: "var r = new RegExp(`\r\n[❇️]`)",
+            errors: [{
+                line: 1,
+                column: 20,
+                endLine: 2,
+                endColumn: 6,
                 messageId: "combiningClass",
                 suggestions: null
             }]
@@ -1029,7 +1147,7 @@ ruleTester.run("no-misleading-character-class", rule, {
                 },
                 {
                     column: 23,
-                    endColumn: 29,
+                    endColumn: 26,
                     messageId: "zwj",
                     suggestions: null
                 },
@@ -1038,6 +1156,12 @@ ruleTester.run("no-misleading-character-class", rule, {
                     endColumn: 27,
                     messageId: "surrogatePairWithoutUFlag",
                     suggestions: [{ messageId: "suggestUnicodeFlag", output: String.raw`var r = new RegExp("[👨‍👩‍👦]", "u")` }]
+                },
+                {
+                    column: 26,
+                    endColumn: 29,
+                    messageId: "zwj",
+                    suggestions: null
                 },
                 {
                     column: 28,
@@ -1053,6 +1177,68 @@ ruleTester.run("no-misleading-character-class", rule, {
                 {
                     column: 22,
                     endColumn: 30,
+                    messageId: "zwj",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: String.raw`var r = new RegExp("[👩‍👦]", "u")`,
+            errors: [
+                {
+                    column: 22,
+                    endColumn: 27,
+                    messageId: "zwj",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: String.raw`var r = new RegExp("[👩‍👦][👩‍👦]", "u")`,
+            errors: [
+                {
+                    column: 22,
+                    endColumn: 27,
+                    messageId: "zwj",
+                    suggestions: null
+                },
+                {
+                    column: 29,
+                    endColumn: 34,
+                    messageId: "zwj",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: String.raw`var r = new RegExp("[👨‍👩‍👦]foo[👨‍👩‍👦]", "u")`,
+            errors: [
+                {
+                    column: 22,
+                    endColumn: 30,
+                    messageId: "zwj",
+                    suggestions: null
+                },
+                {
+                    column: 35,
+                    endColumn: 43,
+                    messageId: "zwj",
+                    suggestions: null
+                }
+            ]
+        },
+        {
+            code: String.raw`var r = new RegExp("[👨‍👩‍👦👩‍👦]", "u")`,
+            errors: [
+                {
+                    column: 22,
+                    endColumn: 30,
+                    messageId: "zwj",
+                    suggestions: null
+                },
+                {
+                    column: 30,
+                    endColumn: 35,
                     messageId: "zwj",
                     suggestions: null
                 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Follow-up for https://github.com/eslint/eslint/pull/17515#discussion_r1444071103.

**Tell us about your environment (`npx eslint --env-info`):**

* **Node version:** v20.9.0
* **npm version:** v10.1.0
* **Local ESLint version:** `main`
* **Global ESLint version:**
* **Operating System:** Windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = [];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint "no-misleading-character-class": "error" */

var r = /   [👩‍👦]    [👩‍👦]  /u;

```

**What did you expect to happen?**

Two errors that underline one ZWJ sequence each.

**What actually happened? Please include the actual, raw output from ESLint.**

 One error that underlines range from the start of the first till the end of the second sequence, including unrelated characters between.

```shell
$ node bin/eslint a.js -f json
[{"filePath":"C:\\projects\\eslint\\a.js","messages":[{"ruleId":"no-misleading-character-class","severity":2,"message":"Unexpected joined character sequence in character class.","line":3,"column":14,"nodeType":null,"messageId":"zwj","endLine":3,"endColumn":30}],"suppressedMessages":[],"errorCount":1,"fatalErrorCount":0,"warningCount":0,"fixableErrorCount":0,"fixableWarningCount":0,"source":"/* eslint \"no-misleading-character-class\": \"error\" */\n\nvar r = /   [�‍�]    [�‍�]  /u;\n\n\n\n","usedDeprecatedRules":[]}]
``` 



<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refactored the code and fixed the problem with reporting granular errors in patterns with multiple ZWJ sequences.

Before this change:

![image](https://github.com/eslint/eslint/assets/44349756/781bfe15-7705-472d-8625-8d44b7993372)

After this change:

![image](https://github.com/eslint/eslint/assets/44349756/26f343a6-92bd-40ac-97e6-c9c479b3029d)

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
