### PR TITLE
fix: throw on `ENFILE`

### DIFF
--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -745,8 +745,7 @@ class ESLint {
             errorOnUnmatchedPattern
         });
         const controller = new AbortController();
-        const retryCodes = new Set(["ENFILE", "EMFILE"]);
-        const retrier = new Retrier(error => retryCodes.has(error.code), { concurrency: 100 });
+        const retrier = new Retrier(error => error.code === "EMFILE", { concurrency: 100 });
 
         debug(`${filePaths.length} files found in: ${Date.now() - startTime}ms`);
 


### PR DESCRIPTION

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Retrying on `EMFILE` (when `eslint` hits its own per-process limit) makes sense here.

However, hitting `ENFILE` (when global limit is exhausted) indicates an issue in system configuration/condition. Constantly retrying and keeping number of opened files at maximum would render whole system unusable: it wouldn't be able to spawn new processes, to start ssh sessions, to open log files; it might cause any service to crash or misbehave, etc. In this case, we should just throw and exit immediately.

#### Is there anything you'd like reviewers to focus on?

It would make sense to search for alternative approach here, since retrier would constantly hit `EMFILE`, causing unnecessary overhead.

IMHO the best approach would be:
- Start with high-concurrency queue
- If we catch `ENFILE` or any other non-`EMFILE` error, throw immediately
- If we catch `EMFILE`, lower the concurrency limit (for example, start with `128` and do `concurrency /= 2` each time we hit it; rethrow `EMFILE` if it happened on `concurrency === 1`) and retry
- (optional) Print a warning each time we got error and had to lower concurrency
- (optional) Make default concurrency limit configurable and/or set it as relative to `os.cpus().length` by default in runtime