### PR TITLE
docs: fix `linebreak-style` examples

### DIFF
--- a/docs/src/rules/linebreak-style.md
+++ b/docs/src/rules/linebreak-style.md
@@ -52,6 +52,7 @@ var a = 'a', // \n
 function foo(params) { // \n
     // do stuff \n
 }// \n
+
 ```
 
 :::
@@ -66,6 +67,7 @@ Examples of **incorrect** code for this rule with the `"windows"` option:
 /*eslint linebreak-style: ["error", "windows"]*/
 
 var a = 'a'; // \n
+
 ```
 
 :::
@@ -75,14 +77,15 @@ Examples of **correct** code for this rule with the `"windows"` option:
 ::: correct
 
 ```js
-/*eslint linebreak-style: ["error", "windows"]*/
-
+/*eslint linebreak-style: ["error", "windows"]*/ // \r\n
+// \r\n
 var a = 'a', // \r\n
     b = 'b'; // \r\n
 // \r\n
 function foo(params) { // \r\n
     // do stuff \r\n
 } // \r\n
+
 ```
 
 :::

--- a/docs/tools/code-block-utils.js
+++ b/docs/tools/code-block-utils.js
@@ -14,11 +14,14 @@
 function docsExampleCodeToParsableCode(code) {
     return code
 
-        // Remove trailing newline and presentational `⏎` characters
-        .replace(/⏎(?=\n)/gu, "")
+        // Code blocks always contain an extra line break at the end, so remove it.
+        .replace(/\n$/u, "")
 
-        // Code blocks always contain extra line breaks, so remove them.
-        .replace(/\n$/u, "");
+        // Replace LF line breaks with CRLF after `\r\n` sequences.
+        .replace(/(?<=\\r\\n)\n/gu, "\r\n")
+
+        // Remove presentational `⏎` characters at the end of lines.
+        .replace(/⏎(?=\n)/gu, "");
 }
 
 module.exports = {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR fixes an issue in the examples of the `linebreak-style` rule, which are supposed to show the differences between Unix style LF line breaks vs. Windows style CRLF line breaks.

Because of our [.gitattributes](https://github.com/eslint/eslint/blob/v9.0.0-rc.0/.gitattributes) repo settings, CRLF line breaks are converted to LF line breaks automatically, so rule examples with CRLF line breaks are currently broken ([link](https://eslint.org/docs/next/rules/linebreak-style#unix)).

To fix the problem, I added a provision to replace LF with CRLF when the is a `\r\n` sequence at the end of a line in a rule example.

#### Is there anything you'd like reviewers to focus on?

Any better solution to fix the examples?

<!-- markdownlint-disable-file MD004 -->
