### PR TITLE
docs: add deprecation on `indent`, `quotes` and `semi` rule types

### DIFF
--- a/lib/types/rules/stylistic-issues.d.ts
+++ b/lib/types/rules/stylistic-issues.d.ts
@@ -493,6 +493,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to enforce consistent indentation.
      *
      * @since 0.14.0
+     * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/indent) in `@stylistic/eslint-plugin-js`.
      * @see https://eslint.org/docs/rules/indent
      */
     indent: Linter.RuleEntry<
@@ -1746,6 +1747,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to enforce the consistent use of either backticks, double, or single quotes.
      *
      * @since 0.0.7
+     * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/quotes) in `@stylistic/eslint-plugin-js`.
      * @see https://eslint.org/docs/rules/quotes
      */
     quotes: Linter.RuleEntry<
@@ -1768,6 +1770,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to require or disallow semicolons instead of ASI.
      *
      * @since 0.0.6
+     * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/semi) in `@stylistic/eslint-plugin-js`.
      * @see https://eslint.org/docs/rules/semi
      */
     semi:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Add deprecation notice on some stylistic issues deprecated rules

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

On `lib/types/rules/stylistic-issues.d.ts` there are some deprecated rules 
that do not have `@deprecated` marker, even if on documentation they are marked as so:

- [indent](https://eslint.org/docs/latest/rules/indent)
- [quote](https://eslint.org/docs/latest/rules/quote)
- [semi](https://eslint.org/docs/latest/rules/semi)

#### Is there anything you'd like reviewers to focus on?

No

<!-- markdownlint-disable-file MD004 -->
