### PR TITLE
docs: Clarify usage of `no-unreachable` with TypeScript

### DIFF
--- a/docs/src/rules/no-unreachable.md
+++ b/docs/src/rules/no-unreachable.md
@@ -2,6 +2,10 @@
 title: no-unreachable
 rule_type: problem
 handled_by_typescript: true
+extra_typescript_info: >-
+    TypeScript must be configured with
+    [`allowUnreachableCode: false`](https://www.typescriptlang.org/tsconfig#allowUnreachableCode)
+    for it to consider unreachable code an error.
 ---
 
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Closes: #18378

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I've updated the documentation for `no-unreachable` to clarify that TypeScript will only consider unreachable code an error if configured to do so.

I checked whether there are any differences in behaviour between TypeScript an ESLint. The only one I found was in this case:

```ts
function foo() {
  try {
    return;
  } catch (err) {
    return err;
  }
}
```

ESLint reports this `catch` block as unreachable, but TypeScript does not. I did not think this was worth documenting.

#### Is there anything you'd like reviewers to focus on?

I've included a link to the TypeScript documentation; let me know if you would prefer not to have it.

<!-- markdownlint-disable-file MD004 -->
