### PR TITLE
chore: remove unused ignore dependency

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -26,10 +26,6 @@
                 "c8",
                 "@wdio/cli",
                 "rollup-plugin-node-polyfills",
-
-                // FIXME: not sure why is eslint-config-eslint reported as unused
-                "eslint-config-eslint",
-
                 // Optional peer dependency used for loading TypeScript configuration files
                 "jiti"
             ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
In the Knip configuration, we had added the `eslint-config-eslint` dependency to the ignore dependencies section to avoid warnings about it being unused. However, I've recently noticed that we are no longer receiving warnings for `eslint-config-eslint` as an unused dependency. Instead, we're now getting warnings for unused items in the ignore dependencies list for that package. So, I have removed `eslint-config-eslint` from the ignore dependencies list.

Reference - https://github.com/eslint/eslint/actions/runs/11191517711/job/31114497345, https://github.com/eslint/eslint/actions/runs/11204350906/job/31142622332?pr=18992

![image](https://github.com/user-attachments/assets/3b6ab225-9b40-4a16-972d-7c5dbb502187)

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
