### PR TITLE
feat: add new rule no-useless-arrow-block

### DIFF
--- a/docs/src/rules/no-useless-arrow-block.md
+++ b/docs/src/rules/no-useless-arrow-block.md
@@ -1,0 +1,72 @@
+---
+title: no-useless-arrow-block
+rule_type: suggestion
+---
+
+
+
+Arrow functions with a block body containing only a single return statement or a single expression statement can be simplified by removing the braces and, in the case of a return statement, the return keyword. This simplification can improve code readability.
+
+## Rule Details
+
+This rule aims to report and fix arrow functions that can have their block body simplified.
+
+Examples of **incorrect** code for this rule:
+
+::: incorrect
+
+```js
+/* eslint no-useless-arrow-block: "error" */
+
+const foo = () => { return 5; };
+
+const bar = (x) => { return x * 2; };
+
+const baz = () => { console.log('Hello'); };
+
+const qux = (a, b) => {
+  return a + b;
+};
+
+```
+
+:::
+
+Examples of **correct** code for this rule:
+
+::: correct
+
+```js
+/* eslint no-useless-arrow-block: "error" */
+
+const foo = () => 5;
+
+const bar = (x) => x * 2;
+
+const baz = () => console.log('Hello');
+
+const qux = (a, b) => a + b;
+
+const complex = () => {
+  doSomething();
+  return result;
+};
+
+const multiLine = () => (
+  veryLongExpression +
+  thatNeedsToBeWrapped
+);
+
+class MyClass {
+  static myMethod = () => {
+    this.doSomething();
+  };
+}
+
+```
+
+:::
+
+## When Not To Use It
+
+If you prefer consistency in all arrow function bodies using blocks, you can disable this rule. Also, if you use arrow functions with a single statement that you prefer to keep in block form for potential future expansion, you might want to disable this rule.

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -229,6 +229,7 @@ module.exports = new LazyLoadingRuleMap(Object.entries({
     "no-unused-private-class-members": () => require("./no-unused-private-class-members"),
     "no-unused-vars": () => require("./no-unused-vars"),
     "no-use-before-define": () => require("./no-use-before-define"),
+    "no-useless-arrow-block": () => require("./no-useless-arrow-block"),
     "no-useless-assignment": () => require("./no-useless-assignment"),
     "no-useless-backreference": () => require("./no-useless-backreference"),
     "no-useless-call": () => require("./no-useless-call"),

--- a/lib/rules/no-useless-arrow-block.js
+++ b/lib/rules/no-useless-arrow-block.js
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Rule to flag no-useless-arrow-block
+ * @author Leon Heess
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import('../shared/types').Rule} */
+module.exports = {
+    meta: {
+        type: "suggestion",
+
+        docs: {
+            description: "Disallow arrow functions with block parentheses where they are not needed",
+            recommended: false,
+            url: "https://eslint.org/docs/latest/rules/no-useless-arrow-block"
+        },
+
+        schema: [],
+
+        fixable: "code",
+
+        messages: {
+            uselessArrowBlock: "This arrow function could drop its block parentheses."
+        }
+    },
+    create(context) {
+        const sourceCode = context.sourceCode;
+
+        return {
+            ArrowFunctionExpression(node) {
+
+                // Check if the arrow function has a block body with a single statement
+                if (node.body.type !== "BlockStatement" || node.body.body.length !== 1) {
+                    return;
+                }
+
+                // Check if the arrow function has comments
+                if (sourceCode.getCommentsInside(node.body).length > 0) {
+                    return;
+                }
+
+                // Check if the arrow function has a newline in its body
+                if (sourceCode.getText(node.body).includes("\n")) {
+                    return;
+                }
+
+                // Check if the arrow function is a class method or static class property
+                if (node.parent.type === "MethodDefinition" || node.parent.static && (node.parent.type === "ClassProperty" || node.parent.type === "PropertyDefinition")) {
+                    return;
+                }
+
+                const statement = node.body.body[0];
+                let fixed;
+
+                if (statement.type === "ReturnStatement") {
+                    if (!statement.argument) {
+                        return;
+                    }
+                    fixed = sourceCode.getText(statement.argument);
+
+                    // Wrap objects in parentheses to avoid it being interpreted as a block
+                    if (statement.argument.type === "ObjectExpression") {
+                        fixed = `(${fixed})`;
+                    }
+                } else if (statement.type === "ExpressionStatement" && statement.expression.type !== "AssignmentExpression" && statement.expression.type !== "SequenceExpression") {
+                    fixed = sourceCode.getText(statement.expression);
+                } else {
+                    return;
+                }
+
+                context.report({
+                    node,
+                    messageId: "uselessArrowBlock",
+                    fix(fixer) {
+                        const arrowToken = sourceCode.getTokenBefore(node.body);
+                        const bodyClosingBrace = sourceCode.getLastToken(node.body);
+
+                        return fixer.replaceTextRange([arrowToken.range[1], bodyClosingBrace.range[1]], ` ${fixed}`);
+                    }
+                });
+            }
+        };
+    }
+};

--- a/tests/lib/rules/no-useless-arrow-block.js
+++ b/tests/lib/rules/no-useless-arrow-block.js
@@ -1,0 +1,124 @@
+/**
+ * @fileoverview Tests for no-useless--arrow-block rule
+ * @author Leon Heess
+ */
+
+"use strict";
+
+const rule = require("../../../lib/rules/no-useless-arrow-block");
+const RuleTester = require("../../../lib/rule-tester/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const languageOptions = {
+    ecmaVersion: 2022,
+    sourceType: "module"
+};
+
+const ruleTester = new RuleTester({ languageOptions });
+
+ruleTester.run("no-useless-arrow-block", rule, {
+    valid: [
+
+        // Basic cases
+        "() => 5",
+        "x => x * 2",
+        "(a, b) => a + b",
+        "() => ({ foo: 'bar' })",
+
+        // Multi-statement arrow functions
+        `
+          () => {
+            doSomething();
+            return result;
+          }
+        `,
+        `
+          () => {
+            if (condition) {
+              return x;
+            } else {
+              return y;
+            }
+          }
+        `,
+
+        // Arrow functions in class methods and object literals
+        "class MyClass { method = () => this.value; }",
+        "const obj = { method: () => 42 };",
+
+        // Async arrow functions
+        "async () => await promise",
+        `async () => {
+           const result = await promise;
+           return result;
+         }`,
+
+        // Arrow functions with destructuring
+        "({ x, y }) => x + y",
+        "([x, y]) => x + y",
+
+        // Arrow functions with default parameters
+        "(x = 1) => x * 2",
+
+        // Arrow functions with rest parameters
+        "(...args) => args.length",
+
+        // Comments
+        "() => { /* comment */ return 5; }",
+        "() => { return /* comment */ 5; }"
+    ],
+
+    invalid: [
+
+        // Basic cases
+        {
+            code: "() => { return 5; }",
+            output: "() => 5",
+            errors: [{ messageId: "uselessArrowBlock", type: "ArrowFunctionExpression" }]
+        },
+        {
+            code: "x => { return x * 2; }",
+            output: "x => x * 2",
+            errors: [{ messageId: "uselessArrowBlock", type: "ArrowFunctionExpression" }]
+        },
+        {
+            code: "(a, b) => { return a + b; }",
+            output: "(a, b) => a + b",
+            errors: [{ messageId: "uselessArrowBlock", type: "ArrowFunctionExpression" }]
+        },
+        {
+            code: "() => { console.log('Hello'); }",
+            output: "() => console.log('Hello')",
+            errors: [{ messageId: "uselessArrowBlock", type: "ArrowFunctionExpression" }]
+        },
+        {
+            code: "() => { return { foo: 'bar' }; }",
+            output: "() => ({ foo: 'bar' })",
+            errors: [{ messageId: "uselessArrowBlock", type: "ArrowFunctionExpression" }]
+        },
+
+        // Async arrow functions
+        {
+            code: "async () => { return await promise; }",
+            output: "async () => await promise",
+            errors: [{ messageId: "uselessArrowBlock", type: "ArrowFunctionExpression" }]
+        },
+
+        // Arrow functions with destructuring
+        {
+            code: "({ x, y }) => { return x + y; }",
+            output: "({ x, y }) => x + y",
+            errors: [{ messageId: "uselessArrowBlock", type: "ArrowFunctionExpression" }]
+        },
+
+        // Arrow functions with default parameters
+        {
+            code: "(x = 1) => { return x * 2; }",
+            output: "(x = 1) => x * 2",
+            errors: [{ messageId: "uselessArrowBlock", type: "ArrowFunctionExpression" }]
+        }
+    ]
+});


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What should the new rule do?**
Arrow functions with a block body containing only a single return statement or a single expression statement can be simplified by removing the braces and, in the case of a return statement, the return keyword. This simplification can improve code readability.

**What new ECMAScript feature does this rule relate to?**
Arrow function expressions

**What category of rule is this?**

[ ] Warns about a potential problem
[x] Suggests an alternate way of doing something

**Please provide some example JavaScript code that this rule will warn about:**

```js
/* eslint no-useless-arrow-block: "error" */

const foo = () => { return 5; };

const bar = (x) => { return x * 2; };

const baz = () => { console.log('Hello'); };

const qux = (a, b) => {
  return a + b;
};

```

**Why should this rule be included in ESLint (instead of a plugin)?**

It promotes code readability and simplicity by encouraging the use of concise arrow function syntax. Given that arrow functions are extremely widely used in modern JavaScript development, simplifying their syntax reduces visual clutter and makes the code easier to understand at a glance, aligning with ESLint's core goals.