### PR TITLE
fix: message template for all files ignored

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -91,7 +91,7 @@ class AllFilesIgnoredError extends Error {
      */
     constructor(pattern) {
         super(`All files matched by '${pattern}' are ignored.`);
-        this.messageTemplate = "all-files-ignored";
+        this.messageTemplate = "all-matched-files-ignored";
         this.messageData = { pattern };
     }
 }

--- a/messages/all-matched-files-ignored.js
+++ b/messages/all-matched-files-ignored.js
@@ -1,0 +1,23 @@
+"use strict";
+
+module.exports = function(it) {
+    const { pattern } = it;
+
+    return `
+You are linting "${pattern}", but all of the files matching the glob pattern "${pattern}" are ignored.
+
+If you don't want to lint these files, remove the pattern "${pattern}" from the list of arguments passed to ESLint.
+
+If you do want to lint these files, explicitly list one or more of the files from this glob that you'd like to lint to see more details about why they are ignored.
+
+  * If the file is ignored because of a matching ignore pattern, check global ignores in your config file.
+
+    https://eslint.org/docs/latest/use/configure/ignore
+
+  * If the file is ignored because no matching configuration was supplied, check file patterns in your config file.
+
+    https://eslint.org/docs/latest/use/configure/configuration-files#specifying-files-with-arbitrary-extensions
+
+  * If the file is ignored because outside of base path, change the location of your config file to be in a parent directory.
+`.trimStart();
+};

--- a/messages/all-matched-files-ignored.js
+++ b/messages/all-matched-files-ignored.js
@@ -16,6 +16,6 @@ If you do want to lint these files, explicitly list one or more of the files fro
   * If the file is ignored because no matching configuration was supplied, check file patterns in your config file.
     https://eslint.org/docs/latest/use/configure/configuration-files#specifying-files-with-arbitrary-extensions
 
-  * If the file is ignored because outside of base path, change the location of your config file to be in a parent directory.
+  * If the file is ignored because it is located outside of the base path, change the location of your config file to be in a parent directory.
 `.trimStart();
 };

--- a/messages/all-matched-files-ignored.js
+++ b/messages/all-matched-files-ignored.js
@@ -11,11 +11,9 @@ If you don't want to lint these files, remove the pattern "${pattern}" from the 
 If you do want to lint these files, explicitly list one or more of the files from this glob that you'd like to lint to see more details about why they are ignored.
 
   * If the file is ignored because of a matching ignore pattern, check global ignores in your config file.
-
     https://eslint.org/docs/latest/use/configure/ignore
 
   * If the file is ignored because no matching configuration was supplied, check file patterns in your config file.
-
     https://eslint.org/docs/latest/use/configure/configuration-files#specifying-files-with-arbitrary-extensions
 
   * If the file is ignored because outside of base path, change the location of your config file to be in a parent directory.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

* **Node version:** v20.12.0
* **npm version:** 10.5.0
* **Local ESLint version:** `main` branch
* **Global ESLint version:** no
* **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
https://github.com/eslint/eslint/blob/main/eslint.config.js

</details>

**What did you do? Please include the actual source code causing the issue.**

```
npx eslint "*.json"
```

**What did you expect to happen?**

An error not mentioning eslintrc concepts like .eslintignore file.

**What actually happened? Please include the actual, raw output from ESLint.**

```
Oops! Something went wrong! :(

ESLint: 9.4.0

You are linting "*.json", but all of the files matching the glob pattern "*.json" are ignored.

If you don't want to lint these files, remove the pattern "*.json" from the list of arguments passed to ESLint.

If you do want to lint these files, try the following solutions:

* Check your .eslintignore file, or the eslintIgnore property in package.json, to ensure that the files are not configured to be ignored.
* Explicitly list the files from this glob that you'd like to lint on the command-line, rather than providing a glob as an argument.
```

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added a new message template for flat config mode.

```
Oops! Something went wrong! :(

ESLint: 9.4.0

You are linting "*.json", but all of the files matching the glob pattern "*.json" are ignored.

If you don't want to lint these files, remove the pattern "*.json" from the list of arguments passed to ESLint.

If you do want to lint these files, explicitly list one or more of the files from this glob that you'd like to lint to see more details about why they are ignored.

  * If the file is ignored because of a matching ignore pattern, check global ignores in your config file.

    https://eslint.org/docs/latest/use/configure/ignore

  * If the file is ignored because no matching configuration was supplied, check file patterns in your config file.

    https://eslint.org/docs/latest/use/configure/configuration-files#specifying-files-with-arbitrary-extensions

  * If the file is ignored because outside of base path, change the location of your config file to be in a parent directory.
```

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
