### PR TITLE
chore: add npm script to run WebdriverIO test

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -604,9 +604,6 @@ target.wdio = () => {
 target.test = function() {
     target.checkRuleFiles();
     target.mocha();
-
-    target.wdio();
-
     target.fuzz({ amount: 150, fuzzBrokenAutofixes: false });
     target.checkLicenses();
 };

--- a/Makefile.js
+++ b/Makefile.js
@@ -605,7 +605,7 @@ target.test = function() {
     target.checkRuleFiles();
     target.mocha();
 
-    // target.wdio(); // Temporarily disabled due to problems on Jenkins
+    target.wdio();
 
     target.fuzz({ amount: 150, fuzzBrokenAutofixes: false });
     target.checkLicenses();

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test": "node Makefile.js test",
     "test:cli": "mocha",
     "test:fuzz": "node Makefile.js fuzz",
-    "test:performance": "node Makefile.js perf"
+    "test:performance": "node Makefile.js perf",
+    "test:wdio": "node Makefile.js wdio"
   },
   "gitHooks": {
     "pre-commit": "lint-staged"

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "release:generate:rc": "node Makefile.js generatePrerelease -- rc",
     "release:publish": "node Makefile.js publishRelease",
     "test": "node Makefile.js test",
+    "test:browser": "node Makefile.js wdio",
     "test:cli": "mocha",
     "test:fuzz": "node Makefile.js fuzz",
-    "test:performance": "node Makefile.js perf",
-    "test:wdio": "node Makefile.js wdio"
+    "test:performance": "node Makefile.js perf"
   },
   "gitHooks": {
     "pre-commit": "lint-staged"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[X] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

<s>Re-enabled WebdriverIO tests.</s> Added npm script `test:wdio` to run the WebdriverIO test locally.

#### Is there anything you'd like reviewers to focus on?

WebdriverIO has been running smoothly in CI for the last couple of months. Shall we try to re-enable it for tests in Jenkins? Or maybe just for local tests?

<!-- markdownlint-disable-file MD004 -->
