### PR TITLE
feat: Provide helpful error message for nullish configs

### DIFF
--- a/lib/config/flat-config-array.js
+++ b/lib/config/flat-config-array.js
@@ -79,7 +79,53 @@ function getObjectId(object) {
     return name;
 }
 
+/**
+ * Wraps a config error with details about where the error occurred.
+ * @param {Error} error The original error.
+ * @param {number} originalLength The original length of the config array.
+ * @param {number} baseLength The length of the base config.
+ * @returns {TypeError} The new error with details.
+ */
+function wrapConfigErrorWithDetails(error, originalLength, baseLength) {
+
+    let location = "user-defined";
+    let configIndex = error.index;
+
+    /*
+     * A config array is set up in this order:
+     * 1. Base config
+     * 2. Original configs
+     * 3. User-defined configs
+     * 4. CLI-defined configs
+     *
+     * So we need to adjust the index to account for the base config.
+     *
+     * - If the index is less than the base length, it's in the base config
+     *   (as specified by `baseConfig` argument to `FlatConfigArray` constructor).
+     * - If the index is greater than the base length but less than the original
+     *   length + base length, it's in the original config. The original config
+     *   is passed to the `FlatConfigArray` constructor as the first argument.
+     * - Otherwise, it's in the user-defined config, which is loaded from the
+     *   config file and merged with any command-line options.
+     */
+    if (error.index < baseLength) {
+        location = "base";
+    } else if (error.index < originalLength + baseLength) {
+        location = "original";
+        configIndex = error.index - baseLength;
+    } else {
+        configIndex = error.index - originalLength - baseLength;
+    }
+
+    return new TypeError(
+        `${error.message.slice(0, -1)} at ${location} index ${configIndex}.`,
+        { cause: error }
+    );
+}
+
 const originalBaseConfig = Symbol("originalBaseConfig");
+const originalLength = Symbol("originalLength");
+const baseLength = Symbol("baseLength");
 
 //-----------------------------------------------------------------------------
 // Exports
@@ -106,11 +152,23 @@ class FlatConfigArray extends ConfigArray {
             schema: flatConfigSchema
         });
 
+        /**
+         * The original length of the array before any modifications.
+         * @type {number}
+         */
+        this[originalLength] = this.length;
+
         if (baseConfig[Symbol.iterator]) {
             this.unshift(...baseConfig);
         } else {
             this.unshift(baseConfig);
         }
+
+        /**
+         * The length of the array after applying the base config.
+         * @type {number}
+         */
+        this[baseLength] = this.length - this[originalLength];
 
         /**
          * The base config used to build the config array.
@@ -127,6 +185,49 @@ class FlatConfigArray extends ConfigArray {
          */
         this.shouldIgnore = shouldIgnore;
         Object.defineProperty(this, "shouldIgnore", { writable: false });
+    }
+
+    /**
+     * Normalizes the array by calling the superclass method and catching/rethrowing
+     * any ConfigError exceptions with additional details.
+     * @param {any} [context] The context to use to normalize the array.
+     * @returns {Promise<void>} A promise that resolves when the array is normalized.
+     */
+    normalize(context) {
+        return super.normalize(context)
+            .catch(error => {
+                if (error.name === "ConfigError") {
+                    throw wrapConfigErrorWithDetails(error, this[originalLength], this[baseLength]);
+                }
+
+                throw error;
+
+            });
+    }
+
+    /**
+     * Normalizes the array by calling the superclass method and catching/rethrowing
+     * any ConfigError exceptions with additional details.
+     * @param {any} [context] The context to use to normalize the array.
+     * @returns {void} A promise that resolves when the array is normalized.
+     * @throws {TypeError} If the config is invalid.
+     */
+    normalizeSync(context) {
+
+        try {
+
+            return super.normalizeSync(context);
+
+        } catch (error) {
+
+            if (error.name === "ConfigError") {
+                throw wrapConfigErrorWithDetails(error, this[originalLength], this[baseLength]);
+            }
+
+            throw error;
+
+        }
+
     }
 
     /* eslint-disable class-methods-use-this -- Desired as instance method */

