### PR TITLE
refactor: replace strip-ansi with native module

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -469,7 +469,7 @@ function getFirstVersionOfDeletion(filePath) {
  * @returns {Object} Output from each formatter
  */
 function getFormatterResults() {
-    const stripAnsi = require("strip-ansi");
+    const util = require("node:util");
     const formattersMetadata = require("./lib/cli-engine/formatters/formatters-meta.json");
 
     const formatterFiles = fs.readdirSync("./lib/cli-engine/formatters/").filter(fileName => !fileName.includes("formatters-meta.json")),
@@ -513,7 +513,7 @@ function getFormatterResults() {
             );
 
             data.formatterResults[name] = {
-                result: stripAnsi(formattedOutput),
+                result: util.stripVTControlCharacters(formattedOutput),
                 description: formattersMetadata.find(formatter => formatter.name === name).description
             };
         }

--- a/lib/cli-engine/formatters/stylish.js
+++ b/lib/cli-engine/formatters/stylish.js
@@ -5,7 +5,7 @@
 "use strict";
 
 const chalk = require("chalk"),
-    stripAnsi = require("strip-ansi"),
+    util = require("node:util"),
     table = require("text-table");
 
 //------------------------------------------------------------------------------
@@ -72,7 +72,7 @@ module.exports = function(results) {
             {
                 align: ["", "r", "l"],
                 stringLength(str) {
-                    return stripAnsi(str).length;
+                    return util.stripVTControlCharacters(str).length;
                 }
             }
         ).split("\n").map(el => el.replace(/(\d+)\s+(\d+)/u, (m, p1, p2) => chalk.dim(`${p1}:${p2}`))).join("\n")}\n\n`;

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "minimatch": "^3.1.2",
     "natural-compare": "^1.4.0",
     "optionator": "^0.9.3",
-    "strip-ansi": "^6.0.1",
     "text-table": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Dependency cleanup. Mainly, replacing `strip-ansi` with native `stripVTControlCharacters` from [Node API](https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr) which is available since Node 16.11.0.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Replaces `strip-ansi` usage with `util.stripVTControlCharacters`
- Remove `strip-ansi` requirement.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
