### PR TITLE
feat: add `ignoreClassWithStaticInitBlock` option to `no-unused-vars`

### DIFF
--- a/docs/src/rules/no-unused-vars.md
+++ b/docs/src/rules/no-unused-vars.md
@@ -410,6 +410,51 @@ var bar;
 
 :::
 
+### ignoreClassWithStaticInitBlock
+
+The `ignoreClassWithStaticInitBlock` option is a boolean (default: `false`). Static initialization blocks or Static blocks was introduced in ES2022. Static blocks lets us to initialize static variables and execute code during the evaluation of defined class. It means that one don't need to create an instance of class to run the code written inside the static block. This option ignore the classes with static initialization block when sets to `true`.
+
+Examples of **incorrect** code for the `{ "ignoreClassWithStaticInitBlock": true }` option
+
+::: incorrect
+
+```js
+/*eslint no-unused-vars: ["error", { "ignoreClassWithStaticInitBlock": true }]*/
+
+class Foo {
+    static myProperty = "some string";
+    static mymethod() {
+        return "some string";
+    }
+}
+
+class Bar {
+    static {
+        let baz; // unused variable
+    }
+}
+```
+
+:::
+
+Examples of **correct** code for the `{ "ignoreClassWithStaticInitBlock": true }` option
+
+::: correct
+
+```js
+/*eslint no-unused-vars: ["error", { "ignoreClassWithStaticInitBlock": true }]*/
+
+class Foo {
+    static {
+        let bar = "some string";
+
+        console.log(bar);
+    }
+}
+```
+
+:::
+
 ## When Not To Use It
 
 If you don't want to be notified about unused variables or function arguments, you can safely turn this rule off.

--- a/docs/src/rules/no-unused-vars.md
+++ b/docs/src/rules/no-unused-vars.md
@@ -412,7 +412,7 @@ var bar;
 
 ### ignoreClassWithStaticInitBlock
 
