### PR TITLE
feat!: Rule Tester checks for missing placeholder data in the message

### DIFF
--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -495,7 +495,7 @@ As announced in our [blog post](/blog/2023/10/flat-config-rollout-plans/), the t
 
 **To address:** Update your rule tests to use the new `RuleTester`. To do so, here are some of the common changes you'll need to make:
 
-* **Be aware of new defaults for `ecmaVersion` and `sourceType`.** By default, `RuleTester` uses the flat config default of `ecmaVersion: "latest"` and `sourceType: "module"`. This may cause some tests to break if their values were expecting the old default of `ecmaVersion: 5` and `sourceType: "script"`. If you'd like to use the old default, you'll need to manually specify that in your `RuleTester` like this:
+* **Be aware of new defaults for `ecmaVersion` and `sourceType`.** By default, `RuleTester` uses the flat config default of `ecmaVersion: "latest"` and `sourceType: "module"`. This may cause some tests to break if they were expecting the old default of `ecmaVersion: 5` and `sourceType: "script"`. If you'd like to use the old default, you'll need to manually specify that in your `RuleTester` like this:
 
     ```js
     // use eslintrc defaults

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -553,11 +553,11 @@ In order to aid in the development of high-quality custom rules that are free fr
 1. **Suggestions must generate valid syntax.** In order for rule suggestions to be helpful, they need to be valid syntax. `RuleTester` now parses the output of suggestions using the same language options as the `code` value and throws an error if parsing fails.
 1. **Test cases must be unique.** Identical test cases can cause confusion and be hard to detect manually in a long test file. Duplicates are now automatically detected and can be safely removed.
 1. **`filename` and `only` must be of the expected type.** `RuleTester` now checks the type of `filename` and `only` properties of test objects. If specified, `filename` must be a string value. If specified, `only` must be a boolean value.
-1. **Messages cannot have unsubstituted placeholders.** The rule tester now checks if there are `{{ placeholder }}` still in the message as their values were not passed via `data` in the respective `context.report`.
+1. **Messages cannot have unsubstituted placeholders.** The rule tester now checks if there are {% raw %}`{{ placeholder }}` {% endraw %} still in the message as their values were not passed via `data` in the respective `context.report()` call.
 
 **To address:** Run your rule tests using `RuleTester` and fix any errors that occur. The changes you'll need to make to satisfy `RuleTester` are compatible with ESLint v8.x.
 
-**Related Issues(s):** [#15104](https://github.com/eslint/eslint/issues/15104), [#15735](https://github.com/eslint/eslint/issues/15735), [#16908](https://github.com/eslint/eslint/issues/16908)
+**Related Issues(s):** [#15104](https://github.com/eslint/eslint/issues/15104), [#15735](https://github.com/eslint/eslint/issues/15735), [#16908](https://github.com/eslint/eslint/issues/16908), [#18016](https://github.com/eslint/eslint/issues/18016)
 
 ## <a name="flat-eslint"></a> `FlatESLint` is now `ESLint`
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -495,7 +495,7 @@ As announced in our [blog post](/blog/2023/10/flat-config-rollout-plans/), the t
 
 **To address:** Update your rule tests to use the new `RuleTester`. To do so, here are some of the common changes you'll need to make:
 
-* **Be aware of new defaults for `ecmaVersion` and `sourceType`.** By default, `RuleTester` uses the flat config default of `ecmaVersion: "latest"` and `sourceType: "module"`. This may cause some tests to break if they were expecting the old default of `ecmaVersion: 5` and `sourceType: "script"`. If you'd like to use the old default, you'll need to manually specify that in your `RuleTester` like this:
+* **Be aware of new defaults for `ecmaVersion` and `sourceType`.** By default, `RuleTester` uses the flat config default of `ecmaVersion: "latest"` and `sourceType: "module"`. This may cause some tests to break if their values were expecting the old default of `ecmaVersion: 5` and `sourceType: "script"`. If you'd like to use the old default, you'll need to manually specify that in your `RuleTester` like this:
 
     ```js
     // use eslintrc defaults
@@ -552,8 +552,8 @@ In order to aid in the development of high-quality custom rules that are free fr
 1. **Suggestions must change the code.** Suggestions are expected to fix the reported problem by changing the code. `RuleTester` now throws an error if the suggestion test `output` is the same as the test `code`.
 1. **Suggestions must generate valid syntax.** In order for rule suggestions to be helpful, they need to be valid syntax. `RuleTester` now parses the output of suggestions using the same language options as the `code` value and throws an error if parsing fails.
 1. **Test cases must be unique.** Identical test cases can cause confusion and be hard to detect manually in a long test file. Duplicates are now automatically detected and can be safely removed.
-1. **Messages cannot have unsubstituted placeholders.** The rule tester now checks if there are `{{ placeholder }}` still in the message as they were not passed via `data` in the respective `context.report`.
 1. **`filename` and `only` must be of the expected type.** `RuleTester` now checks the type of `filename` and `only` properties of test objects. If specified, `filename` must be a string value. If specified, `only` must be a boolean value.
+1. **Messages cannot have unsubstituted placeholders.** The rule tester now checks if there are `{{ placeholder }}` still in the message as their values were not passed via `data` in the respective `context.report`.
 
 **To address:** Run your rule tests using `RuleTester` and fix any errors that occur. The changes you'll need to make to satisfy `RuleTester` are compatible with ESLint v8.x.
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -553,7 +553,7 @@ In order to aid in the development of high-quality custom rules that are free fr
 1. **Suggestions must generate valid syntax.** In order for rule suggestions to be helpful, they need to be valid syntax. `RuleTester` now parses the output of suggestions using the same language options as the `code` value and throws an error if parsing fails.
 1. **Test cases must be unique.** Identical test cases can cause confusion and be hard to detect manually in a long test file. Duplicates are now automatically detected and can be safely removed.
 1. **`filename` and `only` must be of the expected type.** `RuleTester` now checks the type of `filename` and `only` properties of test objects. If specified, `filename` must be a string value. If specified, `only` must be a boolean value.
-1. **Messages cannot have unsubstituted placeholders.** The rule tester now checks if there are {% raw %}`{{ placeholder }}` {% endraw %} still in the message as their values were not passed via `data` in the respective `context.report()` call.
+1. **Messages cannot have unsubstituted placeholders.** The `RuleTester` now also checks if there are {% raw %}`{{ placeholder }}` {% endraw %} still in the message as their values were not passed via `data` in the respective `context.report()` call.
 
 **To address:** Run your rule tests using `RuleTester` and fix any errors that occur. The changes you'll need to make to satisfy `RuleTester` are compatible with ESLint v8.x.
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -552,6 +552,7 @@ In order to aid in the development of high-quality custom rules that are free fr
 1. **Suggestions must change the code.** Suggestions are expected to fix the reported problem by changing the code. `RuleTester` now throws an error if the suggestion test `output` is the same as the test `code`.
 1. **Suggestions must generate valid syntax.** In order for rule suggestions to be helpful, they need to be valid syntax. `RuleTester` now parses the output of suggestions using the same language options as the `code` value and throws an error if parsing fails.
 1. **Test cases must be unique.** Identical test cases can cause confusion and be hard to detect manually in a long test file. Duplicates are now automatically detected and can be safely removed.
