### PR TITLE
refactor: don't use `node.value` when removing unused directives

### DIFF
--- a/lib/linter/apply-disable-directives.js
+++ b/lib/linter/apply-disable-directives.js
@@ -60,34 +60,23 @@ function groupByParentDirective(directives) {
 /**
  * Creates removal details for a set of directives within the same comment.
  * @param {Directive[]} directives Unused directives to be removed.
- * @param {Token} node The backing Comment token.
+ * @param {{node: Token, value: string}} parentDirective Data about the backing directive.
  * @param {SourceCode} sourceCode The source code object for the file being linted.
  * @returns {{ description, fix, unprocessedDirective }[]} Details for later creation of output Problems.
  */
-function createIndividualDirectivesRemoval(directives, node, sourceCode) {
-
-    const range = sourceCode.getRange(node);
+function createIndividualDirectivesRemoval(directives, parentDirective, sourceCode) {
 
     /*
-     * `node.value` starts right after `//` or `/*`.
-     * All calculated offsets will be relative to this index.
-     */
-    const commentValueStart = range[0] + "//".length;
-
-    // Find where the list of rules starts. `\S+` matches with the directive name (e.g. `eslint-disable-line`)
-    const listStartOffset = /^\s*\S+\s+/u.exec(node.value)[0].length;
-
-    /*
-     * Get the list text without any surrounding whitespace. In order to preserve the original
+     * Get the list of the rules text without any surrounding whitespace. In order to preserve the original
      * formatting, we don't want to change that whitespace.
      *
      *     // eslint-disable-line rule-one , rule-two , rule-three -- comment
      *                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      */
-    const listText = node.value
-        .slice(listStartOffset) // remove directive name and all whitespace before the list
-        .split(/\s-{2,}\s/u)[0] // remove `-- comment`, if it exists
-        .trimEnd(); // remove all whitespace after the list
+    const listText = parentDirective.value.trim();
+
+    // Calculate where it starts in the source code text
+    const listStart = sourceCode.text.indexOf(listText, sourceCode.getRange(parentDirective.node)[0]);
 
     /*
      * We can assume that `listText` contains multiple elements.
@@ -101,13 +90,13 @@ function createIndividualDirectivesRemoval(directives, node, sourceCode) {
         const regex = new RegExp(String.raw`(?:^|\s*,\s*)(?<quote>['"]?)${escapeRegExp(ruleId)}\k<quote>(?:\s*,\s*|$)`, "u");
         const match = regex.exec(listText);
         const matchedText = match[0];
-        const matchStartOffset = listStartOffset + match.index;
-        const matchEndOffset = matchStartOffset + matchedText.length;
+        const matchStart = listStart + match.index;
+        const matchEnd = matchStart + matchedText.length;
 
         const firstIndexOfComma = matchedText.indexOf(",");
         const lastIndexOfComma = matchedText.lastIndexOf(",");
 
-        let removalStartOffset, removalEndOffset;
+        let removalStart, removalEnd;
 
         if (firstIndexOfComma !== lastIndexOfComma) {
 
@@ -123,8 +112,8 @@ function createIndividualDirectivesRemoval(directives, node, sourceCode) {
              *     // eslint-disable-line rule-one , rule-two , rule-three -- comment
              *                                     ^^^^^^^^^^^
              */
-            removalStartOffset = matchStartOffset + firstIndexOfComma;
-            removalEndOffset = matchStartOffset + lastIndexOfComma;
+            removalStart = matchStart + firstIndexOfComma;
+            removalEnd = matchStart + lastIndexOfComma;
 
         } else {
 
@@ -146,16 +135,16 @@ function createIndividualDirectivesRemoval(directives, node, sourceCode) {
              *     // eslint-disable-line rule-one , rule-two , rule-three -- comment
              *                                               ^^^^^^^^^^^^^
              */
-            removalStartOffset = matchStartOffset;
-            removalEndOffset = matchEndOffset;
+            removalStart = matchStart;
+            removalEnd = matchEnd;
         }
 
         return {
             description: `'${ruleId}'`,
             fix: {
                 range: [
-                    commentValueStart + removalStartOffset,
-                    commentValueStart + removalEndOffset
+                    removalStart,
+                    removalEnd
                 ],
                 text: ""
             },
@@ -206,7 +195,7 @@ function processUnusedDirectives(allDirectives, sourceCode) {
             }
 
             return remainingRuleIds.size
-                ? createIndividualDirectivesRemoval(directives, parentDirective.node, sourceCode)
+                ? createIndividualDirectivesRemoval(directives, parentDirective, sourceCode)
                 : [createDirectiveRemoval(directives, parentDirective.node, sourceCode)];
         }
     );

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -332,7 +332,7 @@ function createDisableDirectives({ type, value, justification, node }, ruleMappe
         directives: [], // valid disable directives
         directiveProblems: [] // problems in directives
     };
-    const parentDirective = { node, ruleIds };
+    const parentDirective = { node, value, ruleIds };
 
     for (const ruleId of directiveRules) {
 

--- a/tests/lib/linter/apply-disable-directives.js
+++ b/tests/lib/linter/apply-disable-directives.js
@@ -20,7 +20,7 @@ const jslang = require("../../../lib/languages/js");
 /**
  * Creates a ParentDirective for a given range.
  * @param {[number, number]} range total range of the comment
- * @param {string} value String value of the comment
+ * @param {string} value String value of the directive
  * @param {string[]} ruleIds Rule IDs reported in the value
  * @returns {ParentDirective} Test-ready ParentDirective object.
  */
@@ -35,11 +35,11 @@ function createParentDirective(range, value, ruleIds = []) {
                 },
                 end: {
                     line: 1,
-                    column: value ? value.length : 10
+                    column: range[1] + 1
                 }
-            },
-            value
+            }
         },
