### PR TITLE
fix: handle absolute file paths in `FlatRuleTester`

### DIFF
--- a/lib/rule-tester/flat-rule-tester.js
+++ b/lib/rule-tester/flat-rule-tester.js
@@ -13,6 +13,7 @@
 const
     assert = require("assert"),
     util = require("util"),
+    path = require("path"),
     equal = require("fast-deep-equal"),
     Traverser = require("../shared/traverser"),
     { getRuleOptionsSchema } = require("../config/flat-config-helpers"),
@@ -592,7 +593,15 @@ class FlatRuleTester {
          * @private
          */
         function runRuleForItem(item) {
-            const configs = new FlatConfigArray(testerConfig, { baseConfig });
+            const flatConfigArrayOptions = {
+                baseConfig
+            };
+
+            if (item.filename) {
+                flatConfigArrayOptions.basePath = path.parse(item.filename).root;
+            }
+
+            const configs = new FlatConfigArray(testerConfig, flatConfigArrayOptions);
 
             /*
              * Modify the returned config so that the parser is wrapped to catch

--- a/tests/lib/rule-tester/flat-rule-tester.js
+++ b/tests/lib/rule-tester/flat-rule-tester.js
@@ -1808,6 +1808,22 @@ describe("FlatRuleTester", () => {
         }, /Fixable rules must set the `meta\.fixable` property/u);
     });
 
+    // https://github.com/eslint/eslint/issues/17962
+    it("should not throw an error in case of absolute paths", () => {
+        ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+            valid: [
+                "Eval(foo)"
+            ],
+            invalid: [
+                {
+                    code: "eval(foo)",
+                    filename: "/an-absolute-path/foo.js",
+                    errors: [{ message: "eval sucks.", type: "CallExpression" }]
+                }
+            ]
+        });
+    });
+
     describe("suggestions", () => {
         it("should pass with valid suggestions (tested using desc)", () => {
             ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refs https://github.com/eslint/eslint/issues/17966, backports fix for https://github.com/eslint/eslint/issues/17989 to v8.

#### Is there anything you'd like reviewers to focus on?
No
<!-- markdownlint-disable-file MD004 -->
