### PR TITLE
feat!: no-restricted-imports allow multiple config entries for same path

### DIFF
--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -30,6 +30,7 @@ The lists below are ordered roughly by the number of users each change is expect
 * [New checks in `no-implicit-coercion` by default](#no-implicit-coercion)
 * [Case-sensitive flags in `no-invalid-regexp`](#no-invalid-regexp)
 * [`varsIgnorePattern` option of `no-unused-vars` no longer applies to catch arguments](#vars-ignore-pattern)
+* [`no-restricted-imports` now accepts multiple config entries with the same `name`](#no-restricted-imports)
 * [`"eslint:recommended"` and `"eslint:all"` strings no longer accepted in flat config](#string-config)
 * [`no-inner-declarations` has a new default behavior with a new option](#no-inner-declarations)
 
@@ -280,6 +281,41 @@ try {
 **To address:** If you want to specify ignore patterns for `catch` clause variable names, use the `caughtErrorsIgnorePattern` option in addition to `varsIgnorePattern`.
 
 **Related issue(s):** [#17540](https://github.com/eslint/eslint/issues/17540)
+
+## <a name="no-restricted-imports"></a> `no-restricted-imports` now accepts multiple config entries with the same `name`
+
+In previous versions of ESLint, if multiple entries in the `paths` array of your configuration for the `no-restricted-imports` rule had the same `name` property, only the last one would apply, while the previous ones would be ignored.
+
+As of ESLint v9.0.0, all entries apply, allowing for specifying different messages for different imported names. For example, you can now configure the rule like this:
+
+```js
+{
+    rules: {
+        "no-restricted-imports": ["error", {
+            paths: [
+                {
+                    name: "react-native",
+                    importNames: ["Text"],
+                    message: "import 'Text' from 'ui/_components' instead"
+                },
+                {
+                    name: "react-native",
+                    importNames: ["View"],
+                    message: "import 'View' from 'ui/_components' instead"
+                }
+            ]
+        }]
+    }
+}
+```
+
+and both `import { Text } from "react-native"` and `import { View } from "react-native"` will be reported, with different messages.
+
+In previous versions of ESLint, with this configuration only `import { View } from "react-native"` would be reported.
+
+**To address:** If your configuration for this rule has multiple entries with the same `name`, you may need to remove unintentional ones.
+
+**Related issue(s):** [#15261](https://github.com/eslint/eslint/issues/15261)
 
 ## <a name="string-config"></a> `"eslint:recommended"` and `"eslint:all"` no longer accepted in flat config
 

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -161,17 +161,25 @@ module.exports = {
             (Object.hasOwn(options[0], "paths") || Object.hasOwn(options[0], "patterns"));
 
         const restrictedPaths = (isPathAndPatternsObject ? options[0].paths : context.options) || [];
-        const restrictedPathMessages = restrictedPaths.reduce((memo, importSource) => {
+        const groupedRestrictedPaths = restrictedPaths.reduce((memo, importSource) => {
+            const path = typeof importSource === "string"
+                ? importSource
+                : importSource.name;
+
+            if (!memo[path]) {
+                memo[path] = [];
+            }
+
             if (typeof importSource === "string") {
-                memo[importSource] = { message: null };
+                memo[path].push({});
             } else {
-                memo[importSource.name] = {
+                memo[path].push({
                     message: importSource.message,
                     importNames: importSource.importNames
-                };
+                });
             }
             return memo;
-        }, {});
+        }, Object.create(null));
 
         // Handle patterns too, either as strings or groups
         let restrictedPatterns = (isPathAndPatternsObject ? options[0].patterns : []) || [];
@@ -203,57 +211,59 @@ module.exports = {
          * @private
          */
         function checkRestrictedPathAndReport(importSource, importNames, node) {
-            if (!Object.hasOwn(restrictedPathMessages, importSource)) {
+            if (!Object.hasOwn(groupedRestrictedPaths, importSource)) {
                 return;
             }
 
-            const customMessage = restrictedPathMessages[importSource].message;
-            const restrictedImportNames = restrictedPathMessages[importSource].importNames;
+            groupedRestrictedPaths[importSource].forEach(restrictedPathEntry => {
+                const customMessage = restrictedPathEntry.message;
+                const restrictedImportNames = restrictedPathEntry.importNames;
 
-            if (restrictedImportNames) {
-                if (importNames.has("*")) {
-                    const specifierData = importNames.get("*")[0];
+                if (restrictedImportNames) {
+                    if (importNames.has("*")) {
+                        const specifierData = importNames.get("*")[0];
 
+                        context.report({
+                            node,
+                            messageId: customMessage ? "everythingWithCustomMessage" : "everything",
+                            loc: specifierData.loc,
+                            data: {
+                                importSource,
+                                importNames: restrictedImportNames,
+                                customMessage
+                            }
+                        });
+                    }
+
+                    restrictedImportNames.forEach(importName => {
+                        if (importNames.has(importName)) {
+                            const specifiers = importNames.get(importName);
+
+                            specifiers.forEach(specifier => {
+                                context.report({
+                                    node,
+                                    messageId: customMessage ? "importNameWithCustomMessage" : "importName",
+                                    loc: specifier.loc,
+                                    data: {
+                                        importSource,
+                                        customMessage,
+                                        importName
+                                    }
+                                });
+                            });
+                        }
+                    });
+                } else {
                     context.report({
                         node,
-                        messageId: customMessage ? "everythingWithCustomMessage" : "everything",
-                        loc: specifierData.loc,
+                        messageId: customMessage ? "pathWithCustomMessage" : "path",
                         data: {
                             importSource,
-                            importNames: restrictedImportNames,
                             customMessage
                         }
                     });
                 }
-
-                restrictedImportNames.forEach(importName => {
-                    if (importNames.has(importName)) {
-                        const specifiers = importNames.get(importName);
-
-                        specifiers.forEach(specifier => {
-                            context.report({
-                                node,
-                                messageId: customMessage ? "importNameWithCustomMessage" : "importName",
-                                loc: specifier.loc,
-                                data: {
-                                    importSource,
-                                    customMessage,
-                                    importName
-                                }
-                            });
-                        });
-                    }
-                });
-            } else {
-                context.report({
-                    node,
-                    messageId: customMessage ? "pathWithCustomMessage" : "path",
-                    data: {
-                        importSource,
-                        customMessage
-                    }
-                });
-            }
+            });
         }
 
         /**

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -1020,6 +1020,199 @@ ruleTester.run("no-restricted-imports", rule, {
             endColumn: 18
         }]
     },
+
+    // https://github.com/eslint/eslint/issues/15261
+    {
+        code: "import { Image, Text, ScrollView } from 'react-native'",
+        options: [{
+            paths: [
+                {
+                    name: "react-native",
+                    importNames: ["Text"],
+                    message: "import Text from ui/_components instead"
+                },
+                {
+                    name: "react-native",
+                    importNames: ["TextInput"],
+                    message: "import TextInput from ui/_components instead"
+                },
+                { name: "react-native", importNames: ["View"], message: "import View from ui/_components instead " },
+                {
+                    name: "react-native",
+                    importNames: ["ScrollView"],
+                    message: "import ScrollView from ui/_components instead"
+                },
+                {
+                    name: "react-native",
+                    importNames: ["KeyboardAvoidingView"],
+                    message: "import KeyboardAvoidingView from ui/_components instead"
+                },
+                {
+                    name: "react-native",
+                    importNames: ["ImageBackground"],
+                    message: "import ImageBackground from ui/_components instead"
+                },
+                {
+                    name: "react-native",
+                    importNames: ["Image"],
+                    message: "import Image from ui/_components instead"
+                }
+            ]
+        }],
+        errors: [
+            {
+                message: "'Image' import from 'react-native' is restricted. import Image from ui/_components instead",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 10,
+                endColumn: 15
+            },
+            {
+                message: "'Text' import from 'react-native' is restricted. import Text from ui/_components instead",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 17,
+                endColumn: 21
+            },
+            {
+                message: "'ScrollView' import from 'react-native' is restricted. import ScrollView from ui/_components instead",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 23,
+                endColumn: 33
+            }
+        ]
+    },
+    {
+        code: "import { foo, bar, baz } from 'mod'",
+        options: [{
+            paths: [
+                {
+                    name: "mod",
+                    importNames: ["foo"],
+                    message: "Import foo from qux instead."
+                },
+                {
+                    name: "mod",
+                    importNames: ["baz"],
+                    message: "Import baz from qux instead."
+                }
+            ]
+        }],
+        errors: [
+            {
+                message: "'foo' import from 'mod' is restricted. Import foo from qux instead.",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 10,
+                endColumn: 13
+            },
+            {
+                message: "'baz' import from 'mod' is restricted. Import baz from qux instead.",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 20,
+                endColumn: 23
+            }
+        ]
+    },
+    {
+        code: "import * as mod from 'mod'",
+        options: [{
+            paths: [
+                {
+                    name: "mod",
+                    importNames: ["foo"],
+                    message: "Import foo from qux instead."
+                },
+                {
+                    name: "mod",
+                    importNames: ["bar"],
+                    message: "Import bar from qux instead."
+                }
+            ]
+        }],
+        errors: [
+            {
+                message: "* import is invalid because 'foo' from 'mod' is restricted. Import foo from qux instead.",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 8,
+                endColumn: 16
+            },
+            {
+                message: "* import is invalid because 'bar' from 'mod' is restricted. Import bar from qux instead.",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 8,
+                endColumn: 16
+            }
+        ]
+    },
+    {
+        code: "import { foo } from 'mod'",
+        options: [{
+            paths: [
+
+                // restricts importing anything from the module
+                {
+                    name: "mod"
+                },
+
+                // message for a specific import name
+                {
+                    name: "mod",
+                    importNames: ["bar"],
+                    message: "Import bar from qux instead."
+                }
+            ]
+        }],
+        errors: [
+            {
+                message: "'mod' import is restricted from being used.",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 1,
+                endColumn: 26
+            }
+        ]
+    },
+    {
+        code: "import { bar } from 'mod'",
+        options: [{
+            paths: [
+
+                // restricts importing anything from the module
+                {
+                    name: "mod"
+                },
+
+                // message for a specific import name
+                {
+                    name: "mod",
+                    importNames: ["bar"],
+                    message: "Import bar from qux instead."
+                }
+            ]
+        }],
+        errors: [
+            {
+                message: "'mod' import is restricted from being used.",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 1,
+                endColumn: 26
+            },
+            {
+                message: "'bar' import from 'mod' is restricted. Import bar from qux instead.",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 10,
+                endColumn: 13
+            }
+        ]
+    },
+
     {
         code: "import foo, { bar } from 'mod';",
         options: [{

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -1117,6 +1117,91 @@ ruleTester.run("no-restricted-imports", rule, {
         ]
     },
     {
+        code: "import { foo, bar, baz, qux } from 'mod'",
+        options: [{
+            paths: [
+                {
+                    name: "mod",
+                    importNames: ["bar"],
+                    message: "Use `barbaz` instead of `bar`."
+                },
+                {
+                    name: "mod",
+                    importNames: ["foo", "qux"],
+                    message: "Don't use 'foo' and `qux` from 'mod'."
+                }
+            ]
+        }],
+        errors: [
+            {
+                message: "'foo' import from 'mod' is restricted. Don't use 'foo' and `qux` from 'mod'.",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 10,
+                endColumn: 13
+            },
+            {
+                message: "'bar' import from 'mod' is restricted. Use `barbaz` instead of `bar`.",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 15,
+                endColumn: 18
+            },
+            {
+                message: "'qux' import from 'mod' is restricted. Don't use 'foo' and `qux` from 'mod'.",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 25,
+                endColumn: 28
+            }
+        ]
+    },
+    {
+        code: "import { foo, bar, baz, qux } from 'mod'",
+        options: [{
+            paths: [
+                {
+                    name: "mod",
+                    importNames: ["foo", "baz"],
+                    message: "Don't use 'foo' or 'baz' from 'mod'."
+                },
+                {
+                    name: "mod",
+                    importNames: ["a", "c"],
+                    message: "Don't use 'a' or 'c' from 'mod'."
+                },
+                {
+                    name: "mod",
+                    importNames: ["b", "bar"],
+                    message: "Use 'b' or `bar` from 'quux/mod' instead."
+                }
+            ]
+        }],
+        errors: [
+            {
+                message: "'foo' import from 'mod' is restricted. Don't use 'foo' or 'baz' from 'mod'.",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 10,
+                endColumn: 13
+            },
+            {
+                message: "'bar' import from 'mod' is restricted. Use 'b' or `bar` from 'quux/mod' instead.",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 15,
+                endColumn: 18
+            },
+            {
+                message: "'baz' import from 'mod' is restricted. Don't use 'foo' or 'baz' from 'mod'.",
+                type: "ImportDeclaration",
+                line: 1,
+                column: 20,
+                endColumn: 23
+            }
+        ]
+    },
+    {
         code: "import * as mod from 'mod'",
         options: [{
             paths: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #15261

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `no-restricted-imports` to check all config entries that have a matching `name` instead of checking just the last one.

#### Is there anything you'd like reviewers to focus on?

Matching entries produce errors separately from each other. I believe this is the simplest yet the most flexible solution, but a downside may be that in some cases the rule produces multiple errors (see the added test cases).

<!-- markdownlint-disable-file MD004 -->

TODO: update migration guide
