### PR TITLE
fix: EMFILE errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         run: node Makefile mocha
       - name: Fuzz Test
         run: node Makefile fuzz
+      - name: Test EMFILE Handling
+        run: npm run test:emfile
 
   test_on_browser:
     name: Browser Test

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,3 @@ pnpm-lock.yaml
 # Docs site
 _site
 /docs/src/assets/css
-
-# EMFILE test files
-/tests/fixtures/emfile/file*.js

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ pnpm-lock.yaml
 # Docs site
 _site
 /docs/src/assets/css
+
+# EMFILE test files
+/tests/fixtures/emfile/file*.js

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -42,6 +42,7 @@ const {
 const { pathToFileURL } = require("url");
 const { FlatConfigArray } = require("../config/flat-config-array");
 const LintResultCache = require("../cli-engine/lint-result-cache");
+const { Retrier } = require("@humanwhocodes/retry");
 
 /*
  * This is necessary to allow overwriting writeFile for testing purposes.
@@ -851,6 +852,8 @@ class ESLint {
             errorOnUnmatchedPattern
         });
         const controller = new AbortController();
+        const retryCodes = new Set(["ENFILE", "EMFILE"]);
+        const retrier = new Retrier(error => retryCodes.has(error.code));
 
         debug(`${filePaths.length} files found in: ${Date.now() - startTime}ms`);
 
@@ -919,7 +922,7 @@ class ESLint {
                     fixer = message => shouldMessageBeFixed(message, config, fixTypesSet) && originalFix(message);
                 }
 
-                return fs.readFile(filePath, { encoding: "utf8", signal: controller.signal })
+                return retrier.retry(() => fs.readFile(filePath, { encoding: "utf8", signal: controller.signal })
                     .then(text => {
 
                         // fail immediately if an error occurred in another file
@@ -950,10 +953,13 @@ class ESLint {
 
                         return result;
                     }).catch(error => {
-                        controller.abort(error);
-                        throw error;
-                    });
 
+                        if (error.name !== "AbortError" && !retryCodes.has(error.code)) {
+                            controller.abort(error);
+                        }
+
+                        throw error;
+                    }));
             })
         );
 

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -952,14 +952,11 @@ class ESLint {
                         }
 
                         return result;
-                    }).catch(error => {
-
-                        if (error.name !== "AbortError" && !retryCodes.has(error.code)) {
-                            controller.abort(error);
-                        }
-
+                    }))
+                    .catch(error => {
+                        controller.abort(error);
                         throw error;
-                    }));
+                    });
             })
         );
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "test:browser": "node Makefile.js wdio",
     "test:cli": "mocha",
     "test:fuzz": "node Makefile.js fuzz",
-    "test:performance": "node Makefile.js perf"
+    "test:performance": "node Makefile.js perf",
+    "test:emfile": "node tools/check-emfile-handling.js"
   },
   "gitHooks": {
     "pre-commit": "lint-staged"
@@ -71,6 +72,7 @@
     "@eslint/js": "9.0.0",
     "@humanwhocodes/config-array": "^0.12.3",
     "@humanwhocodes/module-importer": "^1.0.1",
+    "@humanwhocodes/retry": "^0.2.2",
     "@nodelib/fs.walk": "^1.2.8",
     "ajv": "^6.12.4",
     "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@eslint/js": "9.0.0",
     "@humanwhocodes/config-array": "^0.12.3",
     "@humanwhocodes/module-importer": "^1.0.1",
-    "@humanwhocodes/retry": "^0.2.2",
+    "@humanwhocodes/retry": "^0.2.3",
     "@nodelib/fs.walk": "^1.2.8",
     "ajv": "^6.12.4",
     "chalk": "^4.0.0",

--- a/tests/fixtures/emfile/eslint.config.js
+++ b/tests/fixtures/emfile/eslint.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    rules: {
+        "no-unused-vars": "error"
+    }
+};

--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -41,7 +41,7 @@ if (os.platform() !== "win32") {
 
         // if we're on a Mac, make sure the limit isn't high enough to cause a call stack error
         if (os.platform() === "darwin") {
-            FILE_COUNT = Math.min(FILE_COUNT, 50000);
+            FILE_COUNT = Math.min(FILE_COUNT, 100000);
         }
     } catch {
 

--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview A utility to test that ESLint doesn't crash with EMFILE/ENFILE errors.
+ * @author Nicholas C. Zakas
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const fs = require("fs");
+const { execSync } = require("child_process");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const OUTPUT_DIRECTORY = "tests/fixtures/emfile";
+const FILE_COUNT = 10000;
+
+/**
+ * Generates files in a directory.
+ * @returns {void}
+ */
+function generateFiles() {
+
+    for (let i = 0; i < FILE_COUNT; i++) {
+        const fileName = `file_${i}.js`;
+        const fileContent = `// This is file ${i}`;
+
+        fs.writeFileSync(`${OUTPUT_DIRECTORY}/${fileName}`, fileContent);
+    }
+
+}
+
+//------------------------------------------------------------------------------
+// Main
+//------------------------------------------------------------------------------
+
+console.log(`Generating ${FILE_COUNT} files in ${OUTPUT_DIRECTORY}...`);
+generateFiles();
+
+console.log("Running ESLint...");
+execSync(`node bin/eslint.js ${OUTPUT_DIRECTORY} -c ${OUTPUT_DIRECTORY}/eslint.config.js`, { stdio: "inherit" });
+console.log("No errors encountered.");

--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -36,6 +36,13 @@ let FILE_COUNT = DEFAULT_FILE_COUNT;
 if (os.platform() !== "win32") {
     try {
         FILE_COUNT = parseInt(execSync("ulimit -n").toString().trim(), 10) + 1;
+
+        console.log(`Detected Linux file limit of ${FILE_COUNT}.`);
+
+        // if we're on a Mac, make sure the limit isn't high enough to cause a call stack error
+        if (os.platform() === "darwin") {
+            FILE_COUNT = Math.min(FILE_COUNT, 50000);
+        }
     } catch {
 
         // ignore error and use default
@@ -90,6 +97,8 @@ generateEmFileError()
     .catch(error => {
         if (error.code === "EMFILE") {
             console.log("✅ EMFILE error encountered:", error.message);
+        } else if (error.code === "ENFILE") {
+            console.log("✅ ENFILE error encountered:", error.message);
         } else {
             console.error("❌ Unexpected error encountered:", error.message);
             throw error;

--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -35,9 +35,10 @@ let FILE_COUNT = DEFAULT_FILE_COUNT;
 // if the platform isn't windows, get the ulimit to see what the actual limit is
 if (os.platform() !== "win32") {
     try {
-        FILE_COUNT = parseInt(execSync("ulimit -n").toString().trim(), 10);
+        FILE_COUNT = parseInt(execSync("ulimit -n").toString().trim(), 10) + 1;
     } catch {
-        FILE_COUNT = DEFAULT_FILE_COUNT;
+
+        // ignore error and use default
     }
 }
 

--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -18,7 +18,8 @@ const os = require("os");
 // Helpers
 //------------------------------------------------------------------------------
 
-const OUTPUT_DIRECTORY = "tests/fixtures/emfile";
+const OUTPUT_DIRECTORY = "tmp/emfile-check";
+const CONFIG_DIRECTORY = "tests/fixtures/emfile";
 
 /*
  * Every operating system has a different limit for the number of files that can
@@ -55,6 +56,8 @@ if (os.platform() !== "win32") {
  */
 function generateFiles() {
 
+    fs.mkdirSync(OUTPUT_DIRECTORY, { recursive: true });
+
     for (let i = 0; i < FILE_COUNT; i++) {
         const fileName = `file_${i}.js`;
         const fileContent = `// This is file ${i}`;
@@ -86,7 +89,7 @@ console.log(`Generating ${FILE_COUNT} files in ${OUTPUT_DIRECTORY}...`);
 generateFiles();
 
 console.log("Running ESLint...");
-execSync(`node bin/eslint.js ${OUTPUT_DIRECTORY} -c ${OUTPUT_DIRECTORY}/eslint.config.js`, { stdio: "inherit" });
+execSync(`node bin/eslint.js ${OUTPUT_DIRECTORY} -c ${CONFIG_DIRECTORY}/eslint.config.js`, { stdio: "inherit" });
 console.log("✅ No errors encountered running ESLint.");
 
 console.log("Checking that this number of files would cause an EMFILE error...");


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

File read operations that throw an EMFILE or ENFILE error will be automatically retried.

I also added a test that runs only in CI to save us time locally. There was an error with the abort handling that I had to fix in order to make the test pass.

fixes #18301

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
