### PR TITLE
fix: ignore files on a different drive on Windows

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -155,16 +155,14 @@ function isGlobPattern(pattern) {
  * Used primarily to help with useful error messages.
  * @param {Object} options The options for the function.
  * @param {string} options.basePath The directory to search.
- * @param {string} options.pattern A glob pattern to match.
+ * @param {string} options.pattern An absolute path glob pattern to match.
  * @returns {Promise<boolean>} True if there is a glob match, false if not.
  */
 async function globMatch({ basePath, pattern }) {
 
     let found = false;
     const { hfs } = await import("@humanfs/node");
-    const patternToUse = path.isAbsolute(pattern)
-        ? normalizeToPosix(path.relative(basePath, pattern))
-        : pattern;
+    const patternToUse = normalizeToPosix(path.relative(basePath, pattern));
 
     const matcher = new Minimatch(patternToUse, MINIMATCH_OPTIONS);
 
@@ -202,7 +200,7 @@ async function globMatch({ basePath, pattern }) {
  * ESLint.
  * @param {Object} options The options for this function.
  * @param {string} options.basePath The directory to search.
- * @param {Array<string>} options.patterns An array of glob patterns
+ * @param {Array<string>} options.patterns An array of absolute path glob patterns
  *      to match.
  * @param {Array<string>} options.rawPatterns An array of glob patterns
  *      as the user inputted them. Used for errors.
@@ -241,9 +239,7 @@ async function globSearch({
      */
     const relativeToPatterns = new Map();
     const matchers = patterns.map((pattern, i) => {
-        const patternToUse = path.isAbsolute(pattern)
-            ? normalizeToPosix(path.relative(basePath, pattern))
-            : pattern;
+        const patternToUse = normalizeToPosix(path.relative(basePath, pattern));
 
         relativeToPatterns.set(patternToUse, patterns[i]);
 
@@ -353,7 +349,7 @@ async function globSearch({
  *      that were used in the original search.
  * @param {Array<string>} options.rawPatterns An array of glob patterns
  *      as the user inputted them. Used for errors.
- * @param {Array<string>} options.unmatchedPatterns A non-empty array of glob patterns
+ * @param {Array<string>} options.unmatchedPatterns A non-empty array of absolute path glob patterns
  *      that were unmatched in the original search.
  * @returns {void} Always throws an error.
  * @throws {NoFilesFoundError} If the first unmatched pattern
@@ -388,7 +384,7 @@ async function throwErrorForUnmatchedPatterns({
  * Performs multiple glob searches in parallel.
  * @param {Object} options The options for this function.
  * @param {Map<string,GlobSearch>} options.searches
- *      An array of glob patterns to match.
+ *      A map of absolute path glob patterns to match.
  * @param {ConfigLoader|LegacyConfigLoader} options.configLoader The config loader to use for
  *      determining what to ignore.
  * @param {boolean} options.errorOnUnmatchedPattern Determines if an
@@ -597,7 +593,7 @@ async function findFiles({
     return [
         ...new Set([
             ...results,
-            ...globbyResults.map(filePath => path.resolve(filePath))
+            ...globbyResults
         ])
     ];
 }
@@ -618,7 +614,7 @@ function isErrorMessage(message) {
 
 /**
  * Returns result with warning by ignore settings
- * @param {string} filePath File path of checked code
+ * @param {string} filePath Absolute file path of checked code
  * @param {string} baseDir Absolute path of base directory
  * @param {"ignored"|"external"|"unconfigured"} configStatus A status that determines why the file is ignored
  * @returns {LintResult} Result with single warning
@@ -648,7 +644,7 @@ function createIgnoreResult(filePath, baseDir, configStatus) {
     }
 
     return {
-        filePath: path.resolve(filePath),
+        filePath,
         messages: [
             {
                 ruleId: null,

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -653,7 +653,7 @@ class RuleTester {
             };
 
             if (item.filename) {
-                flatConfigArrayOptions.basePath = path.parse(item.filename).root;
+                flatConfigArrayOptions.basePath = path.parse(item.filename).root || void 0;
             }
 
             const configs = new FlatConfigArray(testerConfig, flatConfigArrayOptions);

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -656,6 +656,9 @@ class RuleTester {
                 flatConfigArrayOptions.basePath = path.parse(item.filename).root;
             }
 
+            // We must ensure that basePath is set in order to resolve relative file paths.
+            flatConfigArrayOptions.basePath ||= "/";
+
             const configs = new FlatConfigArray(testerConfig, flatConfigArrayOptions);
 
             /*

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -656,9 +656,6 @@ class RuleTester {
                 flatConfigArrayOptions.basePath = path.parse(item.filename).root;
             }
 
-            // We must ensure that basePath is set in order to resolve relative file paths.
-            flatConfigArrayOptions.basePath ||= "/";
-
             const configs = new FlatConfigArray(testerConfig, flatConfigArrayOptions);
 
             /*

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.2.0",
     "@eslint-community/regexpp": "^4.12.1",
-    "@eslint/config-array": "^0.18.0",
+    "@eslint/config-array": "^0.19.0",
     "@eslint/core": "^0.7.0",
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "9.13.0",

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -162,8 +162,7 @@ const baseConfig = {
  */
 function createFlatConfigArray(configs) {
     return new FlatConfigArray(configs, {
-        baseConfig: [baseConfig],
-        basePath: "/"
+        baseConfig: [baseConfig]
     });
 }
 
@@ -254,8 +253,7 @@ describe("FlatConfigArray", () => {
         }];
 
         const configs = new FlatConfigArray([], {
-            baseConfig: base,
-            basePath: "/"
+            baseConfig: base
         });
 
         configs.normalizeSync();
@@ -275,7 +273,7 @@ describe("FlatConfigArray", () => {
                     a: {},
                     b: {}
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -311,7 +309,7 @@ describe("FlatConfigArray", () => {
                         version: "2.3.1"
                     }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -349,7 +347,7 @@ describe("FlatConfigArray", () => {
                         }
                     }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -383,7 +381,7 @@ describe("FlatConfigArray", () => {
                         name: "off"
                     }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -456,7 +454,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -477,7 +475,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -500,7 +498,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -523,7 +521,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -558,7 +556,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -593,7 +591,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -626,7 +624,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -656,7 +654,7 @@ describe("FlatConfigArray", () => {
                     preprocess() { /* empty */ },
                     postprocess() { /* empty */ }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -676,7 +674,7 @@ describe("FlatConfigArray", () => {
                     preprocess() { /* empty */ },
                     postprocess() { /* empty */ }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -699,7 +697,7 @@ describe("FlatConfigArray", () => {
                     preprocess() { /* empty */ },
                     postprocess() { /* empty */ }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -730,7 +728,7 @@ describe("FlatConfigArray", () => {
                     preprocess() { /* empty */ },
                     postprocess() { /* empty */ }
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -764,7 +762,7 @@ describe("FlatConfigArray", () => {
                     preprocess() { /* empty */ },
                     postprocess() { /* empty */ }
                 }
-            }], { basePath: "/" });
+            }]);
 
 
             configs.normalizeSync();
@@ -797,7 +795,7 @@ describe("FlatConfigArray", () => {
                     preprocess() { /* empty */ },
                     postprocess() { /* empty */ }
                 }
-            }], { basePath: "/" });
+            }]);
 
 
             configs.normalizeSync();
@@ -2396,7 +2394,7 @@ describe("FlatConfigArray", () => {
                             "foo/baz": ["error", "always"]
                         }
                     }
-                ], { basePath: "/" });
+                ]);
 
                 await configs.normalize();
 
@@ -2430,7 +2428,7 @@ describe("FlatConfigArray", () => {
                             "foo/bar": "error"
                         }
                     }
-                ], { basePath: "/" });
+                ]);
 
                 await configs.normalize();
 
@@ -2464,7 +2462,7 @@ describe("FlatConfigArray", () => {
                             "foo/bar": "error"
                         }
                     }
-                ], { basePath: "/" });
+                ]);
 
                 await configs.normalize();
 
@@ -2755,7 +2753,7 @@ describe("FlatConfigArray", () => {
                     camelcase: ruleConfig,
                     "default-case": ruleConfig
                 }
-            }], { basePath: "/" });
+            }]);
 
             configs.normalizeSync();
 
