### PR TITLE
feat: requireFlag option

### DIFF
--- a/docs/src/rules/require-unicode-regexp.md
+++ b/docs/src/rules/require-unicode-regexp.md
@@ -98,6 +98,12 @@ function i(flags) {
 
 :::
 
+## Options
+
+This rule has one object option:
+
+* `"requireFlag": "u"|"v"` requires a particular Unicode regex flag
+
 ## When Not To Use It
 
 If you don't want to warn on regular expressions without either a `u` or a `v` flag, then it's safe to disable this rule.

--- a/lib/rules/require-unicode-regexp.js
+++ b/lib/rules/require-unicode-regexp.js
@@ -18,6 +18,26 @@ const {
 const astUtils = require("./utils/ast-utils.js");
 const { isValidWithUnicodeFlag } = require("./utils/regular-expressions");
 
+/**
+ * Checks whether the flag configuration should be treated as a missing flag.
+ * @param {"u"|"v"|undefined} requireFlag A particular flag to require
+ * @param {string} flags The regex flags
+ * @returns {boolean} Whether the flag configuration results in a missing flag.
+ */
+function checkFlags(requireFlag, flags) {
+    let missingFlag;
+
+    if (requireFlag === "v") {
+        missingFlag = !flags.includes("v");
+    } else if (requireFlag === "u") {
+        missingFlag = !flags.includes("u");
+    } else {
+        missingFlag = !flags.includes("u") && !flags.includes("v");
+    }
+
+    return missingFlag;
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -37,31 +57,65 @@ module.exports = {
 
         messages: {
             addUFlag: "Add the 'u' flag.",
-            requireUFlag: "Use the 'u' flag."
+            addVFlag: "Add the 'v' flag.",
+            requireUFlag: "Use the 'u' flag.",
+            requireVFlag: "Use the 'v' flag."
         },
 
-        schema: []
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    requireFlag: {
+                        type: "string"
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
     },
 
     create(context) {
 
         const sourceCode = context.sourceCode;
 
+        const {
+            requireFlag
+        } = context.options[0] ?? {};
+
         return {
             "Literal[regex]"(node) {
                 const flags = node.regex.flags || "";
 
-                if (!flags.includes("u") && !flags.includes("v")) {
+                const missingFlag = checkFlags(requireFlag, flags);
+
+                if (missingFlag) {
                     context.report({
-                        messageId: "requireUFlag",
+                        messageId: requireFlag === "v" ? "requireVFlag" : "requireUFlag",
                         node,
-                        suggest: isValidWithUnicodeFlag(context.languageOptions.ecmaVersion, node.regex.pattern)
+                        suggest: isValidWithUnicodeFlag(context.languageOptions.ecmaVersion, node.regex.pattern, requireFlag)
                             ? [
                                 {
                                     fix(fixer) {
-                                        return fixer.insertTextAfter(node, "u");
+                                        const replaceFlag = requireFlag ?? "u";
+                                        const regex = sourceCode.getText(node);
+                                        const slashPos = regex.lastIndexOf("/");
+
+                                        if (requireFlag) {
+                                            const flag = requireFlag === "u" ? "v" : "u";
+
+                                            if (regex.includes(flag, slashPos)) {
+                                                return fixer.replaceText(
+                                                    node,
+                                                    regex.slice(0, slashPos) +
+                                                    regex.slice(slashPos).replace(flag, requireFlag)
+                                                );
+                                            }
+                                        }
+
+                                        return fixer.insertTextAfter(node, replaceFlag);
                                     },
-                                    messageId: "addUFlag"
+                                    messageId: requireFlag === "v" ? "addVFlag" : "addUFlag"
                                 }
                             ]
                             : null
@@ -85,22 +139,34 @@ module.exports = {
                     const pattern = getStringIfConstant(patternNode, scope);
                     const flags = getStringIfConstant(flagsNode, scope);
 
-                    if (!flagsNode || (typeof flags === "string" && !flags.includes("u") && !flags.includes("v"))) {
+                    let missingFlag = !flagsNode;
+
+                    if (typeof flags === "string") {
+                        missingFlag = checkFlags(requireFlag, flags);
+                    }
+
+                    if (missingFlag) {
                         context.report({
-                            messageId: "requireUFlag",
+                            messageId: requireFlag === "v" ? "requireVFlag" : "requireUFlag",
                             node: refNode,
-                            suggest: typeof pattern === "string" && isValidWithUnicodeFlag(context.languageOptions.ecmaVersion, pattern)
+                            suggest: typeof pattern === "string" && isValidWithUnicodeFlag(context.languageOptions.ecmaVersion, pattern, requireFlag)
                                 ? [
                                     {
                                         fix(fixer) {
+                                            const replaceFlag = requireFlag ?? "u";
+
                                             if (flagsNode) {
                                                 if ((flagsNode.type === "Literal" && typeof flagsNode.value === "string") || flagsNode.type === "TemplateLiteral") {
                                                     const flagsNodeText = sourceCode.getText(flagsNode);
+                                                    const flag = requireFlag === "u" ? "v" : "u";
 
                                                     return fixer.replaceText(flagsNode, [
-                                                        flagsNodeText.slice(0, flagsNodeText.length - 1),
+                                                        flagsNodeText.slice(0, flagsNodeText.length - 1).replace(
+                                                            flag,
+                                                            ""
+                                                        ),
                                                         flagsNodeText.slice(flagsNodeText.length - 1)
-                                                    ].join("u"));
+                                                    ].join(replaceFlag));
                                                 }
 
                                                 // We intentionally don't suggest concatenating + "u" to non-literals
@@ -112,11 +178,11 @@ module.exports = {
                                             return fixer.insertTextAfter(
                                                 penultimateToken,
                                                 astUtils.isCommaToken(penultimateToken)
-                                                    ? ' "u",'
-                                                    : ', "u"'
+                                                    ? ` "'${replaceFlag}'",`
+                                                    : `, "${replaceFlag}"`
                                             );
                                         },
-                                        messageId: "addUFlag"
+                                        messageId: requireFlag === "v" ? "addVFlag" : "addUFlag"
                                     }
                                 ]
                                 : null

--- a/lib/rules/utils/regular-expressions.js
+++ b/lib/rules/utils/regular-expressions.js
@@ -14,12 +14,16 @@ const REGEXPP_LATEST_ECMA_VERSION = 2025;
  * Checks if the given regular expression pattern would be valid with the `u` flag.
  * @param {number} ecmaVersion ECMAScript version to parse in.
  * @param {string} pattern The regular expression pattern to verify.
+ * @param {"u"|"v"} flag The type of Unicode flag
  * @returns {boolean} `true` if the pattern would be valid with the `u` flag.
  * `false` if the pattern would be invalid with the `u` flag or the configured
  * ecmaVersion doesn't support the `u` flag.
  */
-function isValidWithUnicodeFlag(ecmaVersion, pattern) {
-    if (ecmaVersion <= 5) { // ecmaVersion <= 5 doesn't support the 'u' flag
+function isValidWithUnicodeFlag(ecmaVersion, pattern, flag = "u") {
+    if (flag === "u" && ecmaVersion <= 5) { // ecmaVersion <= 5 doesn't support the 'u' flag
+        return false;
+    }
+    if (flag === "v" && ecmaVersion <= 2023) {
         return false;
     }
 
@@ -28,7 +32,11 @@ function isValidWithUnicodeFlag(ecmaVersion, pattern) {
     });
 
     try {
-        validator.validatePattern(pattern, void 0, void 0, { unicode: /* uFlag = */ true });
+        validator.validatePattern(pattern, void 0, void 0, flag === "u" ? {
+            unicode: /* uFlag = */ true
+        } : {
+            unicodeSets: true
+        });
     } catch {
         return false;
     }

--- a/tests/lib/rules/require-unicode-regexp.js
+++ b/tests/lib/rules/require-unicode-regexp.js
@@ -47,6 +47,8 @@ ruleTester.run("require-unicode-regexp", rule, {
         { code: "const flags = 'g'; new globalThis.RegExp('', flags + 'u')", languageOptions: { ecmaVersion: 2020 } },
         { code: "const flags = 'gimu'; new globalThis.RegExp('foo', flags[3])", languageOptions: { ecmaVersion: 2020 } },
         { code: "class C { #RegExp; foo() { new globalThis.#RegExp('foo') } }", languageOptions: { ecmaVersion: 2022 } },
+        { code: "/foo/u", options: [{ requireFlag: "u" }] },
+        { code: "new RegExp('foo', 'u')", options: [{ requireFlag: "u" }] },
 
         // for v flag
         { code: "/foo/v", languageOptions: { ecmaVersion: 2024 } },
@@ -59,7 +61,9 @@ ruleTester.run("require-unicode-regexp", rule, {
         { code: "new RegExp('', 'gimvy')", languageOptions: { ecmaVersion: 2024 } },
         { code: "const flags = 'v'; new RegExp('', flags)", languageOptions: { ecmaVersion: 2024 } },
         { code: "const flags = 'g'; new RegExp('', flags + 'v')", languageOptions: { ecmaVersion: 2024 } },
-        { code: "const flags = 'gimv'; new RegExp('foo', flags[3])", languageOptions: { ecmaVersion: 2024 } }
+        { code: "const flags = 'gimv'; new RegExp('foo', flags[3])", languageOptions: { ecmaVersion: 2024 } },
+        { code: "/foo/v", options: [{ requireFlag: "v" }], languageOptions: { ecmaVersion: 2024 } },
+        { code: "new RegExp('foo', 'v')", options: [{ requireFlag: "v" }], languageOptions: { ecmaVersion: 2024 } }
     ],
     invalid: [
         {
@@ -299,6 +303,117 @@ ruleTester.run("require-unicode-regexp", rule, {
                     {
                         messageId: "addUFlag",
                         output: "new globalThis.RegExp('foo', \"u\")"
+                    }
+                ]
+            }]
+        },
+        {
+            code: "/foo/",
+            options: [{ requireFlag: "v" }],
+            languageOptions: { ecmaVersion: 2024 },
+            errors: [{
+                messageId: "requireVFlag",
+                suggestions: [
+                    {
+                        messageId: "addVFlag",
+                        output: "/foo/v"
+                    }
+                ]
+            }]
+        },
+        {
+            code: "/foo/u",
+            options: [{ requireFlag: "v" }],
+            languageOptions: { ecmaVersion: 2024 },
+            errors: [{
+                messageId: "requireVFlag",
+                suggestions: [
+                    {
+                        messageId: "addVFlag",
+                        output: "/foo/v"
+                    }
+                ]
+            }]
+        },
+        {
+            code: "/foo/u",
+            options: [{ requireFlag: "v" }],
+            languageOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "requireVFlag",
+                suggestions: null
+            }]
+        },
+        {
+            code: "/[[a]/u",
+            options: [{ requireFlag: "v" }],
+            languageOptions: { ecmaVersion: 2024 },
+            errors: [{
+                messageId: "requireVFlag",
+                suggestions: null
+            }]
+        },
+        {
+            code: "new RegExp('foo', 'u')",
+            options: [{ requireFlag: "v" }],
+            languageOptions: { ecmaVersion: 2024 },
+            errors: [{
+                messageId: "requireVFlag",
+                suggestions: [
+                    {
+                        messageId: "addVFlag",
+                        output: "new RegExp('foo', 'v')"
+                    }
+                ]
+            }]
+        },
+        {
+            code: "new RegExp('[[a]', 'u')",
+            options: [{ requireFlag: "v" }],
+            languageOptions: { ecmaVersion: 2024 },
+            errors: [{
+                messageId: "requireVFlag",
+                suggestions: null
+            }]
+        },
+        {
+            code: "/foo/v",
+            options: [{ requireFlag: "u" }],
+            languageOptions: { ecmaVersion: 2024 },
+            errors: [{
+                messageId: "requireUFlag",
+                suggestions: [
+                    {
+                        messageId: "addUFlag",
+                        output: "/foo/u"
+                    }
+                ]
+            }]
+        },
+        {
+            code: "new RegExp('foo')",
+            options: [{ requireFlag: "v" }],
+            languageOptions: { ecmaVersion: 2024 },
+            errors: [{
+                messageId: "requireVFlag",
+                suggestions: [
+                    {
+                        messageId: "addVFlag",
+                        output: "new RegExp('foo', \"v\")"
+                    }
+                ]
+            }]
+        },
+        {
+            code: "new RegExp('foo', 'v')",
+            options: [{ requireFlag: "u" }],
+            languageOptions: { ecmaVersion: 2024 },
+            errors: [{
+                messageId: "requireUFlag",
+                suggestions: [
+                    {
+                        messageId: "addUFlag",
+                        output: "new RegExp('foo', 'u')"
                     }
                 ]
             }]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

https://github.com/eslint/eslint/issues/18712

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Adds a `requireFlag` option. Can be set to `"u"` or `"v"` to require use of a particular Unicode flag.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
No.