### PR TITLE
refactor: Extract parsing logic from Linter

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1682,10 +1682,7 @@ class Linter {
             const parserService = new ParserService();
             const parseResult = parserService.parseSync(
                 file,
-                {
-                    ...config,
-                    languageOptions
-                }
+                config
             );
 
             if (options.stats) {

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -55,6 +55,7 @@ const DEFAULT_ERROR_LOC = { start: { line: 1, column: 0 }, end: { line: 1, colum
 const parserSymbol = Symbol.for("eslint.RuleTester.parser");
 const { LATEST_ECMA_VERSION } = require("../../conf/ecma-version");
 const { VFile } = require("./vfile");
+const { ParserService } = require("../services/parser-service");
 const STEP_KIND_VISIT = 1;
 const STEP_KIND_CALL = 2;
 
@@ -923,43 +924,6 @@ function analyzeScope(ast, languageOptions, visitorKeys) {
 }
 
 /**
- * Parses file into an AST. Moved out here because the try-catch prevents
- * optimization of functions, so it's best to keep the try-catch as isolated
- * as possible
- * @param {VFile} file The file to parse.
- * @param {Language} language The language to use.
- * @param {LanguageOptions} languageOptions Options to pass to the parser
- * @returns {{success: false, error: LintMessage}|{success: true, sourceCode: SourceCode}}
- * An object containing the AST and parser services if parsing was successful, or the error if parsing failed
- * @private
- */
-function parse(file, language, languageOptions) {
-
-    const result = language.parse(file, { languageOptions });
-
-    if (result.ok) {
-        return {
-            success: true,
-            sourceCode: language.createSourceCode(file, result, { languageOptions })
-        };
-    }
-
-    // if we made it to here there was an error
-    return {
-        success: false,
-        errors: result.errors.map(error => ({
-            ruleId: null,
-            nodeType: null,
-            fatal: true,
-            severity: 2,
-            message: `Parsing error: ${error.message}`,
-            line: error.line,
-            column: error.column
-        }))
-    };
-}
-
-/**
  * Runs a rule, and gets its listeners
  * @param {Rule} rule A rule object
  * @param {Context} ruleContext The context that should be passed to the rule
@@ -1407,10 +1371,13 @@ class Linter {
                 t = startTime();
             }
 
-            const parseResult = parse(
+            const parserService = new ParserService();
+            const parseResult = parserService.parseSync(
                 file,
-                jslang,
-                languageOptions
+                {
+                    language: jslang,
+                    languageOptions
+                }
             );
 
             if (options.stats) {
@@ -1420,7 +1387,7 @@ class Linter {
                 storeTime(time, timeOpts, slots);
             }
 
-            if (!parseResult.success) {
+            if (!parseResult.ok) {
                 return parseResult.errors;
             }
 
@@ -1712,10 +1679,13 @@ class Linter {
                 t = startTime();
             }
 
-            const parseResult = parse(
+            const parserService = new ParserService();
+            const parseResult = parserService.parseSync(
                 file,
-                config.language,
-                languageOptions
+                {
+                    ...config,
+                    languageOptions
+                }
             );
 
             if (options.stats) {
@@ -1724,7 +1694,7 @@ class Linter {
                 storeTime(time, { type: "parse" }, slots);
             }
 
-            if (!parseResult.success) {
+            if (!parseResult.ok) {
                 return parseResult.errors;
             }
 

--- a/lib/services/parser-service.js
+++ b/lib/services/parser-service.js
@@ -35,7 +35,7 @@ class ParserService {
         const { language, languageOptions } = config;
         const result = language.parse(file, { languageOptions });
 
-        if (result.then) {
+        if (typeof result.then === "function") {
             throw new Error("Unsupported: Language parser returned a promise.");
         }
 

--- a/lib/services/parser-service.js
+++ b/lib/services/parser-service.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview ESLint Parser
+ * @author Nicholas C. Zakas
+ */
+/* eslint class-methods-use-this: off -- Anticipate future constructor arguments. */
+
+"use strict";
+
+//-----------------------------------------------------------------------------
+// Types
+//-----------------------------------------------------------------------------
+
+/** @typedef {import("../linter/vfile.js").VFile} VFile */
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+/**
+ * The parser for ESLint.
+ */
+class ParserService {
+
+    /**
+     * Parses the given file synchronously.
+     * @param {VFile} file The file to parse.
+     * @param {Object} config The configuration to use.
+     * @returns {Object} An object with the parsed source code or errors.
+     * @throws {Error} If the parser returns a promise.
+     */
+    parseSync(file, config) {
+
+        const { language, languageOptions } = config;
+        const result = language.parse(file, { languageOptions });
+
+        if (result.then) {
+            throw new Error("Unsupported: Language parser returned a promise.");
+        }
+
+        if (result.ok) {
+            return {
+                ok: true,
+                sourceCode: language.createSourceCode(file, result, { languageOptions })
+            };
+        }
+
+        // if we made it to here there was an error
+        return {
+            ok: false,
+            errors: result.errors.map(error => ({
+                ruleId: null,
+                nodeType: null,
+                fatal: true,
+                severity: 2,
+                message: `Parsing error: ${error.message}`,
+                line: error.line,
+                column: error.column
+            }))
+        };
+    }
+}
+
+module.exports = { ParserService };

--- a/lib/services/parser-service.js
+++ b/lib/services/parser-service.js
@@ -11,6 +11,8 @@
 //-----------------------------------------------------------------------------
 
 /** @typedef {import("../linter/vfile.js").VFile} VFile */
+/** @typedef {import("@eslint/core").Language} Language */
+/** @typedef {import("@eslint/core").LanguageOptions} LanguageOptions */
 
 //-----------------------------------------------------------------------------
 // Exports
@@ -24,7 +26,7 @@ class ParserService {
     /**
      * Parses the given file synchronously.
      * @param {VFile} file The file to parse.
-     * @param {Object} config The configuration to use.
+     * @param {{language:Language,languageOptions:LanguageOptions}} config The configuration to use.
      * @returns {Object} An object with the parsed source code or errors.
      * @throws {Error} If the parser returns a promise.
      */


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Refactor

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Extracted the parsing logic from `Linter` into a new class, `ParserService`. I envision this as a step towards the core rewrite, where the API is made up of smaller classes rather than giant ones that do everything. 

Notes:
- I anticipate there being constructor arguments to this class in the future, which is why it's a class rather than a function.
- I also anticipate having an asynchronous `parse()` method, which is why I've named this method `parseSync()` for clarity.
- I named the class "ParserService" to distinguish it from parsers like Espree.

refs #18787


#### Is there anything you'd like reviewers to focus on?



<!-- markdownlint-disable-file MD004 -->