@@ -2797,7 +2795,7 @@ describe("FlatConfigArray", () => {
                         ]
                     }
                 }
-            ], { basePath: "/" });
+            ]);
 
             configs.normalizeSync();
 

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -162,7 +162,8 @@ const baseConfig = {
  */
 function createFlatConfigArray(configs) {
     return new FlatConfigArray(configs, {
-        baseConfig: [baseConfig]
+        baseConfig: [baseConfig],
+        basePath: "/"
     });
 }
 
@@ -253,7 +254,8 @@ describe("FlatConfigArray", () => {
         }];
 
         const configs = new FlatConfigArray([], {
-            baseConfig: base
+            baseConfig: base,
+            basePath: "/"
         });
 
         configs.normalizeSync();
@@ -273,7 +275,7 @@ describe("FlatConfigArray", () => {
                     a: {},
                     b: {}
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -309,7 +311,7 @@ describe("FlatConfigArray", () => {
                         version: "2.3.1"
                     }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -347,7 +349,7 @@ describe("FlatConfigArray", () => {
                         }
                     }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -381,7 +383,7 @@ describe("FlatConfigArray", () => {
                         name: "off"
                     }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -454,7 +456,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -475,7 +477,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -498,7 +500,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -521,7 +523,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -556,7 +558,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -591,7 +593,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -624,7 +626,7 @@ describe("FlatConfigArray", () => {
                         parse() { /* empty */ }
                     }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -654,7 +656,7 @@ describe("FlatConfigArray", () => {
                     preprocess() { /* empty */ },
                     postprocess() { /* empty */ }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -674,7 +676,7 @@ describe("FlatConfigArray", () => {
                     preprocess() { /* empty */ },
                     postprocess() { /* empty */ }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -697,7 +699,7 @@ describe("FlatConfigArray", () => {
                     preprocess() { /* empty */ },
                     postprocess() { /* empty */ }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -728,7 +730,7 @@ describe("FlatConfigArray", () => {
                     preprocess() { /* empty */ },
                     postprocess() { /* empty */ }
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -762,7 +764,7 @@ describe("FlatConfigArray", () => {
                     preprocess() { /* empty */ },
                     postprocess() { /* empty */ }
                 }
-            }]);
+            }], { basePath: "/" });
 
 
             configs.normalizeSync();
@@ -795,7 +797,7 @@ describe("FlatConfigArray", () => {
                     preprocess() { /* empty */ },
                     postprocess() { /* empty */ }
                 }
-            }]);
+            }], { basePath: "/" });
 
 
             configs.normalizeSync();
@@ -2394,7 +2396,7 @@ describe("FlatConfigArray", () => {
                             "foo/baz": ["error", "always"]
                         }
                     }
-                ]);
+                ], { basePath: "/" });
 
                 await configs.normalize();
 
