### PR TITLE
fix: don't remove comments between key and value in object-shorthand

### DIFF
--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -497,6 +497,13 @@ module.exports = {
                         node,
                         messageId: "expectedPropertyShorthand",
                         fix(fixer) {
+                            const lastKeyToken = sourceCode.getLastToken(node.key);
+
+                            // x: /* */ x
+                            if (sourceCode.commentsExistBetween(lastKeyToken, node.value)) {
+                                return null;
+                            }
+
                             return fixer.replaceText(node, node.value.name);
                         }
                     });
@@ -510,6 +517,13 @@ module.exports = {
                         node,
                         messageId: "expectedPropertyShorthand",
                         fix(fixer) {
+                            const lastKeyToken = sourceCode.getLastToken(node.key);
+
+                            // "x": /* */ x
+                            if (sourceCode.commentsExistBetween(lastKeyToken, node.value)) {
+                                return null;
+                            }
+
                             return fixer.replaceText(node, node.value.name);
                         }
                     });

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -497,10 +497,9 @@ module.exports = {
                         node,
                         messageId: "expectedPropertyShorthand",
                         fix(fixer) {
-                            const lastKeyToken = sourceCode.getLastToken(node.key);
 
                             // x: /* */ x
-                            if (sourceCode.commentsExistBetween(lastKeyToken, node.value)) {
+                            if (sourceCode.commentsExistBetween(node.key, node.value)) {
                                 return null;
                             }
 
@@ -517,10 +516,9 @@ module.exports = {
                         node,
                         messageId: "expectedPropertyShorthand",
                         fix(fixer) {
-                            const lastKeyToken = sourceCode.getLastToken(node.key);
 
                             // "x": /* */ x
-                            if (sourceCode.commentsExistBetween(lastKeyToken, node.value)) {
+                            if (sourceCode.commentsExistBetween(node.key, node.value)) {
                                 return null;
                             }
 

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -499,7 +499,8 @@ module.exports = {
                         fix(fixer) {
 
                             // x: /* */ x
-                            if (sourceCode.commentsExistBetween(node.key, node.value)) {
+                            // x: (/* */ x)
+                            if (sourceCode.getCommentsInside(node).length > 0) {
                                 return null;
                             }
 
@@ -518,7 +519,8 @@ module.exports = {
                         fix(fixer) {
 
                             // "x": /* */ x
-                            if (sourceCode.commentsExistBetween(node.key, node.value)) {
+                            // "x": (/* */ x)
+                            if (sourceCode.getCommentsInside(node).length > 0) {
                                 return null;
                             }
 

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -527,7 +527,17 @@ ruleTester.run("object-shorthand", rule, {
             errors: [PROPERTY_ERROR]
         },
         {
+            code: "var x = {a: (a /* comment */)}",
+            output: null,
+            errors: [PROPERTY_ERROR]
+        },
+        {
             code: "var x = {'a': /* comment */ a}",
+            output: null,
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {'a': (a /* comment */)}",
             output: null,
             errors: [PROPERTY_ERROR]
         },

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -517,6 +517,16 @@ ruleTester.run("object-shorthand", rule, {
             errors: [METHOD_ERROR]
         },
         {
+            code: "var x = {a: /* comment */ a}",
+            output: null,
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {a /* comment */: a}",
+            output: null,
+            errors: [PROPERTY_ERROR]
+        },
+        {
             code: "var x = {y: function() {}}",
             output: "var x = {y() {}}",
             errors: [METHOD_ERROR]

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -527,6 +527,16 @@ ruleTester.run("object-shorthand", rule, {
             errors: [PROPERTY_ERROR]
         },
         {
+            code: "var x = {'a': /* comment */ a}",
+            output: null,
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {'a' /* comment */: a}",
+            output: null,
+            errors: [PROPERTY_ERROR]
+        },
+        {
             code: "var x = {y: function() {}}",
             output: "var x = {y() {}}",
             errors: [METHOD_ERROR]


### PR DESCRIPTION
Fixes #18441

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Check for comments between the last key token and the value in the property node.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
