### PR TITLE
feat: Add `ignore-directives` option to `require-await`

### DIFF
--- a/docs/src/rules/require-await.md
+++ b/docs/src/rules/require-await.md
@@ -77,6 +77,69 @@ async function noop() {}
 
 :::
 
+## Options
+
+This rule has an object option, with one option:
+
+* `"ignoreDirectives"` - an optional array of directive values whose containing functions this rule will ignore.
+
+### ignore
+
+You can specify multiple directive values to ignore in the `"ignoreDirectives"` array.
+
+For example, a framework might require functions tagged with the `"use server"` directive to always be async. In this case, they should be async even if they don't contain an `await` operator. You can include `"use server"` in the `"ignoreDirectives"` array to make this rule ignore such functions.
+
+Examples of **incorrect** code for this rule with the `"ignoreDirectives"` option:
+
+::: incorrect
+
+```js
+/*eslint require-await: ["error", { "ignore": ["use server"] }]*/
+
+async function handler() {
+    console.log("Handled")
+}
+
+async function handler() {
+    "use client"
+    console.log("Handled")
+}
+
+async function handler() {
+    console.log("Handled")
+    "use server"
+}
+
+async function handler() {
+    `use server`
+    console.log("Handled")
+}
+
+```
+
+:::
+
+Examples of **correct** code for this rule with the `"ignoreDirectives"` option:
+
+::: correct
+
+```js
+/*eslint require-await: ["error", { "ignore": ["use server"] }]*/
+
+async function handler() {
+    "use server"
+    console.log("Handled")
+}
+
+async function handler() {
+    'use server'
+    console.log("Handled")
+}
+
+```
+
+:::
+
 ## When Not To Use It
 
 Asynchronous functions are designed to work with promises such that throwing an error will cause a promise's rejection handler (such as `catch()`) to be called. For example:

--- a/docs/src/rules/require-await.md
+++ b/docs/src/rules/require-await.md
@@ -94,7 +94,7 @@ Examples of **incorrect** code for this rule with the `"ignoreDirectives"` optio
 ::: incorrect
 
 ```js
-/*eslint require-await: ["error", { "ignore": ["use server"] }]*/
+/*eslint require-await: ["error", { "ignoreDirectives": ["use server"] }]*/
 
 async function handler() {
     console.log("Handled")
@@ -124,7 +124,7 @@ Examples of **correct** code for this rule with the `"ignoreDirectives"` option:
 ::: correct
 
 ```js