@@ -2428,7 +2430,7 @@ describe("FlatConfigArray", () => {
                             "foo/bar": "error"
                         }
                     }
-                ]);
+                ], { basePath: "/" });
 
                 await configs.normalize();
 
@@ -2462,7 +2464,7 @@ describe("FlatConfigArray", () => {
                             "foo/bar": "error"
                         }
                     }
-                ]);
+                ], { basePath: "/" });
 
                 await configs.normalize();
 
@@ -2753,7 +2755,7 @@ describe("FlatConfigArray", () => {
                     camelcase: ruleConfig,
                     "default-case": ruleConfig
                 }
-            }]);
+            }], { basePath: "/" });
 
             configs.normalizeSync();
 
@@ -2795,7 +2797,7 @@ describe("FlatConfigArray", () => {
                         ]
                     }
                 }
-            ]);
+            ], { basePath: "/" });
 
             configs.normalizeSync();
 

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -2976,11 +2976,17 @@ describe("ESLint", () => {
                     let otherDriveLetter;
                     const exec = util.promisify(require("node:child_process").exec);
 
+                    /*
+                     * Map the fixture directory to a new virtual drive.
+                     * Use the first drive letter available.
+                     */
                     before(async () => {
                         const substDir = getFixturePath();
 
                         for (const driveLetter of "ABCDEFGHIJKLMNOPQRSTUVWXYZ") {
                             try {
+
+                                // More info on this command at https://en.wikipedia.org/wiki/SUBST
                                 await exec(`subst ${driveLetter}: "${substDir}"`);
                             } catch {
                                 continue;
@@ -2993,6 +2999,9 @@ describe("ESLint", () => {
                         }
                     });
 
+                    /*
+                     * Delete the virtual drive.
+                     */
                     after(async () => {
                         if (otherDriveLetter) {
                             try {

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -2939,7 +2939,7 @@ describe("ESLint", () => {
 
                 // https://github.com/eslint/eslint/issues/18575
                 describe("on Windows", () => {
-                    if (process.platform !== "win32") {
+                    if (os.platform !== "win32") {
                         return;
                     }
 
@@ -6186,6 +6186,22 @@ describe("ESLint", () => {
 
                 assert(await engine.isPathIgnored("node_modules/foo.js"));
             });
+
+            if (os.platform() === "win32") {
+                it("should return true for a file on a different drive on Windows", async () => {
+                    const currentRoot = path.resolve("\\");
+                    const otherRoot = currentRoot === "A:\\" ? "B:\\" : "A:\\";
+                    const engine = new ESLint({
+                        flags,
+                        overrideConfigFile: true,
+                        cwd: currentRoot
+                    });
+
+                    assert(!await engine.isPathIgnored(`${currentRoot}file.js`));
+                    assert(await engine.isPathIgnored(`${otherRoot}file.js`));
+                    assert(await engine.isPathIgnored("//SERVER//share//file.js"));
+                });
+            }
 
             describe("about the default ignore patterns", () => {
                 it("should always apply default ignore patterns if ignore option is true", async () => {

--- a/tests/lib/languages/js/source-code/source-code.js
+++ b/tests/lib/languages/js/source-code/source-code.js
@@ -2489,7 +2489,7 @@ describe("SourceCode", () => {
                 rules: { "test/checker": "error" }
             };
 
-            flatLinter.verify(code, config, filename, true);
+            flatLinter.verify(code, config, filename);
             assert(spy && spy.calledOnce, "Spy was not called.");
         });
 
@@ -2925,7 +2925,7 @@ describe("SourceCode", () => {
                 }
             });
 
-            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6, sourceType: "module" } }, filename, true);
+            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6, sourceType: "module" } }, filename);
             assert(spy && spy.calledOnce);
         });
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7783,7 +7783,7 @@ describe("Linter with FlatConfigArray", () => {
      * @returns {FlatConfigArray} The created config array.
      */
     function createFlatConfigArray(value) {
-        return new FlatConfigArray(value, { basePath: "" });
+        return new FlatConfigArray(value);
     }
 
     beforeEach(() => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7783,7 +7783,7 @@ describe("Linter with FlatConfigArray", () => {
      * @returns {FlatConfigArray} The created config array.
      */
     function createFlatConfigArray(value) {
-        return new FlatConfigArray(value, { basePath: process.cwd() });
+        return new FlatConfigArray(value, { basePath: "" });
     }
 
     beforeEach(() => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -146,7 +146,7 @@ describe("Linter", () => {
         const code = TEST_CODE;
 
         it("should retrieve SourceCode object after reset", () => {
-            linter.verify(code, {}, filename, true);
+            linter.verify(code, {}, filename);
 
             const sourceCode = linter.getSourceCode();
 
@@ -315,7 +315,7 @@ describe("Linter", () => {
                 })
             });
 
-            const messages = linter.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename);
             const suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 0);
@@ -625,7 +625,7 @@ describe("Linter", () => {
 
             config.rules[rule] = 1;
 
-            const messages = linter.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename);
             const suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 1);
@@ -640,7 +640,7 @@ describe("Linter", () => {
 
             config.rules[rule] = "warn";
 
-            const messages = linter.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename);
             const suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 1);
@@ -656,7 +656,7 @@ describe("Linter", () => {
 
             config.rules[rule] = [1];
 
-            const messages = linter.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename);
             const suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 1);
@@ -671,7 +671,7 @@ describe("Linter", () => {
 
             config.rules[rule] = ["warn"];
 
-            const messages = linter.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename);
             const suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 1);
@@ -687,7 +687,7 @@ describe("Linter", () => {
 
             config.rules[rule] = "1";
 
-            const messages = linter.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename);
             const suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 0);
@@ -696,7 +696,7 @@ describe("Linter", () => {
 
         it("should process empty config", () => {
             const config = {};
-            const messages = linter.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename);
             const suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 0);
@@ -884,7 +884,7 @@ describe("Linter", () => {
             const code = "/* exported horse */";
             const config = { rules: {} };
 
-            linter.verify(code, config, filename, true);
+            linter.verify(code, config, filename);
         });
 
         it("variable should be exported ", () => {
@@ -1398,13 +1398,13 @@ describe("Linter", () => {
             const config = { rules: { strict: 2 } };
             const codeA = "/*eslint strict: 0*/ function bar() { return 2; }";
             const codeB = "function foo() { return 1; }";
-            let messages = linter.verify(codeA, config, filename, false);
+            let messages = linter.verify(codeA, config, filename);
             let suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 0);
             assert.strictEqual(suppressedMessages.length, 0);
 
-            messages = linter.verify(codeB, config, filename, false);
+            messages = linter.verify(codeB, config, filename);
             suppressedMessages = linter.getSuppressedMessages();
             assert.strictEqual(messages.length, 1);
 
@@ -1415,13 +1415,13 @@ describe("Linter", () => {
             const config = { rules: { quotes: [2, "double"] } };
             const codeA = "/*eslint quotes: 0*/ function bar() { return '2'; }";
             const codeB = "function foo() { return '1'; }";
-            let messages = linter.verify(codeA, config, filename, false);
+            let messages = linter.verify(codeA, config, filename);
             let suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 0);
             assert.strictEqual(suppressedMessages.length, 0);
 
-            messages = linter.verify(codeB, config, filename, false);
+            messages = linter.verify(codeB, config, filename);
             suppressedMessages = linter.getSuppressedMessages();
             assert.strictEqual(messages.length, 1);
 
@@ -1433,13 +1433,13 @@ describe("Linter", () => {
             const codeA = "/*eslint quotes: [0, \"single\"]*/ function bar() { return '2'; }";
             const codeB = "function foo() { return '1'; }";
 
-            let messages = linter.verify(codeA, config, filename, false);
+            let messages = linter.verify(codeA, config, filename);
             let suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 0);
             assert.strictEqual(suppressedMessages.length, 0);
 
-            messages = linter.verify(codeB, config, filename, false);
+            messages = linter.verify(codeB, config, filename);
             suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 1);
@@ -1451,13 +1451,13 @@ describe("Linter", () => {
             const codeA = "/*eslint no-unused-vars: [0, {\"vars\": \"local\"}]*/ var a = 44;";
             const codeB = "var b = 55;";
 
-            let messages = linter.verify(codeA, config, filename, false);
+            let messages = linter.verify(codeA, config, filename);
             let suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 0);
             assert.strictEqual(suppressedMessages.length, 0);
 
-            messages = linter.verify(codeB, config, filename, false);
+            messages = linter.verify(codeB, config, filename);
             suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 1);
@@ -1869,13 +1869,13 @@ describe("Linter", () => {
             const codeA = "/*eslint test-plugin/test-rule: 0*/ var a = \"trigger violation\";";
             const codeB = "var a = \"trigger violation\";";
 
-            let messages = linter.verify(codeA, config, filename, false);
+            let messages = linter.verify(codeA, config, filename);
             let suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 0);
             assert.strictEqual(suppressedMessages.length, 0);
 
-            messages = linter.verify(codeB, config, filename, false);
+            messages = linter.verify(codeB, config, filename);
             suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 1);
@@ -7499,7 +7499,7 @@ var a = "test2";
             const parseSpy = { parse: sinon.spy(espree.parse) };
 
             linter.defineParser("stub-parser", parseSpy);
-            linter.verify(code, { parser: "stub-parser" }, filename, true);
+            linter.verify(code, { parser: "stub-parser" }, filename);
 
             sinon.assert.calledWithMatch(parseSpy.parse, "", { filePath: filename });
         });
@@ -7533,7 +7533,7 @@ var a = "test2";
             linter.defineParser("unknown-logical-operator", testParsers.unknownLogicalOperator);
 
             // This shouldn't throw
-            const messages = linter.verify(code, { parser: "unknown-logical-operator" }, filename, true);
+            const messages = linter.verify(code, { parser: "unknown-logical-operator" }, filename);
             const suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 0);
@@ -7546,7 +7546,7 @@ var a = "test2";
             linter.defineParser("unknown-logical-operator-nested", testParsers.unknownLogicalOperatorNested);
 
             // This shouldn't throw
-            const messages = linter.verify(code, { parser: "unknown-logical-operator-nested" }, filename, true);
+            const messages = linter.verify(code, { parser: "unknown-logical-operator-nested" }, filename);
             const suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 0);
@@ -7573,7 +7573,7 @@ var a = "test2";
                 rules: {
                     "collect-node-types": "error"
                 }
-            }, filename, true);
+            }, filename);
             const suppressedMessages = linter.getSuppressedMessages();
 
             assert.strictEqual(messages.length, 0);
@@ -8348,7 +8348,7 @@ describe("Linter with FlatConfigArray", () => {
                             }
                         };
 
-                        linter.verify(code, config, filename, true);
+                        linter.verify(code, config, filename);
 
                         sinon.assert.calledWithMatch(parseSpy.parse, "", { filePath: filename });
                     });
@@ -8428,7 +8428,7 @@ describe("Linter with FlatConfigArray", () => {
                             }
                         };
 
-                        const messages = linter.verify(code, config, filename, true);
+                        const messages = linter.verify(code, config, filename);
                         const suppressedMessages = linter.getSuppressedMessages();
 
                         assert.strictEqual(messages.length, 0);
@@ -9029,7 +9029,7 @@ describe("Linter with FlatConfigArray", () => {
 
                 config.rules[rule] = 1;
 
-                const messages = linter.verify(code, config, filename, true);
+                const messages = linter.verify(code, config, filename);
                 const suppressedMessages = linter.getSuppressedMessages();
 
                 assert.strictEqual(messages.length, 1);
@@ -9044,7 +9044,7 @@ describe("Linter with FlatConfigArray", () => {
 
                 config.rules[rule] = "warn";
 
-                const messages = linter.verify(code, config, filename, true);
+                const messages = linter.verify(code, config, filename);
                 const suppressedMessages = linter.getSuppressedMessages();
 
                 assert.strictEqual(messages.length, 1);
@@ -9060,7 +9060,7 @@ describe("Linter with FlatConfigArray", () => {
 
                 config.rules[rule] = [1];
 
-                const messages = linter.verify(code, config, filename, true);
+                const messages = linter.verify(code, config, filename);
                 const suppressedMessages = linter.getSuppressedMessages();
 
                 assert.strictEqual(messages.length, 1);
@@ -9075,7 +9075,7 @@ describe("Linter with FlatConfigArray", () => {
 
                 config.rules[rule] = ["warn"];
 
-                const messages = linter.verify(code, config, filename, true);
+                const messages = linter.verify(code, config, filename);
                 const suppressedMessages = linter.getSuppressedMessages();
 
                 assert.strictEqual(messages.length, 1);
@@ -9092,13 +9092,13 @@ describe("Linter with FlatConfigArray", () => {
                 config.rules[rule] = "1";
 
                 assert.throws(() => {
-                    linter.verify(code, config, filename, true);
+                    linter.verify(code, config, filename);
                 }, /Key "rules": Key "semi": Expected severity/u);
             });
 
             it("should process empty config", () => {
                 const config = {};
-                const messages = linter.verify(code, config, filename, true);
+                const messages = linter.verify(code, config, filename);
                 const suppressedMessages = linter.getSuppressedMessages();
 
                 assert.strictEqual(messages.length, 0);
@@ -9376,8 +9376,8 @@ describe("Linter with FlatConfigArray", () => {
             );
 
             configs.normalizeSync();
-            const messages1 = linter.verify("foo", configs, "/foo/bar.js", true);
-            const messages2 = linter.verify("foo", configs, "/bar.js", true);
+            const messages1 = linter.verify("foo", configs, "/foo/bar.js");
+            const messages2 = linter.verify("foo", configs, "/bar.js");
 
             assert.strictEqual(messages1.length, 0);
             assert.strictEqual(messages2.length, 1);
@@ -9391,8 +9391,8 @@ describe("Linter with FlatConfigArray", () => {
             );
 
             configs.normalizeSync();
-            const messages1 = linter.verify("foo", configs, "C:\\foo\\bar.js", true);
-            const messages2 = linter.verify("foo", configs, "D:\\foo\\bar.js", true);
+            const messages1 = linter.verify("foo", configs, "C:\\foo\\bar.js");
+            const messages2 = linter.verify("foo", configs, "D:\\foo\\bar.js");
 
             assert.strictEqual(messages1.length, 0);
             assert.strictEqual(messages2.length, 1);
@@ -9552,7 +9552,7 @@ describe("Linter with FlatConfigArray", () => {
                     rules: { "test/checker": "error" }
                 };
 
-                const messages = linter.verify(code, config, filename, true);
+                const messages = linter.verify(code, config, filename);
                 const suppressedMessages = linter.getSuppressedMessages();
 
                 assert.strictEqual(messages.length, 0);
@@ -10088,7 +10088,7 @@ describe("Linter with FlatConfigArray", () => {
                     });
 
                 configs.normalizeSync();
-                const messages = linter.verify("foo", configs, filename, true);
+                const messages = linter.verify("foo", configs, filename);
                 const suppressedMessages = linter.getSuppressedMessages();
 
                 assert.strictEqual(messages.length, 1, "Message length is wrong");
@@ -10106,7 +10106,7 @@ describe("Linter with FlatConfigArray", () => {
                         }
                     }];
 
-                const messages = linter.verify("foo", configs, filename, true);
+                const messages = linter.verify("foo", configs, filename);
                 const suppressedMessages = linter.getSuppressedMessages();
 
                 assert.strictEqual(messages.length, 1, "Message length is wrong");
@@ -10124,7 +10124,7 @@ describe("Linter with FlatConfigArray", () => {
                         }
                     };
 
-                const messages = linter.verify("foo", config, filename, true);
+                const messages = linter.verify("foo", config, filename);
                 const suppressedMessages = linter.getSuppressedMessages();
 
                 assert.strictEqual(messages.length, 1, "Message length is wrong");
@@ -10796,7 +10796,7 @@ describe("Linter with FlatConfigArray", () => {
                     const code = "/* exported horse */";
                     const config = { rules: {} };
 
-                    linter.verify(code, config, filename, true);
+                    linter.verify(code, config, filename);
                 });
 
                 it("variable should be exported", () => {
@@ -11119,13 +11119,13 @@ describe("Linter with FlatConfigArray", () => {
                         };
                         const codeA = "/*eslint strict: 0*/ function bar() { return 2; }";
                         const codeB = "function foo() { return 1; }";
-                        let messages = linter.verify(codeA, config, filename, false);
+                        let messages = linter.verify(codeA, config, filename);
                         let suppressedMessages = linter.getSuppressedMessages();
 
                         assert.strictEqual(messages.length, 0);
                         assert.strictEqual(suppressedMessages.length, 0);
 
-                        messages = linter.verify(codeB, config, filename, false);
+                        messages = linter.verify(codeB, config, filename);
                         suppressedMessages = linter.getSuppressedMessages();
 
                         assert.strictEqual(messages.length, 1);
@@ -11141,13 +11141,13 @@ describe("Linter with FlatConfigArray", () => {
                         };
                         const codeA = "/*eslint quotes: 0*/ function bar() { return '2'; }";
                         const codeB = "function foo() { return '1'; }";
-                        let messages = linter.verify(codeA, config, filename, false);
+                        let messages = linter.verify(codeA, config, filename);
                         let suppressedMessages = linter.getSuppressedMessages();
 
                         assert.strictEqual(messages.length, 0);
                         assert.strictEqual(suppressedMessages.length, 0);
 
-                        messages = linter.verify(codeB, config, filename, false);
+                        messages = linter.verify(codeB, config, filename);
                         suppressedMessages = linter.getSuppressedMessages();
 
                         assert.strictEqual(messages.length, 1);
@@ -11158,13 +11158,13 @@ describe("Linter with FlatConfigArray", () => {
                         const config = { rules: { quotes: [2, "double"] } };
                         const codeA = "/*eslint quotes: [0, \"single\"]*/ function bar() { return '2'; }";
                         const codeB = "function foo() { return '1'; }";
-                        let messages = linter.verify(codeA, config, filename, false);
+                        let messages = linter.verify(codeA, config, filename);
                         let suppressedMessages = linter.getSuppressedMessages();
 
                         assert.strictEqual(messages.length, 0);
                         assert.strictEqual(suppressedMessages.length, 0);
 
-                        messages = linter.verify(codeB, config, filename, false);
+                        messages = linter.verify(codeB, config, filename);
                         suppressedMessages = linter.getSuppressedMessages();
 
                         assert.strictEqual(messages.length, 1);
@@ -11180,13 +11180,13 @@ describe("Linter with FlatConfigArray", () => {
                         };
                         const codeA = "/*eslint no-unused-vars: [0, {\"vars\": \"local\"}]*/ var a = 44;";
                         const codeB = "var b = 55;";
-                        let messages = linter.verify(codeA, config, filename, false);
+                        let messages = linter.verify(codeA, config, filename);
                         let suppressedMessages = linter.getSuppressedMessages();
 
                         assert.strictEqual(messages.length, 0);
                         assert.strictEqual(suppressedMessages.length, 0);
 
-                        messages = linter.verify(codeB, config, filename, false);
+                        messages = linter.verify(codeB, config, filename);
                         suppressedMessages = linter.getSuppressedMessages();
 
                         assert.strictEqual(messages.length, 1);
@@ -11649,13 +11649,13 @@ describe("Linter with FlatConfigArray", () => {
                         const config = { ...baseConfig, rules: { "test-plugin/test-rule": 2 } };
                         const codeA = "/*eslint test-plugin/test-rule: 0*/ var a = \"trigger violation\";";
                         const codeB = "var a = \"trigger violation\";";
-                        let messages = linter.verify(codeA, config, filename, false);
+                        let messages = linter.verify(codeA, config, filename);
                         let suppressedMessages = linter.getSuppressedMessages();
 
                         assert.strictEqual(messages.length, 0);
                         assert.strictEqual(suppressedMessages.length, 0);
 
-                        messages = linter.verify(codeB, config, filename, false);
+                        messages = linter.verify(codeB, config, filename);
                         suppressedMessages = linter.getSuppressedMessages();
 
                         assert.strictEqual(messages.length, 1);
@@ -15848,7 +15848,7 @@ var a = "test2";
         const code = TEST_CODE;
 
         it("should retrieve SourceCode object after reset", () => {
-            linter.verify(code, {}, filename, true);
+            linter.verify(code, {}, filename);
 
             const sourceCode = linter.getSourceCode();
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -3871,7 +3871,7 @@ var a = "test2";
         const config = { rules: { checker: "error" } };
 
         it("should get cwd correctly in the context", () => {
-            const cwd = "cwd";
+            const cwd = "/cwd";
             const linterWithOption = new Linter({ cwd, configType: "eslintrc" });
             let spy;
 
@@ -7783,7 +7783,7 @@ describe("Linter with FlatConfigArray", () => {
      * @returns {FlatConfigArray} The created config array.
      */
     function createFlatConfigArray(value) {
-        return new FlatConfigArray(value, { basePath: "" });
+        return new FlatConfigArray(value, { basePath: process.cwd() });
     }
 
     beforeEach(() => {
@@ -9768,7 +9768,7 @@ describe("Linter with FlatConfigArray", () => {
                 const baseConfig = { rules: { "test/checker": "error" } };
 
                 it("should get cwd correctly in the context", () => {
-                    const cwd = "cwd";
+                    const cwd = "/cwd";
                     const linterWithOption = new Linter({ cwd, configType: "flat" });
                     let spy;
                     const config = {
@@ -9851,7 +9851,7 @@ describe("Linter with FlatConfigArray", () => {
                 const baseConfig = { rules: { "test/checker": "error" } };
 
                 it("should get cwd correctly in the context", () => {
-                    const cwd = "cwd";
+                    const cwd = "/cwd";
                     const linterWithOption = new Linter({ cwd, configType: "flat" });
                     let spy;
                     const config = {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1332,22 +1332,6 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should allow setting the filename to a file path without extension", () => {
-        ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
-            valid: [
-                {
-                    code: "var foo = 'bar'",
-                    filename: "somefile"
-                },
-                {
-                    code: "var foo = 'bar'",
-                    filename: "path/to/somefile"
-                }
-            ],
-            invalid: []
-        });
-    });
-
     it("should allow setting the filename to a file path with extension", () => {
         ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
             valid: [
@@ -1371,6 +1355,10 @@ describe("RuleTester", () => {
     it("should allow setting the filename to a file path without extension", () => {
         ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
             valid: [
+                {
+                    code: "var foo = 'bar'",
+                    filename: "somefile"
+                },
                 {
                     code: "var foo = 'bar'",
                     filename: "path/to/somefile"
@@ -2233,6 +2221,11 @@ describe("RuleTester", () => {
                 {
                     code: "eval(foo)",
                     filename: "/an-absolute-path/foo.js",
+                    errors: [{ message: "eval sucks.", type: "CallExpression" }]
+                },
+                {
+                    code: "eval(bar)",
+                    filename: "C:\\an-absolute-path\\foo.js",
                     errors: [{ message: "eval sucks.", type: "CallExpression" }]
                 }
             ]

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -1030,7 +1030,7 @@ describe("ast-utils", () => {
                     }))
                 });
 
-                linter.verify(key, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 13 } }, "test.js", true);
+                linter.verify(key, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 13 } }, "test.js");
             });
         });
     });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Update a dependency

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

fixes #18575

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR updates `@eslint/config-array` to version `^0.19.0` and adds unit tests to check that files on different drives are correctly ignored on Windows, which closes #18575.

The changes in `lib/eslint/eslint-helpers.js` remove unused logic that is probably a leftover of previous refactorings and is not necessary when paths (including glob patterns) are resolved to absolute paths. The changes in `RuleTester` should not be user-facing.

#### Is there anything you'd like reviewers to focus on?

Am I missing any unit tests?

<!-- markdownlint-disable-file MD004 -->
