### PR TITLE
feat: Added ignoreFilenamesPatterns option to no-restricted-imports

### DIFF
--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -216,6 +216,60 @@ import DisallowedObject from "foo"
 
 :::
 
+#### ignoreFilenamesPatterns
+
+This option in `path` is an array of filename patterns where current restricted import should be allowed.
+It might be useful when there is a need to forbid some imports across all codebase except specific places.
+
+```json
+"no-restricted-imports": ["error", {
+  "paths": [{
+    "name": "import-foo",
+    "importNames": ["Bar"],
+    "message": "Please use Bar from /import-bar/baz/ instead.",
+    "ignoreFilenamesPatterns": ["**/directory/where/import-foo/is/allowed/**"]
+  }]
+}]
+```
+
+Examples of **incorrect** code for `ignoreFilenamesPatterns` in `paths`:
+
+::: incorrect { "sourceType": "module" }
+
+```js
+/*eslint no-restricted-imports: ["error", { paths: [{
+    name: "foo",
+    importNames: ["DisallowedObject"],
+    ignoreFilenamesPatterns: ["**\/directory/where/importfoo/is/allowed/**"]
+}]}]*/
+
+// filePath: "src/js/some-module/file.js"
+
+import { DisallowedObject } from "foo";
+```
+
+:::
+
+Examples of **correct** code for `ignoreFilenamesPatterns` in `paths`:
+
+If the filePath of the linted file is matched by one of the ignoreFilenamesPatterns then error will not be produced
+
+::: correct { "sourceType": "module" }
+
+```js
+/*eslint no-restricted-imports: ["error", { paths: [{
+    name: "foo",
+    importNames: ["DisallowedObject"],
+    ignoreFilenamesPatterns: ["**\/directory/where/importfoo/is/allowed/**"]
+ }]}]*/
+
+// filePath: "src/js/directory/where/import-foo/is/allowed/file.js"
+
+import { DisallowedObject } from "foo"
+```
+
+:::
+
 ::: correct { "sourceType": "module" }
 
 ```js
@@ -514,6 +568,47 @@ Examples of **correct** code for `importNamePattern` option:
 }]}]*/
 
 import isEmpty, { hasValue } from 'utils/collection-utils';
+```
+
+:::
+
+#### ignoreFilenamesPatterns
+
+This option in `patterns` is an array of filename patterns where current restricted import should be allowed.
+It might be useful when there is a need to forbid some imports across all codebase except specific places.
+
+Examples of **incorrect** code for `ignoreFilenamesPatterns` option:
+
+::: incorrect { "sourceType": "module" }
+
+```js
+/*eslint no-restricted-imports: ["error", { patterns: [{
+    group: ["lodash/*"],
+    message: "Please use the default import from 'lodash' instead.",
+    ignoreFilenamesPatterns: ["**\/directory/where/lodash/is/allowed/**"]
+}]}]*/
+
+//  filePath: "src/js/some-module/file.js"
+
+import pick from 'lodash/pick';
+```
+
+:::
+
+Examples of **correct** code for this `ignoreFilenamesPatterns` option:
+
+::: correct { "sourceType": "module" }
+
+```js
+/*eslint no-restricted-imports: ["error", { patterns: [{
+    group: ["lodash/*"],
+    message: "Please use the default import from 'lodash' instead.",
+    ignoreFilenamesPatterns: ["**\/directory/where/lodash/is/allowed/**"]
+}]}]*/
+
+//  filePath: "src/js/directory/where/lodash/is/allowed/file.js"
+
+import pick from 'lodash/pick';
 ```
 
 :::

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -34,6 +34,12 @@ const arrayOfStringsOrObjects = {
                         items: {
                             type: "string"
                         }
+                    },
+                    ignoreFilenamesPatterns: {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        }
                     }
                 },
                 additionalProperties: false,
@@ -83,6 +89,12 @@ const arrayOfStringsOrObjectPatterns = {
                     },
                     caseSensitive: {
                         type: "boolean"
+                    },
+                    ignoreFilenamesPatterns: {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        }
                     }
                 },
                 additionalProperties: false,
@@ -175,7 +187,10 @@ module.exports = {
             } else {
                 memo[path].push({
                     message: importSource.message,
-                    importNames: importSource.importNames
+                    importNames: importSource.importNames,
+                    ignoreFilenamesPatterns: ignore({
+                        allowRelativePaths: true
+                    }).add(importSource.ignoreFilenamesPatterns)
                 });
             }
             return memo;
@@ -190,11 +205,21 @@ module.exports = {
         }
 
         // relative paths are supported for this rule
