### PR TITLE
feat: Implement Language#normalizeLanguageOptions()

### DIFF
--- a/docs/src/extend/languages.md
+++ b/docs/src/extend/languages.md
@@ -87,6 +87,7 @@ The following optional members allow you to customize how ESLint interacts with 
 * `visitorKeys` - visitor keys that are specific to the AST or CST. This is used to optimize traversal of the AST or CST inside of ESLint. While not required, it is strongly recommended, especially for AST or CST formats that deviate significantly from ESTree format.
 * `defaultLanguageOptions` - default `languageOptions` when the language is used. User-specified `languageOptions` are merged with this object when calculating the config for the file being linted.
 * `matchesSelectorClass(className, node, ancestry)` - allows you to specify selector classes, such as `:expression`, that match more than one node. This method is called whenever an [esquery](https://github.com/estools/esquery) selector contains a `:` followed by an identifier.
+* `normalizeLanguageOptions(languageOptions)` - takes a validated language options object and normalizes its values. This is helpful for backwards compatibility when language options properties change.
 
 See [`JSONLanguage`](https://github.com/eslint/json/blob/main/src/languages/json-language.js) as an example of a basic `Language` class.
 

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -215,6 +215,11 @@ class Config {
             throw new TypeError(`Key "languageOptions": ${error.message}`, { cause: error });
         }
 
+        // Normalize language options if necessary
+        if (this.language.normalizeLanguageOptions) {
+            this.languageOptions = this.language.normalizeLanguageOptions(this.languageOptions);
+        }
+
         // Check processor value
         if (processor) {
             this.processor = processor;

--- a/lib/languages/js/index.js
+++ b/lib/languages/js/index.js
@@ -16,6 +16,7 @@ const espree = require("espree");
 const eslintScope = require("eslint-scope");
 const evk = require("eslint-visitor-keys");
 const { validateLanguageOptions } = require("./validate-language-options");
+const { LATEST_ECMA_VERSION } = require("../../../conf/ecma-version");
 
 //-----------------------------------------------------------------------------
 // Type Definitions
@@ -31,6 +32,7 @@ const { validateLanguageOptions } = require("./validate-language-options");
 
 const debug = createDebug("eslint:languages:js");
 const DEFAULT_ECMA_VERSION = 5;
+const parserSymbol = Symbol.for("eslint.RuleTester.parser");
 
 /**
  * Analyze scope of the given AST.
@@ -53,6 +55,47 @@ function analyzeScope(ast, languageOptions, visitorKeys) {
         childVisitorKeys: visitorKeys || evk.KEYS,
         fallback: evk.getKeys
     });
+}
+
+/**
+ * Determines if a given object is Espree.
+ * @param {Object} parser The parser to check.
+ * @returns {boolean} True if the parser is Espree or false if not.
+ */
+function isEspree(parser) {
+    return !!(parser === espree || parser[parserSymbol] === espree);
+}
+
+/**
+ * Normalize ECMAScript version from the initial config into languageOptions (year)
+ * format.
+ * @param {any} [ecmaVersion] ECMAScript version from the initial config
+ * @returns {number} normalized ECMAScript version
+ */
+function normalizeEcmaVersionForLanguageOptions(ecmaVersion) {
+
+    switch (ecmaVersion) {
+        case 3:
+            return 3;
+
+        // void 0 = no ecmaVersion specified so use the default
+        case 5:
+        case void 0:
+            return 5;
+
+        default:
+            if (typeof ecmaVersion === "number") {
+                return ecmaVersion >= 2015 ? ecmaVersion : ecmaVersion + 2009;
+            }
+    }
+
+    /*
+     * We default to the latest supported ecmaVersion for everything else.
+     * Remember, this is for languageOptions.ecmaVersion, which sets the version
+     * that is used for a number of processes inside of ESLint. It's normally
+     * safe to assume people want the latest unless otherwise specified.
+     */
+    return LATEST_ECMA_VERSION;
 }
 
 //-----------------------------------------------------------------------------
@@ -78,6 +121,39 @@ module.exports = {
     },
 
     validateLanguageOptions,
+
+    /**
+     * Normalizes the language options.
+     * @param {Object} languageOptions The language options to normalize.
+     * @returns {Object} The normalized language options.
+     */
+    normalizeLanguageOptions(languageOptions) {
+
+        languageOptions.ecmaVersion = normalizeEcmaVersionForLanguageOptions(
+            languageOptions.ecmaVersion
+        );
+
+        // Espree expects this information to be passed in
+        if (isEspree(languageOptions.parser)) {
+            const parserOptions = languageOptions.parserOptions;
+
+            if (languageOptions.sourceType) {
+
+                parserOptions.sourceType = languageOptions.sourceType;
+
+                if (
+                    parserOptions.sourceType === "module" &&
+                    parserOptions.ecmaFeatures &&
+                    parserOptions.ecmaFeatures.globalReturn
+                ) {
+                    parserOptions.ecmaFeatures.globalReturn = false;
+                }
+            }
+        }
+
+        return languageOptions;
+
+    },
 
     /**
      * Determines if a given node matches a given selector class.

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1640,9 +1640,8 @@ class Linter {
 
         const slots = internalSlotsMap.get(this);
         const config = providedConfig || {};
-        const { language, settings = {}, languageOptions: originalLanguageOptions = {} } = config;
+        const { settings = {}, languageOptions } = config;
         const options = normalizeVerifyOptions(providedOptions, config);
-        const languageOptions = language.normalizeLanguageOptions?.(originalLanguageOptions) ?? originalLanguageOptions;
 
         if (!slots.lastSourceCode) {
             let t;

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1640,34 +1640,9 @@ class Linter {
 
         const slots = internalSlotsMap.get(this);
         const config = providedConfig || {};
+        const { language, settings = {}, languageOptions: originalLanguageOptions = {} } = config;
         const options = normalizeVerifyOptions(providedOptions, config);
-        const languageOptions = config.languageOptions;
-
-        if (config.language === jslang) {
-            languageOptions.ecmaVersion = normalizeEcmaVersionForLanguageOptions(
-                languageOptions.ecmaVersion
-            );
-
-            // Espree expects this information to be passed in
-            if (isEspree(languageOptions.parser)) {
-                const parserOptions = languageOptions.parserOptions;
-
-                if (languageOptions.sourceType) {
-
-                    parserOptions.sourceType = languageOptions.sourceType;
-
-                    if (
-                        parserOptions.sourceType === "module" &&
-                        parserOptions.ecmaFeatures &&
-                        parserOptions.ecmaFeatures.globalReturn
-                    ) {
-                        parserOptions.ecmaFeatures.globalReturn = false;
-                    }
-                }
-            }
-        }
-
-        const settings = config.settings || {};
+        const languageOptions = language.normalizeLanguageOptions?.(originalLanguageOptions) ?? originalLanguageOptions;
 
         if (!slots.lastSourceCode) {
             let t;

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -14,6 +14,7 @@ const assert = require("chai").assert;
 const stringify = require("json-stable-stringify-without-jsonify");
 const espree = require("espree");
 const jslang = require("../../../lib/languages/js");
+const { LATEST_ECMA_VERSION } = require("../../../conf/ecma-version");
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -187,7 +188,7 @@ async function assertMergedResult(values, result) {
     }
 
     if (!result.languageOptions) {
-        result.languageOptions = jslang.defaultLanguageOptions;
+        result.languageOptions = jslang.normalizeLanguageOptions(jslang.defaultLanguageOptions);
     }
 
     assert.deepStrictEqual(config, result);
@@ -282,10 +283,13 @@ describe("FlatConfigArray", () => {
                 plugins: ["@", "a", "b"],
                 language: "@/js",
                 languageOptions: {
-                    ecmaVersion: "latest",
+                    ecmaVersion: LATEST_ECMA_VERSION,
                     sourceType: "module",
                     parser: `espree@${espree.version}`,
-                    parserOptions: {}
+                    parserOptions: {
+                        sourceType: "module"
+                    }
+
                 },
                 linterOptions: {
                     reportUnusedDisableDirectives: 1
@@ -318,10 +322,12 @@ describe("FlatConfigArray", () => {
                 plugins: ["@", "a", "b:b-plugin@2.3.1"],
                 language: "@/js",
                 languageOptions: {
-                    ecmaVersion: "latest",
+                    ecmaVersion: LATEST_ECMA_VERSION,
                     sourceType: "module",
                     parser: `espree@${espree.version}`,
-                    parserOptions: {}
+                    parserOptions: {
+                        sourceType: "module"
+                    }
                 },
                 linterOptions: {
                     reportUnusedDisableDirectives: 1
@@ -356,10 +362,12 @@ describe("FlatConfigArray", () => {
                 plugins: ["@", "a", "b:b-plugin@2.3.1"],
                 language: "@/js",
                 languageOptions: {
-                    ecmaVersion: "latest",
+                    ecmaVersion: LATEST_ECMA_VERSION,
                     sourceType: "module",
                     parser: `espree@${espree.version}`,
-                    parserOptions: {}
+                    parserOptions: {
+                        sourceType: "module"
+                    }
                 },
                 linterOptions: {
                     reportUnusedDisableDirectives: 1
@@ -390,10 +398,12 @@ describe("FlatConfigArray", () => {
                 plugins: ["@"],
                 language: "@/js",
                 languageOptions: {
-                    ecmaVersion: "latest",
+                    ecmaVersion: LATEST_ECMA_VERSION,
                     sourceType: "module",
                     parser: `espree@${espree.version}`,
-                    parserOptions: {},
+                    parserOptions: {
+                        sourceType: "module"
+                    },
                     globals: {
                         name: "off"
                     }
@@ -530,7 +540,7 @@ describe("FlatConfigArray", () => {
             assert.deepStrictEqual(config.toJSON(), {
                 language: "@/js",
                 languageOptions: {
-                    ecmaVersion: "latest",
+                    ecmaVersion: LATEST_ECMA_VERSION,
                     parser: "custom-parser",
                     parserOptions: {},
                     sourceType: "module"
@@ -565,7 +575,7 @@ describe("FlatConfigArray", () => {
             assert.deepStrictEqual(config.toJSON(), {
                 language: "@/js",
                 languageOptions: {
-                    ecmaVersion: "latest",
+                    ecmaVersion: LATEST_ECMA_VERSION,
                     parser: "custom-parser@0.1.0",
                     parserOptions: {},
                     sourceType: "module"
@@ -600,7 +610,7 @@ describe("FlatConfigArray", () => {
             assert.deepStrictEqual(config.toJSON(), {
                 language: "@/js",
                 languageOptions: {
-                    ecmaVersion: "latest",
+                    ecmaVersion: LATEST_ECMA_VERSION,
                     parser: "custom-parser@0.1.0",
                     parserOptions: {},
                     sourceType: "module"
@@ -633,7 +643,7 @@ describe("FlatConfigArray", () => {
             assert.deepStrictEqual(config.toJSON(), {
                 language: "@/js",
                 languageOptions: {
-                    ecmaVersion: "latest",
+                    ecmaVersion: LATEST_ECMA_VERSION,
                     parser: "custom-parser@0.1.0",
                     parserOptions: {},
                     sourceType: "module"
@@ -706,9 +716,11 @@ describe("FlatConfigArray", () => {
             assert.deepStrictEqual(config.toJSON(), {
                 language: "@/js",
                 languageOptions: {
-                    ecmaVersion: "latest",
+                    ecmaVersion: LATEST_ECMA_VERSION,
                     parser: `espree@${espree.version}`,
-                    parserOptions: {},
+                    parserOptions: {
+                        sourceType: "module"
+                    },
                     sourceType: "module"
                 },
                 linterOptions: {
@@ -737,9 +749,11 @@ describe("FlatConfigArray", () => {
             assert.deepStrictEqual(config.toJSON(), {
                 language: "@/js",
                 languageOptions: {
-                    ecmaVersion: "latest",
+                    ecmaVersion: LATEST_ECMA_VERSION,
                     parser: `espree@${espree.version}`,
-                    parserOptions: {},
+                    parserOptions: {
+                        sourceType: "module"
+                    },
                     sourceType: "module"
                 },
                 linterOptions: {
@@ -772,9 +786,11 @@ describe("FlatConfigArray", () => {
             assert.deepStrictEqual(config.toJSON(), {
                 language: "@/js",
                 languageOptions: {
-                    ecmaVersion: "latest",
+                    ecmaVersion: LATEST_ECMA_VERSION,
                     parser: `espree@${espree.version}`,
-                    parserOptions: {},
+                    parserOptions: {
+                        sourceType: "module"
+                    },
                     sourceType: "module"
                 },
                 linterOptions: {
@@ -805,9 +821,11 @@ describe("FlatConfigArray", () => {
             assert.deepStrictEqual(config.toJSON(), {
                 language: "@/js",
                 languageOptions: {
-                    ecmaVersion: "latest",
+                    ecmaVersion: LATEST_ECMA_VERSION,
                     parser: `espree@${espree.version}`,
-                    parserOptions: {},
+                    parserOptions: {
+                        sourceType: "module"
+                    },
                     sourceType: "module"
                 },
                 linterOptions: {
@@ -1446,7 +1464,10 @@ describe("FlatConfigArray", () => {
                 languageOptions: {
                     ...jslang.defaultLanguageOptions,
                     ecmaVersion: 2019,
-                    sourceType: "commonjs"
+                    sourceType: "commonjs",
+                    parserOptions: {
+                        sourceType: "commonjs"
+                    }
                 }
             }));
 
@@ -1658,7 +1679,10 @@ describe("FlatConfigArray", () => {
                     language: jslang,
                     languageOptions: {
                         ...jslang.defaultLanguageOptions,
-                        sourceType: "script"
+                        sourceType: "script",
+                        parserOptions: {
+                            sourceType: "script"
+                        }
                     }
                 }));
 
@@ -1676,7 +1700,10 @@ describe("FlatConfigArray", () => {
                     language: jslang,
                     languageOptions: {
                         ...jslang.defaultLanguageOptions,
-                        sourceType: "script"
+                        sourceType: "script",
+                        parserOptions: {
+                            sourceType: "script"
+                        }
                     }
                 }));
 
@@ -2058,7 +2085,8 @@ describe("FlatConfigArray", () => {
                         ...jslang.defaultLanguageOptions,
                         parserOptions: {
                             foo: "whatever",
-                            bar: "baz"
+                            bar: "baz",
+                            sourceType: "module"
                         }
                     }
                 }));
@@ -2091,8 +2119,9 @@ describe("FlatConfigArray", () => {
                         parserOptions: {
                             ecmaFeatures: {
                                 jsx: true,
-                                globalReturn: true
-                            }
+                                globalReturn: false
+                            },
+                            sourceType: "module"
                         }
                     }
                 }));
@@ -2122,7 +2151,8 @@ describe("FlatConfigArray", () => {
                         parserOptions: {
                             ecmaFeatures: {
                                 jsx: true
-                            }
+                            },
+                            sourceType: "module"
                         }
                     }
                 }));
@@ -2149,7 +2179,8 @@ describe("FlatConfigArray", () => {
                     languageOptions: {
                         ...jslang.defaultLanguageOptions,
                         parserOptions: {
-                            foo: "bar"
+                            foo: "bar",
+                            sourceType: "module"
                         }
                     }
                 }));
@@ -2171,7 +2202,8 @@ describe("FlatConfigArray", () => {
                     languageOptions: {
                         ...jslang.defaultLanguageOptions,
                         parserOptions: {
-                            foo: "whatever"
+                            foo: "whatever",
+                            sourceType: "module"
                         }
                     }
                 }));
@@ -2194,7 +2226,8 @@ describe("FlatConfigArray", () => {
                     languageOptions: {
                         ...jslang.defaultLanguageOptions,
                         parserOptions: {
-                            foo: "bar"
+                            foo: "bar",
+                            sourceType: "module"
                         }
                     }
                 }));


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Added support for `Language#normalizeLanguageOptions()`
- Moved normalization logic from `linter.js` into `js/index.js`
- Updated the docs about language plugins

fixes #19037


#### Is there anything you'd like reviewers to focus on?

I left duplicates of `isEspree()` and `normalizeEcmaVersionForLanguageOptions()` in `linter.js` and `js/index.js`. The ones in `linter.js` can be removed when we drop eslintrc support. Another approach would be to export those methods from `js/index.js` into `linter.js` directly if we want to remove the duplication. I'm unsure of the best approach (these functions aren't likely to change).

I also wasn't sure if we needed separate tests for this change. 

<!-- markdownlint-disable-file MD004 -->
