### PR TITLE
feat: add `regex` option in `no-restricted-imports`

### DIFF
--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -389,7 +389,7 @@ import pick from 'import1/private/someModule';
 
 The `patterns` array can also include objects. The `group` property is used to specify the `gitignore`-style patterns for restricting modules and the `message` property is used to specify a custom message.
 
-Either of the `group` or `regexGroup` property is required when using the `patterns` option.
+Either of the `group` or `regex` property is required when using the `patterns` option.
 
 ```json
 "no-restricted-imports": ["error", {
@@ -433,31 +433,31 @@ import lodash from 'lodash';
 
 :::
 
-#### regexGroup
+#### regex
 
-The `regexGroup` property is used to specify the regex patterns for restricting modules.
+The `regex` property is used to specify the regex patterns for restricting modules.
 
-Note: `regexGroup` cannot be used in combination with `group`.
+Note: `regex` cannot be used in combination with `group`.
 
 ```json
 "no-restricted-imports": ["error", {
     "patterns": [{
-      "regexGroup": "import1/private/",
+      "regex": "import1/private/",
       "message": "usage of import1 private modules not allowed."
     }, {
-      "regexGroup": "import2/(?!good)",
+      "regex": "import2/(?!good)",
       "message": "import2 is deprecated, except the modules in import2/good."
     }]
 }]
 ```
 
-Examples of **incorrect** code for `regexGroup` option:
+Examples of **incorrect** code for `regex` option:
 
 ::: incorrect { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
-    regexGroup: "@app/(?!(api/enums$)).*",
+    regex: "@app/(?!(api/enums$)).*",
 }]}]*/
 
 import Foo from '@app/api';
@@ -468,13 +468,13 @@ import Bux from '@app/api/enums/foo';
 
 :::
 
-Examples of **correct** code for `regexGroup` option:
+Examples of **correct** code for `regex` option:
 
 ::: correct { "sourceType": "module" }
 
 ```js
 /*eslint no-restricted-imports: ["error", { patterns: [{
-    regexGroup: "@app/(?!(api/enums$)).*",
+    regex: "@app/(?!(api/enums$)).*",
 }]}]*/
 
 import Foo from '@app/api/enums';

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -284,7 +284,7 @@ import { AllowedObject } from "foo";
 
 ### patterns
 
-This is also an object option whose value is an array. This option allows you to specify multiple modules to restrict using `gitignore`-style patterns.
+This is also an object option whose value is an array. This option allows you to specify multiple modules to restrict using `gitignore`-style patterns or regular expressions.
 
 Where `paths` option takes exact import paths, `patterns` option can be used to specify the import paths with more flexibility, allowing for the restriction of multiple modules within the same directory. For example:
 
@@ -311,13 +311,15 @@ This configuration restricts import of the `import-foo` module but wouldn't rest
 
 This configuration restricts imports not just from `import-foo` using `path`, but also `import-foo/bar` and `import-foo/baz` using `patterns`.
 
-Because the patterns follow the `gitignore`-style, if you want to reinclude any particular module this can be done by prefixing a negation (`!`) mark in front of the pattern. (Negated patterns should come last in the array because order is important.)
+To re-include a module when using `gitignore-`style patterns, add a negation (`!`) mark before the pattern. (Make sure these negated patterns are placed last in the array, as order matters)
 
 ```json
 "no-restricted-imports": ["error", {
     "patterns": ["import1/private/*", "import2/*", "!import2/good"]
 }]
 ```
