### PR TITLE
feat!: default for `enforceForClassMembers` in `no-useless-computed-key`

### DIFF
--- a/docs/src/rules/no-useless-computed-key.md
+++ b/docs/src/rules/no-useless-computed-key.md
@@ -33,61 +33,6 @@ var a = { ['0+1,234']: 0 };
 var a = { [0]: 0 };
 var a = { ['x']: 0 };
 var a = { ['x']() {} };
-```
-
-:::
-
-Examples of **correct** code for this rule:
-
-::: correct
-
-```js
-/*eslint no-useless-computed-key: "error"*/
-
-var c = { 'a': 0 };
-var c = { 0: 0 };
-var a = { x() {} };
-var c = { a: 0 };
-var c = { '0+1,234': 0 };
-```
-
-:::
-
-Examples of additional **correct** code for this rule:
-
-::: correct
-
-```js
-/*eslint no-useless-computed-key: "error"*/
-
-var c = {
-    "__proto__": foo, // defines object's prototype
-
-    ["__proto__"]: bar // defines a property named "__proto__"
-};
-```
-
-:::
-
-## Options
-
-This rule has an object option:
-
-* `enforceForClassMembers` set to `true` additionally applies this rule to class members (Default `false`).
-
-### enforceForClassMembers
-
-By default, this rule does not check class declarations and class expressions,
-as the default value for `enforceForClassMembers` is `false`.
-
-When `enforceForClassMembers` is set to `true`, the rule will also disallow unnecessary computed keys inside of class fields, class methods, class getters, and class setters.
-
-Examples of **incorrect** code for this rule with the `{ "enforceForClassMembers": true }` option:
-
-::: incorrect
-
-```js
-/*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": true }]*/
 
 class Foo {
     ["foo"] = "bar";
@@ -105,12 +50,18 @@ class Foo {
 
 :::
 
-Examples of **correct** code for this rule with the `{ "enforceForClassMembers": true }` option:
+Examples of **correct** code for this rule:
 
 ::: correct
 
 ```js
-/*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": true }]*/
+/*eslint no-useless-computed-key: "error"*/
+
+var c = { 'a': 0 };
+var c = { 0: 0 };
+var a = { x() {} };
+var c = { a: 0 };
+var c = { '0+1,234': 0 };
 
 class Foo {
     "foo" = "bar";
@@ -128,12 +79,18 @@ class Foo {
 
 :::
 
-Examples of additional **correct** code for this rule with the `{ "enforceForClassMembers": true }` option:
+Examples of additional **correct** code for this rule:
 
 ::: correct
 
 ```js
-/*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": true }]*/
+/*eslint no-useless-computed-key: "error"*/
+
+var c = {
+    "__proto__": foo, // defines object's prototype
+
+    ["__proto__"]: bar // defines a property named "__proto__"
+};
 
 class Foo {
     ["constructor"]; // instance field named "constructor"
@@ -145,6 +102,60 @@ class Foo {
     static ["constructor"]; // static field named "constructor"
 
     static ["prototype"]; // runtime error, it would be a parsing error without `[]`
+}
+```
+
+:::
+
+## Options
+
+This rule has an object option:
+
+* `enforceForClassMembers` set to `false` disables this rule for class members (Default `true`).
+
+### enforceForClassMembers
+
+By default, this rule also checks class declarations and class expressions,
+as the default value for `enforceForClassMembers` is `true`.
+
+When `enforceForClassMembers` is set to `false`, the rule will allow unnecessary computed keys inside of class fields, class methods, class getters, and class setters.
+
+Examples of **incorrect** code for this rule with the `{ "enforceForClassMembers": false }` option:
+
+::: incorrect
+
+```js
+/*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": false }]*/
+
+const obj = {
+    ["foo"]: "bar",
+    [42]: "baz",
+
+    ['a']() {},
+    get ['b']() {},
+    set ['c'](value) {}
+};
+```
+
+:::
+
+Examples of **correct** code for this rule with the `{ "enforceForClassMembers": false }` option:
+
+::: correct
+
+```js
+/*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": false }]*/
+
+class SomeClass {
+    ["foo"] = "bar";
+    [42] = "baz";
+
+    ['a']() {}
+    get ['b']() {}
+    set ['c'](value) {}
+
+    static ["foo"] = "bar";
+    static ['baz']() {}
 }
 ```
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -366,7 +366,7 @@ if (test) {
 ## <a name="no-useless-computed-key"></a> `no-useless-computed-key` flags unnecessary computed member names in classes by default
 
 In ESLint v9.0.0, the default value of the `enforceForClassMembers` option of the `no-useless-computed-key` rule was changed from `false` to `true`.
-The effect of this change ist that unnecessary computed member names in classes will be flagged by default.
+The effect of this change is that unnecessary computed member names in classes will be flagged by default.
 
 ```js
 /*eslint no-useless-computed-key: "error"*/

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -33,6 +33,7 @@ The lists below are ordered roughly by the number of users each change is expect
 * [`no-restricted-imports` now accepts multiple config entries with the same `name`](#no-restricted-imports)
 * [`"eslint:recommended"` and `"eslint:all"` strings no longer accepted in flat config](#string-config)
 * [`no-inner-declarations` has a new default behavior with a new option](#no-inner-declarations)
+* [`no-useless-computed-key` flags unnecessary computed member names in classes by default](#no-useless-computed-key)
 
 ### Breaking changes for plugin developers
 
@@ -361,6 +362,21 @@ if (test) {
 **To address:** If you want to report the block-level `function`s in every condition regardless of strict or non-strict mode, set the `blockScopeFunctions` option to `"disallow"`.
 
 **Related issue(s):** [#15576](https://github.com/eslint/eslint/issues/15576)
+
+## <a name="no-useless-computed-key"></a> `no-useless-computed-key` flags unnecessary computed member names in classes by default
+
+In ESLint v9.0.0, the default value of the `enforceForClassMembers` option of the `no-useless-computed-key` rule was changed from `false` to `true`.
+The effect of this change ist that unnecessary computed member names in classes will be flagged by default.
+
+```js
+/*eslint no-useless-computed-key: "error"*/
+
+class SomeClass {
+    ["someMethod"]() {} // ok in ESLint v8, error in ESLint v9.
+}
+```
+
+**Related issue(s):** [#18042](https://github.com/eslint/eslint/issues/18042)
 
 ## <a name="removed-context-methods"></a> Removed multiple `context` methods
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -376,6 +376,8 @@ class SomeClass {
 }
 ```
 
+**To address:** Fix the problems reported by the rule or revert to the previous behavior by setting the `enforceForClassMembers` option to `false`.
+
 **Related issue(s):** [#18042](https://github.com/eslint/eslint/issues/18042)
 
 ## <a name="removed-context-methods"></a> Removed multiple `context` methods

--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -101,7 +101,7 @@ module.exports = {
             properties: {
                 enforceForClassMembers: {
                     type: "boolean",
-                    default: false
+                    default: true
                 }
             },
             additionalProperties: false
@@ -114,7 +114,7 @@ module.exports = {
     },
     create(context) {
         const sourceCode = context.sourceCode;
-        const enforceForClassMembers = context.options[0] && context.options[0].enforceForClassMembers;
+        const enforceForClassMembers = context.options[0]?.enforceForClassMembers ?? true;
 
         /**
          * Reports a given node if it violated this rule.

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -33,10 +33,10 @@ ruleTester.run("no-useless-computed-key", rule, {
         { code: "(class { [x]() {} })", options: [{ enforceForClassMembers: true }] },
         { code: "(class { ['constructor']() {} })", options: [{ enforceForClassMembers: true }] },
         { code: "(class { static ['prototype']() {} })", options: [{ enforceForClassMembers: true }] },
-        "class Foo { ['x']() {} }",
-        "(class { ['x']() {} })",
-        "class Foo { static ['constructor']() {} }",
-        "class Foo { ['prototype']() {} }",
+        "class Foo { 'x'() {} }",
+        "(class { [x]() {} })",
+        "class Foo { static constructor() {} }",
+        "class Foo { prototype() {} }",
         { code: "class Foo { ['x']() {} }", options: [{ enforceForClassMembers: false }] },
         { code: "(class { ['x']() {} })", options: [{ enforceForClassMembers: false }] },
         { code: "class Foo { static ['constructor']() {} }", options: [{ enforceForClassMembers: false }] },
@@ -272,7 +272,7 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { ['0+1,234']() {} }",
             output: "class Foo { '0+1,234'() {} }",
-            options: [{ enforceForClassMembers: true }],
+            options: [{ }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'0+1,234'" },
@@ -281,7 +281,7 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { ['x']() {} }",
             output: "class Foo { 'x'() {} }",
-            options: [{ enforceForClassMembers: true }],
+            options: [{ enforceForClassMembers: void 0 }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'x'" },
@@ -290,7 +290,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { [/* this comment prevents a fix */ 'x']() {} }",
             output: null,
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'x'" },
@@ -299,7 +298,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { ['x' /* this comment also prevents a fix */]() {} }",
             output: null,
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'x'" },
@@ -308,7 +306,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { [('x')]() {} }",
             output: "class Foo { 'x'() {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'x'" },
@@ -317,7 +314,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { *['x']() {} }",
             output: "class Foo { *'x'() {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'x'" },
@@ -326,7 +322,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { async ['x']() {} }",
             output: "class Foo { async 'x'() {} }",
-            options: [{ enforceForClassMembers: true }],
             languageOptions: { ecmaVersion: 8 },
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
@@ -336,7 +331,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { get[.2]() {} }",
             output: "class Foo { get.2() {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: ".2" },
@@ -345,7 +339,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { set[.2](value) {} }",
             output: "class Foo { set.2(value) {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: ".2" },
@@ -354,7 +347,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { async[.2]() {} }",
             output: "class Foo { async.2() {} }",
-            options: [{ enforceForClassMembers: true }],
             languageOptions: { ecmaVersion: 8 },
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
@@ -364,7 +356,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { [2]() {} }",
             output: "class Foo { 2() {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "2" },
@@ -373,7 +364,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { get [2]() {} }",
             output: "class Foo { get 2() {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "2" },
@@ -382,7 +372,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { set [2](value) {} }",
             output: "class Foo { set 2(value) {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "2" },
@@ -391,7 +380,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { async [2]() {} }",
             output: "class Foo { async 2() {} }",
-            options: [{ enforceForClassMembers: true }],
             languageOptions: { ecmaVersion: 8 },
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
@@ -401,7 +389,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { get[2]() {} }",
             output: "class Foo { get 2() {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "2" },
@@ -410,7 +397,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { set[2](value) {} }",
             output: "class Foo { set 2(value) {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "2" },
@@ -419,7 +405,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { async[2]() {} }",
             output: "class Foo { async 2() {} }",
-            options: [{ enforceForClassMembers: true }],
             languageOptions: { ecmaVersion: 8 },
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
@@ -429,7 +414,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { get['foo']() {} }",
             output: "class Foo { get'foo'() {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'foo'" },
@@ -438,7 +422,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { *[2]() {} }",
             output: "class Foo { *2() {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "2" },
@@ -447,7 +430,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { async*[2]() {} }",
             output: "class Foo { async*2() {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "2" },
@@ -456,7 +438,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { static ['constructor']() {} }",
             output: "class Foo { static 'constructor'() {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'constructor'" },
@@ -465,7 +446,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { ['prototype']() {} }",
             output: "class Foo { 'prototype'() {} }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'prototype'" },
@@ -474,7 +454,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "(class { ['x']() {} })",
             output: "(class { 'x'() {} })",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'x'" },
@@ -483,7 +462,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "(class { ['__proto__']() {} })",
             output: "(class { '__proto__'() {} })",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'__proto__'" },
@@ -492,7 +470,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "(class { static ['__proto__']() {} })",
             output: "(class { static '__proto__'() {} })",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'__proto__'" },
@@ -501,7 +478,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "(class { static ['constructor']() {} })",
             output: "(class { static 'constructor'() {} })",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'constructor'" },
@@ -510,7 +486,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "(class { ['prototype']() {} })",
             output: "(class { 'prototype'() {} })",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'prototype'" },
@@ -519,7 +494,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { ['0'] }",
             output: "class Foo { '0' }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'0'" },
@@ -528,7 +502,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { ['0'] = 0 }",
             output: "class Foo { '0' = 0 }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'0'" },
@@ -537,7 +510,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { static[0] }",
             output: "class Foo { static 0 }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "0" },
@@ -546,7 +518,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { ['#foo'] }",
             output: "class Foo { '#foo' }",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'#foo'" },
@@ -555,7 +526,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "(class { ['__proto__'] })",
             output: "(class { '__proto__' })",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'__proto__'" },
@@ -564,7 +534,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "(class { static ['__proto__'] })",
             output: "(class { static '__proto__' })",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'__proto__'" },
@@ -573,7 +542,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "(class { ['prototype'] })",
             output: "(class { 'prototype' })",
-            options: [{ enforceForClassMembers: true }],
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'prototype'" },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #18042

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR changes the default value of the `enforceForClassMembers` option in the `no-useless-computed-key` rule to `true`.

Since this is a breaking change in v9, I've updated the migration guide.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
