### PR TITLE
feat: add `overrides.namedExports` to `func-style` rule

### DIFF
--- a/docs/src/rules/func-style.md
+++ b/docs/src/rules/func-style.md
@@ -62,6 +62,11 @@ This rule has a string option:
 This rule has an object option for an exception:
 
 * `"allowArrowFunctions"`: `true` (default `false`) allows the use of arrow functions. This option applies only when the string option is set to `"declaration"` (arrow functions are always allowed when the string option is set to `"expression"`, regardless of this option)
+* `"overrrides"`:
+    * `"namedExports": "expression" | "declaration" | "ignore"`: used to override function styles in named exports
+        * `"expression"`: like string option
+        * `"declaration"`: like string option
+        * `"ignore"`: either style is acceptable
 
 ### expression
 
@@ -144,6 +149,90 @@ Examples of additional **correct** code for this rule with the `"declaration", {
 /*eslint func-style: ["error", "declaration", { "allowArrowFunctions": true }]*/
 
 var foo = () => {};
+```
+
+:::
+
+### overrides
+
+#### namedExports
+
+##### expression
+
+Examples of **iincorrect** code for this rule with the `"declaration"` and `{"overrides": { "namedExports": "expression" }}` option:
+
+::: incorrect
+
+```js
+/*eslint func-style: ["error", "declaration", { "overrides": { "namedExports": "expression" } }]*/
+
+function foo() {
+    // ...
+}
+```
+
+Examples of **correct** code for this rule with the `"declaration"` and `{"overrides": { "namedExports": "expression" }}` option:
+
+::: correct
+
+```js
+/*eslint func-style: ["error", "declaration", { "overrides": { "namedExports": "expression" } }]*/
+
+var foo = function() {
+    // ...
+};
+
+var foo = () => {};
+```
+
+##### declaration
+
+Examples of **incorrect** code for this rule with the `"expression"` and `{"overrides": { "namedExports": "declaration" }}` option:
+
+::: incorrect
+
+```js
+/*eslint func-style: ["error", "expression", { "overrides": { "namedExports": "declaration" } }]*/
+
+var foo = function() {
+    // ...
+};
+
+var foo = () => {};
+```
+
+Examples of **correct** code for this rule with the `"expression"` and `{"overrides": { "namedExports": "declaration" }}` option:
+
+::: correct
+
+```js
+/*eslint func-style: ["error", "expression", { "overrides": { "namedExports": "declaration" } }]*/
+
+function foo() {
+    // ...
+}
+```
+
+:::
+
+#### ignore
+
+Examples of **correct** code for this rule with the `{"overrides": { "namedExports": "ignore" }}` option:
+
+::: correct
+
+```js
+/*eslint func-style: ["error", "expression", { "overrides": { "namedExports": "ignores" } }]*/
+
+var foo = function() {
+    // ...
+};
+
+var foo = () => {};
+
+function bar() {
+    // ...
+}
 ```
 
 :::

--- a/lib/rules/func-style.js
+++ b/lib/rules/func-style.js
@@ -29,6 +29,14 @@ module.exports = {
                     allowArrowFunctions: {
                         type: "boolean",
                         default: false
+                    },
+                    overrides: {
+                        type: "object",
+                        properties: {
+                            namedExports: {
+                                enum: ["declaration", "expression", "ignore"]
+                            }
+                        }
                     }
                 },
                 additionalProperties: false
