### PR TITLE
docs: fix malformed `eslint` config comments in rule examples

### DIFF
--- a/docs/src/rules/lines-around-comment.md
+++ b/docs/src/rules/lines-around-comment.md
@@ -233,7 +233,7 @@ class C {
 switch (foo) {
   /* what a great and wonderful day */
 
-  case 1:    
+  case 1:
     bar();
     break;
 }
@@ -317,7 +317,7 @@ class C {
 }
 
 switch (foo) {
-  case 1:    
+  case 1:
     bar();
     break;
 
@@ -663,7 +663,7 @@ Examples of **correct** code for the `ignorePattern` option:
 /*eslint lines-around-comment: ["error"]*/
 
 foo();
-/* eslint mentioned in this comment */
+/* jshint mentioned in this comment */
 bar();
 
 /*eslint lines-around-comment: ["error", { "ignorePattern": "pragma" }] */
@@ -712,7 +712,7 @@ Examples of **incorrect** code for the `{ "applyDefaultIgnorePatterns": false }`
 /*eslint lines-around-comment: ["error", { "applyDefaultIgnorePatterns": false }] */
 
 foo();
-/* eslint mentioned in comment */
+/* jshint mentioned in comment */
 
 ```
 

--- a/tests/fixtures/bad-examples.md
+++ b/tests/fixtures/bad-examples.md
@@ -2,7 +2,7 @@
 title: no-restricted-syntax
 ---
 
-This file contains rule example code with syntax errors.
+This file contains rule example code with syntax errors and other problems.
 
 <!-- markdownlint-capture -->
 <!-- markdownlint-disable MD040 -->
@@ -29,6 +29,16 @@ const foo = "baz";
 
 ```js
 /* eslint another-rule: error */
+```
+
+:::
+
+:::correct
+
+```js
+/* eslint no-restricted-syntax: "error" */
+
+/* eslint doesn't allow this comment */
 ```
 
 :::

--- a/tests/tools/check-rule-examples.js
+++ b/tests/tools/check-rule-examples.js
@@ -55,10 +55,18 @@ describe("check-rule-examples", () => {
                 assert.strictEqual(code, 1);
                 assert.strictEqual(stdout, "");
 
-                // Remove OS-dependent path except base name.
+                /* eslint-disable no-control-regex -- escaping control characters */
+
                 const normalizedStderr =
-                // eslint-disable-next-line no-control-regex -- escaping control character
-                stderr.replace(/(?<=\x1B\[4m).*(?=bad-examples\.md)/u, "");
+                stderr
+
+                    // Remove OS-dependent path except base name.
+                    .replace(/(?<=\x1B\[4m).*(?=bad-examples\.md)/u, "")
+
+                    // Remove runtime-specific error message part (different in Node.js 18, 20 and 21).
+                    .replace(/(?<=' doesn't allow this comment'):.*(?=\x1B\[0m)/u, "");
+
+                /* eslint-enable no-control-regex -- re-enable rule */
 
                 const expectedStderr =
                 "\x1B[0m\x1B[0m\n" +
@@ -68,7 +76,7 @@ describe("check-rule-examples", () => {
                 "\x1B[0m  \x1B[2m20:5\x1B[22m  \x1B[31merror\x1B[39m  Nonstandard language tag 'ts': use one of 'javascript', 'js' or 'jsx'\x1B[0m\n" +
                 "\x1B[0m  \x1B[2m23:7\x1B[22m  \x1B[31merror\x1B[39m  Syntax error: Identifier 'foo' has already been declared\x1B[0m\n" +
                 "\x1B[0m  \x1B[2m31:1\x1B[22m  \x1B[31merror\x1B[39m  Example code should contain a configuration comment like /* eslint no-restricted-syntax: \"error\" */\x1B[0m\n" +
-                "\x1B[0m  \x1B[2m41:1\x1B[22m  \x1B[31merror\x1B[39m  Failed to parse JSON from ' doesn't allow this comment': Expected property name or '}' in JSON at position 2 (line 1 column 3)\x1B[0m\n" +
+                "\x1B[0m  \x1B[2m41:1\x1B[22m  \x1B[31merror\x1B[39m  Failed to parse JSON from ' doesn't allow this comment'\x1B[0m\n" +
                 "\x1B[0m\x1B[0m\n" +
                 "\x1B[0m\x1B[31m\x1B[1m✖ 6 problems (6 errors, 0 warnings)\x1B[22m\x1B[39m\x1B[0m\n" +
                 "\x1B[0m\x1B[31m\x1B[1m\x1B[22m\x1B[39m\x1B[0m\n";

--- a/tests/tools/check-rule-examples.js
+++ b/tests/tools/check-rule-examples.js
@@ -68,8 +68,9 @@ describe("check-rule-examples", () => {
                 "\x1B[0m  \x1B[2m20:5\x1B[22m  \x1B[31merror\x1B[39m  Nonstandard language tag 'ts': use one of 'javascript', 'js' or 'jsx'\x1B[0m\n" +
                 "\x1B[0m  \x1B[2m23:7\x1B[22m  \x1B[31merror\x1B[39m  Syntax error: Identifier 'foo' has already been declared\x1B[0m\n" +
                 "\x1B[0m  \x1B[2m31:1\x1B[22m  \x1B[31merror\x1B[39m  Example code should contain a configuration comment like /* eslint no-restricted-syntax: \"error\" */\x1B[0m\n" +
+                "\x1B[0m  \x1B[2m41:1\x1B[22m  \x1B[31merror\x1B[39m  Failed to parse JSON from ' doesn't allow this comment': Expected property name or '}' in JSON at position 2 (line 1 column 3)\x1B[0m\n" +
                 "\x1B[0m\x1B[0m\n" +
-                "\x1B[0m\x1B[31m\x1B[1m✖ 5 problems (5 errors, 0 warnings)\x1B[22m\x1B[39m\x1B[0m\n" +
+                "\x1B[0m\x1B[31m\x1B[1m✖ 6 problems (6 errors, 0 warnings)\x1B[22m\x1B[39m\x1B[0m\n" +
                 "\x1B[0m\x1B[31m\x1B[1m\x1B[22m\x1B[39m\x1B[0m\n";
 
                 assert.strictEqual(normalizedStderr, expectedStderr);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**Tell us about your environment (`npx eslint --env-info`):**

Node version: v21.6.0
npm version: v10.2.4
Local ESLint version: v9.0.0-alpha.2 (Currently used)
Global ESLint version: Not found
Operating System: darwin 23.3.0

**What parser are you using (place an "X" next to just one item)?**

[X] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
{
  "parserOptions": {
    "ecmaVersion": "latest",
    "sourceType": "module"
  }
}
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint mentioned in this comment */
```

**What did you expect to happen?**

Block comments starting with `eslint` are treated as configuration comments for rules. When ESLint cannot parse them as such, it reports a fatal error ([**repro**](https://eslint.org/play/#eyJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsic291cmNlVHlwZSI6Im1vZHVsZSJ9fSwidGV4dCI6Ii8qZXNsaW50IGxpbmVzLWFyb3VuZC1jb21tZW50OiBbXCJlcnJvclwiXSovXG5cbmZvbygpO1xuLyogZXNsaW50IG1lbnRpb25lZCBpbiB0aGlzIGNvbW1lbnQgKi9cbmJhcigpO1xuXG4vKmVzbGludCBsaW5lcy1hcm91bmQtY29tbWVudDogW1wiZXJyb3JcIiwgeyBcImlnbm9yZVBhdHRlcm5cIjogXCJwcmFnbWFcIiB9XSAqL1xuXG5mb28oKTtcbi8qIGEgdmFsaWQgY29tbWVudCB1c2luZyBwcmFnbWEgaW4gaXQgKi8ifQ==)).

This fatal error should not be allowed to occur in rule examples because it makes the example code unparsable even if the syntax is correct. It should be caught by the tool that validates rule examples (tools/check-rule-examples.js).

**What actually happened? Please include the actual, raw output from ESLint.**

A rule example with a malformed `eslint` config comment can pass validation. We have two such examples in `lines-around-comment`, both fixed in this PR.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Fixed the rule examples in `lines-around-comment` by replacing `eslint` with `jshint` - another special word that doesn't trigger the rule.
* Extended the check-rule-examples tool to account for malformed `eslint` config comments when validating code.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
