### PR TITLE
test: ensure tmp directory cleanup in `check-emfile-handling.js`

### DIFF
--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -56,7 +56,7 @@ if (os.platform() !== "win32") {
  */
 function generateFiles() {
 
-    fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true, maxRetries: 8192 });
+    fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true, maxRetries: 8 });
     fs.mkdirSync(OUTPUT_DIRECTORY, { recursive: true });
 
     for (let i = 0; i < FILE_COUNT; i++) {
@@ -109,5 +109,7 @@ generateEmFileError()
         }
     })
     .finally(() => {
-        fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true, maxRetries: 8192 });
+
+        // pause before cleanup to ensure file descriptors are freed
+        setTimeout(() => fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true, maxRetries: 8 }), 2000);
     });

--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -56,7 +56,7 @@ if (os.platform() !== "win32") {
  */
 function generateFiles() {
 
-    fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true, maxRetries: 8 });
+    fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true, maxRetries: 8192 });
     fs.mkdirSync(OUTPUT_DIRECTORY, { recursive: true });
 
     for (let i = 0; i < FILE_COUNT; i++) {
@@ -109,5 +109,5 @@ generateEmFileError()
         }
     })
     .finally(() => {
-        fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true, maxRetries: 8 });
+        fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true, maxRetries: 8192 });
     });

--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -56,7 +56,7 @@ if (os.platform() !== "win32") {
  */
 function generateFiles() {
 
-    fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true });
+    fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true, maxRetries: 8 });
     fs.mkdirSync(OUTPUT_DIRECTORY, { recursive: true });
 
     for (let i = 0; i < FILE_COUNT; i++) {
@@ -109,5 +109,5 @@ generateEmFileError()
         }
     })
     .finally(() => {
-        fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true });
+        fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true, maxRetries: 8 });
     });

--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -56,6 +56,7 @@ if (os.platform() !== "win32") {
  */
 function generateFiles() {
 
+    fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true });
     fs.mkdirSync(OUTPUT_DIRECTORY, { recursive: true });
 
     for (let i = 0; i < FILE_COUNT; i++) {
@@ -106,4 +107,7 @@ generateEmFileError()
             console.error("❌ Unexpected error encountered:", error.message);
             throw error;
         }
+    })
+    .finally(() => {
+        fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true });
     });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: cleanup in test

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Remove the test directory (`tmp/emfile-check`) before and after the test.

Before, because it might contain files from previous runs. `ulimit` values aren't constant, so the actual amount of files might be bigger than the test generates.

After, because we shouldn't waste inodes (and space, depending on filesystem) on a directory with potentially 100000+ temp files.

#### Is there anything you'd like reviewers to focus on?

Noting that there's no cleanup in case of unexpected failure (from `execSync()` or even `generateFiles()`), which is intentional for easier manual debugging/reproducing.

<!-- markdownlint-disable-file MD004 -->
