### PR TITLE
fix: Ensure config keys are printed for config errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@eslint-community/regexpp": "^4.6.1",
     "@eslint/eslintrc": "^2.1.4",
     "@eslint/js": "8.56.0",
-    "@humanwhocodes/config-array": "^0.11.13",
+    "@humanwhocodes/config-array": "^0.11.14",
     "@humanwhocodes/module-importer": "^1.0.1",
     "@nodelib/fs.walk": "^1.2.8",
     "@ungap/structured-clone": "^1.2.0",

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -440,6 +440,21 @@ describe("bin/eslint.js", () => {
             });
         });
 
+        // https://github.com/eslint/eslint/issues/17960
+        it("should include key information in the error message when there is an invalid config", () => {
+
+            // The error message should include the key name
+            const config = path.join(__dirname, "../fixtures/bin/eslint.config-invalid-key.js");
+            const child = runESLint(["--config", config, "conf", "tools"]);
+            const exitCodeAssertion = assertExitCode(child, 2);
+            const outputAssertion = getOutput(child).then(output => {
+                assert.include(output.stderr, "Key \"linterOptions\": Key \"reportUnusedDisableDirectives\"");
+            });
+
+            return Promise.all([exitCodeAssertion, outputAssertion]);
+
+        });
+
         it("prints the error message pointing to line of code", () => {
             const invalidConfig = path.join(__dirname, "../fixtures/bin/eslint.config.js");
             const child = runESLint(["--no-ignore", "-c", invalidConfig]);

--- a/tests/fixtures/bin/eslint.config-invalid-key.js
+++ b/tests/fixtures/bin/eslint.config-invalid-key.js
@@ -1,0 +1,5 @@
+module.exports = [{
+    linterOptions: {
+        reportUnusedDisableDirectives: "banana"
+    }
+}];

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -1039,7 +1039,7 @@ describe("FlatConfigArray", () => {
                                 reportUnusedDisableDirectives: {}
                             }
                         }
-                    ], /Expected one of: "error", "warn", "off", 0, 1, 2, or a boolean./u);
+                    ], /Key "linterOptions": Key "reportUnusedDisableDirectives": Expected one of: "error", "warn", "off", 0, 1, 2, or a boolean./u);
                 });
 
                 it("should merge two objects when second object has overrides", () => assertMergedResult([
@@ -2054,4 +2054,5 @@ describe("FlatConfigArray", () => {
         });
 
     });
+
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Refs https://github.com/eslint/eslint/issues/17966, backport https://github.com/eslint/eslint/pull/17980 to v8
#### Is there anything you'd like reviewers to focus on?
No
<!-- markdownlint-disable-file MD004 -->
