### PR TITLE
feat!: `no-unused-vars` default caughtErrors to 'all'

### DIFF
--- a/docs/src/rules/no-unused-vars.md
+++ b/docs/src/rules/no-unused-vars.md
@@ -286,11 +286,9 @@ It has two settings:
 * `all` - all named arguments must be used. This is the default setting.
 * `none` - do not check error objects.
 
-:::
-
 #### caughtErrors: all
 
-Not specifying this rule is equivalent of assigning it to `all`.
+Not specifying this option is equivalent of assigning it to `all`.
 
 Examples of **incorrect** code for the `{ "caughtErrors": "all" }` option:
 
@@ -325,6 +323,8 @@ try {
     console.error("errors");
 }
 ```
+
+:::
 
 ### caughtErrorsIgnorePattern
 

--- a/docs/src/rules/no-unused-vars.md
+++ b/docs/src/rules/no-unused-vars.md
@@ -132,12 +132,12 @@ var global_var = 42;
 
 This rule takes one argument which can be a string or an object. The string settings are the same as those of the `vars` property (explained below).
 
-By default this rule is enabled with `all` option for variables and `after-used` for arguments.
+By default this rule is enabled with `all` option for caught errors and variables, and `after-used` for arguments.
 
 ```json
 {
     "rules": {
-        "no-unused-vars": ["error", { "vars": "all", "args": "after-used", "caughtErrors": "none", "ignoreRestSiblings": false }]
+        "no-unused-vars": ["error", { "vars": "all", "args": "after-used", "caughtErrors": "all", "ignoreRestSiblings": false }]
     }
 }
 ```
@@ -283,30 +283,14 @@ The `caughtErrors` option is used for `catch` block arguments validation.
 
 It has two settings:
 
-* `none` - do not check error objects. This is the default setting.
-* `all` - all named arguments must be used.
-
-#### caughtErrors: none
-
-Not specifying this rule is equivalent of assigning it to `none`.
-
-Examples of **correct** code for the `{ "caughtErrors": "none" }` option:
-
-::: correct
-
-```js
-/*eslint no-unused-vars: ["error", { "caughtErrors": "none" }]*/
-
-try {
-    //...
-} catch (err) {
-    console.error("errors");
-}
-```
+* `all` - all named arguments must be used. This is the default setting.
+* `none` - do not check error objects.
 
 :::
 
 #### caughtErrors: all
+
+Not specifying this rule is equivalent of assigning it to `all`.
 
 Examples of **incorrect** code for the `{ "caughtErrors": "all" }` option:
 
@@ -325,6 +309,22 @@ try {
 ```
 
 :::