+1. **Messages cannot have unsubstituted placeholders.** The rule tester now checks if there are `{{ placeholder }}` still in the message as they were not passed via `data` in the respective `context.report`.
 1. **`filename` and `only` must be of the expected type.** `RuleTester` now checks the type of `filename` and `only` properties of test objects. If specified, `filename` must be a string value. If specified, `only` must be a boolean value.
 
 **To address:** Run your rule tests using `RuleTester` and fix any errors that occur. The changes you'll need to make to satisfy `RuleTester` are compatible with ESLint v8.x.

--- a/lib/linter/index.js
+++ b/lib/linter/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { Linter } = require("./linter");
-const interpolate = require("./interpolate");
+const { interpolate } = require("./interpolate");
 const SourceCodeFixer = require("./source-code-fixer");
 
 module.exports = {

--- a/lib/linter/interpolate.js
+++ b/lib/linter/interpolate.js
@@ -9,27 +9,42 @@
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = {
-    getPlaceholderMatcher() {
-        return /\{\{([^{}]+?)\}\}/gu;
-    },
-    interpolate(text, data) {
-        if (!data) {
-            return text;
+/**
+ * Returns a global expression matching placeholders in messages.
+ * @returns {RegExp} Global regular expression matching placeholders
+ */
+function getPlaceholderMatcher() {
+    return /\{\{([^{}]+?)\}\}/gu;
+}
+
+/**
+ * Replaces {{ placeholders }} in the message with the provided data.
+ * Does not replace placeholders not available in the data.
+ * @param {string} text Original message with potential placeholders
+ * @param {Record<string, string>} data Map of placeholder name to its value
+ * @returns {string} Message with replaced placeholders
+ */
+function interpolate(text, data) {
+    if (!data) {
+        return text;
+    }
+
+    const matcher = getPlaceholderMatcher();
+
+    // Substitution content for any {{ }} markers.
+    return text.replace(matcher, (fullMatch, termWithWhitespace) => {
+        const term = termWithWhitespace.trim();
+
+        if (term in data) {
+            return data[term];
         }
 
-        const matcher = module.exports.getPlaceholderMatcher();
+        // Preserve old behavior: If parameter name not provided, don't replace it.
+        return fullMatch;
+    });
+}
 
-        // Substitution content for any {{ }} markers.
-        return text.replace(matcher, (fullMatch, termWithWhitespace) => {
-            const term = termWithWhitespace.trim();
-
-            if (term in data) {
-                return data[term];
-            }
-
-            // Preserve old behavior: If parameter name not provided, don't replace it.
-            return fullMatch;
-        });
-    }
+module.exports = {
+    getPlaceholderMatcher,
+    interpolate
 };

--- a/lib/linter/interpolate.js
+++ b/lib/linter/interpolate.js
@@ -9,20 +9,27 @@
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = (text, data) => {
-    if (!data) {
-        return text;
-    }
-
-    // Substitution content for any {{ }} markers.
-    return text.replace(/\{\{([^{}]+?)\}\}/gu, (fullMatch, termWithWhitespace) => {
-        const term = termWithWhitespace.trim();
-
-        if (term in data) {
-            return data[term];
+module.exports = {
+    getPlaceholderMatcher() {
+        return /\{\{([^{}]+?)\}\}/gu;
+    },
+    interpolate(text, data) {
+        if (!data) {
+            return text;
         }
 
-        // Preserve old behavior: If parameter name not provided, don't replace it.
-        return fullMatch;
-    });
+        const matcher = module.exports.getPlaceholderMatcher();
+
+        // Substitution content for any {{ }} markers.
+        return text.replace(matcher, (fullMatch, termWithWhitespace) => {
+            const term = termWithWhitespace.trim();
+
+            if (term in data) {
+                return data[term];
+            }
+
+            // Preserve old behavior: If parameter name not provided, don't replace it.
+            return fullMatch;
+        });
+    }
 };

--- a/lib/linter/report-translator.js
+++ b/lib/linter/report-translator.js
@@ -11,7 +11,7 @@
 
 const assert = require("assert");
 const ruleFixer = require("./rule-fixer");
-const interpolate = require("./interpolate");
+const { interpolate } = require("./interpolate");
 
 //------------------------------------------------------------------------------
 // Typedefs

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -311,7 +311,7 @@ const messagePlaceholderRegex = /\{\{([^{}]+?)\}\}/gu;
  * @param   {string} message Reported message
  * @returns {string[]} Array of missing placeholder names
  */
-function getMissingMessagePlaceholders(message) {
+function getMessagePlaceholders(message) {
     return Array.from(message.matchAll(messagePlaceholderRegex), ([, name]) => name.trim());
 }
 
@@ -1024,11 +1024,11 @@ class RuleTester {
                                     `Hydrated message "${rehydratedMessage}" does not match "${message.message}"`
                                 );
                             } else {
-                                const missing = getMissingMessagePlaceholders(message.message);
+                                const missing = getMessagePlaceholders(message.message);
 
                                 assert.ok(
                                     missing.length === 0,
-                                    `The reported message has missing placeholders: ${missing.join(", ")}. Please provide them via the 'data' property in the context.report call`
+                                    `The reported message has missing placeholders: ${missing.join(", ")}. Please provide them via the 'data' property in the context.report() call.`
                                 );
                             }
                         } else {
@@ -1124,11 +1124,11 @@ class RuleTester {
                                                     `${suggestionPrefix} Hydrated test desc "${rehydratedDesc}" does not match received desc "${actualSuggestion.desc}".`
                                                 );
                                             } else {
-                                                const missing = getMissingMessagePlaceholders(actualSuggestion.desc);
+                                                const missing = getMessagePlaceholders(actualSuggestion.desc);
 
                                                 assert.ok(
                                                     missing.length === 0,
-                                                    `The message of the suggestion has missing placeholders: ${missing.join(", ")}. Please provide them via the 'data' property for the suggestion in the context.report call`
+                                                    `The message of the suggestion has missing placeholders: ${missing.join(", ")}. Please provide them via the 'data' property for the suggestion in the context.report() call.`
                                                 );
                                             }
                                         } else if (hasOwnProperty(expectedSuggestion, "data")) {

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -316,6 +316,29 @@ function getMessagePlaceholders(message) {
     return Array.from(message.matchAll(matcher), ([, name]) => name.trim());
 }
 
+/**
+ * Returns the placeholders in the reported messages but
+ * only includes the placeholders available in the raw message if data is not specified or
+ * excludes introduced placeholders specified in the data values.
+ * @param {string} message The reported message
+ * @param {string} raw The raw message specified in the rule meta.messages
+ * @param {undefined|Record<unknown, unknown>} data The passed
+ * @returns {string[]} Missing placeholder names
+ */
+function getMissingMessagePlaceholders(message, raw, data) {
+    const existing = getMessagePlaceholders(message);
+
+    if (data === void 0) {
+        const available = getMessagePlaceholders(raw);
+
+        return existing.filter(name => available.includes(name));
+    }
+
+    const introduced = new Set(Object.values(data).flatMap(value => (typeof value === "string" ? getMessagePlaceholders(value) : [])));
+
+    return existing.filter(name => !introduced.has(name));
+}
+
 const metaSchemaDescription = `
 \t- If the rule has options, set \`meta.schema\` to an array or non-empty object to enable options validation.
 \t- If the rule doesn't have options, omit \`meta.schema\` to enforce that no options can be passed to the rule.
@@ -1010,7 +1033,7 @@ class RuleTester {
                                 `messageId '${message.messageId}' does not match expected messageId '${error.messageId}'.`
                             );
 
-                            const missingPlaceholders = getMessagePlaceholders(message.message);
+                            const missingPlaceholders = getMissingMessagePlaceholders(message.message, rule.meta.messages[message.messageId], error.data);
 
                             assert.ok(
                                 missingPlaceholders.length === 0,
@@ -1117,7 +1140,11 @@ class RuleTester {
                                                 `${suggestionPrefix} messageId should be '${expectedSuggestion.messageId}' but got '${actualSuggestion.messageId}' instead.`
                                             );
 
-                                            const missingPlaceholders = getMessagePlaceholders(actualSuggestion.desc);
+                                            const missingPlaceholders = getMissingMessagePlaceholders(
+                                                actualSuggestion.desc,
+                                                rule.meta.messages[expectedSuggestion.messageId],
+                                                expectedSuggestion.data
+                                            );
 
                                             assert.ok(
                                                 missingPlaceholders.length === 0,

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -325,18 +325,19 @@ function getMessagePlaceholders(message) {
  * @param {undefined|Record<unknown, unknown>} data The passed
  * @returns {string[]} Missing placeholder names
  */
-function getMissingMessagePlaceholders(message, raw, data) {
-    const existing = getMessagePlaceholders(message);
+function getUnsubstitutedMessagePlaceholders(message, raw, data = {}) {
+    const unsubstituted = getMessagePlaceholders(message);
 
-    if (data === void 0) {
-        const available = getMessagePlaceholders(raw);
-
-        return existing.filter(name => available.includes(name));
+    if (unsubstituted.length === 0) {
+        return [];
     }
 
-    const introduced = new Set(Object.values(data).flatMap(value => (typeof value === "string" ? getMessagePlaceholders(value) : [])));
+    // Remove false positives by only counting placeholders in the raw message, which were not provided in the data matcher or added with a data property
+    const known = getMessagePlaceholders(raw);
+    const provided = Object.keys(data);
+    const added = new Set(Object.values(data).flatMap(value => (typeof value === "string" ? getMessagePlaceholders(value) : [])));
 
-    return existing.filter(name => !introduced.has(name));
+    return unsubstituted.filter(name => known.includes(name) && !provided.includes(name) && !added.has(name));
 }
 
 const metaSchemaDescription = `
@@ -1033,11 +1034,15 @@ class RuleTester {
                                 `messageId '${message.messageId}' does not match expected messageId '${error.messageId}'.`
                             );
 
-                            const missingPlaceholders = getMissingMessagePlaceholders(message.message, rule.meta.messages[message.messageId], error.data);
+                            const unsubstitutedPlaceholders = getUnsubstitutedMessagePlaceholders(
+                                message.message,
+                                rule.meta.messages[message.messageId],
+                                error.data
+                            );
 
                             assert.ok(
-                                missingPlaceholders.length === 0,
-                                `The reported message has ${missingPlaceholders.length > 1 ? `the missing placeholders: ${missingPlaceholders.map(name => `'${name}'`).join(", ")}` : `a missing placeholder '${missingPlaceholders[0]}'`}. Please provide them via the 'data' property in the context.report() call.`
+                                unsubstitutedPlaceholders.length === 0,
+                                `The reported message has ${unsubstitutedPlaceholders.length > 1 ? `the unsubstituted placeholders: ${unsubstitutedPlaceholders.map(name => `'${name}'`).join(", ")}` : `a unsubstituted placeholder '${unsubstitutedPlaceholders[0]}'`}. Please provide them via the 'data' property in the context.report() call.`
                             );
 
                             if (hasOwnProperty(error, "data")) {
@@ -1140,7 +1145,7 @@ class RuleTester {
                                                 `${suggestionPrefix} messageId should be '${expectedSuggestion.messageId}' but got '${actualSuggestion.messageId}' instead.`
                                             );
 
-                                            const missingPlaceholders = getMissingMessagePlaceholders(
+                                            const missingPlaceholders = getUnsubstitutedMessagePlaceholders(
                                                 actualSuggestion.desc,
                                                 rule.meta.messages[expectedSuggestion.messageId],
                                                 expectedSuggestion.data
@@ -1148,7 +1153,7 @@ class RuleTester {
 
                                             assert.ok(
                                                 missingPlaceholders.length === 0,
-                                                `The message of the suggestion has ${missingPlaceholders.length > 1 ? `the missing placeholders: ${missingPlaceholders.map(name => `'${name}'`).join(", ")}` : `a missing placeholder '${missingPlaceholders[0]}'`}. Please provide them via the 'data' property for the suggestion in the context.report() call.`
+                                                `The message of the suggestion has ${missingPlaceholders.length > 1 ? `the unsubstituted placeholders: ${missingPlaceholders.map(name => `'${name}'`).join(", ")}` : `a unsubstituted placeholder '${missingPlaceholders[0]}'`}. Please provide them via the 'data' property for the suggestion in the context.report() call.`
                                             );
 
                                             if (hasOwnProperty(expectedSuggestion, "data")) {

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -304,6 +304,17 @@ function throwForbiddenMethodError(methodName, prototype) {
     };
 }
 
+const messagePlaceholderRegex = /\{\{([^{}]+?)\}\}/gu;
+
+/**
+ * Extracts names of missing {{ placeholders }} from the reported message.
+ * @param   {string} message Reported message
+ * @returns {string[]} Array of missing placeholder names
+ */
+function getMissingMessagePlaceholders(message) {
+    return Array.from(message.matchAll(messagePlaceholderRegex), ([, name]) => name.trim());
+}
+
 const metaSchemaDescription = `
 \t- If the rule has options, set \`meta.schema\` to an array or non-empty object to enable options validation.
 \t- If the rule doesn't have options, omit \`meta.schema\` to enforce that no options can be passed to the rule.
@@ -1012,6 +1023,13 @@ class RuleTester {
                                     rehydratedMessage,
                                     `Hydrated message "${rehydratedMessage}" does not match "${message.message}"`
                                 );
+                            } else {
+                                const missing = getMissingMessagePlaceholders(message.message);
+
+                                assert.ok(
+                                    missing.length === 0,
+                                    `The reported message has missing placeholders: ${missing.join(", ")}. Please provide them via the 'data' property in the context.report call`
+                                );
                             }
                         } else {
                             assert.fail("Test error must specify either a 'messageId' or 'message'.");
@@ -1104,6 +1122,13 @@ class RuleTester {
                                                     actualSuggestion.desc,
                                                     rehydratedDesc,
                                                     `${suggestionPrefix} Hydrated test desc "${rehydratedDesc}" does not match received desc "${actualSuggestion.desc}".`
+                                                );
+                                            } else {
+                                                const missing = getMissingMessagePlaceholders(actualSuggestion.desc);
+
+                                                assert.ok(
+                                                    missing.length === 0,
+                                                    `The message of the suggestion has missing placeholders: ${missing.join(", ")}. Please provide them via the 'data' property for the suggestion in the context.report call`
                                                 );
                                             }
                                         } else if (hasOwnProperty(expectedSuggestion, "data")) {

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -1008,6 +1008,14 @@ class RuleTester {
                                 error.messageId,
                                 `messageId '${message.messageId}' does not match expected messageId '${error.messageId}'.`
                             );
+
+                            const missingPlaceholders = getMessagePlaceholders(message.message);
+
+                            assert.ok(
+                                missingPlaceholders.length === 0,
+                                `The reported message has ${missingPlaceholders.length > 1 ? `the missing placeholders: ${missingPlaceholders.map(name => `'${name}'`).join(", ")}` : `a missing placeholder '${missingPlaceholders[0]}'`}. Please provide them via the 'data' property in the context.report() call.`
+                            );
+
                             if (hasOwnProperty(error, "data")) {
 
                                 /*
@@ -1022,13 +1030,6 @@ class RuleTester {
                                     message.message,
                                     rehydratedMessage,
                                     `Hydrated message "${rehydratedMessage}" does not match "${message.message}"`
-                                );
-                            } else {
-                                const missing = getMessagePlaceholders(message.message);
-
-                                assert.ok(
-                                    missing.length === 0,
-                                    `The reported message has ${missing.length > 1 ? `the missing placeholders: ${missing.map(name => `'${name}'`).join(", ")}` : `a missing placeholder '${missing[0]}'`}. Please provide them via the 'data' property in the context.report() call.`
                                 );
                             }
                         } else {
@@ -1114,6 +1115,14 @@ class RuleTester {
                                                 expectedSuggestion.messageId,
                                                 `${suggestionPrefix} messageId should be '${expectedSuggestion.messageId}' but got '${actualSuggestion.messageId}' instead.`
                                             );
+
+                                            const missingPlaceholders = getMessagePlaceholders(actualSuggestion.desc);
+
+                                            assert.ok(
+                                                missingPlaceholders.length === 0,
+                                                `The message of the suggestion has ${missingPlaceholders.length > 1 ? `the missing placeholders: ${missingPlaceholders.map(name => `'${name}'`).join(", ")}` : `a missing placeholder '${missingPlaceholders[0]}'`}. Please provide them via the 'data' property for the suggestion in the context.report() call.`
+                                            );
+
                                             if (hasOwnProperty(expectedSuggestion, "data")) {
                                                 const unformattedMetaMessage = rule.meta.messages[expectedSuggestion.messageId];
                                                 const rehydratedDesc = interpolate(unformattedMetaMessage, expectedSuggestion.data);
@@ -1122,13 +1131,6 @@ class RuleTester {
                                                     actualSuggestion.desc,
                                                     rehydratedDesc,
                                                     `${suggestionPrefix} Hydrated test desc "${rehydratedDesc}" does not match received desc "${actualSuggestion.desc}".`
-                                                );
-                                            } else {
-                                                const missing = getMessagePlaceholders(actualSuggestion.desc);
-
-                                                assert.ok(
-                                                    missing.length === 0,
-                                                    `The message of the suggestion has ${missing.length > 1 ? `the missing placeholders: ${missing.map(name => `'${name}'`).join(", ")}` : `a missing placeholder '${missing[0]}'`}. Please provide them via the 'data' property for the suggestion in the context.report() call.`
                                                 );
                                             }
                                         } else if (hasOwnProperty(expectedSuggestion, "data")) {

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -307,9 +307,9 @@ function throwForbiddenMethodError(methodName, prototype) {
 const messagePlaceholderRegex = /\{\{([^{}]+?)\}\}/gu;
 
 /**
- * Extracts names of missing {{ placeholders }} from the reported message.
+ * Extracts names of {{ placeholders }} from the reported message.
  * @param   {string} message Reported message
- * @returns {string[]} Array of missing placeholder names
+ * @returns {string[]} Array of placeholder names
  */
 function getMessagePlaceholders(message) {
     return Array.from(message.matchAll(messagePlaceholderRegex), ([, name]) => name.trim());
@@ -1028,7 +1028,7 @@ class RuleTester {
 
                                 assert.ok(
                                     missing.length === 0,
-                                    `The reported message has missing placeholders: ${missing.join(", ")}. Please provide them via the 'data' property in the context.report() call.`
+                                    `The reported message has ${missing.length > 1 ? `the missing placeholders: ${missing.map(name => `'${name}'`).join(", ")}` : `a missing placeholder '${missing[0]}'`}. Please provide them via the 'data' property in the context.report() call.`
                                 );
                             }
                         } else {
@@ -1128,7 +1128,7 @@ class RuleTester {
 
                                                 assert.ok(
                                                     missing.length === 0,
-                                                    `The message of the suggestion has missing placeholders: ${missing.join(", ")}. Please provide them via the 'data' property for the suggestion in the context.report() call.`
+                                                    `The message of the suggestion has ${missing.length > 1 ? `the missing placeholders: ${missing.map(name => `'${name}'`).join(", ")}` : `a missing placeholder '${missing[0]}'`}. Please provide them via the 'data' property for the suggestion in the context.report() call.`
                                                 );
                                             }
                                         } else if (hasOwnProperty(expectedSuggestion, "data")) {

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -318,8 +318,7 @@ function getMessagePlaceholders(message) {
 
 /**
  * Returns the placeholders in the reported messages but
- * only includes the placeholders available in the raw message if data is not specified or
- * excludes introduced placeholders specified in the data values.
+ * only includes the placeholders available in the raw message and not in the provided data.
  * @param {string} message The reported message
  * @param {string} raw The raw message specified in the rule meta.messages
  * @param {undefined|Record<unknown, unknown>} data The passed
@@ -335,9 +334,8 @@ function getUnsubstitutedMessagePlaceholders(message, raw, data = {}) {
     // Remove false positives by only counting placeholders in the raw message, which were not provided in the data matcher or added with a data property
     const known = getMessagePlaceholders(raw);
     const provided = Object.keys(data);
-    const added = new Set(Object.values(data).flatMap(value => (typeof value === "string" ? getMessagePlaceholders(value) : [])));
 
-    return unsubstituted.filter(name => known.includes(name) && !provided.includes(name) && !added.has(name));
+    return unsubstituted.filter(name => known.includes(name) && !provided.includes(name));
 }
 
 const metaSchemaDescription = `

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -17,7 +17,8 @@ const
     equal = require("fast-deep-equal"),
     Traverser = require("../shared/traverser"),
     { getRuleOptionsSchema } = require("../config/flat-config-helpers"),
-    { Linter, SourceCodeFixer, interpolate } = require("../linter"),
+    { Linter, SourceCodeFixer } = require("../linter"),
+    { interpolate, getPlaceholderMatcher } = require("../linter/interpolate"),
     stringify = require("json-stable-stringify-without-jsonify");
 
 const { FlatConfigArray } = require("../config/flat-config-array");
@@ -304,15 +305,15 @@ function throwForbiddenMethodError(methodName, prototype) {
     };
 }
 
-const messagePlaceholderRegex = /\{\{([^{}]+?)\}\}/gu;
-
 /**
  * Extracts names of {{ placeholders }} from the reported message.
  * @param   {string} message Reported message
  * @returns {string[]} Array of placeholder names
  */
 function getMessagePlaceholders(message) {
-    return Array.from(message.matchAll(messagePlaceholderRegex), ([, name]) => name.trim());
+    const matcher = getPlaceholderMatcher();
+
+    return Array.from(message.matchAll(matcher), ([, name]) => name.trim());
 }
 
 const metaSchemaDescription = `

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -1040,7 +1040,7 @@ class RuleTester {
 
                             assert.ok(
                                 unsubstitutedPlaceholders.length === 0,
-                                `The reported message has ${unsubstitutedPlaceholders.length > 1 ? `unsubstituted placeholders: ${unsubstitutedPlaceholders.map(name => `'${name}'`).join(", ")}` : `an unsubstituted placeholder '${unsubstitutedPlaceholders[0]}'`}. Please provide them via the 'data' property in the context.report() call.`
+                                `The reported message has ${unsubstitutedPlaceholders.length > 1 ? `unsubstituted placeholders: ${unsubstitutedPlaceholders.map(name => `'${name}'`).join(", ")}` : `an unsubstituted placeholder '${unsubstitutedPlaceholders[0]}'`}. Please provide the missing ${unsubstitutedPlaceholders.length > 1 ? "values" : "value"} via the 'data' property in the context.report() call.`
                             );
 
                             if (hasOwnProperty(error, "data")) {
@@ -1143,15 +1143,15 @@ class RuleTester {
                                                 `${suggestionPrefix} messageId should be '${expectedSuggestion.messageId}' but got '${actualSuggestion.messageId}' instead.`
                                             );
 
-                                            const missingPlaceholders = getUnsubstitutedMessagePlaceholders(
+                                            const unsubstitutedPlaceholders = getUnsubstitutedMessagePlaceholders(
                                                 actualSuggestion.desc,
                                                 rule.meta.messages[expectedSuggestion.messageId],
                                                 expectedSuggestion.data
                                             );
 
                                             assert.ok(
-                                                missingPlaceholders.length === 0,
-                                                `The message of the suggestion has ${missingPlaceholders.length > 1 ? `unsubstituted placeholders: ${missingPlaceholders.map(name => `'${name}'`).join(", ")}` : `an unsubstituted placeholder '${missingPlaceholders[0]}'`}. Please provide them via the 'data' property for the suggestion in the context.report() call.`
+                                                unsubstitutedPlaceholders.length === 0,
+                                                `The message of the suggestion has ${unsubstitutedPlaceholders.length > 1 ? `unsubstituted placeholders: ${unsubstitutedPlaceholders.map(name => `'${name}'`).join(", ")}` : `an unsubstituted placeholder '${unsubstitutedPlaceholders[0]}'`}. Please provide the missing ${unsubstitutedPlaceholders.length > 1 ? "values" : "value"} via the 'data' property for the suggestion in the context.report() call.`
                                             );
 
                                             if (hasOwnProperty(expectedSuggestion, "data")) {

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -1042,7 +1042,7 @@ class RuleTester {
 
                             assert.ok(
                                 unsubstitutedPlaceholders.length === 0,
-                                `The reported message has ${unsubstitutedPlaceholders.length > 1 ? `the unsubstituted placeholders: ${unsubstitutedPlaceholders.map(name => `'${name}'`).join(", ")}` : `a unsubstituted placeholder '${unsubstitutedPlaceholders[0]}'`}. Please provide them via the 'data' property in the context.report() call.`
+                                `The reported message has ${unsubstitutedPlaceholders.length > 1 ? `unsubstituted placeholders: ${unsubstitutedPlaceholders.map(name => `'${name}'`).join(", ")}` : `an unsubstituted placeholder '${unsubstitutedPlaceholders[0]}'`}. Please provide them via the 'data' property in the context.report() call.`
                             );
 
                             if (hasOwnProperty(error, "data")) {
@@ -1153,7 +1153,7 @@ class RuleTester {
 
                                             assert.ok(
                                                 missingPlaceholders.length === 0,
-                                                `The message of the suggestion has ${missingPlaceholders.length > 1 ? `the unsubstituted placeholders: ${missingPlaceholders.map(name => `'${name}'`).join(", ")}` : `a unsubstituted placeholder '${missingPlaceholders[0]}'`}. Please provide them via the 'data' property for the suggestion in the context.report() call.`
+                                                `The message of the suggestion has ${missingPlaceholders.length > 1 ? `unsubstituted placeholders: ${missingPlaceholders.map(name => `'${name}'`).join(", ")}` : `an unsubstituted placeholder '${missingPlaceholders[0]}'`}. Please provide them via the 'data' property for the suggestion in the context.report() call.`
                                             );
 
                                             if (hasOwnProperty(expectedSuggestion, "data")) {

--- a/tests/fixtures/testers/rule-tester/messageId.js
+++ b/tests/fixtures/testers/rule-tester/messageId.js
@@ -56,6 +56,27 @@ module.exports.withMissingData = {
     }
 };
 
+module.exports.withMultipleMissingDataProperties = {
+    meta: {
+        messages: {
+            avoidFoo: "Avoid using {{ type }} named '{{ name }}'.",
+            unused: "An unused key"
+        }
+    },
+    create(context) {
+        return {
+            Identifier(node) {
+                if (node.name === "foo") {
+                    context.report({
+                        node,
+                        messageId: "avoidFoo",
+                    });
+                }
+            }
+        };
+    }
+};
+
 module.exports.withPlaceholdersInData = {
     meta: {
         messages: {

--- a/tests/fixtures/testers/rule-tester/messageId.js
+++ b/tests/fixtures/testers/rule-tester/messageId.js
@@ -34,3 +34,24 @@ module.exports.withMessageOnly = {
         };
     }
 };
+
+module.exports.withMissingData = {
+    meta: {
+        messages: {
+            avoidFoo: "Avoid using variables named '{{ name }}'.",
+            unused: "An unused key"
+        }
+    },
+    create(context) {
+        return {
+            Identifier(node) {
+                if (node.name === "foo") {
+                    context.report({
+                        node,
+                        messageId: "avoidFoo",
+                    });
+                }
+            }
+        };
+    }
+};

--- a/tests/fixtures/testers/rule-tester/messageId.js
+++ b/tests/fixtures/testers/rule-tester/messageId.js
@@ -55,3 +55,25 @@ module.exports.withMissingData = {
         };
     }
 };
+
+module.exports.withPlaceholdersInData = {
+    meta: {
+        messages: {
+            avoidFoo: "Avoid using variables named '{{ name }}'.",
+            unused: "An unused key"
+        }
+    },
+    create(context) {
+        return {
+            Identifier(node) {
+                if (node.name === "foo") {
+                    context.report({
+                        node,
+                        messageId: "avoidFoo",
+                        data:      { name: '{{ placeholder }}' },
+                    });
+                }
+            }
+        };
+    }
+};

--- a/tests/fixtures/testers/rule-tester/messageId.js
+++ b/tests/fixtures/testers/rule-tester/messageId.js
@@ -120,3 +120,24 @@ module.exports.withSamePlaceholdersInData = {
         };
     }
 };
+
+module.exports.withNonStringData = {
+    meta: {
+        messages: {
+            avoid: "Avoid using the value '{{ value }}'.",
+        }
+    },
+    create(context) {
+        return {
+            Literal(node) {
+                if (node.value === 0) {
+                    context.report({
+                        node,
+                        messageId: "avoid",
+                        data:      { value: 0 },
+                    });
+                }
+            }
+        };
+    }
+};

--- a/tests/fixtures/testers/rule-tester/messageId.js
+++ b/tests/fixtures/testers/rule-tester/messageId.js
@@ -98,3 +98,25 @@ module.exports.withPlaceholdersInData = {
         };
     }
 };
+
+module.exports.withSamePlaceholdersInData = {
+    meta: {
+        messages: {
+            avoidFoo: "Avoid using variables named '{{ name }}'.",
+            unused: "An unused key"
+        }
+    },
+    create(context) {
+        return {
+            Identifier(node) {
+                if (node.name === "foo") {
+                    context.report({
+                        node,
+                        messageId: "avoidFoo",
+                        data:      { name: '{{ name }}' },
+                    });
+                }
+            }
+        };
+    }
+};

--- a/tests/fixtures/testers/rule-tester/suggestions.js
+++ b/tests/fixtures/testers/rule-tester/suggestions.js
@@ -227,3 +227,32 @@ module.exports.withMissingPlaceholderData = {
         };
     }
 };
+
+module.exports.withMultipleMissingPlaceholderDataProperties = {
+    meta: {
+        messages: {
+            avoidFoo: "Avoid using identifiers named '{{ name }}'.",
+            rename: "Rename identifier '{{ currentName }}' to '{{ newName }}'"
+        },
+        hasSuggestions: true
+    },
+    create(context) {
+        return {
+            Identifier(node) {
+                if (node.name === "foo") {
+                    context.report({
+                        node,
+                        messageId: "avoidFoo",
+                        data: {
+                            name: "foo"
+                        },
+                        suggest: [{
+                            messageId: "rename",
+                            fix: fixer => fixer.replaceText(node, "bar")
+                        }]
+                    });
+                }
+            }
+        };
+    }
+};

--- a/tests/fixtures/testers/rule-tester/suggestions.js
+++ b/tests/fixtures/testers/rule-tester/suggestions.js
@@ -198,3 +198,32 @@ module.exports.withFailingFixer = {
         };
     }
 };
+
+module.exports.withMissingPlaceholderData = {
+    meta: {
+        messages: {
+            avoidFoo: "Avoid using identifiers named '{{ name }}'.",
+            renameFoo: "Rename identifier 'foo' to '{{ newName }}'"
+        },
+        hasSuggestions: true
+    },
+    create(context) {
+        return {
+            Identifier(node) {
+                if (node.name === "foo") {
+                    context.report({
+                        node,
+                        messageId: "avoidFoo",
+                        data: {
+                            name: "foo"
+                        },
+                        suggest: [{
+                            messageId: "renameFoo",
+                            fix: fixer => fixer.replaceText(node, "bar")
+                        }]
+                    });
+                }
+            }
+        };
+    }
+};

--- a/tests/lib/linter/interpolate.js
+++ b/tests/lib/linter/interpolate.js
@@ -5,11 +5,39 @@
 //------------------------------------------------------------------------------
 
 const assert = require("chai").assert;
-const interpolate = require("../../../lib/linter/interpolate");
+const { getPlaceholderMatcher, interpolate } = require("../../../lib/linter/interpolate");
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
+
+describe("getPlaceholderMatcher", () => {
+    it("returns a global regular expression", () => {
+        const matcher = getPlaceholderMatcher();
+
+        assert.strictEqual(matcher.global, true);
+    });
+
+    it("matches text with placeholders", () => {
+        const matcher = getPlaceholderMatcher();
+
+        assert.match("{{ placeholder }}", matcher);
+    });
+
+    it("does not match text without placeholders", () => {
+        const matcher = getPlaceholderMatcher();
+
+        assert.notMatch("no placeholders in sight", matcher);
+    });
+
+    it("captures the text inside the placeholder", () => {
+        const matcher = getPlaceholderMatcher();
+        const text = "{{ placeholder }}";
+        const matches = Array.from(text.matchAll(matcher));
+
+        assert.deepStrictEqual(matches, [[text, " placeholder "]]);
+    });
+});
 
 describe("interpolate()", () => {
     it("passes through text without {{ }}", () => {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1907,31 +1907,31 @@ describe("RuleTester", () => {
         }, "Hydrated message \"Avoid using variables named 'notFoo'.\" does not match \"Avoid using variables named 'foo'.\"");
     });
 
-    it("should throw if the message has a single missing placeholder when data is not specified", () => {
+    it("should throw if the message has a single unsubstituted placeholder when data is not specified", () => {
         assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMissingData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "The reported message has a missing placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
+        }, "The reported message has a unsubstituted placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
     });
 
-    it("should throw if the message has a single missing placeholders when data is specified", () => {
+    it("should throw if the message has a single unsubstituted placeholders when data is specified", () => {
         assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMissingData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo", data: { name: "name" } }] }]
             });
-        }, "The reported message has a missing placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
+        }, "Hydrated message \"Avoid using variables named 'name'.\" does not match \"Avoid using variables named '{{ name }}'.");
     });
 
-    it("should throw if the message has multiple missing placeholders when data is not specified", () => {
+    it("should throw if the message has multiple unsubstituted placeholders when data is not specified", () => {
         assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMultipleMissingDataProperties, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "The reported message has the missing placeholders: 'type', 'name'. Please provide them via the 'data' property in the context.report() call.");
+        }, "The reported message has the unsubstituted placeholders: 'type', 'name'. Please provide them via the 'data' property in the context.report() call.");
     });
 
     it("should not throw if the data in the message contains placeholders not present in the raw message", () => {
@@ -1947,7 +1947,7 @@ describe("RuleTester", () => {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "The reported message has a missing placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
+        }, "The reported message has a unsubstituted placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
     });
 
     it("should not throw if the data in the message contains the same placeholder and data is specified", () => {
@@ -1957,13 +1957,13 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should throw an error for only specifying ignored non-string data property values", () => {
+    it("should not throw an error for specifying non-string data values", () => {
         assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withSamePlaceholdersInData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo", data: { name: 0 } }] }]
             });
-        }, "The reported message has a missing placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
+        }, "Hydrated message \"Avoid using variables named '0'.\" does not match \"Avoid using variables named '{{ name }}'.\"");
     });
 
     // messageId/message misconfiguration cases
@@ -2232,7 +2232,7 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "The message of the suggestion has a missing placeholder 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
+            }, "The message of the suggestion has a unsubstituted placeholder 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
         });
 
         it("should fail with a single missing data placeholder when data is specified", () => {
@@ -2251,7 +2251,7 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "The message of the suggestion has a missing placeholder 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
+            }, "The message of the suggestion has a unsubstituted placeholder 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
         });
 
         it("should fail with multiple missing data placeholders when data is not specified", () => {
@@ -2269,7 +2269,7 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "The message of the suggestion has the missing placeholders: 'currentName', 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
+            }, "The message of the suggestion has the unsubstituted placeholders: 'currentName', 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
         });
 
         it("should fail when tested using empty suggestion test objects even if the array length is correct", () => {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1907,13 +1907,22 @@ describe("RuleTester", () => {
         }, "Hydrated message \"Avoid using variables named 'notFoo'.\" does not match \"Avoid using variables named 'foo'.\"");
     });
 
-    it("should assert match between resulting message output if messageId and data provided in both test and result", () => {
+    it("should throw if the message has missing placeholders when data is not specified", () => {
         assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMissingData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
         }, "The reported message has missing placeholders: name. Please provide them via the 'data' property in the context.report call");
+    });
+
+    it("should throw if the data in the message contains placeholders", () => {
+        assert.throws(() => {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withPlaceholdersInData, {
+                valid: [],
+                invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
+            });
+        }, "The reported message has missing placeholders: placeholder. Please provide them via the 'data' property in the context.report call");
     });
 
     // messageId/message misconfiguration cases
@@ -2167,7 +2176,7 @@ describe("RuleTester", () => {
             });
         });
 
-        it("should pass with valid suggestions (tested using messageIds and data)", () => {
+        it("should fail with missing data placeholders when data is not specified", () => {
             assert.throws(() => {
                 ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMissingPlaceholderData, {
                     valid: [],
@@ -2184,7 +2193,6 @@ describe("RuleTester", () => {
                 });
             }, "The message of the suggestion has missing placeholders: newName. Please provide them via the 'data' property for the suggestion in the context.report call");
         });
-
 
         it("should fail when tested using empty suggestion test objects even if the array length is correct", () => {
             assert.throw(() => {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1907,13 +1907,22 @@ describe("RuleTester", () => {
         }, "Hydrated message \"Avoid using variables named 'notFoo'.\" does not match \"Avoid using variables named 'foo'.\"");
     });
 
-    it("should throw if the message has missing placeholders when data is not specified", () => {
+    it("should throw if the message has a single missing placeholders when data is not specified", () => {
         assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMissingData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "The reported message has missing placeholders: name. Please provide them via the 'data' property in the context.report call");
+        }, "The reported message has a missing placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
+    });
+
+    it("should throw if the message has multiple missing placeholders when data is not specified", () => {
+        assert.throws(() => {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMultipleMissingDataProperties, {
+                valid: [],
+                invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
+            });
+        }, "The reported message has the missing placeholders: 'type', 'name'. Please provide them via the 'data' property in the context.report() call.");
     });
 
     it("should throw if the data in the message contains placeholders", () => {
@@ -1922,7 +1931,7 @@ describe("RuleTester", () => {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "The reported message has missing placeholders: placeholder. Please provide them via the 'data' property in the context.report call");
+        }, "The reported message has a missing placeholder 'placeholder'. Please provide them via the 'data' property in the context.report() call.");
     });
 
     // messageId/message misconfiguration cases
@@ -2176,7 +2185,7 @@ describe("RuleTester", () => {
             });
         });
 
-        it("should fail with missing data placeholders when data is not specified", () => {
+        it("should fail with a single missing data placeholder when data is not specified", () => {
             assert.throws(() => {
                 ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMissingPlaceholderData, {
                     valid: [],
@@ -2191,7 +2200,25 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "The message of the suggestion has missing placeholders: newName. Please provide them via the 'data' property for the suggestion in the context.report call");
+            }, "The message of the suggestion has a missing placeholder 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
+        });
+
+        it("should fail with multiple missing data placeholders when data is not specified", () => {
+            assert.throws(() => {
+                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMultipleMissingPlaceholderDataProperties, {
+                    valid: [],
+                    invalid: [{
+                        code: "var foo;",
+                        errors: [{
+                            messageId: "avoidFoo",
+                            suggestions: [{
+                                messageId: "rename",
+                                output: "var bar;"
+                            }]
+                        }]
+                    }]
+                });
+            }, "The message of the suggestion has the missing placeholders: 'currentName', 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
         });
 
         it("should fail when tested using empty suggestion test objects even if the array length is correct", () => {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1913,7 +1913,7 @@ describe("RuleTester", () => {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "The reported message has a unsubstituted placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
+        }, "The reported message has an unsubstituted placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
     });
 
     it("should throw if the message has a single unsubstituted placeholders when data is specified", () => {
@@ -1931,7 +1931,7 @@ describe("RuleTester", () => {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "The reported message has the unsubstituted placeholders: 'type', 'name'. Please provide them via the 'data' property in the context.report() call.");
+        }, "The reported message has unsubstituted placeholders: 'type', 'name'. Please provide them via the 'data' property in the context.report() call.");
     });
 
     it("should not throw if the data in the message contains placeholders not present in the raw message", () => {
@@ -1947,7 +1947,7 @@ describe("RuleTester", () => {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "The reported message has a unsubstituted placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
+        }, "The reported message has an unsubstituted placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
     });
 
     it("should not throw if the data in the message contains the same placeholder and data is specified", () => {
@@ -2232,7 +2232,7 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "The message of the suggestion has a unsubstituted placeholder 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
+            }, "The message of the suggestion has an unsubstituted placeholder 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
         });
 
         it("should fail with a single missing data placeholder when data is specified", () => {
@@ -2251,7 +2251,7 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "The message of the suggestion has a unsubstituted placeholder 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
+            }, "The message of the suggestion has an unsubstituted placeholder 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
         });
 
         it("should fail with multiple missing data placeholders when data is not specified", () => {
@@ -2269,7 +2269,7 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "The message of the suggestion has the unsubstituted placeholders: 'currentName', 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
+            }, "The message of the suggestion has unsubstituted placeholders: 'currentName', 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
         });
 
         it("should fail when tested using empty suggestion test objects even if the array length is correct", () => {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1897,6 +1897,7 @@ describe("RuleTester", () => {
             invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
         });
     });
+
     it("should assert match between resulting message output if messageId and data provided in both test and result", () => {
         assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
@@ -1904,6 +1905,15 @@ describe("RuleTester", () => {
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo", data: { name: "notFoo" } }] }]
             });
         }, "Hydrated message \"Avoid using variables named 'notFoo'.\" does not match \"Avoid using variables named 'foo'.\"");
+    });
+
+    it("should assert match between resulting message output if messageId and data provided in both test and result", () => {
+        assert.throws(() => {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMissingData, {
+                valid: [],
+                invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
+            });
+        }, "The reported message has missing placeholders: name. Please provide them via the 'data' property in the context.report call");
     });
 
     // messageId/message misconfiguration cases
@@ -2155,6 +2165,24 @@ describe("RuleTester", () => {
                     }]
                 }]
             });
+        });
+
+        it("should pass with valid suggestions (tested using messageIds and data)", () => {
+            assert.throws(() => {
+                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMissingPlaceholderData, {
+                    valid: [],
+                    invalid: [{
+                        code: "var foo;",
+                        errors: [{
+                            messageId: "avoidFoo",
+                            suggestions: [{
+                                messageId: "renameFoo",
+                                output: "var bar;"
+                            }]
+                        }]
+                    }]
+                });
+            }, "The message of the suggestion has missing placeholders: newName. Please provide them via the 'data' property for the suggestion in the context.report call");
         });
 
 

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1913,7 +1913,7 @@ describe("RuleTester", () => {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "The reported message has an unsubstituted placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
+        }, "The reported message has an unsubstituted placeholder 'name'. Please provide the missing value via the 'data' property in the context.report() call.");
     });
 
     it("should throw if the message has a single unsubstituted placeholders when data is specified", () => {
@@ -1931,7 +1931,7 @@ describe("RuleTester", () => {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "The reported message has unsubstituted placeholders: 'type', 'name'. Please provide them via the 'data' property in the context.report() call.");
+        }, "The reported message has unsubstituted placeholders: 'type', 'name'. Please provide the missing values via the 'data' property in the context.report() call.");
     });
 
     it("should not throw if the data in the message contains placeholders not present in the raw message", () => {
@@ -1947,7 +1947,7 @@ describe("RuleTester", () => {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "The reported message has an unsubstituted placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
+        }, "The reported message has an unsubstituted placeholder 'name'. Please provide the missing value via the 'data' property in the context.report() call.");
     });
 
     it("should not throw if the data in the message contains the same placeholder and data is specified", () => {
@@ -1958,12 +1958,10 @@ describe("RuleTester", () => {
     });
 
     it("should not throw an error for specifying non-string data values", () => {
-        assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withSamePlaceholdersInData, {
-                valid: [],
-                invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo", data: { name: 0 } }] }]
-            });
-        }, "Hydrated message \"Avoid using variables named '0'.\" does not match \"Avoid using variables named '{{ name }}'.\"");
+        ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withNonStringData, {
+            valid: [],
+            invalid: [{ code: "0", errors: [{ messageId: "avoid", data: { value: 0 } }] }]
+        });
     });
 
     // messageId/message misconfiguration cases
@@ -2232,7 +2230,7 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "The message of the suggestion has an unsubstituted placeholder 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
+            }, "The message of the suggestion has an unsubstituted placeholder 'newName'. Please provide the missing value via the 'data' property for the suggestion in the context.report() call.");
         });
 
         it("should fail with a single missing data placeholder when data is specified", () => {
@@ -2251,7 +2249,7 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "The message of the suggestion has an unsubstituted placeholder 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
+            }, "The message of the suggestion has an unsubstituted placeholder 'newName'. Please provide the missing value via the 'data' property for the suggestion in the context.report() call.");
         });
 
         it("should fail with multiple missing data placeholders when data is not specified", () => {
@@ -2269,7 +2267,7 @@ describe("RuleTester", () => {
                         }]
                     }]
                 });
-            }, "The message of the suggestion has unsubstituted placeholders: 'currentName', 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
+            }, "The message of the suggestion has unsubstituted placeholders: 'currentName', 'newName'. Please provide the missing values via the 'data' property for the suggestion in the context.report() call.");
         });
 
         it("should fail when tested using empty suggestion test objects even if the array length is correct", () => {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1907,11 +1907,20 @@ describe("RuleTester", () => {
         }, "Hydrated message \"Avoid using variables named 'notFoo'.\" does not match \"Avoid using variables named 'foo'.\"");
     });
 
-    it("should throw if the message has a single missing placeholders when data is not specified", () => {
+    it("should throw if the message has a single missing placeholder when data is not specified", () => {
         assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMissingData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
+            });
+        }, "The reported message has a missing placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
+    });
+
+    it("should throw if the message has a single missing placeholders when data is specified", () => {
+        assert.throws(() => {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMissingData, {
+                valid: [],
+                invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo", data: { name: "name" } }] }]
             });
         }, "The reported message has a missing placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
     });
@@ -2195,6 +2204,25 @@ describe("RuleTester", () => {
                             messageId: "avoidFoo",
                             suggestions: [{
                                 messageId: "renameFoo",
+                                output: "var bar;"
+                            }]
+                        }]
+                    }]
+                });
+            }, "The message of the suggestion has a missing placeholder 'newName'. Please provide them via the 'data' property for the suggestion in the context.report() call.");
+        });
+
+        it("should fail with a single missing data placeholder when data is specified", () => {
+            assert.throws(() => {
+                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMissingPlaceholderData, {
+                    valid: [],
+                    invalid: [{
+                        code: "var foo;",
+                        errors: [{
+                            messageId: "avoidFoo",
+                            suggestions: [{
+                                messageId: "renameFoo",
+                                data: { other: "name" },
                                 output: "var bar;"
                             }]
                         }]

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1934,13 +1934,36 @@ describe("RuleTester", () => {
         }, "The reported message has the missing placeholders: 'type', 'name'. Please provide them via the 'data' property in the context.report() call.");
     });
 
-    it("should throw if the data in the message contains placeholders", () => {
+    it("should not throw if the data in the message contains placeholders not present in the raw message", () => {
+        ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withPlaceholdersInData, {
+            valid: [],
+            invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
+        });
+    });
+
+    it("should throw if the data in the message contains the same placeholder and data is not specified", () => {
         assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withPlaceholdersInData, {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withSamePlaceholdersInData, {
                 valid: [],
                 invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
             });
-        }, "The reported message has a missing placeholder 'placeholder'. Please provide them via the 'data' property in the context.report() call.");
+        }, "The reported message has a missing placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
+    });
+
+    it("should not throw if the data in the message contains the same placeholder and data is specified", () => {
+        ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withSamePlaceholdersInData, {
+            valid: [],
+            invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo", data: { name: "{{ name }}" } }] }]
+        });
+    });
+
+    it("should throw an error for only specifying ignored non-string data property values", () => {
+        assert.throws(() => {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withSamePlaceholdersInData, {
+                valid: [],
+                invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo", data: { name: 0 } }] }]
+            });
+        }, "The reported message has a missing placeholder 'name'. Please provide them via the 'data' property in the context.report() call.");
     });
 
     // messageId/message misconfiguration cases


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Rule Tester

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Fixes #18016.
Added a check for errors and suggestions which provide a `messageId` but not specify a `data` property.
This check makes sure that the replaced message has no placeholders as the required `data` properties were provided.

#### Is there anything you'd like reviewers to focus on?
- I copied the regular expression from `interpolate.js`; maybe the regular expression should be exported?
- Currently the check is only performed if there is no `data` property in the error. Maybe this check should run before as currently the `data` check does two things: detect missing placeholder data and checks whether the values match
- Maybe add a mention for suggestions that the `data` is not shared with the top level `data` ?

<!-- markdownlint-disable-file MD004 -->
