### PR TITLE
docs: fix `ecmaVersion` in one example, add checks

### DIFF
--- a/docs/src/rules/strict.md
+++ b/docs/src/rules/strict.md
@@ -169,7 +169,7 @@ function foo() {
 
 :::
 
-::: incorrect { "ecmaVersion": 6, "sourceType": "script" }
+::: incorrect { "ecmaVersion": 2015, "sourceType": "script" }
 
 ```js
 /*eslint strict: ["error", "function"]*/

--- a/tests/fixtures/bad-examples.md
+++ b/tests/fixtures/bad-examples.md
@@ -52,3 +52,19 @@ const foo = "baz";
 ```
 
 :::
+
+:::correct { "ecmaVersion": "latest" }
+
+```js
+/* eslint no-restricted-syntax: ["error", "ArrayPattern"] */
+```
+
+:::
+
+:::correct { "ecmaVersion": 6 }
+
+```js
+/* eslint no-restricted-syntax: ["error", "ArrayPattern"] */
+```
+
+:::

--- a/tests/fixtures/good-examples.md
+++ b/tests/fixtures/good-examples.md
@@ -19,7 +19,7 @@ const foo = <bar></bar>;
 
 A test with multiple spaces after 'correct':
 <!-- markdownlint-disable-next-line no-trailing-spaces -->
-:::correct
+:::correct  
 
 ```js
 ```

--- a/tests/fixtures/good-examples.md
+++ b/tests/fixtures/good-examples.md
@@ -19,7 +19,7 @@ const foo = <bar></bar>;
 
 A test with multiple spaces after 'correct':
 <!-- markdownlint-disable-next-line no-trailing-spaces -->
-:::correct  
+:::correct
 
 ```js
 ```
@@ -31,3 +31,35 @@ The following code block is not a rule example, so it won't be checked:
 ```js
 !@#$%^&*()
 ```
+
+:::correct { "ecmaVersion": 3, "sourceType": "script" }
+
+```js
+var x;
+```
+
+:::
+
+:::correct { "ecmaVersion": 5, "sourceType": "script" }
+
+```js
+var x = { import: 5 };
+```
+
+:::
+
+:::correct { "ecmaVersion": 2015 }
+
+```js
+let x;
+```
+
+:::
+
+:::correct { "ecmaVersion": 2024 }
+
+```js
+let x = /a/v;
+```
+
+:::

--- a/tests/tools/check-rule-examples.js
+++ b/tests/tools/check-rule-examples.js
@@ -7,6 +7,7 @@
 const assert = require("assert");
 const { execFile } = require("child_process");
 const { promisify } = require("util");
+const { LATEST_ECMA_VERSION } = require("../../conf/ecma-version");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -78,8 +79,10 @@ describe("check-rule-examples", () => {
                 "\x1B[0m  \x1B[2m31:1\x1B[22m  \x1B[31merror\x1B[39m  Example code should contain a configuration comment like /* eslint no-restricted-syntax: \"error\" */\x1B[0m\n" +
                 "\x1B[0m  \x1B[2m41:1\x1B[22m  \x1B[31merror\x1B[39m  Failed to parse JSON from ' doesn't allow this comment'\x1B[0m\n" +
                 "\x1B[0m  \x1B[2m51:1\x1B[22m  \x1B[31merror\x1B[39m  Duplicate /* eslint no-restricted-syntax */ configuration comment. Each example should contain only one. Split this example into multiple examples\x1B[0m\n" +
+                "\x1B[0m  \x1B[2m56:1\x1B[22m  \x1B[31merror\x1B[39m  Remove unnecessary \"ecmaVersion\":\"latest\"\x1B[0m\n" +
+                `\x1B[0m  \x1B[2m64:1\x1B[22m  \x1B[31merror\x1B[39m  "ecmaVersion" must be one of ${[3, 5, ...Array.from({ length: LATEST_ECMA_VERSION - 2015 + 1 }, (_, index) => index + 2015)].join(", ")}\x1B[0m\n` +
                 "\x1B[0m\x1B[0m\n" +
-                "\x1B[0m\x1B[31m\x1B[1m✖ 7 problems (7 errors, 0 warnings)\x1B[22m\x1B[39m\x1B[0m\n" +
+                "\x1B[0m\x1B[31m\x1B[1m✖ 9 problems (9 errors, 0 warnings)\x1B[22m\x1B[39m\x1B[0m\n" +
                 "\x1B[0m\x1B[31m\x1B[1m\x1B[22m\x1B[39m\x1B[0m\n";
 
                 assert.strictEqual(normalizedStderr, expectedStderr);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

While testing https://github.com/eslint/eslint.org/pull/509, I noticed that one example for the `strict` rule has `"ecmaVersion": 6` in the configuration. This works mostly well because `6` is an alias for `2015`, but when the example is opened in the Playground, nothing is selected in the ECMA Version list:

![image](https://github.com/eslint/eslint/assets/44349756/614396a5-ede8-42d8-a387-bf268fc74b08)


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

1. Updated the mentioned configuration to `"ecmaVersion": 2015`.
2. Added a new check in `tools/check-rule-examples.js` - `ecmaVersion`, if present, must be one of 3, 5, 2015, 2016, ..., 2024 (the latest number). `"latest"` string is also disallowed because it is unnecessary since it's the default.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
