### PR TITLE
feat: Set sourceType in defaultConfig based on user's module type

### DIFF
--- a/lib/config/default-config.js
+++ b/lib/config/default-config.js
@@ -10,10 +10,30 @@
 //-----------------------------------------------------------------------------
 
 const Rules = require("../rules");
+const { resolve } = require("node:path");
+const fs = require("node:fs");
 
 //-----------------------------------------------------------------------------
 // Helpers
 //-----------------------------------------------------------------------------
+
+/**
+ * Retrieves the "type" field value from the project's package.json file.
+ * If the "type" field is not present, returns "module" as the default type.
+ * @returns {string} The type specified in package.json, or "module" if not specified or on error.
+ */
+function getProjectType() {
+    const cwd = process.cwd();
+    const packageJsonPath = resolve(cwd, "package.json");
+
+    try {
+        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+
+        return pkg.type || "module";
+    } catch {
+        return "module";
+    }
+}
 
 exports.defaultConfig = [
     {
@@ -43,7 +63,7 @@ exports.defaultConfig = [
         },
         language: "@/js",
         languageOptions: {
-            sourceType: "module",
+            sourceType: getProjectType(),
             ecmaVersion: "latest",
             parser: require("espree"),
             parserOptions: {}
@@ -63,7 +83,14 @@ exports.defaultConfig = [
 
     // intentionally empty config to ensure these files are globbed by default
     {
-        files: ["**/*.js", "**/*.mjs"]
+        files: ["**/*.js"]
+    },
+    {
+        files: ["**/*.mjs"],
+        languageOptions: {
+            sourceType: "module",
+            ecmaVersion: "latest"
+        }
     },
     {
         files: ["**/*.cjs"],

--- a/tests/lib/config/default-config.js
+++ b/tests/lib/config/default-config.js
@@ -1,0 +1,28 @@
+/**
+ * @fileoverview Tests for defaultConfig
+ */
+
+"use strict";
+
+//-----------------------------------------------------------------------------
+// Requirements
+//-----------------------------------------------------------------------------
+
+const { FlatConfigArray } = require("../../../lib/config/flat-config-array");
+const assert = require("chai").assert;
+
+//-----------------------------------------------------------------------------
+// Tests
+//-----------------------------------------------------------------------------
+
+describe("defaultConfig", () => {
+    it("should default to 'module' as sourceType if not specified in package.json", () => {
+        const configs = new FlatConfigArray([]);
+
+        configs.normalizeSync();
+
+        const config = configs.getConfig("foo.js");
+
+        assert.strictEqual("module", config.languageOptions.sourceType);
+    });
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->
Hello,I have modified the default value of sourceType in defaultConfig within lib/config/default-config.js. Previously, the default value was "module". With my modification, it now reads the type field from the package.json in the current working directory and sets sourceType to that value. If type is not specified in package.json, it defaults to "module". I believe this change better aligns with the Node.js project conventions. In the previous version, the default value of sourceType was "module", which could cause issues such as top-level await not throwing an error in CommonJS module files. With this change, simply adding the type field in package.json will set the default sourceType to the correct value.

Additionally, I have added a test file to verify that sourceType is correctly set to "module" when the type field is not specified in package.json.

#### What changes did you make? (Give an overview)


#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
