### PR TITLE
docs: Show prerelease version in dropdown

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -24,6 +24,7 @@
     },
     "devDependencies": {
         "@11ty/eleventy": "^2.0.1",
+        "@11ty/eleventy-fetch": "^4.0.0",
         "@11ty/eleventy-img": "^3.1.1",
         "@11ty/eleventy-navigation": "^0.3.5",
         "@11ty/eleventy-plugin-rss": "^1.1.1",

--- a/docs/src/_data/eslintNextVersion.js
+++ b/docs/src/_data/eslintNextVersion.js
@@ -1,0 +1,32 @@
+/**
+ * @fileoverview
+ * @author Nicholas C. Zakas
+ */
+
+//-----------------------------------------------------------------------------
+// Requirements
+//-----------------------------------------------------------------------------
+
+const eleventyFetch  = require("@11ty/eleventy-fetch");
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+module.exports = async function() {
+
+    // if we're on the next branch, we can just read the package.json file
+    if (true && process.env.BRANCH === "next") {
+        return require("../../package.json").version;
+    }
+
+    // otherwise, we need to fetch the latest version from the GitHub API
+    const url = "https://raw.githubusercontent.com/eslint/eslint/next/docs/package.json";
+
+    const response = await eleventyFetch(url, {
+        duration: "1d",
+        type: "json"
+    });
+
+    return response.version;
+}

--- a/docs/src/_includes/components/nav-version-switcher.html
+++ b/docs/src/_includes/components/nav-version-switcher.html
@@ -14,7 +14,7 @@
         <select name="version selector" id="nav-version-select" aria-describedby="nav-version-infobox" class="c-custom-select switcher__select auto-switcher">
             <option value="HEAD" data-url="/docs/head/" {% if HEAD %}selected{% endif %}>HEAD</option>
             {% if config.showNextVersion == true %}
-                <option value="NEXT" data-url="/docs/next/" {% if GIT_BRANCH == "next" %}selected{% endif %}>NEXT</option>
+                <option value="{{ eslintNextVersion }}" data-url="/docs/next/" {% if GIT_BRANCH == "next" %}selected{% endif %}>{{ eslintNextVersion }}</option>
             {% endif %}
             <option value="{{ eslintVersion }}" data-url="/docs/latest/" {% if GIT_BRANCH == "latest" %}selected{% endif %}>v{{ eslintVersion }}</option>
             {% for version in versions.items %}

--- a/docs/src/_includes/components/version-switcher.html
+++ b/docs/src/_includes/components/version-switcher.html
@@ -14,7 +14,7 @@
         <select name="version selector" id="version-select" aria-describedby="version-infobox" class="c-custom-select switcher__select auto-switcher">
             <option value="HEAD" data-url="/docs/head/"  {% if HEAD %}selected{% endif %}>HEAD</option>
             {% if config.showNextVersion == true %}
-              <option value="NEXT" data-url="/docs/next/" {% if GIT_BRANCH=="next" %}selected{% endif %}>NEXT</option>
+              <option value="{{ eslintNextVersion }}" data-url="/docs/next/" {% if GIT_BRANCH=="next" %}selected{% endif %}>v{{ eslintNextVersion }}</option>
             {% endif %}
             <option value="{{ eslintVersion }}" data-url="/docs/latest/"  {% if GIT_BRANCH == "latest" %}selected{% endif %}>v{{ eslintVersion }}</option>
             {% for version in versions.items %}

--- a/docs/src/_includes/partials/versions-list.html
+++ b/docs/src/_includes/partials/versions-list.html
@@ -1,7 +1,7 @@
 <ul class="versions-list">
     <li><a href="/docs/head/" {% if HEAD %} data-current="true" {% endif %}>HEAD</a></li>
     {% if config.showNextVersion == true %}
-      <li><a href="/docs/next/" {% if GIT_BRANCH == "next" %} data-current="true" {% endif %}>NEXT</a></li>
+      <li><a href="/docs/next/" {% if GIT_BRANCH == "next" %} data-current="true" {% endif %}>v{{ eslintNextVersion }}</a></li>
     {% endif %}
     <li><a href="/docs/latest/" {% if GIT_BRANCH == "latest" %} data-current="true" {% endif %}>v{{ eslintVersion }}</a></li>
     {%- for version in versions.items -%}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Ensured that the version number is displayed instead of NEXT in the dropdown on the docs site. This is accomplished by either reading the version locally (on the `next` branch) or fetching the version from GitHub.

fixes #17943

#### Is there anything you'd like reviewers to focus on?

I'm pulling the `package.json` from the `next` branch, but wasn't sure if it should be `main`. I don't think it matters much but seemed better to use `next` to properly indicate the intent.

**Note:** We'll need to make the same change in the `v8.x` branch.


<!-- markdownlint-disable-file MD004 -->
![versiondropdown](https://github.com/eslint/eslint/assets/38546/f6ea1eb8-3e14-4482-a89f-cbbdd76a2e84)
