### PR TITLE
docs: indicate eslintrc mode for `.eslintignore`

### DIFF
--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -86,8 +86,7 @@ Fix Problems:
 
 Ignore Files:
   --no-ignore                     Disable use of ignore files and patterns
-  --ignore-pattern [String]       Patterns of files to ignore. In eslintrc mode, these are in addition to
-                                  `.eslintignore`
+  --ignore-pattern [String]       Patterns of files to ignore.
 
 Use stdin:
   --stdin                         Lint code provided on <STDIN> - default: false

--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -86,7 +86,7 @@ Fix Problems:
 
 Ignore Files:
   --no-ignore                     Disable use of ignore files and patterns
-  --ignore-pattern [String]       Pattern of files to ignore (in addition to those in .eslintignore)
+  --ignore-pattern [String]       Patterns of files to ignore
 
 Use stdin:
   --stdin                         Lint code provided on <STDIN> - default: false
@@ -426,7 +426,7 @@ npx eslint --no-ignore file.js
 
 #### `--ignore-pattern`
 
-This option allows you to specify patterns of files to ignore (in addition to those in `.eslintignore`).
+This option allows you to specify patterns of files to ignore.
 
 * **Argument Type**: String. The supported syntax is the same as for [`.eslintignore` files](configure/ignore-deprecated#the-eslintignore-file), which use the same patterns as the [`.gitignore` specification](https://git-scm.com/docs/gitignore). You should quote your patterns in order to avoid shell interpretation of glob patterns.
 * **Multiple Arguments**: Yes

--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -86,7 +86,8 @@ Fix Problems:
 
 Ignore Files:
   --no-ignore                     Disable use of ignore files and patterns
-  --ignore-pattern [String]       Patterns of files to ignore
+  --ignore-pattern [String]       Patterns of files to ignore. In eslintrc mode, these are in addition to
+                                  `.eslintignore`
 
 Use stdin:
   --stdin                         Lint code provided on <STDIN> - default: false
@@ -426,7 +427,7 @@ npx eslint --no-ignore file.js
 
 #### `--ignore-pattern`
 
-This option allows you to specify patterns of files to ignore.
+This option allows you to specify patterns of files to ignore. In eslintrc mode, these are in addition to `.eslintignore`.
 
 * **Argument Type**: String. The supported syntax is the same as for [`.eslintignore` files](configure/ignore-deprecated#the-eslintignore-file), which use the same patterns as the [`.gitignore` specification](https://git-scm.com/docs/gitignore). You should quote your patterns in order to avoid shell interpretation of glob patterns.
 * **Multiple Arguments**: Yes

--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -86,7 +86,7 @@ Fix Problems:
 
 Ignore Files:
   --no-ignore                     Disable use of ignore files and patterns
-  --ignore-pattern [String]       Patterns of files to ignore.
+  --ignore-pattern [String]       Patterns of files to ignore
 
 Use stdin:
   --stdin                         Lint code provided on <STDIN> - default: false

--- a/lib/options.js
+++ b/lib/options.js
@@ -261,7 +261,7 @@ module.exports = function(usingFlatConfig) {
             {
                 option: "ignore-pattern",
                 type: "[String]",
-                description: "Patterns of files to ignore. In eslintrc mode, these are in addition to `.eslintignore`",
+                description: `Patterns of files to ignore${usingFlatConfig ? "" : " (in addition to those in .eslintignore)"}`,
                 concatRepeatedArrays: [true, {
                     oneValuePerFlag: true
                 }]

--- a/lib/options.js
+++ b/lib/options.js
@@ -38,7 +38,7 @@ const optionator = require("optionator");
  * @property {boolean} [help] Show help
  * @property {boolean} ignore Disable use of ignore files and patterns
  * @property {string} [ignorePath] Specify path of ignore file
- * @property {string[]} [ignorePattern] Patterns of files to ignore
+ * @property {string[]} [ignorePattern] Patterns of files to ignore. In eslintrc mode, these are in addition to `.eslintignore`
  * @property {boolean} init Run config initialization wizard
  * @property {boolean} inlineConfig Prevent comments from changing config or rules
  * @property {number} maxWarnings Number of warnings to trigger nonzero exit code
@@ -261,7 +261,7 @@ module.exports = function(usingFlatConfig) {
             {
                 option: "ignore-pattern",
                 type: "[String]",
-                description: "Patterns of files to ignore",
+                description: "Patterns of files to ignore. In eslintrc mode, these are in addition to `.eslintignore`",
                 concatRepeatedArrays: [true, {
                     oneValuePerFlag: true
                 }]

--- a/lib/options.js
+++ b/lib/options.js
@@ -38,7 +38,7 @@ const optionator = require("optionator");
  * @property {boolean} [help] Show help
  * @property {boolean} ignore Disable use of ignore files and patterns
  * @property {string} [ignorePath] Specify path of ignore file
- * @property {string[]} [ignorePattern] Pattern of files to ignore (in addition to those in .eslintignore)
+ * @property {string[]} [ignorePattern] Patterns of files to ignore
  * @property {boolean} init Run config initialization wizard
  * @property {boolean} inlineConfig Prevent comments from changing config or rules
  * @property {number} maxWarnings Number of warnings to trigger nonzero exit code
@@ -261,7 +261,7 @@ module.exports = function(usingFlatConfig) {
             {
                 option: "ignore-pattern",
                 type: "[String]",
-                description: "Pattern of files to ignore (in addition to those in .eslintignore)",
+                description: "Patterns of files to ignore",
                 concatRepeatedArrays: [true, {
                     oneValuePerFlag: true
                 }]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated descriptions of the `--ignore-pattern` CLI flag to clarify that `.eslintignore` only applies in eslintrc mode. In the new config system, ignore patterns are defined in the config.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