-/*eslint require-await: ["error", { "ignore": ["use server"] }]*/
+/*eslint require-await: ["error", { "ignoreDirectives": ["use server"] }]*/
 
 async function handler() {
     "use server"

--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -24,6 +24,49 @@ function capitalizeFirstLetter(text) {
     return text[0].toUpperCase() + text.slice(1);
 }
 
+/**
+ * Has AST suggesting a directive.
+ * @param {ASTNode} node any node
+ * @returns {boolean} whether the given node structurally represents a directive
+ */
+function looksLikeDirective(node) {
+    return node.type === "ExpressionStatement" &&
+        node.expression.type === "Literal" && typeof node.expression.value === "string";
+}
+
+/**
+ * Gets the leading sequence of members in a list that pass the predicate.
+ * @param {Function} predicate ([a] -> Boolean) the function used to make the determination
+ * @param {a[]} list the input list
+ * @returns {a[]} the leading sequence of members in the given list that pass the given predicate
+ */
+function takeWhile(predicate, list) {
+    for (let i = 0; i < list.length; ++i) {
+        if (!predicate(list[i])) {
+            return list.slice(0, i);
+        }
+    }
+    return list.slice();
+}
+
+/**
+ * Gets leading directives nodes in a Node body.
+ * @param {ASTNode} node a Program or BlockStatement node
+ * @returns {ASTNode[]} the leading sequence of directive nodes in the given node's body
+ */
+function directiveNodes(node) {
+    return takeWhile(looksLikeDirective, node.body);
+}
+
+/**
+ * Gets directive strings from an array of directive nodes.
+ * @param {ASTNode[]} nodes directive nodes
+ * @returns {string[]} the string contents of the given nodes
+ */
+function directiveValues(nodes) {
+    return nodes.map((node) => node.expression.value);
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -39,7 +82,17 @@ module.exports = {
             url: "https://eslint.org/docs/latest/rules/require-await"
         },
 
-        schema: [],
+        schema: [{
+            type: "object",
+            properties: {
+                ignoreDirectives: {
+                    type: "array",
+                    items: { type: "string" },
+                    uniqueItems: true
+                }
+            },
+            additionalProperties: false
+        }],
 
         messages: {
             missingAwait: "{{name}} has no 'await' expression."
@@ -49,6 +102,7 @@ module.exports = {
     create(context) {
         const sourceCode = context.sourceCode;
         let scopeInfo = null;
+        const ignoredDirectives = context.options[0] && context.options[0].ignoreDirectives || []
 
         /**
          * Push the scope info object to the stack.
@@ -68,6 +122,11 @@ module.exports = {
          * @returns {void}
          */
         function exitFunction(node) {
+            if (node.body.type === "BlockStatement") {
+                const directives = directiveValues(directiveNodes(node.body))
+                if (directives.some((d) => ignoredDirectives.includes(d))) return
+            }
+
             if (!node.generator && node.async && !scopeInfo.hasAwait && !astUtils.isEmptyFunction(node)) {
                 context.report({
                     node,

--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -88,8 +88,16 @@ ruleTester.run("require-await", rule, {
         {
             code: 'async function* run() { console.log("bar") }',
             languageOptions: { ecmaVersion: 9 }
-        }
-
+        },
+        // "ignoreDirectives"
+        {
+            code: "async function foo() { 'use server' }",
+            options: [{ ignoreDirectives: ["use server"] }]
+        },
+        {
+            code: "async function foo() { \"use server\" }",
+            options: [{ ignoreDirectives: ["use server"] }]
+        },
     ],
     invalid: [
         {
@@ -161,6 +169,39 @@ ruleTester.run("require-await", rule, {
                 messageId: "missingAwait",
                 data: { name: "Async arrow function" }
             }]
-        }
+        },
+        // "ignoreDirectives"
+        {
+            code: "async function foo() { `use server` }",
+            options: [{ ignoreDirectives: ["use server"] }],
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async function 'foo'" }
+            }]
+        },
+        {
+            code: "async function foo() { doSomething() }",
+            options: [{ ignoreDirectives: ["use server"] }],
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async function 'foo'" }
+            }]
+        },
+        {
+            code: "async function foo() { 'use client' }",
+            options: [{ ignoreDirectives: ["use server"] }],
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async function 'foo'" }
+            }]
+        },
+        {
+            code: "async function foo() { doSomething(); 'use server' }",
+            options: [{ ignoreDirectives: ["use server"] }],
+            errors: [{
+                messageId: "missingAwait",
+                data: { name: "Async function 'foo'" }
+            }]
+        },
     ]
 });


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

`require-await`

**What change do you want to make (place an "X" next to just one item)?**

[ ] Generate more warnings
[X] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[X] A new option
[ ] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
/*eslint require-await: ["error", { "ignoreDirectives": ["use server"] }]*/

async function handler() {
    "use server"
    console.log("Handled")
}

async function handler() {
    'use server'
    console.log("Handled")
}
```

**What does the rule currently do for this code?**

It will flag the `async` function as requiring an `await` operator.

**What will the rule do after it's changed?**

With the `ignoreDirectives` set to `["use server"]`, no errors/warning will be thrown for these functions.

#### What changes did you make? (Give an overview)

Added an option to `require-await` to ignore functions with the given directives. This is useful for frameworks that require functions with certain directives to always be asynchronous. The biggest example of this is the upcoming React `"use server"` changes which require all functions with the `"use server"` directive to be async.

#### Is there anything you'd like reviewers to focus on?

The code itself is simple! I would just like to point out the benefits this option provides in allowing better error behavior around certain framework requirements while not being prescriptive with what those requirements are. I.E., this change allows users to abide by React `"use server"` requirements, but it would also support similar features in other systems just as well.

<!-- markdownlint-disable-file MD004 -->
