### PR TITLE
feat: use-isnan report NaN in `indexOf` and `lastIndexOf` with fromIndex

### DIFF
--- a/docs/src/rules/use-isnan.md
+++ b/docs/src/rules/use-isnan.md
@@ -226,6 +226,10 @@ var firstIndex = myArray.indexOf(NaN);
 var lastIndex = myArray.lastIndexOf(NaN);
 
 var indexWithSequenceExpression = myArray.indexOf((doStuff(), NaN));
+
+var firstIndexFromSecondElement = myArray.indexOf(NaN, 1);
+
+var lastIndexFromSecondElement = myArray.lastIndexOf(NaN, 1);
 ```
 
 :::
@@ -279,6 +283,6 @@ var hasNaN = myArray.includes(NaN);
 
 :::
 
-#### Known Limitations
+## Known Limitations
 
 This option checks methods with the given names, *even if* the object which has the method is *not* an array.

--- a/docs/src/rules/use-isnan.md
+++ b/docs/src/rules/use-isnan.md
@@ -283,6 +283,6 @@ var hasNaN = myArray.includes(NaN);
 
 :::
 
-## Known Limitations
+#### Known Limitations
 
 This option checks methods with the given names, *even if* the object which has the method is *not* an array.

--- a/lib/rules/use-isnan.js
+++ b/lib/rules/use-isnan.js
@@ -182,7 +182,7 @@ module.exports = {
 
                 if (
                     (methodName === "indexOf" || methodName === "lastIndexOf") &&
-                    node.arguments.length === 1 &&
+                    node.arguments.length <= 2 &&
                     isNaNIdentifier(node.arguments[0])
                 ) {
 
@@ -190,7 +190,7 @@ module.exports = {
                      * To retain side effects, it's essential to address `NaN` beforehand, which
                      * is not possible with fixes like `arr.findIndex(Number.isNaN)`.
                      */
-                    const isSuggestable = node.arguments[0].type !== "SequenceExpression";
+                    const isSuggestable = node.arguments[0].type !== "SequenceExpression" && !node.arguments[1];
                     const suggestedFixes = [];
 
                     if (isSuggestable) {

--- a/tests/lib/rules/use-isnan.js
+++ b/tests/lib/rules/use-isnan.js
@@ -262,24 +262,18 @@ ruleTester.run("use-isnan", rule, {
             code: "foo.indexOf(a, NaN)",
             options: [{ enforceForIndexOf: true }]
         },
-
-        /*
-         * {
-         *     code: "foo.lastIndexOf(NaN, b)",
-         *     options: [{ enforceForIndexOf: true }]
-         * },
-         */
+        {
+            code: "foo.lastIndexOf(NaN, b, c)",
+            options: [{ enforceForIndexOf: true }]
+        },
         {
             code: "foo.indexOf(a, b)",
             options: [{ enforceForIndexOf: true }]
         },
-
-        /*
-         * {
-         *     code: "foo.lastIndexOf(NaN, NaN)",
-         *     options: [{ enforceForIndexOf: true }]
-         * },
-         */
+        {
+            code: "foo.lastIndexOf(NaN, NaN, b)",
+            options: [{ enforceForIndexOf: true }]
+        },
         {
             code: "foo.indexOf(...NaN)",
             options: [{ enforceForIndexOf: true }],
@@ -345,17 +339,14 @@ ruleTester.run("use-isnan", rule, {
             code: "foo.indexOf(a, Number.NaN)",
             options: [{ enforceForIndexOf: true }]
         },
-
-        /*
-         * {
-         *     code: "foo.lastIndexOf(Number.NaN, b)",
-         *     options: [{ enforceForIndexOf: true }]
-         * },
-         * {
-         *     code: "foo.lastIndexOf(Number.NaN, NaN)",
-         *     options: [{ enforceForIndexOf: true }]
-         * },
-         */
+        {
+            code: "foo.lastIndexOf(Number.NaN, b, c)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo.lastIndexOf(Number.NaN, NaN, b)",
+            options: [{ enforceForIndexOf: true }]
+        },
         {
             code: "foo.indexOf(...Number.NaN)",
             options: [{ enforceForIndexOf: true }],

--- a/tests/lib/rules/use-isnan.js
+++ b/tests/lib/rules/use-isnan.js
@@ -262,18 +262,24 @@ ruleTester.run("use-isnan", rule, {
             code: "foo.indexOf(a, NaN)",
             options: [{ enforceForIndexOf: true }]
         },
-        {
-            code: "foo.lastIndexOf(NaN, b)",
-            options: [{ enforceForIndexOf: true }]
-        },
+
+        /*
+         * {
+         *     code: "foo.lastIndexOf(NaN, b)",
+         *     options: [{ enforceForIndexOf: true }]
+         * },
+         */
         {
             code: "foo.indexOf(a, b)",
             options: [{ enforceForIndexOf: true }]
         },
-        {
-            code: "foo.lastIndexOf(NaN, NaN)",
-            options: [{ enforceForIndexOf: true }]
-        },
+
+        /*
+         * {
+         *     code: "foo.lastIndexOf(NaN, NaN)",
+         *     options: [{ enforceForIndexOf: true }]
+         * },
+         */
         {
             code: "foo.indexOf(...NaN)",
             options: [{ enforceForIndexOf: true }],
@@ -339,14 +345,17 @@ ruleTester.run("use-isnan", rule, {
             code: "foo.indexOf(a, Number.NaN)",
             options: [{ enforceForIndexOf: true }]
         },
-        {
-            code: "foo.lastIndexOf(Number.NaN, b)",
-            options: [{ enforceForIndexOf: true }]
-        },
-        {
-            code: "foo.lastIndexOf(Number.NaN, NaN)",
-            options: [{ enforceForIndexOf: true }]
-        },
+
+        /*
+         * {
+         *     code: "foo.lastIndexOf(Number.NaN, b)",
+         *     options: [{ enforceForIndexOf: true }]
+         * },
+         * {
+         *     code: "foo.lastIndexOf(Number.NaN, NaN)",
+         *     options: [{ enforceForIndexOf: true }]
+         * },
+         */
         {
             code: "foo.indexOf(...Number.NaN)",
             options: [{ enforceForIndexOf: true }],
@@ -1287,6 +1296,86 @@ ruleTester.run("use-isnan", rule, {
             errors: [{
                 messageId: "indexOfNaN",
                 data: { methodName: "lastIndexOf" },
+                suggestions: []
+            }]
+        },
+        {
+            code: "foo.indexOf(NaN, 1)",
+            options: [{ enforceForIndexOf: true }],
+            languageOptions: { ecmaVersion: 2020 },
+            errors: [{
+                messageId: "indexOfNaN",
+                data: { methodName: "indexOf" },
+                suggestions: []
+            }]
+        },
+        {
+            code: "foo.lastIndexOf(NaN, 1)",
+            options: [{ enforceForIndexOf: true }],
+            languageOptions: { ecmaVersion: 2020 },
+            errors: [{
+                messageId: "indexOfNaN",
+                data: { methodName: "lastIndexOf" },
+                suggestions: []
+            }]
+        },
+        {
+            code: "foo.indexOf(NaN, b)",
+            options: [{ enforceForIndexOf: true }],
+            languageOptions: { ecmaVersion: 2020 },
+            errors: [{
+                messageId: "indexOfNaN",
+                data: { methodName: "indexOf" },
+                suggestions: []
+            }]
+        },
+        {
+            code: "foo.lastIndexOf(NaN, b)",
+            options: [{ enforceForIndexOf: true }],
+            languageOptions: { ecmaVersion: 2020 },
+            errors: [{
+                messageId: "indexOfNaN",
+                data: { methodName: "lastIndexOf" },
+                suggestions: []
+            }]
+        },
+        {
+            code: "foo.indexOf(Number.NaN, b)",
+            options: [{ enforceForIndexOf: true }],
+            languageOptions: { ecmaVersion: 2020 },
+            errors: [{
+                messageId: "indexOfNaN",
+                data: { methodName: "indexOf" },
+                suggestions: []
+            }]
+        },
+        {
+            code: "foo.lastIndexOf(Number.NaN, b)",
+            options: [{ enforceForIndexOf: true }],
+            languageOptions: { ecmaVersion: 2020 },
+            errors: [{
+                messageId: "indexOfNaN",
+                data: { methodName: "lastIndexOf" },
+                suggestions: []
+            }]
+        },
+        {
+            code: "foo.lastIndexOf(NaN, NaN)",
+            options: [{ enforceForIndexOf: true }],
+            languageOptions: { ecmaVersion: 2020 },
+            errors: [{
+                messageId: "indexOfNaN",
+                data: { methodName: "lastIndexOf" },
+                suggestions: []
+            }]
+        },
+        {
+            code: "foo.indexOf((1, NaN), 1)",
+            options: [{ enforceForIndexOf: true }],
+            languageOptions: { ecmaVersion: 2020 },
+            errors: [{
+                messageId: "indexOfNaN",
+                data: { methodName: "indexOf" },
                 suggestions: []
             }]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)
made the rule `use-isnan` to report NaN in `indexOf` and `lastIndexOf` with fromIndex
now rule will report following code-
```js
var foo = myArray.indexOf(NaN, 1);

var bar = myArray.lastIndexOf(NaN, 1);
```

#### Is there anything you'd like reviewers to focus on?
Fixes: #18161

<!-- markdownlint-disable-file MD004 -->
