### PR TITLE
docs: remove `/* eslint-env */` comments from rule examples

### DIFF
--- a/docs/src/rules/array-bracket-spacing.md
+++ b/docs/src/rules/array-bracket-spacing.md
@@ -13,8 +13,6 @@ A number of style guides require or disallow spaces between array brackets and o
 applies to both array literals and destructuring assignments (ECMAScript 6).
 
 ```js
-/*eslint-env es6*/
-
 var arr = [ 'foo', 'bar' ];
 var [ x, y ] = z;
 
@@ -58,7 +56,6 @@ Examples of **incorrect** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint array-bracket-spacing: ["error", "never"]*/
-/*eslint-env es6*/
 
 var arr = [ 'foo', 'bar' ];
 var arr = ['foo', 'bar' ];
@@ -81,7 +78,6 @@ Examples of **correct** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint array-bracket-spacing: ["error", "never"]*/
-/*eslint-env es6*/
 
 var arr = [];
 var arr = ['foo', 'bar', 'baz'];
@@ -114,7 +110,6 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 
 ```js
 /*eslint array-bracket-spacing: ["error", "always"]*/
-/*eslint-env es6*/
 
 var arr = ['foo', 'bar'];
 var arr = ['foo', 'bar' ];
@@ -140,7 +135,6 @@ Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 /*eslint array-bracket-spacing: ["error", "always"]*/
-/*eslint-env es6*/
 
 var arr = [];
 var arr = [ 'foo', 'bar', 'baz' ];

--- a/docs/src/rules/arrow-body-style.md
+++ b/docs/src/rules/arrow-body-style.md
@@ -31,7 +31,6 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 
 ```js
 /*eslint arrow-body-style: ["error", "always"]*/
-/*eslint-env es6*/
 
 let foo = () => 0;
 ```
