### PR TITLE
feat: replace dependency graphemer with `Intl.Segmenter`

### DIFF
--- a/lib/shared/string-utils.js
+++ b/lib/shared/string-utils.js
@@ -6,20 +6,14 @@
 "use strict";
 
 //------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
-const Graphemer = require("graphemer").default;
-
-//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
 // eslint-disable-next-line no-control-regex -- intentionally including control characters
 const ASCII_REGEX = /^[\u0000-\u007f]*$/u;
 
-/** @type {Graphemer | undefined} */
-let splitter;
+/** @type {Intl.Segmenter | undefined} */
+let segmenter;
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -47,11 +41,15 @@ function getGraphemeCount(value) {
         return value.length;
     }
 
-    if (!splitter) {
-        splitter = new Graphemer();
+    segmenter ??= new Intl.Segmenter("en-US"); // en-US locale should be supported everywhere
+    let graphemeCount = 0;
+
+    // eslint-disable-next-line no-unused-vars -- for-of needs a variable
+    for (const unused of segmenter.segment(value)) {
+        graphemeCount++;
     }
 
-    return splitter.countGraphemes(value);
+    return graphemeCount;
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "file-entry-cache": "^8.0.0",
     "find-up": "^5.0.0",
     "glob-parent": "^6.0.2",
-    "graphemer": "^1.4.0",
     "ignore": "^5.2.0",
     "imurmurhash": "^0.1.4",
     "is-glob": "^4.0.0",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain: replace a dependency with a native implementation.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

See the discussion in #17835

Fixes #17835

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Replaced [graphemer](https://www.npmjs.com/package/graphemer) with the native [`Segments`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments) implementation provided by `Intl.Segmenter`.

#### Is there anything you'd like reviewers to focus on?

* The implementations are not 100% equivalent
* The `Segments` behavior with respect to which sequences are considered graphemes is expected to change with newer version of Unicode
* Graphemer is currently used in the rules `id-length` and `key-spacing`
* As of today, the `Segments` API is not supported in all browsers: https://caniuse.com/?search=Segments

<!-- markdownlint-disable-file MD004 -->
