### PR TITLE
feat: use env npm_execpath instead hardcode "npm" spawn process

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -143,9 +143,9 @@ ${getErrorMessage(error)}`;
         console.warn("You can also run this command directly using 'npm init @eslint/config'.");
 
         const spawn = require("cross-spawn");
-        const npm_execpath = process.env.npm_execpath || "npm";
+        const npm = process.env.npm_execpath || "npm";
 
-        spawn.sync(npm_execpath, ["init", "@eslint/config"], { encoding: "utf8", stdio: "inherit" });
+        spawn.sync(npm, ["init", "@eslint/config"], { encoding: "utf8", stdio: "inherit" });
         return;
     }
 

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -143,8 +143,9 @@ ${getErrorMessage(error)}`;
         console.warn("You can also run this command directly using 'npm init @eslint/config'.");
 
         const spawn = require("cross-spawn");
+        const npm_execpath = process.env.npm_execpath || "npm";
 
-        spawn.sync("npm", ["init", "@eslint/config"], { encoding: "utf8", stdio: "inherit" });
+        spawn.sync(npm_execpath, ["init", "@eslint/config"], { encoding: "utf8", stdio: "inherit" });
         return;
     }
 


### PR DESCRIPTION
**Tell us about your environment (`npx eslint --env-info`):**

* **Node version:** v21.0.0
* **npm version:** v10.2.0
* **Local ESLint version:** Not found
* **Global ESLint version:** Not found
* **Operating System:** linux 5.15.0-97-generic

**What parser are you using (place an "X" next to just one item)?**

[X] `Default (Espree)`

**What did you do? Please include the actual source code causing the issue.**

Add better support to other runimes like **deno** and **bun**.

 * <https://github.com/oven-sh/bun/issues/6728#issuecomment-1981794486>

**What did you expect to happen?**

accept other runtimes as defined by the programmer's environment variables.

**What actually happened? Please include the actual, raw output from ESLint.**

An error occurs when node/npm is not installed (like in **bun** containers)

```
$ bunx eslint . --init
You can also run this command directly using 'npm init @eslint/config'.

Oops! Something went wrong! :(

ESLint: 8.52.0

TypeError: Executable not found in $PATH: "npm"
    at spawnSync (native)
    at <anonymous> (node:child_process:171:24)
    at spawnSync (/tmp/eslint--bunx/node_modules/cross-spawn/index.js:28:59)
    at <anonymous> (/tmp/eslint--bunx/node_modules/eslint/bin/eslint.js:141:8)
    at main (/tmp/eslint--bunx/node_modules/eslint/bin/eslint.js:129:15)
    at <anonymous> (/tmp/eslint--bunx/node_modules/eslint/bin/eslint.js:150:23)
    at global code (/tmp/eslint--bunx/node_modules/eslint/bin/eslint.js:45:8)
```