### PR TITLE
refactor: don't use `parent` property in `NodeEventGenerator`

### DIFF
--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -334,10 +334,8 @@ class NodeEventGenerator {
      * @returns {void}
      */
     enterNode(node) {
-        if (node.parent) {
-            this.currentAncestry.unshift(node.parent);
-        }
         this.applySelectors(node, false);
+        this.currentAncestry.unshift(node);
     }
 
     /**
@@ -346,8 +344,8 @@ class NodeEventGenerator {
      * @returns {void}
      */
     leaveNode(node) {
-        this.applySelectors(node, true);
         this.currentAncestry.shift();
+        this.applySelectors(node, true);
     }
 }
 

--- a/tests/lib/linter/node-event-generator.js
+++ b/tests/lib/linter/node-event-generator.js
@@ -104,8 +104,7 @@ describe("NodeEventGenerator", () => {
             const generator = new NodeEventGenerator(emitter, STANDARD_ESQUERY_OPTION);
 
             Traverser.traverse(ast, {
-                enter(node, parent) {
-                    node.parent = parent;
+                enter(node) {
                     generator.enterNode(node);
                 },
                 leave(node) {
@@ -366,8 +365,7 @@ describe("NodeEventGenerator", () => {
 
             Traverser.traverse(ast, {
                 visitorKeys,
-                enter(node, parent) {
-                    node.parent = parent;
+                enter(node) {
                     generator.enterNode(node);
                 },
                 leave(node) {

--- a/tests/lib/linter/node-event-generator.js
+++ b/tests/lib/linter/node-event-generator.js
@@ -70,12 +70,16 @@ describe("NodeEventGenerator", () => {
         });
 
         it("should generate events for AST queries", () => {
-            const dummyNode = { type: "Bar", parent: { type: "Foo" } };
+            const dummyParent = { type: "Foo" };
+            const dummyNode = { type: "Bar" };
 
+            generator.enterNode(dummyParent);
             generator.enterNode(dummyNode);
 
-            assert(emitter.emit.calledTwice);
+            assert(emitter.emit.calledThrice);
+            assert(emitter.emit.calledWith("Foo", dummyParent));
             assert(emitter.emit.calledWith("Foo > Bar", dummyNode));
+            assert(emitter.emit.calledWith("Bar", dummyNode));
         });
     });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Refs https://github.com/eslint/eslint/issues/16999, https://github.com/eslint/json/pull/4#issuecomment-2208674059

With the current version of ESLint, selectors like `Element > String` or `Element + Element` don't work with the `@eslint/json` language plugin as ESLint passes an empty ancestry to esquery because the calculations in `NodeEventGenerator` are based on the `parent` property of nodes, but JSON AST nodes don't have this property.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refactored `NodeEventGenerator` to not use the `parent` property of nodes because language plugins are not required to produce this property in AST.

The code change is that, instead of adding node's parent to the ancestry when entering the node, `enterNode` now adds the node itself to the ancestry for subsequent calls of `enterNode` for the node's subtree.  

#### Is there anything you'd like reviewers to focus on?


<!-- markdownlint-disable-file MD004 -->
