### PR TITLE
chore: upgrade knip

### DIFF
--- a/lib/source-code/token-store/backward-token-cursor.js
+++ b/lib/source-code/token-store/backward-token-cursor.js
@@ -9,7 +9,7 @@
 //------------------------------------------------------------------------------
 
 const Cursor = require("./cursor");
-const utils = require("./utils");
+const { getLastIndex, getFirstIndex } = require("./utils");
 
 //------------------------------------------------------------------------------
 // Exports
@@ -31,8 +31,8 @@ module.exports = class BackwardTokenCursor extends Cursor {
     constructor(tokens, comments, indexMap, startLoc, endLoc) {
         super();
         this.tokens = tokens;
-        this.index = utils.getLastIndex(tokens, indexMap, endLoc);
-        this.indexEnd = utils.getFirstIndex(tokens, indexMap, startLoc);
+        this.index = getLastIndex(tokens, indexMap, endLoc);
+        this.indexEnd = getFirstIndex(tokens, indexMap, startLoc);
     }
 
     /** @inheritdoc */

--- a/lib/source-code/token-store/cursors.js
+++ b/lib/source-code/token-store/cursors.js
@@ -86,5 +86,7 @@ class CursorFactory {
 // Exports
 //------------------------------------------------------------------------------
 
-exports.forward = new CursorFactory(ForwardTokenCursor, ForwardTokenCommentCursor);
-exports.backward = new CursorFactory(BackwardTokenCursor, BackwardTokenCommentCursor);
+module.exports = {
+    forward: new CursorFactory(ForwardTokenCursor, ForwardTokenCommentCursor),
+    backward: new CursorFactory(BackwardTokenCursor, BackwardTokenCommentCursor)
+};

--- a/lib/source-code/token-store/forward-token-comment-cursor.js
+++ b/lib/source-code/token-store/forward-token-comment-cursor.js
@@ -9,7 +9,7 @@
 //------------------------------------------------------------------------------
 
 const Cursor = require("./cursor");
-const utils = require("./utils");
+const { getFirstIndex, search } = require("./utils");
 
 //------------------------------------------------------------------------------
 // Exports
@@ -32,8 +32,8 @@ module.exports = class ForwardTokenCommentCursor extends Cursor {
         super();
         this.tokens = tokens;
         this.comments = comments;
-        this.tokenIndex = utils.getFirstIndex(tokens, indexMap, startLoc);
-        this.commentIndex = utils.search(comments, startLoc);
+        this.tokenIndex = getFirstIndex(tokens, indexMap, startLoc);
+        this.commentIndex = search(comments, startLoc);
         this.border = endLoc;
     }
 

--- a/lib/source-code/token-store/forward-token-cursor.js
+++ b/lib/source-code/token-store/forward-token-cursor.js
@@ -9,7 +9,7 @@
 //------------------------------------------------------------------------------
 
 const Cursor = require("./cursor");
-const utils = require("./utils");
+const { getFirstIndex, getLastIndex } = require("./utils");
 
 //------------------------------------------------------------------------------
 // Exports
@@ -31,8 +31,8 @@ module.exports = class ForwardTokenCursor extends Cursor {
     constructor(tokens, comments, indexMap, startLoc, endLoc) {
         super();
         this.tokens = tokens;
-        this.index = utils.getFirstIndex(tokens, indexMap, startLoc);
-        this.indexEnd = utils.getLastIndex(tokens, indexMap, endLoc);
+        this.index = getFirstIndex(tokens, indexMap, startLoc);
+        this.indexEnd = getLastIndex(tokens, indexMap, endLoc);
     }
 
     /** @inheritdoc */

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "got": "^11.8.3",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.0",
-    "knip": "^5.0.1",
+    "knip": "^5.8.0",
     "lint-staged": "^11.0.0",
     "load-perf": "^0.2.0",
     "markdown-it": "^12.2.0",


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

After adding support for `exports.key = value` (next to `module.exports`), [Knip's integration tests against ESLint](https://github.com/webpro/knip/actions/runs/8565238201/job/23473008829) failed, since the ESLint codebase contains a few instances of `exports` (without `module.`) that are written in the ambiguous CommonJS style that Knip considers an issue (wrote about this when introducing Knip here: https://knip.dev/guides/commonjs).

#### What changes did you make? (Give an overview)

- Upgrade Knip to the version that adds supports for `exports.key = value` syntax
- Refactored the instances that are ambiguous in terms of default vs named imports/exports.

#### Is there anything you'd like reviewers to focus on?

Not really, but for the sake of completeness:

- The PR were Knip was introduced to this repo: #18005
- The Knip issue were this feature was requested: https://github.com/webpro/knip/issues/580