### PR TITLE
feat: add option `allowEscape` to `no-misleading-character-class` rule

### DIFF
--- a/docs/src/rules/no-misleading-character-class.md
+++ b/docs/src/rules/no-misleading-character-class.md
@@ -97,7 +97,7 @@ This rule has an object option:
 
 Examples of **incorrect** code for this rule with the `{ "allowEscape": true }` option:
 
-:::
+::: incorrect
 
 ```js
 /* eslint no-misleading-character-class: ["error", { "allowEscape": true }] */
@@ -114,7 +114,7 @@ new RegExp(pattern);
 
 Examples of **correct** code for this rule with the `{ "allowEscape": true }` option:
 
-:::
+::: correct
 
 ```js
 /* eslint no-misleading-character-class: ["error", { "allowEscape": true }] */

--- a/docs/src/rules/no-misleading-character-class.md
+++ b/docs/src/rules/no-misleading-character-class.md
@@ -7,10 +7,10 @@ rule_type: problem
 
 
 
-Unicode includes the characters which are made with multiple code points.
-RegExp character class syntax (`/[abc]/`) cannot handle characters which are made by multiple code points as a character; those characters will be dissolved to each code point. For example, `❇️` is made by `❇` (`U+2747`) and VARIATION SELECTOR-16 (`U+FE0F`). If this character is in RegExp character class, it will match to either `❇` (`U+2747`) or VARIATION SELECTOR-16 (`U+FE0F`) rather than `❇️`.
+Unicode includes characters which are made by multiple code points.
+RegExp character class syntax (`/[abc]/`) cannot handle characters which are made by multiple code points as a character; those characters will be dissolved to each code point. For example, `❇️` is made by `❇` (`U+2747`) and VARIATION SELECTOR-16 (`U+FE0F`). If this character is in a RegExp character class, it will match either `❇` (`U+2747`) or VARIATION SELECTOR-16 (`U+FE0F`) rather than `❇️`.
 
-This rule reports the regular expressions which include multiple code point characters in character class syntax. This rule considers the following characters as multiple code point characters.
+This rule reports regular expressions which include multiple code point characters in character class syntax. This rule considers the following characters as multiple code point characters.
 
 **A character with combining characters:**
 
@@ -51,7 +51,7 @@ The combining characters are characters which belong to one of `Mc`, `Me`, and `
 
 ## Rule Details
 
-This rule reports the regular expressions which include multiple code point characters in character class syntax.
+This rule reports regular expressions which include multiple code point characters in character class syntax.
 
 Examples of **incorrect** code for this rule:
 
@@ -66,6 +66,7 @@ Examples of **incorrect** code for this rule:
 /^[🇯🇵]$/u;
 /^[👨‍👩‍👦]$/u;
 /^[👍]$/;
+new RegExp("[🎵]");
 ```
 
 :::
@@ -80,6 +81,8 @@ Examples of **correct** code for this rule:
 /^[abc]$/;
 /^[👍]$/u;
 /^[\q{👶🏻}]$/v;
+new RegExp("^[]$");
+new RegExp(`[Á-${z}]`, "u"); // variable pattern
 ```
 
 :::
@@ -99,11 +102,11 @@ Examples of **incorrect** code for this rule with the `{ "allowEscape": true }` 
 ```js
 /* eslint no-misleading-character-class: ["error", { "allowEscape": true }] */
 
-/[👍]/;
+/[\👍]/; // backslash can be omitted
 
-new RegExp("\ud83d" + "\udc4d");
+new RegExp("[\ud83d" + "\udc4d]");
 