-The `ignoreClassWithStaticInitBlock` option is a boolean (default: `false`). Static initialization blocks or Static blocks was introduced in ES2022. Static blocks lets us to initialize static variables and execute code during the evaluation of defined class. It means that one don't need to create an instance of class to run the code written inside the static block. This option ignore the classes with static initialization block when sets to `true`.
+The `ignoreClassWithStaticInitBlock` option is a boolean (default: `false`). Static initialization blocks allow you to initialize static variables and execute code during the evaluation of a class definition, meaning the static block code is executed without creating a new instance of the class. When set to `true`, this option ignores classes containing static initialization blocks.
 
 Examples of **incorrect** code for the `{ "ignoreClassWithStaticInitBlock": true }` option
 

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -619,7 +619,7 @@ module.exports = {
                         }
 
                         if (type === "ClassName") {
-                            const hasStaticBlock = def.node.body.body.filter(node => node.type === "StaticBlock");
+                            const hasStaticBlock = def.node.body.body.some(node => node.type === "StaticBlock");
 
                             if (config.ignoreClassWithStaticInitBlock && hasStaticBlock) {
                                 continue;

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -70,6 +70,9 @@ module.exports = {
                             },
                             destructuredArrayIgnorePattern: {
                                 type: "string"
+                            },
+                            ignoreClassWithStaticInitBlock: {
+                                type: "boolean"
                             }
                         },
                         additionalProperties: false
@@ -92,7 +95,8 @@ module.exports = {
             vars: "all",
             args: "after-used",
             ignoreRestSiblings: false,
-            caughtErrors: "all"
+            caughtErrors: "all",
+            ignoreClassWithStaticInitBlock: false
         };
 
         const firstOption = context.options[0];
@@ -105,6 +109,7 @@ module.exports = {
                 config.args = firstOption.args || config.args;
                 config.ignoreRestSiblings = firstOption.ignoreRestSiblings || config.ignoreRestSiblings;
                 config.caughtErrors = firstOption.caughtErrors || config.caughtErrors;
+                config.ignoreClassWithStaticInitBlock = firstOption.ignoreClassWithStaticInitBlock || config.ignoreClassWithStaticInitBlock;
 
                 if (firstOption.varsIgnorePattern) {
                     config.varsIgnorePattern = new RegExp(firstOption.varsIgnorePattern, "u");
@@ -611,6 +616,14 @@ module.exports = {
                             config.destructuredArrayIgnorePattern.test(def.name.name)
                         ) {
                             continue;
+                        }
+
+                        if (type === "ClassName") {
+                            const hasStaticBlock = def.node.body.body.filter(node => node.type === "StaticBlock");
+
+                            if (config.ignoreClassWithStaticInitBlock && hasStaticBlock) {
+                                continue;
+                            }
                         }
 
                         // skip catch variables

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -445,6 +445,21 @@ ruleTester.run("no-unused-vars", rule, {
         {
             code: "var a; a ??= 1;",
             languageOptions: { ecmaVersion: 2021 }
+        },
+        {
+            code: "class Foo { static {} }",
+            options: [{ ignoreClassWithStaticInitBlock: true }],
+            languageOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class Foo { static {} }",
+            options: [{ ignoreClassWithStaticInitBlock: true, varsIgnorePattern: "^_" }],
+            languageOptions: { ecmaVersion: 2022 }
+        },
+        {
+            code: "class Foo { static {} }",
+            options: [{ ignoreClassWithStaticInitBlock: false, varsIgnorePattern: "^Foo" }],
+            languageOptions: { ecmaVersion: 2022 }
         }
     ],
     invalid: [
@@ -1557,6 +1572,18 @@ function foo1() {
 c = foo1`,
             languageOptions: { ecmaVersion: 2020 },
             errors: [{ ...assignedError("c"), line: 10, column: 1 }]
+        },
+        {
+            code: "class Foo { static {} }",
+            options: [{ ignoreClassWithStaticInitBlock: false }],
+            languageOptions: { ecmaVersion: 2022 },
+            errors: [{ ...definedError("Foo"), line: 1, column: 7 }]
+        },
+        {
+            code: "class Foo { static { var bar; } }",
+            options: [{ ignoreClassWithStaticInitBlock: true }],
+            languageOptions: { ecmaVersion: 2022 },
+            errors: [{ ...definedError("bar"), line: 1, column: 26 }]
         }
     ]
 });

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -1601,7 +1601,14 @@ c = foo1`,
             errors: [{ ...definedError("Foo"), line: 1, column: 7 }]
         },
         {
-            code: "class Foo { static bar }",
+            code: "class Foo { static bar; }",
+            options: [{ ignoreClassWithStaticInitBlock: true }],
+            languageOptions: { ecmaVersion: 2022 },
+            errors: [{ ...definedError("Foo"), line: 1, column: 7 }]
+        },
+        {
+            code: "class Foo { static bar() {} }",
+            options: [{ ignoreClassWithStaticInitBlock: true }],
             languageOptions: { ecmaVersion: 2022 },
             errors: [{ ...definedError("Foo"), line: 1, column: 7 }]
         }

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -446,6 +446,8 @@ ruleTester.run("no-unused-vars", rule, {
             code: "var a; a ??= 1;",
             languageOptions: { ecmaVersion: 2021 }
         },
+
+        // ignore class with static initialization block https://github.com/eslint/eslint/issues/17772
         {
             code: "class Foo { static {} }",
             options: [{ ignoreClassWithStaticInitBlock: true }],
@@ -1573,9 +1575,16 @@ c = foo1`,
             languageOptions: { ecmaVersion: 2020 },
             errors: [{ ...assignedError("c"), line: 10, column: 1 }]
         },
+
+        // ignore class with static initialization block https://github.com/eslint/eslint/issues/17772
         {
             code: "class Foo { static {} }",
             options: [{ ignoreClassWithStaticInitBlock: false }],
+            languageOptions: { ecmaVersion: 2022 },
+            errors: [{ ...definedError("Foo"), line: 1, column: 7 }]
+        },
+        {
+            code: "class Foo { static {} }",
             languageOptions: { ecmaVersion: 2022 },
             errors: [{ ...definedError("Foo"), line: 1, column: 7 }]
         },
@@ -1584,6 +1593,17 @@ c = foo1`,
             options: [{ ignoreClassWithStaticInitBlock: true }],
             languageOptions: { ecmaVersion: 2022 },
             errors: [{ ...definedError("bar"), line: 1, column: 26 }]
+        },
+        {
+            code: "class Foo {}",
+            options: [{ ignoreClassWithStaticInitBlock: true }],
+            languageOptions: { ecmaVersion: 2022 },
+            errors: [{ ...definedError("Foo"), line: 1, column: 7 }]
+        },
+        {
+            code: "class Foo { static bar }",
+            languageOptions: { ecmaVersion: 2022 },
+            errors: [{ ...definedError("Foo"), line: 1, column: 7 }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

 **What rule do you want to change?**
`no-unused-vars`

**What change do you want to make (place an "X" next to just one item)?**

[ ] Generate more warnings
[x] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[x] A new option
[ ] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
/* eslint no-unused-vars: "error" */

class ClassWithSIB {
  static {
    // …
  }
}
```

**What does the rule currently do for this code?**
rule reports this code.

**What will the rule do after it's changed?**
rule will not report the classes as unused that have static initialization block.

#### What changes did you make? (Give an overview)
added a new option called `ignoreClassWithStaticInitBlock` that is a boolean and by default it is `false`
#### Is there anything you'd like reviewers to focus on?
Fixes: #17772
<!-- markdownlint-disable-file MD004 -->
