### PR TITLE
refactor: Move directive gathering to SourceCode

### DIFF
--- a/lib/linter/apply-disable-directives.js
+++ b/lib/linter/apply-disable-directives.js
@@ -159,7 +159,7 @@ function createIndividualDirectivesRemoval(directives, node) {
 }
 
 /**
- * Creates a description of deleting an entire unused disable diretive.
+ * Creates a description of deleting an entire unused disable directive.
  * @param {Directive[]} directives Unused directives to be removed.
  * @param {Token} node The backing Comment token.
  * @returns {{ description, fix, unprocessedDirective }} Details for later creation of an output problem.

--- a/lib/linter/apply-disable-directives.js
+++ b/lib/linter/apply-disable-directives.js
@@ -38,16 +38,16 @@ function compareLocations(itemA, itemB) {
  * @param {Iterable<Directive>} directives Unused directives to be removed.
  * @returns {Directive[][]} Directives grouped by their parent comment.
  */
-function groupByParentComment(directives) {
+function groupByParentDirective(directives) {
     const groups = new Map();
 
     for (const directive of directives) {
-        const { unprocessedDirective: { parentComment } } = directive;
+        const { unprocessedDirective: { parentDirective } } = directive;
 
-        if (groups.has(parentComment)) {
-            groups.get(parentComment).push(directive);
+        if (groups.has(parentDirective)) {
+            groups.get(parentDirective).push(directive);
         } else {
-            groups.set(parentComment, [directive]);
+            groups.set(parentDirective, [directive]);
         }
     }
 
@@ -57,19 +57,19 @@ function groupByParentComment(directives) {
 /**
  * Creates removal details for a set of directives within the same comment.
  * @param {Directive[]} directives Unused directives to be removed.
- * @param {Token} commentToken The backing Comment token.
+ * @param {Token} node The backing Comment token.
  * @returns {{ description, fix, unprocessedDirective }[]} Details for later creation of output Problems.
  */
-function createIndividualDirectivesRemoval(directives, commentToken) {
+function createIndividualDirectivesRemoval(directives, node) {
 
     /*
-     * `commentToken.value` starts right after `//` or `/*`.
+     * `node.value` starts right after `//` or `/*`.
      * All calculated offsets will be relative to this index.
      */
-    const commentValueStart = commentToken.range[0] + "//".length;
+    const commentValueStart = node.range[0] + "//".length;
 
     // Find where the list of rules starts. `\S+` matches with the directive name (e.g. `eslint-disable-line`)
-    const listStartOffset = /^\s*\S+\s+/u.exec(commentToken.value)[0].length;
+    const listStartOffset = /^\s*\S+\s+/u.exec(node.value)[0].length;
 
     /*
      * Get the list text without any surrounding whitespace. In order to preserve the original
@@ -78,7 +78,7 @@ function createIndividualDirectivesRemoval(directives, commentToken) {
      *     // eslint-disable-line rule-one , rule-two , rule-three -- comment
      *                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      */
-    const listText = commentToken.value
+    const listText = node.value
         .slice(listStartOffset) // remove directive name and all whitespace before the list
         .split(/\s-{2,}\s/u)[0] // remove `-- comment`, if it exists
         .trimEnd(); // remove all whitespace after the list
@@ -159,13 +159,13 @@ function createIndividualDirectivesRemoval(directives, commentToken) {
 }
 
 /**
- * Creates a description of deleting an entire unused disable comment.
+ * Creates a description of deleting an entire unused disable diretive.
  * @param {Directive[]} directives Unused directives to be removed.
- * @param {Token} commentToken The backing Comment token.
- * @returns {{ description, fix, unprocessedDirective }} Details for later creation of an output Problem.
+ * @param {Token} node The backing Comment token.
+ * @returns {{ description, fix, unprocessedDirective }} Details for later creation of an output problem.
  */
-function createCommentRemoval(directives, commentToken) {
-    const { range } = commentToken;
+function createDirectiveRemoval(directives, node) {
+    const { range } = node;
     const ruleIds = directives.filter(directive => directive.ruleId).map(directive => `'${directive.ruleId}'`);
 
     return {
@@ -186,20 +186,20 @@ function createCommentRemoval(directives, commentToken) {
  * @returns {{ description, fix, unprocessedDirective }[]} Details for later creation of output Problems.
  */
 function processUnusedDirectives(allDirectives) {
-    const directiveGroups = groupByParentComment(allDirectives);
+    const directiveGroups = groupByParentDirective(allDirectives);
 
     return directiveGroups.flatMap(
         directives => {
-            const { parentComment } = directives[0].unprocessedDirective;
-            const remainingRuleIds = new Set(parentComment.ruleIds);
+            const { parentDirective } = directives[0].unprocessedDirective;
+            const remainingRuleIds = new Set(parentDirective.ruleIds);
 
             for (const directive of directives) {
                 remainingRuleIds.delete(directive.ruleId);
             }
 
             return remainingRuleIds.size
-                ? createIndividualDirectivesRemoval(directives, parentComment.commentToken)
-                : [createCommentRemoval(directives, parentComment.commentToken)];
+                ? createIndividualDirectivesRemoval(directives, parentDirective.node)
+                : [createDirectiveRemoval(directives, parentDirective.node)];
         }
     );
 }
@@ -372,7 +372,7 @@ function applyDirectives(options) {
 
     const unusedDirectives = processed
         .map(({ description, fix, unprocessedDirective }) => {
-            const { parentComment, type, line, column } = unprocessedDirective;
+            const { parentDirective, type, line, column } = unprocessedDirective;
 
             let message;
 
@@ -388,8 +388,8 @@ function applyDirectives(options) {
             return {
                 ruleId: null,
                 message,
-                line: type === "disable-next-line" ? parentComment.commentToken.loc.start.line : line,
-                column: type === "disable-next-line" ? parentComment.commentToken.loc.start.column + 1 : column,
+                line: type === "disable-next-line" ? parentDirective.node.loc.start.line : line,
+                column: type === "disable-next-line" ? parentDirective.node.loc.start.column + 1 : column,
                 severity: options.reportUnusedDisableDirectives === "warn" ? 1 : 2,
                 nodeType: null,
                 ...options.disableFixes ? {} : { fix }

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -273,23 +273,21 @@ function createLintingProblem(options) {
  * Creates a collection of disable directives from a comment
  * @param {Object} options to create disable directives
  * @param {("disable"|"enable"|"disable-line"|"disable-next-line")} options.type The type of directive comment
- * @param {token} options.commentToken The Comment token
  * @param {string} options.value The value after the directive in the comment
  * comment specified no specific rules, so it applies to all rules (e.g. `eslint-disable`)
  * @param {string} options.justification The justification of the directive
- * @param {function(string): {create: Function}} options.ruleMapper A map from rule IDs to defined rules
+ * @param {ASTNode|token} options.node The Comment node/token.
+ * @param {function(string): {create: Function}} ruleMapper A map from rule IDs to defined rules
  * @returns {Object} Directives and problems from the comment
  */
-function createDisableDirectives(options) {
-    const { commentToken, type, value, justification, ruleMapper } = options;
+function createDisableDirectives({ type, value, justification, node }, ruleMapper) {
     const ruleIds = Object.keys(commentParser.parseListConfig(value));
     const directiveRules = ruleIds.length ? ruleIds : [null];
     const result = {
         directives: [], // valid disable directives
         directiveProblems: [] // problems in directives
     };
-
-    const parentComment = { commentToken, ruleIds };
+    const parentDirective = { node, ruleIds };
 
     for (const ruleId of directiveRules) {
 
@@ -297,25 +295,25 @@ function createDisableDirectives(options) {
         if (ruleId === null || !!ruleMapper(ruleId)) {
             if (type === "disable-next-line") {
                 result.directives.push({
-                    parentComment,
+                    parentDirective,
                     type,
-                    line: commentToken.loc.end.line,
-                    column: commentToken.loc.end.column + 1,
+                    line: node.loc.end.line,
+                    column: node.loc.end.column + 1,
                     ruleId,
                     justification
                 });
             } else {
                 result.directives.push({
-                    parentComment,
+                    parentDirective,
                     type,
-                    line: commentToken.loc.start.line,
-                    column: commentToken.loc.start.column + 1,
+                    line: node.loc.start.line,
+                    column: node.loc.start.column + 1,
                     ruleId,
                     justification
                 });
             }
         } else {
-            result.directiveProblems.push(createLintingProblem({ ruleId, loc: commentToken.loc }));
+            result.directiveProblems.push(createLintingProblem({ ruleId, loc: node.loc }));
         }
     }
     return result;
@@ -388,8 +386,12 @@ function getDirectiveComments(sourceCode, ruleMapper, warnInlineConfig, config) 
             case "eslint-disable-next-line":
             case "eslint-disable-line": {
                 const directiveType = directiveText.slice("eslint-".length);
-                const options = { commentToken: comment, type: directiveType, value: directiveValue, justification: justificationPart, ruleMapper };
-                const { directives, directiveProblems } = createDisableDirectives(options);
+                const { directives, directiveProblems } = createDisableDirectives({
+                    type: directiveType,
+                    value: directiveValue,
+                    justification: justificationPart,
+                    node: comment
+                }, ruleMapper);
 
                 disableDirectives.push(...directives);
                 problems.push(...directiveProblems);
@@ -543,53 +545,21 @@ function getDirectiveComments(sourceCode, ruleMapper, warnInlineConfig, config) 
  * A collection of the directive comments that were found, along with any problems that occurred when parsing
  */
 function getDirectiveCommentsForFlatConfig(sourceCode, ruleMapper) {
-    const problems = [];
     const disableDirectives = [];
+    const problems = [];
 
-    sourceCode.getInlineConfigNodes().filter(token => token.type !== "Shebang").forEach(comment => {
-        const { directivePart, justificationPart } = commentParser.extractDirectiveComment(comment.value);
+    const {
+        directives: directivesSources,
+        problems: directivesProblems
+    } = sourceCode.getDisableDirectives();
 
-        const match = directivesPattern.exec(directivePart);
+    problems.push(...directivesProblems.map(createLintingProblem));
 
-        if (!match) {
-            return;
-        }
-        const directiveText = match[1];
-        const lineCommentSupported = /^eslint-disable-(next-)?line$/u.test(directiveText);
+    directivesSources.forEach(directive => {
+        const { directives, directiveProblems } = createDisableDirectives(directive, ruleMapper);
 
-        if (comment.type === "Line" && !lineCommentSupported) {
-            return;
-        }
-
-        if (directiveText === "eslint-disable-line" && comment.loc.start.line !== comment.loc.end.line) {
-            const message = `${directiveText} comment should not span multiple lines.`;
-
-            problems.push(createLintingProblem({
-                ruleId: null,
-                message,
-                loc: comment.loc
-            }));
-            return;
-        }
-
-        const directiveValue = directivePart.slice(match.index + directiveText.length);
-
-        switch (directiveText) {
-            case "eslint-disable":
-            case "eslint-enable":
-            case "eslint-disable-next-line":
-            case "eslint-disable-line": {
-                const directiveType = directiveText.slice("eslint-".length);
-                const options = { commentToken: comment, type: directiveType, value: directiveValue, justification: justificationPart, ruleMapper };
-                const { directives, directiveProblems } = createDisableDirectives(options);
-
-                disableDirectives.push(...directives);
-                problems.push(...directiveProblems);
-                break;
-            }
-
-            // no default
-        }
+        disableDirectives.push(...directives);
+        problems.push(...directiveProblems);
     });
 
     return {

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -979,6 +979,13 @@ class SourceCode extends TokenStore {
      */
     getDisableDirectives() {
 
+        // check the cache first
+        const cachedDirectives = this[caches].get("disableDirectives");
+
+        if (cachedDirectives) {
+            return cachedDirectives;
+        }
+
         const problems = [];
         const directives = [];
 
@@ -1035,7 +1042,11 @@ class SourceCode extends TokenStore {
             }
         });
 
-        return { problems, directives };
+        const result = { problems, directives };
+
+        this[caches].set("disableDirectives", result);
+
+        return result;
     }
 
     /**

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -373,6 +373,56 @@ class TraversalStep {
     }
 }
 
+/**
+ * A class to represent a directive comment.
+ */
+class Directive {
+
+    /**
+     * The type of directive.
+     * @type {"disable"|"enable"|"disable-next-line"|"disable-line"}
+     * @readonly
+     */
+    type;
+
+    /**
+     * The node representing the directive.
+     * @type {ASTNode|Comment}
+     * @readonly
+     */
+    node;
+
+    /**
+     * Everything after the "eslint-disable" portion of the directive,
+     * but before the "--" that indicates the justification.
+     * @type {string}
+     * @readonly
+     */
+    value;
+
+    /**
+     * The justification for the directive.
+     * @type {string}
+     * @readonly
+     */
+    justification;
+
+    /**
+     * Creates a new instance.
+     * @param {Object} options The options for the directive.
+     * @param {"disable"|"enable"|"disable-next-line"|"disable-line"} options.type The type of directive.
+     * @param {ASTNode|Comment} options.node The node representing the directive.
+     * @param {string} options.value The value of the directive.
+     * @param {string} options.justification The justification for the directive.
+     */
+    constructor({ type, node, value, justification }) {
+        this.type = type;
+        this.node = node;
+        this.value = value;
+        this.justification = justification;
+    }
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -919,6 +969,73 @@ class SourceCode extends TokenStore {
         this[caches].set("configNodes", configNodes);
 
         return configNodes;
+    }
+
+    /**
+     * Returns an all directive nodes that enable or disable rules along with any problems
+     * encountered while parsing the directives.
+     * @returns {{problems:Array<Problem>,directives:Array<Directive>}} Information
+     *      that ESLint needs to further process the directives.
+     */
+    getDisableDirectives() {
+
+        const problems = [];
+        const directives = [];
+
+        this.getInlineConfigNodes().forEach(comment => {
+            const { directivePart, justificationPart } = commentParser.extractDirectiveComment(comment.value);
+
+            // Step 1: Extract the directive text
+            const match = directivesPattern.exec(directivePart);
+
+            if (!match) {
+                return;
+            }
+
+            const directiveText = match[1];
+
+            // Step 2: Extract the directive value
+            const lineCommentSupported = /^eslint-disable-(next-)?line$/u.test(directiveText);
+
+            if (comment.type === "Line" && !lineCommentSupported) {
+                return;
+            }
+
+            // Step 3: Validate the directive does not span multiple lines
+            if (directiveText === "eslint-disable-line" && comment.loc.start.line !== comment.loc.end.line) {
+                const message = `${directiveText} comment should not span multiple lines.`;
+
+                problems.push({
+                    ruleId: null,
+                    message,
+                    loc: comment.loc
+                });
+                return;
+            }
+
+            // Step 4: Extract the directive value and create the Directive object
+            const directiveValue = directivePart.slice(match.index + directiveText.length);
+
+            switch (directiveText) {
+                case "eslint-disable":
+                case "eslint-enable":
+                case "eslint-disable-next-line":
+                case "eslint-disable-line": {
+                    const directiveType = directiveText.slice("eslint-".length);
+
+                    directives.push(new Directive({
+                        type: directiveType,
+                        node: comment,
+                        value: directiveValue,
+                        justification: justificationPart
+                    }));
+                }
+
+                // no default
+            }
+        });
+
+        return { problems, directives };
     }
 
     /**

--- a/tests/lib/linter/apply-disable-directives.js
+++ b/tests/lib/linter/apply-disable-directives.js
@@ -17,15 +17,15 @@ const applyDisableDirectives = require("../../../lib/linter/apply-disable-direct
 //-----------------------------------------------------------------------------
 
 /**
- * Creates a ParentComment for a given range.
+ * Creates a ParentDirective for a given range.
  * @param {[number, number]} range total range of the comment
  * @param {string} value String value of the comment
  * @param {string[]} ruleIds Rule IDs reported in the value
- * @returns {ParentComment} Test-ready ParentComment object.
+ * @returns {ParentDirective} Test-ready ParentDirective object.
  */
-function createParentComment(range, value, ruleIds = []) {
+function createParentDirective(range, value, ruleIds = []) {
     return {
-        commentToken: {
+        node: {
             range,
             loc: {
                 start: {
@@ -52,7 +52,7 @@ describe("apply-disable-directives", () => {
         it("keeps problems before the comment on the same line", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
-                    directives: [{ parentComment: createParentComment([0, 7]), type: "disable", line: 1, column: 8, ruleId: null, justification: "justification" }],
+                    directives: [{ parentDirective: createParentDirective([0, 7]), type: "disable", line: 1, column: 8, ruleId: null, justification: "justification" }],
                     problems: [{ line: 1, column: 7, ruleId: "foo" }]
                 }),
                 [{ line: 1, column: 7, ruleId: "foo" }]
@@ -62,7 +62,7 @@ describe("apply-disable-directives", () => {
         it("keeps problems on a previous line before the comment", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
-                    directives: [{ parentComment: createParentComment([21, 27]), type: "disable", line: 2, column: 1, ruleId: null, justification: "justification" }],
+                    directives: [{ parentDirective: createParentDirective([21, 27]), type: "disable", line: 2, column: 1, ruleId: null, justification: "justification" }],
                     problems: [{ line: 1, column: 10, ruleId: "foo" }]
                 }),
                 [{ line: 1, column: 10, ruleId: "foo" }]
@@ -125,7 +125,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([26, 29]),
+                        parentDirective: createParentDirective([26, 29]),
                         type: "disable",
                         line: 1,
                         column: 1,
@@ -142,7 +142,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([7, 31]),
+                        parentDirective: createParentDirective([7, 31]),
                         type: "disable",
                         line: 1,
                         column: 8,
@@ -161,7 +161,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 26]),
+                            parentDirective: createParentDirective([0, 26]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -169,7 +169,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([27, 45]),
+                            parentDirective: createParentDirective([27, 45]),
                             type: "enable",
                             line: 1,
                             column: 26,
@@ -188,7 +188,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 25]),
+                            parentDirective: createParentDirective([0, 25]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -196,7 +196,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([26, 40]),
+                            parentDirective: createParentDirective([26, 40]),
                             type: "enable",
                             line: 1,
                             column: 26,
@@ -228,7 +228,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 20]),
+                            parentDirective: createParentDirective([0, 20]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -236,7 +236,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([26, 44]),
+                            parentDirective: createParentDirective([26, 44]),
                             type: "enable",
                             line: 1,
                             column: 26,
@@ -244,7 +244,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment: createParentComment([45, 63]),
+                            parentDirective: createParentDirective([45, 63]),
                             type: "disable",
                             line: 2,
                             column: 1,
@@ -263,7 +263,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 20]),
+                            parentDirective: createParentDirective([0, 20]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -271,7 +271,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([21, 44]),
+                            parentDirective: createParentDirective([21, 44]),
                             type: "enable",
                             line: 1,
                             column: 26,
@@ -279,7 +279,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment: createParentComment([45, 63]),
+                            parentDirective: createParentDirective([45, 63]),
                             type: "disable",
                             line: 2,
                             column: 1,
@@ -298,7 +298,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 20]),
+                            parentDirective: createParentDirective([0, 20]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -306,7 +306,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([25, 44]),
+                            parentDirective: createParentDirective([25, 44]),
                             type: "enable",
                             line: 1,
                             column: 26,
@@ -327,7 +327,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 20]),
+                            parentDirective: createParentDirective([0, 20]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -335,7 +335,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([21, 44]),
+                            parentDirective: createParentDirective([21, 44]),
                             type: "enable",
                             line: 2,
                             column: 1,
@@ -354,7 +354,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 20]),
+                            parentDirective: createParentDirective([0, 20]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -362,7 +362,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([21, 44]),
+                            parentDirective: createParentDirective([21, 44]),
                             type: "enable",
                             line: 2,
                             column: 1,
@@ -381,7 +381,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 20]),
+                            parentDirective: createParentDirective([0, 20]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -389,7 +389,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([21, 44]),
+                            parentDirective: createParentDirective([21, 44]),
                             type: "enable",
                             line: 2,
                             column: 1,
@@ -437,7 +437,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([6, 27]),
+                        parentDirective: createParentDirective([6, 27]),
                         type: "disable-line",
                         line: 2,
                         column: 1,
@@ -454,7 +454,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([7, 28]),
+                        parentDirective: createParentDirective([7, 28]),
                         type: "disable-line",
                         line: 1,
                         column: 8,
@@ -471,7 +471,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([7, 28]),
+                        parentDirective: createParentDirective([7, 28]),
                         type: "disable-line",
                         line: 1,
                         column: 8,
@@ -488,7 +488,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([7, 34]),
+                        parentDirective: createParentDirective([7, 34]),
                         type: "disable-line",
                         line: 1,
                         column: 8,
@@ -507,7 +507,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([7, 34]),
+                        parentDirective: createParentDirective([7, 34]),
                         type: "disable-line",
                         line: 1,
                         column: 8,
@@ -524,7 +524,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 27]),
+                        parentDirective: createParentDirective([0, 27]),
                         type: "disable-line",
                         line: 1,
                         column: 1,
@@ -542,7 +542,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -550,7 +550,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([24, 28]),
+                            parentDirective: createParentDirective([24, 28]),
                             type: "disable-line",
                             line: 1,
                             column: 22,
@@ -569,7 +569,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([7, 34]),
+                            parentDirective: createParentDirective([7, 34]),
                             type: "disable-line",
                             line: 1,
                             column: 8,
@@ -577,7 +577,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([38, 73]),
+                            parentDirective: createParentDirective([38, 73]),
                             type: "disable-line",
                             line: 2,
                             column: 8,
@@ -585,7 +585,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment: createParentComment([76, 111]),
+                            parentDirective: createParentDirective([76, 111]),
                             type: "disable-line",
                             line: 3,
                             column: 8,
@@ -593,7 +593,7 @@ describe("apply-disable-directives", () => {
                             justification: "j3"
                         },
                         {
-                            parentComment: createParentComment([114, 149]),
+                            parentDirective: createParentDirective([114, 149]),
                             type: "disable-line",
                             line: 4,
                             column: 8,
@@ -601,7 +601,7 @@ describe("apply-disable-directives", () => {
                             justification: "j4"
                         },
                         {
-                            parentComment: createParentComment([152, 187]),
+                            parentDirective: createParentDirective([152, 187]),
                             type: "disable-line",
                             line: 5,
                             column: 8,
@@ -609,7 +609,7 @@ describe("apply-disable-directives", () => {
                             justification: "j5"
                         },
                         {
-                            parentComment: createParentComment([190, 225]),
+                            parentDirective: createParentDirective([190, 225]),
                             type: "disable-line",
                             line: 6,
                             column: 8,
@@ -629,7 +629,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 31]),
+                        parentDirective: createParentDirective([0, 31]),
                         type: "disable-next-line",
                         line: 1,
                         column: 1,
@@ -646,7 +646,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 31]),
+                        parentDirective: createParentDirective([0, 31]),
                         type: "disable-next-line",
                         line: 1,
                         column: 1,
@@ -662,7 +662,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 31]),
+                        parentDirective: createParentDirective([0, 31]),
                         type: "disable-next-line",
                         line: 1,
                         column: 1,
@@ -679,8 +679,8 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
-                        { parentComment: createParentComment([0, 31]), type: "disable-next-line", line: 1, column: 1, ruleId: null, justification: "j1" },
-                        { parentComment: createParentComment([31, 50]), type: "enable", line: 1, column: 31, ruleId: null, justification: "j2" }
+                        { parentDirective: createParentDirective([0, 31]), type: "disable-next-line", line: 1, column: 1, ruleId: null, justification: "j1" },
+                        { parentDirective: createParentDirective([31, 50]), type: "enable", line: 1, column: 31, ruleId: null, justification: "j2" }
                     ],
                     problems: [{ line: 2, column: 2, ruleId: "foo" }]
                 }),
@@ -704,7 +704,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 31]),
+                        parentDirective: createParentDirective([0, 31]),
                         type: "disable-next-line",
                         line: 1,
                         column: 1,
@@ -736,7 +736,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 20]),
+                        parentDirective: createParentDirective([0, 20]),
                         type: "disable",
                         line: 1,
                         column: 1,
@@ -764,7 +764,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 20]),
+                        parentDirective: createParentDirective([0, 20]),
                         type: "disable",
                         line: 1,
                         column: 1,
@@ -800,7 +800,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 21]),
+                        parentDirective: createParentDirective([0, 21]),
                         type: "disable",
                         line: 1,
                         column: 1,
@@ -829,7 +829,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 24]),
+                        parentDirective: createParentDirective([0, 24]),
                         type: "disable",
                         line: 1,
                         column: 1,
@@ -866,7 +866,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "disable",
                             line: 1,
                             column: 8,
@@ -874,7 +874,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "enable",
                             line: 1,
                             column: 24,
@@ -912,7 +912,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 20]),
+                            parentDirective: createParentDirective([0, 20]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -920,7 +920,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([21, 41]),
+                            parentDirective: createParentDirective([21, 41]),
                             type: "enable",
                             line: 1,
                             column: 12,
@@ -951,7 +951,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -959,7 +959,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([21, 42]),
+                            parentDirective: createParentDirective([21, 42]),
                             type: "disable",
                             line: 2,
                             column: 1,
@@ -1004,7 +1004,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1012,7 +1012,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([22, 45]),
+                            parentDirective: createParentDirective([22, 45]),
                             type: "disable",
                             line: 2,
                             column: 1,
@@ -1054,7 +1054,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1062,7 +1062,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([22, 45]),
+                            parentDirective: createParentDirective([22, 45]),
                             type: "disable",
                             line: 2,
                             column: 1,
@@ -1115,7 +1115,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1123,7 +1123,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([22, 45]),
+                            parentDirective: createParentDirective([22, 45]),
                             type: "disable",
                             line: 2,
                             column: 1,
@@ -1165,7 +1165,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 20]),
+                            parentDirective: createParentDirective([0, 20]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1173,7 +1173,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([21, 45]),
+                            parentDirective: createParentDirective([21, 45]),
                             type: "disable",
                             line: 2,
                             column: 1,
@@ -1212,7 +1212,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 20]),
+                            parentDirective: createParentDirective([0, 20]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1220,7 +1220,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([25, 46]),
+                            parentDirective: createParentDirective([25, 46]),
                             type: "enable",
                             line: 1,
                             column: 26,
@@ -1258,7 +1258,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 24]),
+                            parentDirective: createParentDirective([0, 24]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1266,7 +1266,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([25, 49]),
+                            parentDirective: createParentDirective([25, 49]),
                             type: "enable",
                             line: 1,
                             column: 26,
@@ -1304,7 +1304,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1312,7 +1312,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([22, 45]),
+                            parentDirective: createParentDirective([22, 45]),
                             type: "disable",
                             line: 2,
                             column: 1,
@@ -1320,7 +1320,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment: createParentComment([46, 69]),
+                            parentDirective: createParentDirective([46, 69]),
                             type: "enable",
                             line: 3,
                             column: 1,
@@ -1369,7 +1369,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 20]),
+                        parentDirective: createParentDirective([0, 20]),
                         type: "enable",
                         line: 1,
                         column: 1,
@@ -1397,7 +1397,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 20]),
+                        parentDirective: createParentDirective([0, 20]),
                         type: "enable",
                         line: 1,
                         column: 1,
@@ -1436,7 +1436,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 21]),
+                        parentDirective: createParentDirective([0, 21]),
                         type: "enable",
                         line: 1,
                         column: 1,
