### PR TITLE
refactor: Use language.visitorKeys and check for non-JS SourceCode

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1143,7 +1143,7 @@ function runRules(
     });
 
     const eventGenerator = new NodeEventGenerator(emitter, {
-        visitorKeys: sourceCode.visitorKeys,
+        visitorKeys: sourceCode.visitorKeys ?? language.visitorKeys,
         fallback: Traverser.getKeys,
         matchClass: language.matchesSelectorClass ?? (() => false),
         nodeTypeKey: language.nodeTypeKey
@@ -1711,8 +1711,13 @@ class Linter {
             /*
              * If the given source code object as the first argument does not have scopeManager, analyze the scope.
              * This is for backward compatibility (SourceCode is frozen so it cannot rebind).
+             *
+             * We check explicitly for `null` to ensure that this is a JS-flavored language.
+             * For non-JS languages we don't want to do this.
+             *
+             * TODO: Remove this check when we stop exporting the `SourceCode` object.
              */
-            if (!slots.lastSourceCode.scopeManager) {
+            if (slots.lastSourceCode.scopeManager === null) {
                 slots.lastSourceCode = new SourceCode({
                     text: slots.lastSourceCode.text,
                     ast: slots.lastSourceCode.ast,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Small refactors.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Updated so `Linter` will fall back to `language.visitorKeys` if `sourceCode.visitorKeys` is not present.
- Updated `Linter` with a better check for an uninitialized `SourceCode` object.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
