### PR TITLE
Revert "chore: add tab index to powered by algolia text"

### DIFF
--- a/docs/src/_includes/components/search.html
+++ b/docs/src/_includes/components/search.html
@@ -10,7 +10,6 @@
         <div class="search__inner-input-wrapper">
             <input type="search" id="search" class="search__input" autocomplete="off" aria-describedby="search-hint" pattern="\S+">
             <a class="search_powered-by-wrapper"
-                tabindex="-1"
                 href="https://www.algolia.com/developers/?utm_source=eslint&amp;utm_medium=referral" target="_blank"
                 rel="noopener noreferrer">
                 <div class="search__powered-by">


### PR DESCRIPTION
We should not remove tab accessibility from links. Let's think of a different way to solve this problem.

Reverts eslint/eslint#18792