### PR TITLE
fix: allow the usage of |= 0 when int32Hint is enabled, `no-bitwise`

### DIFF
--- a/docs/src/rules/no-bitwise.md
+++ b/docs/src/rules/no-bitwise.md
@@ -100,7 +100,8 @@ Examples of **correct** code for this rule with the `{ "int32Hint": true }` opti
 ```js
 /*eslint no-bitwise: ["error", { "int32Hint": true }] */
 
-var b = a|0;
+var b = a | 0;
+b |= 0;
 ```
 
 :::

--- a/lib/rules/no-bitwise.js
+++ b/lib/rules/no-bitwise.js
@@ -94,8 +94,16 @@ module.exports = {
          * @returns {boolean} whether the node is used in integer typecasting.
          */
         function isInt32Hint(node) {
-            return int32Hint && node.operator === "|" && node.right &&
-              node.right.type === "Literal" && node.right.value === 0;
+
+            // Check for "|0"
+            const isDirectHint = node.operator === "|" && node.right &&
+                                 node.right.type === "Literal" && node.right.value === 0;
+
+            // Check for "exp |= 0"
+            const isAssignmentHint = node.operator === "|=" && node.right &&
+                                     node.right.type === "Literal" && node.right.value === 0;
+
+            return int32Hint && (isDirectHint || isAssignmentHint);
         }
 
         /**

--- a/tests/lib/rules/no-bitwise.js
+++ b/tests/lib/rules/no-bitwise.js
@@ -30,6 +30,7 @@ ruleTester.run("no-bitwise", rule, {
         { code: "a ??= b", languageOptions: { ecmaVersion: 2021 } },
         { code: "~[1, 2, 3].indexOf(1)", options: [{ allow: ["~"] }] },
         { code: "~1<<2 === -8", options: [{ allow: ["~", "<<"] }] },
+        { code: "a|=0", options: [{ allow: ["|"], int32Hint: true }] },
         { code: "a|0", options: [{ int32Hint: true }] },
         { code: "a|0", options: [{ allow: ["|"], int32Hint: false }] }
     ],

--- a/tests/lib/rules/no-bitwise.js
+++ b/tests/lib/rules/no-bitwise.js
@@ -30,7 +30,7 @@ ruleTester.run("no-bitwise", rule, {
         { code: "a ??= b", languageOptions: { ecmaVersion: 2021 } },
         { code: "~[1, 2, 3].indexOf(1)", options: [{ allow: ["~"] }] },
         { code: "~1<<2 === -8", options: [{ allow: ["~", "<<"] }] },
-        { code: "a|=0", options: [{ allow: ["|"], int32Hint: true }] },
+        { code: "a|=0", options: [{ int32Hint: true }] },
         { code: "a|0", options: [{ int32Hint: true }] },
         { code: "a|0", options: [{ allow: ["|"], int32Hint: false }] }
     ],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**
`no-bitwise`

**What change do you want to make (place an "X" next to just one item)?**

[ ] Generate more warnings
[x] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**Please provide some example code that this change will affect:**

```js
let a = 16.16;
a |= 0; // 16, equivalent to a = a | 0
```

**What does the rule currently do for this code?**
It doesn't let the usage of `a |= 0`

**What will the rule do after it's changed?**
It will let the aforementioned usage

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
We no longer mark `a |= 0` as an error when `in32Hint` is enabled since it's semantically equivalent to `a = a | 0`.

#### Is there anything you'd like reviewers to focus on?
We need it for obvious reasons, but especially because otherwise we have a conflict with `operator-assignment`, which forces the usage of `a |= 0` instead of `a = a | 0`

<!-- markdownlint-disable-file MD004 -->