+        value,
         ruleIds
     };
 }
@@ -2423,12 +2423,15 @@ describe("apply-disable-directives", () => {
 
     describe("unused rules within directives", () => {
         it("Adds a problem for /* eslint-disable used, unused */", () => {
-            const parentDirective = createParentDirective([0, 32], " eslint-disable used, unused ", ["used", "unused"]);
+            const parentDirective = createParentDirective([0, 32], "used, unused", ["used", "unused"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable used, unused */"
+                    },
                     directives: [
                         {
                             parentDirective,
@@ -2473,12 +2476,15 @@ describe("apply-disable-directives", () => {
             );
         });
         it("Adds a problem for /* eslint-disable used , unused , -- unused and used are ok */", () => {
-            const parentDirective = createParentDirective([0, 62], " eslint-disable used , unused , -- unused and used are ok ", ["used", "unused"]);
+            const parentDirective = createParentDirective([0, 62], "used , unused ,", ["used", "unused"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable used , unused , -- unused and used are ok */"
+                    },
                     directives: [
                         {
                             parentDirective,
@@ -2524,12 +2530,15 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable unused, used */", () => {
-            const parentDirective = createParentDirective([0, 32], " eslint-disable unused, used ", ["unused", "used"]);
+            const parentDirective = createParentDirective([0, 32], "unused, used", ["unused", "used"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable unused, used */"
+                    },
                     directives: [
                         {
                             parentDirective,
@@ -2575,12 +2584,15 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable unused,, ,, used */", () => {
-            const parentDirective = createParentDirective([0, 37], " eslint-disable unused,, ,, used ", ["unused", "used"]);
+            const parentDirective = createParentDirective([0, 37], " unused,, ,, used ", ["unused", "used"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable unused,, ,, used */"
+                    },
                     directives: [
                         {
                             parentDirective,
@@ -2626,12 +2638,15 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable unused-1, unused-2, used */", () => {
-            const parentDirective = createParentDirective([0, 45], " eslint-disable unused-1, unused-2, used ", ["unused-1", "unused-2", "used"]);
+            const parentDirective = createParentDirective([0, 45], "unused-1, unused-2, used", ["unused-1", "unused-2", "used"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable unused-1, unused-2, used */"
+                    },
                     directives: [
                         {
                             parentDirective,
@@ -2697,12 +2712,15 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable unused-1, unused-2, used, unused-3 */", () => {
-            const parentDirective = createParentDirective([0, 55], " eslint-disable unused-1, unused-2, used, unused-3 ", ["unused-1", "unused-2", "used", "unused-3"]);
+            const parentDirective = createParentDirective([0, 55], "unused-1, unused-2, used, unused-3", ["unused-1", "unused-2", "used", "unused-3"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable unused-1, unused-2, used, unused-3 */"
+                    },
                     directives: [
                         {
                             parentDirective,
@@ -2788,12 +2806,15 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable unused-1, unused-2 */", () => {
-            const parentDirective = createParentDirective([0, 39], " eslint-disable unused-1, unused-2 ", ["unused-1", "unused-2"]);
+            const parentDirective = createParentDirective([0, 39], "unused-1, unused-2", ["unused-1", "unused-2"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable unused-1, unused-2 */"
+                    },
                     directives: [
                         {
                             parentDirective,
@@ -2833,12 +2854,15 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable unused-1, unused-2, unused-3 */", () => {
-            const parentDirective = createParentDirective([0, 49], " eslint-disable unused-1, unused-2, unused-3 ", ["unused-1", "unused-2", "unused-3"]);
+            const parentDirective = createParentDirective([0, 49], "unused-1, unused-2, unused-3", ["unused-1", "unused-2", "unused-3"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable unused-1, unused-2, unused-3 */"
+                    },
                     directives: [
                         {
                             parentDirective,
@@ -2886,10 +2910,13 @@ describe("apply-disable-directives", () => {
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable foo */ \n  (problem)    // eslint-disable-line foo, bar"
+                    },
                     directives: [
                         {
-                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], "foo", ["foo"]),
                             ruleId: "foo",
                             type: "disable",
                             line: 1,
@@ -2897,7 +2924,7 @@ describe("apply-disable-directives", () => {
                             justification: "j1"
                         },
                         {
-                            parentDirective: createParentDirective([41, 81], " eslint-disable-line foo, bar", ["foo", "bar"]),
+                            parentDirective: createParentDirective([41, 81], "foo, bar", ["foo", "bar"]),
                             ruleId: "foo",
                             type: "disable-line",
                             line: 2,
@@ -2905,7 +2932,7 @@ describe("apply-disable-directives", () => {
                             justification: "j2"
                         },
                         {
-                            parentDirective: createParentDirective([41, 81], " eslint-disable-line foo, bar ", ["foo", "bar"]),
+                            parentDirective: createParentDirective([41, 81], "foo, bar", ["foo", "bar"]),
                             ruleId: "bar",
                             type: "disable-line",
                             line: 2,
@@ -2952,15 +2979,18 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable used */ /* (problem from used) */ /* eslint-enable used, unused */", () => {
-            const parentDirective = createParentDirective([0, 32], " eslint-enable used, unused ", ["used", "unused"]);
+            const parentDirective = createParentDirective([52, 84], "used, unused", ["used", "unused"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable used */\n/* (problem from used) */\n/* eslint-enable used, unused */"
+                    },
                     directives: [
                         {
-                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], "used", ["used"]),
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -2979,7 +3009,7 @@ describe("apply-disable-directives", () => {
                             parentDirective,
                             ruleId: "unused",
                             type: "enable",
-                            line: 4,
+                            line: 3,
                             column: 1,
                             justification: "j3"
                         }
@@ -2997,10 +3027,10 @@ describe("apply-disable-directives", () => {
                     {
                         ruleId: null,
                         message: "Unused eslint-enable directive (no matching eslint-disable directives were found for 'unused').",
-                        line: 4,
+                        line: 3,
                         column: 1,
                         fix: {
-                            range: [21, 29],
+                            range: [73, 81],
                             text: ""
                         },
                         severity: 2,
@@ -3010,15 +3040,18 @@ describe("apply-disable-directives", () => {
             );
         });
         it("Adds a problem for /* eslint-disable used */ /* (problem from used) */ /* eslint-enable used , unused , -- unused and used are ok */", () => {
-            const parentDirective = createParentDirective([0, 62], " eslint-enable used , unused , -- unused and used are ok ", ["used", "unused"]);
+            const parentDirective = createParentDirective([52, 113], " eslint-enable used , unused , -- unused and used are ok ", ["used", "unused"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable used */\n/* (problem from used) */\n/* eslint-enable used , unused , -- unused and used are ok */"
+                    },
                     directives: [
                         {
-                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], "used", ["used"]),
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -3037,7 +3070,7 @@ describe("apply-disable-directives", () => {
                             parentDirective,
                             ruleId: "unused",
                             type: "enable",
-                            line: 4,
+                            line: 3,
                             column: 1,
                             justification: "j3"
                         }
@@ -3055,10 +3088,10 @@ describe("apply-disable-directives", () => {
                     {
                         ruleId: null,
                         message: "Unused eslint-enable directive (no matching eslint-disable directives were found for 'unused').",
-                        line: 4,
+                        line: 3,
                         column: 1,
                         fix: {
-                            range: [22, 31],
+                            range: [74, 83],
                             text: ""
                         },
                         severity: 2,
@@ -3069,15 +3102,18 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable used */ /* (problem from used) */ /* eslint-enable unused, used */", () => {
-            const parentDirective = createParentDirective([0, 32], " eslint-enable unused, used ", ["unused", "used"]);
+            const parentDirective = createParentDirective([52, 84], "unused, used", ["unused", "used"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable used */\n/* (problem from used) */\n/* eslint-enable unused, used */"
+                    },
                     directives: [
                         {
-                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], "used", ["used"]),
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -3096,7 +3132,7 @@ describe("apply-disable-directives", () => {
                             parentDirective,
                             ruleId: "used",
                             type: "enable",
-                            line: 4,
+                            line: 3,
                             column: 1,
                             justification: "j3"
                         }
@@ -3117,7 +3153,7 @@ describe("apply-disable-directives", () => {
                         line: 3,
                         column: 1,
                         fix: {
-                            range: [17, 25],
+                            range: [69, 77],
                             text: ""
                         },
                         severity: 2,
@@ -3128,15 +3164,18 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable used */ /* (problem from used) */ /* eslint-enable unused,, ,, used */", () => {
-            const parentDirective = createParentDirective([0, 37], " eslint-enable unused,, ,, used ", ["unused", "used"]);
+            const parentDirective = createParentDirective([52, 88], "unused,, ,, used", ["unused", "used"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable used */\n/* (problem from used) */\n/* eslint-enable unused,, ,, used */"
+                    },
                     directives: [
                         {
-                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], "used", ["used"]),
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -3155,7 +3194,7 @@ describe("apply-disable-directives", () => {
                             parentDirective,
                             ruleId: "used",
                             type: "enable",
-                            line: 4,
+                            line: 3,
                             column: 1,
                             justification: "j3"
                         }
@@ -3176,7 +3215,7 @@ describe("apply-disable-directives", () => {
                         line: 3,
                         column: 1,
                         fix: {
-                            range: [17, 24],
+                            range: [69, 76],
                             text: ""
                         },
                         severity: 2,
@@ -3187,15 +3226,18 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable used */ /* (problem from used) */ /* eslint-enable unused-1, unused-2, used */", () => {
-            const parentDirective = createParentDirective([0, 45], " eslint-enable unused-1, unused-2, used ", ["unused-1", "unused-2", "used"]);
+            const parentDirective = createParentDirective([52, 96], "unused-1, unused-2, used", ["unused-1", "unused-2", "used"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable used */\n/* (problem from used) */\n/* eslint-enable unused-1, unused-2, used */"
+                    },
                     directives: [
                         {
-                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], "used", ["used"]),
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -3214,7 +3256,7 @@ describe("apply-disable-directives", () => {
                             parentDirective,
                             ruleId: "unused-2",
                             type: "enable",
-                            line: 4,
+                            line: 3,
                             column: 1,
                             justification: "j3"
                         },
@@ -3222,7 +3264,7 @@ describe("apply-disable-directives", () => {
                             parentDirective,
                             ruleId: "used",
                             type: "enable",
-                            line: 5,
+                            line: 3,
                             column: 1,
                             justification: "j4"
                         }
@@ -3243,7 +3285,7 @@ describe("apply-disable-directives", () => {
                         line: 3,
                         column: 1,
                         fix: {
-                            range: [17, 27],
+                            range: [69, 79],
                             text: ""
                         },
                         severity: 2,
@@ -3252,10 +3294,10 @@ describe("apply-disable-directives", () => {
                     {
                         ruleId: null,
                         message: "Unused eslint-enable directive (no matching eslint-disable directives were found for 'unused-2').",
-                        line: 4,
+                        line: 3,
                         column: 1,
                         fix: {
-                            range: [25, 35],
+                            range: [77, 87],
                             text: ""
                         },
                         severity: 2,
@@ -3266,15 +3308,18 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable used */ /* (problem from used) */ /* eslint-enable unused-1, unused-2, used, unused-3 */", () => {
-            const parentDirective = createParentDirective([0, 55], " eslint-enable unused-1, unused-2, used, unused-3 ", ["unused-1", "unused-2", "used", "unused-3"]);
+            const parentDirective = createParentDirective([52, 106], "unused-1, unused-2, used, unused-3", ["unused-1", "unused-2", "used", "unused-3"]);
 
             assert.deepStrictEqual(
                 applyDisableDirectives({
                     language: jslang,
-                    sourceCode,
+                    sourceCode: {
+                        ...sourceCode,
+                        text: "/* eslint-disable used */\n/* (problem from used) */\n/* eslint-enable unused-1, unused-2, used, unused-3 */"
+                    },
                     directives: [
                         {
-                            parentDirective: createParentDirective([0, 29], " eslint-disable foo ", ["foo"]),
+                            parentDirective: createParentDirective([0, 29], "used", ["used"]),
                             ruleId: "used",
                             type: "disable",
                             line: 1,
@@ -3293,7 +3338,7 @@ describe("apply-disable-directives", () => {
                             parentDirective,
                             ruleId: "unused-2",
                             type: "enable",
-                            line: 4,
+                            line: 3,
                             column: 1,
                             justification: "j3"
                         },
@@ -3301,7 +3346,7 @@ describe("apply-disable-directives", () => {
                             parentDirective,
                             ruleId: "used",
                             type: "enable",
-                            line: 5,
+                            line: 3,
                             column: 1,
                             justification: "j4"
                         },
@@ -3309,7 +3354,7 @@ describe("apply-disable-directives", () => {
                             parentDirective,
                             ruleId: "unused-3",
                             type: "enable",
-                            line: 6,
+                            line: 3,
                             column: 1,
                             justification: "j5"
                         }
@@ -3330,7 +3375,7 @@ describe("apply-disable-directives", () => {
                         line: 3,
                         column: 1,
                         fix: {
-                            range: [17, 27],
+                            range: [69, 79],
                             text: ""
                         },
                         severity: 2,
@@ -3339,10 +3384,10 @@ describe("apply-disable-directives", () => {
                     {
                         ruleId: null,
                         message: "Unused eslint-enable directive (no matching eslint-disable directives were found for 'unused-2').",
-                        line: 4,
+                        line: 3,
                         column: 1,
                         fix: {
-                            range: [25, 35],
+                            range: [77, 87],
                             text: ""
                         },
                         severity: 2,
@@ -3351,10 +3396,10 @@ describe("apply-disable-directives", () => {
                     {
                         ruleId: null,
                         message: "Unused eslint-enable directive (no matching eslint-disable directives were found for 'unused-3').",
-                        line: 6,
+                        line: 3,
                         column: 1,
                         fix: {
-                            range: [41, 51],
+                            range: [93, 103],
                             text: ""
                         },
                         severity: 2,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Refactors code for removing unused disable directives to not use `Node#value` (`Comment#value`) as this property might not exist on nodes/tokens/comment that are used for directives in other languages.

I noticed this while working on https://github.com/eslint/json/issues/21. For example, eslint would crash while trying to remove unused `json/no-duplicate-keys` when linting the following code:

```js
{
    // eslint-disable-next-line json/no-empty-keys, json/no-duplicate-keys
    "": "foo"
}
```

```
Oops! Something went wrong! :(

ESLint: 9.9.1

TypeError: Cannot read properties of null (reading '0')
    at createIndividualDirectivesRemoval (C:\projects\json\node_modules\eslint\lib\linter\apply-disable-directives.js:78:59)
```

https://github.com/eslint/eslint/blob/90e699bd9d76139ed0aeb3894839b2d4856b4a72/lib/linter/apply-disable-directives.js#L78

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Instead of using mentioned `value`, eslint will now search for `Directive#value` in `SourceCode#text` starting from the directive node.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
