### PR TITLE
feat: show an explicit message when `undefined` is included as a config

### DIFF
--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -395,6 +395,10 @@ async function calculateConfigArray(eslint, {
         const fileConfig = await loadFlatConfigFile(configFilePath);
 
         if (Array.isArray(fileConfig)) {
+            if (fileConfig.includes(void 0)) {
+                throw new Error("You have included `undefined` in your array of configs - this is commonly the result of trying to use a config from a plugin that does not exist; make sure you have not typo'd the name!");
+            }
+
             configs.push(...fileConfig);
         } else {
             configs.push(fileConfig);

--- a/tests/fixtures/undefined-config/a.js
+++ b/tests/fixtures/undefined-config/a.js
@@ -1,0 +1,1 @@
+var foo = "bar";

--- a/tests/fixtures/undefined-config/eslint.config.js
+++ b/tests/fixtures/undefined-config/eslint.config.js
@@ -1,0 +1,14 @@
+// as in '= require("eslint-plugin-mine")'
+const myPlugin = {
+    configs: { recommended: {} }
+}
+
+module.exports = [
+    {
+        rules: {
+            quotes: ["error", "single"]
+        }
+    },
+    // 'whoops, this should really be "recommended"'
+    myPlugin.configs.eslint_recommended
+]

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -1222,6 +1222,16 @@ describe("ESLint", () => {
             assert.strictEqual(results[0].messages[0].ruleId, "quotes");
         });
 
+        it("should error early with config files that include an undefined", async () => {
+            eslint = new ESLint({
+                cwd: getFixturePath("undefined-config")
+            });
+
+            await assert.rejects(async () => {
+                await eslint.lintFiles(["a*.js"]);
+            }, /You have included `undefined` in your array of configs - this is commonly the result of trying to use a config from a plugin that does not exist; make sure you have not typo'd the name!/u);
+        });
+
         // https://github.com/eslint/eslint/issues/16265
         describe("Dot files in searches", () => {
 


### PR DESCRIPTION
Fixes #18259

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I've included an explicit check for `undefined` being present in the configs array that causes an error to be thrown with a message indicating a common source for this value being present.

#### Is there anything you'd like reviewers to focus on?

I have no strong feelings about the message or tests - I've gone with something I think is ok but by no means think its perfect I'd like input from the core team as I feel they'll know better what kind of style and wording would fit best to align with related content in docs and other messaging in the tool itself.

<!-- markdownlint-disable-file MD004 -->
