### PR TITLE
feat: Autofix via user-defined pattern and replacement

### DIFF
--- a/docs/src/rules/no-restricted-syntax.md
+++ b/docs/src/rules/no-restricted-syntax.md
@@ -13,11 +13,11 @@ JavaScript has a lot of language features, and not everyone likes all of them. A
 
 Rather than creating separate rules for every language feature you want to turn off, this rule allows you to configure the syntax elements you want to restrict use of. These elements are represented by their [ESTree](https://github.com/estree/estree) node types. For example, a function declaration is represented by `FunctionDeclaration` and the `with` statement is represented by `WithStatement`. You may find the full list of AST node names you can use [on GitHub](https://github.com/eslint/eslint-visitor-keys/blob/main/lib/visitor-keys.js) and use [AST Explorer](https://astexplorer.net/) with the espree parser to see what type of nodes your code consists of.
 
-You can also specify [AST selectors](../extend/selectors) to restrict, allowing much more precise control over syntax patterns.
+You can also specify [AST selectors](../extend/selectors) to restrict, allowing much more precise control over syntax patterns. Additionally, replacements can be defined to autofix matched occurrences.
 
 ## Rule Details
 
-This rule disallows specified (that is, user-defined) syntax.
+This rule disallows specified (that is, user-defined) syntax and optionally fixes said syntax via specified replacements.
 
 ## Options
 
@@ -31,7 +31,7 @@ This rule takes a list of strings, where each string is an AST selector:
 }
 ```
 
-Alternatively, the rule also accepts objects, where the selector and an optional custom message are specified:
+Alternatively, the rule also accepts objects, where the selector, an optional custom message and an optional replacement can be specified:
 
 ```json
 {
@@ -45,7 +45,15 @@ Alternatively, the rule also accepts objects, where the selector and an optional
             {
                 "selector": "CallExpression[callee.name='setTimeout'][arguments.length!=2]",
                 "message": "setTimeout must always be invoked with two arguments."
-            }
+            },
+            {
+                "selector": "UnaryExpression[operator='!'][argument.operator='!']",
+                "message": "double bangs are not allowed. Use Boolean.",
+                "replace": {
+                    "pattern": "/!!(.*)/",
+                    "replacement": "Boolean($1)"
+                }
+            },
         ]
     }
 }
@@ -54,6 +62,12 @@ Alternatively, the rule also accepts objects, where the selector and an optional
 If a custom message is specified with the `message` property, ESLint will use that message when reporting occurrences of the syntax specified in the `selector` property.
 
 The string and object formats can be freely mixed in the configuration as needed.
