### PR TITLE
docs: Updated configure/parser.md about refering external config files

### DIFF
--- a/docs/src/use/configure/parser.md
+++ b/docs/src/use/configure/parser.md
@@ -68,6 +68,33 @@ export default [
 ];
 ```
 
+Parsers also refer external config files. Here's an example of using `babel.config.json` for Babel ESlint parser:
+
+```json
+// babel.config.json
+{
+     presets: ["@babel/preset-env"]
+}
+```
+
+```js
+// eslint.config.js
+import babelParser from "@babel/eslint-parser";
+
+export default [
+    {
+        languageOptions: {
+            parser: babelParser,
+            parserOptions: {
+                babelOptions: {
+                  configFile: "./babel.config.json"
+                }
+            }
+        }
+    }
+];
+```
+
 ::: tip
 In addition to the options specified in `languageOptions.parserOptions`, ESLint also passes `ecmaVersion` and `sourceType` to all parsers. This allows custom parsers to understand the context in which ESLint is evaluating JavaScript code.
 :::


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
As ESLint provided an example implementation of Babel parser, having a section for refering `babel.config.json` in `eslint.config.js` ease out developer's understanding and upgrading the existing systems. This PR will provision those extra details.

#### Is there anything you'd like reviewers to focus on?
No
<!-- markdownlint-disable-file MD004 -->
