### PR TITLE
build: fix TypeError in prism-eslint-hooks.js

### DIFF
--- a/docs/tools/prism-eslint-hook.js
+++ b/docs/tools/prism-eslint-hook.js
@@ -317,7 +317,7 @@ function installPrismESLintMarkerHook() {
                     continue;
                 }
 
-                if (Array.isArray(token.content) || typeof token.content !== "string") {
+                if (Array.isArray(token.content)) {
                     token.content = [...splitTokensByLineFeed([token.content].flat())];
                 }
                 yield token;

--- a/docs/tools/prism-eslint-hook.js
+++ b/docs/tools/prism-eslint-hook.js
@@ -305,6 +305,10 @@ function installPrismESLintMarkerHook() {
          */
         function *splitTokensByLineFeed(tokens) {
             for (const token of tokens) {
+                if (typeof token === "string") {
+                    yield token;
+                    continue;
+                }
 
                 const content = getTokenContent(token);
 
@@ -317,7 +321,7 @@ function installPrismESLintMarkerHook() {
                     continue;
                 }
 
-                if (Array.isArray(token.content)) {
+                if (typeof token.content !== "string") {
                     token.content = [...splitTokensByLineFeed([token.content].flat())];
                 }
                 yield token;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR fixes an issue in the docs build process that is causing some incorrect rule examples in the `indent` and `indent-legacy` rules to be displayed without red markers for errors, for example [here](https://eslint.org/docs/next/rules/indent#functiondeclaration).

![image](https://github.com/eslint/eslint/assets/6367844/d890c093-c86f-4f5b-8ce8-c854901f475f)

This is due to a `TypeError` that occurs because of an incorrect condition in another part of the code. This incorrect condition allows the creation of an array with an undefined element where only strings or plain objects are expected as elements:

```
js TypeError: Cannot read properties of undefined (reading 'content')
    at getTokenContent (/Users/noone/GitHub/eslint/eslint/docs/tools/prism-eslint-hook.js:189:30)
    at splitTokensByLineFeed (/Users/noone/GitHub/eslint/eslint/docs/tools/prism-eslint-hook.js:309:33)
    at splitTokensByLineFeed.next (<anonymous>)
    at splitTokensByLineFeed (/Users/noone/GitHub/eslint/eslint/docs/tools/prism-eslint-hook.js:321:41)
    at splitTokensByLineFeed.next (<anonymous>)
    at splitTokensByLineFeed (/Users/noone/GitHub/eslint/eslint/docs/tools/prism-eslint-hook.js:321:41)
    at splitTokensByLineFeed.next (<anonymous>)
    at convertMarked (/Users/noone/GitHub/eslint/eslint/docs/tools/prism-eslint-hook.js:392:24)
    at convertMarked.next (<anonymous>)
    at /Users/noone/GitHub/eslint/eslint/docs/tools/prism-eslint-hook.js:402:30
```

The error is visibile in the Netlify logs under Deploy log > Building > Lines 219-306 (last production deploy: https://app.netlify.com/sites/docs-eslint/deploys/65f345a38ee0750008f1a05c#L219-L306) or when manually running `npm run build` in the `docs` folder.

#### Is there anything you'd like reviewers to focus on?

There are no unit tests for prism-eslint-hooks.js. Shall we add one?

<!-- markdownlint-disable-file MD004 -->
