### PR TITLE
fix: destructuring in catch clause in `no-unused-vars`

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -340,12 +340,12 @@ module.exports = {
         /**
          * Determines if a variable has a sibling rest property
          * @param {Variable} variable eslint-scope variable object.
-         * @returns {boolean} True if the variable is exported, false if not.
+         * @returns {boolean} True if the variable has a sibling rest property, false if not.
          * @private
          */
         function hasRestSpreadSibling(variable) {
             if (config.ignoreRestSiblings) {
-                const hasRestSiblingDefinition = variable.defs.some(def => hasRestSibling(def.name.parent));
+                const hasRestSiblingDefinition = variable.identifiers.some(identifier => hasRestSibling(identifier.parent));
                 const hasRestSiblingReference = variable.references.some(ref => hasRestSibling(ref.identifier.parent));
 
                 return hasRestSiblingDefinition || hasRestSiblingReference;
@@ -726,19 +726,20 @@ module.exports = {
                     if (def) {
                         const type = def.type;
                         const refUsedInArrayPatterns = variable.references.some(ref => ref.identifier.parent.type === "ArrayPattern");
+                        const defNameNode = variable.identifiers[0];
 
                         // skip elements of array destructuring patterns
                         if (
                             (
-                                def.name.parent.type === "ArrayPattern" ||
+                                defNameNode.parent.type === "ArrayPattern" ||
                                 refUsedInArrayPatterns
                             ) &&
                             config.destructuredArrayIgnorePattern &&
-                            config.destructuredArrayIgnorePattern.test(def.name.name)
+                            config.destructuredArrayIgnorePattern.test(defNameNode.name)
                         ) {
                             if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
                                 context.report({
-                                    node: def.name,
+                                    node: defNameNode,
                                     messageId: "usedIgnoredVar",
                                     data: getUsedIgnoredMessageData(variable, "array-destructure")
                                 });
@@ -762,10 +763,10 @@ module.exports = {
                             }
 
                             // skip ignored parameters
-                            if (config.caughtErrorsIgnorePattern && config.caughtErrorsIgnorePattern.test(def.name.name)) {
+                            if (config.caughtErrorsIgnorePattern && config.caughtErrorsIgnorePattern.test(defNameNode.name)) {
                                 if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
                                     context.report({
-                                        node: def.name,
+                                        node: defNameNode,
                                         messageId: "usedIgnoredVar",
                                         data: getUsedIgnoredMessageData(variable, "catch-clause")
                                     });
@@ -786,10 +787,10 @@ module.exports = {
                             }
 
                             // skip ignored parameters
-                            if (config.argsIgnorePattern && config.argsIgnorePattern.test(def.name.name)) {
+                            if (config.argsIgnorePattern && config.argsIgnorePattern.test(defNameNode.name)) {
                                 if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
                                     context.report({
-                                        node: def.name,
+                                        node: defNameNode,
                                         messageId: "usedIgnoredVar",
                                         data: getUsedIgnoredMessageData(variable, "parameter")
                                     });
@@ -799,16 +800,16 @@ module.exports = {
                             }
 
                             // if "args" option is "after-used", skip used variables
-                            if (config.args === "after-used" && astUtils.isFunction(def.name.parent) && !isAfterLastUsedArg(variable)) {
+                            if (config.args === "after-used" && astUtils.isFunction(defNameNode.parent) && !isAfterLastUsedArg(variable)) {
                                 continue;
                             }
                         } else {
 
                             // skip ignored variables
-                            if (config.varsIgnorePattern && config.varsIgnorePattern.test(def.name.name)) {
+                            if (config.varsIgnorePattern && config.varsIgnorePattern.test(defNameNode.name)) {
                                 if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
                                     context.report({
-                                        node: def.name,
+                                        node: defNameNode,
                                         messageId: "usedIgnoredVar",
                                         data: getUsedIgnoredMessageData(variable, "variable")
                                     });

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -345,7 +345,7 @@ module.exports = {
          */
         function hasRestSpreadSibling(variable) {
             if (config.ignoreRestSiblings) {
-                const hasRestSiblingDefinition = variable.identifiers.some(identifier => hasRestSibling(identifier.parent));
+                const hasRestSiblingDefinition = variable.defs.some(def => hasRestSibling(def.name.parent));
                 const hasRestSiblingReference = variable.references.some(ref => hasRestSibling(ref.identifier.parent));
 
                 return hasRestSiblingDefinition || hasRestSiblingReference;
@@ -726,20 +726,19 @@ module.exports = {
                     if (def) {
                         const type = def.type;
                         const refUsedInArrayPatterns = variable.references.some(ref => ref.identifier.parent.type === "ArrayPattern");
-                        const defNameNode = variable.identifiers[0];
 
                         // skip elements of array destructuring patterns
                         if (
                             (
-                                defNameNode.parent.type === "ArrayPattern" ||
+                                def.name.parent.type === "ArrayPattern" ||
                                 refUsedInArrayPatterns
                             ) &&
                             config.destructuredArrayIgnorePattern &&
-                            config.destructuredArrayIgnorePattern.test(defNameNode.name)
+                            config.destructuredArrayIgnorePattern.test(def.name.name)
                         ) {
                             if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
                                 context.report({
-                                    node: defNameNode,
+                                    node: def.name,
                                     messageId: "usedIgnoredVar",
                                     data: getUsedIgnoredMessageData(variable, "array-destructure")
                                 });
@@ -763,10 +762,10 @@ module.exports = {
                             }
 
                             // skip ignored parameters
-                            if (config.caughtErrorsIgnorePattern && config.caughtErrorsIgnorePattern.test(defNameNode.name)) {
+                            if (config.caughtErrorsIgnorePattern && config.caughtErrorsIgnorePattern.test(def.name.name)) {
                                 if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
                                     context.report({
-                                        node: defNameNode,
+                                        node: def.name,
                                         messageId: "usedIgnoredVar",
                                         data: getUsedIgnoredMessageData(variable, "catch-clause")
                                     });
@@ -787,10 +786,10 @@ module.exports = {
                             }
 
                             // skip ignored parameters
-                            if (config.argsIgnorePattern && config.argsIgnorePattern.test(defNameNode.name)) {
+                            if (config.argsIgnorePattern && config.argsIgnorePattern.test(def.name.name)) {
                                 if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
                                     context.report({
-                                        node: defNameNode,
+                                        node: def.name,
                                         messageId: "usedIgnoredVar",
                                         data: getUsedIgnoredMessageData(variable, "parameter")
                                     });
@@ -800,16 +799,16 @@ module.exports = {
                             }
 
                             // if "args" option is "after-used", skip used variables
-                            if (config.args === "after-used" && astUtils.isFunction(defNameNode.parent) && !isAfterLastUsedArg(variable)) {
+                            if (config.args === "after-used" && astUtils.isFunction(def.name.parent) && !isAfterLastUsedArg(variable)) {
                                 continue;
                             }
                         } else {
 
                             // skip ignored variables
-                            if (config.varsIgnorePattern && config.varsIgnorePattern.test(defNameNode.name)) {
+                            if (config.varsIgnorePattern && config.varsIgnorePattern.test(def.name.name)) {
                                 if (config.reportUsedIgnorePattern && isUsedVariable(variable)) {
                                     context.report({
-                                        node: defNameNode,
+                                        node: def.name,
                                         messageId: "usedIgnoredVar",
                                         data: getUsedIgnoredMessageData(variable, "variable")
                                     });

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "cross-spawn": "^7.0.2",
     "debug": "^4.3.2",
     "escape-string-regexp": "^4.0.0",
-    "eslint-scope": "^8.0.1",
+    "eslint-scope": "eslint/eslint-scope#prepare-for-eslint-18636",
     "eslint-visitor-keys": "^4.0.0",
     "espree": "^10.1.0",
     "esquery": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "cross-spawn": "^7.0.2",
     "debug": "^4.3.2",
     "escape-string-regexp": "^4.0.0",
-    "eslint-scope": "eslint/eslint-scope#prepare-for-eslint-18636",
+    "eslint-scope": "^8.0.2",
     "eslint-visitor-keys": "^4.0.0",
     "espree": "^10.1.0",
     "esquery": "^1.5.0",

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -270,6 +270,11 @@ ruleTester.run("no-unused-vars", rule, {
             options: [{ destructuredArrayIgnorePattern: "^_", ignoreRestSiblings: true }],
             languageOptions: { ecmaVersion: 2018 }
         },
+        {
+            code: "try {} catch ([firstError]) {}",
+            options: [{ destructuredArrayIgnorePattern: "Error$" }],
+            languageOptions: { ecmaVersion: 2015 }
+        },
 
         // for-in loops (see #2342)
         "(function(obj) { var name; for ( name in obj ) return; })({});",
@@ -316,6 +321,16 @@ ruleTester.run("no-unused-vars", rule, {
             code: "try{}catch(ignoreErr){}",
             options: [{ caughtErrors: "all", caughtErrorsIgnorePattern: "^ignore" }]
         },
+        {
+            code: "try {} catch ({ message, stack }) {}",
+            options: [{ caughtErrorsIgnorePattern: "message|stack" }],
+            languageOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "try {} catch ({ errors: [firstError] }) {}",
+            options: [{ caughtErrorsIgnorePattern: "Error$" }],
+            languageOptions: { ecmaVersion: 2015 }
+        },
 
         // caughtErrors with other combinations
         {
@@ -326,6 +341,11 @@ ruleTester.run("no-unused-vars", rule, {
         // Using object rest for variable omission
         {
             code: "const data = { type: 'coords', x: 1, y: 2 };\nconst { type, ...coords } = data;\n console.log(coords);",
+            options: [{ ignoreRestSiblings: true }],
+            languageOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: "try {} catch ({ foo, ...bar }) { console.log(bar); }",
             options: [{ ignoreRestSiblings: true }],
             languageOptions: { ecmaVersion: 2018 }
         },
@@ -1675,6 +1695,30 @@ c = foo1`,
             errors: [usedIgnoredError("_err", ". Used caught errors must not match /^_/u")]
         },
         {
+            code: "try {} catch ({ message }) { console.error(message); }",
+            options: [{ caughtErrorsIgnorePattern: "message", reportUsedIgnorePattern: true }],
+            languageOptions: { ecmaVersion: 2015 },
+            errors: [usedIgnoredError("message", ". Used caught errors must not match /message/u")]
+        },
+        {
+            code: "try {} catch ([_a, _b]) { doSomething(_a, _b); }",
+            options: [{ caughtErrorsIgnorePattern: "^_", reportUsedIgnorePattern: true }],
+            languageOptions: { ecmaVersion: 6 },
+            errors: [
+                usedIgnoredError("_a", ". Used caught errors must not match /^_/u"),
+                usedIgnoredError("_b", ". Used caught errors must not match /^_/u")
+            ]
+        },
+        {
+            code: "try {} catch ([_a, _b]) { doSomething(_a, _b); }",
+            options: [{ destructuredArrayIgnorePattern: "^_", reportUsedIgnorePattern: true }],
+            languageOptions: { ecmaVersion: 6 },
+            errors: [
+                usedIgnoredError("_a", ". Used elements of array destructuring must not match /^_/u"),
+                usedIgnoredError("_b", ". Used elements of array destructuring must not match /^_/u")
+            ]
+        },
+        {
             code: `
 try {
 } catch (_) {
@@ -1702,6 +1746,35 @@ try {
             errors: [
                 {
                     message: "'_' is assigned a value but never used. Allowed unused caught errors must match /ignored/u."
+                }
+            ]
+        },
+        {
+            code: "try {} catch ({ message, errors: [firstError] }) {}",
+            options: [{ caughtErrorsIgnorePattern: "foo" }],
+            languageOptions: { ecmaVersion: 2015 },
+            errors: [
+                {
+                    message: "'message' is defined but never used. Allowed unused caught errors must match /foo/u.",
+                    column: 17,
+                    endColumn: 24
+                },
+                {
+                    message: "'firstError' is defined but never used. Allowed unused caught errors must match /foo/u.",
+                    column: 35,
+                    endColumn: 45
+                }
+            ]
+        },
+        {
+            code: "try {} catch ({ stack: $ }) { $ = 'Something broke: ' + $; }",
+            options: [{ caughtErrorsIgnorePattern: "\\w" }],
+            languageOptions: { ecmaVersion: 2015 },
+            errors: [
+                {
+                    message: "'$' is assigned a value but never used. Allowed unused caught errors must match /\\w/u.",
+                    column: 31,
+                    endColumn: 32
                 }
             ]
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v22.3.0
npm version: v10.8.1
Local ESLint version: v9.6.0 (Currently used)
Global ESLint version: Not found
Operating System: darwin 23.5.0

**What parser are you using (place an "X" next to just one item)?**

[X] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
// All config is inline
export default [];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint no-unused-vars: ["error", {
    "caughtErrorsIgnorePattern": "message",
    "destructuredArrayIgnorePattern": "^_",
    "ignoreRestSiblings": true
}]*/

try {
} catch ({ message }) {
}

try {
} catch ({ errors: [_firstError] }) {
}

try {
} catch ({ stack, ...error }) {
  console.log(error);
}
```

[**Playground link**](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tdW51c2VkLXZhcnM6IFtcImVycm9yXCIsIHtcbiAgICBcImNhdWdodEVycm9yc0lnbm9yZVBhdHRlcm5cIjogXCJtZXNzYWdlXCIsXG4gICAgXCJkZXN0cnVjdHVyZWRBcnJheUlnbm9yZVBhdHRlcm5cIjogXCJeX1wiLFxuICAgIFwiaWdub3JlUmVzdFNpYmxpbmdzXCI6IHRydWVcbn1dKi9cblxudHJ5IHtcbn0gY2F0Y2ggKHsgbWVzc2FnZSB9KSB7XG59XG5cbnRyeSB7XG59IGNhdGNoICh7IGVycm9yczogW19maXJzdEVycm9yXSB9KSB7XG59XG5cbnRyeSB7XG59IGNhdGNoICh7IHN0YWNrLCAuLi5lcnJvciB9KSB7XG4gIGNvbnNvbGUubG9nKGVycm9yKTtcbn0iLCJvcHRpb25zIjp7InJ1bGVzIjp7fSwibGFuZ3VhZ2VPcHRpb25zIjp7InNvdXJjZVR5cGUiOiJtb2R1bGUiLCJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319fX19)


**What did you expect to happen?**

No problems should be reported.

* In the first catch clause, `message` should be allowed because of `"caughtErrorsIgnorePattern": "message"`.
* In the second catch clause, `_firstError` should be allowed because of `"destructuredArrayIgnorePattern": "^_"`.
* In the last catch clause, `stack` should be allowed because of `"ignoreRestSiblings": true`.

**What actually happened? Please include the actual, raw output from ESLint.**

Problems were reported:

```console
8:12  'message' is defined but never used. Allowed unused caught errors must match /message/u.  (no-unused-vars)
12:21 '_firstError' is defined but never used. Allowed unused caught errors must match /message/u.  (no-unused-vars)
16:12 'stack' is defined but never used. Allowed unused caught errors must match /message/u.  (no-unused-vars)
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

<s>Fixed the logic that locates identifier names to account for destructured variables in a catch clause.</s> Updated `eslint-scope` to upcoming version 8.0.2; added unit tests.

#### Is there anything you'd like reviewers to focus on?

This bug already existed before #18608 and #18609, it's not a regression.

<!-- markdownlint-disable-file MD004 -->