--- a/lib/config/flat-config-array.js
+++ b/lib/config/flat-config-array.js
@@ -191,7 +191,7 @@ class FlatConfigArray extends ConfigArray {
      * Normalizes the array by calling the superclass method and catching/rethrowing
      * any ConfigError exceptions with additional details.
      * @param {any} [context] The context to use to normalize the array.
-     * @returns {Promise<void>} A promise that resolves when the array is normalized.
+     * @returns {Promise<FlatConfigArray>} A promise that resolves when the array is normalized.
      */
     normalize(context) {
         return super.normalize(context)

--- a/lib/config/flat-config-array.js
+++ b/lib/config/flat-config-array.js
@@ -209,7 +209,7 @@ class FlatConfigArray extends ConfigArray {
      * Normalizes the array by calling the superclass method and catching/rethrowing
      * any ConfigError exceptions with additional details.
      * @param {any} [context] The context to use to normalize the array.
-     * @returns {void} A promise that resolves when the array is normalized.
+     * @returns {FlatConfigArray} The current instance.
      * @throws {TypeError} If the config is invalid.
      */
     normalizeSync(context) {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@eslint-community/regexpp": "^4.6.1",
     "@eslint/eslintrc": "^3.0.2",
     "@eslint/js": "9.0.0",
-    "@humanwhocodes/config-array": "^0.12.3",
+    "@humanwhocodes/config-array": "^0.13.0",
     "@humanwhocodes/module-importer": "^1.0.1",
     "@humanwhocodes/retry": "^0.2.3",
     "@nodelib/fs.walk": "^1.2.8",

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -191,9 +191,9 @@ async function assertMergedResult(values, result) {
 async function assertInvalidConfig(values, message) {
     const configs = createFlatConfigArray(values);
 
-    await configs.normalize();
 
     assert.throws(() => {
+        configs.normalizeSync();
         configs.getConfig("foo.js");
     }, message);
 }
@@ -719,13 +719,161 @@ describe("FlatConfigArray", () => {
     describe("Config array elements", () => {
         it("should error on 'eslint:recommended' string config", async () => {
 
-            await assertInvalidConfig(["eslint:recommended"], "All arguments must be objects.");
+            await assertInvalidConfig(["eslint:recommended"], "Config (unnamed): Unexpected non-object config at original index 0.");
         });
 
         it("should error on 'eslint:all' string config", async () => {
 
-            await assertInvalidConfig(["eslint:all"], "All arguments must be objects.");
+            await assertInvalidConfig(["eslint:all"], "Config (unnamed): Unexpected non-object config at original index 0.");
         });
+
+
+        it("should throw an error when undefined original config is normalized", () => {
+
+            const configs = new FlatConfigArray([void 0]);
+
+            assert.throws(() => {
+                configs.normalizeSync();
+            }, "Config (unnamed): Unexpected undefined config at original index 0.");
+
+        });
+
+        it("should throw an error when undefined original config is normalized asynchronously", async () => {
+
+            const configs = new FlatConfigArray([void 0]);
+
+            try {
+                await configs.normalize();
+                assert.fail("Error not thrown");
+            } catch (error) {
+                assert.strictEqual(error.message, "Config (unnamed): Unexpected undefined config at original index 0.");
+            }
+
+        });
+
+        it("should throw an error when null original config is normalized", () => {
+
+            const configs = new FlatConfigArray([null]);
+
+            assert.throws(() => {
+                configs.normalizeSync();
+            }, "Config (unnamed): Unexpected null config at original index 0.");
+
+        });
+
+        it("should throw an error when null original config is normalized asynchronously", async () => {
+
+            const configs = new FlatConfigArray([null]);
+
+            try {
+                await configs.normalize();
+                assert.fail("Error not thrown");
+            } catch (error) {
+                assert.strictEqual(error.message, "Config (unnamed): Unexpected null config at original index 0.");
+            }
+
+        });
+
+        it("should throw an error when undefined base config is normalized", () => {
+
+            const configs = new FlatConfigArray([], { baseConfig: [void 0] });
+
+            assert.throws(() => {
+                configs.normalizeSync();
+            }, "Config (unnamed): Unexpected undefined config at base index 0.");
+
+        });
+
+        it("should throw an error when undefined base config is normalized asynchronously", async () => {
+
+            const configs = new FlatConfigArray([], { baseConfig: [void 0] });
+
+            try {
+                await configs.normalize();
+                assert.fail("Error not thrown");
+            } catch (error) {
+                assert.strictEqual(error.message, "Config (unnamed): Unexpected undefined config at base index 0.");
+            }
+
+        });
+
+        it("should throw an error when null base config is normalized", () => {
+
+            const configs = new FlatConfigArray([], { baseConfig: [null] });
+
+            assert.throws(() => {
+                configs.normalizeSync();
+            }, "Config (unnamed): Unexpected null config at base index 0.");
+
+        });
+
+        it("should throw an error when null base config is normalized asynchronously", async () => {
+
+            const configs = new FlatConfigArray([], { baseConfig: [null] });
+
+            try {
+                await configs.normalize();
+                assert.fail("Error not thrown");
+            } catch (error) {
+                assert.strictEqual(error.message, "Config (unnamed): Unexpected null config at base index 0.");
+            }
+
+        });
+
+        it("should throw an error when undefined user-defined config is normalized", () => {
+
+            const configs = new FlatConfigArray([]);
+
+            configs.push(void 0);
+
+            assert.throws(() => {
+                configs.normalizeSync();
+            }, "Config (unnamed): Unexpected undefined config at user-defined index 0.");
+
+        });
+
+        it("should throw an error when undefined user-defined config is normalized asynchronously", async () => {
+
+            const configs = new FlatConfigArray([]);
+
+            configs.push(void 0);
+
+            try {
+                await configs.normalize();
+                assert.fail("Error not thrown");
+            } catch (error) {
+                assert.strictEqual(error.message, "Config (unnamed): Unexpected undefined config at user-defined index 0.");
+            }
+
+        });
+
+        it("should throw an error when null user-defined config is normalized", () => {
+
+            const configs = new FlatConfigArray([]);
+
+            configs.push(null);
+
+            assert.throws(() => {
+                configs.normalizeSync();
+            }, "Config (unnamed): Unexpected null config at user-defined index 0.");
+
+        });
+
+        it("should throw an error when null user-defined config is normalized asynchronously", async () => {
+
+            const configs = new FlatConfigArray([]);
+
+            configs.push(null);
+
+            try {
+                await configs.normalize();
+                assert.fail("Error not thrown");
+            } catch (error) {
+                assert.strictEqual(error.message, "Config (unnamed): Unexpected null config at user-defined index 0.");
+            }
+
+        });
+
 
     });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Upgraded `@humanwhocodes/config-array` to include new error details, then updated `FlatConfigArray` to use that info to produce an error message containing the index of the config that caused the error.

fixes #18259

#### Is there anything you'd like reviewers to focus on?

I used the terms "original", "base", and "user-defined" to differentiate between the different parts of the config array. I'm not sure how accurate those are but they are at least indicating the different parts of the array where the error occurred.

<!-- markdownlint-disable-file MD004 -->