+
+#### caughtErrors: none
+
+Examples of **correct** code for the `{ "caughtErrors": "none" }` option:
+
+::: correct
+
+```js
+/*eslint no-unused-vars: ["error", { "caughtErrors": "none" }]*/
+
+try {
+    //...
+} catch (err) {
+    console.error("errors");
+}
+```
 
 ### caughtErrorsIgnorePattern
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -366,7 +366,7 @@ if (test) {
 ## <a name="no-unused-vars"></a> `no-unused-vars` now defaults `caughtErrors` to `"all"`
 
 ESLint v9.0.0 changes the default value for the `no-unused-vars` rule's `caughtErrors` option.
-Previously it defaulted to `"none"` to never check whether caught errors are used.
+Previously it defaulted to `"none"` to never check whether caught errors were used.
 It now defaults to `"all"` to check caught errors for being used.
 
 ```js

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -33,6 +33,7 @@ The lists below are ordered roughly by the number of users each change is expect
 * [`no-restricted-imports` now accepts multiple config entries with the same `name`](#no-restricted-imports)
 * [`"eslint:recommended"` and `"eslint:all"` strings no longer accepted in flat config](#string-config)
 * [`no-inner-declarations` has a new default behavior with a new option](#no-inner-declarations)
+* [`no-unused-vars` now defaults `caughtErrors` to `"all"`](#no-unused-vars)
 
 ### Breaking changes for plugin developers
 
@@ -361,6 +362,33 @@ if (test) {
 **To address:** If you want to report the block-level `function`s in every condition regardless of strict or non-strict mode, set the `blockScopeFunctions` option to `"disallow"`.
 
 **Related issue(s):** [#15576](https://github.com/eslint/eslint/issues/15576)
+
+## <a name="no-unused-vars"></a> `no-unused-vars` now defaults `caughtErrors` to `"all"`
+
+ESLint v9.0.0 changes the default value for the `no-unused-vars` rule's `caughtErrors` option.
+Previously it defaulted to `"none"` to never check whether caught errors are used.
+It now defaults to `"all"` to check caught errors for being used.
+
+```js
+/*eslint no-unused-vars: "error"*/
+try {}
+catch (error) {
+    // 'error' is defined but never used
+}
+```
+
+**To address:** If you want to allow unused caught errors, such as when writing code that will be directly run in a environment that does not support ES2019 optional catch bindings, set the `caughtErrors` option to `"none"`.
+Otherwise, delete the unused caught errors.
+
+```js
+/*eslint no-unused-vars: "error"*/
+try {}
+catch {
+    // no error
+}
+```
+
+**Related issue(s):** [#17974](https://github.com/eslint/eslint/issues/17974)
 
 ## <a name="removed-context-methods"></a> Removed multiple `context` methods
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -377,7 +377,7 @@ catch (error) {
 }
 ```
 
-**To address:** If you want to allow unused caught errors, such as when writing code that will be directly run in a environment that does not support ES2019 optional catch bindings, set the `caughtErrors` option to `"none"`.
+**To address:** If you want to allow unused caught errors, such as when writing code that will be directly run in an environment that does not support ES2019 optional catch bindings, set the `caughtErrors` option to `"none"`.
 Otherwise, delete the unused caught errors.
 
 ```js

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -92,7 +92,7 @@ module.exports = {
             vars: "all",
             args: "after-used",
             ignoreRestSiblings: false,
-            caughtErrors: "none"
+            caughtErrors: "all"
         };
 
         const firstOption = context.options[0];

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -113,7 +113,6 @@ ruleTester.run("no-unused-vars", rule, {
         "myFunc(function foo(){}.toString())",
         "function foo(first, second) {\ndoStuff(function() {\nconsole.log(second);});}; foo()",
         "(function() { var doSomething = function doSomething() {}; doSomething() }())",
-        "try {} catch(e) {}",
         "/*global a */ a;",
         { code: "var a=10; (function() { alert(a); })();", options: [{ vars: "all" }] },
         { code: "function g(bar, baz) { return baz; }; g();", options: [{ vars: "all" }] },
@@ -284,12 +283,16 @@ ruleTester.run("no-unused-vars", rule, {
 
         // caughtErrors
         {
+            code: "try{}catch(err){}",
+            options: [{ caughtErrors: "none" }]
+        },
+        {
             code: "try{}catch(err){console.error(err);}",
             options: [{ caughtErrors: "all" }]
         },
         {
-            code: "try{}catch(err){}",
-            options: [{ caughtErrors: "none" }]
+            code: "try{}catch(ignoreErr){}",
+            options: [{ caughtErrorsIgnorePattern: "^ignore" }]
         },
         {
             code: "try{}catch(ignoreErr){}",
@@ -299,7 +302,7 @@ ruleTester.run("no-unused-vars", rule, {
         // caughtErrors with other combinations
         {
             code: "try{}catch(err){}",
-            options: [{ vars: "all", args: "all" }]
+            options: [{ caughtErrors: "none", vars: "all", args: "all" }]
         },
 
         // Using object rest for variable omission
@@ -1122,6 +1125,10 @@ ruleTester.run("no-unused-vars", rule, {
         },
 
         // caughtErrors
+        {
+            code: "try{}catch(err){};",
+            errors: [definedError("err")]
+        },
         {
             code: "try{}catch(err){};",
             options: [{ caughtErrors: "all" }],


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changes the default value for the `no-unused-vars` rule's `caughtErrors` option from `"none"` to `"all"`.

Fixes #17974.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
