### PR TITLE
refactor: Extract processor logic into ProcessorService

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -54,6 +54,7 @@ const { LATEST_ECMA_VERSION } = require("../../conf/ecma-version");
 const { VFile } = require("./vfile");
 const { ParserService } = require("../services/parser-service");
 const { FileContext } = require("./file-context");
+const { ProcessorService } = require("../services/processor-service");
 const STEP_KIND_VISIT = 1;
 const STEP_KIND_CALL = 2;
 
@@ -1292,27 +1293,18 @@ class Linter {
     }
 
     /**
-     * Same as linter.verify, except without support for processors.
-     * @param {string|SourceCode} textOrSourceCode The text to parse or a SourceCode object.
+     * Lint using eslintrc and without processors.
+     * @param {VFile} file The file to lint.
      * @param {ConfigData} providedConfig An ESLintConfig instance to configure everything.
      * @param {VerifyOptions} [providedOptions] The optional filename of the file being checked.
      * @throws {Error} If during rule execution.
      * @returns {(LintMessage|SuppressedLintMessage)[]} The results as an array of messages or an empty array if no messages.
      */
-    _verifyWithoutProcessors(textOrSourceCode, providedConfig, providedOptions) {
+    #eslintrcVerifyWithoutProcessors(file, providedConfig, providedOptions) {
+
         const slots = internalSlotsMap.get(this);
         const config = providedConfig || {};
         const options = normalizeVerifyOptions(providedOptions, config);
-        let text;
-
-        // evaluate arguments
-        if (typeof textOrSourceCode === "string") {
-            slots.lastSourceCode = null;
-            text = textOrSourceCode;
-        } else {
-            slots.lastSourceCode = textOrSourceCode;
-            text = textOrSourceCode.text;
-        }
 
         // Resolve parser.
         let parserName = DEFAULT_PARSER_NAME;
@@ -1339,7 +1331,7 @@ class Linter {
 
         // search and apply "eslint-env *".
         const envInFile = options.allowInlineConfig && !options.warnInlineConfig
-            ? findEslintEnv(text)
+            ? findEslintEnv(file.body)
             : {};
         const resolvedEnvConfig = Object.assign({ builtin: true }, config.env, envInFile);
         const enabledEnvs = Object.keys(resolvedEnvConfig)
@@ -1354,9 +1346,6 @@ class Linter {
             globals: config.globals,
             parser,
             parserOptions
-        });
-        const file = new VFile(options.filename, text, {
-            physicalPath: providedOptions.physicalFilename
         });
 
         if (!slots.lastSourceCode) {
@@ -1468,6 +1457,36 @@ class Linter {
                 .sort((problemA, problemB) => problemA.line - problemB.line || problemA.column - problemB.column),
             reportUnusedDisableDirectives: options.reportUnusedDisableDirectives
         });
+
+    }
+
+    /**
+     * Same as linter.verify, except without support for processors.
+     * @param {string|SourceCode} textOrSourceCode The text to parse or a SourceCode object.
+     * @param {ConfigData} providedConfig An ESLintConfig instance to configure everything.
+     * @param {VerifyOptions} [providedOptions] The optional filename of the file being checked.
+     * @throws {Error} If during rule execution.
+     * @returns {(LintMessage|SuppressedLintMessage)[]} The results as an array of messages or an empty array if no messages.
+     */
+    _verifyWithoutProcessors(textOrSourceCode, providedConfig, providedOptions) {
+        const slots = internalSlotsMap.get(this);
+        const filename = normalizeFilename(providedOptions.filename || "<input>");
+        let text;
+
+        // evaluate arguments
+        if (typeof textOrSourceCode === "string") {
+            slots.lastSourceCode = null;
+            text = textOrSourceCode;
+        } else {
+            slots.lastSourceCode = textOrSourceCode;
+            text = textOrSourceCode.text;
+        }
+
+        const file = new VFile(filename, text, {
+            physicalPath: providedOptions.physicalFilename
+        });
+
+        return this.#eslintrcVerifyWithoutProcessors(file, providedConfig, providedOptions);
     }
 
     /**
@@ -1537,42 +1556,38 @@ class Linter {
      * @returns {(LintMessage|SuppressedLintMessage)[]} The found problems.
      */
     _verifyWithFlatConfigArrayAndProcessor(textOrSourceCode, config, options, configForRecursive) {
+        const slots = internalSlotsMap.get(this);
         const filename = options.filename || "<input>";
         const filenameToExpose = normalizeFilename(filename);
         const physicalFilename = options.physicalFilename || filenameToExpose;
         const text = ensureText(textOrSourceCode);
+        const file = new VFile(filenameToExpose, text, {
+            physicalPath: physicalFilename
+        });
+
         const preprocess = options.preprocess || (rawText => [rawText]);
         const postprocess = options.postprocess || (messagesList => messagesList.flat());
+
+        const processorService = new ProcessorService();
+        const preprocessResult = processorService.preprocessSync(file, {
+            processor: {
+                preprocess,
+                postprocess
+            }
+        });
+
+        if (!preprocessResult.ok) {
+            return preprocessResult.errors;
+        }
+
         const filterCodeBlock =
             options.filterCodeBlock ||
             (blockFilename => blockFilename.endsWith(".js"));
         const originalExtname = path.extname(filename);
 
-        let blocks;
+        const { files } = preprocessResult;
 
-        try {
-            blocks = preprocess(text, filenameToExpose);
-        } catch (ex) {
-
-            // If the message includes a leading line number, strip it:
-            const message = `Preprocessing error: ${ex.message.replace(/^line \d+:/iu, "").trim()}`;
-
-            debug("%s\n%s", message, ex.stack);
-
-            return [
-                {
-                    ruleId: null,
-                    fatal: true,
-                    severity: 2,
-                    message,
-                    line: ex.lineNumber,
-                    column: ex.column,
-                    nodeType: null
-                }
-            ];
-        }
-
-        const messageLists = blocks.map((block, i) => {
+        const messageLists = files.map(block => {
             debug("A code block was found: %o", block.filename || "(unnamed)");
 
             // Keep the legacy behavior.
@@ -1580,30 +1595,29 @@ class Linter {
                 return this._verifyWithFlatConfigArrayAndWithoutProcessors(block, config, options);
             }
 
-            const blockText = block.text;
-            const blockName = path.join(filename, `${i}_${block.filename}`);
-
             // Skip this block if filtered.
-            if (!filterCodeBlock(blockName, blockText)) {
+            if (!filterCodeBlock(path.basename(block.path), block.body)) {
                 debug("This code block was skipped.");
                 return [];
             }
 
             // Resolve configuration again if the file content or extension was changed.
-            if (configForRecursive && (text !== blockText || path.extname(blockName) !== originalExtname)) {
+            if (configForRecursive && (text !== block.body || path.extname(block.path) !== originalExtname)) {
                 debug("Resolving configuration again because the file content or extension was changed.");
                 return this._verifyWithFlatConfigArray(
-                    blockText,
+                    block.body,
                     configForRecursive,
-                    { ...options, filename: blockName, physicalFilename }
+                    { ...options, filename: block.path, physicalFilename: block.physicalPath }
                 );
             }
 
+            slots.lastSourceCode = null;
+
             // Does lint.
-            return this._verifyWithFlatConfigArrayAndWithoutProcessors(
-                blockText,
+            return this.#flatVerifyWithoutProcessors(
+                block,
                 config,
-                { ...options, filename: blockName, physicalFilename }
+                { ...options, filename: block.path, physicalFilename: block.physicalPath }
             );
         });
 
@@ -1611,28 +1625,18 @@ class Linter {
     }
 
     /**
-     * Same as linter.verify, except without support for processors.
-     * @param {string|SourceCode} textOrSourceCode The text to parse or a SourceCode object.
+     * Verify using flat config and without any processors.
+     * @param {VFile} file The file to lint.
      * @param {FlatConfig} providedConfig An ESLintConfig instance to configure everything.
      * @param {VerifyOptions} [providedOptions] The optional filename of the file being checked.
      * @throws {Error} If during rule execution.
      * @returns {(LintMessage|SuppressedLintMessage)[]} The results as an array of messages or an empty array if no messages.
      */
-    _verifyWithFlatConfigArrayAndWithoutProcessors(textOrSourceCode, providedConfig, providedOptions) {
+    #flatVerifyWithoutProcessors(file, providedConfig, providedOptions) {
+
         const slots = internalSlotsMap.get(this);
         const config = providedConfig || {};
         const options = normalizeVerifyOptions(providedOptions, config);
-        let text;
-
-        // evaluate arguments
-        if (typeof textOrSourceCode === "string") {
-            slots.lastSourceCode = null;
-            text = textOrSourceCode;
-        } else {
-            slots.lastSourceCode = textOrSourceCode;
-            text = textOrSourceCode.text;
-        }
-
         const languageOptions = config.languageOptions;
 
         languageOptions.ecmaVersion = normalizeEcmaVersionForLanguageOptions(
@@ -1663,9 +1667,6 @@ class Linter {
         }
 
         const settings = config.settings || {};
-        const file = new VFile(options.filename, text, {
-            physicalPath: providedOptions.physicalFilename
-        });
 
         if (!slots.lastSourceCode) {
             let t;
@@ -1957,6 +1958,37 @@ class Linter {
             ruleFilter: options.ruleFilter,
             configuredRules
         });
+
+
+    }
+
+    /**
+     * Same as linter.verify, except without support for processors.
+     * @param {string|SourceCode} textOrSourceCode The text to parse or a SourceCode object.
+     * @param {FlatConfig} providedConfig An ESLintConfig instance to configure everything.
+     * @param {VerifyOptions} [providedOptions] The optional filename of the file being checked.
+     * @throws {Error} If during rule execution.
+     * @returns {(LintMessage|SuppressedLintMessage)[]} The results as an array of messages or an empty array if no messages.
+     */
+    _verifyWithFlatConfigArrayAndWithoutProcessors(textOrSourceCode, providedConfig, providedOptions) {
+        const slots = internalSlotsMap.get(this);
+        const filename = normalizeFilename(providedOptions.filename || "<input>");
+        let text;
+
+        // evaluate arguments
+        if (typeof textOrSourceCode === "string") {
+            slots.lastSourceCode = null;
+            text = textOrSourceCode;
+        } else {
+            slots.lastSourceCode = textOrSourceCode;
+            text = textOrSourceCode.text;
+        }
+
+        const file = new VFile(filename, text, {
+            physicalPath: providedOptions.physicalFilename
+        });
+
+        return this.#flatVerifyWithoutProcessors(file, providedConfig, providedOptions);
     }
 
     /**
@@ -2057,77 +2089,78 @@ class Linter {
      * @returns {(LintMessage|SuppressedLintMessage)[]} The found problems.
      */
     _verifyWithProcessor(textOrSourceCode, config, options, configForRecursive) {
+        const slots = internalSlotsMap.get(this);
         const filename = options.filename || "<input>";
         const filenameToExpose = normalizeFilename(filename);
         const physicalFilename = options.physicalFilename || filenameToExpose;
         const text = ensureText(textOrSourceCode);
+        const file = new VFile(filenameToExpose, text, {
+            physicalPath: physicalFilename
+        });
+
         const preprocess = options.preprocess || (rawText => [rawText]);
         const postprocess = options.postprocess || (messagesList => messagesList.flat());
-        const filterCodeBlock =
-            options.filterCodeBlock ||
-            (blockFilename => blockFilename.endsWith(".js"));
-        const originalExtname = path.extname(filename);
 
-        let blocks;
+        const processorService = new ProcessorService();
+        const preprocessResult = processorService.preprocessSync(file, {
+            processor: {
+                preprocess,
+                postprocess
+            }
+        });
 
-        try {
-            blocks = preprocess(text, filenameToExpose);
-        } catch (ex) {
-
-            // If the message includes a leading line number, strip it:
-            const message = `Preprocessing error: ${ex.message.replace(/^line \d+:/iu, "").trim()}`;
-
-            debug("%s\n%s", message, ex.stack);
-
-            return [
-                {
-                    ruleId: null,
-                    fatal: true,
-                    severity: 2,
-                    message,
-                    line: ex.lineNumber,
-                    column: ex.column,
-                    nodeType: null
-                }
-            ];
+        if (!preprocessResult.ok) {
+            return preprocessResult.errors;
         }
 
-        const messageLists = blocks.map((block, i) => {
-            debug("A code block was found: %o", block.filename || "(unnamed)");
+        const filterCodeBlock =
+            options.filterCodeBlock ||
+            (blockFilePath => blockFilePath.endsWith(".js"));
+        const originalExtname = path.extname(filename);
+
+        const { files } = preprocessResult;
+
+        const messageLists = files.map(block => {
+            debug("A code block was found: %o", block.path ?? "(unnamed)");
 
             // Keep the legacy behavior.
             if (typeof block === "string") {
                 return this._verifyWithoutProcessors(block, config, options);
             }
 
-            const blockText = block.text;
-            const blockName = path.join(filename, `${i}_${block.filename}`);
-
             // Skip this block if filtered.
-            if (!filterCodeBlock(blockName, blockText)) {
+            if (!filterCodeBlock(path.basename(block.path), block.body)) {
                 debug("This code block was skipped.");
                 return [];
             }
 
             // Resolve configuration again if the file content or extension was changed.
-            if (configForRecursive && (text !== blockText || path.extname(blockName) !== originalExtname)) {
+            if (configForRecursive && (text !== block.body || path.extname(block.path) !== originalExtname)) {
                 debug("Resolving configuration again because the file content or extension was changed.");
                 return this._verifyWithConfigArray(
-                    blockText,
+                    block.body,
                     configForRecursive,
-                    { ...options, filename: blockName, physicalFilename }
+                    { ...options, filename: block.path, physicalFilename: block.physicalPath }
                 );
             }
 
+            slots.lastSourceCode = null;
+
             // Does lint.
-            return this._verifyWithoutProcessors(
-                blockText,
+            return this.#eslintrcVerifyWithoutProcessors(
+                block,
                 config,
-                { ...options, filename: blockName, physicalFilename }
+                { ...options, filename: block.path, physicalFilename: block.physicalPath }
             );
         });
 
-        return postprocess(messageLists, filenameToExpose);
+        return processorService.postprocessSync(file, messageLists, {
+            processor: {
+                preprocess,
+                postprocess
+            }
+        });
+
     }
 
     /**

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1601,10 +1601,10 @@ class Linter {
             }
 
             // Resolve configuration again if the file content or extension was changed.
-            if (configForRecursive && (text !== block.body || path.extname(block.path) !== originalExtname)) {
+            if (configForRecursive && (text !== block.rawBody || path.extname(block.path) !== originalExtname)) {
                 debug("Resolving configuration again because the file content or extension was changed.");
                 return this._verifyWithFlatConfigArray(
-                    block.body,
+                    block.rawBody,
                     configForRecursive,
                     { ...options, filename: block.path, physicalFilename: block.physicalPath }
                 );
@@ -1620,7 +1620,12 @@ class Linter {
             );
         });
 
-        return postprocess(messageLists, filenameToExpose);
+        return processorService.postprocessSync(file, messageLists, {
+            processor: {
+                preprocess,
+                postprocess
+            }
+        });
     }
 
     /**
@@ -2134,10 +2139,10 @@ class Linter {
             }
 
             // Resolve configuration again if the file content or extension was changed.
-            if (configForRecursive && (text !== block.body || path.extname(block.path) !== originalExtname)) {
+            if (configForRecursive && (text !== block.rawBody || path.extname(block.path) !== originalExtname)) {
                 debug("Resolving configuration again because the file content or extension was changed.");
                 return this._verifyWithConfigArray(
-                    block.body,
+                    block.rawBody,
                     configForRecursive,
                     { ...options, filename: block.path, physicalFilename: block.physicalPath }
                 );

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1584,11 +1584,10 @@ class Linter {
             options.filterCodeBlock ||
             (blockFilename => blockFilename.endsWith(".js"));
         const originalExtname = path.extname(filename);
-
         const { files } = preprocessResult;
 
         const messageLists = files.map(block => {
-            debug("A code block was found: %o", block.filename || "(unnamed)");
+            debug("A code block was found: %o", block.path || "(unnamed)");
 
             // Keep the legacy behavior.
             if (typeof block === "string") {
@@ -1596,7 +1595,7 @@ class Linter {
             }
 
             // Skip this block if filtered.
-            if (!filterCodeBlock(path.basename(block.path), block.body)) {
+            if (!filterCodeBlock(block.path, block.body)) {
                 debug("This code block was skipped.");
                 return [];
             }
@@ -2129,7 +2128,7 @@ class Linter {
             }
 
             // Skip this block if filtered.
-            if (!filterCodeBlock(path.basename(block.path), block.body)) {
+            if (!filterCodeBlock(block.path, block.body)) {
                 debug("This code block was skipped.");
                 return [];
             }

--- a/lib/linter/vfile.js
+++ b/lib/linter/vfile.js
@@ -86,6 +86,13 @@ class VFile {
     body;
 
     /**
+     * The raw body of the file, including a BOM if present.
+     * @type {string|Uint8Array}
+     * @readonly
+     */
+    rawBody;
+
+    /**
      * Indicates whether the file has a byte order mark (BOM).
      * @type {boolean}
      * @readonly
@@ -104,8 +111,8 @@ class VFile {
         this.physicalPath = physicalPath ?? path;
         this.bom = hasUnicodeBOM(body);
         this.body = stripUnicodeBOM(body);
+        this.rawBody = this.bom ? body : this.body;
     }
-
 }
 
 module.exports = { VFile };

--- a/lib/linter/vfile.js
+++ b/lib/linter/vfile.js
@@ -111,7 +111,7 @@ class VFile {
         this.physicalPath = physicalPath ?? path;
         this.bom = hasUnicodeBOM(body);
         this.body = stripUnicodeBOM(body);
-        this.rawBody = this.bom ? body : this.body;
+        this.rawBody = body;
     }
 }
 

--- a/lib/services/processor-service.js
+++ b/lib/services/processor-service.js
@@ -101,11 +101,7 @@ class ProcessorService {
 
         const { processor } = config;
 
-        if (processor.postprocess) {
-            return processor.postprocess(messages, file.path);
-        }
-
-        return messages;
+        return processor.postprocess(messages, file.path);
     }
 
 }

--- a/lib/services/processor-service.js
+++ b/lib/services/processor-service.js
@@ -1,0 +1,113 @@
+/**
+ * @fileoverview ESLint Processor Service
+ * @author Nicholas C. Zakas
+ */
+/* eslint class-methods-use-this: off -- Anticipate future constructor arguments. */
+
+"use strict";
+
+//-----------------------------------------------------------------------------
+// Requirements
+//-----------------------------------------------------------------------------
+
+const path = require("node:path");
+const { VFile } = require("../linter/vfile.js");
+
+//-----------------------------------------------------------------------------
+// Types
+//-----------------------------------------------------------------------------
+
+/** @typedef {import("../shared/types.js").LintMessage} LintMessage */
+/** @typedef {import("../linter/vfile.js").VFile} VFile */
+/** @typedef {import("@eslint/core").Language} Language */
+/** @typedef {import("@eslint/core").LanguageOptions} LanguageOptions */
+/** @typedef {import("eslint").Linter.Processor} Processor */
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+/**
+ * The service that applies processors to files.
+ */
+class ProcessorService {
+
+    /**
+     * Preprocesses the given file synchronously.
+     * @param {VFile} file The file to preprocess.
+     * @param {{processor:Processor}} config The configuration to use.
+     * @returns {{ok:boolean, files?: Array<VFile>, errors?: Array<LintMessage>}} An array of preprocessed files or errors.
+     * @throws {Error} If the preprocessor returns a promise.
+     */
+    preprocessSync(file, config) {
+
+        const { processor } = config;
+        let blocks;
+
+        try {
+            blocks = processor.preprocess(file.rawBody, file.path);
+        } catch (ex) {
+
+            // If the message includes a leading line number, strip it:
+            const message = `Preprocessing error: ${ex.message.replace(/^line \d+:/iu, "").trim()}`;
+
+            return {
+                ok: false,
+                errors: [
+                    {
+                        ruleId: null,
+                        fatal: true,
+                        severity: 2,
+                        message,
+                        line: ex.lineNumber,
+                        column: ex.column,
+                        nodeType: null
+                    }
+                ]
+            };
+        }
+
+        if (typeof blocks.then === "function") {
+            throw new Error("Unsupported: Preprocessor returned a promise.");
+        }
+
+        return {
+            ok: true,
+            files: blocks.map((block, i) => {
+
+                // Legacy behavior: return the block as a string
+                if (typeof block === "string") {
+                    return block;
+                }
+
+                const filePath = path.join(file.path, `${i}_${block.filename}`);
+
+                return new VFile(filePath, block.text, {
+                    physicalPath: file.physicalPath
+                });
+            })
+        };
+
+    }
+
+    /**
+     * Postprocesses the given messages synchronously.
+     * @param {VFile} file The file to postprocess.
+     * @param {LintMessage[][]} messages The messages to postprocess.
+     * @param {{processor:Processor}} config The configuration to use.
+     * @returns {LintMessage[]} The postprocessed messages.
+     */
+    postprocessSync(file, messages, config) {
+
+        const { processor } = config;
+
+        if (processor.postprocess) {
+            return processor.postprocess(messages, file.path);
+        }
+
+        return messages;
+    }
+
+}
+
+module.exports = { ProcessorService };

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -1246,6 +1246,36 @@ describe("ESLint", () => {
             });
 
         });
+
+        it("should pass BOM through processors", async () => {
+            eslint = new ESLint({
+                overrideConfigFile: true,
+                overrideConfig: [
+                    {
+                        files: ["**/*.myjs"],
+                        processor: {
+                            preprocess(text, filename) {
+                                return [{ text, filename }];
+                            },
+                            postprocess(messages) {
+                                return messages.flat();
+                            },
+                            supportsAutofix: true
+                        },
+                        rules: {
+                            "unicode-bom": ["error", "never"]
+                        }
+                    }
+                ],
+                cwd: path.join(fixtureDir)
+            });
+            const results = await eslint.lintText("\uFEFFvar foo = 'bar';", { filePath: "test.myjs" });
+
+            assert.strictEqual(results.length, 1);
+            assert.strictEqual(results[0].messages.length, 1);
+            assert.strictEqual(results[0].messages[0].severity, 2);
+            assert.strictEqual(results[0].messages[0].ruleId, "unicode-bom");
+        });
     });
 
     describe("lintFiles()", () => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7080,7 +7080,7 @@ var a = "test2";
                 assert.deepStrictEqual(preprocess.args[0], [code, filename]);
             });
 
-            it.only("should receive text even if a SourceCode object was given (with BOM).", () => {
+            it("should receive text even if a SourceCode object was given (with BOM).", () => {
                 const code = "\uFEFFfoo";
                 const preprocess = sinon.spy(text => text.split(" "));
 
@@ -16034,7 +16034,7 @@ var a = "test2";
             receivedPhysicalFilenames = [];
         });
 
-        describe.only("preprocessors", () => {
+        describe("preprocessors", () => {
             it("should receive text and filename.", () => {
                 const code = "foo bar baz";
                 const preprocess = sinon.spy(text => text.split(" "));
@@ -16211,7 +16211,7 @@ var a = "test2";
             });
         });
 
-        describe.only("postprocessors", () => {
+        describe("postprocessors", () => {
             it("should receive result and filename.", () => {
                 const code = "foo bar baz";
                 const preprocess = sinon.spy(text => text.split(" "));

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -16071,6 +16071,35 @@ var a = "test2";
                 assert.strictEqual(logs.length, 1, "preprocess() should only be called once.");
             });
 
+            it("should pass the BOM to preprocess", () => {
+                const logs = [];
+                const code = "\uFEFFfoo";
+                const config = {
+                    files: ["*.md"],
+                    processor: {
+                        preprocess(text, filenameForText) {
+                            logs.push({
+                                text,
+                                filename: filenameForText
+                            });
+
+                            return [{ text: "bar", filename: "0.js" }];
+                        },
+                        postprocess() {
+                            return [];
+                        }
+                    }
+                };
+
+                linter.verify(code, config, "a.md");
+                assert.deepStrictEqual(logs, [
+                    {
+                        text: code,
+                        filename: "a.md"
+                    }
+                ]);
+            });
+
             it("should apply a preprocessor to the code, and lint each code sample separately", () => {
                 const code = "foo bar baz";
                 const configs = createFlatConfigArray([

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -16075,7 +16075,7 @@ var a = "test2";
                 const logs = [];
                 const code = "\uFEFFfoo";
                 const config = {
-                    files: ["*.md"],
+                    files: ["**/*.myjs"],
                     processor: {
                         preprocess(text, filenameForText) {
                             logs.push({
@@ -16083,21 +16083,33 @@ var a = "test2";
                                 filename: filenameForText
                             });
 
-                            return [{ text: "bar", filename: "0.js" }];
+                            return [{ text, filename: filenameForText }];
                         },
-                        postprocess() {
-                            return [];
+                        postprocess(messages) {
+                            return messages.flat();
                         }
+                    },
+                    rules: {
+                        "unicode-bom": ["error", "never"]
                     }
                 };
 
-                linter.verify(code, config, "a.md");
+                const results = linter.verify(code, config, {
+                    filename: "a.myjs",
+                    filterCodeBlock() {
+                        return true;
+                    }
+                });
+
                 assert.deepStrictEqual(logs, [
                     {
                         text: code,
-                        filename: "a.md"
+                        filename: "a.myjs"
                     }
                 ]);
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].ruleId, "unicode-bom");
             });
 
             it("should apply a preprocessor to the code, and lint each code sample separately", () => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7080,7 +7080,7 @@ var a = "test2";
                 assert.deepStrictEqual(preprocess.args[0], [code, filename]);
             });
 
-            it("should receive text even if a SourceCode object was given (with BOM).", () => {
+            it.only("should receive text even if a SourceCode object was given (with BOM).", () => {
                 const code = "\uFEFFfoo";
                 const preprocess = sinon.spy(text => text.split(" "));
 
@@ -16034,7 +16034,7 @@ var a = "test2";
             receivedPhysicalFilenames = [];
         });
 
-        describe("preprocessors", () => {
+        describe.only("preprocessors", () => {
             it("should receive text and filename.", () => {
                 const code = "foo bar baz";
                 const preprocess = sinon.spy(text => text.split(" "));
@@ -16211,7 +16211,7 @@ var a = "test2";
             });
         });
 
-        describe("postprocessors", () => {
+        describe.only("postprocessors", () => {
             it("should receive result and filename.", () => {
                 const code = "foo bar baz";
                 const preprocess = sinon.spy(text => text.split(" "));

--- a/tests/lib/linter/vfile.js
+++ b/tests/lib/linter/vfile.js
@@ -26,6 +26,7 @@ describe("VFile", () => {
             assert.strictEqual(vfile.path, "foo.js");
             assert.strictEqual(vfile.physicalPath, "foo.js");
             assert.strictEqual(vfile.body, "var foo = bar;");
+            assert.strictEqual(vfile.rawBody, "var foo = bar;");
             assert.isFalse(vfile.bom);
         });
 
@@ -35,6 +36,7 @@ describe("VFile", () => {
             assert.strictEqual(vfile.path, "foo.js");
             assert.strictEqual(vfile.physicalPath, "foo.js");
             assert.strictEqual(vfile.body, "var foo = bar;");
+            assert.strictEqual(vfile.rawBody, "\uFEFFvar foo = bar;");
             assert.isTrue(vfile.bom);
         });
 
@@ -44,6 +46,7 @@ describe("VFile", () => {
             assert.strictEqual(vfile.path, "foo.js");
             assert.strictEqual(vfile.physicalPath, "foo/bar");
             assert.strictEqual(vfile.body, "var foo = bar;");
+            assert.strictEqual(vfile.rawBody, "var foo = bar;");
             assert.isFalse(vfile.bom);
         });
 
@@ -55,6 +58,7 @@ describe("VFile", () => {
             assert.strictEqual(vfile.path, "foo.js");
             assert.strictEqual(vfile.physicalPath, "foo.js");
             assert.deepStrictEqual(vfile.body, body);
+            assert.deepStrictEqual(vfile.rawBody, body);
             assert.isFalse(vfile.bom);
         });
 
@@ -66,6 +70,7 @@ describe("VFile", () => {
             assert.strictEqual(vfile.path, "foo.js");
             assert.strictEqual(vfile.physicalPath, "foo.js");
             assert.deepStrictEqual(vfile.body, body.slice(3));
+            assert.deepStrictEqual(vfile.rawBody, body);
             assert.isTrue(vfile.bom);
         });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This extracts processor logic into `ProcessService`:

- Created `ProcessorService`
- Refactored `Linter` to use `ProcessorService`
- Added `rawBody` to `VFile`
- Updated `VFile` tests

The biggest difference is that `ProcessorService` takes a `VFile` and returns an array of `VFile`s (or strings for legacy compat). This makes it easier to pass `VFile` instances around without worrying if it's from a processor or not.

#### Is there anything you'd like reviewers to focus on?

- I'm unsure if the parameter order for `ProcessorService#postprocessSync()` makes sense. I like the idea of always having `config` as the last parameter, but would like some other opinions.
- I think we can avoid adding `rawBody` to `VFile` if we always pass BOM-less file contents to a processor. See inline comment.

<!-- markdownlint-disable-file MD004 -->
