### PR TITLE
chore: extract formatting rules into separate config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,6 +31,7 @@ const eslintPluginRulesRecommendedConfig = require("eslint-plugin-eslint-plugin/
 const eslintPluginTestsRecommendedConfig = require("eslint-plugin-eslint-plugin/configs/tests-recommended");
 const globals = require("globals");
 const eslintConfigESLintCJS = require("eslint-config-eslint/cjs");
+const eslintConfigESLintFormatting = require("eslint-config-eslint/formatting");
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -75,6 +76,7 @@ function createInternalFilesPatterns(pattern = null) {
 
 module.exports = [
     ...eslintConfigESLintCJS,
+    eslintConfigESLintFormatting,
     {
         name: "eslint/global-ignores",
         ignores: [

--- a/packages/eslint-config-eslint/README.md
+++ b/packages/eslint-config-eslint/README.md
@@ -73,6 +73,20 @@ module.exports = [
 ];
 ```
 
+### Formatting config
+
+Note that none of the above configurations includes formatting rules. If you want to enable formatting rules, add the formatting config.
+
+```js
+import eslintConfigESLint from "eslint-config-eslint";
+import eslintConfigESLintFormatting from "eslint-config-eslint/formatting";
+
+export default [
+    ...eslintConfigESLint,
+    eslintConfigESLintFormatting
+];
+```
+
 ### Where to ask for help?
 
 Open a [discussion](https://github.com/eslint/eslint/discussions) or stop by our [Discord server](https://eslint.org/chat) instead of filing an issue.

--- a/packages/eslint-config-eslint/base.js
+++ b/packages/eslint-config-eslint/base.js
@@ -9,65 +9,27 @@ const unicorn = require("eslint-plugin-unicorn");
 const jsConfigs = [js.configs.recommended, {
     name: "eslint-config-eslint/js",
     rules: {
-        "array-bracket-spacing": "error",
         "array-callback-return": "error",
         "arrow-body-style": ["error", "as-needed"],
-        "arrow-parens": ["error", "as-needed"],
-        "arrow-spacing": "error",
-        indent: ["error", 4, { SwitchCase: 1 }],
-        "block-spacing": "error",
-        "brace-style": ["error", "1tbs"],
         camelcase: "error",
         "class-methods-use-this": "error",
-        "comma-dangle": "error",
-        "comma-spacing": "error",
-        "comma-style": ["error", "last"],
-        "computed-property-spacing": "error",
         "consistent-return": "error",
         curly: ["error", "all"],
         "default-case": "error",
         "default-case-last": "error",
         "default-param-last": "error",
-        "dot-location": ["error", "property"],
         "dot-notation": [
             "error",
             { allowKeywords: true }
         ],
-        "eol-last": "error",
         eqeqeq: "error",
-        "func-call-spacing": "error",
         "func-style": ["error", "declaration"],
-        "function-call-argument-newline": ["error", "consistent"],
-        "function-paren-newline": ["error", "consistent"],
-        "generator-star-spacing": "error",
         "grouped-accessor-pairs": "error",
         "guard-for-in": "error",
-        "key-spacing": ["error", { beforeColon: false, afterColon: true }],
-        "keyword-spacing": "error",
-        "lines-around-comment": ["error",
-            {
-                beforeBlockComment: true,
-                afterBlockComment: false,
-                beforeLineComment: true,
-                afterLineComment: false
-            }
-        ],
-        "max-len": ["error", 160,
-            {
-                ignoreComments: true,
-                ignoreUrls: true,
-                ignoreStrings: true,
-                ignoreTemplateLiterals: true,
-                ignoreRegExpLiterals: true
-            }
-        ],
-        "max-statements-per-line": "error",
         "new-cap": "error",
-        "new-parens": "error",
         "no-alert": "error",
         "no-array-constructor": "error",
         "no-caller": "error",
-        "no-confusing-arrow": "error",
         "no-console": "error",
         "no-constructor-return": "error",
         "no-else-return": ["error", { allowElseIf: false }
@@ -75,8 +37,6 @@ const jsConfigs = [js.configs.recommended, {
         "no-eval": "error",
         "no-extend-native": "error",
         "no-extra-bind": "error",
-        "no-extra-semi": "error",
-        "no-floating-decimal": "error",
         "no-implied-eval": "error",
         "no-inner-declarations": "error",
         "no-invalid-this": "error",
@@ -85,17 +45,7 @@ const jsConfigs = [js.configs.recommended, {
         "no-labels": "error",
         "no-lone-blocks": "error",
         "no-loop-func": "error",
-        "no-mixed-spaces-and-tabs": ["error", false],
-        "no-multi-spaces": "error",
         "no-multi-str": "error",
-        "no-multiple-empty-lines": [
-            "error",
-            {
-                max: 2,
-                maxBOF: 0,
-                maxEOF: 0
-            }
-        ],
         "no-nested-ternary": "error",
         "no-new": "error",
         "no-new-func": "error",
@@ -140,9 +90,7 @@ const jsConfigs = [js.configs.recommended, {
         "no-self-compare": "error",
         "no-sequences": "error",
         "no-shadow": "error",
-        "no-tabs": "error",
         "no-throw-literal": "error",
-        "no-trailing-spaces": "error",
         "no-undef": ["error", { typeof: true }],
         "no-undef-init": "error",
         "no-undefined": "error",
@@ -166,41 +114,14 @@ const jsConfigs = [js.configs.recommended, {
         "no-useless-constructor": "error",
         "no-useless-rename": "error",
         "no-useless-return": "error",
-        "no-whitespace-before-property": "error",
         "no-var": "error",
-        "object-curly-newline": ["error",
-            {
-                consistent: true,
-                multiline: true
-            }
-        ],
-        "object-curly-spacing": ["error", "always"],
-        "object-property-newline": ["error",
-            {
-                allowAllPropertiesOnSameLine: true
-            }
-        ],
         "object-shorthand": ["error",
             "always",
             {
                 avoidExplicitReturnArrows: true
             }
         ],
-        "one-var-declaration-per-line": "error",
         "operator-assignment": "error",
-        "operator-linebreak": "error",
-        "padding-line-between-statements": ["error",
-            {
-                blankLine: "always",
-                prev: ["const", "let", "var"],
-                next: "*"
-            },
-            {
-                blankLine: "any",
-                prev: ["const", "let", "var"],
-                next: ["const", "let", "var"]
-            }
-        ],
         "prefer-arrow-callback": "error",
         "prefer-const": "error",
         "prefer-exponentiation-operator": "error",
@@ -211,49 +132,11 @@ const jsConfigs = [js.configs.recommended, {
         "prefer-rest-params": "error",
         "prefer-spread": "error",
         "prefer-template": "error",
-        quotes: ["error", "double", { avoidEscape: true }],
-        "quote-props": ["error", "as-needed"],
         radix: "error",
         "require-unicode-regexp": "error",
-        "rest-spread-spacing": "error",
-        semi: "error",
-        "semi-spacing": ["error",
-            {
-                before: false,
-                after: true
-            }
-        ],
-        "semi-style": "error",
-        "space-before-blocks": "error",
-        "space-before-function-paren": ["error",
-            {
-                anonymous: "never",
-                named: "never",
-                asyncArrow: "always"
-            }
-        ],
-        "space-in-parens": "error",
-        "space-infix-ops": "error",
-        "space-unary-ops": ["error",
-            {
-                words: true,
-                nonwords: false
-            }
-        ],
-        "spaced-comment": ["error",
-            "always",
-            {
-                exceptions: ["-"]
-            }
-        ],
         strict: ["error", "global"],
-        "switch-colon-spacing": "error",
         "symbol-description": "error",
-        "template-curly-spacing": ["error", "never"],
-        "template-tag-spacing": "error",
         "unicode-bom": "error",
-        "wrap-iife": "error",
-        "yield-star-spacing": "error",
         yoda: ["error", "never", { exceptRange: true }]
     }
 }];

--- a/packages/eslint-config-eslint/formatting.js
+++ b/packages/eslint-config-eslint/formatting.js
@@ -1,0 +1,123 @@
+"use strict";
+
+module.exports = {
+    rules: {
+        "array-bracket-spacing": "error",
+        "arrow-parens": ["error", "as-needed"],
+        "arrow-spacing": "error",
+        "block-spacing": "error",
+        "brace-style": ["error", "1tbs"],
+        "comma-dangle": "error",
+        "comma-spacing": "error",
+        "comma-style": ["error", "last"],
+        "computed-property-spacing": "error",
+        "dot-location": ["error", "property"],
+        "eol-last": "error",
+        "func-call-spacing": "error",
+        "function-call-argument-newline": ["error", "consistent"],
+        "function-paren-newline": ["error", "consistent"],
+        "generator-star-spacing": "error",
+        indent: ["error", 4, { SwitchCase: 1 }],
+        "key-spacing": ["error", { beforeColon: false, afterColon: true }],
+        "keyword-spacing": "error",
+        "lines-around-comment": ["error",
+            {
+                beforeBlockComment: true,
+                afterBlockComment: false,
+                beforeLineComment: true,
+                afterLineComment: false
+            }
+        ],
+        "max-len": ["error", 160,
+            {
+                ignoreComments: true,
+                ignoreUrls: true,
+                ignoreStrings: true,
+                ignoreTemplateLiterals: true,
+                ignoreRegExpLiterals: true
+            }
+        ],
+        "max-statements-per-line": "error",
+        "new-parens": "error",
+        "no-confusing-arrow": "error",
+        "no-extra-semi": "error",
+        "no-floating-decimal": "error",
+        "no-mixed-spaces-and-tabs": ["error", false],
+        "no-multi-spaces": "error",
+        "no-multiple-empty-lines": [
+            "error",
+            {
+                max: 2,
+                maxBOF: 0,
+                maxEOF: 0
+            }
+        ],
+        "no-tabs": "error",
+        "no-trailing-spaces": "error",
+        "no-whitespace-before-property": "error",
+        "object-curly-newline": ["error",
+            {
+                consistent: true,
+                multiline: true
+            }
+        ],
+        "object-curly-spacing": ["error", "always"],
+        "object-property-newline": ["error",
+            {
+                allowAllPropertiesOnSameLine: true
+            }
+        ],
+        "one-var-declaration-per-line": "error",
+        "operator-linebreak": "error",
+        "padding-line-between-statements": ["error",
+            {
+                blankLine: "always",
+                prev: ["const", "let", "var"],
+                next: "*"
+            },
+            {
+                blankLine: "any",
+                prev: ["const", "let", "var"],
+                next: ["const", "let", "var"]
+            }
+        ],
+        quotes: ["error", "double", { avoidEscape: true }],
+        "quote-props": ["error", "as-needed"],
+        "rest-spread-spacing": "error",
+        semi: "error",
+        "semi-spacing": ["error",
+            {
+                before: false,
+                after: true
+            }
+        ],
+        "semi-style": "error",
+        "space-before-blocks": "error",
+        "space-before-function-paren": ["error",
+            {
+                anonymous: "never",
+                named: "never",
+                asyncArrow: "always"
+            }
+        ],
+        "space-in-parens": "error",
+        "space-infix-ops": "error",
+        "space-unary-ops": ["error",
+            {
+                words: true,
+                nonwords: false
+            }
+        ],
+        "spaced-comment": ["error",
+            "always",
+            {
+                exceptions: ["-"]
+            }
+        ],
+        "switch-colon-spacing": "error",
+        "template-curly-spacing": ["error", "never"],
+        "template-tag-spacing": "error",
+        "wrap-iife": "error",
+        "yield-star-spacing": "error"
+    }
+};

--- a/packages/eslint-config-eslint/package.json
+++ b/packages/eslint-config-eslint/package.json
@@ -7,10 +7,11 @@
     "./package.json": "./package.json",
     ".": "./index.js",
     "./base": "./base.js",
-    "./cjs": "./cjs.js"
+    "./cjs": "./cjs.js",
+    "./formatting": "./formatting.js"
   },
   "scripts": {
-    "test": "node ./index.js && node ./cjs.js",
+    "test": "node ./index.js && node ./cjs.js && node ./formatting.js",
     "prepublish": "npm test"
   },
   "files": [
@@ -18,6 +19,7 @@
     "README.md",
     "base.js",
     "cjs.js",
+    "formatting.js",
     "index.js",
     "nodejs.js"
   ],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Updates `eslint-config-eslint`. Extracts formatting rules into separate config.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Moved formatting rules from `base` config to the new `formatting` config and added an export for it.

#### Is there anything you'd like reviewers to focus on?

Since our projects already use 3 different configurations from `eslint-config-eslint`, it would be complicated to make all combinations with and without formatting rules. So I removed formatting rules from those configurations and added them as a separate config.

Projects that don't need formatting rules (e.g., eslint/rewrite) will just use one of the three configs they need:

```js
import eslintConfigESLint from "eslint-config-eslint";
export default [
    ...eslintConfigESLint
];
```

Projects that still need formatting rules will add the formatting config:

```js
import eslintConfigESLint from "eslint-config-eslint";
import eslintConfigESLintFormatting from "eslint-config-eslint/formatting";

export default [
    ...eslintConfigESLint,
    eslintConfigESLintFormatting
];
```



<!-- markdownlint-disable-file MD004 -->
