### PR TITLE
fix: fallback to default `structuredClone` export

### DIFF
--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -13,7 +13,7 @@
  * Note: This can be removed in ESLint v9 because structuredClone is available globally
  * starting in Node.js v17.
  */
-const structuredClone = require("@ungap/structured-clone").default || require("@ungap/structured-clone");
+const structuredClone = require("@ungap/structured-clone").default;
 const { normalizeSeverityToNumber } = require("../shared/severity");
 
 //-----------------------------------------------------------------------------

--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -13,7 +13,7 @@
  * Note: This can be removed in ESLint v9 because structuredClone is available globally
  * starting in Node.js v17.
  */
-const structuredClone = require("@ungap/structured-clone").default;
+const structuredClone = require("@ungap/structured-clone").default || require("@ungap/structured-clone");
 const { normalizeSeverityToNumber } = require("../shared/severity");
 
 //-----------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "semver": "^7.5.3",
     "shelljs": "^0.8.2",
     "sinon": "^11.0.0",
-    "vite-plugin-commonjs": "^0.10.0",
+    "vite-plugin-commonjs": "0.10.1",
     "webdriverio": "^8.14.6",
     "webpack": "^5.23.0",
     "webpack-cli": "^4.5.0",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

This PR fixes a browser test error in branch v8.x-dev. See for example https://github.com/eslint/eslint/actions/runs/10872529728/job/30168035747#step:5:129

`@ungap/structured-clone` includes both a CommonJS and an ESM export. ESLint always uses the CommonJS export which can be required with `require("@ungap/structured-clone").default`, but the browser test generates a bundle that includes the transpiled ESM code, which must be required with `require("@ungap/structured-clone")`.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated require syntax for `"@ungap/structured-clone"` in lib/config/flat-config-schema.js.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
