### PR TITLE
chore: update dependency shelljs to ^0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "regenerator-runtime": "^0.14.0",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "semver": "^7.5.3",
-    "shelljs": "^0.8.2",
+    "shelljs": "^0.8.5",
     "sinon": "^11.0.0",
     "vite-plugin-commonjs": "^0.10.0",
     "webdriverio": "^8.14.6",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Upgrade a dependency's version range.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Versions of shelljs before v.0.8.5 are affected by a high rated vulnerability. It's unlikely that anyone working with the ESLint repo has one of those older versions installed, but they are not automatically updated as long as they match the version range in package.json. This PR updates package.json to ensure that only shelljs ^0.8.5 is used.

NVD advisory: https://nvd.nist.gov/vuln/detail/CVE-2022-0144

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
