### PR TITLE
fix: Throw error when invalid flags passed

### DIFF
--- a/docs/src/_data/flags.js
+++ b/docs/src/_data/flags.js
@@ -1,0 +1,20 @@
+/**
+ * @fileoverview Convenience helper for feature flags.
+ * @author Nicholas C. Zakas
+ */
+
+"use strict";
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+module.exports = function() {
+
+    const { activeFlags, inactiveFlags } = require("../../../lib/shared/flags");
+
+    return {
+        active: Object.fromEntries([...activeFlags]),
+        inactive: Object.fromEntries([...inactiveFlags])
+    };
+};

--- a/docs/src/pages/flags.md
+++ b/docs/src/pages/flags.md
@@ -1,0 +1,107 @@
+---
+title: Feature Flags
+permalink: /flags/index.html
+eleventyNavigation:
+    key: feature flags
+    parent: use eslint
+    title: Feature Flags
+    order: 6
+---
+
+ESLint ships experimental and future breaking changes behind feature flags to let users opt-in to behavior they want. Flags are used in these situations:
+
+1. When a feature is experimental and not ready to be enabled for everyone.
+1. When a feature is a breaking change that will be formally merged in the next major release, but users may opt-in to that behavior prior to the next major release.
+
+## Flag Prefixes
+
+The prefix of a flag indicates its status:
+
+* `unstable_` indicates that the feature is experimental and the implementation may change before the feature is stabilized. This is a "use at your own risk" feature.
+* `v##_` indicates that the feature is stabilized and will be available in the next major release. For example, `v10_some_feature` indicates that this is a breaking change that will be formally released in ESLint v10.0.0. These flags are removed each major release.
+
+A feature may move from unstable to stable without a major release if it is a non-breaking change.
+
+## Active Flags
+
+The following flags are currently available for use in ESLint.
+
+<table>
+    <thead>
+        <tr>
+            <th>Flag</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+{%- for name, desc in flags.active -%}
+        <tr><td><code>{{name}}</code></td><td>{{desc}}</td></tr>
+{%- endfor -%}
+    </tbody>
+</table>
+
+## Inactive Flags
+
+The following flags were once used but are no longer active.
+
+<table>
+    <thead>
+        <tr>
+            <th>Flag</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+{%- for name, desc in flags.inactive -%}
+        <tr><td><code>{{name}}</code></td><td>{{desc}}</td></tr>
+{%- endfor -%}
+    </tbody>
+</table>
+
+## How to Use Feature Flags
+
+Because feature flags are strictly opt-in, you need to manually enable the flags that you want.
+
+### Enable Feature Flags with the CLI
+
+On the command line, you can specify feature flags using the `--flag` option. You can specify as many flags as you'd like:
+
+```shell
+npx eslint --flag flag_one --flag flag_two file.js
+```
+
+### Enable Feature Flags with the API
+
+When using the API, you can pass a `flags` array to both the `ESLint` and `Linter` classes:
+
+```js
+const { ESLint, Linter } = require("eslint");
+
+const eslint = new ESLint({
+    flags: ["flag_one", "flag_two"]
+});
+
+const linter = new Linter({
+    flags: ["flag_one", "flag_two"]
+});
+```
+
+### Enable Feature Flags in VS Code
+
+To enable flags in the VS Code ESLint Extension for the editor, specify the flags you'd like in the `eslint.options` setting in your `settings.json` file:
+
+```json
+{
+  "eslint.options": { "flags": ["flag_one", "flag_two"] }
+}
+```
+
+To enable flags in the VS Code ESLint Extension for a lint task, specify the `eslint.lintTask.options` settings:
+
+```json
+{
+  "eslint.lintTask.options": "--flag flag_one --flag flag_two ."
+}
+```
+
+{# <!-- markdownlint-disable-file MD046 --> #}

--- a/docs/src/use/formatters/index.md
+++ b/docs/src/use/formatters/index.md
@@ -4,7 +4,7 @@ eleventyNavigation:
     key: formatters
     parent: use eslint
     title: Formatters Reference
-    order: 6
+    order: 7
 edit_link: https://github.com/eslint/eslint/edit/main/templates/formatter-examples.md.ejs
 ---
 

--- a/docs/src/use/integrations.md
+++ b/docs/src/use/integrations.md
@@ -4,7 +4,7 @@ eleventyNavigation:
     key: integrations
     parent: use eslint
     title: Integrations
-    order: 7
+    order: 8
 
 ---
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -4,7 +4,7 @@ eleventyNavigation:
     key: migrate to v9
     parent: use eslint
     title: Migrate to v9.x
-    order: 7
+    order: 9
 
 ---
 

--- a/docs/src/use/troubleshooting/index.md
+++ b/docs/src/use/troubleshooting/index.md
@@ -4,7 +4,7 @@ eleventyNavigation:
     key: troubleshooting
     title: Troubleshooting
     parent: use eslint
-    order: 8
+    order: 10
 ---
 
 This page serves as a reference for common issues working with ESLint.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -26,7 +26,6 @@ const fs = require("node:fs"),
     { normalizeSeverityToString } = require("./shared/severity");
 const { Legacy: { naming } } = require("@eslint/eslintrc");
 const { ModuleImporter } = require("@humanwhocodes/module-importer");
-const { inactiveFlags, activeFlags } = require("./shared/flags");
 const debug = require("debug")("eslint:cli");
 
 //------------------------------------------------------------------------------
@@ -488,25 +487,6 @@ const cli = {
 
         const ActiveESLint = usingFlatConfig ? ESLint : LegacyESLint;
         const eslintOptions = await translateOptions(options, usingFlatConfig ? "flat" : "eslintrc");
-
-        if (eslintOptions.flags) {
-            debug("Checking for inactive flags");
-
-            for (const flag of eslintOptions.flags) {
-                if (inactiveFlags.has(flag)) {
-                    log.warn(`InactiveFlag: The '${flag}' flag is no longer active: ${inactiveFlags.get(flag)}`);
-                    continue;
-                }
-
-                if (activeFlags.has(flag)) {
-                    continue;
-                }
-
-                log.error(`InvalidFlag: The '${flag}' flag is invalid.`);
-                return 2;
-            }
-        }
-
         const engine = new ActiveESLint(eslintOptions);
         let results;
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -45,7 +45,7 @@ const { RuleValidator } = require("../config/rule-validator");
 const { assertIsRuleSeverity } = require("../config/flat-config-schema");
 const { normalizeSeverityToString } = require("../shared/severity");
 const jslang = require("../languages/js");
-const { activeFlags } = require("../shared/flags");
+const { activeFlags, inactiveFlags } = require("../shared/flags");
 const debug = require("debug")("eslint:linter");
 const MAX_AUTOFIX_PASSES = 10;
 const DEFAULT_PARSER_NAME = "espree";
@@ -1282,9 +1282,20 @@ class Linter {
      * @param {"flat"|"eslintrc"} [config.configType="flat"] the type of config used.
      */
     constructor({ cwd, configType = "flat", flags = [] } = {}) {
+
+        flags.forEach(flag => {
+            if (inactiveFlags.has(flag)) {
+                throw new Error(`The flag '${flag}' is inactive: ${inactiveFlags.get(flag)}`);
+            }
+
+            if (!activeFlags.has(flag)) {
+                throw new Error(`Unknown flag '${flag}'.`);
+            }
+        });
+
         internalSlotsMap.set(this, {
             cwd: normalizeCwd(cwd),
-            flags: flags.filter(flag => activeFlags.has(flag)),
+            flags,
             lastConfigArray: null,
             lastSourceCode: null,
             lastSuppressedMessages: [],

--- a/lib/shared/flags.js
+++ b/lib/shared/flags.js
@@ -9,7 +9,7 @@
  * @type {Map<string, string>}
  */
 const activeFlags = new Map([
-    ["test_only", "This flag is only used for testing."]
+    ["test_only", "Used only for testing."]
 ]);
 
 /**
@@ -17,7 +17,7 @@ const activeFlags = new Map([
  * @type {Map<string, string>}
  */
 const inactiveFlags = new Map([
-    ["test_only_old", "This flag is no longer used for testing."]
+    ["test_only_old", "Used only for testing."]
 ]);
 
 module.exports = {

--- a/templates/formatter-examples.md.ejs
+++ b/templates/formatter-examples.md.ejs
@@ -4,7 +4,7 @@ eleventyNavigation:
     key: formatters
     parent: use eslint
     title: Formatters Reference
-    order: 6
+    order: 7
 edit_link: https://github.com/eslint/eslint/edit/main/templates/formatter-examples.md.ejs
 ---
 

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -22,8 +22,7 @@ const assert = require("chai").assert,
     sinon = require("sinon"),
     fs = require("node:fs"),
     os = require("node:os"),
-    sh = require("shelljs"),
-    { inactiveFlags } = require("../../lib/shared/flags");
+    sh = require("shelljs");
 
 const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
 
@@ -1908,32 +1907,24 @@ describe("cli", () => {
 
             describe("--flag option", () => {
 
-                it("should emit a warning when an inactive flag is used", async () => {
+                it("should throw an error when an inactive flag is used", async () => {
                     const configPath = getFixturePath("eslint.config.js");
                     const filePath = getFixturePath("passing.js");
                     const input = `--flag test_only_old --config ${configPath} ${filePath}`;
-                    const exitCode = await cli.execute(input, null, true);
 
-                    sinon.assert.calledOnce(log.warn);
-
-                    const formattedOutput = log.warn.firstCall.args[0];
-
-                    assert.include(formattedOutput, `InactiveFlag: The 'test_only_old' flag is no longer active: ${inactiveFlags.get("test_only_old")}`);
-                    assert.strictEqual(exitCode, 0);
+                    stdAssert.rejects(async () => {
+                        await cli.execute(input, null, true);
+                    }, /The 'test_only_old' flag is inactive: Used only for testing\.*/u);
                 });
 
                 it("should error out when an unknown flag is used", async () => {
                     const configPath = getFixturePath("eslint.config.js");
                     const filePath = getFixturePath("passing.js");
                     const input = `--flag test_only_oldx --config ${configPath} ${filePath}`;
-                    const exitCode = await cli.execute(input, null, true);
 
-                    sinon.assert.calledOnce(log.error);
-
-                    const formattedOutput = log.error.firstCall.args[0];
-
-                    assert.include(formattedOutput, "InvalidFlag: The 'test_only_oldx' flag is invalid.");
-                    assert.strictEqual(exitCode, 2);
+                    stdAssert.rejects(async () => {
+                        await cli.execute(input, null, true);
+                    }, /Unknown flag 'test_only_old'\.*/u);
                 });
 
                 it("should not error when a valid flag is used", async () => {

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -1922,9 +1922,9 @@ describe("cli", () => {
                     const filePath = getFixturePath("passing.js");
                     const input = `--flag test_only_oldx --config ${configPath} ${filePath}`;
 
-                    stdAssert.rejects(async () => {
+                    await stdAssert.rejects(async () => {
                         await cli.execute(input, null, true);
-                    }, /Unknown flag 'test_only_old'\.*/u);
+                    }, /Unknown flag 'test_only_oldx'\./u);
                 });
 
                 it("should not error when a valid flag is used", async () => {

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -1912,9 +1912,9 @@ describe("cli", () => {
                     const filePath = getFixturePath("passing.js");
                     const input = `--flag test_only_old --config ${configPath} ${filePath}`;
 
-                    stdAssert.rejects(async () => {
+                    await stdAssert.rejects(async () => {
                         await cli.execute(input, null, true);
-                    }, /The 'test_only_old' flag is inactive: Used only for testing\.*/u);
+                    }, /The flag 'test_only_old' is inactive: Used only for testing\./u);
                 });
 
                 it("should error out when an unknown flag is used", async () => {

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -327,10 +327,12 @@ describe("ESLint", () => {
             assert.strictEqual(eslint.hasFlag("test_only"), true);
         });
 
-        it("should return false if the flag is present and inactive", () => {
-            eslint = new ESLint({ cwd: getFixturePath(), flags: ["test_only_old"] });
+        it("should throw an error if the flag is inactive", () => {
 
-            assert.strictEqual(eslint.hasFlag("test_only_old"), false);
+            assert.throws(() => {
+                eslint = new ESLint({ cwd: getFixturePath(), flags: ["test_only_old"] });
+            }, /The flag 'test_only_old' is inactive/u);
+
         });
 
         it("should return false if the flag is not present", () => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7803,11 +7803,18 @@ describe("Linter with FlatConfigArray", () => {
             );
         });
 
-        it("should return false if an inactive flag is present", () => {
-            assert.strictEqual(
-                new Linter({ configType: "flat", flags: ["test_only_old"] }).hasFlag("test_only_old"),
-                false
-            );
+        it("should throw an error if an inactive flag is present", () => {
+            assert.throws(() => {
+                // eslint-disable-next-line no-new -- needed for test
+                new Linter({ configType: "flat", flags: ["test_only_old"] });
+            }, /The flag 'test_only_old' is inactive: Used only for testing/u);
+        });
+
+        it("should throw an error if an unknown flag is present", () => {
+            assert.throws(() => {
+                // eslint-disable-next-line no-new -- needed for test
+                new Linter({ configType: "flat", flags: ["x_unknown"] });
+            }, /Unknown flag 'x_unknown'/u);
         });
 
         it("should return false if the flag is not present", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- `Linter` now validates `flags` and throws an error for any inactive or unknown flags. Previously, these flags were ignored, which made it difficult to track down problems.
- Added a new "Feature Flags" page that dynamically populates the available feature flags and shows how to use them.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
