### PR TITLE
ci: fix CLI flags for c8, raise thresholds

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -651,7 +651,7 @@ target.mocha = () => {
         errors++;
     }
 
-    lastReturn = exec(`${getBinFile("c8")} check-coverage --statement 98 --branch 97 --function 98 --lines 98`);
+    lastReturn = exec(`${getBinFile("c8")} check-coverage --statements 99 --branches 98 --functions 99 --lines 99`);
     if (lastReturn.code !== 0) {
         errors++;
     }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Changed the command for npm test script.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed the command line for `c8 check-coverage`:
* Fixed the spelling of the CLI flags `--statements`, `--branches` and `--functions` (see [documentation](https://github.com/bcoe/c8/tree/v7.14.0?tab=readme-ov-file#checking-coverage)). Unfortunately, c8 silently ignores invalid options, so previously those flags would have no effect.
* Increased the branches coverage threshold to 98% and the other thresholds to 99%. ESLint code coverage is already over those values, and probably we don't want to get below the level we are now. In Node.js 20 LTS on windows-latest:
 <pre>
=============================== Coverage summary ===============================
Statements   : 99.27% ( 82439/83037 )
Branches     : 98.3% ( 15629/15898 )
Functions    : 99.52% ( 3368/3384 )
Lines        : 99.27% ( 82439/83037 )
================================================================================
</pre>

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
