### PR TITLE
fix: do not throw when defining a global named __defineSetter__

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -775,7 +775,7 @@ function createLanguageOptions({ globals: configuredGlobals, parser, parserOptio
  */
 function resolveGlobals(providedGlobals, enabledEnvironments) {
     return Object.assign(
-        {},
+        Object.create(null),
         ...enabledEnvironments.filter(env => env.globals).map(env => env.globals),
         providedGlobals
     );

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -1063,7 +1063,7 @@ class SourceCode extends TokenStore {
          * https://github.com/eslint/eslint/issues/16302
          */
         const configGlobals = Object.assign(
-            {},
+            Object.create(null), // https://github.com/eslint/eslint/issues/18363
             getGlobalsForEcmaVersion(languageOptions.ecmaVersion),
             languageOptions.sourceType === "commonjs" ? globals.commonjs : void 0,
             languageOptions.globals

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -10250,6 +10250,48 @@ describe("Linter with FlatConfigArray", () => {
 
                 describe("when evaluating code containing /*global */ and /*globals */ blocks", () => {
 
+                    /**
+                     * Asserts the global variables in the provided code using the specified language options and data.
+                     * @param {string} code The code to verify.
+                     * @param {Object} languageOptions The language options to use.
+                     * @param {Object} [data={}] Additional data for the assertion.
+                     * @returns {void}
+                     */
+                    function assertGlobalVariable(code, languageOptions, data = {}) {
+                        let spy;
+
+                        const config = {
+                            plugins: {
+                                test: {
+                                    rules: {
+                                        checker: {
+                                            create(context) {
+                                                spy = sinon.spy(node => {
+                                                    const scope = context.sourceCode.getScope(node);
+                                                    const g = getVariable(scope, data.name);
+
+                                                    assert.strictEqual(g.name, data.name);
+                                                    assert.strictEqual(g.writeable, data.writeable);
+                                                });
+
+                                                return { Program: spy };
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            rules: { "test/checker": "error" }
+                        };
+
+                        if (languageOptions !== void 0) {
+                            config.languageOptions = languageOptions;
+                        }
+
+                        linter.verify(code, config);
+                        assert(spy && spy.calledOnce);
+
+                    }
+
                     it("variables should be available in global scope", () => {
                         const code = `
                         /*global a b:true c:false d:readable e:writeable Math:off */
@@ -10309,6 +10351,15 @@ describe("Linter with FlatConfigArray", () => {
 
                         linter.verify(code, config);
                         assert(spy && spy.calledOnce);
+                    });
+
+                    // https://github.com/eslint/eslint/issues/18363
+                    it("not throw when defining a global named __defineSetter__", () => {
+                        assertGlobalVariable("/*global __defineSetter__ */", {}, { name: "__defineSetter__", writeable: false });
+                        assertGlobalVariable("/*global __defineSetter__ */", void 0, { name: "__defineSetter__", writeable: false });
+                        assertGlobalVariable("/*global __defineSetter__ */", { globals: { __defineSetter__: "off" } }, { name: "__defineSetter__", writeable: false });
+                        assertGlobalVariable("/*global __defineSetter__ */", { globals: { __defineSetter__: "writeable" } }, { name: "__defineSetter__", writeable: false });
+                        assertGlobalVariable("/*global __defineSetter__:writeable */", {}, { name: "__defineSetter__", writeable: true });
                     });
                 });
 


### PR DESCRIPTION
It replaced {} with `Object.create(null)` to avoid accessing properties on the `Object prototype`.

fixes #18363

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

#### Is there anything you'd like reviewers to focus on?
Not sure if I should write a test for eslintrc as well: it's deprecated and will eventually be removed.
<!-- markdownlint-disable-file MD004 -->
