### PR TITLE
chore: use eslint-plugin-yml on yaml files only

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,6 +37,7 @@ const INTERNAL_FILES = Object.fromEntries(
 );
 
 const ALL_JS_FILES = "**/*.js";
+const ALL_YAML_FILES = "**/*.y?(a)ml";
 
 /**
  * Resolve an absolute path or glob pattern.
@@ -274,5 +275,8 @@ module.exports = [
             ]]
         }
     },
-    ...eslintPluginYml.configs["flat/recommended"]
+    ...eslintPluginYml.configs["flat/recommended"].map(config => ({
+        ...config,
+        files: [ALL_YAML_FILES]
+    }))
 ];


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

When I run `npx eslint .`, I'm getting the following error:

```
Oops! Something went wrong! :(

ESLint: 9.9.0

TypeError: Error while loading rule 'yml/no-empty-document': Cannot read properties of undefined (reading 'defineCustomBlocksVisitor')
Occurred while linting C:\projects\eslint\.c8rc
    at Object.create (C:\projects\eslint\node_modules\eslint-plugin-yml\lib\utils\index.js:38:50)
    at createRuleListeners (C:\projects\eslint\lib\linter\linter.js:977:21)
    at C:\projects\eslint\lib\linter\linter.js:1108:84
    at Array.forEach (<anonymous>)
    at runRules (C:\projects\eslint\lib\linter\linter.js:1039:34)
    at Linter._verifyWithFlatConfigArrayAndWithoutProcessors (C:\projects\eslint\lib\linter\linter.js:1947:31)
    at Linter._verifyWithFlatConfigArray (C:\projects\eslint\lib\linter\linter.js:2086:21)
    at Linter.verify (C:\projects\eslint\lib\linter\linter.js:1547:61)
    at Linter.verifyAndFix (C:\projects\eslint\lib\linter\linter.js:2323:29)
    at verifyText (C:\projects\eslint\lib\eslint\eslint.js:574:48)
```

This is because eslint-plugin-yml's recommended rules are enabled on all files.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated eslint.config.js to use eslint-plugin-yml configs on yaml files only.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