@@ -1466,7 +1466,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 24]),
+                            parentDirective: createParentDirective([0, 24]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1474,7 +1474,7 @@ describe("apply-disable-directives", () => {
                             justification: "justification"
                         },
                         {
-                            parentComment: createParentComment([48, 72]),
+                            parentDirective: createParentDirective([48, 72]),
                             type: "enable",
                             line: 3,
                             column: 1,
@@ -1513,7 +1513,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1521,7 +1521,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([42, 63]),
+                            parentDirective: createParentDirective([42, 63]),
                             type: "enable",
                             line: 3,
                             column: 1,
@@ -1529,7 +1529,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([63, 84]),
+                            parentDirective: createParentDirective([63, 84]),
                             type: "enable",
                             line: 4,
                             column: 1,
@@ -1537,7 +1537,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([84, 105]),
+                            parentDirective: createParentDirective([84, 105]),
                             type: "enable",
                             line: 5,
                             column: 1,
@@ -1588,7 +1588,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1596,7 +1596,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([42, 63]),
+                            parentDirective: createParentDirective([42, 63]),
                             type: "enable",
                             line: 3,
                             column: 1,
@@ -1604,7 +1604,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([63, 84]),
+                            parentDirective: createParentDirective([63, 84]),
                             type: "enable",
                             line: 4,
                             column: 1,
@@ -1643,7 +1643,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "enable",
                             line: 1,
                             column: 1,
@@ -1651,7 +1651,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([21, 42]),
+                            parentDirective: createParentDirective([21, 42]),
                             type: "enable",
                             line: 2,
                             column: 1,
@@ -1696,7 +1696,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "enable",
                             line: 1,
                             column: 1,
@@ -1704,7 +1704,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([21, 42]),
+                            parentDirective: createParentDirective([21, 42]),
                             type: "disable",
                             line: 2,
                             column: 1,
@@ -1712,7 +1712,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment: createParentComment([63, 84]),
+                            parentDirective: createParentDirective([63, 84]),
                             type: "enable",
                             line: 4,
                             column: 1,
@@ -1751,7 +1751,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1759,7 +1759,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([42, 63]),
+                            parentDirective: createParentDirective([42, 63]),
                             type: "enable",
                             line: 3,
                             column: 1,
@@ -1767,7 +1767,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment: createParentComment([63, 84]),
+                            parentDirective: createParentDirective([63, 84]),
                             type: "enable",
                             line: 4,
                             column: 1,
@@ -1820,7 +1820,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 21]),
+                            parentDirective: createParentDirective([0, 21]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1828,7 +1828,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([42, 63]),
+                            parentDirective: createParentDirective([42, 63]),
                             type: "enable",
                             line: 3,
                             column: 1,
@@ -1836,7 +1836,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment: createParentComment([63, 84]),
+                            parentDirective: createParentDirective([63, 84]),
                             type: "enable",
                             line: 4,
                             column: 1,
@@ -1877,7 +1877,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 20]),
+                            parentDirective: createParentDirective([0, 20]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1885,7 +1885,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([60, 80]),
+                            parentDirective: createParentDirective([60, 80]),
                             type: "enable",
                             line: 3,
                             column: 1,
@@ -1893,7 +1893,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment: createParentComment([80, 100]),
+                            parentDirective: createParentDirective([80, 100]),
                             type: "enable",
                             line: 4,
                             column: 1,
@@ -1932,7 +1932,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 20]),
+                            parentDirective: createParentDirective([0, 20]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1940,7 +1940,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([60, 80]),
+                            parentDirective: createParentDirective([60, 80]),
                             type: "enable",
                             line: 3,
                             column: 1,
@@ -1948,7 +1948,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment: createParentComment([80, 100]),
+                            parentDirective: createParentDirective([80, 100]),
                             type: "enable",
                             line: 4,
                             column: 1,
@@ -1987,7 +1987,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 20]),
+                            parentDirective: createParentDirective([0, 20]),
                             type: "disable",
                             line: 1,
                             column: 1,
