### PR TITLE
fix: skip processor code blocks that match only universal patterns

### DIFF
--- a/docs/src/use/configure/plugins.md
+++ b/docs/src/use/configure/plugins.md
@@ -213,7 +213,41 @@ export default [
 ];
 ```
 
-ESLint only lints named code blocks when they are JavaScript files or if they match a `files` entry in a config object. Be sure to add a config object with a matching `files` entry if you want to lint non-JavaScript named code blocks.
+ESLint only lints named code blocks when they are JavaScript files or if they match a `files` entry in a config object. Be sure to add a config object with a matching `files` entry if you want to lint non-JavaScript named code blocks. Also note that [global ignores](./ignore) apply to named code blocks as well.
+
+```js
+// eslint.config.js
+import markdown from "eslint-plugin-markdown";
+
+export default [
+
+    // applies to Markdown files
+    {
+        files: ["**/*.md"],
+        plugins: {
+            markdown
+        },
+        processor: "markdown/markdown"
+    },
+
+    // applies to all .jsx files, including jsx blocks inside of Markdown files
+    {
+        files: ["**/*.jsx"],
+        languageOptions: {
+            parserOptions: {
+                ecmaFeatures: {
+                    jsx: true
+                }
+            }
+        }
+    },
+
+    // ignore jsx blocks inside of test.md files
+    {
+        ignores: ["**/test.md/*.jsx"]
+    }
+];
+```
 
 ## Common Problems
 

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -509,7 +509,7 @@ function verifyText({
              * @returns {boolean} `true` if the linter should adopt the code block.
              */
             filterCodeBlock(blockFilename) {
-                return configs.isExplicitMatch(blockFilename);
+                return configs.getConfig(blockFilename) !== void 0;
             }
         }
     );


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #18493

Closes #15949

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Fixed #18493 by changing the code block filter condition to `configs.getConfig(blockFilename) !== void 0`.
* Updated documentation and added tests for #15949.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
