### PR TITLE
fix: `func-style` false positive with arrow functions and `super`

### DIFF
--- a/lib/rules/func-style.js
+++ b/lib/rules/func-style.js
@@ -100,7 +100,7 @@ module.exports = {
                 stack.pop();
             },
 
-            ThisExpression() {
+            "ThisExpression, Super"() {
                 if (stack.length > 0) {
                     stack[stack.length - 1] = true;
                 }
@@ -113,9 +113,9 @@ module.exports = {
             };
 
             nodesToCheck["ArrowFunctionExpression:exit"] = function(node) {
-                const hasThisExpr = stack.pop();
+                const hasThisOrSuperExpr = stack.pop();
 
-                if (!hasThisExpr && node.parent.type === "VariableDeclarator") {
+                if (!hasThisOrSuperExpr && node.parent.type === "VariableDeclarator") {
                     if (
                         enforceDeclarations &&
                         (typeof exportFunctionStyle === "undefined" || node.parent.parent.parent.type !== "ExportNamedDeclaration")

--- a/tests/lib/rules/func-style.js
+++ b/tests/lib/rules/func-style.js
@@ -69,6 +69,16 @@ ruleTester.run("func-style", rule, {
             languageOptions: { ecmaVersion: 6 }
         },
         {
+            code: "class C extends D { foo() { var bar = () => { super.baz(); }; } }",
+            options: ["declaration"],
+            languageOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var obj = { foo() { var bar = () => super.baz; } }",
+            options: ["declaration"],
+            languageOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "export default function () {};",
             languageOptions: { ecmaVersion: 6, sourceType: "module" }
         },
@@ -79,6 +89,11 @@ ruleTester.run("func-style", rule, {
         },
         {
             code: "var foo = () => { function foo() { this; } };",
+            options: ["declaration", { allowArrowFunctions: true }],
+            languageOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var foo = () => ({ bar() { super.baz(); } });",
             options: ["declaration", { allowArrowFunctions: true }],
             languageOptions: { ecmaVersion: 6 }
         },
@@ -176,6 +191,17 @@ ruleTester.run("func-style", rule, {
         },
         {
             code: "var foo = () => { function foo() { this; } };",
+            options: ["declaration"],
+            languageOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "declaration",
+                    type: "VariableDeclarator"
+                }
+            ]
+        },
+        {
+            code: "var foo = () => ({ bar() { super.baz(); } });",
             options: ["declaration"],
             languageOptions: { ecmaVersion: 6 },
             errors: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

* **Node version:** v20.12.0
* **npm version:** 10.5.0
* **Local ESLint version:** v9.3.0
* **Global ESLint version:** no
* **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
export default [];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint func-style: ["error", "declaration"]*/

class C {
    print() {
        console.log("I'm print of C");
    }
}

class D extends C {
    print() {
        console.log("I'm print of D");
    }

    test() {
        const arr1 = () => { // allowed
            this.print();
        }
        const arr2 = () => { // reported, false positive
            super.print();
        }

        arr1(); // logs "I'm print of D"
        arr2(); // logs "I'm print of C"
    }
}

new D().test();

```

**What did you expect to happen?**

No lint errors from `func-style`, because `arr1` and `arr2` cannot be replaced with function declarations.

**What actually happened? Please include the actual, raw output from ESLint.**

Error on `arr2`:

```
  18:15  error  Expected a function declaration  func-style
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `func-style` rule to treat `super` the same as `this`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