-const pattern = "\ud83d\udc4d";
+const pattern = "[\ud83d\udc4d]";
 new RegExp(pattern);
 ```
 

--- a/docs/src/rules/no-misleading-character-class.md
+++ b/docs/src/rules/no-misleading-character-class.md
@@ -84,6 +84,48 @@ Examples of **correct** code for this rule:
 
 :::
 
+## Options
+
+This rule has an object option:
+
+* `"allowEscape"`: When set to `true`, the rule allows any grouping of code points inside a character class as long as they are written using escape sequences. This option only has effect on regular expression literals and on regular expressions created with the `RegExp` constructor with a literal argument as a pattern.
+
+### allowEscape
+
+Examples of **incorrect** code for this rule with the `{ "allowEscape": true }` option:
+
+:::
+
+```js
+/* eslint no-misleading-character-class: ["error", { "allowEscape": true }] */
+
+/[👍]/;
+
+new RegExp("\ud83d" + "\udc4d");
+
+const pattern = "\ud83d\udc4d";
+new RegExp(pattern);
+```
+
+:::
+
+Examples of **correct** code for this rule with the `{ "allowEscape": true }` option:
+
+:::
+
+```js
+/* eslint no-misleading-character-class: ["error", { "allowEscape": true }] */
+
+/[\ud83d\udc4d]/;
+/[\u00B7\u0300-\u036F]/u;
+/[👨\u200d👩]/u;
+new RegExp("[\x41\u0301]");
+new RegExp(`[\u{1F1EF}\u{1F1F5}]`, "u");
+new RegExp("[\\u{1F1EF}\\u{1F1F5}]", "u");
+```
+
+:::
+
 ## When Not To Use It
 
 You can turn this rule off if you don't want to check RegExp character class syntax for multiple code point characters.

--- a/lib/rules/no-misleading-character-class.js
+++ b/lib/rules/no-misleading-character-class.js
@@ -85,12 +85,10 @@ function isUnicodeCodePointEscape(char) {
 const findCharacterSequences = {
     *surrogatePairWithoutUFlag(chars) {
         for (const [index, char] of chars.entries()) {
-            if (index === 0) {
-                continue;
-            }
             const previous = chars[index - 1];
 
             if (
+                previous && char &&
                 isSurrogatePair(previous.value, char.value) &&
                 !isUnicodeCodePointEscape(previous) &&
                 !isUnicodeCodePointEscape(char)
@@ -102,12 +100,10 @@ const findCharacterSequences = {
 
     *surrogatePair(chars) {
         for (const [index, char] of chars.entries()) {
-            if (index === 0) {
-                continue;
-            }
             const previous = chars[index - 1];
 
             if (
+                previous && char &&
                 isSurrogatePair(previous.value, char.value) &&
                 (
                     isUnicodeCodePointEscape(previous) ||
@@ -121,12 +117,10 @@ const findCharacterSequences = {
 
     *combiningClass(chars) {
         for (const [index, char] of chars.entries()) {
-            if (index === 0) {
-                continue;
-            }
             const previous = chars[index - 1];
 
             if (
+                previous && char &&
                 isCombiningCharacter(char.value) &&
                 !isCombiningCharacter(previous.value)
             ) {
@@ -137,12 +131,10 @@ const findCharacterSequences = {
 
     *emojiModifier(chars) {
         for (const [index, char] of chars.entries()) {
-            if (index === 0) {
-                continue;
-            }
             const previous = chars[index - 1];
 
             if (
+                previous && char &&
                 isEmojiModifier(char.value) &&
                 !isEmojiModifier(previous.value)
             ) {
@@ -153,12 +145,10 @@ const findCharacterSequences = {
 
     *regionalIndicatorSymbol(chars) {
         for (const [index, char] of chars.entries()) {
-            if (index === 0) {
-                continue;
-            }
             const previous = chars[index - 1];
 
             if (
+                previous && char &&
                 isRegionalIndicatorSymbol(char.value) &&
                 isRegionalIndicatorSymbol(previous.value)
             ) {
@@ -171,17 +161,18 @@ const findCharacterSequences = {
         let sequence = null;
 
         for (const [index, char] of chars.entries()) {
-            if (index === 0 || index === chars.length - 1) {
-                continue;
-            }
+            const previous = chars[index - 1];
+            const next = chars[index + 1];
+
             if (
+                previous && char && next &&
                 char.value === 0x200d &&
-                chars[index - 1].value !== 0x200d &&
-                chars[index + 1].value !== 0x200d
+                previous.value !== 0x200d &&
+                next.value !== 0x200d
             ) {
                 if (sequence) {
-                    if (sequence.at(-1) === chars[index - 1]) {
-                        sequence.push(char, chars[index + 1]); // append to the sequence
+                    if (sequence.at(-1) === previous) {
+                        sequence.push(char, next); // append to the sequence
                     } else {
                         yield sequence;
                         sequence = chars.slice(index - 1, index + 2);
@@ -227,6 +218,41 @@ function getStaticValueOrRegex(node, initialScope) {
     return staticValue;
 }
 
+/**
+ * Checks whether a specified regexpp character is represented as an acceptable escape sequence.
+ * This function requires the source text of the character to be known.
+ * @param {Character} char Character to check.
+ * @param {string} charSource Source text of the character to check.
+ * @returns {boolean} Whether the specified regexpp character is represented as an acceptable escape sequence.
+ */
+function checkForAcceptableEscape(char, charSource) {
+    if (!charSource.startsWith("\\")) {
+        return false;
+    }
+    const match = /(?<=^\\+).$/su.exec(charSource);
+
+    return match?.[0] !== String.fromCodePoint(char.value);
+}
+
+/**
+ * Checks whether a specified regexpp character is represented as an acceptable escape sequence.
+ * This function works with characters that are produced by a string or template literal.
+ * It requires the source text and the CodeUnit list of the literal to be known.
+ * @param {Character} char Character to check.
+ * @param {string} nodeSource Source text of the string or template literal that produces the character.
+ * @param {CodeUnit[]} codeUnits List of CodeUnit objects of the literal that produces the character.
+ * @returns {boolean} Whether the specified regexpp character is represented as an acceptable escape sequence.
+ */
+function checkForAcceptableEscapeInString(char, nodeSource, codeUnits) {
+    const firstIndex = char.start;
+    const lastIndex = char.end - 1;
+    const start = codeUnits[firstIndex].start;
+    const end = codeUnits[lastIndex].end;
+    const charSource = nodeSource.slice(start, end);
+
+    return checkForAcceptableEscape(char, charSource);
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -244,7 +270,18 @@ module.exports = {
 
         hasSuggestions: true,
 
-        schema: [],
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    allowEscape: {
+                        type: "boolean",
+                        default: false
+                    }
+                },
+                additionalProperties: false
+            }
+        ],
 
         messages: {
             surrogatePairWithoutUFlag: "Unexpected surrogate pair in character class. Use 'u' flag.",
@@ -257,6 +294,7 @@ module.exports = {
         }
     },
     create(context) {
+        const allowEscape = context.options[0]?.allowEscape;
         const sourceCode = context.sourceCode;
         const parser = new RegExpParser();
         const checkedPatternNodes = new Set();
@@ -288,23 +326,57 @@ module.exports = {
                 return;
             }
 
+            let codeUnits = null;
+
+            /**
+             * Checks whether a specified regexpp character is represented as an acceptable escape sequence.
+             * For the purposes of this rule, an escape sequence is considered acceptable if it consists of one or more backslashes followed by the character being escaped.
+             * @param {Character} char Character to check.
+             * @returns {boolean} Whether the specified regexpp character is represented as an acceptable escape sequence.
+             */
+            function isAcceptableEscapeSequence(char) {
+                if (node.type === "Literal" && node.regex) {
+                    return checkForAcceptableEscape(char, char.raw);
+                }
+                if (node.type === "Literal" && typeof node.value === "string") {
+                    const nodeSource = node.raw;
+
+                    codeUnits ??= parseStringLiteral(nodeSource);
+
+                    return checkForAcceptableEscapeInString(char, nodeSource, codeUnits);
+                }
+                if (astUtils.isStaticTemplateLiteral(node)) {
+                    const nodeSource = sourceCode.getText(node);
+
+                    codeUnits ??= parseTemplateToken(nodeSource);
+
+                    return checkForAcceptableEscapeInString(char, nodeSource, codeUnits);
+                }
+                return false;
+            }
+
             const foundKindMatches = new Map();
 
             visitRegExpAST(patternNode, {
                 onCharacterClassEnter(ccNode) {
-                    for (const chars of iterateCharacterSequence(ccNode.elements)) {
+                    for (let chars of iterateCharacterSequence(ccNode.elements)) {
+                        if (allowEscape) {
+
+                            // Replace escape sequences with null to avoid having them flagged.
+                            chars = chars.map(char => (isAcceptableEscapeSequence(char) ? null : char));
+                        }
                         for (const kind of kinds) {
+                            const matches = findCharacterSequences[kind](chars);
+
                             if (foundKindMatches.has(kind)) {
-                                foundKindMatches.get(kind).push(...findCharacterSequences[kind](chars));
+                                foundKindMatches.get(kind).push(...matches);
                             } else {
-                                foundKindMatches.set(kind, [...findCharacterSequences[kind](chars)]);
+                                foundKindMatches.set(kind, [...matches]);
                             }
                         }
                     }
                 }
             });
-
-            let codeUnits = null;
 
             /**
              * Finds the report loc(s) for a range of matches.

--- a/lib/rules/no-misleading-character-class.js
+++ b/lib/rules/no-misleading-character-class.js
@@ -115,9 +115,14 @@ const findCharacterSequences = {
         }
     },
 
-    *combiningClass(chars) {
+    *combiningClass(chars, unfilteredChars) {
+
+        /*
+         * When `allowEscape` is `true`, a combined character should only be allowed if the combining mark appears as an escape sequence.
+         * This means that the base character should be considered even if it's escaped.
+         */
         for (const [index, char] of chars.entries()) {
-            const previous = chars[index - 1];
+            const previous = unfilteredChars[index - 1];
 
             if (
                 previous && char &&
@@ -359,14 +364,18 @@ module.exports = {
 
             visitRegExpAST(patternNode, {
                 onCharacterClassEnter(ccNode) {
-                    for (let chars of iterateCharacterSequence(ccNode.elements)) {
+                    for (const unfilteredChars of iterateCharacterSequence(ccNode.elements)) {
+                        let chars;
+
                         if (allowEscape) {
 
                             // Replace escape sequences with null to avoid having them flagged.
-                            chars = chars.map(char => (isAcceptableEscapeSequence(char) ? null : char));
+                            chars = unfilteredChars.map(char => (isAcceptableEscapeSequence(char) ? null : char));
+                        } else {
+                            chars = unfilteredChars;
                         }
                         for (const kind of kinds) {
-                            const matches = findCharacterSequences[kind](chars);
+                            const matches = findCharacterSequences[kind](chars, unfilteredChars);
 
                             if (foundKindMatches.has(kind)) {
                                 foundKindMatches.get(kind).push(...matches);

--- a/tests/lib/rules/no-misleading-character-class.js
+++ b/tests/lib/rules/no-misleading-character-class.js
@@ -126,7 +126,7 @@ ruleTester.run("no-misleading-character-class", rule, {
             options: [{ allowEscape: true }]
         },
         {
-            code: String.raw`/[\\ud83d\\udc4d]/`,
+            code: String.raw`/[\n̅]/`,
             options: [{ allowEscape: true }]
         },
         {

--- a/tests/lib/rules/no-misleading-character-class.js
+++ b/tests/lib/rules/no-misleading-character-class.js
@@ -126,7 +126,7 @@ ruleTester.run("no-misleading-character-class", rule, {
             options: [{ allowEscape: true }]
         },
         {
-            code: String.raw`/[\n̅]/`,
+            code: String.raw`/[\n\u0305]/`,
             options: [{ allowEscape: true }]
         },
         {
@@ -1677,6 +1677,11 @@ ruleTester.run("no-misleading-character-class", rule, {
         },
         {
             code: String.raw`/[\\̶]/`, // Backslash + Backslash + Combining Long Stroke Overlay
+            options: [{ allowEscape: true }],
+            errors: [{ messageId: "combiningClass" }]
+        },
+        {
+            code: String.raw`/[\n̅]/`,
             options: [{ allowEscape: true }],
             errors: [{ messageId: "combiningClass" }]
         },

--- a/tests/lib/rules/no-misleading-character-class.js
+++ b/tests/lib/rules/no-misleading-character-class.js
@@ -94,7 +94,57 @@ ruleTester.run("no-misleading-character-class", rule, {
         { code: String.raw`var r = /^[\q{👶🏻}]$/v`, languageOptions: { ecmaVersion: 2024 } },
         { code: String.raw`var r = /[🇯\q{abc}🇵]/v`, languageOptions: { ecmaVersion: 2024 } },
         { code: "var r = /[🇯[A]🇵]/v", languageOptions: { ecmaVersion: 2024 } },
-        { code: "var r = /[🇯[A--B]🇵]/v", languageOptions: { ecmaVersion: 2024 } }
+        { code: "var r = /[🇯[A--B]🇵]/v", languageOptions: { ecmaVersion: 2024 } },
+
+        // allowEscape
+        {
+            code: String.raw`/[\ud83d\udc4d]/`,
+            options: [{ allowEscape: true }]
+        },
+        {
+            code: '/[\ud83d\\udc4d]/u // U+D83D + Backslash + "udc4d"',
+            options: [{ allowEscape: true }]
+        },
+        {
+            code: String.raw`/[A\u0301]/`,
+            options: [{ allowEscape: true }]
+        },
+        {
+            code: String.raw`/[👶\u{1f3fb}]/u`,
+            options: [{ allowEscape: true }]
+        },
+        {
+            code: String.raw`/[\u{1F1EF}\u{1F1F5}]/u`,
+            options: [{ allowEscape: true }]
+        },
+        {
+            code: String.raw`/[👨\u200d👩\u200d👦]/u`,
+            options: [{ allowEscape: true }]
+        },
+        {
+            code: String.raw`/[\u00B7\u0300-\u036F]/u`,
+            options: [{ allowEscape: true }]
+        },
+        {
+            code: String.raw`/[\\ud83d\\udc4d]/`,
+            options: [{ allowEscape: true }]
+        },
+        {
+            code: String.raw`RegExp("[\uD83D\uDC4D]")`,
+            options: [{ allowEscape: true }]
+        },
+        {
+            code: String.raw`RegExp("[A\u0301]")`,
+            options: [{ allowEscape: true }]
+        },
+        {
+            code: String.raw`RegExp("[\x41\\u0301]")`,
+            options: [{ allowEscape: true }]
+        },
+        {
+            code: 'RegExp(`[\\uD83D\\uDC4D]`) // Backslash + "uD83D" + Backslash + "uDC4D"',
+            options: [{ allowEscape: true }]
+        }
     ],
     invalid: [
 
@@ -1589,7 +1639,7 @@ ruleTester.run("no-misleading-character-class", rule, {
                 messageId: "surrogatePairWithoutUFlag",
                 suggestions: [{ messageId: "suggestUnicodeFlag", output: "new RegExp(/^[👍]$/v, 'u')" }]
             }]
-        }
+        },
 
         /*
          * This test case has been disabled because of a limitation in Node.js 18, see https://github.com/eslint/eslint/pull/18082#discussion_r1506142421.
@@ -1612,6 +1662,75 @@ ruleTester.run("no-misleading-character-class", rule, {
          *     }]
          * }
          */
+
+        // allowEscape
+
+        {
+            code: String.raw`/[Á]/`,
+            options: [{ allowEscape: false }],
+            errors: [{ messageId: "combiningClass" }]
+        },
+        {
+            code: String.raw`/[Á]/`,
+            options: [{ allowEscape: void 0 }],
+            errors: [{ messageId: "combiningClass" }]
+        },
+        {
+            code: String.raw`/[\\̶]/`, // Backslash + Backslash + Combining Long Stroke Overlay
+            options: [{ allowEscape: true }],
+            errors: [{ messageId: "combiningClass" }]
+        },
+        {
+            code: String.raw`/[\👍]/`,
+            options: [{ allowEscape: true }],
+            errors: [{ messageId: "surrogatePairWithoutUFlag" }]
+        },
+        {
+            code: String.raw`RegExp('[\è]')`, // Backslash + Latin Small Letter E + Combining Grave Accent
+            options: [{ allowEscape: true }],
+            errors: [{ messageId: "combiningClass" }]
+        },
+        {
+            code: String.raw`RegExp('[\👍]')`,
+            options: [{ allowEscape: true }],
+            errors: [{
+                messageId: "surrogatePairWithoutUFlag",
+                suggestions: [{
+                    messageId: "suggestUnicodeFlag",
+                    output: String.raw`RegExp('[\👍]', "u")`
+                }]
+            }]
+        },
+        {
+            code: String.raw`RegExp('[\\👍]')`,
+            options: [{ allowEscape: true }],
+            errors: [{ messageId: "surrogatePairWithoutUFlag" }]
+        },
+        {
+            code: String.raw`RegExp('[\❇️]')`,
+            options: [{ allowEscape: true }],
+            errors: [{ messageId: "combiningClass" }]
+        },
+        {
+            code: "RegExp(`[\\👍]`) // Backslash + U+D83D + U+DC4D",
+            options: [{ allowEscape: true }],
+            errors: [{
+                messageId: "surrogatePairWithoutUFlag",
+                suggestions: [{
+                    messageId: "suggestUnicodeFlag",
+                    output: 'RegExp(`[\\👍]`, "u") // Backslash + U+D83D + U+DC4D'
+                }]
+            }]
+        },
+        {
+            /*
+             * In this case the rule can determine the value of `pattern` statically but has no information about the source,
+             * so it doesn't know that escape sequences were used. This is a limitation with our tools.
+             */
+            code: String.raw`const pattern = "[\x41\u0301]"; RegExp(pattern);`,
+            options: [{ allowEscape: true }],
+            errors: [{ messageId: "combiningClass" }]
+        }
 
         /* eslint-enable lines-around-comment, internal-rules/multiline-comment-style -- re-enable rule */
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #15080 

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds an option to allow escape sequences in regexp character classes to the `no-misleading-character-class` rule. The new option only has effect on nodes whose source location can be statically determined with our tools. These are the same nodes that report granular errors:
* regular expression literals
* string literals as first arguments of the `RegExp` constructor
* template literals without expressions as first arguments of the `RegExp` constructor

#### Is there anything you'd like reviewers to focus on?

I would like to fine tune this rule to allow only escape sequence that are not confusing, and I'm not sure I've got the right balance. For example `/[\👍]/` contains an escape sequence where the backslash just escapes the next character without changing its value. I think that those escape sequences should be still forbidden even when the new option is set. Other cases are less trivial.

In the current implementation, the new option will allow any escape sequences except those where the character being escaped is prepended by one or more backslashes. If one or more of the characters in a group are escaped, the group will be allowed.

| Node | Status |
|------|--------|
| `/[A\u0301]/` | allowed, second character in class is escaped |
| `/[👨\u200d👩\u200d👦]/u` | allowed, ZWNJ character is escaped |
| `/[\n̅]/` | allowed, `\n` is a non-trivial escape sequence |
| `/[\e̅]/` | not allowed, `\e` is `e` |

<!-- markdownlint-disable-file MD004 -->