@@ -1995,7 +1995,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([40, 60]),
+                            parentDirective: createParentDirective([40, 60]),
                             type: "enable",
                             line: 3,
                             column: 1,
@@ -2003,7 +2003,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment: createParentComment([60, 80]),
+                            parentDirective: createParentDirective([60, 80]),
                             type: "enable",
                             line: 4,
                             column: 1,
@@ -2011,7 +2011,7 @@ describe("apply-disable-directives", () => {
                             justification: "j3"
                         },
                         {
-                            parentComment: createParentComment([80, 100]),
+                            parentDirective: createParentDirective([80, 100]),
                             type: "enable",
                             line: 5,
                             column: 1,
@@ -2062,7 +2062,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 20]),
+                            parentDirective: createParentDirective([0, 20]),
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -2070,7 +2070,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([40, 60]),
+                            parentDirective: createParentDirective([40, 60]),
                             ruleId: "used",
                             type: "disable",
                             line: 3,
@@ -2078,7 +2078,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment: createParentComment([80, 100]),
+                            parentDirective: createParentDirective([80, 100]),
                             ruleId: "used",
                             type: "enable",
                             line: 5,
@@ -2086,7 +2086,7 @@ describe("apply-disable-directives", () => {
                             justification: "j3"
                         },
                         {
-                            parentComment: createParentComment([100, 120]),
+                            parentDirective: createParentDirective([100, 120]),
                             ruleId: null,
                             type: "enable",
                             line: 6,
@@ -2130,7 +2130,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 22]),
+                        parentDirective: createParentDirective([0, 22]),
                         type: "disable-line",
                         line: 1,
                         column: 1,
