### PR TITLE
docs: `loadESLint` does not support option `cwd`

### DIFF
--- a/docs/src/integrate/nodejs-api.md
+++ b/docs/src/integrate/nodejs-api.md
@@ -481,9 +481,6 @@ const { loadESLint } = require("eslint");
 // loads the default ESLint that the CLI would use based on process.cwd()
 const DefaultESLint = await loadESLint();
 
-// loads the default ESLint that the CLI would use based on the provided cwd
-const CwdDefaultESLint = await loadESLint({ cwd: "/foo/bar" });
-
 // loads the flat config version specifically
 const FlatESLint = await loadESLint({ useFlatConfig: true });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR removes a code example from the `loadESLint()` API docs. The example was using an unsupported option `cwd`, suggesting that `loadESLint()` could be used to determine the `ESLint` constructor for a specified directory.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