-        const restrictedPatternGroups = restrictedPatterns.map(({ group, message, caseSensitive, importNames, importNamePattern }) => ({
+        const restrictedPatternGroups = restrictedPatterns.map(({
+            group,
+            message,
+            caseSensitive,
+            importNames,
+            importNamePattern,
+            ignoreFilenamesPatterns
+        }) => ({
             matcher: ignore({ allowRelativePaths: true, ignorecase: !caseSensitive }).add(group),
             customMessage: message,
             importNames,
-            importNamePattern
+            importNamePattern,
+            ignoreFilenamesPatterns: ignore({
+                allowRelativePaths: true
+            }).add(ignoreFilenamesPatterns)
         }));
 
         // if no imports are restricted we don't need to check
@@ -219,49 +244,55 @@ module.exports = {
                 const customMessage = restrictedPathEntry.message;
                 const restrictedImportNames = restrictedPathEntry.importNames;
 
-                if (restrictedImportNames) {
-                    if (importNames.has("*")) {
-                        const specifierData = importNames.get("*")[0];
+                if (
+                    !restrictedPathEntry.ignoreFilenamesPatterns?.ignores(
+                        context.filename
+                    )
+                ) {
+                    if (restrictedImportNames) {
+                        if (importNames.has("*")) {
+                            const specifierData = importNames.get("*")[0];
 
+                            context.report({
+                                node,
+                                messageId: customMessage ? "everythingWithCustomMessage" : "everything",
+                                loc: specifierData.loc,
+                                data: {
+                                    importSource,
+                                    importNames: restrictedImportNames,
+                                    customMessage
+                                }
+                            });
+                        }
+
+                        restrictedImportNames.forEach(importName => {
+                            if (importNames.has(importName)) {
+                                const specifiers = importNames.get(importName);
+
+                                specifiers.forEach(specifier => {
+                                    context.report({
+                                        node,
+                                        messageId: customMessage ? "importNameWithCustomMessage" : "importName",
+                                        loc: specifier.loc,
+                                        data: {
+                                            importSource,
+                                            customMessage,
+                                            importName
+                                        }
+                                    });
+                                });
+                            }
+                        });
+                    } else {
                         context.report({
                             node,
-                            messageId: customMessage ? "everythingWithCustomMessage" : "everything",
-                            loc: specifierData.loc,
+                            messageId: customMessage ? "pathWithCustomMessage" : "path",
                             data: {
                                 importSource,
-                                importNames: restrictedImportNames,
                                 customMessage
                             }
                         });
                     }
-
-                    restrictedImportNames.forEach(importName => {
-                        if (importNames.has(importName)) {
-                            const specifiers = importNames.get(importName);
-
-                            specifiers.forEach(specifier => {
-                                context.report({
-                                    node,
-                                    messageId: customMessage ? "importNameWithCustomMessage" : "importName",
-                                    loc: specifier.loc,
-                                    data: {
-                                        importSource,
-                                        customMessage,
-                                        importName
-                                    }
-                                });
-                            });
-                        }
-                    });
-                } else {
-                    context.report({
-                        node,
-                        messageId: customMessage ? "pathWithCustomMessage" : "path",
-                        data: {
-                            importSource,
-                            customMessage
-                        }
-                    });
                 }
             });
         }
@@ -357,7 +388,7 @@ module.exports = {
          * @private
          */
         function isRestrictedPattern(importSource, group) {
-            return group.matcher.ignores(importSource);
+            return !group.ignoreFilenamesPatterns?.ignores(context.filename) && group.matcher.ignores(importSource);
         }
 
         /**


### PR DESCRIPTION
#### What changes did you make? (Give an overview)
We are using `no-restricted-imports` rule pretty extensively to limit devs doing wrong stuff, and also to help ourselves during migrations. But the thing is, in almost all our use cases we need a way to whitelist some directory for some specific option, like, for example, we want to prohibit devs from using particular imports from library in favor of our local wrapper of it which does additional logic. In this case local wrapper should allow the restricted import for this particular library, but still disallow all other restricted imports in the project..

Before we were achieving this by leveraging `eslint` `overrides`. So the config looked like this:

```js
// eslintrc.js:
module.exports = {
  // ... other props
  rules: [
    no-restricted-imports': [
      2,
      {
        patterns: [
          '@companyname/privateLib/*',
          '@testing-library/*'
        ],
      },
    ],
  ],
  overrides: [
    {
      files: [
        'src/build-tools/**/*.js',
        'src/index.js',
      ],
      rules: {
        'no-restricted-imports': [
          0,
          { patterns: ['@companyname/privateLib/*'] },
        ],
      },
    },
    {
      files: [
        'src/**/*.test.js',
        'src/**/*.test.helpers.js',
        'src/**/test.helpers.js',
        'src/**/*',
      ],
      rules: {
        'no-restricted-imports': [0, { patterns: ['@testing-library/*'] }],
      },
    },
  ]
}
```

But with recent updates to the latest version of eslint overrides are not working in that way - they are disabling the whole rule for the given `files` in `overrides` instead of switching off specific option.

That's why I got the idea of introducing `ignoreFilenamesPatterns` option to whitelist directories where specific restricted import is allowed.

Let me know if I'm missing anything, looking forward to any feedback on this proposal

<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


**What rule do you want to change?**
`no-restricted-impotrs`

**What change do you want to make (place an "X" next to just one item)?**

[ ] Generate more warnings
[x] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[x] A new option
[ ] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
// filePath: /user.name/projects/appName/src/build-scripts/compile.js

/*eslintrc.js:
no-restricted-imports: ["error", { patterns: [{
    group: ["@companyName/privateLib/*"],
    message: "Please do not use privateLib in the codebase it is for build utils only.",
    ignoreFilenamesPatterns: ["**/src/build-scripts/**"]
}]}]*/

import { util } from @companyName/privateLib/compile-utils.js
```

**What does the rule currently do for this code?**
The rule will generate an error because the import is restricted

**What will the rule do after it's changed?**
The rule won't produce an error because the fileName ` /user.name/projects/appName/src/build-scripts/compile.js` is being whitelisted by `ignoreFilenamesPatterns` parameters.


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