@@ -44,7 +43,6 @@ Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 /*eslint arrow-body-style: ["error", "always"]*/
-/*eslint-env es6*/
 
 let foo = () => {
     return 0;
@@ -65,7 +63,6 @@ Examples of **incorrect** code for this rule with the default `"as-needed"` opti
 
 ```js
 /*eslint arrow-body-style: ["error", "as-needed"]*/
-/*eslint-env es6*/
 
 let foo = () => {
     return 0;
@@ -88,7 +85,6 @@ Examples of **correct** code for this rule with the default `"as-needed"` option
 
 ```js
 /*eslint arrow-body-style: ["error", "as-needed"]*/
-/*eslint-env es6*/
 
 let foo1 = () => 0;
 let foo2 = (retv, name) => {
@@ -122,7 +118,7 @@ Examples of **incorrect** code for this rule with the `{ "requireReturnForObject
 
 ```js
 /*eslint arrow-body-style: ["error", "as-needed", { "requireReturnForObjectLiteral": true }]*/
-/*eslint-env es6*/
+
 let foo = () => ({});
 let bar = () => ({ bar: 0 });
 ```
@@ -135,7 +131,6 @@ Examples of **correct** code for this rule with the `{ "requireReturnForObjectLi
 
 ```js
 /*eslint arrow-body-style: ["error", "as-needed", { "requireReturnForObjectLiteral": true }]*/
-/*eslint-env es6*/
 
 let foo = () => {};
 let bar = () => { return { bar: 0 }; };
@@ -151,7 +146,6 @@ Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint arrow-body-style: ["error", "never"]*/
-/*eslint-env es6*/
 
 let foo = () => {
     return 0;
@@ -170,7 +164,6 @@ Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint arrow-body-style: ["error", "never"]*/
-/*eslint-env es6*/
 
 let foo = () => 0;
 let bar = () => ({ foo: 0 });

--- a/docs/src/rules/arrow-parens.md
+++ b/docs/src/rules/arrow-parens.md
@@ -15,8 +15,6 @@ be wrapped in parentheses. This rule enforces the consistent use of parentheses 
 This rule enforces parentheses around arrow function parameters regardless of arity. For example:
 
 ```js
-/*eslint-env es6*/
-
 // Bad
 a => {}
 
@@ -28,8 +26,6 @@ Following this style will help you find arrow functions (`=>`) which may be mist
 when a comparison such as `>=` was the intent.
 
 ```js
-/*eslint-env es6*/
-
 // Bad
 if (a => 2) {
 }
@@ -42,8 +38,6 @@ if (a >= 2) {
 The rule can also be configured to discourage the use of parens when they are not required:
 
 ```js
-/*eslint-env es6*/
-
 // Bad
 (a) => {}
 
@@ -72,7 +66,6 @@ Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint arrow-parens: ["error", "always"]*/
-/*eslint-env es6*/
 
 a => {};
 a => a;
@@ -90,7 +83,6 @@ Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint arrow-parens: ["error", "always"]*/
-/*eslint-env es6*/
 
 () => {};
 (a) => {};
@@ -107,8 +99,6 @@ a.then((foo) => { if (true) {} });
 One of the benefits of this option is that it prevents the incorrect use of arrow functions in conditionals:
 
 ```js
-/*eslint-env es6*/
-
 var a = 1;
 var b = 2;
 // ...
@@ -125,8 +115,6 @@ The contents of the `if` statement is an arrow function, not a comparison.
 If the arrow function is intentional, it should be wrapped in parens to remove ambiguity.
 
 ```js
-/*eslint-env es6*/
-
 var a = 1;
 var b = 0;
 // ...
@@ -141,8 +129,6 @@ if ((a) => b) {
 The following is another example of this behavior:
 
 ```js
-/*eslint-env es6*/
-
 var a = 1, b = 2, c = 3, d = 4;
 var f = a => b ? c: d;
 // f = ?
@@ -153,8 +139,6 @@ var f = a => b ? c: d;
 This should be rewritten like so:
 
 ```js
-/*eslint-env es6*/
-
 var a = 1, b = 2, c = 3, d = 4;
 var f = (a) => b ? c: d;
 ```
@@ -167,7 +151,6 @@ Examples of **incorrect** code for this rule with the `"as-needed"` option:
 
 ```js
 /*eslint arrow-parens: ["error", "as-needed"]*/
-/*eslint-env es6*/
 
 (a) => {};
 (a) => a;
@@ -188,7 +171,6 @@ Examples of **correct** code for this rule with the `"as-needed"` option:
 
 ```js
 /*eslint arrow-parens: ["error", "as-needed"]*/
-/*eslint-env es6*/
 
 () => {};
 a => {};
@@ -215,7 +197,6 @@ Examples of **incorrect** code for the `{ "requireForBlockBody": true }` option:
 
 ```js
 /*eslint arrow-parens: [2, "as-needed", { "requireForBlockBody": true }]*/
-/*eslint-env es6*/
 
 (a) => a;
 a => {};
@@ -235,7 +216,6 @@ Examples of **correct** code for the `{ "requireForBlockBody": true }` option:
 
 ```js
 /*eslint arrow-parens: [2, "as-needed", { "requireForBlockBody": true }]*/
-/*eslint-env es6*/
 
 (a) => {};
 (a) => {'\n'};

--- a/docs/src/rules/arrow-spacing.md
+++ b/docs/src/rules/arrow-spacing.md
@@ -8,8 +8,6 @@ This rule was **deprecated** in ESLint v8.53.0. Please use the [corresponding ru
 This rule normalize style of spacing before/after an arrow function's arrow(`=>`).
 
 ```js
-/*eslint-env es6*/
-
 // { "before": true, "after": true }
 (a) => {}
 
@@ -31,7 +29,6 @@ Examples of **incorrect** code for this rule with the default `{ "before": true,
 
 ```js
 /*eslint arrow-spacing: "error"*/
-/*eslint-env es6*/
 
 ()=> {};
 () =>{};
@@ -51,7 +48,6 @@ Examples of **correct** code for this rule with the default `{ "before": true, "
 
 ```js
 /*eslint arrow-spacing: "error"*/
-/*eslint-env es6*/
 
 () => {};
 (a) => {};
@@ -67,7 +63,6 @@ Examples of **incorrect** code for this rule with the `{ "before": false, "after
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": false }]*/
-/*eslint-env es6*/
 
 () =>{};
 (a) => {};
@@ -82,7 +77,6 @@ Examples of **correct** code for this rule with the `{ "before": false, "after":
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": false }]*/
-/*eslint-env es6*/
 
 ()=>{};
 (a)=>{};
@@ -97,7 +91,6 @@ Examples of **incorrect** code for this rule with the `{ "before": false, "after
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": true }]*/
-/*eslint-env es6*/
 
 () =>{};
 (a) => {};
@@ -112,7 +105,6 @@ Examples of **correct** code for this rule with the `{ "before": false, "after":
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": true }]*/
-/*eslint-env es6*/
 
 ()=> {};
 (a)=> {};

--- a/docs/src/rules/capitalized-comments.md
+++ b/docs/src/rules/capitalized-comments.md
@@ -42,7 +42,6 @@ Examples of **correct** code for this rule:
 // 丈 Non-Latin character at beginning of comment
 
 /* eslint semi:off */
-/* eslint-env node */
 /* eslint-disable */
 /* eslint-enable */
 /* istanbul ignore next */
@@ -118,7 +117,6 @@ Examples of **correct** code for this rule:
 // 丈 Non-Latin character at beginning of comment
 
 /* eslint semi:off */
-/* eslint-env node */
 /* eslint-disable */
 /* eslint-enable */
 /* istanbul ignore next */

--- a/docs/src/rules/class-methods-use-this.md
+++ b/docs/src/rules/class-methods-use-this.md
@@ -62,7 +62,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint class-methods-use-this: "error"*/
-/*eslint-env es6*/
 
 class A {
     foo() {
@@ -79,7 +78,7 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint class-methods-use-this: "error"*/
-/*eslint-env es6*/
+
 class A {
     foo() {
         this.bar = "Hello World"; // OK, this is used

--- a/docs/src/rules/computed-property-spacing.md
+++ b/docs/src/rules/computed-property-spacing.md
@@ -13,8 +13,6 @@ While formatting preferences are very personal, a number of style guides require
 or disallow spaces between computed properties in the following situations:
 
 ```js
-/*eslint-env es6*/
-
 var obj = { prop: "value" };
 var a = "prop";
 var x = obj[a]; // computed property in object member expression
@@ -57,7 +55,6 @@ Examples of **incorrect** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint computed-property-spacing: ["error", "never"]*/
-/*eslint-env es6*/
 
 obj[foo ]
 obj[ 'foo']
@@ -76,7 +73,6 @@ Examples of **correct** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint computed-property-spacing: ["error", "never"]*/
-/*eslint-env es6*/
 
 obj[foo]
 obj['foo']
@@ -97,7 +93,6 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 
 ```js
 /*eslint computed-property-spacing: ["error", "always"]*/
-/*eslint-env es6*/
 
 obj[foo]
 var x = {[b]: a}
@@ -117,7 +112,6 @@ Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 /*eslint computed-property-spacing: ["error", "always"]*/
-/*eslint-env es6*/
 
 obj[ foo ]
 obj[ 'foo' ]
@@ -139,7 +133,6 @@ Examples of **incorrect** code for this rule with `"never"` and `{ "enforceForCl
 
 ```js
 /*eslint computed-property-spacing: ["error", "never", { "enforceForClassMembers": true }]*/
-/*eslint-env es6*/
 
 class Foo {
   [a ]() {}
@@ -163,7 +156,6 @@ Examples of **correct** code for this rule with `"never"` and `{ "enforceForClas
 
 ```js
 /*eslint computed-property-spacing: ["error", "never", { "enforceForClassMembers": true }]*/
-/*eslint-env es6*/
 
 class Foo {
   [a]() {}
@@ -187,7 +179,6 @@ Examples of **correct** code for this rule with `"never"` and `{ "enforceForClas
 
 ```js
 /*eslint computed-property-spacing: ["error", "never", { "enforceForClassMembers": false }]*/
-/*eslint-env es6*/
 
 class Foo {
   [a ]() {}

--- a/docs/src/rules/constructor-super.md
+++ b/docs/src/rules/constructor-super.md
@@ -30,7 +30,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint constructor-super: "error"*/
-/*eslint-env es6*/
 
 class A extends B {
     constructor() { }  // Would throw a ReferenceError.
@@ -56,7 +55,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint constructor-super: "error"*/
-/*eslint-env es6*/
 
 class A {
     constructor() { }

--- a/docs/src/rules/func-name-matching.md
+++ b/docs/src/rules/func-name-matching.md
@@ -100,7 +100,6 @@ module['exports'] = function foo(name) {};
 
 ```js
 /*eslint func-name-matching: ["error", "never"] */
-/*eslint-env es6*/
 
 var foo = function bar() {};
 var foo = function() {};

--- a/docs/src/rules/generator-star-spacing.md
+++ b/docs/src/rules/generator-star-spacing.md
@@ -13,8 +13,6 @@ These special functions are indicated by placing an `*` after the `function` key
 Here is an example of a generator function:
 
 ```js
-/*eslint-env es6*/
-
 function* generator() {
     yield "44";
     yield "55";
@@ -24,8 +22,6 @@ function* generator() {
 This is also valid:
 
 ```js
-/*eslint-env es6*/
-
 function *generator() {
     yield "44";
     yield "55";
@@ -35,8 +31,6 @@ function *generator() {
 This is valid as well:
 
 ```js
-/*eslint-env es6*/
-
 function * generator() {
     yield "44";
     yield "55";
@@ -113,7 +107,6 @@ Examples of **correct** code for this rule with the `"before"` option:
 
 ```js
 /*eslint generator-star-spacing: ["error", {"before": true, "after": false}]*/
-/*eslint-env es6*/
 
 function *generator() {}
 
@@ -132,7 +125,6 @@ Examples of **correct** code for this rule with the `"after"` option:
 
 ```js
 /*eslint generator-star-spacing: ["error", {"before": false, "after": true}]*/
-/*eslint-env es6*/
 
 function* generator() {}
 
@@ -151,7 +143,6 @@ Examples of **correct** code for this rule with the `"both"` option:
 
 ```js
 /*eslint generator-star-spacing: ["error", {"before": true, "after": true}]*/
-/*eslint-env es6*/
 
 function * generator() {}
 
@@ -170,7 +161,6 @@ Examples of **correct** code for this rule with the `"neither"` option:
 
 ```js
 /*eslint generator-star-spacing: ["error", {"before": false, "after": false}]*/
-/*eslint-env es6*/
 
 function*generator() {}
 
@@ -192,7 +182,6 @@ Examples of **incorrect** code for this rule with overrides present:
     "anonymous": "neither",
     "method": {"before": true, "after": true}
 }]*/
-/*eslint-env es6*/
 
 function * generator() {}
 
@@ -216,7 +205,6 @@ Examples of **correct** code for this rule with overrides present:
     "anonymous": "neither",
     "method": {"before": true, "after": true}
 }]*/
-/*eslint-env es6*/
 
 function* generator() {}
 

--- a/docs/src/rules/generator-star.md
+++ b/docs/src/rules/generator-star.md
@@ -16,8 +16,6 @@ These special functions are indicated by placing an `*` after the `function` key
 Here is an example of a generator function:
 
 ```js
-/*eslint-env es6*/
-
 function* generator() {
     yield "44";
     yield "55";
@@ -27,8 +25,6 @@ function* generator() {
 This is also valid:
 
 ```js
-/*eslint-env es6*/
-
 function *generator() {
     yield "44";
     yield "55";
@@ -38,8 +34,6 @@ function *generator() {
 This is valid as well:
 
 ```js
-/*eslint-env es6*/
-
 function * generator() {
     yield "44";
     yield "55";
@@ -63,8 +57,6 @@ You can set the style in configuration like this:
 When using `"start"` this placement will be enforced:
 
 ```js
-/*eslint-env es6*/
-
 function* generator() {
 }
 ```
@@ -72,8 +64,6 @@ function* generator() {
 When using `"middle"` this placement will be enforced:
 
 ```js
-/*eslint-env es6*/
-
 function * generator() {
 }
 ```
@@ -81,8 +71,6 @@ function * generator() {
 When using `"end"` this placement will be enforced:
 
 ```js
-/*eslint-env es6*/
-
 function *generator() {
 }
 ```
@@ -90,8 +78,6 @@ function *generator() {
 When using the expression syntax `"start"` will be enforced here:
 
 ```js
-/*eslint-env es6*/
-
 var generator = function* () {
 }
 ```
@@ -99,8 +85,6 @@ var generator = function* () {
 When using the expression syntax `"middle"` will be enforced here:
 
 ```js
-/*eslint-env es6*/
-
 var generator = function * () {
 }
 ```
@@ -108,8 +92,6 @@ var generator = function * () {
 When using the expression syntax `"end"` will be enforced here:
 
 ```js
-/*eslint-env es6*/
-
 var generator = function *() {
 }
 ```
@@ -117,8 +99,6 @@ var generator = function *() {
 When using the expression syntax this is valid for both `"start"` and `"end"`:
 
 ```js
-/*eslint-env es6*/
-
 var generator = function*() {
 }
 ```

--- a/docs/src/rules/global-require.md
+++ b/docs/src/rules/global-require.md
@@ -36,7 +36,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint global-require: "error"*/
-/*eslint-env es6*/
 
 // calling require() inside of a function is not allowed
 function readFile(filename, callback) {

--- a/docs/src/rules/id-length.md
+++ b/docs/src/rules/id-length.md
@@ -29,7 +29,6 @@ Examples of **incorrect** code for this rule with the default options:
 
 ```js
 /*eslint id-length: "error"*/     // default is minimum 2-chars ({ "min": 2 })
-/*eslint-env es6*/
 
 var x = 5;
 obj.e = document.body;
@@ -64,7 +63,6 @@ Examples of **correct** code for this rule with the default options:
 
 ```js
 /*eslint id-length: "error"*/     // default is minimum 2-chars ({ "min": 2 })
-/*eslint-env es6*/
 
 var num = 5;
 function _f() { return 42; }
@@ -117,7 +115,6 @@ Examples of **incorrect** code for this rule with the `{ "min": 4 }` option:
 
 ```js
 /*eslint id-length: ["error", { "min": 4 }]*/
-/*eslint-env es6*/
 
 var val = 5;
 obj.e = document.body;
@@ -147,7 +144,6 @@ Examples of **correct** code for this rule with the `{ "min": 4 }` option:
 
 ```js
 /*eslint id-length: ["error", { "min": 4 }]*/
-/*eslint-env es6*/
 
 var value = 5;
 function func() { return 42; }
@@ -183,7 +179,6 @@ Examples of **incorrect** code for this rule with the `{ "max": 10 }` option:
 
 ```js
 /*eslint id-length: ["error", { "max": 10 }]*/
-/*eslint-env es6*/
 
 var reallyLongVarName = 5;
 function reallyLongFuncName() { return 42; }
@@ -206,7 +201,6 @@ Examples of **correct** code for this rule with the `{ "max": 10 }` option:
 
 ```js
 /*eslint id-length: ["error", { "max": 10 }]*/
-/*eslint-env es6*/
 
 var varName = 5;
 function funcName() { return 42; }
@@ -231,7 +225,6 @@ Examples of **correct** code for this rule with the `{ "properties": "never" }` 
 
 ```js
 /*eslint id-length: ["error", { "properties": "never" }]*/
-/*eslint-env es6*/
 
 var myObj = { a: 1 };
 ({ a: obj.x.y.z } = {});
@@ -248,7 +241,6 @@ Examples of additional **correct** code for this rule with the `{ "exceptions": 
 
 ```js
 /*eslint id-length: ["error", { "exceptions": ["x", "y", "z", "ζ"] }]*/
-/*eslint-env es6*/
 
 var x = 5;
 function y() { return 42; }
@@ -275,7 +267,6 @@ Examples of additional **correct** code for this rule with the `{ "exceptionPatt
 
 ```js
 /*eslint id-length: ["error", { "exceptionPatterns": ["E|S", "[x-z]"] }]*/
-/*eslint-env es6*/
 
 var E = 5;
 function S() { return 42; }

--- a/docs/src/rules/indent-legacy.md
+++ b/docs/src/rules/indent-legacy.md
@@ -202,7 +202,6 @@ Examples of **incorrect** code for this rule with the `2, { "VariableDeclarator"
 
 ```js
 /*eslint indent-legacy: ["error", 2, { "VariableDeclarator": 1 }]*/
-/*eslint-env es6*/
 
 var a,
     b,
@@ -223,7 +222,6 @@ Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 
 
 ```js
 /*eslint indent-legacy: ["error", 2, { "VariableDeclarator": 1 }]*/
-/*eslint-env es6*/
 
 var a,
   b,
@@ -244,7 +242,6 @@ Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 
 
 ```js
 /*eslint indent-legacy: ["error", 2, { "VariableDeclarator": 2 }]*/
-/*eslint-env es6*/
 
 var a,
     b,
@@ -265,7 +262,6 @@ Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 
 
 ```js
 /*eslint indent-legacy: ["error", 2, { "VariableDeclarator": { "var": 2, "let": 2, "const": 3 } }]*/
-/*eslint-env es6*/
 
 var a,
     b,

--- a/docs/src/rules/indent.md
+++ b/docs/src/rules/indent.md
@@ -246,7 +246,6 @@ Examples of **incorrect** code for this rule with the `2, { "VariableDeclarator"
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": 1 }]*/
-/*eslint-env es6*/
 
 var a,
     b,
@@ -267,7 +266,6 @@ Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": 1 }]*/
-/*eslint-env es6*/
 
 var a,
   b,
@@ -288,7 +286,6 @@ Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": 2 }]*/
-/*eslint-env es6*/
 
 var a,
     b,
@@ -309,7 +306,6 @@ Examples of **incorrect** code for this rule with the `2, { "VariableDeclarator"
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": "first" }]*/
-/*eslint-env es6*/
 
 var a,
   b,
@@ -330,7 +326,6 @@ Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": "first" }]*/
-/*eslint-env es6*/
 
 var a,
     b,
@@ -351,7 +346,6 @@ Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 
 
 ```js
 /*eslint indent: ["error", 2, { "VariableDeclarator": { "var": 2, "let": 2, "const": 3 } }]*/
-/*eslint-env es6*/
 
 var a,
     b,

--- a/docs/src/rules/init-declarations.md
+++ b/docs/src/rules/init-declarations.md
@@ -71,7 +71,6 @@ Examples of **incorrect** code for the default `"always"` option:
 
 ```js
 /*eslint init-declarations: ["error", "always"]*/
-/*eslint-env es6*/
 
 function foo() {
     var bar;
@@ -87,7 +86,6 @@ Examples of **correct** code for the default `"always"` option:
 
 ```js
 /*eslint init-declarations: ["error", "always"]*/
-/*eslint-env es6*/
 
 function foo() {
     var bar = 1;
@@ -106,7 +104,6 @@ Examples of **incorrect** code for the `"never"` option:
 
 ```js
 /*eslint init-declarations: ["error", "never"]*/
-/*eslint-env es6*/
 
 function foo() {
     var bar = 1;
@@ -124,7 +121,6 @@ Examples of **correct** code for the `"never"` option:
 
 ```js
 /*eslint init-declarations: ["error", "never"]*/
-/*eslint-env es6*/
 
 function foo() {
     var bar;

--- a/docs/src/rules/keyword-spacing.md
+++ b/docs/src/rules/keyword-spacing.md
@@ -62,7 +62,6 @@ Examples of **correct** code for this rule with the default `{ "before": true }`
 
 ```jsx
 /*eslint keyword-spacing: ["error", { "before": true }]*/
-/*eslint-env es6*/
 
 if (foo) {
     //...

--- a/docs/src/rules/max-params.md
+++ b/docs/src/rules/max-params.md
@@ -40,7 +40,6 @@ Examples of **incorrect** code for this rule with the default `{ "max": 3 }` opt
 
 ```js
 /*eslint max-params: ["error", 3]*/
-/*eslint-env es6*/
 
 function foo1 (bar, baz, qux, qxx) {
     doSomething();
@@ -59,7 +58,6 @@ Examples of **correct** code for this rule with the default `{ "max": 3 }` optio
 
 ```js
 /*eslint max-params: ["error", 3]*/
-/*eslint-env es6*/
 
 function foo1 (bar, baz, qux) {
     doSomething();

--- a/docs/src/rules/max-statements.md
+++ b/docs/src/rules/max-statements.md
@@ -46,7 +46,6 @@ Examples of **incorrect** code for this rule with the default `{ "max": 10 }` op
 
 ```js
 /*eslint max-statements: ["error", 10]*/
-/*eslint-env es6*/
 
 function foo() {
   var foo1 = 1;
@@ -87,7 +86,6 @@ Examples of **correct** code for this rule with the default `{ "max": 10 }` opti
 
 ```js
 /*eslint max-statements: ["error", 10]*/
-/*eslint-env es6*/
 
 function foo() {
   var foo1 = 1;

--- a/docs/src/rules/newline-after-var.md
+++ b/docs/src/rules/newline-after-var.md
@@ -46,7 +46,6 @@ Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint newline-after-var: ["error", "always"]*/
-/*eslint-env es6*/
 
 var greet = "hello,",
     name = "world";
@@ -74,7 +73,6 @@ Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint newline-after-var: ["error", "always"]*/
-/*eslint-env es6*/
 
 var greet = "hello,",
     name = "world";
@@ -108,7 +106,6 @@ Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint newline-after-var: ["error", "never"]*/
-/*eslint-env es6*/
 
 var greet = "hello,",
     name = "world";
@@ -140,7 +137,6 @@ Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint newline-after-var: ["error", "never"]*/
-/*eslint-env es6*/
 
 var greet = "hello,",
     name = "world";

--- a/docs/src/rules/no-arrow-condition.md
+++ b/docs/src/rules/no-arrow-condition.md
@@ -43,7 +43,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-arrow-condition: "error"*/
-/*eslint-env es6*/
 
 if (a => 1) {}
 while (a => 1) {}

--- a/docs/src/rules/no-case-declarations.md
+++ b/docs/src/rules/no-case-declarations.md
@@ -25,7 +25,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-case-declarations: "error"*/
-/*eslint-env es6*/
 
 switch (foo) {
     case 1:
@@ -50,7 +49,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-case-declarations: "error"*/
-/*eslint-env es6*/
 
 // Declarations outside switch-statements are valid
 const a = 0;

--- a/docs/src/rules/no-class-assign.md
+++ b/docs/src/rules/no-class-assign.md
@@ -8,8 +8,6 @@ rule_type: problem
 `ClassDeclaration` creates a variable, and we can modify the variable.
 
 ```js
-/*eslint-env es6*/
-
 class A { }
 A = 0;
 ```
@@ -26,7 +24,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-class-assign: "error"*/
-/*eslint-env es6*/
 
 class A { }
 A = 0;
@@ -38,7 +35,6 @@ A = 0;
 
 ```js
 /*eslint no-class-assign: "error"*/
-/*eslint-env es6*/
 
 A = 0;
 class A { }
@@ -50,7 +46,6 @@ class A { }
 
 ```js
 /*eslint no-class-assign: "error"*/
-/*eslint-env es6*/
 
 class A {
     b() {
@@ -65,7 +60,6 @@ class A {
 
 ```js
 /*eslint no-class-assign: "error"*/
-/*eslint-env es6*/
 
 let A = class A {
     b() {
@@ -83,7 +77,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-class-assign: "error"*/
-/*eslint-env es6*/
 
 let A = class A { }
 A = 0; // A is a variable.
@@ -95,7 +88,6 @@ A = 0; // A is a variable.
 
 ```js
 /*eslint no-class-assign: "error"*/
-/*eslint-env es6*/
 
 let A = class {
     b() {
@@ -110,7 +102,6 @@ let A = class {
 
 ```js
 /*eslint no-class-assign: 2*/
-/*eslint-env es6*/
 
 class A {
     b(A) {

--- a/docs/src/rules/no-confusing-arrow.md
+++ b/docs/src/rules/no-confusing-arrow.md
@@ -31,7 +31,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-confusing-arrow: "error"*/
-/*eslint-env es6*/
 
 var x = a => 1 ? 2 : 3;
 var x = (a) => 1 ? 2 : 3;
@@ -45,7 +44,7 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-confusing-arrow: "error"*/
-/*eslint-env es6*/
+
 var x = a => (1 ? 2 : 3);
 var x = (a) => (1 ? 2 : 3);
 var x = (a) => {
@@ -82,7 +81,7 @@ Examples of **incorrect** code for this rule with the `{"allowParens": false}` o
 
 ```js
 /*eslint no-confusing-arrow: ["error", {"allowParens": false}]*/
-/*eslint-env es6*/
+
 var x = a => (1 ? 2 : 3);
 var x = (a) => (1 ? 2 : 3);
 ```
@@ -100,7 +99,7 @@ Examples of **correct** code for this rule with the `{"onlyOneSimpleParam": true
 
 ```js
 /*eslint no-confusing-arrow: ["error", {"onlyOneSimpleParam": true}]*/
-/*eslint-env es6*/
+
 () => 1 ? 2 : 3;
 (a, b) => 1 ? 2 : 3;
 (a = b) => 1 ? 2 : 3;

--- a/docs/src/rules/no-const-assign.md
+++ b/docs/src/rules/no-const-assign.md
@@ -21,7 +21,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-const-assign: "error"*/
-/*eslint-env es6*/
 
 const a = 0;
 a = 1;
@@ -33,7 +32,6 @@ a = 1;
 
 ```js
 /*eslint no-const-assign: "error"*/
-/*eslint-env es6*/
 
 const a = 0;
 a += 1;
@@ -45,7 +43,6 @@ a += 1;
 
 ```js
 /*eslint no-const-assign: "error"*/
-/*eslint-env es6*/
 
 const a = 0;
 ++a;
@@ -59,7 +56,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-const-assign: "error"*/
-/*eslint-env es6*/
 
 const a = 0;
 console.log(a);
@@ -71,7 +67,6 @@ console.log(a);
 
 ```js
 /*eslint no-const-assign: "error"*/
-/*eslint-env es6*/
 
 for (const a in [1, 2, 3]) { // `a` is re-defined (not modified) on each loop step.
     console.log(a);
@@ -84,7 +79,6 @@ for (const a in [1, 2, 3]) { // `a` is re-defined (not modified) on each loop st
 
 ```js
 /*eslint no-const-assign: "error"*/
-/*eslint-env es6*/
 
 for (const a of [1, 2, 3]) { // `a` is re-defined (not modified) on each loop step.
     console.log(a);

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -10,8 +10,6 @@ If there are declarations of the same name in class members, the last declaratio
 It can cause unexpected behaviors.
 
 ```js
-/*eslint-env es6*/
-
 class Foo {
   bar() { console.log("hello"); }
   bar() { console.log("goodbye"); }

--- a/docs/src/rules/no-empty-function.md
+++ b/docs/src/rules/no-empty-function.md
@@ -34,7 +34,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-empty-function: "error"*/
-/*eslint-env es6*/
 
 function foo() {}
 
@@ -89,7 +88,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-empty-function: "error"*/
-/*eslint-env es6*/
 
 function foo() {
     // do nothing.
@@ -222,7 +220,6 @@ Examples of **correct** code for the `{ "allow": ["arrowFunctions"] }` option:
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["arrowFunctions"] }]*/
-/*eslint-env es6*/
 
 var foo = () => {};
 ```
@@ -237,7 +234,6 @@ Examples of **correct** code for the `{ "allow": ["generatorFunctions"] }` optio
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["generatorFunctions"] }]*/
-/*eslint-env es6*/
 
 function* foo() {}
 
@@ -258,7 +254,6 @@ Examples of **correct** code for the `{ "allow": ["methods"] }` option:
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["methods"] }]*/
-/*eslint-env es6*/
 
 var obj = {
     foo() {}
@@ -280,7 +275,6 @@ Examples of **correct** code for the `{ "allow": ["generatorMethods"] }` option:
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["generatorMethods"] }]*/
-/*eslint-env es6*/
 
 var obj = {
     *foo() {}
@@ -302,7 +296,6 @@ Examples of **correct** code for the `{ "allow": ["getters"] }` option:
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["getters"] }]*/
-/*eslint-env es6*/
 
 var obj = {
     get foo() {}
@@ -324,7 +317,6 @@ Examples of **correct** code for the `{ "allow": ["setters"] }` option:
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["setters"] }]*/
-/*eslint-env es6*/
 
 var obj = {
     set foo(value) {}
@@ -346,7 +338,6 @@ Examples of **correct** code for the `{ "allow": ["constructors"] }` option:
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["constructors"] }]*/
-/*eslint-env es6*/
 
 class A {
     constructor() {}
@@ -363,7 +354,6 @@ Examples of **correct** code for the `{ "allow": ["asyncFunctions"] }` options:
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["asyncFunctions"] }]*/
-/*eslint-env es2017*/
 
 async function a(){}
 ```
@@ -378,7 +368,6 @@ Examples of **correct** code for the `{ "allow": ["asyncMethods"] }` options:
 
 ```js
 /*eslint no-empty-function: ["error", { "allow": ["asyncMethods"] }]*/
-/*eslint-env es2017*/
 
 var obj = {
     async foo() {}

--- a/docs/src/rules/no-eval.md
+++ b/docs/src/rules/no-eval.md
@@ -43,26 +43,26 @@ this.eval("var a = 0");
 
 :::
 
-Example of additional **incorrect** code for this rule when `browser` environment is set to `true`:
+Example of additional **incorrect** code for this rule with `window` global variable:
 
 ::: incorrect
 
 ```js
 /*eslint no-eval: "error"*/
-/*eslint-env browser*/
+/*global window*/
 
 window.eval("var a = 0");
 ```
 
 :::
 
-Example of additional **incorrect** code for this rule when `node` environment is set to `true`:
+Example of additional **incorrect** code for this rule with `global` global variable:
 
 ::: incorrect
 
 ```js
 /*eslint no-eval: "error"*/
-/*eslint-env node*/
+/*global global*/
 
 global.eval("var a = 0");
 ```
@@ -75,7 +75,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-eval: "error"*/
-/*eslint-env es6*/
 
 var obj = { x: "foo" },
     key = "x",
@@ -150,7 +149,7 @@ this.eval("var a = 0");
 
 ```js
 /*eslint no-eval: ["error", {"allowIndirect": true} ]*/
-/*eslint-env browser*/
+/*global window*/
 
 window.eval("var a = 0");
 ```
@@ -161,7 +160,7 @@ window.eval("var a = 0");
 
 ```js
 /*eslint no-eval: ["error", {"allowIndirect": true} ]*/
-/*eslint-env node*/
+/*global global*/
 
 global.eval("var a = 0");
 ```

--- a/docs/src/rules/no-extra-bind.md
+++ b/docs/src/rules/no-extra-bind.md
@@ -45,7 +45,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-extra-bind: "error"*/
-/*eslint-env es6*/
 
 var x = function () {
     foo();

--- a/docs/src/rules/no-global-assign.md
+++ b/docs/src/rules/no-global-assign.md
@@ -43,22 +43,9 @@ undefined = 1
 
 ```js
 /*eslint no-global-assign: "error"*/
-/*eslint-env browser*/
+/*global window:readonly*/
 
 window = {}
-length = 1
-top = 1
-```
-
-:::
-
-::: incorrect
-
-```js
-/*eslint no-global-assign: "error"*/
-/*global a:readonly*/
-
-a = 1
 ```
 
 :::
@@ -81,20 +68,9 @@ b = 2
 
 ```js
 /*eslint no-global-assign: "error"*/
-/*eslint-env browser*/
+/*global onload:writable*/
 
 onload = function() {}
-```
-
-:::
-
-::: correct
-
-```js
-/*eslint no-global-assign: "error"*/
-/*global a:writable*/
-
-a = 1
 ```
 
 :::

--- a/docs/src/rules/no-implied-eval.md
+++ b/docs/src/rules/no-implied-eval.md
@@ -35,7 +35,7 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-implied-eval: "error"*/
-/*eslint-env browser*/
+/*global window*/
 
 setTimeout("alert('Hi!');", 100);
 

--- a/docs/src/rules/no-inner-declarations.md
+++ b/docs/src/rules/no-inner-declarations.md
@@ -47,8 +47,6 @@ doSomething(); // error
 A variable declaration is permitted anywhere a statement can go, even nested deeply inside other blocks. This is often undesirable due to variable hoisting, and moving declarations to the root of the program or function body can increase clarity. Note that [block bindings](https://leanpub.com/understandinges6/read#leanpub-auto-block-bindings) (`let`, `const`) are not hoisted and therefore they are not affected by this rule.
 
 ```js
-/*eslint-env es6*/
-
 // Good
 var foo = 42;
 
@@ -126,7 +124,7 @@ function doSomethingElse() {
 
 function doSomethingElse() {
     "use strict";
-    
+
     if (test) {
         function doAnotherThing() { }
     }

--- a/docs/src/rules/no-invalid-this.md
+++ b/docs/src/rules/no-invalid-this.md
@@ -53,7 +53,6 @@ Examples of **incorrect** code for this rule in strict mode:
 
 ```js
 /*eslint no-invalid-this: "error"*/
-/*eslint-env es6*/
 
 "use strict";
 
@@ -101,7 +100,6 @@ Examples of **correct** code for this rule in strict mode:
 
 ```js
 /*eslint no-invalid-this: "error"*/
-/*eslint-env es6*/
 
 "use strict";
 

--- a/docs/src/rules/no-irregular-whitespace.md
+++ b/docs/src/rules/no-irregular-whitespace.md
@@ -117,7 +117,6 @@ var thing = function() {
     return / <NBSP>regexp/;
 }
 
-/*eslint-env es6*/
 var thing = function() {
     return `template <NBSP>string`;
 }
@@ -191,7 +190,6 @@ Examples of additional **correct** code for this rule with the `{ "skipTemplates
 
 ```js
 /*eslint no-irregular-whitespace: ["error", { "skipTemplates": true }]*/
-/*eslint-env es6*/
 
 function thing() {
     return `template <NBSP>string`;
@@ -208,7 +206,6 @@ Examples of additional **correct** code for this rule with the `{ "skipJSXText":
 
 ```jsx
 /*eslint no-irregular-whitespace: ["error", { "skipJSXText": true }]*/
-/*eslint-env es6*/
 
 function Thing() {
     return <div>text in JSX</div>; // <NBSP> before `JSX`

--- a/docs/src/rules/no-lone-blocks.md
+++ b/docs/src/rules/no-lone-blocks.md
@@ -60,13 +60,12 @@ class C {
 
 :::
 
-Examples of **correct** code for this rule with ES6 environment:
+Examples of **correct** code for this rule:
 
 ::: correct
 
 ```js
 /*eslint no-lone-blocks: "error"*/
-/*eslint-env es6*/
 
 while (foo) {
     bar();
@@ -118,7 +117,6 @@ Examples of **correct** code for this rule with ES6 environment and strict mode 
 
 ```js
 /*eslint no-lone-blocks: "error"*/
-/*eslint-env es6*/
 
 "use strict";
 

--- a/docs/src/rules/no-loop-func.md
+++ b/docs/src/rules/no-loop-func.md
@@ -19,8 +19,6 @@ In this case, you would expect each function created within the loop to return a
 `let` or `const` mitigate this problem.
 
 ```js
-/*eslint-env es6*/
-
 for (let i = 0; i < 10; i++) {
     funcs[i] = function() {
         return i;
@@ -42,7 +40,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-loop-func: "error"*/
-/*eslint-env es6*/
 
 for (var i=10; i; i--) {
     (function() { return i; })();
@@ -86,7 +83,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-loop-func: "error"*/
-/*eslint-env es6*/
 
 var a = function() {};
 

--- a/docs/src/rules/no-native-reassign.md
+++ b/docs/src/rules/no-native-reassign.md
@@ -44,22 +44,9 @@ undefined = 1
 
 ```js
 /*eslint no-native-reassign: "error"*/
-/*eslint-env browser*/
+/*global window:readonly*/
 
 window = {}
-length = 1
-top = 1
-```
-
-:::
-
-::: incorrect
-
-```js
-/*eslint no-native-reassign: "error"*/
-/*global a:readonly*/
-
-a = 1
 ```
 
 :::
@@ -82,20 +69,9 @@ b = 2
 
 ```js
 /*eslint no-native-reassign: "error"*/
-/*eslint-env browser*/
+/*global onload:writable*/
 
 onload = function() {}
-```
-
-:::
-
-::: correct
-
-```js
-/*eslint no-native-reassign: "error"*/
-/*global a:writable*/
-
-a = 1
 ```
 
 :::

--- a/docs/src/rules/no-new-native-nonconstructor.md
+++ b/docs/src/rules/no-new-native-nonconstructor.md
@@ -38,7 +38,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-new-native-nonconstructor: "error"*/
-/*eslint-env es2022*/
 
 var foo = new Symbol('foo');
 var bar = new BigInt(9007199254740991);
@@ -52,7 +51,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-new-native-nonconstructor: "error"*/
-/*eslint-env es2022*/
 
 var foo = Symbol('foo');
 var bar = BigInt(9007199254740991);

--- a/docs/src/rules/no-new-symbol.md
+++ b/docs/src/rules/no-new-symbol.md
@@ -28,7 +28,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-new-symbol: "error"*/
-/*eslint-env es6*/
 
 var foo = new Symbol('foo');
 ```
@@ -41,7 +40,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-new-symbol: "error"*/
-/*eslint-env es6*/
 
 var foo = Symbol('foo');
 

--- a/docs/src/rules/no-obj-calls.md
+++ b/docs/src/rules/no-obj-calls.md
@@ -38,7 +38,7 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-obj-calls: "error"*/
-/*eslint-env es2017, browser */
+/*global Intl*/
 
 var math = Math();
 
@@ -69,7 +69,7 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-obj-calls: "error"*/
-/*eslint-env es2017, browser*/
+/*global Intl*/
 
 function area(r) {
     return Math.PI * r * r;

--- a/docs/src/rules/no-promise-executor-return.md
+++ b/docs/src/rules/no-promise-executor-return.md
@@ -38,7 +38,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-promise-executor-return: "error"*/
-/*eslint-env es6*/
 
 new Promise((resolve, reject) => {
     if (someCondition) {
@@ -76,7 +75,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-promise-executor-return: "error"*/
-/*eslint-env es6*/
 
 // Turn return inline into two lines
 new Promise((resolve, reject) => {
@@ -125,7 +123,6 @@ Examples of **correct** code for this rule with the `{ "allowVoid": true }` opti
 
 ```js
 /*eslint no-promise-executor-return: ["error", { allowVoid: true }]*/
-/*eslint-env es6*/
 
 new Promise((resolve, reject) => {
     if (someCondition) {

--- a/docs/src/rules/no-redeclare.md
+++ b/docs/src/rules/no-redeclare.md
@@ -87,19 +87,4 @@ var Object = 0;
 
 :::
 
-Examples of **incorrect** code for the `{ "builtinGlobals": true }` option and the `browser` environment:
-
-::: incorrect { "sourceType": "script" }
-
-```js
-/*eslint no-redeclare: ["error", { "builtinGlobals": true }]*/
-/*eslint-env browser*/
-
-var top = 0;
-```
-
-:::
-
-The `browser` environment has many built-in global variables (for example, `top`). Some of built-in global variables cannot be redeclared.
-
-Note that when using the `node` or `commonjs` environments (or `ecmaFeatures.globalReturn`, if using the default parser), the top scope of a program is not actually the global scope, but rather a "module" scope. When this is the case, declaring a variable named after a builtin global is not a redeclaration, but rather a shadowing of the global variable. In that case, the [`no-shadow`](no-shadow) rule with the `"builtinGlobals"` option should be used.
+Note that when using `sourceType: "commonjs"` (or `ecmaFeatures.globalReturn`, if using the default parser), the top scope of a program is not actually the global scope, but rather a "module" scope. When this is the case, declaring a variable named after a builtin global is not a redeclaration, but rather a shadowing of the global variable. In that case, the [`no-shadow`](no-shadow) rule with the `"builtinGlobals"` option should be used.

--- a/docs/src/rules/no-shadow.md
+++ b/docs/src/rules/no-shadow.md
@@ -29,7 +29,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-shadow: "error"*/
-/*eslint-env es6*/
 
 var a = 3;
 function b() {
@@ -97,7 +96,6 @@ Examples of **incorrect** code for the default `{ "hoist": "functions" }` option
 
 ```js
 /*eslint no-shadow: ["error", { "hoist": "functions" }]*/
-/*eslint-env es6*/
 
 if (true) {
     let b = 6;
@@ -116,7 +114,6 @@ Examples of **correct** code for the default `{ "hoist": "functions" }` option:
 
 ```js
 /*eslint no-shadow: ["error", { "hoist": "functions" }]*/
-/*eslint-env es6*/
 
 if (true) {
     let a = 3;
@@ -137,7 +134,6 @@ Examples of **incorrect** code for the `{ "hoist": "all" }` option:
 
 ```js
 /*eslint no-shadow: ["error", { "hoist": "all" }]*/
-/*eslint-env es6*/
 
 if (true) {
     let a = 3;
@@ -158,7 +154,6 @@ Examples of **correct** code for the `{ "hoist": "never" }` option:
 
 ```js
 /*eslint no-shadow: ["error", { "hoist": "never" }]*/
-/*eslint-env es6*/
 
 if (true) {
     let a = 3;
@@ -183,7 +178,6 @@ Examples of **correct** code for the `{ "allow": ["done"] }` option:
 
 ```js
 /*eslint no-shadow: ["error", { "allow": ["done"] }]*/
-/*eslint-env es6*/
 
 import async from 'async';
 

--- a/docs/src/rules/no-this-before-super.md
+++ b/docs/src/rules/no-this-before-super.md
@@ -22,7 +22,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-this-before-super: "error"*/
-/*eslint-env es6*/
 
 class A1 extends B {
     constructor() {
@@ -60,7 +59,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-this-before-super: "error"*/
-/*eslint-env es6*/
 
 class A1 {
     constructor() {

--- a/docs/src/rules/no-throw-literal.md
+++ b/docs/src/rules/no-throw-literal.md
@@ -19,7 +19,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-throw-literal: "error"*/
-/*eslint-env es6*/
 
 throw "error";
 

--- a/docs/src/rules/no-useless-concat.md
+++ b/docs/src/rules/no-useless-concat.md
@@ -26,7 +26,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-useless-concat: "error"*/
-/*eslint-env es6*/
 
 var a = `some` + `string`;
 

--- a/docs/src/rules/no-useless-constructor.md
+++ b/docs/src/rules/no-useless-constructor.md
@@ -31,7 +31,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-useless-constructor: "error"*/
-/*eslint-env es6*/
 
 class A {
     constructor () {

--- a/docs/src/rules/no-var.md
+++ b/docs/src/rules/no-var.md
@@ -47,7 +47,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-var: "error"*/
-/*eslint-env es6*/
 
 let x = "y";
 const CONFIG = {};

--- a/docs/src/rules/no-with.md
+++ b/docs/src/rules/no-with.md
@@ -35,7 +35,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-with: "error"*/
-/*eslint-env es6*/
 
 const r = ({x, y}) => Math.sqrt(x * x + y * y);
 ```

--- a/docs/src/rules/object-curly-newline.md
+++ b/docs/src/rules/object-curly-newline.md
@@ -55,7 +55,6 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 
 ```js
 /*eslint object-curly-newline: ["error", "always"]*/
-/*eslint-env es6*/
 
 let a = {};
 let b = {foo: 1};
@@ -84,7 +83,6 @@ Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 /*eslint object-curly-newline: ["error", "always"]*/
-/*eslint-env es6*/
 
 let a = {
 };
@@ -133,7 +131,6 @@ Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint object-curly-newline: ["error", "never"]*/
-/*eslint-env es6*/
 
 let a = {
 };
@@ -180,7 +177,6 @@ Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint object-curly-newline: ["error", "never"]*/
-/*eslint-env es6*/
 
 let a = {};
 let b = {foo: 1};
@@ -211,7 +207,6 @@ Examples of **incorrect** code for this rule with the `{ "multiline": true }` op
 
 ```js
 /*eslint object-curly-newline: ["error", { "multiline": true }]*/
-/*eslint-env es6*/
 
 let a = {
 };
@@ -250,7 +245,6 @@ Examples of **correct** code for this rule with the `{ "multiline": true }` opti
 
 ```js
 /*eslint object-curly-newline: ["error", { "multiline": true }]*/
-/*eslint-env es6*/
 
 let a = {};
 let b = {foo: 1};
@@ -289,7 +283,6 @@ Examples of **incorrect** code for this rule with the `{ "minProperties": 2 }` o
 
 ```js
 /*eslint object-curly-newline: ["error", { "minProperties": 2 }]*/
-/*eslint-env es6*/
 
 let a = {
 };
@@ -328,7 +321,6 @@ Examples of **correct** code for this rule with the `{ "minProperties": 2 }` opt
 
 ```js
 /*eslint object-curly-newline: ["error", { "minProperties": 2 }]*/
-/*eslint-env es6*/
 
 let a = {};
 let b = {foo: 1};
@@ -367,7 +359,6 @@ Examples of **incorrect** code for this rule with the default `{ "consistent": t
 
 ```js
 /*eslint object-curly-newline: ["error", { "consistent": true }]*/
-/*eslint-env es6*/
 
 let a = {foo: 1
 };
@@ -415,7 +406,6 @@ Examples of **correct** code for this rule with the default `{ "consistent": tru
 
 ```js
 /*eslint object-curly-newline: ["error", { "consistent": true }]*/
-/*eslint-env es6*/
 
 let empty1 = {};
 let empty2 = {
@@ -473,7 +463,6 @@ Examples of **incorrect** code for this rule with the `{ "ObjectExpression": "al
 
 ```js
 /*eslint object-curly-newline: ["error", { "ObjectExpression": "always", "ObjectPattern": "never" }]*/
-/*eslint-env es6*/
 
 let a = {};
 let b = {foo: 1};
@@ -511,7 +500,6 @@ Examples of **correct** code for this rule with the `{ "ObjectExpression": "alwa
 
 ```js
 /*eslint object-curly-newline: ["error", { "ObjectExpression": "always", "ObjectPattern": "never" }]*/
-/*eslint-env es6*/
 
 let a = {
 };
@@ -551,7 +539,6 @@ Examples of **incorrect** code for this rule with the `{ "ImportDeclaration": "a
 
 ```js
 /*eslint object-curly-newline: ["error", { "ImportDeclaration": "always", "ExportDeclaration": "never" }]*/
-/*eslint-env es6*/
 
 import {foo, bar} from 'foo-bar';
 import {foo as f, baz} from 'foo-bar';
@@ -576,7 +563,6 @@ Examples of **correct** code for this rule with the `{ "ImportDeclaration": "alw
 
 ```js
 /*eslint object-curly-newline: ["error", { "ImportDeclaration": "always", "ExportDeclaration": "never" }]*/
-/*eslint-env es6*/
 
 import {
     foo,

--- a/docs/src/rules/object-shorthand.md
+++ b/docs/src/rules/object-shorthand.md
@@ -32,8 +32,6 @@ var foo = {
 Now here are ES6 equivalents:
 
 ```js
-/*eslint-env es6*/
-
 // properties
 var foo = {x, y, z};
 
@@ -54,7 +52,6 @@ Each of the following properties would warn:
 
 ```js
 /*eslint object-shorthand: "error"*/
-/*eslint-env es6*/
 
 var foo = {
     w: function() {},
@@ -68,7 +65,6 @@ In that case the expected syntax would have been:
 
 ```js
 /*eslint object-shorthand: "error"*/
-/*eslint-env es6*/
 
 var foo = {
     w() {},
@@ -83,7 +79,6 @@ The following will *not* warn:
 
 ```js
 /*eslint object-shorthand: "error"*/
-/*eslint-env es6*/
 
 var foo = {
     x: (y) => y
@@ -130,7 +125,6 @@ Example of **incorrect** code for this rule with the `"always", { "avoidQuotes":
 
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidQuotes": true }]*/
-/*eslint-env es6*/
 
 var foo = {
     "bar-baz"() {}
@@ -145,7 +139,6 @@ Example of **correct** code for this rule with the `"always", { "avoidQuotes": t
 
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidQuotes": true }]*/
-/*eslint-env es6*/
 
 var foo = {
     "bar-baz": function() {},
@@ -169,7 +162,6 @@ Example of **correct** code for this rule with the `"always", { "ignoreConstruct
 
 ```js
 /*eslint object-shorthand: ["error", "always", { "ignoreConstructors": true }]*/
-/*eslint-env es6*/
 
 var foo = {
     ConstructorFunction: function() {}
@@ -208,7 +200,6 @@ Example of **incorrect** code for this rule with the `"always", { "avoidExplicit
 
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidExplicitReturnArrows": true }]*/
-/*eslint-env es6*/
 
 var foo = {
   foo: (bar, baz) => {
@@ -229,7 +220,6 @@ Example of **correct** code for this rule with the `"always", { "avoidExplicitRe
 
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidExplicitReturnArrows": true }]*/
-/*eslint-env es6*/
 
 var foo = {
   foo(bar, baz) {
@@ -248,7 +238,6 @@ Example of **incorrect** code for this rule with the `"consistent"` option:
 
 ```js
 /*eslint object-shorthand: [2, "consistent"]*/
-/*eslint-env es6*/
 
 var foo = {
     a,
@@ -264,7 +253,6 @@ Examples of **correct** code for this rule with the `"consistent"` option:
 
 ```js
 /*eslint object-shorthand: [2, "consistent"]*/
-/*eslint-env es6*/
 
 var foo = {
     a: a,
@@ -285,7 +273,6 @@ Example of **incorrect** code with the `"consistent-as-needed"` option, which is
 
 ```js
 /*eslint object-shorthand: [2, "consistent-as-needed"]*/
-/*eslint-env es6*/
 
 var foo = {
     a: a,

--- a/docs/src/rules/one-var-declaration-per-line.md
+++ b/docs/src/rules/one-var-declaration-per-line.md
@@ -42,7 +42,6 @@ Examples of **incorrect** code for this rule with the default `"initializations"
 
 ```js
 /*eslint one-var-declaration-per-line: ["error", "initializations"]*/
-/*eslint-env es6*/
 
 var a, b, c = 0;
 
@@ -58,7 +57,6 @@ Examples of **correct** code for this rule with the default `"initializations"` 
 
 ```js
 /*eslint one-var-declaration-per-line: ["error", "initializations"]*/
-/*eslint-env es6*/
 
 var a, b;
 
@@ -79,7 +77,6 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 
 ```js
 /*eslint one-var-declaration-per-line: ["error", "always"]*/
-/*eslint-env es6*/
 
 var a, b;
 
@@ -96,7 +93,6 @@ Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 /*eslint one-var-declaration-per-line: ["error", "always"]*/
-/*eslint-env es6*/
 
 var a,
     b;

--- a/docs/src/rules/one-var.md
+++ b/docs/src/rules/one-var.md
@@ -347,7 +347,6 @@ Examples of **incorrect** code for this rule with the `{ var: "always", let: "ne
 
 ```js
 /*eslint one-var: ["error", { var: "always", let: "never", const: "never" }]*/
-/*eslint-env es6*/
 
 function foo1() {
     var bar;
@@ -372,7 +371,6 @@ Examples of **correct** code for this rule with the `{ var: "always", let: "neve
 
 ```js
 /*eslint one-var: ["error", { var: "always", let: "never", const: "never" }]*/
-/*eslint-env es6*/
 
 function foo1() {
     var bar,
@@ -397,7 +395,6 @@ Examples of **incorrect** code for this rule with the `{ var: "never" }` option:
 
 ```js
 /*eslint one-var: ["error", { var: "never" }]*/
-/*eslint-env es6*/
 
 function foo() {
     var bar,
@@ -413,7 +410,6 @@ Examples of **correct** code for this rule with the `{ var: "never" }` option:
 
 ```js
 /*eslint one-var: ["error", { var: "never" }]*/
-/*eslint-env es6*/
 
 function foo() {
     var bar;
@@ -437,7 +433,6 @@ Examples of **incorrect** code for this rule with the `{ separateRequires: true 
 
 ```js
 /*eslint one-var: ["error", { separateRequires: true, var: "always" }]*/
-/*eslint-env node*/
 
 var foo = require("foo"),
     bar = "bar";
@@ -451,7 +446,6 @@ Examples of **correct** code for this rule with the `{ separateRequires: true }`
 
 ```js
 /*eslint one-var: ["error", { separateRequires: true, var: "always" }]*/
-/*eslint-env node*/
 
 var foo = require("foo");
 var bar = "bar";
@@ -463,7 +457,6 @@ var bar = "bar";
 
 ```js
 /*eslint one-var: ["error", { separateRequires: true, var: "always" }]*/
-/*eslint-env node*/
 
 var foo = require("foo"),
     bar = require("bar");
@@ -477,7 +470,6 @@ Examples of **incorrect** code for this rule with the `{ var: "never", let: "con
 
 ```js
 /*eslint one-var: ["error", { var: "never", let: "consecutive", const: "consecutive" }]*/
-/*eslint-env es6*/
 
 function foo1() {
     let a,
@@ -506,7 +498,6 @@ Examples of **correct** code for this rule with the `{ var: "never", let: "conse
 
 ```js
 /*eslint one-var: ["error", { var: "never", let: "consecutive", const: "consecutive" }]*/
-/*eslint-env es6*/
 
 function foo1() {
     let a,
@@ -537,7 +528,6 @@ Examples of **incorrect** code for this rule with the `{ var: "consecutive" }` o
 
 ```js
 /*eslint one-var: ["error", { var: "consecutive" }]*/
-/*eslint-env es6*/
 
 function foo() {
     var a;
@@ -553,7 +543,6 @@ Examples of **correct** code for this rule with the `{ var: "consecutive" }` opt
 
 ```js
 /*eslint one-var: ["error", { var: "consecutive" }]*/
-/*eslint-env es6*/
 
 function foo() {
     var a,
@@ -575,7 +564,6 @@ Examples of **incorrect** code for this rule with the `{ "initialized": "always"
 
 ```js
 /*eslint one-var: ["error", { "initialized": "always", "uninitialized": "never" }]*/
-/*eslint-env es6*/
 
 function foo() {
     var a, b, c;
@@ -619,7 +607,6 @@ Examples of **incorrect** code for this rule with the `{ "initialized": "never" 
 
 ```js
 /*eslint one-var: ["error", { "initialized": "never" }]*/
-/*eslint-env es6*/
 
 function foo() {
     var foo = true,

--- a/docs/src/rules/prefer-arrow-callback.md
+++ b/docs/src/rules/prefer-arrow-callback.md
@@ -45,7 +45,6 @@ The following examples **will not** be flagged:
 
 ```js
 /* eslint prefer-arrow-callback: "error" */
-/* eslint-env es6 */
 
 // arrow function callback
 foo(a => a); // OK
@@ -101,7 +100,6 @@ When set to `false` this option prohibits the use of function expressions as cal
 
 ```js
 /* eslint prefer-arrow-callback: [ "error", { "allowUnboundThis": false } ] */
-/* eslint-env es6 */
 
 foo(function() { this.a; });
 

--- a/docs/src/rules/prefer-const.md
+++ b/docs/src/rules/prefer-const.md
@@ -149,7 +149,6 @@ Examples of **incorrect** code for the default `{"destructuring": "any"}` option
 
 ```js
 /*eslint prefer-const: "error"*/
-/*eslint-env es6*/
 
 let {a, b} = obj;    /*error 'b' is never reassigned, use 'const' instead.*/
 a = a + 1;
@@ -163,7 +162,6 @@ Examples of **correct** code for the default `{"destructuring": "any"}` option:
 
 ```js
 /*eslint prefer-const: "error"*/
-/*eslint-env es6*/
 
 // using const.
 const {a: a0, b} = obj;
@@ -183,7 +181,6 @@ Examples of **incorrect** code for the `{"destructuring": "all"}` option:
 
 ```js
 /*eslint prefer-const: ["error", {"destructuring": "all"}]*/
-/*eslint-env es6*/
 
 // all of `a` and `b` should be const, so those are warned.
 let {a, b} = obj;    /*error 'a' is never reassigned, use 'const' instead.
@@ -198,7 +195,6 @@ Examples of **correct** code for the `{"destructuring": "all"}` option:
 
 ```js
 /*eslint prefer-const: ["error", {"destructuring": "all"}]*/
-/*eslint-env es6*/
 
 // 'b' is never reassigned, but all of `a` and `b` should not be const, so those are ignored.
 let {a, b} = obj;
@@ -219,7 +215,6 @@ Examples of **correct** code for the `{"ignoreReadBeforeAssign": true}` option:
 
 ```js
 /*eslint prefer-const: ["error", {"ignoreReadBeforeAssign": true}]*/
-/*eslint-env es6*/
 
 let timer;
 function initialize() {
@@ -238,7 +233,6 @@ Examples of **correct** code for the default `{"ignoreReadBeforeAssign": false}`
 
 ```js
 /*eslint prefer-const: ["error", {"ignoreReadBeforeAssign": false}]*/
-/*eslint-env es6*/
 
 const timer = setInterval(initialize, 100);
 function initialize() {

--- a/docs/src/rules/prefer-numeric-literals.md
+++ b/docs/src/rules/prefer-numeric-literals.md
@@ -40,7 +40,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint prefer-numeric-literals: "error"*/
-/*eslint-env es6*/
 
 parseInt(1);
 parseInt(1, 3);

--- a/docs/src/rules/prefer-spread.md
+++ b/docs/src/rules/prefer-spread.md
@@ -16,8 +16,6 @@ Math.max.apply(Math, args);
 In ES2015, one can use spread syntax to call variadic functions.
 
 ```js
-/*eslint-env es6*/
-
 var args = [1, 2, 3, 4];
 Math.max(...args);
 ```

--- a/docs/src/rules/prefer-template.md
+++ b/docs/src/rules/prefer-template.md
@@ -15,8 +15,6 @@ var str = "Hello, " + name + "!";
 ```
 
 ```js
-/*eslint-env es6*/
-
 var str = `Hello, ${name}!`;
 ```
 
@@ -45,7 +43,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint prefer-template: "error"*/
-/*eslint-env es6*/
 
 var str = "Hello World!";
 var str = `Hello, ${name}!`;

--- a/docs/src/rules/quote-props.md
+++ b/docs/src/rules/quote-props.md
@@ -83,7 +83,6 @@ Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint quote-props: ["error", "always"]*/
-/*eslint-env es6*/
 
 var object1 = {
     "foo": "bar",
@@ -131,7 +130,6 @@ Examples of **correct** code for this rule with the `"as-needed"` option:
 
 ```js
 /*eslint quote-props: ["error", "as-needed"]*/
-/*eslint-env es6*/
 
 var object1 = {
     "a-b": 0,

--- a/docs/src/rules/quotes.md
+++ b/docs/src/rules/quotes.md
@@ -8,8 +8,6 @@ This rule was **deprecated** in ESLint v8.53.0. Please use the [corresponding ru
 JavaScript allows you to define strings in one of three ways: double quotes, single quotes, and backticks (as of ECMAScript 6). For example:
 
 ```js
-/*eslint-env es6*/
-
 var double = "double";
 var single = 'single';
 var backtick = `backtick`;    // ES6 only
@@ -64,7 +62,6 @@ Examples of **correct** code for this rule with the default `"double"` option:
 
 ```js
 /*eslint quotes: ["error", "double"]*/
-/*eslint-env es6*/
 
 var double = "double";
 var backtick = `back
@@ -95,7 +92,6 @@ Examples of **correct** code for this rule with the `"single"` option:
 
 ```js
 /*eslint quotes: ["error", "single"]*/
-/*eslint-env es6*/
 
 var single = 'single';
 var backtick = `back${x}tick`; // backticks are allowed due to substitution
@@ -125,7 +121,6 @@ Examples of **correct** code for this rule with the `"backtick"` option:
 
 ```js
 /*eslint quotes: ["error", "backtick"]*/
-/*eslint-env es6*/
 
 "use strict"; // directives must use single or double quotes
 var backtick = `backtick`;

--- a/docs/src/rules/require-yield.md
+++ b/docs/src/rules/require-yield.md
@@ -19,7 +19,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint require-yield: "error"*/
-/*eslint-env es6*/
 
 function* foo() {
   return 10;
@@ -34,7 +33,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint require-yield: "error"*/
-/*eslint-env es6*/
 
 function* foo() {
   yield 5;

--- a/docs/src/rules/sort-keys.md
+++ b/docs/src/rules/sort-keys.md
@@ -19,7 +19,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint sort-keys: "error"*/
-/*eslint-env es6*/
 
 let obj1 = {a: 1, c: 3, b: 2};
 let obj2 = {a: 1, "c": 3, b: 2};
@@ -45,7 +44,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint sort-keys: "error"*/
-/*eslint-env es6*/
 
 let obj1 = {a: 1, b: 2, c: 3};
 let obj2 = {a: 1, "b": 2, c: 3};
@@ -116,7 +114,6 @@ Examples of **incorrect** code for the `"desc"` option:
 
 ```js
 /*eslint sort-keys: ["error", "desc"]*/
-/*eslint-env es6*/
 
 let obj1 = {b: 2, c: 3, a: 1};
 let obj2 = {"b": 2, c: 3, a: 1};
@@ -136,7 +133,6 @@ Examples of **correct** code for the `"desc"` option:
 
 ```js
 /*eslint sort-keys: ["error", "desc"]*/
-/*eslint-env es6*/
 
 let obj1 = {c: 3, b: 2, a: 1};
 let obj2 = {c: 3, "b": 2, a: 1};
@@ -158,7 +154,6 @@ Examples of **incorrect** code for the `{caseSensitive: false}` option:
 
 ```js
 /*eslint sort-keys: ["error", "asc", {caseSensitive: false}]*/
-/*eslint-env es6*/
 
 let obj1 = {a: 1, c: 3, C: 4, b: 2};
 let obj2 = {a: 1, C: 3, c: 4, b: 2};
@@ -172,7 +167,6 @@ Examples of **correct** code for the `{caseSensitive: false}` option:
 
 ```js
 /*eslint sort-keys: ["error", "asc", {caseSensitive: false}]*/
-/*eslint-env es6*/
 
 let obj1 = {a: 1, b: 2, c: 3, C: 4};
 let obj2 = {a: 1, b: 2, C: 3, c: 4};
@@ -188,7 +182,6 @@ Examples of **incorrect** code for the `{natural: true}` option:
 
 ```js
 /*eslint sort-keys: ["error", "asc", {natural: true}]*/
-/*eslint-env es6*/
 
 let obj = {1: a, 10: c, 2: b};
 ```
@@ -201,7 +194,6 @@ Examples of **correct** code for the `{natural: true}` option:
 
 ```js
 /*eslint sort-keys: ["error", "asc", {natural: true}]*/
-/*eslint-env es6*/
 
 let obj = {1: a, 2: b, 10: c};
 ```
@@ -216,7 +208,6 @@ Examples of **incorrect** code for the `{minKeys: 4}` option:
 
 ```js
 /*eslint sort-keys: ["error", "asc", {minKeys: 4}]*/
-/*eslint-env es6*/
 
 // 4 keys
 let obj1 = {
@@ -244,7 +235,6 @@ Examples of **correct** code for the `{minKeys: 4}` option:
 
 ```js
 /*eslint sort-keys: ["error", "asc", {minKeys: 4}]*/
-/*eslint-env es6*/
 
 // 3 keys
 let obj1 = {
@@ -270,7 +260,6 @@ Examples of **incorrect** code for the `{allowLineSeparatedGroups: true}` option
 
 ```js
 /*eslint sort-keys: ["error", "asc", {allowLineSeparatedGroups: true}]*/
-/*eslint-env es6*/
 
 let obj1 = {
     b: 1,
@@ -316,7 +305,6 @@ Examples of **correct** code for the `{allowLineSeparatedGroups: true}` option:
 
 ```js
 /*eslint sort-keys: ["error", "asc", {allowLineSeparatedGroups: true}]*/
-/*eslint-env es6*/
 
 let obj1 = {
     e: 1,
@@ -342,7 +330,7 @@ let obj3 = {
 
     b () {
 
-    }, 
+    },
     e: 3,
 }
 

--- a/docs/src/rules/space-before-blocks.md
+++ b/docs/src/rules/space-before-blocks.md
@@ -151,7 +151,6 @@ Examples of **incorrect** code for this rule when configured `{ "functions": "ne
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "always", "classes": "never" }]*/
-/*eslint-env es6*/
 
 function a() {}
 
@@ -170,7 +169,6 @@ Examples of **correct** code for this rule when configured `{ "functions": "neve
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "always", "classes": "never" }]*/
-/*eslint-env es6*/
 
 for (;;) {
   // ...
@@ -193,7 +191,6 @@ Examples of **incorrect** code for this rule when configured `{ "functions": "al
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", "classes": "never" }]*/
-/*eslint-env es6*/
 
 function a(){}
 
@@ -212,7 +209,6 @@ Examples of **correct** code for this rule when configured `{ "functions": "alwa
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", "classes": "never" }]*/
-/*eslint-env es6*/
 
 if (a){
   b();
@@ -233,7 +229,6 @@ Examples of **incorrect** code for this rule when configured `{ "functions": "ne
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "never", "classes": "always" }]*/
-/*eslint-env es6*/
 
 class Foo{
   constructor(){}
@@ -248,7 +243,6 @@ Examples of **correct** code for this rule when configured `{ "functions": "neve
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "never", "classes": "always" }]*/
-/*eslint-env es6*/
 
 class Foo {
   constructor(){}

--- a/docs/src/rules/space-before-function-paren.md
+++ b/docs/src/rules/space-before-function-paren.md
@@ -65,7 +65,6 @@ Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint space-before-function-paren: "error"*/
-/*eslint-env es6*/
 
 function foo() {
     // ...
@@ -102,7 +101,6 @@ Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint space-before-function-paren: "error"*/
-/*eslint-env es6*/
 
 function foo () {
     // ...
@@ -141,7 +139,6 @@ Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", "never"]*/
-/*eslint-env es6*/
 
 function foo () {
     // ...
@@ -178,7 +175,6 @@ Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", "never"]*/
-/*eslint-env es6*/
 
 function foo() {
     // ...
@@ -217,7 +213,6 @@ Examples of **incorrect** code for this rule with the `{"anonymous": "always", "
 
 ```js
 /*eslint space-before-function-paren: ["error", {"anonymous": "always", "named": "never", "asyncArrow": "always"}]*/
-/*eslint-env es6*/
 
 function foo () {
     // ...
@@ -250,7 +245,6 @@ Examples of **correct** code for this rule with the `{"anonymous": "always", "na
 
 ```js
 /*eslint space-before-function-paren: ["error", {"anonymous": "always", "named": "never", "asyncArrow": "always"}]*/
-/*eslint-env es6*/
 
 function foo() {
     // ...
@@ -285,7 +279,6 @@ Examples of **incorrect** code for this rule with the `{"anonymous": "never", "n
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
-/*eslint-env es6*/
 
 function foo() {
     // ...
@@ -316,7 +309,6 @@ Examples of **correct** code for this rule with the `{"anonymous": "never", "nam
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
-/*eslint-env es6*/
 
 function foo () {
     // ...
@@ -349,7 +341,6 @@ Examples of **incorrect** code for this rule with the `{"anonymous": "ignore", "
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/
-/*eslint-env es6*/
 
 function foo() {
     // ...
@@ -376,7 +367,6 @@ Examples of **correct** code for this rule with the `{"anonymous": "ignore", "na
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/
-/*eslint-env es6*/
 
 var bar = function() {
     // ...

--- a/docs/src/rules/space-before-function-parentheses.md
+++ b/docs/src/rules/space-before-function-parentheses.md
@@ -41,8 +41,6 @@ Examples of **incorrect** code for this rule with the default `"always"` option:
 ::: incorrect
 
 ```js
-/*eslint-env es6*/
-
 function foo() {
     // ...
 }
@@ -75,8 +73,6 @@ Examples of **correct** code for this rule with the default `"always"` option:
 ::: correct
 
 ```js
-/*eslint-env es6*/
-
 function foo () {
     // ...
 }
@@ -109,8 +105,6 @@ Examples of **incorrect** code for this rule with the `"never"` option:
 ::: incorrect
 
 ```js
-/*eslint-env es6*/
-
 function foo () {
     // ...
 }
@@ -143,8 +137,6 @@ Examples of **correct** code for this rule with the `"never"` option:
 ::: correct
 
 ```js
-/*eslint-env es6*/
-
 function foo() {
     // ...
 }
@@ -177,8 +169,6 @@ Examples of **incorrect** code for this rule with the `{"anonymous": "always", "
 ::: incorrect
 
 ```js
-/*eslint-env es6*/
-
 function foo () {
     // ...
 }
@@ -207,8 +197,6 @@ Examples of **correct** code for this rule with the `{"anonymous": "always", "na
 ::: correct
 
 ```js
-/*eslint-env es6*/
-
 function foo() {
     // ...
 }
@@ -237,8 +225,6 @@ Examples of **incorrect** code for this rule with the `{"anonymous": "never", "n
 ::: incorrect
 
 ```js
-/*eslint-env es6*/
-
 function foo() {
     // ...
 }
@@ -267,8 +253,6 @@ Examples of **correct** code for this rule with the `{"anonymous": "never", "nam
 ::: correct
 
 ```js
-/*eslint-env es6*/
-
 function foo () {
     // ...
 }

--- a/docs/src/rules/space-before-keywords.md
+++ b/docs/src/rules/space-before-keywords.md
@@ -49,7 +49,6 @@ Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint space-before-keywords: ["error", "always"]*/
-/*eslint-env es6*/
 
 if (foo) {
     // ...
@@ -72,7 +71,6 @@ Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint space-before-keywords: ["error", "always"]*/
-/*eslint-env es6*/
 
 if (foo) {
     // ...

--- a/docs/src/rules/space-in-brackets.md
+++ b/docs/src/rules/space-in-brackets.md
@@ -50,8 +50,6 @@ Examples of **incorrect** code for this rule with the default `"never"` option:
 ::: incorrect
 
 ```js
-/*eslint-env es6*/
-
 foo[ 'bar' ];
 foo['bar' ];
 
@@ -122,8 +120,6 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 ::: incorrect
 
 ```js
-/*eslint-env es6*/
-
 foo['bar'];
 foo['bar' ];
 foo[ 'bar'];

--- a/docs/src/rules/space-infix-ops.md
+++ b/docs/src/rules/space-infix-ops.md
@@ -45,7 +45,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint space-infix-ops: "error"*/
-/*eslint-env es6*/
 
 a+b
 
@@ -70,7 +69,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint space-infix-ops: "error"*/
-/*eslint-env es6*/
 
 a + b
 

--- a/docs/src/rules/space-unary-ops.md
+++ b/docs/src/rules/space-unary-ops.md
@@ -96,7 +96,6 @@ foo --;
 
 ```js
 /*eslint space-unary-ops: "error"*/
-/*eslint-env es6*/
 
 function *foo() {
     yield(0)
@@ -155,7 +154,6 @@ foo--;
 
 ```js
 /*eslint space-unary-ops: "error"*/
-/*eslint-env es6*/
 
 function *foo() {
     yield (0)

--- a/docs/src/rules/strict.md
+++ b/docs/src/rules/strict.md
@@ -173,7 +173,6 @@ function foo() {
 
 ```js
 /*eslint strict: ["error", "function"]*/
-/*eslint-env es6*/
 
 // Illegal "use strict" directive in function with non-simple parameter list.
 // This is a syntax error since ES2016.

--- a/docs/src/rules/symbol-description.md
+++ b/docs/src/rules/symbol-description.md
@@ -38,7 +38,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint symbol-description: "error"*/
-/*eslint-env es6*/
 
 var foo = Symbol();
 ```
@@ -51,7 +50,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint symbol-description: "error"*/
-/*eslint-env es6*/
 
 var foo = Symbol("some description");
 

--- a/docs/src/rules/valid-jsdoc.md
+++ b/docs/src/rules/valid-jsdoc.md
@@ -94,7 +94,6 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint valid-jsdoc: "error"*/
-/*eslint-env es6*/
 
 /**
  * Add two numbers.
@@ -192,7 +191,6 @@ Examples of additional **incorrect** code for this rule with sample `"prefer": {
 
 ```js
 /*eslint valid-jsdoc: ["error", { "prefer": { "arg": "param", "argument": "param", "class": "constructor", "return": "returns", "virtual": "abstract" } }]*/
-/*eslint-env es6*/
 
 /**
  * Add two numbers.
@@ -238,7 +236,6 @@ Examples of additional **incorrect** code for this rule with sample `"preferType
 
 ```js
 /*eslint valid-jsdoc: ["error", { "preferType": { "Boolean": "boolean", "Number": "number", "object": "Object", "String": "string" } }]*/
-/*eslint-env es6*/
 
 /**
  * Add two numbers.

--- a/docs/src/rules/yield-star-spacing.md
+++ b/docs/src/rules/yield-star-spacing.md
@@ -48,7 +48,6 @@ Examples of **correct** code for this rule with the default `"after"` option:
 
 ```js
 /*eslint yield-star-spacing: ["error", "after"]*/
-/*eslint-env es6*/
 
 function* generator() {
   yield* other();
@@ -65,7 +64,6 @@ Examples of **correct** code for this rule with the `"before"` option:
 
 ```js
 /*eslint yield-star-spacing: ["error", "before"]*/
-/*eslint-env es6*/
 
 function *generator() {
   yield *other();
@@ -82,7 +80,6 @@ Examples of **correct** code for this rule with the `"both"` option:
 
 ```js
 /*eslint yield-star-spacing: ["error", "both"]*/
-/*eslint-env es6*/
 
 function * generator() {
   yield * other();
@@ -99,7 +96,6 @@ Examples of **correct** code for this rule with the `"neither"` option:
 
 ```js
 /*eslint yield-star-spacing: ["error", "neither"]*/
-/*eslint-env es6*/
 
 function*generator() {
   yield*other();

--- a/tests/fixtures/bad-examples.md
+++ b/tests/fixtures/bad-examples.md
@@ -76,6 +76,7 @@ const foo = "baz";
 /* eslint-env es6 */
 
 /*eslint-env node */
+/*eslint-env*/
 ```
 
 :::

--- a/tests/fixtures/bad-examples.md
+++ b/tests/fixtures/bad-examples.md
@@ -68,3 +68,14 @@ const foo = "baz";
 ```
 
 :::
+
+:::correct
+
+```js
+/* eslint no-restricted-syntax: ["error", "ArrayPattern"] */
+/* eslint-env es6 */
+
+/*eslint-env node */
+```
+
+:::

--- a/tests/tools/check-rule-examples.js
+++ b/tests/tools/check-rule-examples.js
@@ -81,8 +81,10 @@ describe("check-rule-examples", () => {
                 "\x1B[0m  \x1B[2m51:1\x1B[22m  \x1B[31merror\x1B[39m  Duplicate /* eslint no-restricted-syntax */ configuration comment. Each example should contain only one. Split this example into multiple examples\x1B[0m\n" +
                 "\x1B[0m  \x1B[2m56:1\x1B[22m  \x1B[31merror\x1B[39m  Remove unnecessary \"ecmaVersion\":\"latest\"\x1B[0m\n" +
                 `\x1B[0m  \x1B[2m64:1\x1B[22m  \x1B[31merror\x1B[39m  "ecmaVersion" must be one of ${[3, 5, ...Array.from({ length: LATEST_ECMA_VERSION - 2015 + 1 }, (_, index) => index + 2015)].join(", ")}\x1B[0m\n` +
+                "\x1B[0m  \x1B[2m76:1\x1B[22m  \x1B[31merror\x1B[39m  /* eslint-env */ comments are no longer supported. Remove the comment\x1B[0m\n" +
+                "\x1B[0m  \x1B[2m78:1\x1B[22m  \x1B[31merror\x1B[39m  /* eslint-env */ comments are no longer supported. Remove the comment\x1B[0m\n" +
                 "\x1B[0m\x1B[0m\n" +
-                "\x1B[0m\x1B[31m\x1B[1m✖ 9 problems (9 errors, 0 warnings)\x1B[22m\x1B[39m\x1B[0m\n" +
+                "\x1B[0m\x1B[31m\x1B[1m✖ 11 problems (11 errors, 0 warnings)\x1B[22m\x1B[39m\x1B[0m\n" +
                 "\x1B[0m\x1B[31m\x1B[1m\x1B[22m\x1B[39m\x1B[0m\n";
 
                 assert.strictEqual(normalizedStderr, expectedStderr);

--- a/tests/tools/check-rule-examples.js
+++ b/tests/tools/check-rule-examples.js
@@ -83,8 +83,9 @@ describe("check-rule-examples", () => {
                 `\x1B[0m  \x1B[2m64:1\x1B[22m  \x1B[31merror\x1B[39m  "ecmaVersion" must be one of ${[3, 5, ...Array.from({ length: LATEST_ECMA_VERSION - 2015 + 1 }, (_, index) => index + 2015)].join(", ")}\x1B[0m\n` +
                 "\x1B[0m  \x1B[2m76:1\x1B[22m  \x1B[31merror\x1B[39m  /* eslint-env */ comments are no longer supported. Remove the comment\x1B[0m\n" +
                 "\x1B[0m  \x1B[2m78:1\x1B[22m  \x1B[31merror\x1B[39m  /* eslint-env */ comments are no longer supported. Remove the comment\x1B[0m\n" +
+                "\x1B[0m  \x1B[2m79:1\x1B[22m  \x1B[31merror\x1B[39m  /* eslint-env */ comments are no longer supported. Remove the comment\x1B[0m\n" +
                 "\x1B[0m\x1B[0m\n" +
-                "\x1B[0m\x1B[31m\x1B[1m✖ 11 problems (11 errors, 0 warnings)\x1B[22m\x1B[39m\x1B[0m\n" +
+                "\x1B[0m\x1B[31m\x1B[1m✖ 12 problems (12 errors, 0 warnings)\x1B[22m\x1B[39m\x1B[0m\n" +
                 "\x1B[0m\x1B[31m\x1B[1m\x1B[22m\x1B[39m\x1B[0m\n";
 
                 assert.strictEqual(normalizedStderr, expectedStderr);

--- a/tools/check-rule-examples.js
+++ b/tools/check-rule-examples.js
@@ -115,6 +115,17 @@ async function findProblems(filename) {
                 let hasRuleConfigComment = false;
 
                 for (const comment of ast.comments) {
+
+                    if (comment.type === "Block" && /^\s*eslint-env\s/u.test(comment.value)) {
+                        problems.push({
+                            fatal: false,
+                            severity: 2,
+                            message: "/* eslint-env */ comments are no longer supported. Remove the comment.",
+                            line: codeBlockToken.map[0] + 1 + comment.loc.start.line,
+                            column: comment.loc.start.column + 1
+                        });
+                    }
+
                     if (comment.type !== "Block" || !/^\s*eslint(?!\S)/u.test(comment.value)) {
                         continue;
                     }

--- a/tools/check-rule-examples.js
+++ b/tools/check-rule-examples.js
@@ -116,7 +116,7 @@ async function findProblems(filename) {
 
                 for (const comment of ast.comments) {
 
-                    if (comment.type === "Block" && /^\s*eslint-env\s/u.test(comment.value)) {
+                    if (comment.type === "Block" && /^\s*eslint-env(?!\S)/u.test(comment.value)) {
                         problems.push({
                             fatal: false,
                             severity: 2,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

`/* eslint-env */` have no effect in flat config mode. This PR removes those comments from rule examples.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Added a check for `/* eslint-env */` comments to `tools/check-rule-examples.js`
* Removed `/* eslint-env */` comments from rule examples.
  * Most of these comments were intended just to enable new ES syntax and/or new ES globals. Since the default is now `"latest"`, I just removed them.
  * Several comments were enabling `browser` or `node` environments to enable specific globals. I replaced those comments with `/* global */` comments.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
