### PR TITLE
fix: add missing types for `no-shadow` rule

### DIFF
--- a/lib/types/rules/variables.d.ts
+++ b/lib/types/rules/variables.d.ts
@@ -100,6 +100,11 @@ export interface Variables extends Linter.RulesRecord {
                  */
                 hoist: "functions" | "all" | "never";
                 allow: string[];
+                /**
+                 * @since 8.10.0
+                 * @default false
+                 */
+                ignoreOnInitialization: boolean;
             }>,
         ]
     >;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v22.8.0
- **npm version:** v10.8.2
- **Local ESLint version:** v9.11.0 (Currently used)
- **Global ESLint version:** Not found
- **Operating System:** darwin 24.0.0

**What parser are you using (place an "X" next to just one item)?**

N/A

**Please show your full configuration:**

N/A

**What did you do? Please include the actual source code causing the issue.**

Tried to create a custom config using TypeScript as follows:

```ts
import type { Linter } from "eslint";
import type { ESLintRules } from "eslint/rules";

export default {
  rules: {
    "no-shadow": [
      "error",
      {
        builtinGlobals: true,
        ignoreOnInitialization: true, // does not exist in type
      },
    ],
  },
} satisfies Linter.Config<ESLintRules>;

```

**What did you expect to happen?**

Options existing at runtime should be available on the type level.

**What actually happened? Please include the actual, raw output from ESLint.**

TypeScript flagged a type-level issue as highlighted in the comment above.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the types to include `ignoreOnInitialization` option for the `no-shadow` rule.

#### Is there anything you'd like reviewers to focus on?

N/A

<!-- markdownlint-disable-file MD004 -->
