### PR TITLE
fix: do not crash on error in `fs.walk` filter

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -287,7 +287,7 @@ async function globSearch({
          * @param {Function} filter A filter function to wrap.
          * @returns {Function} A function similar to the wrapped filter that rejects the promise if an error occurs.
          */
-        function wrapCallback(filter) {
+        function wrapFilter(filter) {
             return (...args) => {
 
                 // No need to run the filter if an error has been thrown.
@@ -306,13 +306,13 @@ async function globSearch({
         fswalk.walk(
             basePath,
             {
-                deepFilter: wrapCallback(entry => {
+                deepFilter: wrapFilter(entry => {
                     const relativePath = normalizeToPosix(path.relative(basePath, entry.path));
                     const matchesPattern = matchers.some(matcher => matcher.match(relativePath, true));
 
                     return matchesPattern && !configs.isDirectoryIgnored(entry.path);
                 }),
-                entryFilter: wrapCallback(entry => {
+                entryFilter: wrapFilter(entry => {
                     const relativePath = normalizeToPosix(path.relative(basePath, entry.path));
 
                     // entries may be directories or files so filter out directories

--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -280,7 +280,7 @@ async function globSearch({
 
     const filePaths = (await new Promise((resolve, reject) => {
 
-        let promiseSettled = false;
+        let promiseRejected = false;
 
         /**
          * Wraps a boolean-returning filter function. The wrapped function will reject the promise if an error occurs.
@@ -291,11 +291,11 @@ async function globSearch({
             return (...args) => {
 
                 // No need to run the filter if an error has been thrown.
-                if (!promiseSettled) {
+                if (!promiseRejected) {
                     try {
                         return filter(...args);
                     } catch (error) {
-                        promiseSettled = true;
+                        promiseRejected = true;
                         reject(error);
                     }
                 }
@@ -356,17 +356,11 @@ async function globSearch({
             },
             (error, entries) => {
 
-                /*
-                 * Do not call `resolve` or `reject` if the promise has been already settled.
-                 * This will avoid a `multipleResolves` event in the Node.js process: a https://nodejs.org/api/process.html#event-multipleresolves.
-                 */
-                if (!promiseSettled) {
-                    promiseSettled = true;
-                    if (error) {
-                        reject(error);
-                    } else {
-                        resolve(entries);
-                    }
+                // If the promise is already rejected, calling `resolve` or `reject` will do nothing.
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve(entries);
                 }
             }
         );

--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -15,7 +15,6 @@ const fsp = fs.promises;
 const isGlob = require("is-glob");
 const hash = require("../cli-engine/hash");
 const minimatch = require("minimatch");
-const util = require("util");
 const fswalk = require("@nodelib/fs.walk");
 const globParent = require("glob-parent");
 const isPathInside = require("is-path-inside");
@@ -24,7 +23,6 @@ const isPathInside = require("is-path-inside");
 // Fixup references
 //-----------------------------------------------------------------------------
 
-const doFsWalk = util.promisify(fswalk.walk);
 const Minimatch = minimatch.Minimatch;
 const MINIMATCH_OPTIONS = { dot: true };
 
@@ -280,56 +278,98 @@ async function globSearch({
      */
     const unmatchedPatterns = new Set([...relativeToPatterns.keys()]);
 
-    const filePaths = (await doFsWalk(basePath, {
+    const filePaths = (await new Promise((resolve, reject) => {
 
-        deepFilter(entry) {
-            const relativePath = normalizeToPosix(path.relative(basePath, entry.path));
-            const matchesPattern = matchers.some(matcher => matcher.match(relativePath, true));
+        let promiseSettled = false;
 
-            return matchesPattern && !configs.isDirectoryIgnored(entry.path);
-        },
-        entryFilter(entry) {
-            const relativePath = normalizeToPosix(path.relative(basePath, entry.path));
+        /**
+         * Wraps a boolean-returning filter function. The wrapped function will reject the promise if an error occurs.
+         * @param {Function} filter A filter function to wrap.
+         * @returns {Function} A function similar to the wrapped filter that rejects the promise if an error occurs.
+         */
+        function wrapCallback(filter) {
+            return (...args) => {
 
-            // entries may be directories or files so filter out directories
-            if (entry.dirent.isDirectory()) {
-                return false;
-            }
-
-            /*
-             * Optimization: We need to track when patterns are left unmatched
-             * and so we use `unmatchedPatterns` to do that. There is a bit of
-             * complexity here because the same file can be matched by more than
-             * one pattern. So, when we start, we actually need to test every
-             * pattern against every file. Once we know there are no remaining
-             * unmatched patterns, then we can switch to just looking for the
-             * first matching pattern for improved speed.
-             */
-            const matchesPattern = unmatchedPatterns.size > 0
-                ? matchers.reduce((previousValue, matcher) => {
-                    const pathMatches = matcher.match(relativePath);
-
-                    /*
-                     * We updated the unmatched patterns set only if the path
-                     * matches and the file isn't ignored. If the file is
-                     * ignored, that means there wasn't a match for the
-                     * pattern so it should not be removed.
-                     *
-                     * Performance note: isFileIgnored() aggressively caches
-                     * results so there is no performance penalty for calling
-                     * it twice with the same argument.
-                     */
-                    if (pathMatches && !configs.isFileIgnored(entry.path)) {
-                        unmatchedPatterns.delete(matcher.pattern);
+                // No need to run the filter if an error has been thrown.
+                if (!promiseSettled) {
+                    try {
+                        return filter(...args);
+                    } catch (error) {
+                        promiseSettled = true;
+                        reject(error);
                     }
-
-                    return pathMatches || previousValue;
-                }, false)
-                : matchers.some(matcher => matcher.match(relativePath));
-
-            return matchesPattern && !configs.isFileIgnored(entry.path);
+                }
+                return false;
+            };
         }
 
+        fswalk.walk(
+            basePath,
+            {
+                deepFilter: wrapCallback(entry => {
+                    const relativePath = normalizeToPosix(path.relative(basePath, entry.path));
+                    const matchesPattern = matchers.some(matcher => matcher.match(relativePath, true));
+
+                    return matchesPattern && !configs.isDirectoryIgnored(entry.path);
+                }),
+                entryFilter: wrapCallback(entry => {
+                    const relativePath = normalizeToPosix(path.relative(basePath, entry.path));
+
+                    // entries may be directories or files so filter out directories
+                    if (entry.dirent.isDirectory()) {
+                        return false;
+                    }
+
+                    /*
+                     * Optimization: We need to track when patterns are left unmatched
+                     * and so we use `unmatchedPatterns` to do that. There is a bit of
+                     * complexity here because the same file can be matched by more than
+                     * one pattern. So, when we start, we actually need to test every
+                     * pattern against every file. Once we know there are no remaining
+                     * unmatched patterns, then we can switch to just looking for the
+                     * first matching pattern for improved speed.
+                     */
+                    const matchesPattern = unmatchedPatterns.size > 0
+                        ? matchers.reduce((previousValue, matcher) => {
+                            const pathMatches = matcher.match(relativePath);
+
+                            /*
+                             * We updated the unmatched patterns set only if the path
+                             * matches and the file isn't ignored. If the file is
+                             * ignored, that means there wasn't a match for the
+                             * pattern so it should not be removed.
+                             *
+                             * Performance note: isFileIgnored() aggressively caches
+                             * results so there is no performance penalty for calling
+                             * it twice with the same argument.
+                             */
+                            if (pathMatches && !configs.isFileIgnored(entry.path)) {
+                                unmatchedPatterns.delete(matcher.pattern);
+                            }
+
+                            return pathMatches || previousValue;
+                        }, false)
+                        : matchers.some(matcher => matcher.match(relativePath));
+
+                    return matchesPattern && !configs.isFileIgnored(entry.path);
+                })
+            },
+            (error, entries) => {
+
+                /*
+                 * Do not call `resolve` or `reject` if the promise has been already settled.
+                 * This will avoid a `multipleResolves` event in the Node.js process: a https://nodejs.org/api/process.html#event-multipleresolves.
+                 */
+                if (!promiseSettled) {
+                    promiseSettled = true;
+                    if (error) {
+                        reject(error);
+                    } else {
+                        resolve(entries);
+                    }
+                }
+            }
+        );
     })).map(entry => entry.path);
 
     // now check to see if we have any unmatched patterns

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -4481,6 +4481,41 @@ describe("ESLint", () => {
             assert.strictEqual(createCallCount, 1);
         });
 
+        describe("Error while globbing", () => {
+
+            it("should throw an error with a glob pattern if an invalid config was provided", async () => {
+
+                const cwd = getFixturePath("files");
+
+                eslint = new ESLint({
+                    cwd,
+                    overrideConfig: [{ invalid: "foobar" }]
+                });
+
+                await assert.rejects(eslint.lintFiles("*.js"));
+            });
+
+            it("should throw an error with a glob pattern if an error occurs traversing a directory", async () => {
+
+                const fsWalk = require("@nodelib/fs.walk");
+                const error = new Error("Boom!");
+
+                sinon
+                    .stub(fsWalk, "walk")
+                    .value(sinon.stub().yieldsRight(error)); // call the callback passed to `fs.walk` with an error
+
+                const cwd = getFixturePath("files");
+
+                eslint = new ESLint({
+                    cwd,
+                    overrideConfigFile: true
+                });
+
+                await assert.rejects(eslint.lintFiles("*.js"), error);
+            });
+
+        });
+
     });
 
     describe("Fix Types", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #18250

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I replaced [`util.promisify`](https://github.com/eslint/eslint/compare/issue-18250?expand=1#diff-87d53094b12d82e4c11a0e1167d79cf2f471d2f5e5ebb6fc483e891f9dc87a5aL27) around `fs.walk` with a plain promise. In this way, the promise can be rejected not only when the implicit callback provided by `util.promisify` reports an error, but also when an error is caught in one of the filter functions [`deepFilter`](https://github.com/eslint/eslint/compare/issue-18250?expand=1#diff-87d53094b12d82e4c11a0e1167d79cf2f471d2f5e5ebb6fc483e891f9dc87a5aL285-L290) or [`entryFilter`](https://github.com/eslint/eslint/compare/issue-18250?expand=1#diff-87d53094b12d82e4c11a0e1167d79cf2f471d2f5e5ebb6fc483e891f9dc87a5aL291-L297). This allows Node.js to catch the rejection in the current execution context (where the promise was created) and avoid an unhandled exception.

Related issue in NodeLib: https://github.com/nodelib/nodelib/issues/105

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
