### PR TITLE
fix: do not throw when defining a global named `__defineSetter__`

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -733,7 +733,7 @@ function createLanguageOptions({ globals: configuredGlobals, parser, parserOptio
  */
 function resolveGlobals(providedGlobals, enabledEnvironments) {
     return Object.assign(
-        {},
+        Object.create(null),
         ...enabledEnvironments.filter(env => env.globals).map(env => env.globals),
         providedGlobals
     );

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -934,7 +934,7 @@ class SourceCode extends TokenStore {
          * https://github.com/eslint/eslint/issues/16302
          */
         const configGlobals = Object.assign(
-            {},
+            Object.create(null), // https://github.com/eslint/eslint/issues/18363
             getGlobalsForEcmaVersion(languageOptions.ecmaVersion),
             languageOptions.sourceType === "commonjs" ? globals.commonjs : void 0,
             languageOptions.globals

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -12510,6 +12510,48 @@ describe("Linter with FlatConfigArray", () => {
 
                 describe("when evaluating code containing /*global */ and /*globals */ blocks", () => {
 
+                    /**
+                     * Asserts the global variables in the provided code using the specified language options and data.
+                     * @param {string} code The code to verify.
+                     * @param {Object} languageOptions The language options to use.
+                     * @param {Object} [data={}] Additional data for the assertion.
+                     * @returns {void}
+                     */
+                    function assertGlobalVariable(code, languageOptions, data = {}) {
+                        let spy;
+
+                        const config = {
+                            plugins: {
+                                test: {
+                                    rules: {
+                                        checker: {
+                                            create(context) {
+                                                spy = sinon.spy(node => {
+                                                    const scope = context.sourceCode.getScope(node);
+                                                    const g = getVariable(scope, data.name);
+
+                                                    assert.strictEqual(g.name, data.name);
+                                                    assert.strictEqual(g.writeable, data.writeable);
+                                                });
+
+                                                return { Program: spy };
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            rules: { "test/checker": "error" }
+                        };
+
+                        if (languageOptions !== void 0) {
+                            config.languageOptions = languageOptions;
+                        }
+
+                        linter.verify(code, config);
+                        assert(spy && spy.calledOnce);
+
+                    }
+
                     it("variables should be available in global scope", () => {
                         const code = `
                         /*global a b:true c:false d:readable e:writeable Math:off */
@@ -12569,6 +12611,15 @@ describe("Linter with FlatConfigArray", () => {
 
                         linter.verify(code, config);
                         assert(spy && spy.calledOnce);
+                    });
+
+                    // https://github.com/eslint/eslint/issues/18363
+                    it("not throw when defining a global named __defineSetter__", () => {
+                        assertGlobalVariable("/*global __defineSetter__ */", {}, { name: "__defineSetter__", writeable: false });
+                        assertGlobalVariable("/*global __defineSetter__ */", void 0, { name: "__defineSetter__", writeable: false });
+                        assertGlobalVariable("/*global __defineSetter__ */", { globals: { __defineSetter__: "off" } }, { name: "__defineSetter__", writeable: false });
+                        assertGlobalVariable("/*global __defineSetter__ */", { globals: { __defineSetter__: "writeable" } }, { name: "__defineSetter__", writeable: false });
+                        assertGlobalVariable("/*global __defineSetter__:writeable */", {}, { name: "__defineSetter__", writeable: true });
                     });
                 });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #18363 on the v8.x-dev branch

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Applied commit eeec41346738afb491958fdbf0bcf45a302ca1b7 to the v8.x-dev branch.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
