### PR TITLE
fix: correct locations of invalid `/* eslint */` comments

### DIFF
--- a/lib/languages/js/source-code/source-code.js
+++ b/lib/languages/js/source-code/source-code.js
@@ -1147,7 +1147,7 @@ class SourceCode extends TokenStore {
                     break;
 
                 case "eslint": {
-                    const parseResult = commentParser.parseJsonConfig(directiveValue, comment.loc);
+                    const parseResult = commentParser.parseJsonConfig(directiveValue);
 
                     if (parseResult.success) {
                         configs.push({
@@ -1157,7 +1157,11 @@ class SourceCode extends TokenStore {
                             node: comment
                         });
                     } else {
-                        problems.push(parseResult.error);
+                        problems.push({
+                            ruleId: null,
+                            loc: comment.loc,
+                            message: parseResult.error.message
+                        });
                     }
 
                     break;

--- a/lib/linter/config-comment-parser.js
+++ b/lib/linter/config-comment-parser.js
@@ -23,12 +23,6 @@ const levn = require("levn"),
 const debug = require("debug")("eslint:config-comment-parser");
 
 //------------------------------------------------------------------------------
-// Typedefs
-//------------------------------------------------------------------------------
-
-/** @typedef {import("../shared/types").LintMessage} LintMessage */
-
-//------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
@@ -69,10 +63,9 @@ module.exports = class ConfigCommentParser {
     /**
      * Parses a JSON-like config.
      * @param {string} string The string to parse.
-     * @param {Object} location Start line and column of comments for potential error message.
-     * @returns {({success: true, config: Object}|{success: false, error: LintMessage})} Result map object
+     * @returns {({success: true, config: Object}|{success: false, error: {message: string}})} Result map object
      */
-    parseJsonConfig(string, location) {
+    parseJsonConfig(string) {
         debug("Parsing JSON config");
 
         // Parses a JSON-like comment by the same way as parsing CLI option.
@@ -115,13 +108,7 @@ module.exports = class ConfigCommentParser {
             return {
                 success: false,
                 error: {
-                    ruleId: null,
-                    fatal: true,
-                    severity: 2,
-                    message: `Failed to parse JSON from '${normalizedString}': ${ex.message}`,
-                    line: location.start.line,
-                    column: location.start.column + 1,
-                    nodeType: null
+                    message: `Failed to parse JSON from '${normalizedString}': ${ex.message}`
                 }
             };
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -470,7 +470,7 @@ function getDirectiveComments(sourceCode, ruleMapper, warnInlineConfig, config) 
                 break;
 
             case "eslint": {
-                const parseResult = commentParser.parseJsonConfig(directiveValue, comment.loc);
+                const parseResult = commentParser.parseJsonConfig(directiveValue);
 
                 if (parseResult.success) {
                     Object.keys(parseResult.config).forEach(name => {
@@ -557,7 +557,14 @@ function getDirectiveComments(sourceCode, ruleMapper, warnInlineConfig, config) 
                         configuredRules[name] = ruleOptions;
                     });
                 } else {
-                    problems.push(parseResult.error);
+                    const problem = createLintingProblem({
+                        ruleId: null,
+                        loc: comment.loc,
+                        message: parseResult.error.message
+                    });
+
+                    problem.fatal = true;
+                    problems.push(problem);
                 }
 
                 break;

--- a/tests/lib/languages/js/source-code/source-code.js
+++ b/tests/lib/languages/js/source-code/source-code.js
@@ -3242,13 +3242,12 @@ describe("SourceCode", () => {
             const problem = result.problems[0];
 
             // Node.js 19 changes the JSON parsing error format, so we need to check each field separately to use a regex
-            assert.strictEqual(problem.column, 1);
-            assert.strictEqual(problem.line, 1);
-            assert.isTrue(problem.fatal);
+            assert.strictEqual(problem.loc.start.column, 0);
+            assert.strictEqual(problem.loc.start.line, 1);
+            assert.strictEqual(problem.loc.end.column, 24);
+            assert.strictEqual(problem.loc.end.line, 1);
             assert.match(problem.message, /Failed to parse JSON from ' "some-rule"::,': Unexpected token '?:'?/u);
-            assert.isNull(problem.nodeType);
             assert.isNull(problem.ruleId);
-            assert.strictEqual(problem.severity, 2);
         });
     });
 });

--- a/tests/lib/linter/config-comment-parser.js
+++ b/tests/lib/linter/config-comment-parser.js
@@ -19,12 +19,6 @@ const assert = require("chai").assert,
 describe("ConfigCommentParser", () => {
 
     let commentParser;
-    const location = {
-        start: {
-            line: 1,
-            column: 0
-        }
-    };
 
     beforeEach(() => {
         commentParser = new ConfigCommentParser();
@@ -34,7 +28,7 @@ describe("ConfigCommentParser", () => {
 
         it("should parse JSON config with one item", () => {
             const code = "no-alert:0";
-            const result = commentParser.parseJsonConfig(code, location);
+            const result = commentParser.parseJsonConfig(code);
 
 
             assert.deepStrictEqual(result, {
@@ -47,7 +41,7 @@ describe("ConfigCommentParser", () => {
 
         it("should parse JSON config with two items", () => {
             const code = "no-alert:0 semi: 2";
-            const result = commentParser.parseJsonConfig(code, location);
+            const result = commentParser.parseJsonConfig(code);
 
 
             assert.deepStrictEqual(result, {
@@ -61,7 +55,7 @@ describe("ConfigCommentParser", () => {
 
         it("should parse JSON config with two comma-separated items", () => {
             const code = "no-alert:0,semi: 2";
-            const result = commentParser.parseJsonConfig(code, location);
+            const result = commentParser.parseJsonConfig(code);
 
 
             assert.deepStrictEqual(result, {
@@ -75,7 +69,7 @@ describe("ConfigCommentParser", () => {
 
         it("should parse JSON config with two items and a string severity", () => {
             const code = "no-alert:off,semi: 2";
-            const result = commentParser.parseJsonConfig(code, location);
+            const result = commentParser.parseJsonConfig(code);
 
 
             assert.deepStrictEqual(result, {
@@ -89,7 +83,7 @@ describe("ConfigCommentParser", () => {
 
         it("should parse JSON config with two items and options", () => {
             const code = "no-alert:off, semi: [2, always]";
-            const result = commentParser.parseJsonConfig(code, location);
+            const result = commentParser.parseJsonConfig(code);
 
 
             assert.deepStrictEqual(result, {
@@ -103,7 +97,7 @@ describe("ConfigCommentParser", () => {
 
         it("should parse JSON config with two items and options from plugins", () => {
             const code = "plugin/no-alert:off, plugin/semi: [2, always]";
-            const result = commentParser.parseJsonConfig(code, location);
+            const result = commentParser.parseJsonConfig(code);
 
             assert.deepStrictEqual(result, {
                 success: true,

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -3176,6 +3176,12 @@ describe("Linter", () => {
             assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":'1'':/u);
             assert.strictEqual(messages[0].line, 1);
             assert.strictEqual(messages[0].column, 1);
+            assert.strictEqual(messages[0].endLine, 1);
+            assert.strictEqual(messages[0].endColumn, 24);
+            assert.strictEqual(messages[0].ruleId, null);
+            assert.strictEqual(messages[0].fatal, true);
+            assert.strictEqual(messages[0].severity, 2);
+            assert.strictEqual(messages[0].nodeType, null);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
             assert.strictEqual(messages[1].message, "Unexpected alert.");
@@ -3204,6 +3210,12 @@ describe("Linter", () => {
             assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":abc':/u);
             assert.strictEqual(messages[0].line, 1);
             assert.strictEqual(messages[0].column, 1);
+            assert.strictEqual(messages[0].endLine, 1);
+            assert.strictEqual(messages[0].endColumn, 24);
+            assert.strictEqual(messages[0].ruleId, null);
+            assert.strictEqual(messages[0].fatal, true);
+            assert.strictEqual(messages[0].severity, 2);
+            assert.strictEqual(messages[0].nodeType, null);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
             assert.strictEqual(messages[1].message, "Unexpected alert.");
@@ -3213,7 +3225,7 @@ describe("Linter", () => {
         });
 
         it("should report a violation", () => {
-            const code = "/*eslint no-alert:0 2*/ alert('test');";
+            const code = "\n\n\n    /*eslint no-alert:0 2*/ alert('test');";
 
             const config = { rules: { "no-alert": 1 } };
 
@@ -3230,8 +3242,14 @@ describe("Linter", () => {
              * parseJsonConfig function in lib/eslint.js
              */
             assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":0 2':/u);
-            assert.strictEqual(messages[0].line, 1);
-            assert.strictEqual(messages[0].column, 1);
+            assert.strictEqual(messages[0].line, 4);
+            assert.strictEqual(messages[0].column, 5);
+            assert.strictEqual(messages[0].endLine, 4);
+            assert.strictEqual(messages[0].endColumn, 28);
+            assert.strictEqual(messages[0].ruleId, null);
+            assert.strictEqual(messages[0].fatal, true);
+            assert.strictEqual(messages[0].severity, 2);
+            assert.strictEqual(messages[0].nodeType, null);
 
             assert.strictEqual(messages[1].ruleId, "no-alert");
             assert.strictEqual(messages[1].message, "Unexpected alert.");
@@ -11811,6 +11829,12 @@ describe("Linter with FlatConfigArray", () => {
                         assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":'1'':/u);
                         assert.strictEqual(messages[0].line, 1);
                         assert.strictEqual(messages[0].column, 1);
+                        assert.strictEqual(messages[0].endLine, 1);
+                        assert.strictEqual(messages[0].endColumn, 24);
+                        assert.strictEqual(messages[0].ruleId, null);
+                        assert.strictEqual(messages[0].fatal, true);
+                        assert.strictEqual(messages[0].severity, 2);
+                        assert.strictEqual(messages[0].nodeType, null);
 
                         assert.strictEqual(messages[1].ruleId, "no-alert");
                         assert.strictEqual(messages[1].message, "Unexpected alert.");
@@ -11839,6 +11863,12 @@ describe("Linter with FlatConfigArray", () => {
                         assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":abc':/u);
                         assert.strictEqual(messages[0].line, 1);
                         assert.strictEqual(messages[0].column, 1);
+                        assert.strictEqual(messages[0].endLine, 1);
+                        assert.strictEqual(messages[0].endColumn, 24);
+                        assert.strictEqual(messages[0].ruleId, null);
+                        assert.strictEqual(messages[0].fatal, true);
+                        assert.strictEqual(messages[0].severity, 2);
+                        assert.strictEqual(messages[0].nodeType, null);
 
                         assert.strictEqual(messages[1].ruleId, "no-alert");
                         assert.strictEqual(messages[1].message, "Unexpected alert.");
@@ -11848,7 +11878,7 @@ describe("Linter with FlatConfigArray", () => {
                     });
 
                     it("should report a violation", () => {
-                        const code = "/*eslint no-alert:0 2*/ alert('test');";
+                        const code = "\n\n\n    /*eslint no-alert:0 2*/ alert('test');";
 
                         const config = { rules: { "no-alert": 1 } };
 
@@ -11865,8 +11895,14 @@ describe("Linter with FlatConfigArray", () => {
                          * parseJsonConfig function in lib/eslint.js
                          */
                         assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":0 2':/u);
-                        assert.strictEqual(messages[0].line, 1);
-                        assert.strictEqual(messages[0].column, 1);
+                        assert.strictEqual(messages[0].line, 4);
+                        assert.strictEqual(messages[0].column, 5);
+                        assert.strictEqual(messages[0].endLine, 4);
+                        assert.strictEqual(messages[0].endColumn, 28);
+                        assert.strictEqual(messages[0].ruleId, null);
+                        assert.strictEqual(messages[0].fatal, true);
+                        assert.strictEqual(messages[0].severity, 2);
+                        assert.strictEqual(messages[0].nodeType, null);
 
                         assert.strictEqual(messages[1].ruleId, "no-alert");
                         assert.strictEqual(messages[1].message, "Unexpected alert.");

--- a/tools/check-rule-examples.js
+++ b/tools/check-rule-examples.js
@@ -130,12 +130,17 @@ async function findProblems(filename) {
                         continue;
                     }
                     const { directiveValue } = commentParser.parseDirective(comment);
-                    const parseResult = commentParser.parseJsonConfig(directiveValue, comment.loc);
+                    const parseResult = commentParser.parseJsonConfig(directiveValue);
                     const parseError = parseResult.error;
 
                     if (parseError) {
-                        parseError.line += codeBlockToken.map[0] + 1;
-                        problems.push(parseError);
+                        problems.push({
+                            fatal: true,
+                            severity: 2,
+                            message: parseError.message,
+                            line: comment.loc.start.line + codeBlockToken.map[0] + 1,
+                            column: comment.loc.start.column + 1
+                        });
                     } else if (Object.hasOwn(parseResult.config, title)) {
                         if (hasRuleConfigComment) {
                             problems.push({


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

* **Node version:** v20.12.0
* **npm version:** v10.5.0
* **Local ESLint version:** v9.5.0
* **Global ESLint version:** no
* **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
export default [];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
// line 1
// line 2
/* eslint no-alert: [2 */
```

**What did you expect to happen?**

An error about invalid JSON in inlline config on line 3.

**What actually happened? Please include the actual, raw output from ESLint.**

Error on line 1 instead of line 3:

```
 1:1  error  Failed to parse JSON from ' "no-alert": [2': Expected ',' or ']' after array element in JSON at position 16
```

[Playground Demo](https://eslint.org/play/#eyJ0ZXh0IjoiLy8gbGluZSAxXG4vLyBsaW5lIDJcbi8qIGVzbGludCBuby1hbGVydDogWzIgKi8iLCJvcHRpb25zIjp7InJ1bGVzIjp7fSwibGFuZ3VhZ2VPcHRpb25zIjp7InNvdXJjZVR5cGUiOiJtb2R1bGUiLCJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319fX19)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`SourceCode#applyInlineConfig()` was returning these errors without the `loc` property (`line` and `column` were directly on the error as received from the config comment parser) so the error loc start was defaulting to 1:1. I fixed this to return `loc` on the error, and also refactored code to create lint errors in the Linter rather than in the config comment parser. This also adds `endLine` and `endColumn` so the whole comment will be underlined.

#### Is there anything you'd like reviewers to focus on?

This bug was not introduced in https://github.com/eslint/eslint/pull/18448, we missed it earlier.

<!-- markdownlint-disable-file MD004 -->
