### PR TITLE
feat: export rules group from rules types

### DIFF
--- a/lib/types/rules/index.d.ts
+++ b/lib/types/rules/index.d.ts
@@ -25,7 +25,6 @@
  * SOFTWARE
  */
 
-
 import { Linter } from "../index";
 
 import { BestPractices } from "./best-practices";
@@ -48,3 +47,16 @@ export interface ESLintRules
     StylisticIssues,
     ECMAScript6,
     Deprecated { }
+
+type NoStringIndex<T> = {
+    [K in keyof T as string extends K ? never : K]: T[K];
+};
+
+export type ESLintRulesPossibleErrors = NoStringIndex<PossibleErrors>;
+export type ESLintRulesBestPractices = NoStringIndex<BestPractices>;
+export type ESLintRulesStrictMode = NoStringIndex<StrictMode>;
+export type ESLintRulesVariables = NoStringIndex<Variables>;
+export type ESLintRulesNodeJSAndCommonJS = NoStringIndex<NodeJSAndCommonJS>;
+export type ESLintRulesStylisticIssues = NoStringIndex<StylisticIssues>;
+export type ESLintRulesECMAScript6 = NoStringIndex<ECMAScript6>;
+export type ESLintRulesDeprecated = NoStringIndex<Deprecated>;

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -26,7 +26,7 @@
  */
 
 import { AST, ESLint, Linter, loadESLint, Rule, RuleTester, Scope, SourceCode } from "eslint";
-import { ESLintRules } from "eslint/rules";
+import { ESLintRules, ESLintRulesStrictMode, ESLintRulesVariables } from "eslint/rules";
 import { Linter as ESLinter } from "eslint/universal";
 import {
     builtinRules,
@@ -1281,6 +1281,26 @@ eslintConfig3.rules; // $ExpectType Partial<ESLintRules & TSLinterRules> | undef
 eslintConfig3.overrides?.[1].rules; // $ExpectType Partial<ESLintRules & TSLinterRules> | undefined
 
 // #endregion
+
+// #region ESLintRulesGroup
+
+// @ts-expect-error contains only one rule of the group
+let myES6RulesConfig: ESLintRulesVariables = {
+    'init-declarations': 'error'
+}
+
+// should work because group is wrapped in a Partial
+let myES6RulesConfigPartial: Partial<ESLintRulesVariables> = {
+    'init-declarations': 'error'
+}
+
+const myStrictModeRulesConfig: ESLintRulesStrictMode = {
+    'strict': 'error',
+    // @ts-expect-error `no-label-var` is not part of strict mode group
+    'no-label-var': 'error',
+};
+
+// #endregion ESLintRulesGroup
 
 // #region RuleTester
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Exported rule groups types  from `lib/types/rules/index.d.ts`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`ESLintRules` type exported from `eslint/rules` gives all the relevant configuration information for each rule.

When writing custom config it's useful to split the rules configuration into multiple files.

Since ESLint types already split rules into groups (PossibleErrors, BestPractices, ...) I added an export for each group.

This allows to be sure that all rules of a specific group are configured.
Additionally I removed the `string` index signature to be sure that keys that are not part of the group are reported when performing typecheck.

---

Using the proposed patch the following code:

```ts
import { ESLintRulesVariables } from 'eslint/rules';

export const VARIABLES_RULES: ESLintRulesVariables = {
  // https://eslint.org/docs/rules/no-unused-vars
  'no-unused-vars': 'error',

  // https://eslint.org/docs/latest/rules/no-label-var
  'no-label-var': 'error',
};
```

will produce the following type error:

```text
Type '{ 'no-unused-vars': "error"; 'no-label-var': "error"; }' is missing the following properties from type 
'NoStringIndex<Variables>': "init-declarations", "no-delete-var", "no-restricted-globals", "no-shadow", and 5 more.ts(2740)
```

If someone doesn't wan't to customise all group rules it can wrap the relevant group into a `Partial<...>`

```diff
- export const VARIABLES_RULES: ESLintRulesVariables = {
+export const VARIABLES_RULES: Partial<ESLintRulesVariables> = { 
```

#### Is there anything you'd like reviewers to focus on?

No

<!-- markdownlint-disable-file MD004 -->
