### PR TITLE
fix: add missing types for `no-restricted-exports` rule

### DIFF
--- a/lib/types/rules/ecmascript-6.d.ts
+++ b/lib/types/rules/ecmascript-6.d.ts
@@ -232,6 +232,52 @@ export interface ECMAScript6 extends Linter.RulesRecord {
     "no-new-symbol": Linter.RuleEntry<[]>;
 
     /**
+     * Rule to disallow specified names in exports.
+     *
+     * @since 7.0.0-alpha.0
+     * @see https://eslint.org/docs/rules/no-restricted-exports
+     */
+    "no-restricted-exports": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default []
+                 */
+                restrictedNamedExports: string[];
+                /**
+                 * @since 9.3.0
+                 */
+                restrictedNamedExportsPattern: string;
+                /**
+                 * @since 8.33.0
+                 */
+                restrictDefaultExports: Partial<{
+                    /**
+                     * @default false
+                     */
+                    direct: boolean;
+                    /**
+                     * @default false
+                     */
+                    named: boolean;
+                    /**
+                     * @default false
+                     */
+                    defaultFrom: boolean;
+                    /**
+                     * @default false
+                     */
+                    namedFrom: boolean;
+                    /**
+                     * @default false
+                     */
+                    namespaceFrom: boolean;
+                }>;
+            }>,
+        ]
+    >;
+
+    /**
      * Rule to disallow specified modules when loaded by `import`.
      *
      * @since 2.0.0-alpha-1


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v22.8.0
- **npm version:** v10.8.2
- **Local ESLint version:** v9.10.0 (Currently used)
- **Global ESLint version:** Not found
- **Operating System:** darwin 23.6.0

**What parser are you using (place an "X" next to just one item)?**

N/A

**Please show your full configuration:**

N/A

**What did you do? Please include the actual source code causing the issue.**

```ts
import type { Linter } from "eslint";
import type { ESLintRules } from "eslint/rules";

export default {
  rules: {
    "no-restricted-exports": [
      "error",
      {
        restrictedNamedExports: [
          // Ambiguous with dynamic imports
          // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#module_namespace_object
          "then",
        ],
        restrictDefaultExports: {
          // Prefer `export default` expressions
          named: true,

          // Avoid re-exporting entire modules as is
          namespaceFrom: true,
        },
      },
    ],
  },
} satisfies Linter.Config<ESLintRules>;
```

**What did you expect to happen?**

Autocompletion and type checking should be in place for the `no-restricted-exports` rule.

**What actually happened? Please include the actual, raw output from ESLint.**

No assistance was given by TypeScript.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added type declarations for the `no-restricted-exports` rule.

#### Is there anything you'd like reviewers to focus on?

N/A

<!-- markdownlint-disable-file MD004 -->
