### PR TITLE
perf: new grapheme library

### DIFF
--- a/lib/shared/string-utils.js
+++ b/lib/shared/string-utils.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const Graphemer = require("graphemer").default;
+const { countGrapheme } = require("unicode-segmenter/grapheme");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -17,9 +17,6 @@ const Graphemer = require("graphemer").default;
 
 // eslint-disable-next-line no-control-regex -- intentionally including control characters
 const ASCII_REGEX = /^[\u0000-\u007f]*$/u;
-
-/** @type {Graphemer | undefined} */
-let splitter;
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -47,11 +44,7 @@ function getGraphemeCount(value) {
         return value.length;
     }
 
-    if (!splitter) {
-        splitter = new Graphemer();
-    }
-
-    return splitter.countGraphemes(value);
+    return countGrapheme(value);
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "file-entry-cache": "^8.0.0",
     "find-up": "^5.0.0",
     "glob-parent": "^6.0.2",
-    "graphemer": "^1.4.0",
     "ignore": "^5.2.0",
     "imurmurhash": "^0.1.4",
     "is-glob": "^4.0.0",
@@ -100,7 +99,8 @@
     "natural-compare": "^1.4.0",
     "optionator": "^0.9.3",
     "strip-ansi": "^6.0.1",
-    "text-table": "^0.2.0"
+    "text-table": "^0.2.0",
+    "unicode-segmenter": "^0.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",


### PR DESCRIPTION
Replace [graphemer](https://github.com/flmnt/graphemer) library to [unicode-segmenter] library which is ligher and faster See [benchmark](https://github.com/cometkim/unicode-segmenter#grapheme-clusters)

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[X] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The Unicode grapheme splitter library that the ESLint core currently relies on was last updated two years ago and does not include the Unicode 15.1.0 specification.

I created an alternative, the [unicode-segmeneter](https://github.com/cometkim/unicode-segmeneter) library, for a lighter bundle and better performance.

unicode-segmeneter is based on the latest (v15.1.0) Unicode data, is smaller than graphemer, and has over 6x faster count performance.

Specification compliance is tested through fast-check property assertion with V8's built-in [`Intl.Segmenter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) which is based on ICU.

#### Is there anything you'd like reviewers to focus on?

[unicode-segmenter]: https://github.com/cometkim/unicode-segmenter

<!-- markdownlint-disable-file MD004 -->
