### PR TITLE
fix: flat config name on ignores object

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@eslint-community/regexpp": "^4.6.1",
     "@eslint/eslintrc": "^3.0.2",
     "@eslint/js": "9.0.0-rc.0",
-    "@humanwhocodes/config-array": "^0.12.1",
+    "@humanwhocodes/config-array": "^0.12.2",
     "@humanwhocodes/module-importer": "^1.0.1",
     "@nodelib/fs.walk": "^1.2.8",
     "ajv": "^6.12.4",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Dependency upgrade

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Upgraded `@humanwhocodes/config-array`

This fixes a bug where a config object containing `name` and `ignores` won't honor the ignores.

refs https://github.com/humanwhocodes/config-array/pull/131

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
