### PR TITLE
fix: validate options when comment with just severity enables rule

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -43,7 +43,7 @@ const
 const { getRuleFromConfig } = require("../config/flat-config-helpers");
 const { FlatConfigArray } = require("../config/flat-config-array");
 const { RuleValidator } = require("../config/rule-validator");
-const { assertIsRuleOptions, assertIsRuleSeverity } = require("../config/flat-config-schema");
+const { assertIsRuleSeverity } = require("../config/flat-config-schema");
 const { normalizeSeverityToString } = require("../shared/severity");
 const debug = require("debug")("eslint:linter");
 const MAX_AUTOFIX_PASSES = 10;
@@ -326,10 +326,11 @@ function createDisableDirectives(options) {
  * @param {SourceCode} sourceCode The SourceCode object to get comments from.
  * @param {function(string): {create: Function}} ruleMapper A map from rule IDs to defined rules
  * @param {string|null} warnInlineConfig If a string then it should warn directive comments as disabled. The string value is the config name what the setting came from.
+ * @param {ConfigData} config Provided config.
  * @returns {{configuredRules: Object, enabledGlobals: {value:string,comment:Token}[], exportedVariables: Object, problems: LintMessage[], disableDirectives: DisableDirective[]}}
  * A collection of the directive comments that were found, along with any problems that occurred when parsing
  */
-function getDirectiveComments(sourceCode, ruleMapper, warnInlineConfig) {
+function getDirectiveComments(sourceCode, ruleMapper, warnInlineConfig, config) {
     const configuredRules = {};
     const enabledGlobals = Object.create(null);
     const exportedVariables = {};
@@ -438,8 +439,50 @@ function getDirectiveComments(sourceCode, ruleMapper, warnInlineConfig) {
                             return;
                         }
 
+                        let ruleOptions = Array.isArray(ruleValue) ? ruleValue : [ruleValue];
+
+                        /*
+                         * If the rule was already configured, inline rule configuration that
+                         * only has severity should retain options from the config and just override the severity.
+                         *
+                         * Example:
+                         *
+                         *   {
+                         *       rules: {
+                         *           curly: ["error", "multi"]
+                         *       }
+                         *   }
+                         *
+                         *   /* eslint curly: ["warn"] * /
+                         *
+                         *   Results in:
+                         *
+                         *   curly: ["warn", "multi"]
+                         */
+                        if (
+
+                            /*
+                             * If inline config for the rule has only severity
+                             */
+                            ruleOptions.length === 1 &&
+
+                            /*
+                             * And the rule was already configured
+                             */
+                            config.rules && Object.hasOwn(config.rules, name)
+                        ) {
+
+                            /*
+                             * Then use severity from the inline config and options from the provided config
+                             */
+                            ruleOptions = [
+                                ruleOptions[0], // severity from the inline config
+                                ...Array.isArray(config.rules[name]) ? config.rules[name].slice(1) : [] // options from the provided config
+                            ];
+                        }
+
                         try {
-                            validator.validateRuleOptions(rule, name, ruleValue);
+                            validator.validateRuleOptions(rule, name, ruleOptions);
                         } catch (err) {
 
                             /*
@@ -460,7 +503,7 @@ function getDirectiveComments(sourceCode, ruleMapper, warnInlineConfig) {
                             return;
                         }
 
-                        configuredRules[name] = ruleValue;
+                        configuredRules[name] = ruleOptions;
                     });
                 } else {
                     problems.push(parseResult.error);
@@ -1322,7 +1365,7 @@ class Linter {
 
         const sourceCode = slots.lastSourceCode;
         const commentDirectives = options.allowInlineConfig
-            ? getDirectiveComments(sourceCode, ruleId => getRule(slots, ruleId), options.warnInlineConfig)
+            ? getDirectiveComments(sourceCode, ruleId => getRule(slots, ruleId), options.warnInlineConfig, config)
             : { configuredRules: {}, enabledGlobals: {}, exportedVariables: {}, problems: [], disableDirectives: [] };
 
         // augment global scope with declared global variables
@@ -1332,55 +1375,7 @@ class Linter {
             { exportedVariables: commentDirectives.exportedVariables, enabledGlobals: commentDirectives.enabledGlobals }
         );
 
-        /*
-         * Now we determine the final configurations for rules.
-         * First, let all inline rule configurations override those from the config.
-         * Then, check for a special case: if a rule is configured in both places,
-         * inline rule configuration that only has severity should retain options from
-         * the config and just override the severity.
-         *
-         * Example:
-         *
-         *   {
-         *       rules: {
-         *           curly: ["error", "multi"]
-         *       }
-         *   }
-         *
-         *   /* eslint curly: ["warn"] * /
-         *
-         *   Results in:
-         *
-         *   curly: ["warn", "multi"]
-         */
         const configuredRules = Object.assign({}, config.rules, commentDirectives.configuredRules);
-
-        if (config.rules) {
-            for (const [ruleId, ruleInlineConfig] of Object.entries(commentDirectives.configuredRules)) {
-                if (
-
-                    /*
-                     * If inline config for the rule has only severity
-                     */
-                    (!Array.isArray(ruleInlineConfig) || ruleInlineConfig.length === 1) &&
-
-                    /*
-                     * And provided config for the rule has options
-                     */
-                    Object.hasOwn(config.rules, ruleId) &&
-                    (Array.isArray(config.rules[ruleId]) && config.rules[ruleId].length > 1)
-                ) {
-
-                    /*
-                     * Then use severity from the inline config and options from the provided config
-                     */
-                    configuredRules[ruleId] = [
-                        Array.isArray(ruleInlineConfig) ? ruleInlineConfig[0] : ruleInlineConfig, // severity from the inline config
-                        ...config.rules[ruleId].slice(1) // options from the provided config
-                    ];
-                }
-            }
-        }
 
         let lintingProblems;
 
@@ -1713,17 +1708,67 @@ class Linter {
 
                         try {
 
-                            const ruleOptions = Array.isArray(ruleValue) ? ruleValue : [ruleValue];
+                            let ruleOptions = Array.isArray(ruleValue) ? ruleValue : [ruleValue];
 
-                            assertIsRuleOptions(ruleId, ruleValue);
                             assertIsRuleSeverity(ruleId, ruleOptions[0]);
 
-                            ruleValidator.validate({
-                                plugins: config.plugins,
-                                rules: {
-                                    [ruleId]: ruleOptions
+                            /*
+                             * If the rule was already configured, inline rule configuration that
+                             * only has severity should retain options from the config and just override the severity.
+                             *
+                             * Example:
+                             *
+                             *   {
+                             *       rules: {
+                             *           curly: ["error", "multi"]
+                             *       }
+                             *   }
+                             *
+                             *   /* eslint curly: ["warn"] * /
+                             *
+                             *   Results in:
+                             *
+                             *   curly: ["warn", "multi"]
+                             */
+
+                            let shouldValidateOptions = true;
+
+                            if (
+
+                                /*
+                                 * If inline config for the rule has only severity
+                                 */
+                                ruleOptions.length === 1 &&
+
+                                /*
+                                 * And the rule was already configured
+                                 */
+                                config.rules && Object.hasOwn(config.rules, ruleId)
+                            ) {
+
+                                /*
+                                 * Then use severity from the inline config and options from the provided config
+                                 */
+                                ruleOptions = [
+                                    ruleOptions[0], // severity from the inline config
+                                    ...config.rules[ruleId].slice(1) // options from the provided config
+                                ];
+
+                                // if the rule was enabled, the options have already been validated
+                                if (config.rules[ruleId][0] > 0) {
+                                    shouldValidateOptions = false;
                                 }
-                            });
+                            }
+
+                            if (shouldValidateOptions) {
+                                ruleValidator.validate({
+                                    plugins: config.plugins,
+                                    rules: {
+                                        [ruleId]: ruleOptions
+                                    }
+                                });
+                            }
+
                             mergedInlineConfig.rules[ruleId] = ruleOptions;
                         } catch (err) {
 
@@ -1763,57 +1808,7 @@ class Linter {
             )
             : { problems: [], disableDirectives: [] };
 
-        /*
-         * Now we determine the final configurations for rules.
-         * First, let all inline rule configurations override those from the config.
-         * Then, check for a special case: if a rule is configured in both places,
-         * inline rule configuration that only has severity should retain options from
-         * the config and just override the severity.
-         *
-         * Example:
-         *
-         *   {
-         *       rules: {
-         *           curly: ["error", "multi"]
-         *       }
-         *   }
-         *
-         *   /* eslint curly: ["warn"] * /
-         *
-         *   Results in:
-         *
-         *   curly: ["warn", "multi"]
-         *
-         * At this point, all rule configurations are normalized to arrays.
-         */
         const configuredRules = Object.assign({}, config.rules, mergedInlineConfig.rules);
-
-        if (config.rules) {
-            for (const [ruleId, ruleInlineConfig] of Object.entries(mergedInlineConfig.rules)) {
-                if (
-
-                    /*
-                     * If inline config for the rule has only severity
-                     */
-                    ruleInlineConfig.length === 1 &&
-
-                    /*
-                     * And provided config for the rule has options
-                     */
-                    Object.hasOwn(config.rules, ruleId) &&
-                    config.rules[ruleId].length > 1
-                ) {
-
-                    /*
-                     * Then use severity from the inline config and options from the provided config
-                     */
-                    configuredRules[ruleId] = [
-                        ruleInlineConfig[0], // severity from the inline config
-                        ...config.rules[ruleId].slice(1) // options from the provided config
-                    ];
-                }
-            }
-        }
 
         let lintingProblems;
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

* **Node version:** 20.9.0
* **npm version:** 10.2.0
* **Local ESLint version:** 9.0.0-beta.0
* **Global ESLint version:** no
* **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
// eslint.config.js
module.exports = [{
    rules: {
        "accessor-pairs": [0, "foo"]
    }
}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint accessor-pairs: "error" */
```

**What did you expect to happen?**

A lint error about invalid configuration for rule `accessor-pairs`, because the final configuration for this rule is `["error", "foo"]` (severity from the inline config comment, options from the config file), which isn't valid.

**What actually happened? Please include the actual, raw output from ESLint.**

No errors.

This happens because config arrays (both eslintrc and flat) don't validate options when rule is set to `"off"` in the configuration, which is intended behavior, but when that rule is later enabled by a comment and inherits options from the configurations, those options should be validated.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This scenario wasn't covered in https://github.com/eslint/eslint/pull/17945. Now I moved the logic that calculates options for a configuration comment to an earlier point so that the validation gets the final options.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
