### PR TITLE
fix: Don't lint same file multiple times

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -494,7 +494,7 @@ async function globMultiSearch({ searches, configs, errorOnUnmatchedPattern }) {
 
     }
 
-    return [...new Set(filePaths)];
+    return filePaths;
 
 }
 
@@ -601,8 +601,10 @@ async function findFiles({
     });
 
     return [
-        ...results,
-        ...globbyResults.map(filePath => (path.resolve(filePath)))
+        ...new Set([
+            ...results,
+            ...globbyResults.map(filePath => path.resolve(filePath))
+        ])
     ];
 }
 

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -1164,6 +1164,56 @@ describe("ESLint", () => {
             });
         });
 
+        describe("Overlapping searches", () => {
+            it("should not lint the same file multiple times when the file path was passed multiple times", async () => {
+                const cwd = getFixturePath();
+
+                eslint = new ESLint({
+                    cwd,
+                    overrideConfigFile: true
+                });
+
+                const results = await eslint.lintFiles(["files/foo.js", "files/../files/foo.js", "files/foo.js"]);
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].filePath, path.resolve(cwd, "files/foo.js"));
+                assert.strictEqual(results[0].messages.length, 0);
+                assert.strictEqual(results[0].suppressedMessages.length, 0);
+            });
+
+            it("should not lint the same file multiple times when the file path and a pattern that matches the file were passed", async () => {
+                const cwd = getFixturePath();
+
+                eslint = new ESLint({
+                    cwd,
+                    overrideConfigFile: true
+                });
+
+                const results = await eslint.lintFiles(["files/foo.js", "files/foo*"]);
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].filePath, path.resolve(cwd, "files/foo.js"));
+                assert.strictEqual(results[0].messages.length, 0);
+                assert.strictEqual(results[0].suppressedMessages.length, 0);
+            });
+
+            it("should not lint the same file multiple times when multiple patterns that match the file were passed", async () => {
+                const cwd = getFixturePath();
+
+                eslint = new ESLint({
+                    cwd,
+                    overrideConfigFile: true
+                });
+
+                const results = await eslint.lintFiles(["files/f*.js", "files/foo*"]);
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].filePath, path.resolve(cwd, "files/foo.js"));
+                assert.strictEqual(results[0].messages.length, 0);
+                assert.strictEqual(results[0].suppressedMessages.length, 0);
+            });
+        });
+
         describe("Invalid inputs", () => {
 
             [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v20.12.0
npm version: 10.5.0
Local ESLint version: v9.4.0
Global ESLint version: no
Operating System: windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
export default [
  {
    rules: {
      'no-undef': 2,
    },
  },
];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

foo.js:

```js
bar;
```

Command:

```
eslint "f*.js" foo.js
```

**What did you expect to happen?**

One lint error for file `foo.js`.

**What actually happened? Please include the actual, raw output from ESLint.**

ESLint reports the same file twice:

```
$ npm run lint

> lint
> eslint "f*.js" foo.js


C:\projects\tmp\tmp\foo.js
  1:1  error  'bar' is not defined  no-undef

C:\projects\tmp\tmp\foo.js
  1:1  error  'bar' is not defined  no-undef

✖ 2 problems (2 errors, 0 warnings)
```

https://stackblitz.com/edit/stackblitz-starters-34mrhh?file=package.json

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `findFiles()` to return unique file paths.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
