### PR TITLE
fix: check null `overrideConfigFile` to prevent config file lookup

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -854,8 +854,8 @@ function processOptions({
         cacheLocation,
         cacheStrategy,
 
-        // when overrideConfigFile is true that means don't do config file lookup
-        configFile: overrideConfigFile === true ? false : overrideConfigFile,
+        // when overrideConfigFile is true or null that means don't do config file lookup
+        configFile: overrideConfigFile === true || overrideConfigFile === null ? false : overrideConfigFile,
         overrideConfig,
         cwd: path.normalize(cwd),
         errorOnUnmatchedPattern,

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1478,7 +1478,7 @@ export namespace ESLint {
         allowInlineConfig?: boolean | undefined;
         baseConfig?: Linter.Config | Linter.Config[] | null | undefined;
         overrideConfig?: Linter.Config | Linter.Config[] | null | undefined;
-        overrideConfigFile?: string | boolean | undefined;
+        overrideConfigFile?: string | boolean | null | undefined;
         plugins?: Record<string, Plugin> | null | undefined;
         ruleFilter?: ((arg: { ruleId: string; severity: Exclude<Linter.Severity, 0> }) => boolean) | undefined;
         stats?: boolean | undefined;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**Tell us about your environment (`npx eslint --env-info`):**

* **Node version:**: 18.15.0
* **npm version:**: 8.13.2
* **Local ESLint version:**: 9.12.0
* **Global ESLint version:**: 9.12.0
* **Operating System:**: Windows 11

**What parser are you using (place an "X" next to just one item)?**

[ ] `Default (Espree)`
[x] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**What did you do? Please include the actual source code causing the issue.**

```
    const lint = new ESLint({
      fix: true,
      overrideConfigFile: null,
      baseConfig: {
        rules: {
          'no-tabs': 'off',
          indent: ['error', 'tab'],
          curly: ['error', 'all'],
          'brace-style': ['error', 'stroustrup'],
          'array-bracket-newline': ['error', 'never'],
          'array-element-newline': ['error', 'never'],
          'object-curly-newline': ['error', 'never']
        }
      }
    });
    
    const lintResults = await lint.lintText(code)
```

also same.  

```
    const lint = new ESLint({
      fix: true,
      overrideConfigFile: null,
      overrideConfig: {
        rules: {
          'no-tabs': 'off',
          indent: ['error', 'tab'],
          curly: ['error', 'all'],
          'brace-style': ['error', 'stroustrup'],
          'array-bracket-newline': ['error', 'never'],
          'array-element-newline': ['error', 'never'],
          'object-curly-newline': ['error', 'never']
        }
      }
    });
    
    const lintResults = await lint.lintText(code)
```

**What did you expect to happen?**

When I use the code above, it works fine with ESLint version 8.57.1, but it throws an error in version 9.

**What actually happened? Please include the actual, raw output from ESLint.**

```
ESLintInvalidOptionsError: Invalid Options:
- 'overrideConfigFile' must be a non-empty string or null.
    at processOptions (C:\Users\lumyj\Documents\GitHub\tool/script\node_modules\eslint\lib\eslint\eslint.js:282:15)
    at new ESLint (C:\Users\lumyj\Documents\GitHub\tool\script\node_modules\eslint\lib\eslint\eslint.js:429:34)
    at C:\Users\lumyj\Documents\GitHub\tool\script\src\private\script\scriptParser.ts:46:18
    at Generator.next (<anonymous>)
    at fulfilled (C:\Users\lumyj\Documents\GitHub\tool\script\src\private\script\scriptParser.ts:28:58) {
  code: 'ESLINT_INVALID_OPTIONS'
}
```

#### What changes did you make? (Give an overview)
Check null about `overrideConfigFile`, But not handle value of null.

https://github.com/eslint/eslint/blob/468e3bdadfdf5f197a44efd6c8dc5cf2b241f964/lib/eslint/eslint-helpers.js#L823-L825

#### Is there anything you'd like reviewers to focus on?  
