### PR TITLE
feat!: move AST traversal into SourceCode

### DIFF
--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -42,6 +42,7 @@ The lists below are ordered roughly by the number of users each change is expect
 * [Removed multiple `context` methods](#removed-context-methods)
 * [Removed `sourceCode.getComments()`](#removed-sourcecode-getcomments)
 * [Removed `CodePath#currentSegments`](#removed-codepath-currentsegments)
+* [Code paths are now precalculated](#codepath-precalc)
 * [Function-style rules are no longer supported](#drop-function-style-rules)
 * [`meta.schema` is required for rules with options](#meta-schema-required)
 * [`FlatRuleTester` is now `RuleTester`](#flat-rule-tester)
@@ -464,6 +465,19 @@ ESLint v9.0.0 removes the deprecated `CodePath#currentSegments` property.
 **To address:** Update your code following the recommendations in the [blog post](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#codepath%23currentsegments).
 
 **Related Issues(s):** [#17457](https://github.com/eslint/eslint/issues/17457)
+
+## <a name="codepath-precalc"></a> Code paths are now precalculated
+
+Prior to ESLint v9.0.0, code paths were calculated during the same AST traversal used by rules, meaning that the information passed to methods like `onCodePathStart` and `onCodePathSegmentStart` was incomplete. Specifically, array properties like `CodePath#childCodePaths` and `CodePathSegment#nextSegments` began empty and then were filled with the appropriate information as the traversal completed, meaning that those arrays could have different elements depending on when you checked their values.
+
+ESLint v9.0.0 now precalculates code path information before the traversal used by rules. As a result, the code path information is now complete regardless of where it is accessed inside of a rule.
+
+**To address:** If you are accessing any array properties on `CodePath` or `CodePathSegment`, you'll need to update your code. Specifically:
+
+* If you are checking the `length` of any array properties, ensure you are using relative comparison operators like `<`, `>`, `<=`, and `>=` instead of equals.
+* If you are accessing the `nextSegments`, `prevSegments`, `allNextSegments`, or `allPrevSegments` properties on a `CodePathSegment`, or `CodePath#childCodePaths`, verify that your code will still work as expected. To be backwards compatible, consider moving the logic that checks these properties into `onCodePathEnd`.
+
+**Related Issues(s):** [#16999](https://github.com/eslint/eslint/issues/16999)
 
 ## <a name="drop-function-style-rules"></a> Function-style rules are no longer supported
 

--- a/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -222,7 +222,6 @@ function forwardCurrentToHead(analyzer, node) {
                 : "onUnreachableCodePathSegmentStart";
 
             debug.dump(`${eventName} ${headSegment.id}`);
-
             CodePathSegment.markUsed(headSegment);
             analyzer.emitter.emit(
                 eventName,

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -52,6 +52,8 @@ const commentParser = new ConfigCommentParser();
 const DEFAULT_ERROR_LOC = { start: { line: 1, column: 0 }, end: { line: 1, column: 1 } };
 const parserSymbol = Symbol.for("eslint.RuleTester.parser");
 const { LATEST_ECMA_VERSION } = require("../../conf/ecma-version");
+const STEP_KIND_VISIT = 1;
+const STEP_KIND_CALL = 2;
 
 //------------------------------------------------------------------------------
 // Typedefs
@@ -940,7 +942,6 @@ function createRuleListeners(rule, ruleContext) {
  */
 function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageOptions, settings, filename, disableFixes, cwd, physicalFilename, ruleFilter) {
     const emitter = createEmitter();
-    let currentNode = sourceCode.ast;
 
     // must happen first to assign all node.parent properties
     const eventQueue = sourceCode.traverse();
@@ -1075,61 +1076,11 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
 
     const eventGenerator = new NodeEventGenerator(emitter, { visitorKeys: sourceCode.visitorKeys, fallback: Traverser.getKeys });
 
-
-    // const eventSequence = [
-    //     "Program",
-    //     "FunctionDeclaration",
-    //     "Identifier",
-    //     "Identifier:exit",
-    //     "BlockStatement",
-    //     "SwitchStatement",
-    //     "Identifier",
-    //     "Identifier:exit",
-    //     "SwitchCase",
-    //     "ExpressionStatement",
-    //     "CallExpression",
-    //     "Identifier",
-    //     "Identifier:exit",
-    //     "CallExpression:exit",
-    //     "ExpressionStatement:exit",
-    //     "ReturnStatement",
-    //     "ReturnStatement:exit",
-    //     "SwitchCase",
-    //     "SwitchCase",
-    //     "Literal",
-    //     "Literal:exit",
-    //     "ExpressionStatement",
-    //     "CallExpression",
-    //     "Identifier",
-    //     "Identifier:exit",
-    //     "CallExpression:exit",
-    //     "ExpressionStatement:exit",
-    //     "SwitchCase:exit",
-    //     "SwitchStatement:exit",
-    //     "BlockStatement:exit",
-    //     "FunctionDeclaration:exit",
-    //     "Program:exit",
-    //     "onCodePathStart",
-    //     "onCodePathEnd",
-    //     "onCodePathSegmentStart",
-    //     "onCodePathSegmentEnd",
-    //     "onCodePathSegmentLoop",
-    //     "onUnreachableCodePathSegmentStart",
-    //     "onUnreachableCodePathSegmentEnd"
-    // ];
-
-    // eventSequence.forEach(eventName => {
-    //     emitter.on(eventName, (...args) => {
-    //         console.log(eventName, eventName.startsWith("on") ? args[0].id : args[0].type);
-    //     });
-    // });
-
-
     for (const step of eventQueue) {
-        switch (step.type) {
-            case "visit": {
+        switch (step.kind) {
+            case STEP_KIND_VISIT: {
                 try {
-                    if (step.isEntering) {
+                    if (step.phase === 1) {
                         eventGenerator.enterNode(step.target);
                     } else {
                         eventGenerator.leaveNode(step.target);
@@ -1141,7 +1092,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
                 break;
             }
 
-            case "call": {
+            case STEP_KIND_CALL: {
                 emitter.emit(step.target, ...step.args);
                 break;
             }

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -942,7 +942,9 @@ function createRuleListeners(rule, ruleContext) {
 function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageOptions, settings, filename, disableFixes, cwd, physicalFilename, ruleFilter) {
     const emitter = createEmitter();
     let currentNode = sourceCode.ast;
-    const nodeQueue = sourceCode.traverse();
+
+    // must happen first to assign all node.parent properties
+    const eventQueue = sourceCode.traverse();
 
     /*
      * Create a frozen object with the ruleContext properties and methods that are shared by all rules.
@@ -1073,23 +1075,35 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
     });
 
     // only run code path analyzer if the top level node is "Program", skip otherwise
-    const eventGenerator = sourceCode.ast.type === "Program"
-        ? new CodePathAnalyzer(new NodeEventGenerator(emitter, { visitorKeys: sourceCode.visitorKeys, fallback: Traverser.getKeys }))
-        : new NodeEventGenerator(emitter, { visitorKeys: sourceCode.visitorKeys, fallback: Traverser.getKeys });
+    const eventGenerator = new NodeEventGenerator(emitter, { visitorKeys: sourceCode.visitorKeys, fallback: Traverser.getKeys });
+console.dir(eventQueue.map(step => ({ type: step.type, target: step.target.type ? step.target.type : step.target})))
+    for (const step of eventQueue) {
 
-    for (const { isEntering, target } of nodeQueue) {
-        currentNode = target;
-
-        try {
-            if (isEntering) {
-                eventGenerator.enterNode(currentNode);
-            } else {
-                eventGenerator.leaveNode(currentNode);
+        switch (step.type) {
+            case "visit": {
+                currentNode = step.target;
+                try {
+                    if (step.isEntering) {
+                        eventGenerator.enterNode(step.target);
+                    } else {
+                        eventGenerator.leaveNode(step.target);
+                    }
+                } catch (err) {
+                    err.currentNode = step.target;
+                    throw err;
+                }
+                break;
             }
-        } catch (err) {
-            err.currentNode = currentNode;
-            throw err;
+
+            case "call": {
+                emitter.emit(step.target, ...step.args);
+                break;
+            }
+
+            default:
+                throw new Error(`Invalid traversal step found: "${step.type}".`);
         }
+
     }
 
     return lintingProblems;

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -30,7 +30,6 @@ const
     } = require("@eslint/eslintrc/universal"),
     Traverser = require("../shared/traverser"),
     { SourceCode } = require("../source-code"),
-    CodePathAnalyzer = require("./code-path-analysis/code-path-analyzer"),
     applyDisableDirectives = require("./apply-disable-directives"),
     ConfigCommentParser = require("./config-comment-parser"),
     NodeEventGenerator = require("./node-event-generator"),
@@ -1074,14 +1073,61 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
         });
     });
 
-    // only run code path analyzer if the top level node is "Program", skip otherwise
     const eventGenerator = new NodeEventGenerator(emitter, { visitorKeys: sourceCode.visitorKeys, fallback: Traverser.getKeys });
-console.dir(eventQueue.map(step => ({ type: step.type, target: step.target.type ? step.target.type : step.target})))
-    for (const step of eventQueue) {
 
+
+    // const eventSequence = [
+    //     "Program",
+    //     "FunctionDeclaration",
+    //     "Identifier",
+    //     "Identifier:exit",
+    //     "BlockStatement",
+    //     "SwitchStatement",
+    //     "Identifier",
+    //     "Identifier:exit",
+    //     "SwitchCase",
+    //     "ExpressionStatement",
+    //     "CallExpression",
+    //     "Identifier",
+    //     "Identifier:exit",
+    //     "CallExpression:exit",
+    //     "ExpressionStatement:exit",
+    //     "ReturnStatement",
+    //     "ReturnStatement:exit",
+    //     "SwitchCase",
+    //     "SwitchCase",
+    //     "Literal",
+    //     "Literal:exit",
+    //     "ExpressionStatement",
+    //     "CallExpression",
+    //     "Identifier",
+    //     "Identifier:exit",
+    //     "CallExpression:exit",
+    //     "ExpressionStatement:exit",
+    //     "SwitchCase:exit",
+    //     "SwitchStatement:exit",
+    //     "BlockStatement:exit",
+    //     "FunctionDeclaration:exit",
+    //     "Program:exit",
+    //     "onCodePathStart",
+    //     "onCodePathEnd",
+    //     "onCodePathSegmentStart",
+    //     "onCodePathSegmentEnd",
+    //     "onCodePathSegmentLoop",
+    //     "onUnreachableCodePathSegmentStart",
+    //     "onUnreachableCodePathSegmentEnd"
+    // ];
+
+    // eventSequence.forEach(eventName => {
+    //     emitter.on(eventName, (...args) => {
+    //         console.log(eventName, eventName.startsWith("on") ? args[0].id : args[0].type);
+    //     });
+    // });
+
+
+    for (const step of eventQueue) {
         switch (step.type) {
             case "visit": {
-                currentNode = step.target;
                 try {
                     if (step.isEntering) {
                         eventGenerator.enterNode(step.target);

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -937,22 +937,12 @@ function createRuleListeners(rule, ruleContext) {
  * @param {string} physicalFilename The full path of the file on disk without any code block information
  * @param {Function} ruleFilter A predicate function to filter which rules should be executed.
  * @returns {LintMessage[]} An array of reported problems
+ * @throws {Error} If traversal into a node fails.
  */
 function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageOptions, settings, filename, disableFixes, cwd, physicalFilename, ruleFilter) {
     const emitter = createEmitter();
-    const nodeQueue = [];
     let currentNode = sourceCode.ast;
-
-    Traverser.traverse(sourceCode.ast, {
-        enter(node, parent) {
-            node.parent = parent;
-            nodeQueue.push({ isEntering: true, node });
-        },
-        leave(node) {
-            nodeQueue.push({ isEntering: false, node });
-        },
-        visitorKeys: sourceCode.visitorKeys
-    });
+    const nodeQueue = sourceCode.traverse();
 
     /*
      * Create a frozen object with the ruleContext properties and methods that are shared by all rules.
@@ -1083,15 +1073,15 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
     });
 
     // only run code path analyzer if the top level node is "Program", skip otherwise
-    const eventGenerator = nodeQueue[0].node.type === "Program"
+    const eventGenerator = sourceCode.ast.type === "Program"
         ? new CodePathAnalyzer(new NodeEventGenerator(emitter, { visitorKeys: sourceCode.visitorKeys, fallback: Traverser.getKeys }))
         : new NodeEventGenerator(emitter, { visitorKeys: sourceCode.visitorKeys, fallback: Traverser.getKeys });
 
-    nodeQueue.forEach(traversalInfo => {
-        currentNode = traversalInfo.node;
+    for (const { isEntering, target } of nodeQueue) {
+        currentNode = target;
 
         try {
-            if (traversalInfo.isEntering) {
+            if (isEntering) {
                 eventGenerator.enterNode(currentNode);
             } else {
                 eventGenerator.leaveNode(currentNode);
@@ -1100,7 +1090,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserName, languageO
             err.currentNode = currentNode;
             throw err;
         }
-    });
+    }
 
     return lintingProblems;
 }

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -119,6 +119,30 @@ function isPossibleConstructor(node) {
     }
 }
 
+/**
+ * A class to store information about a code path segment.
+ */
+class SegmentInfo {
+
+    /**
+     * Indicates if super() is called in all code paths.
+     * @type {boolean}
+     */
+    calledInEveryPaths = false;
+
+    /**
+     * Indicates if super() is called in any code paths.
+     * @type {boolean}
+     */
+    calledInSomePaths = false;
+
+    /**
+     * The nodes which have been validated and don't need to be reconsidered.
+     * @type {ASTNode[]}
+     */
+    validNodes = [];
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -159,12 +183,8 @@ module.exports = {
          */
         let funcInfo = null;
 
-        /*
-         * {Map<string, {calledInSomePaths: boolean, calledInEveryPaths: boolean}>}
-         * Information for each code path segment.
-         * - calledInSomePaths:  A flag of be called `super()` in some code paths.
-         * - calledInEveryPaths: A flag of be called `super()` in all code paths.
-         * - validNodes:
+        /**
+         * @type {Record<string, SegmentInfo>}
          */
         let segInfoMap = Object.create(null);
 
@@ -174,7 +194,7 @@ module.exports = {
          * @returns {boolean} The flag which shows `super()` is called in some paths
          */
         function isCalledInSomePath(segment) {
-            return segment.reachable && segInfoMap[segment.id].calledInSomePaths;
+            return segment.reachable && segInfoMap[segment.id]?.calledInSomePaths;
         }
 
         /**
@@ -189,12 +209,12 @@ module.exports = {
              * skip the segment.
              * If not skipped, this never becomes true after a loop.
              */
-            if (segment.nextSegments.length === 1 &&
+            if (segment.nextSegments.length &&
                 segment.nextSegments[0].isLoopedPrevSegment(segment)
             ) {
                 return true;
             }
-            return segment.reachable && segInfoMap[segment.id].calledInEveryPaths;
+            return segment.reachable && segInfoMap[segment.id]?.calledInEveryPaths;
         }
 
         return {
@@ -278,11 +298,7 @@ module.exports = {
                 }
 
                 // Initialize info.
-                const info = segInfoMap[segment.id] = {
-                    calledInSomePaths: false,
-                    calledInEveryPaths: false,
-                    validNodes: []
-                };
+                const info = segInfoMap[segment.id] = new SegmentInfo();
 
                 // When there are previous segments, aggregates these.
                 const prevSegments = segment.prevSegments;
@@ -326,7 +342,7 @@ module.exports = {
                 funcInfo.codePath.traverseSegments(
                     { first: toSegment, last: fromSegment },
                     segment => {
-                        const info = segInfoMap[segment.id];
+                        const info = segInfoMap[segment.id] ?? new SegmentInfo();
                         const prevSegments = segment.prevSegments;
 
                         // Updates flags.
@@ -348,6 +364,9 @@ module.exports = {
                                 });
                             }
                         }
+
+                        // save just in case we created a new SegmentInfo object
+                        segInfoMap[segment.id] = info;
                     }
                 );
             },

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -198,6 +198,15 @@ module.exports = {
         }
 
         /**
+         * Determines if a segment has been seen in the traversal.
+         * @param {CodePathSegment} segment A code path segment to check.
+         * @returns {boolean} `true` if the segment has been seen.
+         */
+        function hasSegmentBeenSeen(segment) {
+            return !!segInfoMap[segment.id];
+        }
+
+        /**
          * Gets the flag which shows `super()` is called in all paths.
          * @param {CodePathSegment} segment A code path segment to get.
          * @returns {boolean} The flag which shows `super()` is called in all paths.
@@ -209,12 +218,12 @@ module.exports = {
              * skip the segment.
              * If not skipped, this never becomes true after a loop.
              */
-            if (segment.nextSegments.length &&
-                segment.nextSegments[0].isLoopedPrevSegment(segment)
-            ) {
+            if (segment.nextSegments.length === 1 &&
+                segment.nextSegments[0]?.isLoopedPrevSegment(segment)) {
                 return true;
             }
-            return segment.reachable && segInfoMap[segment.id]?.calledInEveryPaths;
+
+            return segment.reachable && segInfoMap[segment.id].calledInEveryPaths;
         }
 
         return {
@@ -270,9 +279,9 @@ module.exports = {
                 }
 
                 // Reports if `super()` lacked.
-                const segments = codePath.returnedSegments;
-                const calledInEveryPaths = segments.every(isCalledInEveryPath);
-                const calledInSomePaths = segments.some(isCalledInSomePath);
+                const seenSegments = codePath.returnedSegments.filter(hasSegmentBeenSeen);
+                const calledInEveryPaths = seenSegments.every(isCalledInEveryPath);
+                const calledInSomePaths = seenSegments.some(isCalledInSomePath);
 
                 if (!calledInEveryPaths) {
                     context.report({
@@ -304,8 +313,10 @@ module.exports = {
                 const prevSegments = segment.prevSegments;
 
                 if (prevSegments.length > 0) {
-                    info.calledInSomePaths = prevSegments.some(isCalledInSomePath);
-                    info.calledInEveryPaths = prevSegments.every(isCalledInEveryPath);
+                    const seenPrevSegments = prevSegments.filter(hasSegmentBeenSeen);
+
+                    info.calledInSomePaths = seenPrevSegments.some(isCalledInSomePath);
+                    info.calledInEveryPaths = seenPrevSegments.every(isCalledInEveryPath);
                 }
             },
 
@@ -343,11 +354,11 @@ module.exports = {
                     { first: toSegment, last: fromSegment },
                     segment => {
                         const info = segInfoMap[segment.id] ?? new SegmentInfo();
-                        const prevSegments = segment.prevSegments;
+                        const seenPrevSegments = segment.prevSegments.filter(hasSegmentBeenSeen);
 
                         // Updates flags.
-                        info.calledInSomePaths = prevSegments.some(isCalledInSomePath);
-                        info.calledInEveryPaths = prevSegments.every(isCalledInEveryPath);
+                        info.calledInSomePaths = seenPrevSegments.some(isCalledInSomePath);
+                        info.calledInEveryPaths = seenPrevSegments.every(isCalledInEveryPath);
 
                         // If flags become true anew, reports the valid nodes.
                         if (info.calledInSomePaths || isRealLoop) {

--- a/lib/rules/no-this-before-super.js
+++ b/lib/rules/no-this-before-super.js
@@ -30,6 +30,29 @@ function isConstructorFunction(node) {
     );
 }
 
+/*
+ * Information for each code path segment.
+ * - superCalled:  The flag which shows `super()` called in all code paths.
+ * - invalidNodes: The array of invalid ThisExpression and Super nodes.
+ */
+/**
+ *
+ */
+class SegmentInfo {
+
+    /**
+     * Indicates whether `super()` is called in all code paths.
+     * @type {boolean}
+     */
+    superCalled = false;
+
+    /**
+     * The array of invalid ThisExpression and Super nodes.
+     * @type {ASTNode[]}
+     */
+    invalidNodes = [];
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -64,13 +87,7 @@ module.exports = {
          */
         let funcInfo = null;
 
-        /*
-         * Information for each code path segment.
-         * Each key is the id of a code path segment.
-         * Each value is an object:
-         * - superCalled:  The flag which shows `super()` called in all code paths.
-         * - invalidNodes: The array of invalid ThisExpression and Super nodes.
-         */
+        /** @type {Record<string, SegmentInfo>} */
         let segInfoMap = Object.create(null);
 
         /**
@@ -79,7 +96,7 @@ module.exports = {
          * @returns {boolean} `true` if `super()` is called.
          */
         function isCalled(segment) {
-            return !segment.reachable || segInfoMap[segment.id].superCalled;
+            return !segment.reachable || segInfoMap[segment.id]?.superCalled;
         }
 
         /**
@@ -285,7 +302,7 @@ module.exports = {
                 funcInfo.codePath.traverseSegments(
                     { first: toSegment, last: fromSegment },
                     (segment, controller) => {
-                        const info = segInfoMap[segment.id];
+                        const info = segInfoMap[segment.id] ?? new SegmentInfo();
 
                         if (info.superCalled) {
                             controller.skip();
@@ -295,6 +312,8 @@ module.exports = {
                         ) {
                             info.superCalled = true;
                         }
+
+                        segInfoMap[segment.id] = info;
                     }
                 );
             },

--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -282,7 +282,7 @@ module.exports = {
                     uselessReturns: getUselessReturns([], segment.allPrevSegments),
                     returned: false
                 };
-
+console.log("received", segment);
                 // Stores the info.
                 segmentInfoMap.set(segment, info);
             },

--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -184,6 +184,10 @@ module.exports = {
 
             const info = segmentInfoMap.get(segment);
 
+            if (!info) {
+                return;
+            }
+
             info.uselessReturns = info.uselessReturns.filter(node => {
                 if (scopeInfo.traversedTryBlockStatements && scopeInfo.traversedTryBlockStatements.length > 0) {
                     const returnInitialRange = node.range[0];

--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -243,7 +243,7 @@ module.exports = {
             },
 
             // Reports useless return statements if exist.
-            onCodePathEnd() {
+            onCodePathEnd(codePath) {
                 for (const node of scopeInfo.uselessReturns) {
                     context.report({
                         node,
@@ -275,14 +275,13 @@ module.exports = {
              * NOTE: This event is notified for only reachable segments.
              */
             onCodePathSegmentStart(segment) {
-
                 scopeInfo.currentSegments.add(segment);
 
                 const info = {
                     uselessReturns: getUselessReturns([], segment.allPrevSegments),
                     returned: false
                 };
-console.log("received", segment);
+
                 // Stores the info.
                 segmentInfoMap.set(segment, info);
             },

--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -146,7 +146,9 @@ module.exports = {
                     continue;
                 }
 
-                uselessReturns.push(...segmentInfoMap.get(segment).uselessReturns);
+                if (segmentInfoMap.has(segment)) {
+                    uselessReturns.push(...segmentInfoMap.get(segment).uselessReturns);
+                }
             }
 
             return uselessReturns;
@@ -243,7 +245,7 @@ module.exports = {
             },
 
             // Reports useless return statements if exist.
-            onCodePathEnd(codePath) {
+            onCodePathEnd() {
                 for (const node of scopeInfo.uselessReturns) {
                     context.report({
                         node,

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -17,6 +17,10 @@ const
     {
         directivesPattern
     } = require("../shared/directives"),
+    CodePathAnalyzer = require("../linter/code-path-analysis/code-path-analyzer"),
+    NodeEventGenerator = require("../linter/node-event-generator"),
+    createEmitter = require("../linter/safe-emitter"),
+
 
     /* eslint-disable-next-line n/no-restricted-require -- Too messy to figure out right now. */
     ConfigCommentParser = require("../linter/config-comment-parser"),
@@ -33,6 +37,14 @@ const
 //------------------------------------------------------------------------------
 
 const commentParser = new ConfigCommentParser();
+
+const CODE_PATH_EVENTS = [
+    "onCodePathStart",
+    "onCodePathEnd",
+    "onCodePathSegmentStart",
+    "onCodePathSegmentEnd",
+    "onCodePathSegmentLoop"
+];
 
 /**
  * Validates that the given AST has the required information.
@@ -975,13 +987,17 @@ class SourceCode extends TokenStore {
     traverse() {
 
         const steps = [];
+        const isESTree = this.ast.type === "Program";
 
-        Traverser.traverse(this.ast, {
-            enter(node, parent) {
-
-                // save the parent node on a property for backwards compatibility
-                node.parent = parent;
-
+        /*
+         * We do code path analysis for ESTree only. At the moment, this code path is still
+         * supporting non-ESTree ASTs, so we need to take that into account avoid doing code
+         * path analysis.
+         */
+        const emitter = createEmitter();
+        let analyzer = {
+            enterNode(node, parent) {
+                console.log("enter", node.type)
                 steps.push({
                     type: "visit",
                     target: node,
@@ -989,13 +1005,42 @@ class SourceCode extends TokenStore {
                     args: [node, parent]
                 });
             },
-            leave(node, parent) {
+            leaveNode(node, parent) {
+                console.log("exit", node.type)
                 steps.push({
                     type: "visit",
                     target: node,
                     isEntering: false,
                     args: [node, parent]
                 });
+            },
+            emitter
+        };
+
+        if (isESTree) {
+            analyzer = new CodePathAnalyzer(analyzer);
+
+            CODE_PATH_EVENTS.forEach(eventName => {
+                emitter.on(eventName, (...args) => {console.log(eventName, args[1].type);
+                    steps.push({
+                        type: "call",
+                        target: eventName,
+                        args
+                    });
+                });
+            })
+        }
+
+        Traverser.traverse(this.ast, {
+            enter(node, parent) {
+
+                // save the parent node on a property for backwards compatibility
+                node.parent = parent;
+
+                analyzer.enterNode(node, parent);
+            },
+            leave(node, parent) {
+                analyzer.leaveNode(node, parent);
             },
             visitorKeys: this.visitorKeys
         });

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -314,6 +314,11 @@ function markExportedVariables(globalScope, variables) {
 
 }
 
+const STEP_KIND = {
+    visit: 1,
+    call: 2
+};
+
 /**
  * A class to represent a step in the traversal process.
  */
@@ -354,15 +359,14 @@ class TraversalStep {
      * Creates a new instance.
      * @param {Object} options The options for the step.
      * @param {string} options.type The type of the step.
-     * @param {number} options.kind The kind of the step.
      * @param {ASTNode|string} options.target The target of the step.
      * @param {number|undefined} [options.phase] The phase of the step.
      * @param {Array<any>} options.args The arguments of the step.
      * @returns {void}
      */
-    constructor({ type, kind, target, phase, args }) {
+    constructor({ type, target, phase, args }) {
         this.type = type;
-        this.kind = kind;
+        this.kind = STEP_KIND[type];
         this.target = target;
         this.phase = phase;
         this.args = args;
@@ -1070,7 +1074,6 @@ class SourceCode extends TokenStore {
             enterNode(node, parent) {
                 steps.push(new TraversalStep({
                     type: "visit",
-                    kind: 1,
                     target: node,
                     phase: 1,
                     args: [node, parent]
@@ -1079,7 +1082,6 @@ class SourceCode extends TokenStore {
             leaveNode(node, parent) {
                 steps.push(new TraversalStep({
                     type: "visit",
-                    kind: 1,
                     target: node,
                     phase: 2,
                     args: [node, parent]
@@ -1106,7 +1108,6 @@ class SourceCode extends TokenStore {
                 emitter.on(eventName, (...args) => {
                     steps.push(new TraversalStep({
                         type: "call",
-                        kind: 2,
                         target: eventName,
                         args
                     }));

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -17,13 +17,13 @@ const
     {
         directivesPattern
     } = require("../shared/directives"),
+
+    /* eslint-disable n/no-restricted-require -- Should eventually be moved into SourceCode. */
     CodePathAnalyzer = require("../linter/code-path-analysis/code-path-analyzer"),
-    NodeEventGenerator = require("../linter/node-event-generator"),
     createEmitter = require("../linter/safe-emitter"),
-
-
-    /* eslint-disable-next-line n/no-restricted-require -- Too messy to figure out right now. */
     ConfigCommentParser = require("../linter/config-comment-parser"),
+    /* eslint-enable n/no-restricted-require -- Should eventually be moved into SourceCode. */
+
     eslintScope = require("eslint-scope");
 
 //------------------------------------------------------------------------------
@@ -43,7 +43,9 @@ const CODE_PATH_EVENTS = [
     "onCodePathEnd",
     "onCodePathSegmentStart",
     "onCodePathSegmentEnd",
-    "onCodePathSegmentLoop"
+    "onCodePathSegmentLoop",
+    "onUnreachableCodePathSegmentStart",
+    "onUnreachableCodePathSegmentEnd"
 ];
 
 /**
@@ -984,15 +986,30 @@ class SourceCode extends TokenStore {
 
     }
 
+    /**
+     * Traverse the source code and return the steps that were taken.
+     * @returns {Array} The steps that were taken while traversing the source code.
+     */
     traverse() {
 
         const steps = [];
-        const isESTree = this.ast.type === "Program";
+        const queue = [];
+
+        Traverser.traverse(this.ast, {
+            enter(node, parent) {
+                node.parent = parent;
+                queue.push({ isEntering: true, node });
+            },
+            leave(node) {
+                queue.push({ isEntering: false, node });
+            },
+            visitorKeys: this.visitorKeys
+        });
 
         /*
-         * We do code path analysis for ESTree only. At the moment, this code path is still
-         * supporting non-ESTree ASTs, so we need to take that into account avoid doing code
-         * path analysis.
+         * This logic works for any AST, not just ESTree. Because ESLint has allowed
+         * custom parsers to return any AST, we need to ensure that the traversal
+         * logic works for any AST.
          */
         const emitter = createEmitter();
         let analyzer = {
@@ -1015,6 +1032,17 @@ class SourceCode extends TokenStore {
             emitter
         };
 
+        /*
+         * We do code path analysis for ESTree only. Code path analysis is not
+         * necessary for other ASTs, and it's also not possible to do for other
+         * ASTs because the necessary information is not available.
+         *
+         * Generally speaking, we can tell that the AST is an ESTree if it has a
+         * Program node at the top level. This is not a perfect heuristic, but it
+         * is good enough for now.
+         */
+        const isESTree = this.ast.type === "Program";
+
         if (isESTree) {
             analyzer = new CodePathAnalyzer(analyzer);
 
@@ -1026,21 +1054,34 @@ class SourceCode extends TokenStore {
                         args
                     });
                 });
-            })
+            });
         }
 
-        Traverser.traverse(this.ast, {
-            enter(node, parent) {
+        /*
+         * The actual AST traversal is done by the `Traverser` class. This class
+         * is responsible for walking the AST and calling the appropriate methods
+         * on the `analyzer` object, which is appropriate for the given AST.
+         */
+        // Traverser.traverse(this.ast, {
+        //     enter(node, parent) {
 
-                // save the parent node on a property for backwards compatibility
-                node.parent = parent;
+        //         // save the parent node on a property for backwards compatibility
+        //         node.parent = parent;
 
+        //         analyzer.enterNode(node);
+        //     },
+        //     leave(node) {
+        //         analyzer.leaveNode(node);
+        //     },
+        //     visitorKeys: this.visitorKeys
+        // });
+
+        queue.forEach(({ isEntering, node }) => {
+            if (isEntering) {
                 analyzer.enterNode(node);
-            },
-            leave(node) {
+            } else {
                 analyzer.leaveNode(node);
-            },
-            visitorKeys: this.visitorKeys
+            }
         });
 
         return steps;

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -997,7 +997,6 @@ class SourceCode extends TokenStore {
         const emitter = createEmitter();
         let analyzer = {
             enterNode(node, parent) {
-                console.log("enter", node.type)
                 steps.push({
                     type: "visit",
                     target: node,
@@ -1006,7 +1005,6 @@ class SourceCode extends TokenStore {
                 });
             },
             leaveNode(node, parent) {
-                console.log("exit", node.type)
                 steps.push({
                     type: "visit",
                     target: node,
@@ -1021,7 +1019,7 @@ class SourceCode extends TokenStore {
             analyzer = new CodePathAnalyzer(analyzer);
 
             CODE_PATH_EVENTS.forEach(eventName => {
-                emitter.on(eventName, (...args) => {console.log(eventName, args[1].type);
+                emitter.on(eventName, (...args) => {
                     steps.push({
                         type: "call",
                         target: eventName,
@@ -1037,10 +1035,10 @@ class SourceCode extends TokenStore {
                 // save the parent node on a property for backwards compatibility
                 node.parent = parent;
 
-                analyzer.enterNode(node, parent);
+                analyzer.enterNode(node);
             },
-            leave(node, parent) {
-                analyzer.leaveNode(node, parent);
+            leave(node) {
+                analyzer.leaveNode(node);
             },
             visitorKeys: this.visitorKeys
         });

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -314,6 +314,61 @@ function markExportedVariables(globalScope, variables) {
 
 }
 
+/**
+ * A class to represent a step in the traversal process.
+ */
+class TraversalStep {
+
+    /**
+     * The type of the step.
+     * @type {string}
+     */
+    type;
+
+    /**
+     * The kind of the step. Represents the same data as the `type` property
+     * but it's a number for performance.
+     * @type {number}
+     */
+    kind;
+
+    /**
+     * The target of the step.
+     * @type {ASTNode|string}
+     */
+    target;
+
+    /**
+     * The phase of the step.
+     * @type {number|undefined}
+     */
+    phase;
+
+    /**
+     * The arguments of the step.
+     * @type {Array<any>}
+     */
+    args;
+
+    /**
+     * Creates a new instance.
+     * @param {Object} options The options for the step.
+     * @param {string} options.type The type of the step.
+     * @param {number} options.kind The kind of the step.
+     * @param {ASTNode|string} options.target The target of the step.
+     * @param {number|undefined} [options.phase] The phase of the step.
+     * @param {Array<any>} options.args The arguments of the step.
+     * @returns {void}
+     */
+    constructor({ type, kind, target, phase, args }) {
+        this.type = type;
+        this.kind = kind;
+        this.target = target;
+        this.phase = phase;
+        this.args = args;
+    }
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -324,6 +379,12 @@ const caches = Symbol("caches");
  * Represents parsed source code.
  */
 class SourceCode extends TokenStore {
+
+    /**
+     * The cache of steps that were taken while traversing the source code.
+     * @type {Array<TraversalStep>}
+     */
+    #steps;
 
     /**
      * @param {string|Object} textOrConfig The source code text or config object.
@@ -988,11 +1049,16 @@ class SourceCode extends TokenStore {
 
     /**
      * Traverse the source code and return the steps that were taken.
-     * @returns {Array} The steps that were taken while traversing the source code.
+     * @returns {Array<TraversalStep>} The steps that were taken while traversing the source code.
      */
     traverse() {
 
-        const steps = [];
+        // Because the AST doesn't mutate, we can cache the steps
+        if (this.#steps) {
+            return this.#steps;
+        }
+
+        const steps = this.#steps = [];
 
         /*
          * This logic works for any AST, not just ESTree. Because ESLint has allowed
@@ -1002,22 +1068,22 @@ class SourceCode extends TokenStore {
         const emitter = createEmitter();
         let analyzer = {
             enterNode(node, parent) {
-                steps.push({
+                steps.push(new TraversalStep({
                     type: "visit",
                     kind: 1,
                     target: node,
                     phase: 1,
                     args: [node, parent]
-                });
+                }));
             },
             leaveNode(node, parent) {
-                steps.push({
+                steps.push(new TraversalStep({
                     type: "visit",
                     kind: 1,
                     target: node,
                     phase: 2,
                     args: [node, parent]
-                });
+                }));
             },
             emitter
         };
@@ -1038,12 +1104,12 @@ class SourceCode extends TokenStore {
 
             CODE_PATH_EVENTS.forEach(eventName => {
                 emitter.on(eventName, (...args) => {
-                    steps.push({
+                    steps.push(new TraversalStep({
                         type: "call",
                         kind: 2,
                         target: eventName,
                         args
-                    });
+                    }));
                 });
             });
         }

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -972,6 +972,36 @@ class SourceCode extends TokenStore {
 
     }
 
+    traverse() {
+
+        const steps = [];
+
+        Traverser.traverse(this.ast, {
+            enter(node, parent) {
+
+                // save the parent node on a property for backwards compatibility
+                node.parent = parent;
+
+                steps.push({
+                    type: "visit",
+                    target: node,
+                    isEntering: true,
+                    args: [node, parent]
+                });
+            },
+            leave(node, parent) {
+                steps.push({
+                    type: "visit",
+                    target: node,
+                    isEntering: false,
+                    args: [node, parent]
+                });
+            },
+            visitorKeys: this.visitorKeys
+        });
+
+        return steps;
+    }
 }
 
 module.exports = SourceCode;

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -1071,20 +1071,20 @@ class SourceCode extends TokenStore {
          */
         const emitter = createEmitter();
         let analyzer = {
-            enterNode(node, parent) {
+            enterNode(node) {
                 steps.push(new TraversalStep({
                     type: "visit",
                     target: node,
                     phase: 1,
-                    args: [node, parent]
+                    args: [node, node.parent]
                 }));
             },
-            leaveNode(node, parent) {
+            leaveNode(node) {
                 steps.push(new TraversalStep({
                     type: "visit",
                     target: node,
                     phase: 2,
-                    args: [node, parent]
+                    args: [node, node.parent]
                 }));
             },
             emitter

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -993,18 +993,6 @@ class SourceCode extends TokenStore {
     traverse() {
 
         const steps = [];
-        const queue = [];
-
-        Traverser.traverse(this.ast, {
-            enter(node, parent) {
-                node.parent = parent;
-                queue.push({ isEntering: true, node });
-            },
-            leave(node) {
-                queue.push({ isEntering: false, node });
-            },
-            visitorKeys: this.visitorKeys
-        });
 
         /*
          * This logic works for any AST, not just ESTree. Because ESLint has allowed
@@ -1016,16 +1004,18 @@ class SourceCode extends TokenStore {
             enterNode(node, parent) {
                 steps.push({
                     type: "visit",
+                    kind: 1,
                     target: node,
-                    isEntering: true,
+                    phase: 1,
                     args: [node, parent]
                 });
             },
             leaveNode(node, parent) {
                 steps.push({
                     type: "visit",
+                    kind: 1,
                     target: node,
-                    isEntering: false,
+                    phase: 2,
                     args: [node, parent]
                 });
             },
@@ -1050,6 +1040,7 @@ class SourceCode extends TokenStore {
                 emitter.on(eventName, (...args) => {
                     steps.push({
                         type: "call",
+                        kind: 2,
                         target: eventName,
                         args
                     });
@@ -1062,26 +1053,18 @@ class SourceCode extends TokenStore {
          * is responsible for walking the AST and calling the appropriate methods
          * on the `analyzer` object, which is appropriate for the given AST.
          */
-        // Traverser.traverse(this.ast, {
-        //     enter(node, parent) {
+        Traverser.traverse(this.ast, {
+            enter(node, parent) {
 
-        //         // save the parent node on a property for backwards compatibility
-        //         node.parent = parent;
+                // save the parent node on a property for backwards compatibility
+                node.parent = parent;
 
-        //         analyzer.enterNode(node);
-        //     },
-        //     leave(node) {
-        //         analyzer.leaveNode(node);
-        //     },
-        //     visitorKeys: this.visitorKeys
-        // });
-
-        queue.forEach(({ isEntering, node }) => {
-            if (isEntering) {
                 analyzer.enterNode(node);
-            } else {
+            },
+            leave(node) {
                 analyzer.leaveNode(node);
-            }
+            },
+            visitorKeys: this.visitorKeys
         });
 
         return steps;

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -13944,7 +13944,7 @@ var a = "test2";
                     const code = "switch (foo) { case 0: a(); \n// eslint-disable-next-line no-fallthrough\n case 1: }";
                     const config = {
                         linterOptions: {
-                            reportUnusedDisableDirectives: true,
+                            reportUnusedDisableDirectives: true
                         },
                         rules: {
                             "no-fallthrough": 2

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -13940,6 +13940,30 @@ var a = "test2";
                     assert.strictEqual(suppressedMessages.length, 0);
                 });
 
+                it("reports no problems for no-fallthrough despite comment pattern match", () => {
+                    const code = "switch (foo) { case 0: a(); \n// eslint-disable-next-line no-fallthrough\n case 1: }";
+                    const config = {
+                        linterOptions: {
+                            reportUnusedDisableDirectives: true,
+                        },
+                        rules: {
+                            "no-fallthrough": 2
+                        }
+                    };
+
+                    const messages = linter.verify(code, config, {
+                        filename,
+                        allowInlineConfig: true
+                    });
+                    const suppressedMessages = linter.getSuppressedMessages();
+
+                    assert.strictEqual(messages.length, 0);
+
+                    assert.strictEqual(suppressedMessages.length, 1);
+                    assert.strictEqual(suppressedMessages[0].ruleId, "no-fallthrough");
+                });
+
+
                 describe("autofix", () => {
                     const alwaysReportsRule = {
                         create(context) {

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -272,6 +272,19 @@ ruleTester.run("constructor-super", rule, {
                 }
             }`,
             errors: [{ messageId: "missingAll", type: "MethodDefinition" }]
+        },
+
+        {
+            code: `class C extends D {
+
+                constructor() {
+                    do {
+                        something();
+                    } while (foo);
+                }
+
+            }`,
+            errors: [{ messageId: "missingAll", type: "MethodDefinition" }]
         }
     ]
 });

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -50,7 +50,7 @@ ruleTester.run("no-useless-return", rule, {
             }
           }
         `,
-        `
+        { code: `
           function foo() {
             switch (bar) {
               default:
@@ -60,7 +60,7 @@ ruleTester.run("no-useless-return", rule, {
                 doSomethingElse();
             }
           }
-        `,
+        `, only: true },
         `
           function foo() {
             switch (bar) {
@@ -581,7 +581,7 @@ ruleTester.run("no-useless-return", rule, {
             languageOptions: { ecmaVersion: 6 }
         },
         {
-            code: "function foo() { return; return; }",only: true,
+            code: "function foo() { return; return; }",
             output: "function foo() {  return; }",
             errors: [
                 {

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -50,7 +50,7 @@ ruleTester.run("no-useless-return", rule, {
             }
           }
         `,
-        { code: `
+        `
           function foo() {
             switch (bar) {
               default:
@@ -60,7 +60,7 @@ ruleTester.run("no-useless-return", rule, {
                 doSomethingElse();
             }
           }
-        `, only: true },
+        `,
         `
           function foo() {
             switch (bar) {
@@ -263,7 +263,7 @@ ruleTester.run("no-useless-return", rule, {
             output: `
               function foo() {
                 if (foo) {
-
+                  
                 }
                 return;
               }
@@ -292,7 +292,7 @@ ruleTester.run("no-useless-return", rule, {
                     doSomething();
                   default:
                     doSomethingElse();
-
+                    
                 }
               }
             `
@@ -316,7 +316,7 @@ ruleTester.run("no-useless-return", rule, {
                     doSomething();
                   case 1:
                     doSomething();
-
+                    
                 }
               }
             `
@@ -342,7 +342,7 @@ ruleTester.run("no-useless-return", rule, {
                   case 1:
                     if (a) {
                       doSomething();
-
+                      
                     }
                     break;
                   default:
@@ -374,7 +374,7 @@ ruleTester.run("no-useless-return", rule, {
                   case 1:
                     if (a) {
                       doSomething();
-
+                      
                     } else {
                       doSomething();
                     }
@@ -404,7 +404,7 @@ ruleTester.run("no-useless-return", rule, {
                   case 1:
                     if (a) {
                       doSomething();
-
+                      
                     }
                   default:
                 }
@@ -438,7 +438,7 @@ ruleTester.run("no-useless-return", rule, {
               function foo() {
                 try {
                   foo();
-
+                  
                 } catch (err) {
                   return 5;
                 }
@@ -461,7 +461,7 @@ ruleTester.run("no-useless-return", rule, {
                   if (something) {
                       try {
                           bar();
-
+                          
                       } catch (err) {}
                   }
               }
@@ -480,7 +480,7 @@ ruleTester.run("no-useless-return", rule, {
             output: `
               function foo() {
                 try {
-
+                  
                 } catch (err) {
                   foo();
                 }
@@ -500,7 +500,7 @@ ruleTester.run("no-useless-return", rule, {
             output: `
               function foo() {
                   try {
-
+                      
                   } finally {
                       bar();
                   }
@@ -529,7 +529,7 @@ ruleTester.run("no-useless-return", rule, {
                 } catch (e) {
                   try {
                     baz();
-
+                    
                   } catch (e) {
                     qux();
                   }
@@ -547,7 +547,7 @@ ruleTester.run("no-useless-return", rule, {
             output: `
               function foo() {
                 try {} finally {}
-
+                
               }
             `
         },
@@ -569,7 +569,7 @@ ruleTester.run("no-useless-return", rule, {
                   return 5;
                 } finally {
                   function bar() {
-
+                    
                   }
                 }
               }

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -263,7 +263,7 @@ ruleTester.run("no-useless-return", rule, {
             output: `
               function foo() {
                 if (foo) {
-                  
+
                 }
                 return;
               }
@@ -292,7 +292,7 @@ ruleTester.run("no-useless-return", rule, {
                     doSomething();
                   default:
                     doSomethingElse();
-                    
+
                 }
               }
             `
@@ -316,7 +316,7 @@ ruleTester.run("no-useless-return", rule, {
                     doSomething();
                   case 1:
                     doSomething();
-                    
+
                 }
               }
             `
@@ -342,7 +342,7 @@ ruleTester.run("no-useless-return", rule, {
                   case 1:
                     if (a) {
                       doSomething();
-                      
+
                     }
                     break;
                   default:
@@ -374,7 +374,7 @@ ruleTester.run("no-useless-return", rule, {
                   case 1:
                     if (a) {
                       doSomething();
-                      
+
                     } else {
                       doSomething();
                     }
@@ -404,7 +404,7 @@ ruleTester.run("no-useless-return", rule, {
                   case 1:
                     if (a) {
                       doSomething();
-                      
+
                     }
                   default:
                 }
@@ -438,7 +438,7 @@ ruleTester.run("no-useless-return", rule, {
               function foo() {
                 try {
                   foo();
-                  
+
                 } catch (err) {
                   return 5;
                 }
@@ -461,7 +461,7 @@ ruleTester.run("no-useless-return", rule, {
                   if (something) {
                       try {
                           bar();
-                          
+
                       } catch (err) {}
                   }
               }
@@ -480,7 +480,7 @@ ruleTester.run("no-useless-return", rule, {
             output: `
               function foo() {
                 try {
-                  
+
                 } catch (err) {
                   foo();
                 }
@@ -500,7 +500,7 @@ ruleTester.run("no-useless-return", rule, {
             output: `
               function foo() {
                   try {
-                      
+
                   } finally {
                       bar();
                   }
@@ -529,7 +529,7 @@ ruleTester.run("no-useless-return", rule, {
                 } catch (e) {
                   try {
                     baz();
-                    
+
                   } catch (e) {
                     qux();
                   }
@@ -547,7 +547,7 @@ ruleTester.run("no-useless-return", rule, {
             output: `
               function foo() {
                 try {} finally {}
-                
+
               }
             `
         },
@@ -569,7 +569,7 @@ ruleTester.run("no-useless-return", rule, {
                   return 5;
                 } finally {
                   function bar() {
-                    
+
                   }
                 }
               }
@@ -581,7 +581,7 @@ ruleTester.run("no-useless-return", rule, {
             languageOptions: { ecmaVersion: 6 }
         },
         {
-            code: "function foo() { return; return; }",
+            code: "function foo() { return; return; }",only: true,
             output: "function foo() {  return; }",
             errors: [
                 {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Moved AST traversal out of `Linter` and into `SourceCode#traverse()`. 
- Updated `no-useless-returns`, `constructor-super`, and `no-this-before-super` to they still work. These rules were also tested against v8.57.0 to ensure that such changes would be backwards compatible.
- Updated the v9 migration guide

Refs #16999 

#### Is there anything you'd like reviewers to focus on?

I deviated from the [RFC](https://github.com/eslint/rfcs/tree/main/designs/2022-languages) in how I represented the traversal steps. I realized while implementing that relying on `type` and `phase` as string comparisons would be a big performance hit, so I added the `kind` property as a number (keeping `type` for easier debugging, though not sure if that's needed) and switched `phase` to a number. That saves us a lot of string comparisons during traversal.

<!-- markdownlint-disable-file MD004 -->
