### PR TITLE
Support config files starting with a dot

### DIFF
--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -452,6 +452,8 @@ class ConfigLoader {
         const configFilenames = allowTS
             ? [...FLAT_CONFIG_FILENAMES, ...TS_FLAT_CONFIG_FILENAMES]
             : FLAT_CONFIG_FILENAMES;
+        
+        configFilename.push(...configFilenames.map((name) => `.${name}`);
 
         // determine where to load config file from
         let configFilePath;


### PR DESCRIPTION
Hiding configuration files is an esthetic choice of project owners that aims to helps to distinguish source files from tooling. 

If it is not much work it would be great if eslint would offer an option to use config files starting with a dot.

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
