### PR TITLE
refactor: Config class

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -11,7 +11,7 @@
 
 const { RuleValidator } = require("./rule-validator");
 const { flatConfigSchema, hasMethod } = require("./flat-config-schema");
-const {ObjectSchema} = require("@eslint/object-schema");
+const { ObjectSchema } = require("@eslint/config-array");
 
 //-----------------------------------------------------------------------------
 // Helpers

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -193,22 +193,15 @@ class Config {
         }
 
         // Check language value
-        if (typeof language === "string") {
-            const { pluginName, objectName: localLanguageName } = splitPluginIdentifier(language);
+        const { pluginName: languagePluginName, objectName: localLanguageName } = splitPluginIdentifier(language);
 
-            this.#languageName = language;
+        this.#languageName = language;
 
-            if (!plugins || !plugins[pluginName] || !plugins[pluginName].languages || !plugins[pluginName].languages[localLanguageName]) {
-                throw new TypeError(`Key "language": Could not find "${localLanguageName}" in plugin "${pluginName}".`);
-            }
-
-            this.language = plugins[pluginName].languages[localLanguageName];
-        } else if (typeof language === "object") {
-            this.#languageName = getObjectId(language);
-            this.language = language;
-        } else {
-            throw new TypeError("Key 'language' must be a string or an object.");
+        if (!plugins || !plugins[languagePluginName] || !plugins[languagePluginName].languages || !plugins[languagePluginName].languages[localLanguageName]) {
+            throw new TypeError(`Key "language": Could not find "${localLanguageName}" in plugin "${languagePluginName}".`);
         }
+
+        this.language = plugins[languagePluginName].languages[localLanguageName];
 
         // Validate language options
         if (this.languageOptions) {

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -1,0 +1,285 @@
+/**
+ * @fileoverview The `Config` class
+ * @author Nicholas C. Zakas
+ */
+
+"use strict";
+
+//-----------------------------------------------------------------------------
+// Requirements
+//-----------------------------------------------------------------------------
+
+const { RuleValidator } = require("./rule-validator");
+const { flatConfigSchema, hasMethod } = require("./flat-config-schema");
+const {ObjectSchema} = require("@eslint/object-schema");
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+const ruleValidator = new RuleValidator();
+
+const severities = new Map([
+    [0, 0],
+    [1, 1],
+    [2, 2],
+    ["off", 0],
+    ["warn", 1],
+    ["error", 2]
+]);
+
+/**
+ * Splits a plugin identifier in the form a/b/c into two parts: a/b and c.
+ * @param {string} identifier The identifier to parse.
+ * @returns {{objectName: string, pluginName: string}} The parts of the plugin
+ *      name.
+ */
+function splitPluginIdentifier(identifier) {
+    const parts = identifier.split("/");
+
+    return {
+        objectName: parts.pop(),
+        pluginName: parts.join("/")
+    };
+}
+
+/**
+ * Returns the name of an object in the config by reading its `meta` key.
+ * @param {Object} object The object to check.
+ * @returns {string?} The name of the object if found or `null` if there
+ *      is no name.
+ */
+function getObjectId(object) {
+
+    // first check old-style name
+    let name = object.name;
+
+    if (!name) {
+
+        if (!object.meta) {
+            return null;
+        }
+
+        name = object.meta.name;
+
+        if (!name) {
+            return null;
+        }
+    }
+
+    // now check for old-style version
+    let version = object.version;
+
+    if (!version) {
+        version = object.meta && object.meta.version;
+    }
+
+    // if there's a version then append that
+    if (version) {
+        return `${name}@${version}`;
+    }
+
+    return name;
+}
+
+/**
+ * Converts a languageOptions object to a JSON representation.
+ * @param {Record<string, any>} languageOptions The options to create a JSON
+ *     representation of.
+ * @param {string} objectKey The key of the object being converted.
+ * @returns {Record<string, any>} The JSON representation of the languageOptions.
+ * @throws {TypeError} If a function is found in the languageOptions.
+ */
+function languageOptionsToJSON(languageOptions, objectKey = "languageOptions") {
+
+    const result = {};
+
+    for (const [key, value] of Object.entries(languageOptions)) {
+        if (value) {
+            if (typeof value === "object") {
+                const name = getObjectId(value);
+
+                if (name && hasMethod(value)) {
+                    result[key] = name;
+                } else {
+                    result[key] = languageOptionsToJSON(value, key);
+                }
+                continue;
+            }
+
+            if (typeof value === "function") {
+                throw new TypeError(`Cannot serialize key "${key}" in ${objectKey}: Function values are not supported.`);
+            }
+
+        }
+
+        result[key] = value;
+    }
+
+    return result;
+}
+
+/**
+ * Normalizes the rules configuration. Ensure that each rule config is
+ * an array and that the severity is a number. This function modifies the
+ * rulesConfig.
+ * @param {Record<string, any>} rulesConfig The rules configuration to normalize.
+ * @returns {void}
+ */
+function normalizeRulesConfig(rulesConfig) {
+
+    for (const [ruleId, ruleConfig] of Object.entries(rulesConfig)) {
+
+        // ensure rule config is an array
+        if (!Array.isArray(ruleConfig)) {
+            rulesConfig[ruleId] = [ruleConfig];
+        }
+
+        // normalize severity
+        rulesConfig[ruleId][0] = severities.get(rulesConfig[ruleId][0]);
+    }
+
+}
+
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+/**
+ * Represents a normalized configuration object.
+ */
+class Config {
+
+    /**
+     * The name to use for the language when serializing to JSON.
+     * @type {string|undefined}
+     */
+    #languageName;
+
+    /**
+     * The name to use for the processor when serializing to JSON.
+     * @type {string|undefined}
+     */
+    #processorName;
+
+    /**
+     * Creates a new instance.
+     * @param {Object} config The configuration object.
+     */
+    constructor(config) {
+
+        const { plugins, language, languageOptions, processor, ...otherKeys } = config;
+
+        // Validate config object
+        const schema = new ObjectSchema(flatConfigSchema);
+
+        schema.validate(config);
+
+        // first, copy all the other keys over
+        Object.assign(this, otherKeys);
+
+        // ensure that a language is specified
+        if (!language) {
+            throw new TypeError("Key 'language' is required.");
+        }
+
+        // copy the rest over
+        this.plugins = plugins;
+        this.language = language;
+
+        if (languageOptions) {
+            this.languageOptions = languageOptions;
+        }
+
+        // Check language value
+        if (typeof language === "string") {
+            const { pluginName, objectName: localLanguageName } = splitPluginIdentifier(language);
+
+            this.#languageName = language;
+
+            if (!plugins || !plugins[pluginName] || !plugins[pluginName].languages || !plugins[pluginName].languages[localLanguageName]) {
+                throw new TypeError(`Key "language": Could not find "${localLanguageName}" in plugin "${pluginName}".`);
+            }
+
+            this.language = plugins[pluginName].languages[localLanguageName];
+        } else if (typeof language === "object") {
+            this.#languageName = getObjectId(language);
+            this.language = language;
+        } else {
+            throw new TypeError("Key 'language' must be a string or an object.");
+        }
+
+        // Validate language options
+        if (this.languageOptions) {
+            try {
+                this.language.validateLanguageOptions(this.languageOptions);
+            } catch (error) {
+                throw new TypeError(`Key "languageOptions": ${error.message}`, { cause: error });
+            }
+        }
+
+        // Check processor value
+        if (processor) {
+            this.processor = processor;
+
+            if (typeof processor === "string") {
+                const { pluginName, objectName: localProcessorName } = splitPluginIdentifier(processor);
+
+                this.#processorName = processor;
+
+                if (!plugins || !plugins[pluginName] || !plugins[pluginName].processors || !plugins[pluginName].processors[localProcessorName]) {
+                    throw new TypeError(`Key "processor": Could not find "${localProcessorName}" in plugin "${pluginName}".`);
+                }
+
+                this.processor = plugins[pluginName].processors[localProcessorName];
+            } else if (typeof processor === "object") {
+                this.#processorName = getObjectId(processor);
+                this.processor = processor;
+            } else {
+                throw new TypeError("Key 'processor' must be a string or an object.");
+            }
+        }
+
+        // Process the rules
+        if (this.rules) {
+            normalizeRulesConfig(this.rules);
+            ruleValidator.validate(this);
+        }
+    }
+
+    /**
+     * Converts the configuration to a JSON representation.
+     * @returns {Record<string, any>} The JSON representation of the configuration.
+     * @throws {Error} If the configuration cannot be serialized.
+     */
+    toJSON() {
+
+        if (this.processor && !this.#processorName) {
+            throw new Error("Could not serialize processor object (missing 'meta' object).");
+        }
+
+        if (!this.#languageName) {
+            throw new Error("Could not serialize language object (missing 'meta' object).");
+        }
+
+        return {
+            ...this,
+            plugins: Object.entries(this.plugins).map(([namespace, plugin]) => {
+
+                const pluginId = getObjectId(plugin);
+
+                if (!pluginId) {
+                    return namespace;
+                }
+
+                return `${namespace}:${pluginId}`;
+            }),
+            language: this.#languageName,
+            languageOptions: languageOptionsToJSON(this.languageOptions),
+            processor: this.#processorName
+        };
+    }
+}
+
+module.exports = { Config };

--- a/lib/config/flat-config-array.js
+++ b/lib/config/flat-config-array.js
@@ -11,7 +11,6 @@
 
 const { ConfigArray, ConfigArraySymbol } = require("@eslint/config-array");
 const { flatConfigSchema } = require("./flat-config-schema");
-const { RuleValidator } = require("./rule-validator");
 const { defaultConfig } = require("./default-config");
 const { Config } = require("./config");
 
@@ -23,8 +22,6 @@ const { Config } = require("./config");
  * Fields that are considered metadata and not part of the config object.
  */
 const META_FIELDS = new Set(["name"]);
-
-const ruleValidator = new RuleValidator();
 
 /**
  * Wraps a config error with details about where the error occurred.

--- a/lib/config/flat-config-array.js
+++ b/lib/config/flat-config-array.js
@@ -10,9 +10,10 @@
 //-----------------------------------------------------------------------------
 
 const { ConfigArray, ConfigArraySymbol } = require("@eslint/config-array");
-const { flatConfigSchema, hasMethod } = require("./flat-config-schema");
+const { flatConfigSchema } = require("./flat-config-schema");
 const { RuleValidator } = require("./rule-validator");
 const { defaultConfig } = require("./default-config");
+const { Config } = require("./config");
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -24,60 +25,6 @@ const { defaultConfig } = require("./default-config");
 const META_FIELDS = new Set(["name"]);
 
 const ruleValidator = new RuleValidator();
-
-/**
- * Splits a plugin identifier in the form a/b/c into two parts: a/b and c.
- * @param {string} identifier The identifier to parse.
- * @returns {{objectName: string, pluginName: string}} The parts of the plugin
- *      name.
- */
-function splitPluginIdentifier(identifier) {
-    const parts = identifier.split("/");
-
-    return {
-        objectName: parts.pop(),
-        pluginName: parts.join("/")
-    };
-}
-
-/**
- * Returns the name of an object in the config by reading its `meta` key.
- * @param {Object} object The object to check.
- * @returns {string?} The name of the object if found or `null` if there
- *      is no name.
- */
-function getObjectId(object) {
-
-    // first check old-style name
-    let name = object.name;
-
-    if (!name) {
-
-        if (!object.meta) {
-            return null;
-        }
-
-        name = object.meta.name;
-
-        if (!name) {
-            return null;
-        }
-    }
-
-    // now check for old-style version
-    let version = object.version;
-
-    if (!version) {
-        version = object.meta && object.meta.version;
-    }
-
-    // if there's a version then append that
-    if (version) {
-        return `${name}@${version}`;
-    }
-
-    return name;
-}
 
 /**
  * Wraps a config error with details about where the error occurred.
@@ -123,42 +70,6 @@ function wrapConfigErrorWithDetails(error, originalLength, baseLength) {
     );
 }
 
-/**
- * Converts a languageOptions object to a JSON representation.
- * @param {Record<string, any>} languageOptions The options to create a JSON
- *     representation of.
- * @param {string} objectKey The key of the object being converted.
- * @returns {Record<string, any>} The JSON representation of the languageOptions.
- * @throws {TypeError} If a function is found in the languageOptions.
- */
-function languageOptionsToJSON(languageOptions, objectKey = "languageOptions") {
-
-    const result = {};
-
-    for (const [key, value] of Object.entries(languageOptions)) {
-        if (value) {
-            if (typeof value === "object") {
-                const name = getObjectId(value);
-
-                if (name && hasMethod(value)) {
-                    result[key] = name;
-                } else {
-                    result[key] = languageOptionsToJSON(value, key);
-                }
-                continue;
-            }
-
-            if (typeof value === "function") {
-                throw new TypeError(`Cannot serialize key "${key}" in ${objectKey}: Function values are not supported.`);
-            }
-
-        }
-
-        result[key] = value;
-    }
-
-    return result;
-}
 
 const originalBaseConfig = Symbol("originalBaseConfig");
 const originalLength = Symbol("originalLength");
@@ -305,116 +216,7 @@ class FlatConfigArray extends ConfigArray {
      * @throws {TypeError} If the config is invalid.
      */
     [ConfigArraySymbol.finalizeConfig](config) {
-
-        const { plugins, language, languageOptions, processor } = config;
-        let parserName, processorName, languageName;
-        let invalidParser = false,
-            invalidProcessor = false,
-            invalidLanguage = false;
-
-        // Check parser value
-        if (languageOptions && languageOptions.parser) {
-            const { parser } = languageOptions;
-
-            if (typeof parser === "object") {
-                parserName = getObjectId(parser);
-
-                if (!parserName) {
-                    invalidParser = true;
-                }
-
-            } else {
-                invalidParser = true;
-            }
-        }
-
-        // Check language value
-        if (language) {
-            if (typeof language === "string") {
-                const { pluginName, objectName: localLanguageName } = splitPluginIdentifier(language);
-
-                languageName = language;
-
-                if (!plugins || !plugins[pluginName] || !plugins[pluginName].languages || !plugins[pluginName].languages[localLanguageName]) {
-                    throw new TypeError(`Key "language": Could not find "${localLanguageName}" in plugin "${pluginName}".`);
-                }
-
-                config.language = plugins[pluginName].languages[localLanguageName];
-            } else {
-                invalidLanguage = true;
-            }
-
-            try {
-                config.language.validateLanguageOptions(config.languageOptions);
-            } catch (error) {
-                throw new TypeError(`Key "languageOptions": ${error.message}`, { cause: error });
-            }
-        }
-
-        // Check processor value
-        if (processor) {
-            if (typeof processor === "string") {
-                const { pluginName, objectName: localProcessorName } = splitPluginIdentifier(processor);
-
-                processorName = processor;
-
-                if (!plugins || !plugins[pluginName] || !plugins[pluginName].processors || !plugins[pluginName].processors[localProcessorName]) {
-                    throw new TypeError(`Key "processor": Could not find "${localProcessorName}" in plugin "${pluginName}".`);
-                }
-
-                config.processor = plugins[pluginName].processors[localProcessorName];
-            } else if (typeof processor === "object") {
-                processorName = getObjectId(processor);
-
-                if (!processorName) {
-                    invalidProcessor = true;
-                }
-
-            } else {
-                invalidProcessor = true;
-            }
-        }
-
-        ruleValidator.validate(config);
-
-        // apply special logic for serialization into JSON
-        /* eslint-disable object-shorthand -- shorthand would change "this" value */
-        Object.defineProperty(config, "toJSON", {
-            value: function() {
-
-                if (invalidParser) {
-                    throw new Error("Could not serialize parser object (missing 'meta' object).");
-                }
-
-                if (invalidProcessor) {
-                    throw new Error("Could not serialize processor object (missing 'meta' object).");
-                }
-
-                if (invalidLanguage) {
-                    throw new Error("Caching is not supported when language is an object.");
-                }
-
-                return {
-                    ...this,
-                    plugins: Object.entries(plugins).map(([namespace, plugin]) => {
-
-                        const pluginId = getObjectId(plugin);
-
-                        if (!pluginId) {
-                            return namespace;
-                        }
-
-                        return `${namespace}:${pluginId}`;
-                    }),
-                    language: languageName,
-                    languageOptions: languageOptionsToJSON(languageOptions),
-                    processor: processorName
-                };
-            }
-        });
-        /* eslint-enable object-shorthand -- ok to enable now */
-
-        return config;
+        return new Config(config);
     }
     /* eslint-enable class-methods-use-this -- Desired as instance method */
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.2.0",
     "@eslint-community/regexpp": "^4.11.0",
-    "@eslint/config-array": "^0.17.1",
+    "@eslint/config-array": "^0.18.0",
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "9.8.0",
     "@humanwhocodes/module-importer": "^1.0.1",

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -21,6 +21,7 @@ const jslang = require("../../../lib/languages/js");
 
 const baseConfig = {
     files: ["**/*.js"],
+    language: "@/js",
     plugins: {
         "@": {
             languages: {
@@ -181,6 +182,10 @@ async function assertMergedResult(values, result) {
 
     const config = configs.getConfig("foo.js");
 
+    if (!result.language) {
+        result.language = jslang;
+    }
+
     assert.deepStrictEqual(config, result);
 }
 
@@ -228,6 +233,14 @@ describe("FlatConfigArray", () => {
     it("should not reuse languageOptions.parserOptions across configs", () => {
         const base = [{
             files: ["**/*.js"],
+            plugins: {
+                "@": {
+                    languages: {
+                        js: jslang
+                    }
+                }
+            },
+            language: "@/js",
             languageOptions: {
                 parserOptions: {
                     foo: true
@@ -409,7 +422,7 @@ describe("FlatConfigArray", () => {
 
             assert.throws(() => {
                 config.toJSON();
-            }, /Could not serialize parser/u);
+            }, /Cannot serialize key "parse"/u);
 
         });
 
@@ -430,7 +443,7 @@ describe("FlatConfigArray", () => {
 
             assert.throws(() => {
                 config.toJSON();
-            }, /Could not serialize parser/u);
+            }, /Cannot serialize key "parse"/u);
 
         });
 
@@ -453,7 +466,7 @@ describe("FlatConfigArray", () => {
 
             assert.throws(() => {
                 config.toJSON();
-            }, /Could not serialize parser/u);
+            }, /Cannot serialize key "parse"/u);
 
         });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Extracted the normalization and validation of individual config objects into a `Config` class.

Up to this point, all of that logic was contained inside of `FlatConfigArray`, meaning any time we wanted a normalized and validated config object, we had to first create a `FlatConfigArray` even if we already had all of the config data handy.

This is a first-step refactor to validate the approach. After this, there are other changes we can go through and make.

refs #18787

#### Is there anything you'd like reviewers to focus on?

Right now, the `Config` class may or may not have the following instance properties (depending on the object that was passed in):

* `processor`
* `languageOptions`
* `linterOptions`
* `rules`

We could further normalize so that these keys are always present, so `processor` would default to `undefined` and the others would default to an empty object. I think this would be beneficial because a) it would allow for creating an accurate type definition for `Config` and b) it would prevent us from needing to check if `languageOptions`/`linterOptions`/`rules` is an object throughout the code base.

However, that would require updating all of the `FlatConfigArray` tests to include the missing keys.

I think it's worth it, but would like some other opinions before moving forward.

<!-- markdownlint-disable-file MD004 -->