+
+If a custom replacement is specified with the `replace` property, ESLint will try to fix the reported occurrence by replacing the matched node text according to the specified `pattern` and `replacement`.
+
+The `pattern` property accepts the same syntax as the [esquery attribute](https://github.com/estools/esquery) value/regex used in AST selectors. Replacing is then delegated to [String.prototype.replace](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) where the `replacement` parameter works the same.
+
+To replace the whole occurrence with a static string, `replace` also accepts just a string instead of an object.
 
 Examples of **incorrect** code for this rule with the `"FunctionExpression", "WithStatement", BinaryExpression[operator='in']` options:
 

--- a/lib/rules/no-restricted-syntax.js
+++ b/lib/rules/no-restricted-syntax.js
@@ -5,6 +5,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const esquery = require("esquery");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -19,6 +25,8 @@ module.exports = {
             url: "https://eslint.org/docs/latest/rules/no-restricted-syntax"
         },
 
+        fixable: "code",
+
         schema: {
             type: "array",
             items: {
@@ -30,7 +38,23 @@ module.exports = {
                         type: "object",
                         properties: {
                             selector: { type: "string" },
-                            message: { type: "string" }
+                            message: { type: "string" },
+                            replace: {
+                                oneOf: [
+                                    {
+                                        type: "string"
+                                    },
+                                    {
+                                        type: "object",
+                                        properties: {
+                                            pattern: { type: "string" },
+                                            replacement: { type: "string" }
+                                        },
+                                        required: ["pattern", "replacement"],
+                                        additionalProperties: false
+                                    }
+                                ]
+                            }
                         },
                         required: ["selector"],
                         additionalProperties: false
@@ -48,6 +72,45 @@ module.exports = {
     },
 
     create(context) {
+        const sourceCode = context.sourceCode;
+
+        /**
+         * Tries to replace the node using the given replacement.
+         * @param {RuleFixer} fixer Rule fixer
+         * @param {Node} node The node to fix
+         * @param {string|object} selectorOrObject The selector or object
+         * @returns {null|{range: [number, number], text: string}} null or a fix object
+         */
+        function tryReplacement(fixer, node, selectorOrObject) {
+            if (typeof selectorOrObject.replace === "string") {
+                return fixer.replaceText(
+                    node,
+                    selectorOrObject.replace
+                );
+            }
+
+            const text = sourceCode.getText(node);
+
+            const { pattern, replacement } =
+                selectorOrObject.replace;
+
+            const isRegex = pattern.startsWith("/") && /\/[gimuy]*$/u.test(pattern);
+
+            if (!isRegex) {
+                return fixer.replaceText(pattern, replacement);
+            }
+
+            const parsed = esquery.parse(`[attr=${pattern}]`).value;
+
+            if (parsed.type !== "regexp") {
+                return null;
+            }
+
+            const fixedText = text.replace(parsed.value, replacement);
+
+            return fixer.replaceText(node, fixedText);
+        }
+
         return context.options.reduce((result, selectorOrObject) => {
             const isStringFormat = (typeof selectorOrObject === "string");
             const hasCustomMessage = !isStringFormat && Boolean(selectorOrObject.message);
@@ -60,7 +123,18 @@ module.exports = {
                     context.report({
                         node,
                         messageId: "restrictedSyntax",
-                        data: { message }
+                        data: { message },
+                        fix(fixer) {
+                            if (isStringFormat || !("replace" in selectorOrObject)) {
+                                return null;
+                            }
+
+                            try {
+                                return tryReplacement(fixer, node, selectorOrObject);
+                            } catch {
+                                return null;
+                            }
+                        }
                     });
                 }
             });

--- a/tests/lib/rules/no-restricted-syntax.js
+++ b/tests/lib/rules/no-restricted-syntax.js
@@ -46,16 +46,19 @@ ruleTester.run("no-restricted-syntax", rule, {
         // string format
         {
             code: "var foo = 41;",
+            output: null,
             options: ["VariableDeclaration"],
             errors: [{ messageId: "restrictedSyntax", data: { message: "Using 'VariableDeclaration' is not allowed." }, type: "VariableDeclaration" }]
         },
         {
             code: ";function lol(a) { return 42; }",
+            output: null,
             options: ["EmptyStatement"],
             errors: [{ messageId: "restrictedSyntax", data: { message: "Using 'EmptyStatement' is not allowed." }, type: "EmptyStatement" }]
         },
         {
             code: "try { voila(); } catch (e) { oops(); }",
+            output: null,
             options: ["TryStatement", "CallExpression", "CatchClause"],
             errors: [
                 { messageId: "restrictedSyntax", data: { message: "Using 'TryStatement' is not allowed." }, type: "TryStatement" },
@@ -66,11 +69,13 @@ ruleTester.run("no-restricted-syntax", rule, {
         },
         {
             code: "bar;",
+            output: null,
             options: ["Identifier[name=\"bar\"]"],
             errors: [{ messageId: "restrictedSyntax", data: { message: "Using 'Identifier[name=\"bar\"]' is not allowed." }, type: "Identifier" }]
         },
         {
             code: "bar;",
+            output: null,
             options: ["Identifier", "Identifier[name=\"bar\"]"],
             errors: [
                 { messageId: "restrictedSyntax", data: { message: "Using 'Identifier' is not allowed." }, type: "Identifier" },
@@ -79,22 +84,26 @@ ruleTester.run("no-restricted-syntax", rule, {
         },
         {
             code: "() => {}",
+            output: null,
             options: ["ArrowFunctionExpression > BlockStatement"],
             languageOptions: { ecmaVersion: 6 },
             errors: [{ messageId: "restrictedSyntax", data: { message: "Using 'ArrowFunctionExpression > BlockStatement' is not allowed." }, type: "BlockStatement" }]
         },
         {
             code: "({ foo: 1, 'bar': 2 })",
+            output: null,
             options: ["Property > Literal.key"],
             errors: [{ messageId: "restrictedSyntax", data: { message: "Using 'Property > Literal.key' is not allowed." }, type: "Literal" }]
         },
         {
             code: "A: for (;;) break A;",
+            output: null,
             options: ["BreakStatement[label]"],
             errors: [{ messageId: "restrictedSyntax", data: { message: "Using 'BreakStatement[label]' is not allowed." }, type: "BreakStatement" }]
         },
         {
             code: "function foo(bar, baz, qux) {}",
+            output: null,
             options: ["FunctionDeclaration[params.length>2]"],
             errors: [{ messageId: "restrictedSyntax", data: { message: "Using 'FunctionDeclaration[params.length>2]' is not allowed." }, type: "FunctionDeclaration" }]
         },
@@ -102,16 +111,19 @@ ruleTester.run("no-restricted-syntax", rule, {
         // object format
         {
             code: "var foo = 41;",
+            output: null,
             options: [{ selector: "VariableDeclaration" }],
             errors: [{ messageId: "restrictedSyntax", data: { message: "Using 'VariableDeclaration' is not allowed." }, type: "VariableDeclaration" }]
         },
         {
             code: "function foo(bar, baz, qux) {}",
+            output: null,
             options: [{ selector: "FunctionDeclaration[params.length>2]" }],
             errors: [{ messageId: "restrictedSyntax", data: { message: "Using 'FunctionDeclaration[params.length>2]' is not allowed." }, type: "FunctionDeclaration" }]
         },
         {
             code: "function foo(bar, baz, qux) {}",
+            output: null,
             options: [{ selector: "FunctionDeclaration[params.length>2]", message: "custom error message." }],
             errors: [{ messageId: "restrictedSyntax", data: { message: "custom error message." }, type: "FunctionDeclaration" }]
         },
@@ -119,6 +131,7 @@ ruleTester.run("no-restricted-syntax", rule, {
         // with object format, the custom message may contain the string '{{selector}}'
         {
             code: "function foo(bar, baz, qux) {}",
+            output: null,
             options: [{ selector: "FunctionDeclaration[params.length>2]", message: "custom message with {{selector}}" }],
             errors: [{ messageId: "restrictedSyntax", data: { message: "custom message with {{selector}}" }, type: "FunctionDeclaration" }]
         },
@@ -126,6 +139,7 @@ ruleTester.run("no-restricted-syntax", rule, {
         // https://github.com/eslint/eslint/issues/8733
         {
             code: "console.log(/a/i);",
+            output: null,
             options: ["Literal[regex.flags=/./]"],
             errors: [{ messageId: "restrictedSyntax", data: { message: "Using 'Literal[regex.flags=/./]' is not allowed." }, type: "Literal" }]
         },
@@ -133,12 +147,14 @@ ruleTester.run("no-restricted-syntax", rule, {
         // Optional chaining
         {
             code: "var foo = foo?.bar?.();",
+            output: null,
             options: ["ChainExpression"],
             languageOptions: { ecmaVersion: 2020 },
             errors: [{ messageId: "restrictedSyntax", data: { message: "Using 'ChainExpression' is not allowed." }, type: "ChainExpression" }]
         },
         {
             code: "var foo = foo?.bar?.();",
+            output: null,
             options: ["[optional=true]"],
             languageOptions: { ecmaVersion: 2020 },
             errors: [
@@ -150,6 +166,7 @@ ruleTester.run("no-restricted-syntax", rule, {
         // fix https://github.com/estools/esquery/issues/110
         {
             code: "a?.b",
+            output: null,
             options: [":nth-child(1)"],
             languageOptions: { ecmaVersion: 2020 },
             errors: [
@@ -160,11 +177,39 @@ ruleTester.run("no-restricted-syntax", rule, {
         // https://github.com/eslint/eslint/issues/13639#issuecomment-683976062
         {
             code: "const foo = [<div/>, <div/>]",
+            output: null,
             options: ["* ~ *"],
             languageOptions: { ecmaVersion: 2020, parserOptions: { ecmaFeatures: { jsx: true } } },
             errors: [
                 { messageId: "restrictedSyntax", data: { message: "Using '* ~ *' is not allowed." }, type: "JSXElement" }
             ]
+        },
+
+        // Replace with pattern
+        {
+            code: "const isFoo = !!foo",
+            output: "const isFoo = Boolean(foo)",
+            options: [{
+                selector: "UnaryExpression[operator='!'][argument.operator='!']",
+                message: "Double bangs are not allowed. Use Boolean.",
+                replace: {
+                    pattern: "/!!(\\w+)/",
+                    replacement: "Boolean($1)"
+                }
+            }],
+            errors: [{ messageId: "restrictedSyntax", data: { message: "Double bangs are not allowed. Use Boolean." }, type: "UnaryExpression" }]
+        },
+
+        // Replace static
+        {
+            code: "'use strict'",
+            output: "",
+            options: [{
+                selector: "Program .body[expression.value='use strict']",
+                message: "Strict mode is not allowed.",
+                replace: ""
+            }],
+            errors: [{ messageId: "restrictedSyntax", data: { message: "Strict mode is not allowed." }, type: "ExpressionStatement" }]
         }
     ]
 });


### PR DESCRIPTION
Fixes #18210

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[X] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added ability for users to specify how to autofix no-restricted-syntax violations:

```js
{
    code: "const isFoo = !!foo",
    output: "const isFoo = Boolean(foo)",
    options: [{
        selector: "UnaryExpression[operator='!'][argument.operator='!']",
        message: "Double bangs are not allowed. Use Boolean.",
        replace: {
            pattern: "/!!(\\w+)/",
            replacement: "Boolean($1)"
        }
    }],
}
```

#### Is there anything you'd like reviewers to focus on?
No, but open to any suggestions for improvement.

<!-- markdownlint-disable-file MD004 -->
