### PR TITLE
docs: Update sort-keys options properties count

### DIFF
--- a/docs/src/rules/sort-keys.md
+++ b/docs/src/rules/sort-keys.md
@@ -85,7 +85,7 @@ The 1st option is `"asc"` or `"desc"`.
 * `"asc"` (default) - enforce properties to be in ascending order.
 * `"desc"` - enforce properties to be in descending order.
 
-The 2nd option is an object which has 3 properties.
+The 2nd option is an object which has the following properties.
 
 * `caseSensitive` - if `true`, enforce properties to be in case-sensitive order. Default is `true`.
 * `minKeys` - Specifies the minimum number of keys that an object should have in order for the object's unsorted keys to produce an error. Default is `2`, which means by default all objects with unsorted keys will result in lint errors.


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Currently the options listing for `sort-keys` says there are 3 properties, however this is not accurate. I have updated this to be generic so it does not have to be modified if new properties are added.

It appears that the 4th property `allowLineSeparatedGroups` was added via https://github.com/eslint/eslint/pull/16138 & relates to https://github.com/eslint/eslint/issues/12759 

I could not see any open PRs or issues for this.

#### Is there anything you'd like reviewers to focus on?

N/A
