### PR TITLE
chore: remove unused eslint-disable directive

### DIFF
--- a/tests/lib/rules/no-misleading-character-class.js
+++ b/tests/lib/rules/no-misleading-character-class.js
@@ -1596,9 +1596,6 @@ ruleTester.run("no-misleading-character-class", rule, {
                 suggestions: null
             }]
         },
-
-        /* eslint-disable lines-around-comment -- see https://github.com/eslint/eslint/issues/18081 */
-
         {
             code: String.raw`
 
@@ -1728,6 +1725,7 @@ ruleTester.run("no-misleading-character-class", rule, {
             }]
         },
         {
+
             /*
              * In this case the rule can determine the value of `pattern` statically but has no information about the source,
              * so it doesn't know that escape sequences were used. This is a limitation with our tools.
@@ -1736,8 +1734,5 @@ ruleTester.run("no-misleading-character-class", rule, {
             options: [{ allowEscape: true }],
             errors: [{ messageId: "combiningClass" }]
         }
-
-        /* eslint-enable lines-around-comment -- re-enable rule */
-
     ]
 });

--- a/tests/lib/rules/no-misleading-character-class.js
+++ b/tests/lib/rules/no-misleading-character-class.js
@@ -1597,7 +1597,7 @@ ruleTester.run("no-misleading-character-class", rule, {
             }]
         },
 
-        /* eslint-disable lines-around-comment, internal-rules/multiline-comment-style -- see https://github.com/eslint/eslint/issues/18081 */
+        /* eslint-disable lines-around-comment -- see https://github.com/eslint/eslint/issues/18081 */
 
         {
             code: String.raw`
@@ -1737,7 +1737,7 @@ ruleTester.run("no-misleading-character-class", rule, {
             errors: [{ messageId: "combiningClass" }]
         }
 
-        /* eslint-enable lines-around-comment, internal-rules/multiline-comment-style -- re-enable rule */
+        /* eslint-enable lines-around-comment -- re-enable rule */
 
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Removes unused disable directive to fix a lint error in CI.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed disable directive for `internal-rules/multiline-comment-style` that was added because of a bug in Acorn (https://github.com/acornjs/acorn/issues/1275) that was fixed in the newly-released version.

#### Is there anything you'd like reviewers to focus on?

It seems that the bug fix didn't help with the lines-around-comment rule (https://github.com/eslint/eslint/issues/18081) as it still needs to be disabled in this block.

<!-- markdownlint-disable-file MD004 -->
