### PR TITLE
feat: report duplicate allowed flags in `no-invalid-regexp`

### DIFF
--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -55,7 +55,7 @@ module.exports = {
             const temp = options.allowConstructorFlags.join("").replace(new RegExp(`[${validFlags}]`, "gu"), "");
 
             if (temp) {
-                allowedFlags = temp.split("");
+                allowedFlags = [...new Set(temp)];
             }
         }
 

--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -55,7 +55,7 @@ module.exports = {
             const temp = options.allowConstructorFlags.join("").replace(validFlags, "");
 
             if (temp) {
-                allowedFlags = new RegExp(`[${temp}]`, "gu");
+                allowedFlags = temp.split("");
             }
         }
 
@@ -154,13 +154,16 @@ module.exports = {
                     return;
                 }
 
-                let flags = getFlags(node);
+                const flags = getFlags(node);
+                let flagsToCheck = flags;
 
-                if (flags && allowedFlags) {
-                    flags = flags.replace(allowedFlags, "");
+                if (flags && allowedFlags && allowedFlags.length > 0) {
+                    allowedFlags.forEach(flag => {
+                        flagsToCheck = flagsToCheck.replace(new RegExp(flag, "u"), "");
+                    });
                 }
 
-                let message = validateRegExpFlags(flags);
+                let message = validateRegExpFlags(flagsToCheck);
 
                 if (message) {
                     report(node, message);

--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -159,7 +159,7 @@ module.exports = {
 
                 if (flags && allowedFlags && allowedFlags.length > 0) {
                     allowedFlags.forEach(flag => {
-                        flagsToCheck = flagsToCheck.replace(new RegExp(flag, "u"), "");
+                        flagsToCheck = flagsToCheck.replace(flag, "");
                     });
                 }
 

--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -10,7 +10,7 @@
 
 const RegExpValidator = require("@eslint-community/regexpp").RegExpValidator;
 const validator = new RegExpValidator();
-const validFlags = /[dgimsuvy]/gu;
+const validFlags = "dgimsuvy";
 const undefined1 = void 0;
 
 //------------------------------------------------------------------------------
@@ -49,10 +49,10 @@ module.exports = {
     create(context) {
 
         const options = context.options[0];
-        let allowedFlags = null;
+        let allowedFlags = [];
 
         if (options && options.allowConstructorFlags) {
-            const temp = options.allowConstructorFlags.join("").replace(validFlags, "");
+            const temp = options.allowConstructorFlags.join("").replace(new RegExp(`[${validFlags}]`, "gu"), "");
 
             if (temp) {
                 allowedFlags = temp.split("");
@@ -125,27 +125,25 @@ module.exports = {
         /**
          * Check syntax error in a given flags.
          * @param {string|null} flags The RegExp flags to validate.
+         * @param {string|null} flagsToCheck The RegExp invalid flags.
          * @returns {string|null} The syntax error.
          */
-        function validateRegExpFlags(flags) {
-            if (!flags) {
-                return null;
-            }
-            try {
-                validator.validateFlags(flags);
-            } catch {
-                return `Invalid flags supplied to RegExp constructor '${flags}'`;
-            }
+        function validateRegExpFlags(flags, flagsToCheck) {
 
             /*
              * `regexpp` checks the combination of `u` and `v` flags when parsing `Pattern` according to `ecma262`,
              * but this rule may check only the flag when the pattern is unidentifiable, so check it here.
              * https://tc39.es/ecma262/multipage/text-processing.html#sec-parsepattern
              */
-            if (flags.includes("u") && flags.includes("v")) {
+            if (flags && flags.includes("u") && flags.includes("v")) {
                 return "Regex 'u' and 'v' flags cannot be used together";
             }
-            return null;
+
+            if (!flagsToCheck) {
+                return null;
+            }
+
+            return `Invalid flags supplied to RegExp constructor '${flagsToCheck}'`;
         }
 
         return {
@@ -156,14 +154,15 @@ module.exports = {
 
                 const flags = getFlags(node);
                 let flagsToCheck = flags;
+                const allFlags = allowedFlags.length > 0 ? validFlags.split("").concat(allowedFlags) : validFlags.split("");
 
-                if (flags && allowedFlags && allowedFlags.length > 0) {
-                    allowedFlags.forEach(flag => {
+                if (flags) {
+                    allFlags.forEach(flag => {
                         flagsToCheck = flagsToCheck.replace(flag, "");
                     });
                 }
 
-                let message = validateRegExpFlags(flagsToCheck);
+                let message = validateRegExpFlags(flags, flagsToCheck);
 
                 if (message) {
                     report(node, message);

--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -129,6 +129,15 @@ module.exports = {
          * @returns {string|null} The syntax error.
          */
         function validateRegExpFlags(flags, flagsToCheck) {
+            const flagsToReport = [];
+
+            if (typeof flags === "string") {
+                for (const flag of flags) {
+                    if (flagsToCheck.includes(flag)) {
+                        flagsToReport.push(flag);
+                    }
+                }
+            }
 
             /*
              * `regexpp` checks the combination of `u` and `v` flags when parsing `Pattern` according to `ecma262`,
@@ -143,7 +152,7 @@ module.exports = {
                 return null;
             }
 
-            return `Invalid flags supplied to RegExp constructor '${flagsToCheck}'`;
+            return `Invalid flags supplied to RegExp constructor '${flagsToReport.join("")}'`;
         }
 
         return {

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -214,6 +214,51 @@ ruleTester.run("no-invalid-regexp", rule, {
             }]
         },
         {
+            code: "new RegExp('.', 'aa');",
+            options: [{ allowConstructorFlags: ["a"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'a'" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "new RegExp('.', 'aA');",
+            options: [{ allowConstructorFlags: ["a"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'A'" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "new RegExp('.', 'aaz');",
+            options: [{ allowConstructorFlags: ["a", "z"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'a'" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "new RegExp('.', 'azz');",
+            options: [{ allowConstructorFlags: ["a", "z"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'z'" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "new RegExp('.', 'aga');",
+            options: [{ allowConstructorFlags: ["a"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'ga'" },
+                type: "NewExpression"
+            }]
+        },
+        {
             code: "new RegExp(')');",
             errors: [{
                 messageId: "regexMessage",

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -218,7 +218,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid flags supplied to RegExp constructor 'a'" },
+                data: { message: "Invalid flags supplied to RegExp constructor 'aa'" },
                 type: "NewExpression"
             }]
         },
@@ -236,7 +236,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a", "z"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid flags supplied to RegExp constructor 'a'" },
+                data: { message: "Invalid flags supplied to RegExp constructor 'aa'" },
                 type: "NewExpression"
             }]
         },
@@ -245,7 +245,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a", "z"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid flags supplied to RegExp constructor 'z'" },
+                data: { message: "Invalid flags supplied to RegExp constructor 'zz'" },
                 type: "NewExpression"
             }]
         },
@@ -254,7 +254,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid flags supplied to RegExp constructor 'a'" },
+                data: { message: "Invalid flags supplied to RegExp constructor 'aa'" },
                 type: "NewExpression"
             }]
         },
@@ -263,7 +263,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["u"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid flags supplied to RegExp constructor 'u'" },
+                data: { message: "Invalid flags supplied to RegExp constructor 'uu'" },
                 type: "NewExpression"
             }]
         },

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -254,7 +254,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid flags supplied to RegExp constructor 'ga'" },
+                data: { message: "Invalid flags supplied to RegExp constructor 'a'" },
                 type: "NewExpression"
             }]
         },
@@ -263,7 +263,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["u"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid flags supplied to RegExp constructor 'uu'" },
+                data: { message: "Invalid flags supplied to RegExp constructor 'u'" },
                 type: "NewExpression"
             }]
         },

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -259,6 +259,15 @@ ruleTester.run("no-invalid-regexp", rule, {
             }]
         },
         {
+            code: "new RegExp('.', 'uu');",
+            options: [{ allowConstructorFlags: ["u"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'uu'" },
+                type: "NewExpression"
+            }]
+        },
+        {
             code: "new RegExp(')');",
             errors: [{
                 messageId: "regexMessage",

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -223,6 +223,15 @@ ruleTester.run("no-invalid-regexp", rule, {
             }]
         },
         {
+            code: "new RegExp('.', 'aa');",
+            options: [{ allowConstructorFlags: ["a", "a"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'aa'" },
+                type: "NewExpression"
+            }]
+        },
+        {
             code: "new RegExp('.', 'aA');",
             options: [{ allowConstructorFlags: ["a"] }],
             errors: [{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
`no-invalid-regexp` rule  doesn't report duplicate flags that are allowed by the `allowConstructorFlags` option.
```js
/*eslint no-invalid-regexp: ["error", { "allowConstructorFlags": ["a"] }]*/

new RegExp('.', 'aa'); // not reported
```
made the rule to report these flags
#### Is there anything you'd like reviewers to focus on?
Fixes #18748

<!-- markdownlint-disable-file MD004 -->
