### PR TITLE
feat: drop support for jiti v1.21

### DIFF
--- a/docs/src/use/configure/configuration-files.md
+++ b/docs/src/use/configure/configuration-files.md
@@ -529,7 +529,7 @@ npx eslint --flag unstable_ts_config
 
 For more information about using feature flags, see [Feature Flags](../../flags/).
 
-For Deno and Bun, TypeScript configuration files are natively supported; for Node.js, you must install the optional dev dependency [`jiti`](https://github.com/unjs/jiti) in your project (this dependency is not automatically installed by ESLint):
+For Deno and Bun, TypeScript configuration files are natively supported; for Node.js, you must install the optional dev dependency [`jiti`](https://github.com/unjs/jiti) in version 2.0.0 or later in your project (this dependency is not automatically installed by ESLint):
 
 ```bash
 npm install -D jiti

--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -193,7 +193,7 @@ async function loadConfigFile(filePath, allowTS) {
 
         importedConfigFileModificationTime.set(filePath, mtime);
 
-        return config.default ?? config;
+        return config?.default ?? config;
     }
 
 

--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -173,9 +173,15 @@ async function loadConfigFile(filePath, allowTS) {
      */
     if (allowTS && isTS && !isDeno && !isBun) {
 
-        const createJiti = await import("jiti").then(jitiModule => (typeof jitiModule?.createJiti === "function" ? jitiModule.createJiti : jitiModule.default), () => {
+        // eslint-disable-next-line no-use-before-define -- `ConfigLoader.loadJiti` can be overwritten for testing
+        const { createJiti } = await ConfigLoader.loadJiti().catch(() => {
             throw new Error("The 'jiti' library is required for loading TypeScript configuration files. Make sure to install it.");
         });
+
+        // `createJiti` was added in jiti v2.
+        if (typeof createJiti !== "function") {
+            throw new Error("You are using an outdated version of the 'jiti' library. Please update to the latest version of 'jiti' to ensure compatibility and access to the latest features.");
+        }
 
         /*
          * Disabling `moduleCache` allows us to reload a
@@ -183,16 +189,11 @@ async function loadConfigFile(filePath, allowTS) {
          */
 
         const jiti = createJiti(__filename, { moduleCache: false, interopDefault: false });
-
-        if (typeof jiti?.import !== "function") {
-            throw new Error("You are using an outdated version of the 'jiti' library. Please update to the latest version of 'jiti' to ensure compatibility and access to the latest features.");
-        }
-
         const config = await jiti.import(fileURL.href);
 
         importedConfigFileModificationTime.set(filePath, mtime);
 
-        return config?.default ?? config;
+        return config.default ?? config;
     }
 
 
@@ -293,7 +294,6 @@ async function calculateConfigArray(configFilePath, basePath, options) {
 
     return configs;
 }
-
 
 //-----------------------------------------------------------------------------
 // Exports
@@ -515,6 +515,15 @@ class ConfigLoader {
         const { configFilePath } = this.#configFilePaths.get(absoluteDirPath);
 
         return this.#configArrays.get(configFilePath);
+    }
+
+    /**
+     * Used to import the jiti dependency. This method is exposed internally for testing purposes.
+     * @returns {Promise<Record<string, unknown>>} A promise that fulfills with a module object
+     *      or rejects with an error if jiti is not found.
+     */
+    static loadJiti() {
+        return import("jiti");
     }
 
 }

--- a/tests/fixtures/ts-config-files/ts/eslint.undefined.config.ts
+++ b/tests/fixtures/ts-config-files/ts/eslint.undefined.config.ts
@@ -1,0 +1,1 @@
+export = void 0;

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -1308,6 +1308,44 @@ describe("ESLint", () => {
 
                 });
 
+                it("should fail to load a TS config file if jiti is not installed", async () => {
+
+                    const { ConfigLoader } = require("../../../lib/config/config-loader");
+
+                    sinon.stub(ConfigLoader, "loadJiti").rejects();
+
+                    const cwd = getFixturePath("ts-config-files", "ts");
+
+                    eslint = new ESLint({
+                        cwd,
+                        flags: tsFlags
+                    });
+
+                    await assert.rejects(
+                        eslint.lintText("foo();"),
+                        { message: "The 'jiti' library is required for loading TypeScript configuration files. Make sure to install it." }
+                    );
+                });
+
+                it("should fail to load a TS config file if an outdated version of jiti is installed", async () => {
+
+                    const { ConfigLoader } = require("../../../lib/config/config-loader");
+
+                    sinon.stub(ConfigLoader, "loadJiti").resolves({});
+
+                    const cwd = getFixturePath("ts-config-files", "ts");
+
+                    eslint = new ESLint({
+                        cwd,
+                        flags: tsFlags
+                    });
+
+                    await assert.rejects(
+                        eslint.lintText("foo();"),
+                        { message: "You are using an outdated version of the 'jiti' library. Please update to the latest version of 'jiti' to ensure compatibility and access to the latest features." }
+                    );
+                });
+
             });
 
             it("should pass BOM through processors", async () => {
@@ -5746,6 +5784,44 @@ describe("ESLint", () => {
                     assert.strictEqual(results[0].messages[0].severity, 2);
                     assert.strictEqual(results[0].messages[0].ruleId, "no-undef");
 
+                });
+
+                it("should fail to load a TS config file if jiti is not installed", async () => {
+
+                    const { ConfigLoader } = require("../../../lib/config/config-loader");
+
+                    sinon.stub(ConfigLoader, "loadJiti").rejects();
+
+                    const cwd = getFixturePath("ts-config-files", "ts");
+
+                    eslint = new ESLint({
+                        cwd,
+                        flags: newFlags
+                    });
+
+                    await assert.rejects(
+                        eslint.lintFiles("foo.js"),
+                        { message: "The 'jiti' library is required for loading TypeScript configuration files. Make sure to install it." }
+                    );
+                });
+
+                it("should fail to load a TS config file if an outdated version of jiti is installed", async () => {
+
+                    const { ConfigLoader } = require("../../../lib/config/config-loader");
+
+                    sinon.stub(ConfigLoader, "loadJiti").resolves({});
+
+                    const cwd = getFixturePath("ts-config-files", "ts");
+
+                    eslint = new ESLint({
+                        cwd,
+                        flags: newFlags
+                    });
+
+                    await assert.rejects(
+                        eslint.lintFiles("foo.js"),
+                        { message: "You are using an outdated version of the 'jiti' library. Please update to the latest version of 'jiti' to ensure compatibility and access to the latest features." }
+                    );
                 });
 
             });

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -1346,6 +1346,23 @@ describe("ESLint", () => {
                     );
                 });
 
+                it("should fail to load a CommonJS TS config file that exports undefined with a helpful error message", async () => {
+
+                    const cwd = getFixturePath("ts-config-files", "ts");
+
+                    eslint = new ESLint({
+                        cwd,
+                        flags: tsFlags,
+                        overrideConfigFile: "eslint.undefined.config.ts"
+                    });
+
+                    await assert.rejects(
+                        eslint.lintText("foo"),
+                        { message: "Config (unnamed): Unexpected undefined config at user-defined index 0." }
+                    );
+
+                });
+
             });
 
             it("should pass BOM through processors", async () => {
@@ -5822,6 +5839,23 @@ describe("ESLint", () => {
                         eslint.lintFiles("foo.js"),
                         { message: "You are using an outdated version of the 'jiti' library. Please update to the latest version of 'jiti' to ensure compatibility and access to the latest features." }
                     );
+                });
+
+                it("should fail to load a CommonJS TS config file that exports undefined with a helpful error message", async () => {
+
+                    const cwd = getFixturePath("ts-config-files", "ts");
+
+                    eslint = new ESLint({
+                        cwd,
+                        flags: newFlags,
+                        overrideConfigFile: "eslint.undefined.config.ts"
+                    });
+
+                    await assert.rejects(
+                        eslint.lintFiles("foo.js"),
+                        { message: "Config (unnamed): Unexpected undefined config at user-defined index 0." }
+                    );
+
                 });
 
             });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

- Drop support for jiti versions prior to v2
- Improve the error message in a special case
- Add unit tests for when jiti is outdated or not found

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Support for jiti v2 was added in PR #18954, but jiti v1.21 is still supported. This can lead to a confusing error message when a project with jiti v1.21 tries to use a TypeScript ESLint config with top-level await:

```console
Oops! Something went wrong! :(

ESLint: 9.12.0

.../project/eslint.config.ts:1
(function (exports, require, module, __filename, __dirname) { "use strict";Object.defineProperty(exports, "__esModule", { value: true });exports.default = void 0;const { default: pkg } = await Promise.resolve().then(() => require('./package.json'));var _default = exports.default =
                                                                                                                                                                                           ^^^^^

SyntaxError: await is only valid in async functions and the top level bodies of modules
    at new Script (node:vm:117:7)
    at createScript (node:vm:269:10)
    at Object.runInThisContext (node:vm:317:10)
    at evalModule (.../project/node_modules/jiti/dist/jiti.js:1:247124)
    at jiti (.../project/node_modules/jiti/dist/jiti.js:1:245241)
    at .../project/node_modules/jiti/dist/jiti.js:1:248272
    at Generator.next (<anonymous>)
    at .../project/node_modules/jiti/dist/jiti.js:1:238153
    at new Promise (<anonymous>)
    at __awaiter (.../project/node_modules/jiti/dist/jiti.js:1:237714)
    at jiti.import (.../project/node_modules/jiti/dist/jiti.js:1:248217)
    at loadConfigFile (.../project/node_modules/eslint/lib/config/config-loader.js:191:41)
    at async calculateConfigArray (.../project/node_modules/eslint/lib/config/config-loader.js:235:28)
    at async #calculateConfigArray (.../project/node_modules/eslint/lib/config/config-loader.js:622:25)
    at async entryFilter (.../project/node_modules/eslint/lib/eslint/eslint-helpers.js:285:33)
    at async NodeHfs.<anonymous> (file://.../project/node_modules/@humanfs/core/src/hfs.js:560:24)
    at async NodeHfs.walk (file://.../project/node_modules/@humanfs/core/src/hfs.js:600:3)
    at async globSearch (.../project/node_modules/eslint/lib/eslint/eslint-helpers.js:327:26)
    at async Promise.allSettled (index 0)
    at async globMultiSearch (.../project/node_modules/eslint/lib/eslint/eslint-helpers.js:412:21)
    at async findFiles (.../project/node_modules/eslint/lib/eslint/eslint-helpers.js:591:27)
    at async ESLint.lintFiles (.../project/node_modules/eslint/lib/eslint/eslint.js:729:27)
    at async Object.execute (.../project/node_modules/eslint/lib/cli.js:497:23)
    at async main (.../project/node_modules/eslint/bin/eslint.js:153:22)
```

The correct message should state:

> You are using an outdated version of the 'jiti' library. Please update to the latest version of 'jiti' to ensure compatibility and access to the latest features.

[**StackBlitz Repro**](https://stackblitz.com/edit/stackblitz-starters-7gka2h)

This is not a regression in #18954. We were getting the same error message previously with jiti v1 where TLA is not supported. Now that jiti v2 is available it seems no longer necessary to maintain compatibility with jiti v1. TypeScript config files are still an experimental feature, so this change will not be a breaking one.

I've also added unit tests to check the error behavior when an outdated jiti versions is installed, or when jiti is not installed.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