+
+You can also use regular expressions to restrict modules (See the [`regex` option](#regex)), which can make re-including specific modules easier.
 
 Examples of **incorrect** code for `patterns` option:
 
@@ -484,7 +486,7 @@ import Foo from '@app/api/enums';
 
 #### caseSensitive
 
-This is a boolean option and sets the patterns specified in the `group` array to be case-sensitive when `true`. Default is `false`.
+This is a boolean option and sets the patterns specified in the `group` or `regex` properties to be case-sensitive when `true`. Default is `false`.
 
 ```json
 "no-restricted-imports": ["error", {
@@ -527,7 +529,7 @@ import pick from 'food';
 
 #### importNames
 
-You can also specify `importNames` on objects inside of `patterns`. In this case, the specified names are applied only to the specified `group`.
+You can also specify `importNames` within objects inside the `patterns` array. In this case, the specified names apply only to the associated `group` or `regex` property.
 
 ```json
 "no-restricted-imports": ["error", {
@@ -573,7 +575,7 @@ import { hasValues } from 'utils/collection-utils';
 
 #### allowImportNames
 
-You can also specify `allowImportNames` on objects inside of `patterns`. In this case, the specified names are applied only to the specified `group`.
+You can also specify `allowImportNames` within objects inside the `patterns` array. In this case, the specified names apply only to the associated `group` or `regex` property.
 
 Note: `allowImportNames` cannot be used in combination with `importNames`, `importNamePattern` or `allowImportNamePattern`.
 

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -389,7 +389,7 @@ import pick from 'import1/private/someModule';
 
 The `patterns` array can also include objects. The `group` property is used to specify the `gitignore`-style patterns for restricting modules and the `message` property is used to specify a custom message.
 
-The `group` property is required property when using objects inside the `patterns` array.
+Either of the `group` or `regexGroup` property is required when using the `patterns` option.
 
 ```json
 "no-restricted-imports": ["error", {
@@ -429,6 +429,53 @@ Examples of **correct** code for this `group` option:
 }]}]*/
 
 import lodash from 'lodash';
+```
+
+:::
+
+#### regexGroup
+
+The `regexGroup` property is used to specify the regex patterns for restricting modules.
+
+```json
+"no-restricted-imports": ["error", {
+    "patterns": [{
+      "regexGroup": "import1/private/",
+      "message": "usage of import1 private modules not allowed."
+    }, {
+      "regexGroup": "import2/(?!good)",
+      "message": "import2 is deprecated, except the modules in import2/good."
+    }]
+}]
+```
+
+Examples of **incorrect** code for `regexGroup` option:
+
+::: incorrect { "sourceType": "module" }
+
+```js
+/*eslint no-restricted-imports: ["error", { patterns: [{
+    regexGroup: "@app/(?!(api/enums$)).*",
+}]}]*/
+
+import Foo from '@app/api';
+import Bar from '@app/api/bar';
+import Baz from '@app/api/baz';
+import Bux from '@app/api/enums/foo';
+```
+
+:::
+
+Examples of **correct** code for `regexGroup` option:
+
+::: correct { "sourceType": "module" }
+
+```js
+/*eslint no-restricted-imports: ["error", { patterns: [{
+    regexGroup: "@app/(?!(api/enums$)).*",
+}]}]*/
+
+import Foo from '@app/api/enums';
 ```
 
 :::

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -437,6 +437,8 @@ import lodash from 'lodash';
 
 The `regexGroup` property is used to specify the regex patterns for restricting modules.
 
+Note: `regexGroup` cannot be used in combination with `group`.
+
 ```json
 "no-restricted-imports": ["error", {
     "patterns": [{

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -389,7 +389,7 @@ import pick from 'import1/private/someModule';
 
 The `patterns` array can also include objects. The `group` property is used to specify the `gitignore`-style patterns for restricting modules and the `message` property is used to specify a custom message.
 
-Either of the `group` or `regex` property is required when using the `patterns` option.
+Either of the `group` or `regex` properties is required when using the `patterns` option.
 
 ```json
 "no-restricted-imports": ["error", {

--- a/docs/src/rules/no-restricted-imports.md
+++ b/docs/src/rules/no-restricted-imports.md
@@ -319,7 +319,7 @@ To re-include a module when using `gitignore-`style patterns, add a negation (`!
 }]
 ```
 
-You can also use regular expressions to restrict modules (See the [`regex` option](#regex)), which can make re-including specific modules easier.
+You can also use regular expressions to restrict modules (see the [`regex` option](#regex)).
 
 Examples of **incorrect** code for `patterns` option:
 

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -89,7 +89,7 @@ const arrayOfStringsOrObjectPatterns = {
                         minItems: 1,
                         uniqueItems: true
                     },
-                    regexGroup: {
+                    regex: {
                         type: "string"
                     },
                     importNamePattern: {
@@ -109,14 +109,18 @@ const arrayOfStringsOrObjectPatterns = {
                 additionalProperties: false,
                 not: {
                     anyOf: [
-                        { required: ["group", "regexGroup"] },
+                        { required: ["group", "regex"] },
                         { required: ["importNames", "allowImportNames"] },
                         { required: ["importNamePattern", "allowImportNamePattern"] },
                         { required: ["importNames", "allowImportNamePattern"] },
                         { required: ["importNamePattern", "allowImportNames"] },
                         { required: ["allowImportNames", "allowImportNamePattern"] }
                     ]
-                }
+                },
+                oneOf: [
+                    { required: ["group"] },
+                    { required: ["regex"] }
+                ]
             },
             uniqueItems: true
         }
@@ -238,10 +242,10 @@ module.exports = {
 
         // relative paths are supported for this rule
         const restrictedPatternGroups = restrictedPatterns.map(
-            ({ group, regexGroup, message, caseSensitive, importNames, importNamePattern, allowImportNames, allowImportNamePattern }) => (
+            ({ group, regex, message, caseSensitive, importNames, importNamePattern, allowImportNames, allowImportNamePattern }) => (
                 {
                     matcher: ignore({ allowRelativePaths: true, ignorecase: !caseSensitive }).add(group),
-                    ...(regexGroup ? { regexMatcher: new RegExp(regexGroup, caseSensitive ? "u" : "iu") } : {}),
+                    ...(regex ? { regexMatcher: new RegExp(regex, caseSensitive ? "u" : "iu") } : {}),
                     customMessage: message,
                     importNames,
                     importNamePattern,

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -89,6 +89,9 @@ const arrayOfStringsOrObjectPatterns = {
                         minItems: 1,
                         uniqueItems: true
                     },
+                    regexGroup: {
+                        type: "string"
+                    },
                     importNamePattern: {
                         type: "string"
                     },
@@ -104,9 +107,9 @@ const arrayOfStringsOrObjectPatterns = {
                     }
                 },
                 additionalProperties: false,
-                required: ["group"],
                 not: {
                     anyOf: [
+                        { required: ["group", "regexGroup"] },
                         { required: ["importNames", "allowImportNames"] },
                         { required: ["importNamePattern", "allowImportNamePattern"] },
                         { required: ["importNames", "allowImportNamePattern"] },
@@ -235,9 +238,10 @@ module.exports = {
 
         // relative paths are supported for this rule
         const restrictedPatternGroups = restrictedPatterns.map(
-            ({ group, message, caseSensitive, importNames, importNamePattern, allowImportNames, allowImportNamePattern }) => (
+            ({ group, regexGroup, message, caseSensitive, importNames, importNamePattern, allowImportNames, allowImportNamePattern }) => (
                 {
                     matcher: ignore({ allowRelativePaths: true, ignorecase: !caseSensitive }).add(group),
+                    ...(regexGroup ? { regexMatcher: new RegExp(regexGroup, caseSensitive ? "u" : "iu") } : {}),
                     customMessage: message,
                     importNames,
                     importNamePattern,
@@ -493,7 +497,7 @@ module.exports = {
          * @private
          */
         function isRestrictedPattern(importSource, group) {
-            return group.matcher.ignores(importSource);
+            return group.regexMatcher ? group.regexMatcher.test(importSource) : group.matcher.ignores(importSource);
         }
 
         /**

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -109,7 +109,6 @@ const arrayOfStringsOrObjectPatterns = {
                 additionalProperties: false,
                 not: {
                     anyOf: [
-                        { required: ["group", "regex"] },
                         { required: ["importNames", "allowImportNames"] },
                         { required: ["importNamePattern", "allowImportNamePattern"] },
                         { required: ["importNames", "allowImportNamePattern"] },
@@ -244,7 +243,7 @@ module.exports = {
         const restrictedPatternGroups = restrictedPatterns.map(
             ({ group, regex, message, caseSensitive, importNames, importNamePattern, allowImportNames, allowImportNamePattern }) => (
                 {
-                    matcher: ignore({ allowRelativePaths: true, ignorecase: !caseSensitive }).add(group),
+                    ...(group ? { matcher: ignore({ allowRelativePaths: true, ignorecase: !caseSensitive }).add(group) } : {}),
                     ...(regex ? { regexMatcher: new RegExp(regex, caseSensitive ? "u" : "iu") } : {}),
                     customMessage: message,
                     importNames,

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -244,7 +244,7 @@ module.exports = {
             ({ group, regex, message, caseSensitive, importNames, importNamePattern, allowImportNames, allowImportNamePattern }) => (
                 {
                     ...(group ? { matcher: ignore({ allowRelativePaths: true, ignorecase: !caseSensitive }).add(group) } : {}),
-                    ...(regex ? { regexMatcher: new RegExp(regex, caseSensitive ? "u" : "iu") } : {}),
+                    ...(typeof regex === "string" ? { regexMatcher: new RegExp(regex, caseSensitive ? "u" : "iu") } : {}),
                     customMessage: message,
                     importNames,
                     importNamePattern,

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -433,13 +433,13 @@ ruleTester.run("no-restricted-imports", rule, {
         },
         {
             code: "import withPatterns from \"foo/bar\";",
-            options: [{ patterns: [{ regexGroup: "foo/(?!bar)", message: "foo is forbidden, use bar instead" }] }]
+            options: [{ patterns: [{ regex: "foo/(?!bar)", message: "foo is forbidden, use bar instead" }] }]
         },
         {
             code: "import withPatternsCaseSensitive from 'foo';",
             options: [{
                 patterns: [{
-                    regexGroup: "FOO",
+                    regex: "FOO",
                     message: "foo is forbidden, use bar instead",
                     caseSensitive: true
                 }]
@@ -449,7 +449,7 @@ ruleTester.run("no-restricted-imports", rule, {
             code: "import Foo from '../../my/relative-module';",
             options: [{
                 patterns: [{
-                    regexGroup: "my/relative-module",
+                    regex: "my/relative-module",
                     importNamePattern: "^Foo"
                 }]
             }]
@@ -458,7 +458,7 @@ ruleTester.run("no-restricted-imports", rule, {
             code: "import { Bar } from '../../my/relative-module';",
             options: [{
                 patterns: [{
-                    regexGroup: "my/relative-module",
+                    regex: "my/relative-module",
                     importNamePattern: "^Foo"
                 }]
             }]
@@ -2241,7 +2241,7 @@ ruleTester.run("no-restricted-imports", rule, {
     },
     {
         code: "import withPatterns from \"foo/baz\";",
-        options: [{ patterns: [{ regexGroup: "foo/(?!bar)", message: "foo is forbidden, use bar instead" }] }],
+        options: [{ patterns: [{ regex: "foo/(?!bar)", message: "foo is forbidden, use bar instead" }] }],
         errors: [{
             message: "'foo/baz' import is restricted from being used by a pattern. foo is forbidden, use bar instead",
             type: "ImportDeclaration",
@@ -2254,7 +2254,7 @@ ruleTester.run("no-restricted-imports", rule, {
         code: "import withPatternsCaseSensitive from 'FOO';",
         options: [{
             patterns: [{
-                regexGroup: "FOO",
+                regex: "FOO",
                 message: "foo is forbidden, use bar instead",
                 caseSensitive: true
             }]
@@ -2271,7 +2271,7 @@ ruleTester.run("no-restricted-imports", rule, {
         code: "import { Foo } from '../../my/relative-module';",
         options: [{
             patterns: [{
-                regexGroup: "my/relative-module",
+                regex: "my/relative-module",
                 importNamePattern: "^Foo"
             }]
         }],
@@ -2296,7 +2296,7 @@ ruleTester.run("no-restricted-imports", rule, {
         `,
         options: [{
             patterns: [{
-                regexGroup: "@app/(?!(api/enums$)).*",
+                regex: "@app/(?!(api/enums$)).*",
                 importNamePattern: "_Enum$"
             }]
         }],

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -430,6 +430,38 @@ ruleTester.run("no-restricted-imports", rule, {
                     allowImportNamePattern: "^Foo"
                 }]
             }]
+        },
+        {
+            code: "import withPatterns from \"foo/bar\";",
+            options: [{ patterns: [{ regexGroup: "foo/(?!bar)", message: "foo is forbidden, use bar instead" }] }]
+        },
+        {
+            code: "import withPatternsCaseSensitive from 'foo';",
+            options: [{
+                patterns: [{
+                    regexGroup: "FOO",
+                    message: "foo is forbidden, use bar instead",
+                    caseSensitive: true
+                }]
+            }]
+        },
+        {
+            code: "import Foo from '../../my/relative-module';",
+            options: [{
+                patterns: [{
+                    regexGroup: "my/relative-module",
+                    importNamePattern: "^Foo"
+                }]
+            }]
+        },
+        {
+            code: "import { Bar } from '../../my/relative-module';",
+            options: [{
+                patterns: [{
+                    regexGroup: "my/relative-module",
+                    importNamePattern: "^Foo"
+                }]
+            }]
         }
     ],
     invalid: [{
@@ -2206,6 +2238,98 @@ ruleTester.run("no-restricted-imports", rule, {
             column: 8,
             endColumn: 26
         }]
+    },
+    {
+        code: "import withPatterns from \"foo/baz\";",
+        options: [{ patterns: [{ regexGroup: "foo/(?!bar)", message: "foo is forbidden, use bar instead" }] }],
+        errors: [{
+            message: "'foo/baz' import is restricted from being used by a pattern. foo is forbidden, use bar instead",
+            type: "ImportDeclaration",
+            line: 1,
+            column: 1,
+            endColumn: 36
+        }]
+    },
+    {
+        code: "import withPatternsCaseSensitive from 'FOO';",
+        options: [{
+            patterns: [{
+                regexGroup: "FOO",
+                message: "foo is forbidden, use bar instead",
+                caseSensitive: true
+            }]
+        }],
+        errors: [{
+            message: "'FOO' import is restricted from being used by a pattern. foo is forbidden, use bar instead",
+            type: "ImportDeclaration",
+            line: 1,
+            column: 1,
+            endColumn: 45
+        }]
+    },
+    {
+        code: "import { Foo } from '../../my/relative-module';",
+        options: [{
+            patterns: [{
+                regexGroup: "my/relative-module",
+                importNamePattern: "^Foo"
+            }]
+        }],
+        errors: [{
+            message: "'Foo' import from '../../my/relative-module' is restricted from being used by a pattern.",
+            type: "ImportDeclaration",
+            line: 1,
+            column: 10,
+            endColumn: 13
+        }]
+    },
+    {
+        code: `
+        // error
+        import { Foo_Enum } from '@app/api';
+        import { Bar_Enum } from '@app/api/bar';
+        import { Baz_Enum } from '@app/api/baz';
+        import { B_Enum } from '@app/api/enums/foo';
+
+        // no error
+        import { C_Enum } from '@app/api/enums';
+        `,
+        options: [{
+            patterns: [{
+                regexGroup: "@app/(?!(api/enums$)).*",
+                importNamePattern: "_Enum$"
+            }]
+        }],
+        errors: [
+            {
+                message: "'Foo_Enum' import from '@app/api' is restricted from being used by a pattern.",
+                type: "ImportDeclaration",
+                line: 3,
+                column: 18,
+                endColumn: 26
+            },
+            {
+                message: "'Bar_Enum' import from '@app/api/bar' is restricted from being used by a pattern.",
+                type: "ImportDeclaration",
+                line: 4,
+                column: 18,
+                endColumn: 26
+            },
+            {
+                message: "'Baz_Enum' import from '@app/api/baz' is restricted from being used by a pattern.",
+                type: "ImportDeclaration",
+                line: 5,
+                column: 18,
+                endColumn: 26
+            },
+            {
+                message: "'B_Enum' import from '@app/api/enums/foo' is restricted from being used by a pattern.",
+                type: "ImportDeclaration",
+                line: 6,
+                column: 18,
+                endColumn: 24
+            }
+        ]
     }
     ]
 });

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -2284,6 +2284,23 @@ ruleTester.run("no-restricted-imports", rule, {
         }]
     },
     {
+        code: "import withPatternsCaseSensitive from 'foo';",
+        options: [{
+            patterns: [{
+                group: ["FOO"],
+                message: "foo is forbidden, use bar instead",
+                caseSensitive: false
+            }]
+        }],
+        errors: [{
+            message: "'foo' import is restricted from being used by a pattern. foo is forbidden, use bar instead",
+            type: "ImportDeclaration",
+            line: 1,
+            column: 1,
+            endColumn: 45
+        }]
+    },
+    {
         code: `
         // error
         import { Foo_Enum } from '@app/api';


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Fix https://github.com/eslint/eslint/issues/18536

```js
/*eslint no-restricted-imports: ["error", { patterns: [{
    "importNamePattern": "_Enum$",
    "regexGroup": "@app/(?!(api/enums$)).*"
}]}]*/

// error
import { Foo_Enum } from '@app/api';
import { Bar_Enum } from '@app/api/bar';
import { Baz_Enum } from '@app/api/baz';
import { B_Enum } from '@app/api/enums/foo';

// no error
import { C_Enum } from '@app/api/enums';
```
#### Is there anything you'd like reviewers to focus on?

Earlier `group` was a required property in the schema and would throw an error if not defined, which isn't the case anymore as we need either `group` or `regexGroup`.

<!-- markdownlint-disable-file MD004 -->
