### PR TITLE
refactor: use `/` separator when adjusting `ignorePatterns` on Windows

### DIFF
--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -421,7 +421,7 @@ async function calculateConfigArray(eslint, {
             relativeIgnorePatterns = ignorePatterns;
         } else {
 
-            const relativeIgnorePath = path.relative(basePath, cwd);
+            const relativeIgnorePath = path.relative(basePath, cwd).replaceAll(path.sep, "/");
 
             relativeIgnorePatterns = ignorePatterns.map(pattern => {
                 const negated = pattern.startsWith("!");

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -421,6 +421,7 @@ async function calculateConfigArray(eslint, {
             relativeIgnorePatterns = ignorePatterns;
         } else {
 
+            // In minimatch patterns, only `/` can be used as path separator
             const relativeIgnorePath = path.relative(basePath, cwd).replaceAll(path.sep, "/");
 
             relativeIgnorePatterns = ignorePatterns.map(pattern => {

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -5144,6 +5144,16 @@ describe("ESLint", () => {
                 assert(!await engine.isPathIgnored("c.js"), "c.js should not be ignored");
             });
 
+            it("should interpret ignorePatterns as relative to cwd", async () => {
+                const cwd = getFixturePath("ignored-paths", "subdir");
+                const engine = new ESLint({
+                    ignorePatterns: ["undef.js"],
+                    cwd // using ../../eslint.config.js
+                });
+
+                assert(await engine.isPathIgnored(path.join(cwd, "undef.js")));
+            });
+
             it("should return true for files which match an ignorePattern even if they do not exist on the filesystem", async () => {
                 const cwd = getFixturePath("ignored-paths");
                 const engine = new ESLint({


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

When converting `ignorePatterns` (`--ignore-pattern`), which are relative to `cwd`, to patterns relative to `basePath`, we were prepending `path.relative(basePath, cwd)`.

On Windows, this was producing a mix of `\` and `/` as path separators in the result. For example, if the config file is in the root, and you run `eslint --ignore-pattern a.js` in a subfolder `src\app`, the ignore pattern passed to the config array would be `src\app/a.js`. 

#### What changes did you make? (Give an overview)

Added `.replaceAll(path.sep, "/")` to the relative path to replace `\` with `/` on Windows and thus consistently produce ignore patterns with `/` separators.

#### Is there anything you'd like reviewers to focus on?

I marked this as a refactor because the previous code currently doesn't cause any bugs, but it would cause bugs after we update config-array to always treat `\` as an escape character (https://github.com/eslint/rewrite/pull/61).

<!-- markdownlint-disable-file MD004 -->
