### PR TITLE
fix: stop linting files after an error

### DIFF
--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -838,6 +838,7 @@ class ESLint {
             configs,
             errorOnUnmatchedPattern
         });
+        const controller = new AbortController();
 
         debug(`${filePaths.length} files found in: ${Date.now() - startTime}ms`);
 
@@ -906,8 +907,11 @@ class ESLint {
                     fixer = message => shouldMessageBeFixed(message, config, fixTypesSet) && originalFix(message);
                 }
 
-                return fs.readFile(filePath, "utf8")
+                return fs.readFile(filePath, { encoding: "utf8", signal: controller.signal })
                     .then(text => {
+
+                        // fail immediately if an error occurred in another file
+                        controller.signal.throwIfAborted();
 
                         // do the linting
                         const result = verifyText({
@@ -932,6 +936,9 @@ class ESLint {
                         }
 
                         return result;
+                    }).catch(error => {
+                        controller.abort(error);
+                        throw error;
                     });
 
             })


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #17621

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds functionality in `ESLint.#lintFiles()` to cancel parallel tasks after an error occurs. The tasks spawn by `Promise.all()` contain only one asynchronous operation, which is the file access by `readFile`, where each task reads a different file. If an error occurs in one of the tasks, the other pending tasks will be canceled with an exception during or immediately after the file access.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
