### PR TITLE
fix: improve message for ignored files without a matching config

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -630,17 +630,20 @@ function isErrorMessage(message) {
  * Returns result with warning by ignore settings
  * @param {string} filePath File path of checked code
  * @param {string} baseDir Absolute path of base directory
+ * @param {boolean} configured A boolean value indicating if a configuration for the file was found.
  * @returns {LintResult} Result with single warning
  * @private
  */
-function createIgnoreResult(filePath, baseDir) {
+function createIgnoreResult(filePath, baseDir, configured = true) {
     let message;
     const isInNodeModules = baseDir && path.dirname(path.relative(baseDir, filePath)).split(path.sep).includes("node_modules");
 
     if (isInNodeModules) {
         message = "File ignored by default because it is located under the node_modules directory. Use ignore pattern \"!**/node_modules/\" to disable file ignore settings or use \"--no-warn-ignored\" to suppress this warning.";
-    } else {
+    } else if (configured) {
         message = "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to disable file ignore settings or use \"--no-warn-ignored\" to suppress this warning.";
+    } else {
+        message = "File ignored because no matching configration was supplied.";
     }
 
     return {

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -873,7 +873,7 @@ class ESLint {
                  */
                 if (ignored) {
                     if (warnIgnored) {
-                        return createIgnoreResult(filePath, cwd);
+                        return createIgnoreResult(filePath, cwd, configs.isFileConfigured(filePath));
                     }
 
                     return void 0;
@@ -1038,7 +1038,7 @@ class ESLint {
             const shouldWarnIgnored = typeof warnIgnored === "boolean" ? warnIgnored : constructorWarnIgnored;
 
             if (shouldWarnIgnored) {
-                results.push(createIgnoreResult(resolvedFilename, cwd));
+                results.push(createIgnoreResult(resolvedFilename, cwd, configs.isFileConfigured(resolvedFilename)));
             }
         } else {
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@eslint-community/regexpp": "^4.6.1",
     "@eslint/eslintrc": "^3.0.2",
     "@eslint/js": "9.1.1",
-    "@humanwhocodes/config-array": "^0.13.0",
+    "@humanwhocodes/config-array": "github:humanwhocodes/config-array#pull/138/head",
     "@humanwhocodes/module-importer": "^1.0.1",
     "@humanwhocodes/retry": "^0.2.3",
     "@nodelib/fs.walk": "^1.2.8",

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -416,6 +416,29 @@ describe("ESLint", () => {
             assert.strictEqual(results[0].suppressedMessages.length, 0);
         });
 
+        it("should return a warning when given a filename without a matching config by --stdin-filename if warnIgnored is true", async () => {
+            eslint = new ESLint({
+                cwd: getFixturePath(".."),
+                overrideConfigFile: true
+            });
+
+            const options = { filePath: "fixtures/file.ts", warnIgnored: true };
+            const results = await eslint.lintText("type foo = { bar: string };", options);
+
+            assert.strictEqual(results.length, 1);
+            assert.strictEqual(results[0].filePath, getFixturePath("file.ts"));
+            assert.strictEqual(results[0].messages[0].severity, 1);
+            assert.strictEqual(results[0].messages[0].message, "File ignored because no matching configration was supplied.");
+            assert.strictEqual(results[0].messages[0].output, void 0);
+            assert.strictEqual(results[0].errorCount, 0);
+            assert.strictEqual(results[0].warningCount, 1);
+            assert.strictEqual(results[0].fatalErrorCount, 0);
+            assert.strictEqual(results[0].fixableErrorCount, 0);
+            assert.strictEqual(results[0].fixableWarningCount, 0);
+            assert.strictEqual(results[0].usedDeprecatedRules.length, 0);
+            assert.strictEqual(results[0].suppressedMessages.length, 0);
+        });
+
         it("should return a warning when given a filename by --stdin-filename in excluded files list if constructor warnIgnored is false, but lintText warnIgnored is true", async () => {
             eslint = new ESLint({
                 cwd: getFixturePath(".."),
@@ -1722,6 +1745,26 @@ describe("ESLint", () => {
                 assert.strictEqual(results[0].filePath, filePath);
                 assert.strictEqual(results[0].messages[0].severity, 1);
                 assert.strictEqual(results[0].messages[0].message, "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to disable file ignore settings or use \"--no-warn-ignored\" to suppress this warning.");
+                assert.strictEqual(results[0].errorCount, 0);
+                assert.strictEqual(results[0].warningCount, 1);
+                assert.strictEqual(results[0].fatalErrorCount, 0);
+                assert.strictEqual(results[0].fixableErrorCount, 0);
+                assert.strictEqual(results[0].fixableWarningCount, 0);
+                assert.strictEqual(results[0].suppressedMessages.length, 0);
+            });
+
+            it("should return a warning when an explicitly given file has no matching config", async () => {
+                eslint = new ESLint({
+                    overrideConfigFile: true,
+                    cwd: getFixturePath()
+                });
+                const filePath = getFixturePath("files", "foo.js2");
+                const results = await eslint.lintFiles([filePath]);
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].filePath, filePath);
+                assert.strictEqual(results[0].messages[0].severity, 1);
+                assert.strictEqual(results[0].messages[0].message, "File ignored because no matching configration was supplied.");
                 assert.strictEqual(results[0].errorCount, 0);
                 assert.strictEqual(results[0].warningCount, 1);
                 assert.strictEqual(results[0].fatalErrorCount, 0);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #18263

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Extended `createIgnoreResult` with an additional parameter that indicates whether a file has a matching configuration, in order to provide a better message when this is not the case. The value passed with this parameter is retrieved directly from `ConfigArray`, which got a new method `isFileConfigured` for this purpose. See the PR in `config-array`: https://github.com/humanwhocodes/config-array/pull/138.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
