### PR TITLE
fix: do not crash when directory is deleted while walking it

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -151,6 +151,15 @@ function isGlobPattern(pattern) {
     return isGlob(path.sep === "\\" ? normalizeToPosix(pattern) : pattern);
 }
 
+/**
+ * Check if the error can be ignored during fs.walk calls.
+ * @param {NodeJS.ErrnoException} error The error thrown by fs.walk
+ */
+function canIgnoreError(error) {
+    // file/directory not found can be ignored during fs.walk
+    return error.code === "ENOENT";
+}
+
 
 /**
  * Determines if a given glob pattern will return any results.
@@ -170,6 +179,10 @@ function globMatch({ basePath, pattern }) {
     const matcher = new Minimatch(patternToUse, MINIMATCH_OPTIONS);
 
     const fsWalkSettings = {
+
+        errorFilter(error) {
+            return canIgnoreError(error);
+        },
 
         deepFilter(entry) {
             const relativePath = normalizeToPosix(path.relative(basePath, entry.path));
@@ -306,6 +319,9 @@ async function globSearch({
         fswalk.walk(
             basePath,
             {
+                errorFilter(error) {
+                    return canIgnoreError(error);
+                },
                 deepFilter: wrapFilter(entry => {
                     const relativePath = normalizeToPosix(path.relative(basePath, entry.path));
                     const matchesPattern = matchers.some(matcher => matcher.match(relativePath, true));

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -6464,6 +6464,25 @@ describe("ESLint", () => {
                 await assert.rejects(eslint.lintFiles("*.js"), error);
             });
 
+            it("should not throw with a glob pattern if a file-not-found error occurs traversing a directory", async () => {
+                const fsWalk = require("@nodelib/fs.walk");
+
+                const walkSpy = sinon.spy(fsWalk, "walk");
+
+                const cwd = getFixturePath("files");
+
+                eslint = new ESLint({
+                    cwd,
+                    overrideConfigFile: true
+                });
+
+                await eslint.lintFiles("*.js");
+
+                assert.strictEqual(walkSpy.calledOnce, true);
+                assert.strictEqual(walkSpy.firstCall.args[1].errorFilter({ code: "ENOENT" }), true);
+                assert.strictEqual(walkSpy.firstCall.args[1].errorFilter({ code: "EACCES" }), false);
+            });
+
         });
 
     });


### PR DESCRIPTION
cli-engine/file-enumerator.js already performs similar check in `readdirSafeSync`

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- Node version: v20.12.2
- npm version: v10.8.1
- Local ESLint version: v9.4.0 (Currently used)
- Global ESLint version: Not found
- Operating System: win32 10.0.22000

**What did you do? Please include the actual source code causing the issue.**

A parallel build writes lock directories in the same folder that eslint is validating at that moment.

**What did you expect to happen?**

Such empty directory appearing and disappearing during linting process would be ignored by eslint.

**What actually happened? Please include the actual, raw output from ESLint.**

```
Oops! Something went wrong! :(
ESLint: 9.4.0
Error: ENOENT: no such file or directory, scandir '/builds/path/to/the/directory.lock'
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
