### PR TITLE
feat!: disallow multiple configuration comments for same rule

### DIFF
--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -206,7 +206,7 @@ In ESLint v9.0.0, the first one is applied, while the others are reported as lin
 
 ```js
 /* eslint semi: ["error", "always"] */
-/* eslint semi: ["error", "never"] */ // error: Rule "semi" is already configured by another configuration comment in the preceding code
+/* eslint semi: ["error", "never"] */ // error: Rule "semi" is already configured by another configuration comment in the preceding code. This configuration is ignored.
 
 foo() // error: Missing semicolon
 ```

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -25,6 +25,7 @@ The lists below are ordered roughly by the number of users each change is expect
 * [`--output-file` now writes a file to disk even with an empty output](#output-file)
 * [Change in behavior when no patterns are passed to CLI](#cli-empty-patterns)
 * [`/* eslint */` comments with only severity now retain options from the config file](#eslint-comment-options)
+* [Multiple `/* eslint */` comments for the same rule are now disallowed](#multiple-eslint-comments)
 * [Stricter `/* exported */` parsing](#exported-parsing)
 * [`no-constructor-return` and `no-sequences` rule schemas are stricter](#stricter-rule-schemas)
 * [New checks in `no-implicit-coercion` by default](#no-implicit-coercion)
@@ -189,6 +190,30 @@ Note that this change only affects cases where the same rule is configured in th
 ```
 
 **Related issue(s):** [#17381](https://github.com/eslint/eslint/issues/17381)
+
+## <a name="multiple-eslint-comments"></a> Multiple `/* eslint */` comments for the same rule are now disallowed
+
+Prior to ESLint v9.0.0, if the file being linted contained multiple `/* eslint */` configuration comments for the same rule, the last one would be applied, while the others would be silently ignored. For example:
+
+```js
+/* eslint semi: ["error", "always"] */
+/* eslint semi: ["error", "never"] */
+
+foo() // valid, because the configuration is "never"
+```
+
+In ESLint v9.0.0, the first one is applied, while the others are reported as lint errors:
+
+```js
+/* eslint semi: ["error", "always"] */
+/* eslint semi: ["error", "never"] */ // error: Rule "semi" is already configured by another configuration comment in the preceding code
+
+foo() // error: Missing semicolon
+```
+
+**To address:** Remove duplicate `/* eslint */` comments.
+
+**Related issue(s):** [#18132](https://github.com/eslint/eslint/issues/18132)
 
 ## <a name="exported-parsing"></a> Stricter `/* exported */` parsing
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -439,6 +439,14 @@ function getDirectiveComments(sourceCode, ruleMapper, warnInlineConfig, config) 
                             return;
                         }
 
+                        if (Object.hasOwn(configuredRules, name)) {
+                            problems.push(createLintingProblem({
+                                message: `Rule "${name}" is already configured by another configuration comment in the preceding code.`,
+                                loc: comment.loc
+                            }));
+                            return;
+                        }
+
                         let ruleOptions = Array.isArray(ruleValue) ? ruleValue : [ruleValue];
 
                         /*
@@ -1703,6 +1711,14 @@ class Linter {
 
                         if (!rule) {
                             inlineConfigProblems.push(createLintingProblem({ ruleId, loc: node.loc }));
+                            return;
+                        }
+
+                        if (Object.hasOwn(mergedInlineConfig.rules, ruleId)) {
+                            inlineConfigProblems.push(createLintingProblem({
+                                message: `Rule "${ruleId}" is already configured by another configuration comment in the preceding code.`,
+                                loc: node.loc
+                            }));
                             return;
                         }
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -441,7 +441,7 @@ function getDirectiveComments(sourceCode, ruleMapper, warnInlineConfig, config) 
 
                         if (Object.hasOwn(configuredRules, name)) {
                             problems.push(createLintingProblem({
-                                message: `Rule "${name}" is already configured by another configuration comment in the preceding code.`,
+                                message: `Rule "${name}" is already configured by another configuration comment in the preceding code. This configuration is ignored.`,
                                 loc: comment.loc
                             }));
                             return;
@@ -1716,7 +1716,7 @@ class Linter {
 
                         if (Object.hasOwn(mergedInlineConfig.rules, ruleId)) {
                             inlineConfigProblems.push(createLintingProblem({
-                                message: `Rule "${ruleId}" is already configured by another configuration comment in the preceding code.`,
+                                message: `Rule "${ruleId}" is already configured by another configuration comment in the preceding code. This configuration is ignored.`,
                                 loc: node.loc
                             }));
                             return;

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -1908,7 +1908,7 @@ describe("Linter", () => {
                 {
                     ruleId: null,
                     severity: 2,
-                    message: "Rule \"no-foo\" is already configured by another configuration comment in the preceding code.",
+                    message: "Rule \"no-foo\" is already configured by another configuration comment in the preceding code. This configuration is ignored.",
                     line: 1,
                     column: 37,
                     endLine: 1,
@@ -1939,7 +1939,7 @@ describe("Linter", () => {
                 {
                     ruleId: null,
                     severity: 2,
-                    message: "Rule \"no-foo\" is already configured by another configuration comment in the preceding code.",
+                    message: "Rule \"no-foo\" is already configured by another configuration comment in the preceding code. This configuration is ignored.",
                     line: 1,
                     column: 37,
                     endLine: 1,
@@ -1949,7 +1949,7 @@ describe("Linter", () => {
                 {
                     ruleId: null,
                     severity: 2,
-                    message: "Rule \"no-foo\" is already configured by another configuration comment in the preceding code.",
+                    message: "Rule \"no-foo\" is already configured by another configuration comment in the preceding code. This configuration is ignored.",
                     line: 1,
                     column: 73,
                     endLine: 1,
@@ -1980,7 +1980,7 @@ describe("Linter", () => {
                 {
                     ruleId: null,
                     severity: 2,
-                    message: "Rule \"no-foo\" is already configured by another configuration comment in the preceding code.",
+                    message: "Rule \"no-foo\" is already configured by another configuration comment in the preceding code. This configuration is ignored.",
                     line: 1,
                     column: 27,
                     endLine: 1,
@@ -2020,7 +2020,7 @@ describe("Linter", () => {
             const suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 3);
-            assert.include(messages[0].message, "Rule \"no-foo\" is already configured by another configuration comment in the preceding code.");
+            assert.strictEqual(messages[0].message, "Rule \"no-foo\" is already configured by another configuration comment in the preceding code. This configuration is ignored.");
             assert.strictEqual(messages[1].message, "Replace 'foo' with 'bar'.");
             assert.strictEqual(messages[2].ruleId, "no-alert");
             assert.strictEqual(suppressedMessages.length, 0);
@@ -11416,7 +11416,7 @@ describe("Linter with FlatConfigArray", () => {
                             {
                                 ruleId: null,
                                 severity: 2,
-                                message: "Rule \"test-plugin/no-foo\" is already configured by another configuration comment in the preceding code.",
+                                message: "Rule \"test-plugin/no-foo\" is already configured by another configuration comment in the preceding code. This configuration is ignored.",
                                 line: 1,
                                 column: 49,
                                 endLine: 1,
@@ -11447,7 +11447,7 @@ describe("Linter with FlatConfigArray", () => {
                             {
                                 ruleId: null,
                                 severity: 2,
-                                message: "Rule \"test-plugin/no-foo\" is already configured by another configuration comment in the preceding code.",
+                                message: "Rule \"test-plugin/no-foo\" is already configured by another configuration comment in the preceding code. This configuration is ignored.",
                                 line: 1,
                                 column: 49,
                                 endLine: 1,
@@ -11457,7 +11457,7 @@ describe("Linter with FlatConfigArray", () => {
                             {
                                 ruleId: null,
                                 severity: 2,
-                                message: "Rule \"test-plugin/no-foo\" is already configured by another configuration comment in the preceding code.",
+                                message: "Rule \"test-plugin/no-foo\" is already configured by another configuration comment in the preceding code. This configuration is ignored.",
                                 line: 1,
                                 column: 97,
                                 endLine: 1,
@@ -11488,7 +11488,7 @@ describe("Linter with FlatConfigArray", () => {
                             {
                                 ruleId: null,
                                 severity: 2,
-                                message: "Rule \"test-plugin/no-foo\" is already configured by another configuration comment in the preceding code.",
+                                message: "Rule \"test-plugin/no-foo\" is already configured by another configuration comment in the preceding code. This configuration is ignored.",
                                 line: 1,
                                 column: 39,
                                 endLine: 1,
@@ -11528,7 +11528,7 @@ describe("Linter with FlatConfigArray", () => {
                         const suppressedMessages = linter.getSuppressedMessages();
 
                         assert.strictEqual(messages.length, 3);
-                        assert.include(messages[0].message, "Rule \"test-plugin/no-foo\" is already configured by another configuration comment in the preceding code.");
+                        assert.strictEqual(messages[0].message, "Rule \"test-plugin/no-foo\" is already configured by another configuration comment in the preceding code. This configuration is ignored.");
                         assert.strictEqual(messages[1].message, "Replace 'foo' with 'bar'.");
                         assert.strictEqual(messages[2].ruleId, "no-alert");
                         assert.strictEqual(suppressedMessages.length, 0);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

Fixes https://github.com/eslint/eslint/issues/18132


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated code that processes `/*eslint*/` comments (both in flat and eslintrc modes) to check if the rule has already been configured by another comment. In that case, the previous comment still applies, while the duplicate is reported as a lint error.

#### Is there anything you'd like reviewers to focus on?

This doesn't cover cases where a rule appears multiple times in the same comment. Configuration comments are parsed by `levn` (with a fallback to JSON parsing), which allows duplicate keys in objects and just returns the last entry. Detecting these duplicates would probably require another tool or custom parsing. I think these cases are much less important than the cases with multiple comments.

<!-- markdownlint-disable-file MD004 -->
