### PR TITLE
docs: fix typo in `id-match` rule

### DIFF
--- a/docs/src/rules/id-match.md
+++ b/docs/src/rules/id-match.md
@@ -9,7 +9,7 @@ rule_type: suggestion
 Naming things consistently in a project is an often underestimated aspect of code creation.
 When done correctly, it can save your team hours of unnecessary head scratching and misdirections.
 This rule allows you to precisely define and enforce the variables and function names on your team should use.
-No more limiting yourself to camelCase, snake_case, PascalCase or HungarianNotation. Id-match has all your needs covered!
+No more limiting yourself to camelCase, snake_case, PascalCase, or HungarianNotation. Id-match has all your needs covered!
 
 ## Rule Details
 

--- a/docs/src/rules/id-match.md
+++ b/docs/src/rules/id-match.md
@@ -9,7 +9,7 @@ rule_type: suggestion
 Naming things consistently in a project is an often underestimated aspect of code creation.
 When done correctly, it can save your team hours of unnecessary head scratching and misdirections.
 This rule allows you to precisely define and enforce the variables and function names on your team should use.
-No more limiting yourself to camelCase, snake_case, PascalCase or oHungarianNotation. Id-match has all your needs covered!
+No more limiting yourself to camelCase, snake_case, PascalCase or HungarianNotation. Id-match has all your needs covered!
 
 ## Rule Details
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

Fixes a typo in `id-match` rule docs page.

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


#### What changes did you make? (Give an overview)
 
`"oHungarianNotation"` to `"HungarianNotation"`
