### PR TITLE
fix: load plugins in the CLI in flat config mode

### DIFF
--- a/docs/src/extend/plugins.md
+++ b/docs/src/extend/plugins.md
@@ -36,6 +36,8 @@ export default plugin;
 module.exports = plugin;
 ```
 
+If you plan to distribute your plugin as an npm package, make sure that the module that exports the plugin object is the default export of your package. This will enable ESLint to import the plugin when it is specified in the command line in the `--plugin` option.
+
 ### Meta Data in Plugins
 
 For easier debugging and more effective caching of plugins, it's recommended to provide a name and version in a `meta` object at the root of your plugin, like this:

--- a/docs/src/extend/plugins.md
+++ b/docs/src/extend/plugins.md
@@ -36,7 +36,7 @@ export default plugin;
 module.exports = plugin;
 ```
 
-If you plan to distribute your plugin as an npm package, make sure that the module that exports the plugin object is the default export of your package. This will enable ESLint to import the plugin when it is specified in the command line in the `--plugin` option.
+If you plan to distribute your plugin as an npm package, make sure that the module that exports the plugin object is the default export of your package. This will enable ESLint to import the plugin when it is specified in the command line in the [`--plugin` option](../use/command-line-interface#--plugin).
 
 ### Meta Data in Plugins
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -59,13 +59,15 @@ async function loadPlugins(importer, pluginNames) {
 
     await Promise.all(pluginNames.map(async pluginName => {
 
-        const shortName = naming.getShorthandName(pluginName, "eslint-plugin");
         const longName = naming.normalizePackageName(pluginName, "eslint-plugin");
         const module = await importer.import(longName);
 
         if (!("default" in module)) {
-            throw Error(`"${longName}" cannot be imported because it does not provide a default export`);
+            throw new Error(`"${longName}" cannot be imported because it does not provide a default export`);
         }
+
+        const shortName = naming.getShorthandName(pluginName, "eslint-plugin");
+
         plugins[shortName] = module.default;
     }));
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -63,7 +63,7 @@ async function loadPlugins(importer, pluginNames) {
         const module = await importer.import(longName);
 
         if (!("default" in module)) {
-            throw new Error(`"${longName}" cannot be imported because it does not provide a default export`);
+            throw new Error(`"${longName}" cannot be used with the \`--plugin\` option because its default module does not provide a \`default\` export`);
         }
 
         const shortName = naming.getShorthandName(pluginName, "eslint-plugin");

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -37,6 +37,7 @@ const debug = require("debug")("eslint:cli");
 /** @typedef {import("./eslint/eslint").LintMessage} LintMessage */
 /** @typedef {import("./eslint/eslint").LintResult} LintResult */
 /** @typedef {import("./options").ParsedCLIOptions} ParsedCLIOptions */
+/** @typedef {import("./shared/types").Plugin} Plugin */
 /** @typedef {import("./shared/types").ResultsMeta} ResultsMeta */
 
 //------------------------------------------------------------------------------
@@ -46,6 +47,30 @@ const debug = require("debug")("eslint:cli");
 const mkdir = promisify(fs.mkdir);
 const stat = promisify(fs.stat);
 const writeFile = promisify(fs.writeFile);
+
+/**
+ * Loads plugins with the specified names.
+ * @param {{ "import": (name: string) => Promise<any> }} importer An object with an `import` method called once for each plugin.
+ * @param {string[]} pluginNames The names of the plugins to be loaded, with or without the "eslint-plugin-" prefix.
+ * @returns {Promise<Record<string, Plugin>>} A mapping of plugin short names to implementations.
+ */
+async function loadPlugins(importer, pluginNames) {
+    const plugins = {};
+
+    await Promise.all(pluginNames.map(async pluginName => {
+
+        const shortName = naming.getShorthandName(pluginName, "eslint-plugin");
+        const longName = naming.normalizePackageName(pluginName, "eslint-plugin");
+        const module = await importer.import(longName);
+
+        if (!("default" in module)) {
+            throw Error(`"${longName}" cannot be imported because it does not provide a default export`);
+        }
+        plugins[shortName] = module.default;
+    }));
+
+    return plugins;
+}
 
 /**
  * Predicate function for whether or not to apply fixes in quiet mode.
@@ -152,17 +177,7 @@ async function translateOptions({
         }
 
         if (plugin) {
-            const plugins = {};
-
-            for (const pluginName of plugin) {
-
-                const shortName = naming.getShorthandName(pluginName, "eslint-plugin");
-                const longName = naming.normalizePackageName(pluginName, "eslint-plugin");
-
-                plugins[shortName] = await importer.import(longName);
-            }
-
-            overrideConfig[0].plugins = plugins;
+            overrideConfig[0].plugins = await loadPlugins(importer, plugin);
         }
 
     } else {

--- a/tests/fixtures/plugins/node_modules/@scope/eslint-plugin-example.js
+++ b/tests/fixtures/plugins/node_modules/@scope/eslint-plugin-example.js
@@ -1,0 +1,11 @@
+const plugin = {
+    rules: {
+        test: {
+            create() {
+                return { };
+            }
+        }
+    },
+};
+
+module.exports = plugin;

--- a/tests/fixtures/plugins/node_modules/eslint-plugin-hello-cjs/index.js
+++ b/tests/fixtures/plugins/node_modules/eslint-plugin-hello-cjs/index.js
@@ -1,0 +1,15 @@
+const plugin = {
+    rules: {
+        hello: {
+            create(context) {
+                return {
+                    Program(node) {
+                        context.report({ node, message: 'Hello CommonJS!' });
+                    }
+                };
+            }
+        }
+    },
+};
+
+module.exports = plugin;

--- a/tests/fixtures/plugins/node_modules/eslint-plugin-hello-cjs/package.json
+++ b/tests/fixtures/plugins/node_modules/eslint-plugin-hello-cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/tests/fixtures/plugins/node_modules/eslint-plugin-hello-esm/index.js
+++ b/tests/fixtures/plugins/node_modules/eslint-plugin-hello-esm/index.js
@@ -1,0 +1,15 @@
+const plugin = {
+    rules: {
+        hello: {
+            create(context) {
+                return {
+                    Program(node) {
+                        context.report({ node, message: 'Hello ESM!' });
+                    }
+                };
+            }
+        }
+    },
+};
+
+export default plugin;

--- a/tests/fixtures/plugins/node_modules/eslint-plugin-hello-esm/package.json
+++ b/tests/fixtures/plugins/node_modules/eslint-plugin-hello-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/fixtures/plugins/node_modules/eslint-plugin-no-default-export/index.js
+++ b/tests/fixtures/plugins/node_modules/eslint-plugin-no-default-export/index.js
@@ -1,0 +1,12 @@
+export const meta = {
+    name: "eslint-plugin-no-default-export",
+    version: "1.2.3"
+};
+
+export const rules = {
+    rule: {
+        create() {
+            return {};
+        }
+    }
+};

--- a/tests/fixtures/plugins/node_modules/eslint-plugin-no-default-export/package.json
+++ b/tests/fixtures/plugins/node_modules/eslint-plugin-no-default-export/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -1850,7 +1850,7 @@ describe("cli", () => {
 
                 await stdAssert.rejects(
                     cli.execute(code, null, true),
-                    { message: '"eslint-plugin-no-default-export" cannot be imported because it does not provide a default export' }
+                    { message: '"eslint-plugin-no-default-export" cannot be used with the `--plugin` option because its default module does not provide a `default` export' }
                 );
             });
         });

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -1649,105 +1649,6 @@ describe("cli", () => {
             });
         });
 
-        describe("flat Only", () => {
-
-            describe("`--plugin` option", () => {
-
-                let originalCwd;
-
-                beforeEach(() => {
-                    originalCwd = process.cwd();
-                    process.chdir(getFixturePath("plugins"));
-                });
-
-                afterEach(() => {
-                    process.chdir(originalCwd);
-                    originalCwd = void 0;
-                });
-
-                it("should load a plugin from a CommonJS package", async () => {
-                    const code = "--plugin hello-cjs --rule 'hello-cjs/hello: error' ../files/*.js";
-
-                    const exitCode = await cli.execute(code, null, true);
-
-                    assert.strictEqual(exitCode, 1);
-                    assert.ok(log.info.calledOnce);
-                    assert.include(log.info.firstCall.firstArg, "Hello CommonJS!");
-                });
-
-                it("should load a plugin from an ESM package", async () => {
-                    const code = "--plugin hello-esm --rule 'hello-esm/hello: error' ../files/*.js";
-
-                    const exitCode = await cli.execute(code, null, true);
-
-                    assert.strictEqual(exitCode, 1);
-                    assert.ok(log.info.calledOnce);
-                    assert.include(log.info.firstCall.firstArg, "Hello ESM!");
-                });
-
-                it("should load multiple plugins", async () => {
-                    const code = "--plugin 'hello-cjs, hello-esm' --rule 'hello-cjs/hello: warn, hello-esm/hello: error' ../files/*.js";
-
-                    const exitCode = await cli.execute(code, null, true);
-
-                    assert.strictEqual(exitCode, 1);
-                    assert.ok(log.info.calledOnce);
-                    assert.include(log.info.firstCall.firstArg, "Hello CommonJS!");
-                    assert.include(log.info.firstCall.firstArg, "Hello ESM!");
-                });
-
-                it("should resolve plugins specified with 'eslint-plugin-'", async () => {
-                    const code = "--plugin 'eslint-plugin-schema-array, @scope/eslint-plugin-example' --rule 'schema-array/rule1: warn, @scope/example/test: warn' ../passing.js";
-
-                    const exitCode = await cli.execute(code, null, true);
-
-                    assert.strictEqual(exitCode, 0);
-                });
-
-                it("should resolve plugins in the parent directory's node_module subdirectory", async () => {
-                    process.chdir("subdir");
-                    const code = "--plugin 'example, @scope/example' file.js";
-
-                    const exitCode = await cli.execute(code, null, true);
-
-                    assert.strictEqual(exitCode, 0);
-                });
-
-                it("should fail if a plugin is not found", async () => {
-                    const code = "--plugin 'example, no-such-plugin' ../passing.js";
-
-                    await stdAssert.rejects(
-                        cli.execute(code, null, true),
-                        ({ message }) => {
-                            assert(
-                                message.startsWith("Cannot find module 'eslint-plugin-no-such-plugin'\n"),
-                                `Unexpected error message:\n${message}`
-                            );
-                            return true;
-                        }
-                    );
-                });
-
-                it("should fail if a plugin throws an error while loading", async () => {
-                    const code = "--plugin 'example, throws-on-load' ../passing.js";
-
-                    await stdAssert.rejects(
-                        cli.execute(code, null, true),
-                        { message: "error thrown while loading this module" }
-                    );
-                });
-
-                it("should fail to load a plugin from a package without a default export", async () => {
-                    const code = "--plugin 'example, no-default-export' ../passing.js";
-
-                    await stdAssert.rejects(
-                        cli.execute(code, null, true),
-                        { message: '"eslint-plugin-no-default-export" cannot be imported because it does not provide a default export' }
-                    );
-                });
-            });
-        });
-
         describe("when loading a custom rule", () => {
             it("should return an error when rule isn't found", async () => {
                 const rulesPath = getFixturePath("rules", "wrong");
@@ -1855,5 +1756,104 @@ describe("cli", () => {
 
     });
 
+
+    describe("flat Only", () => {
+
+        describe("`--plugin` option", () => {
+
+            let originalCwd;
+
+            beforeEach(() => {
+                originalCwd = process.cwd();
+                process.chdir(getFixturePath("plugins"));
+            });
+
+            afterEach(() => {
+                process.chdir(originalCwd);
+                originalCwd = void 0;
+            });
+
+            it("should load a plugin from a CommonJS package", async () => {
+                const code = "--plugin hello-cjs --rule 'hello-cjs/hello: error' ../files/*.js";
+
+                const exitCode = await cli.execute(code, null, true);
+
+                assert.strictEqual(exitCode, 1);
+                assert.ok(log.info.calledOnce);
+                assert.include(log.info.firstCall.firstArg, "Hello CommonJS!");
+            });
+
+            it("should load a plugin from an ESM package", async () => {
+                const code = "--plugin hello-esm --rule 'hello-esm/hello: error' ../files/*.js";
+
+                const exitCode = await cli.execute(code, null, true);
+
+                assert.strictEqual(exitCode, 1);
+                assert.ok(log.info.calledOnce);
+                assert.include(log.info.firstCall.firstArg, "Hello ESM!");
+            });
+
+            it("should load multiple plugins", async () => {
+                const code = "--plugin 'hello-cjs, hello-esm' --rule 'hello-cjs/hello: warn, hello-esm/hello: error' ../files/*.js";
+
+                const exitCode = await cli.execute(code, null, true);
+
+                assert.strictEqual(exitCode, 1);
+                assert.ok(log.info.calledOnce);
+                assert.include(log.info.firstCall.firstArg, "Hello CommonJS!");
+                assert.include(log.info.firstCall.firstArg, "Hello ESM!");
+            });
+
+            it("should resolve plugins specified with 'eslint-plugin-'", async () => {
+                const code = "--plugin 'eslint-plugin-schema-array, @scope/eslint-plugin-example' --rule 'schema-array/rule1: warn, @scope/example/test: warn' ../passing.js";
+
+                const exitCode = await cli.execute(code, null, true);
+
+                assert.strictEqual(exitCode, 0);
+            });
+
+            it("should resolve plugins in the parent directory's node_module subdirectory", async () => {
+                process.chdir("subdir");
+                const code = "--plugin 'example, @scope/example' file.js";
+
+                const exitCode = await cli.execute(code, null, true);
+
+                assert.strictEqual(exitCode, 0);
+            });
+
+            it("should fail if a plugin is not found", async () => {
+                const code = "--plugin 'example, no-such-plugin' ../passing.js";
+
+                await stdAssert.rejects(
+                    cli.execute(code, null, true),
+                    ({ message }) => {
+                        assert(
+                            message.startsWith("Cannot find module 'eslint-plugin-no-such-plugin'\n"),
+                            `Unexpected error message:\n${message}`
+                        );
+                        return true;
+                    }
+                );
+            });
+
+            it("should fail if a plugin throws an error while loading", async () => {
+                const code = "--plugin 'example, throws-on-load' ../passing.js";
+
+                await stdAssert.rejects(
+                    cli.execute(code, null, true),
+                    { message: "error thrown while loading this module" }
+                );
+            });
+
+            it("should fail to load a plugin from a package without a default export", async () => {
+                const code = "--plugin 'example, no-default-export' ../passing.js";
+
+                await stdAssert.rejects(
+                    cli.execute(code, null, true),
+                    { message: '"eslint-plugin-no-default-export" cannot be imported because it does not provide a default export' }
+                );
+            });
+        });
+    });
 
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #18159 

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The changes in this PR relate to how the CLI option `--plugin` works in flat config mode:

* When a plugin is loaded, the `default` property of the imported module is now used. This aligns the plugin loading behavior with eslintrc and with the recommendations for creating a custom plugin.
* A specific error message is printed if a plugin has no default export.
* Multiple plugins are loaded concurrently.

This PR also adds unit tests and a new note to the custom plugins docs.

#### Is there anything you'd like reviewers to focus on?

Some of the new unit tests in this PR, the ones with CommonJS plugins, can be generalized to cover the eslintrc case. Do we want to add tests for eslintrc to make sure that the behavior in flat config mode is similar?

<!-- markdownlint-disable-file MD004 -->