@@ -46,13 +54,22 @@ module.exports = {
         const style = context.options[0],
             allowArrowFunctions = context.options[1] && context.options[1].allowArrowFunctions,
             enforceDeclarations = (style === "declaration"),
+            exportFunctionStyle = context.options[1] && context.options[1].overrides && context.options[1].overrides.namedExports,
             stack = [];
 
         const nodesToCheck = {
             FunctionDeclaration(node) {
                 stack.push(false);
 
-                if (!enforceDeclarations && node.parent.type !== "ExportDefaultDeclaration") {
+                if (
+                    !enforceDeclarations &&
+                    node.parent.type !== "ExportDefaultDeclaration" &&
+                    typeof exportFunctionStyle === "undefined"
+                ) {
+                    context.report({ node, messageId: "expression" });
+                }
+
+                if (node.parent.type === "ExportNamedDeclaration" && exportFunctionStyle === "expression") {
                     context.report({ node, messageId: "expression" });
                 }
             },
@@ -63,7 +80,18 @@ module.exports = {
             FunctionExpression(node) {
                 stack.push(false);
 
-                if (enforceDeclarations && node.parent.type === "VariableDeclarator") {
+                if (
+                    enforceDeclarations &&
+                    node.parent.type === "VariableDeclarator" &&
+                    typeof exportFunctionStyle === "undefined"
+                ) {
+                    context.report({ node: node.parent, messageId: "declaration" });
+                }
+
+                if (
+                    node.parent.type === "VariableDeclarator" && node.parent.parent.parent.type === "ExportNamedDeclaration" &&
+                    exportFunctionStyle === "declaration"
+                ) {
                     context.report({ node: node.parent, messageId: "declaration" });
                 }
             },
@@ -86,8 +114,14 @@ module.exports = {
             nodesToCheck["ArrowFunctionExpression:exit"] = function(node) {
                 const hasThisExpr = stack.pop();
 
-                if (enforceDeclarations && !hasThisExpr && node.parent.type === "VariableDeclarator") {
-                    context.report({ node: node.parent, messageId: "declaration" });
+                if (!hasThisExpr && node.parent.type === "VariableDeclarator") {
+                    if (enforceDeclarations && typeof exportFunctionStyle === "undefined") {
+                        context.report({ node: node.parent, messageId: "declaration" });
+                    }
+
+                    if (node.parent.parent.parent.type === "ExportNamedDeclaration" && exportFunctionStyle === "declaration") {
+                        context.report({ node: node.parent, messageId: "declaration" });
+                    }
                 }
             };
         }

--- a/tests/lib/rules/func-style.js
+++ b/tests/lib/rules/func-style.js
@@ -81,6 +81,74 @@ ruleTester.run("func-style", rule, {
             code: "var foo = () => { function foo() { this; } };",
             options: ["declaration", { allowArrowFunctions: true }],
             languageOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "export function foo() {};",
+            options: ["declaration"]
+        },
+        {
+            code: "export function foo() {};",
+            options: ["expression", { overrides: { namedExports: "declaration" } }]
+        },
+        {
+            code: "export function foo() {};",
+            options: ["declaration", { overrides: { namedExports: "declaration" } }]
+        },
+        {
+            code: "export function foo() {};",
+            options: ["expression", { overrides: { namedExports: "ignore" } }]
+        },
+        {
+            code: "export function foo() {};",
+            options: ["declaration", { overrides: { namedExports: "ignore" } }]
+        },
+        {
+            code: "export var foo = function(){};",
+            options: ["expression"]
+        },
+        {
+            code: "export var foo = function(){};",
+            options: ["declaration", { overrides: { namedExports: "expression" } }]
+        },
+        {
+            code: "export var foo = function(){};",
+            options: ["expression", { overrides: { namedExports: "expression" } }]
+        },
+        {
+            code: "export var foo = function(){};",
+            options: ["declaration", { overrides: { namedExports: "ignore" } }]
+        },
+        {
+            code: "export var foo = function(){};",
+            options: ["expression", { overrides: { namedExports: "ignore" } }]
+        },
+        {
+            code: "export var foo = () => {};",
+            options: ["expression", { overrides: { namedExports: "expression" } }]
+        },
+        {
+            code: "export var foo = () => {};",
+            options: ["declaration", { overrides: { namedExports: "expression" } }]
+        },
+        {
+            code: "export var foo = () => {};",
+            options: ["declaration", { overrides: { namedExports: "ignore" } }]
+        },
+        {
+            code: "export var foo = () => {};",
+            options: ["expression", { overrides: { namedExports: "ignore" } }]
+        },
+        {
+            code: "export var foo = () => {};",
+            options: ["declaration", { allowArrowFunctions: true, overrides: { namedExports: "expression" } }]
+        },
+        {
+            code: "export var foo = () => {};",
+            options: ["expression", { allowArrowFunctions: true, overrides: { namedExports: "expression" } }]
+        },
+        {
+            code: "export var foo = () => {};",
+            options: ["declaration", { allowArrowFunctions: true, overrides: { namedExports: "ignore" } }]
         }
     ],
 
@@ -124,6 +192,102 @@ ruleTester.run("func-style", rule, {
                 {
                     messageId: "expression",
                     type: "FunctionDeclaration"
+                }
+            ]
+        },
+        {
+            code: "export function foo(){}",
+            options: ["expression"],
+            errors: [
+                {
+                    messageId: "expression",
+                    type: "FunctionDeclaration"
+                }
+            ]
+        },
+        {
+            code: "export function foo() {};",
+            options: ["declaration", { overrides: { namedExports: "expression" } }],
+            errors: [
+                {
+                    messageId: "expression",
+                    type: "FunctionDeclaration"
+                }
+            ]
+        },
+        {
+            code: "export function foo() {};",
+            options: ["expression", { overrides: { namedExports: "expression" } }],
+            errors: [
+                {
+                    messageId: "expression",
+                    type: "FunctionDeclaration"
+                }
+            ]
+        },
+        {
+            code: "export var foo = function(){};",
+            options: ["declaration"],
+            languageOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "declaration",
+                    type: "VariableDeclarator"
+                }
+            ]
+        },
+        {
+            code: "export var foo = function(){};",
+            options: ["expression", { overrides: { namedExports: "declaration" } }],
+            languageOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "declaration",
+                    type: "VariableDeclarator"
+                }
+            ]
+        },
+        {
+            code: "export var foo = function(){};",
+            options: ["declaration", { overrides: { namedExports: "declaration" } }],
+            languageOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "declaration",
+                    type: "VariableDeclarator"
+                }
+            ]
+        },
+        {
+            code: "export var foo = () => {};",
+            options: ["declaration"],
+            languageOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "declaration",
+                    type: "VariableDeclarator"
+                }
+            ]
+        },
+        {
+            code: "export var b = () => {};",
+            options: ["expression", { overrides: { namedExports: "declaration" } }],
+            languageOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "declaration",
+                    type: "VariableDeclarator"
+                }
+            ]
+        },
+        {
+            code: "export var c = () => {};",
+            options: ["declaration", { overrides: { namedExports: "declaration" } }],
+            languageOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "declaration",
+                    type: "VariableDeclarator"
                 }
             ]
         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

add `overrides.namedExports` to `func-style` rule

```js
{
  "overrides":
    {
      "namedExports": "expression" | "declaration" | "ignore"
    }
}
```

close https://github.com/eslint/eslint/issues/12829

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
