### PR TITLE
feat: add error message for duplicate flags in `no-invalid-regexp`

### DIFF
--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -126,15 +126,16 @@ module.exports = {
          * Check syntax error in a given flags.
          * @param {string|null} flags The RegExp flags to validate.
          * @param {string|null} flagsToCheck The RegExp invalid flags.
+         * @param {string} allFlags all valid and allowed flags.
          * @returns {string|null} The syntax error.
          */
-        function validateRegExpFlags(flags, flagsToCheck) {
-            const flagsToReport = [];
+        function validateRegExpFlags(flags, flagsToCheck, allFlags) {
+            const duplicateFlags = [];
 
-            if (typeof flags === "string") {
-                for (const flag of flags) {
-                    if (flagsToCheck.includes(flag)) {
-                        flagsToReport.push(flag);
+            if (typeof flagsToCheck === "string") {
+                for (const flag of flagsToCheck) {
+                    if (allFlags.includes(flag)) {
+                        duplicateFlags.push(flag);
                     }
                 }
             }
@@ -148,11 +149,15 @@ module.exports = {
                 return "Regex 'u' and 'v' flags cannot be used together";
             }
 
+            if (duplicateFlags.length > 0) {
+                return `Duplicate flags supplied to RegExp constructor '${duplicateFlags.join("")}'`;
+            }
+
             if (!flagsToCheck) {
                 return null;
             }
 
-            return `Invalid flags supplied to RegExp constructor '${flagsToReport.join("")}'`;
+            return `Invalid flags supplied to RegExp constructor '${flagsToCheck}'`;
         }
 
         return {
@@ -171,7 +176,7 @@ module.exports = {
                     });
                 }
 
-                let message = validateRegExpFlags(flags, flagsToCheck);
+                let message = validateRegExpFlags(flags, flagsToCheck, allFlags);
 
                 if (message) {
                     report(node, message);

--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -150,7 +150,7 @@ module.exports = {
             }
 
             if (duplicateFlags.length > 0) {
-                return `Duplicate flags supplied to RegExp constructor '${duplicateFlags.join("")}'`;
+                return `Duplicate flags ('${duplicateFlags.join("")}') supplied to RegExp constructor`;
             }
 
             if (!flagsToCheck) {

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -218,7 +218,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Duplicate flags supplied to RegExp constructor 'a'" },
+                data: { message: "Duplicate flags ('a') supplied to RegExp constructor" },
                 type: "NewExpression"
             }]
         },
@@ -227,7 +227,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a", "a"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Duplicate flags supplied to RegExp constructor 'a'" },
+                data: { message: "Duplicate flags ('a') supplied to RegExp constructor" },
                 type: "NewExpression"
             }]
         },
@@ -245,7 +245,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a", "z"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Duplicate flags supplied to RegExp constructor 'a'" },
+                data: { message: "Duplicate flags ('a') supplied to RegExp constructor" },
                 type: "NewExpression"
             }]
         },
@@ -254,7 +254,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a", "z"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Duplicate flags supplied to RegExp constructor 'z'" },
+                data: { message: "Duplicate flags ('z') supplied to RegExp constructor" },
                 type: "NewExpression"
             }]
         },
@@ -263,7 +263,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Duplicate flags supplied to RegExp constructor 'a'" },
+                data: { message: "Duplicate flags ('a') supplied to RegExp constructor" },
                 type: "NewExpression"
             }]
         },
@@ -272,7 +272,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["u"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Duplicate flags supplied to RegExp constructor 'u'" },
+                data: { message: "Duplicate flags ('u') supplied to RegExp constructor" },
                 type: "NewExpression"
             }]
         },

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -218,7 +218,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid flags supplied to RegExp constructor 'aa'" },
+                data: { message: "Duplicate flags supplied to RegExp constructor 'a'" },
                 type: "NewExpression"
             }]
         },
@@ -227,7 +227,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a", "a"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid flags supplied to RegExp constructor 'aa'" },
+                data: { message: "Duplicate flags supplied to RegExp constructor 'a'" },
                 type: "NewExpression"
             }]
         },
@@ -245,7 +245,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a", "z"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid flags supplied to RegExp constructor 'aa'" },
+                data: { message: "Duplicate flags supplied to RegExp constructor 'a'" },
                 type: "NewExpression"
             }]
         },
@@ -254,7 +254,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a", "z"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid flags supplied to RegExp constructor 'zz'" },
+                data: { message: "Duplicate flags supplied to RegExp constructor 'z'" },
                 type: "NewExpression"
             }]
         },
@@ -263,7 +263,7 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["a"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid flags supplied to RegExp constructor 'aa'" },
+                data: { message: "Duplicate flags supplied to RegExp constructor 'a'" },
                 type: "NewExpression"
             }]
         },
@@ -272,7 +272,16 @@ ruleTester.run("no-invalid-regexp", rule, {
             options: [{ allowConstructorFlags: ["u"] }],
             errors: [{
                 messageId: "regexMessage",
-                data: { message: "Invalid flags supplied to RegExp constructor 'uu'" },
+                data: { message: "Duplicate flags supplied to RegExp constructor 'u'" },
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "new RegExp('.', 'ouo');",
+            options: [{ allowConstructorFlags: ["u"] }],
+            errors: [{
+                messageId: "regexMessage",
+                data: { message: "Invalid flags supplied to RegExp constructor 'oo'" },
                 type: "NewExpression"
             }]
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added a separate error message for duplicate flags (only those are valid and allowed flags) in `no-invalid-regexp` rule.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
