### PR TITLE
feat: Add language to types

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -26,6 +26,7 @@
  */
 
 import * as ESTree from "estree";
+import { Language } from "@eslint/core";
 import { JSONSchema4 } from "json-schema";
 import { LegacyESLint } from "./use-at-your-own-risk.js";
 
@@ -1266,6 +1267,13 @@ export namespace Linter {
         ignores?: string[];
 
         /**
+         * The name of the language used for linting. This is used to determine the
+         * parser and other language-specific settings.
+         * @since 9.7.0
+         */
+        language?: string;
+
+        /**
          * An object containing settings related to how JavaScript is configured for
          * linting.
          */
@@ -1441,6 +1449,7 @@ export namespace ESLint {
     interface Plugin extends ObjectMetaProperties {
         configs?: Record<string, Linter.LegacyConfig | Linter.Config | Linter.Config[]> | undefined;
         environments?: Record<string, Environment> | undefined;
+        languages?: Record<string, Language> | undefined;
         processors?: Record<string, Linter.Processor> | undefined;
         rules?: Record<string, Rule.RuleModule> | undefined;
     }

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -35,6 +35,7 @@ import {
     shouldUseFlatConfig,
 } from "eslint/use-at-your-own-risk";
 import { Comment, PrivateIdentifier, PropertyDefinition, StaticBlock, WhileStatement } from "estree";
+import { Language } from "@eslint/core";
 
 const SOURCE = `var foo = bar;`;
 
@@ -1355,6 +1356,15 @@ ruleTester.run("simple-valid-test", rule, {
 // #region Config
 
 ((): Linter.Config => ({
+    language: "js/js"
+}));
+
+((): Linter.Config => ({
+    // @ts-expect-error
+    language: null
+}));
+
+((): Linter.Config => ({
     languageOptions: {
         parser: {
             parse: () => AST,
@@ -1495,6 +1505,16 @@ config = flatConfig;
 flatConfig = config;
 
 // #endregion Config
+
+// #region Plugins
+
+((): ESLint.Plugin => ({
+    languages: {
+        "js": {} as Language
+    }
+}));
+
+// #endregion Plugins
 
 (async (useFlatConfig?: boolean) => {
     await loadESLint(); // $ExpectType typeof ESLint | typeof LegacyESLint


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Update types

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

1. Added `language` to `Linter.Config`
2. Added `languages` to `ESLint.Plugin`
3. Added type tests for both changes

#### Is there anything you'd like reviewers to focus on?

This is just a first step towards fully supporting languages through the type system. At the least, it lets people create plugins containing the `languages` key. We will need to continue tweaking this so that rules, etc. for other languages can also be included in plugins.

<!-- markdownlint-disable-file MD004 -->
