### PR TITLE
fix!: correct `camelcase` rule schema for `allow` option

### DIFF
--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -36,6 +36,7 @@ The lists below are ordered roughly by the number of users each change is expect
 * [`no-inner-declarations` has a new default behavior with a new option](#no-inner-declarations)
 * [`no-unused-vars` now defaults `caughtErrors` to `"all"`](#no-unused-vars)
 * [`no-useless-computed-key` flags unnecessary computed member names in classes by default](#no-useless-computed-key)
+* [`camelcase` allow option only accepts an array of strings](#camelcase)
 
 ### Breaking changes for plugin developers
 
@@ -433,6 +434,14 @@ class SomeClass {
 **To address:** Fix the problems reported by the rule or revert to the previous behavior by setting the `enforceForClassMembers` option to `false`.
 
 **Related issue(s):** [#18042](https://github.com/eslint/eslint/issues/18042)
+
+## <a name="camelcase"></a> `camelcase` allow option only accepts an array of strings
+
+Previously the camelcase rule didn't enforce the `allow` option to be an array of strings. In ESLint v9.0.0, the `allow` option now only accepts an array of strings.
+
+**To address:** If ESLint reports invalid configuration for this rule, update your configuration.
+
+**Related issue(s):** [#18232](https://github.com/eslint/eslint/pull/18232)
 
 ## <a name="removed-context-methods"></a> Removed multiple `context` methods
 

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -47,11 +47,9 @@ module.exports = {
                     },
                     allow: {
                         type: "array",
-                        items: [
-                            {
-                                type: "string"
-                            }
-                        ],
+                        items: {
+                            type: "string"
+                        },
                         minItems: 0,
                         uniqueItems: true
                     }

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -338,6 +338,18 @@ ruleTester.run("camelcase", rule, {
             options: [{ allow: ["__option_foo__"] }]
         },
         {
+            code: "__option_foo__ = 0; user_id = 0; foo = 1",
+            options: [{ allow: ["__option_foo__", "_id$"] }]
+        },
+        {
+            code: "fo_o = 0;",
+            options: [{ allow: ["__option_foo__", "fo_o"] }]
+        },
+        {
+            code: "user = 0;",
+            options: [{ allow: [] }]
+        },
+        {
             code: "foo = { [computedBar]: 0 };",
             options: [{ ignoreDestructuring: true }],
             languageOptions: { ecmaVersion: 6 }


### PR DESCRIPTION

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

The Json schema of the camelCase rule validate that the first element is a string instead of validating that it's an array of string

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


#### What changes did you make? (Give an overview)

Correct the Json Schema

#### Is there anything you'd like reviewers to focus on?

Nope
