### PR TITLE
feat: add type `FormatterFunction`, update `LoadedFormatter`

### DIFF
--- a/lib/shared/types.js
+++ b/lib/shared/types.js
@@ -245,6 +245,6 @@ module.exports = {};
  * A formatter function.
  * @callback FormatterFunction
  * @param {LintResult[]} results The list of linting results.
- * @param {{cwd: string, maxWarningsExceeded?: MaxWarningsExceeded, rulesMeta: Record<string, RuleMeta>}} [context] A context object.
+ * @param {{cwd: string, maxWarningsExceeded?: MaxWarningsExceeded, rulesMeta: Record<string, RuleMeta>}} context A context object.
  * @returns {string | Promise<string>} Formatted text.
  */

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1567,7 +1567,13 @@ export namespace ESLint {
     // The documented type name is `LoadedFormatter`, but `Formatter` has been historically more used.
     type Formatter = LoadedFormatter;
 
-    /** The expected signature of a custom formatter. */
+    /**
+     * The expected signature of a custom formatter.
+     * @param results An array of lint results to format.
+     * @param context Optional additional information for the formatter.
+     * When the `FormatterFunction` is called by ESLint, this argument is always specified.
+     * @return The formatter output.
+     */
     type FormatterFunction =
     (results: LintResult[], context?: LintResultData) => string | Promise<string>;
 

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1561,6 +1561,15 @@ export namespace ESLint {
 
     /** The type of an object resolved by {@link ESLint.loadFormatter}. */
     interface LoadedFormatter {
+
+        /**
+         * Used to call the underlying formatter.
+         * @param results An array of lint results to format.
+         * @param resultsMeta An object with an optional `maxWarningsExceeded` property that will be
+         * passed to the underlying formatter function along with other properties set by ESLint.
+         * This argument can be omitted if `maxWarningsExceeded` is not needed.
+         * @return The formatter output.
+         */
         format(results: LintResult[], resultsMeta?: ResultsMeta): string | Promise<string>;
     }
 
@@ -1570,12 +1579,11 @@ export namespace ESLint {
     /**
      * The expected signature of a custom formatter.
      * @param results An array of lint results to format.
-     * @param context Optional additional information for the formatter.
-     * When the `FormatterFunction` is called by ESLint, this argument is always specified.
+     * @param context Additional information for the formatter.
      * @return The formatter output.
      */
     type FormatterFunction =
-    (results: LintResult[], context?: LintResultData) => string | Promise<string>;
+    (results: LintResult[], context: LintResultData) => string | Promise<string>;
 
     // Docs reference the types by those name
     type EditInfo = Rule.Fix;

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1411,7 +1411,7 @@ export class ESLint {
 
     isPathIgnored(filePath: string): Promise<boolean>;
 
-    loadFormatter(nameOrPath?: string): Promise<ESLint.Formatter>;
+    loadFormatter(nameOrPath?: string): Promise<ESLint.LoadedFormatter>;
 }
 
 export namespace ESLint {
@@ -1555,14 +1555,24 @@ export namespace ESLint {
         replacedBy: string[];
     }
 
-    interface Formatter {
-        format(results: LintResult[], data?: LintResultData): string | Promise<string>;
+    interface ResultsMeta {
+        maxWarningsExceeded?: MaxWarningsExceeded | undefined;
     }
+
+    /** The type of an object resolved by {@link ESLint.loadFormatter}. */
+    interface LoadedFormatter {
+        format(results: LintResult[], resultsMeta?: ResultsMeta): string | Promise<string>;
+    }
+
+    // The documented type name is `LoadedFormatter`, but `Formatter` has been historically more used.
+    type Formatter = LoadedFormatter;
+
+    /** The expected signature of a custom formatter. */
+    type FormatterFunction =
+    (results: LintResult[], context?: LintResultData) => string | Promise<string>;
 
     // Docs reference the types by those name
     type EditInfo = Rule.Fix;
-    type LoadedFormatter = Formatter;
-    type ResultsMeta = LintResultData;
 }
 
 // #endregion

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -1003,7 +1003,7 @@ linterWithEslintrcConfig.getRules();
     const customFormatter1: ESLint.Formatter = { format: () => "ok" };
     const customFormatter2: ESLint.Formatter = { format: () => Promise.resolve("ok") };
 
-    let data: ESLint.LintResultData;
+    let resultsMeta: ESLint.ResultsMeta;
     const meta: Rule.RuleMetaData = {
         type: "suggestion",
         docs: {
@@ -1019,7 +1019,7 @@ linterWithEslintrcConfig.getRules();
         },
     };
 
-    data = { cwd: "/foo/bar", rulesMeta: { "no-extra-semi": meta } };
+    resultsMeta = { maxWarningsExceeded: { maxWarnings: 42, foundWarnings: 43 } };
 
     const version: string = ESLint.version;
 
@@ -1027,7 +1027,7 @@ linterWithEslintrcConfig.getRules();
         const results: ESLint.LintResult[] = await resultsPromise;
         const formatter = await formatterPromise;
 
-        const output: string = await formatter.format(results, data);
+        const output: string = await formatter.format(results, resultsMeta);
 
         eslint.getRulesMetaForResults(results);
 
@@ -1131,7 +1131,7 @@ linterWithEslintrcConfig.getRules();
     const customFormatter1: ESLint.Formatter = { format: () => "ok" };
     const customFormatter2: ESLint.Formatter = { format: () => Promise.resolve("ok") };
 
-    let data: ESLint.LintResultData;
+    let resultsMeta: ESLint.ResultsMeta;
     const meta: Rule.RuleMetaData = {
         type: "suggestion",
         docs: {
@@ -1147,7 +1147,7 @@ linterWithEslintrcConfig.getRules();
         },
     };
 
-    data = { cwd: "/foo/bar", rulesMeta: { "no-extra-semi": meta } };
+    resultsMeta = { maxWarningsExceeded: { maxWarnings: 42, foundWarnings: 43 } };
 
     const version: string = LegacyESLint.version;
 
@@ -1155,7 +1155,7 @@ linterWithEslintrcConfig.getRules();
         const results: ESLint.LintResult[] = await resultsPromise;
         const formatter = await formatterPromise;
 
-        const output: string = await formatter.format(results, data);
+        const output: string = await formatter.format(results, resultsMeta);
 
         eslint.getRulesMetaForResults(results);
 
@@ -1168,6 +1168,20 @@ linterWithEslintrcConfig.getRules();
 }
 
 // #endregion
+
+// #region ESLint.Formatter
+
+function jsonFormatter(results: ESLint.LintResult[]) {
+    return JSON.stringify(results, null, 2);
+};
+
+const customFormatter: ESLint.FormatterFunction = jsonFormatter;
+
+function wrapperFormatter(results: ESLint.LintResult[], { cwd, maxWarningsExceeded, rulesMeta }: ESLint.LintResultData) {
+    customFormatter(results, { cwd, maxWarningsExceeded, rulesMeta });
+}
+
+// #endregion ESLint.Formatter
 
 // #region ESLint.LintResult
 
@@ -1216,7 +1230,7 @@ for (const result of results) {
     }
 }
 
-// #region ESLint.LintResult
+// #endregion ESLint.LintResult
 
 // #region ESLintRules
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Updated type declarations.

Fixes #18821

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Added type `FormatterFunction`. The `context` argument is no longer marked as optional.
  https://github.com/eslint/eslint/blob/adcc50dbf1fb98c0884f841e2a627796a4490373/lib/shared/types.js#L244-L250

* Updated type `ResultsMeta`. This is the type of the second argument passed to a `LoadedFormatter` function. `ResultsMeta` is currently used as a synonym for `LintResultData`, but that type contains additional fields, so I redefined it as a separate interface.
  https://github.com/eslint/eslint/blob/adcc50dbf1fb98c0884f841e2a627796a4490373/lib/shared/types.js#L238-L242

* Updated type `LoadedFormatter`/`Formatter`
  https://github.com/eslint/eslint/blob/59cfc0f1b3bbb62260602579f79bd1c36ab5a00f/docs/src/integrate/nodejs-api.md?plain=1#L465-L470

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
