### PR TITLE
fix: `--no-ignore` should not apply to non-global ignores

### DIFF
--- a/lib/config/flat-config-array.js
+++ b/lib/config/flat-config-array.js
@@ -18,6 +18,11 @@ const { defaultConfig } = require("./default-config");
 // Helpers
 //-----------------------------------------------------------------------------
 
+/**
+ * Fields that are considered metadata and not part of the config object.
+ */
+const META_FIELDS = new Set(["name"]);
+
 const ruleValidator = new RuleValidator();
 
 /**
@@ -135,15 +140,15 @@ class FlatConfigArray extends ConfigArray {
     [ConfigArraySymbol.preprocessConfig](config) {
 
         /*
-         * If `shouldIgnore` is false, we remove any ignore patterns specified
-         * in the config so long as it's not a default config and it doesn't
-         * have a `files` entry.
+         * If a config object has `ignores` and no other non-meta fields, then it's an object
+         * for global ignores. If `shouldIgnore` is false, that object shouldn't apply,
+         * so we'll remove its `ignores`.
          */
         if (
             !this.shouldIgnore &&
             !this[originalBaseConfig].includes(config) &&
             config.ignores &&
-            !config.files
+            Object.keys(config).filter(key => !META_FIELDS.has(key)).length === 1
         ) {
             /* eslint-disable-next-line no-unused-vars -- need to strip off other keys */
             const { ignores, ...otherKeys } = config;

--- a/tests/fixtures/eslint.config-with-ignores3.js
+++ b/tests/fixtures/eslint.config-with-ignores3.js
@@ -1,0 +1,9 @@
+const eslintConfig = require("./eslint.config.js");
+
+module.exports = [
+    eslintConfig,
+    {
+        name: "Global ignores",
+        ignores: ["**/*.json", "**/*.js"]
+    }
+];

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -1630,6 +1630,16 @@ describe("ESLint", () => {
                 }, /All files matched by 'tests\/fixtures\/cli-engine\/' are ignored\./u);
             });
 
+            it("should throw an error when all given files are ignored by a config object that has `name`", async () => {
+                eslint = new ESLint({
+                    overrideConfigFile: getFixturePath("eslint.config-with-ignores3.js")
+                });
+
+                await assert.rejects(async () => {
+                    await eslint.lintFiles(["tests/fixtures/cli-engine/"]);
+                }, /All files matched by 'tests\/fixtures\/cli-engine\/' are ignored\./u);
+            });
+
             it("should throw an error when all given files are ignored even with a `./` prefix", async () => {
                 eslint = new ESLint({
                     overrideConfigFile: getFixturePath("eslint.config-with-ignores.js")
@@ -1757,6 +1767,29 @@ describe("ESLint", () => {
                     cwd: getFixturePath(),
                     ignore: false,
                     overrideConfigFile: getFixturePath("eslint.config-with-ignores.js"),
+                    overrideConfig: {
+                        rules: {
+                            "no-undef": 2
+                        }
+                    }
+                });
+                const filePath = fs.realpathSync(getFixturePath("undef.js"));
+                const results = await eslint.lintFiles([filePath]);
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].filePath, filePath);
+                assert.strictEqual(results[0].messages[0].ruleId, "no-undef");
+                assert.strictEqual(results[0].messages[0].severity, 2);
+                assert.strictEqual(results[0].messages[1].ruleId, "no-undef");
+                assert.strictEqual(results[0].messages[1].severity, 2);
+                assert.strictEqual(results[0].suppressedMessages.length, 0);
+            });
+
+            it("should return two messages when given a file in excluded files list by a config object that has `name` while ignore is off", async () => {
+                eslint = new ESLint({
+                    cwd: getFixturePath(),
+                    ignore: false,
+                    overrideConfigFile: getFixturePath("eslint.config-with-ignores3.js"),
                     overrideConfig: {
                         rules: {
                             "no-undef": 2
@@ -5680,6 +5713,30 @@ describe("ESLint", () => {
             it("should apply to all files except for 'error.js'", async () => {
                 const engine = new ESLint({
                     cwd
+                });
+
+                const results = await engine.lintFiles("{error,warn}.js");
+
+                assert.strictEqual(results.length, 2);
+
+                const [errorResult, warnResult] = results;
+
+                assert.strictEqual(errorResult.filePath, path.join(getPath(), "error.js"));
+                assert.strictEqual(errorResult.messages.length, 1);
+                assert.strictEqual(errorResult.messages[0].ruleId, "no-unused-vars");
+                assert.strictEqual(errorResult.messages[0].severity, 2);
+
+                assert.strictEqual(warnResult.filePath, path.join(getPath(), "warn.js"));
+                assert.strictEqual(warnResult.messages.length, 1);
+                assert.strictEqual(warnResult.messages[0].ruleId, "no-unused-vars");
+                assert.strictEqual(warnResult.messages[0].severity, 1);
+            });
+
+            // https://github.com/eslint/eslint/issues/18261
+            it("should apply to all files except for 'error.js' even with `ignore: false` option", async () => {
+                const engine = new ESLint({
+                    cwd,
+                    ignore: false
                 });
 
                 const results = await engine.lintFiles("{error,warn}.js");


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #18261

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated condition for whether `ignore:false` (`--no-ignore`) should apply to a config object to check if the object has any other keys (excluding `name`) instead of just checking if it has the `files` key.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
