### PR TITLE
fix: avoid call stack overflow while processing globs

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -430,9 +430,16 @@ async function globMultiSearch({ searches, configLoader, errorOnUnmatchedPattern
 
         if (result.status === "fulfilled") {
 
-            // if the search was successful just add the results
+            /*
+             * If the search was successful just add the results.
+             * Use chunks to avoid exceeding the call stack limit
+             */
             if (result.value.length > 0) {
-                filePaths.push(...result.value);
+                const CHUNK_SIZE = 1024;
+
+                for (let j = 0; j < result.value.length; j += CHUNK_SIZE) {
+                    filePaths.push(...result.value.slice(j, j + CHUNK_SIZE));
+                }
             }
 
             continue;

--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -421,27 +421,12 @@ async function globMultiSearch({ searches, configLoader, errorOnUnmatchedPattern
         )
     );
 
-    const filePaths = [];
-
     for (let i = 0; i < results.length; i++) {
 
         const result = results[i];
         const currentSearch = normalizedSearches[i];
 
         if (result.status === "fulfilled") {
-
-            /*
-             * If the search was successful just add the results.
-             * Use chunks to avoid exceeding the call stack limit
-             */
-            if (result.value.length > 0) {
-                const CHUNK_SIZE = 1024;
-
-                for (let j = 0; j < result.value.length; j += CHUNK_SIZE) {
-                    filePaths.push(...result.value.slice(j, j + CHUNK_SIZE));
-                }
-            }
-
             continue;
         }
 
@@ -464,7 +449,7 @@ async function globMultiSearch({ searches, configLoader, errorOnUnmatchedPattern
 
     }
 
-    return filePaths;
+    return results.flatMap(result => result.value);
 
 }
 

--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -421,6 +421,13 @@ async function globMultiSearch({ searches, configLoader, errorOnUnmatchedPattern
         )
     );
 
+    /*
+     * The first loop handles errors from the glob searches. Since we can't
+     * use `await` inside `flatMap`, we process errors separately in this loop.
+     * This results in two iterations over `results`, but since the length is
+     * less than or equal to the number of globs and directories passed on the
+     * command line, the performance impact should be minimal.
+     */
     for (let i = 0; i < results.length; i++) {
 
         const result = results[i];
@@ -449,6 +456,7 @@ async function globMultiSearch({ searches, configLoader, errorOnUnmatchedPattern
 
     }
 
+    // second loop for `fulfulled` results
     return results.flatMap(result => result.value);
 
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

If there's a directory with considerable amount of files (I encountered it at 150_000), pushing them at once exceeds call stack limit.
`Array.prototype.push.apply(filePaths, result.value);` without spread operator would fail as well.

#### Is there anything you'd like reviewers to focus on?

Performance.
I've tried different `CHUNK_SIZE`s between 512 and 10000, and the time curve wasn't even weakly monotonic.
A good alternative would be pre-allocating the array, something like this:
```js
let index = filePaths.length;
filePaths.length += result.value.length;
for (let i = 0; i < result.value.length; i++) {
    filePaths[index++] = result.value[i];
}
 ```
But the performance benefit is negligible and IMHO it looks uglier.

<!-- markdownlint-disable-file MD004 -->