@@ -2173,7 +2173,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 27]),
+                        parentDirective: createParentDirective([0, 27]),
                         type: "disable-next-line",
                         line: 1,
                         column: 2,
@@ -2215,8 +2215,8 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
-                        { parentComment: createParentComment([0, 20]), type: "disable", line: 1, column: 1, ruleId: null },
-                        { parentComment: createParentComment([20, 43]), type: "disable-line", line: 1, column: 22, ruleId: null }
+                        { parentDirective: createParentDirective([0, 20]), type: "disable", line: 1, column: 1, ruleId: null },
+                        { parentDirective: createParentDirective([20, 43]), type: "disable-line", line: 1, column: 22, ruleId: null }
                     ],
                     problems: [],
                     reportUnusedDisableDirectives: "error"
@@ -2254,7 +2254,7 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{
-                        parentComment: createParentComment([0, 27]),
+                        parentDirective: createParentDirective([0, 27]),
                         type: "disable-next-line",
                         line: 1,
                         column: 1,
@@ -2271,13 +2271,13 @@ describe("apply-disable-directives", () => {
 
     describe("unused rules within directives", () => {
         it("Adds a problem for /* eslint-disable used, unused */", () => {
-            const parentComment = createParentComment([0, 32], " eslint-disable used, unused ", ["used", "unused"]);
+            const parentDirective = createParentDirective([0, 32], " eslint-disable used, unused ", ["used", "unused"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -2285,7 +2285,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused",
                             type: "disable",
                             line: 1,
@@ -2319,13 +2319,13 @@ describe("apply-disable-directives", () => {
             );
         });
         it("Adds a problem for /* eslint-disable used , unused , -- unused and used are ok */", () => {
-            const parentComment = createParentComment([0, 62], " eslint-disable used , unused , -- unused and used are ok ", ["used", "unused"]);
+            const parentDirective = createParentDirective([0, 62], " eslint-disable used , unused , -- unused and used are ok ", ["used", "unused"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -2333,7 +2333,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused",
                             type: "disable",
                             line: 1,
@@ -2368,13 +2368,13 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable unused, used */", () => {
-            const parentComment = createParentComment([0, 32], " eslint-disable unused, used ", ["unused", "used"]);
+            const parentDirective = createParentDirective([0, 32], " eslint-disable unused, used ", ["unused", "used"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused",
                             type: "disable",
                             line: 1,
@@ -2382,7 +2382,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -2417,13 +2417,13 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable unused,, ,, used */", () => {
-            const parentComment = createParentComment([0, 37], " eslint-disable unused,, ,, used ", ["unused", "used"]);
+            const parentDirective = createParentDirective([0, 37], " eslint-disable unused,, ,, used ", ["unused", "used"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused",
                             type: "disable",
                             line: 1,
@@ -2431,7 +2431,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -2466,13 +2466,13 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable unused-1, unused-2, used */", () => {
-            const parentComment = createParentComment([0, 45], " eslint-disable unused-1, unused-2, used ", ["unused-1", "unused-2", "used"]);
+            const parentDirective = createParentDirective([0, 45], " eslint-disable unused-1, unused-2, used ", ["unused-1", "unused-2", "used"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-1",
                             type: "disable",
                             line: 1,
@@ -2480,7 +2480,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-2",
                             type: "disable",
                             line: 1,
@@ -2488,7 +2488,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -2535,13 +2535,13 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable unused-1, unused-2, used, unused-3 */", () => {
-            const parentComment = createParentComment([0, 55], " eslint-disable unused-1, unused-2, used, unused-3 ", ["unused-1", "unused-2", "used", "unused-3"]);
+            const parentDirective = createParentDirective([0, 55], " eslint-disable unused-1, unused-2, used, unused-3 ", ["unused-1", "unused-2", "used", "unused-3"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-1",
                             type: "disable",
                             line: 1,
@@ -2549,7 +2549,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-2",
                             type: "disable",
                             line: 1,
@@ -2557,7 +2557,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -2565,7 +2565,7 @@ describe("apply-disable-directives", () => {
                             justification: "j3"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-3",
                             type: "disable",
                             line: 1,
@@ -2624,13 +2624,13 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable unused-1, unused-2 */", () => {
-            const parentComment = createParentComment([0, 39], " eslint-disable unused-1, unused-2 ", ["unused-1", "unused-2"]);
+            const parentDirective = createParentDirective([0, 39], " eslint-disable unused-1, unused-2 ", ["unused-1", "unused-2"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-1",
                             type: "disable",
                             line: 1,
@@ -2638,7 +2638,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-2",
                             type: "disable",
                             line: 1,
@@ -2667,27 +2667,27 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable unused-1, unused-2, unused-3 */", () => {
-            const parentComment = createParentComment([0, 49], " eslint-disable unused-1, unused-2, unused-3 ", ["unused-1", "unused-2", "unused-3"]);
+            const parentDirective = createParentDirective([0, 49], " eslint-disable unused-1, unused-2, unused-3 ", ["unused-1", "unused-2", "unused-3"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-1",
                             type: "disable",
                             line: 1,
                             column: 18
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-2",
                             type: "disable",
                             line: 1,
                             column: 28
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-3",
                             type: "disable",
                             line: 1,
@@ -2719,7 +2719,7 @@ describe("apply-disable-directives", () => {
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
                             ruleId: "foo",
                             type: "disable",
                             line: 1,
@@ -2727,7 +2727,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment: createParentComment([41, 81], " eslint-disable-line foo, bar", ["foo", "bar"]),
+                            parentDirective: createParentDirective([41, 81], " eslint-disable-line foo, bar", ["foo", "bar"]),
                             ruleId: "foo",
                             type: "disable-line",
                             line: 2,
@@ -2735,7 +2735,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment: createParentComment([41, 81], " eslint-disable-line foo, bar ", ["foo", "bar"]),
+                            parentDirective: createParentDirective([41, 81], " eslint-disable-line foo, bar ", ["foo", "bar"]),
                             ruleId: "bar",
                             type: "disable-line",
                             line: 2,
@@ -2782,13 +2782,13 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable used */ /* (problem from used) */ /* eslint-enable used, unused */", () => {
-            const parentComment = createParentComment([0, 32], " eslint-enable used, unused ", ["used", "unused"]);
+            const parentDirective = createParentDirective([0, 32], " eslint-enable used, unused ", ["used", "unused"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -2796,7 +2796,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "used",
                             type: "enable",
                             line: 3,
@@ -2804,7 +2804,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused",
                             type: "enable",
                             line: 4,
@@ -2838,13 +2838,13 @@ describe("apply-disable-directives", () => {
             );
         });
         it("Adds a problem for /* eslint-disable used */ /* (problem from used) */ /* eslint-enable used , unused , -- unused and used are ok */", () => {
-            const parentComment = createParentComment([0, 62], " eslint-enable used , unused , -- unused and used are ok ", ["used", "unused"]);
+            const parentDirective = createParentDirective([0, 62], " eslint-enable used , unused , -- unused and used are ok ", ["used", "unused"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -2852,7 +2852,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "used",
                             type: "enable",
                             line: 3,
@@ -2860,7 +2860,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused",
                             type: "enable",
                             line: 4,
@@ -2895,13 +2895,13 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable used */ /* (problem from used) */ /* eslint-enable unused, used */", () => {
-            const parentComment = createParentComment([0, 32], " eslint-enable unused, used ", ["unused", "used"]);
+            const parentDirective = createParentDirective([0, 32], " eslint-enable unused, used ", ["unused", "used"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -2909,7 +2909,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused",
                             type: "enable",
                             line: 3,
@@ -2917,7 +2917,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "used",
                             type: "enable",
                             line: 4,
@@ -2952,13 +2952,13 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable used */ /* (problem from used) */ /* eslint-enable unused,, ,, used */", () => {
-            const parentComment = createParentComment([0, 37], " eslint-enable unused,, ,, used ", ["unused", "used"]);
+            const parentDirective = createParentDirective([0, 37], " eslint-enable unused,, ,, used ", ["unused", "used"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -2966,7 +2966,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused",
                             type: "enable",
                             line: 3,
@@ -2974,7 +2974,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "used",
                             type: "enable",
                             line: 4,
@@ -3009,13 +3009,13 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable used */ /* (problem from used) */ /* eslint-enable unused-1, unused-2, used */", () => {
-            const parentComment = createParentComment([0, 45], " eslint-enable unused-1, unused-2, used ", ["unused-1", "unused-2", "used"]);
+            const parentDirective = createParentDirective([0, 45], " eslint-enable unused-1, unused-2, used ", ["unused-1", "unused-2", "used"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -3023,7 +3023,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-1",
                             type: "enable",
                             line: 3,
@@ -3031,7 +3031,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-2",
                             type: "enable",
                             line: 4,
@@ -3039,7 +3039,7 @@ describe("apply-disable-directives", () => {
                             justification: "j3"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "used",
                             type: "enable",
                             line: 5,
@@ -3086,13 +3086,13 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable used */ /* (problem from used) */ /* eslint-enable unused-1, unused-2, used, unused-3 */", () => {
-            const parentComment = createParentComment([0, 55], " eslint-enable unused-1, unused-2, used, unused-3 ", ["unused-1", "unused-2", "used", "unused-3"]);
+            const parentDirective = createParentDirective([0, 55], " eslint-enable unused-1, unused-2, used, unused-3 ", ["unused-1", "unused-2", "used", "unused-3"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment: createParentComment([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -3100,7 +3100,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-1",
                             type: "enable",
                             line: 3,
@@ -3108,7 +3108,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-2",
                             type: "enable",
                             line: 4,
@@ -3116,7 +3116,7 @@ describe("apply-disable-directives", () => {
                             justification: "j3"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "used",
                             type: "enable",
                             line: 5,
@@ -3124,7 +3124,7 @@ describe("apply-disable-directives", () => {
                             justification: "j4"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-3",
                             type: "enable",
                             line: 6,
@@ -3183,13 +3183,13 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-enable unused-1, unused-2 */", () => {
-            const parentComment = createParentComment([0, 39], " eslint-enable unused-1, unused-2 ", ["unused-1", "unused-2"]);
+            const parentDirective = createParentDirective([0, 39], " eslint-enable unused-1, unused-2 ", ["unused-1", "unused-2"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-1",
                             type: "enable",
                             line: 1,
@@ -3197,7 +3197,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-2",
                             type: "enable",
                             line: 1,
@@ -3226,27 +3226,27 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-enable unused-1, unused-2, unused-3 */", () => {
-            const parentComment = createParentComment([0, 49], " eslint-enable unused-1, unused-2, unused-3 ", ["unused-1", "unused-2", "unused-3"]);
+            const parentDirective = createParentDirective([0, 49], " eslint-enable unused-1, unused-2, unused-3 ", ["unused-1", "unused-2", "unused-3"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-1",
                             type: "enable",
                             line: 1,
                             column: 18
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-2",
                             type: "enable",
                             line: 1,
                             column: 28
                         },
                         {
-                            parentComment,
+                            parentDirective,
                             ruleId: "unused-3",
                             type: "enable",
                             line: 1,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Refactor

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Continues the work on implementing language plugins by moving directive gathering into `SourceCode`. The changes here primarily affect the flat config path.

I also renamed parts of directive processing to better reflect the reality that some languages might not use comments for directives and instead use actual syntax, so I renamed things from "comment" to "node". Otherwise, the functionality remains the same for apply disable directives. I believe this should now work for any language, but we'll need to do further testing to verify.

refs #16999

#### Is there anything you'd like reviewers to focus on?

I did need to deviate from the RFC design to make this work, in particular, the method needs to returns problems in addition to the directives in order to maintain our current behavior.

We could remove the need to return problems by moving the check for `disable-next-line` back into the linter, as there is an argument to be made that this should carry across any language.

I think the larger question is if we always want this method to be able to return problems, as there may be other validation errors that come up besides the `disable-next-line` check.

<!-- markdownlint-disable-file MD004 -->
