### PR TITLE
docs: add `no-useless-computed-key` examples with object patterns

### DIFF
--- a/docs/src/rules/no-useless-computed-key.md
+++ b/docs/src/rules/no-useless-computed-key.md
@@ -34,6 +34,9 @@ var a = { [0]: 0 };
 var a = { ['x']: 0 };
 var a = { ['x']() {} };
 
+var { [0]: a } = obj;
+var { ['x']: a } = obj;
+
 class Foo {
     ["foo"] = "bar";
 
@@ -62,6 +65,9 @@ var c = { 0: 0 };
 var a = { x() {} };
 var c = { a: 0 };
 var c = { '0+1,234': 0 };
+
+var { 0: a } = obj;
+var { 'x': a } = obj;
 
 class Foo {
     "foo" = "bar";

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -24,6 +24,15 @@ ruleTester.run("no-useless-computed-key", rule, {
         "({ [x]: 0 });",
         "({ a: 0, [b](){} })",
         "({ ['__proto__']: [] })",
+        "var { 'a': foo } = obj",
+        "var { [a]: b } = obj;",
+        "var { a } = obj;",
+        "var { a: a } = obj;",
+        "var { a: b } = obj;",
+
+        // ['__proto__'] is useless computed key in object patterns, but the rule doesn't report it for backwards compatibility since it's frozen
+        "var { ['__proto__']: a } = obj",
+
         { code: "class Foo { a() {} }", options: [{ enforceForClassMembers: true }] },
         { code: "class Foo { 'a'() {} }", options: [{ enforceForClassMembers: true }] },
         { code: "class Foo { [x]() {} }", options: [{ enforceForClassMembers: true }] },
@@ -65,6 +74,14 @@ ruleTester.run("no-useless-computed-key", rule, {
                 type: "Property"
             }]
         }, {
+            code: "var { ['0']: a } = obj",
+            output: "var { '0': a } = obj",
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "'0'" },
+                type: "Property"
+            }]
+        }, {
             code: "({ ['0+1,234']: 0 })",
             output: "({ '0+1,234': 0 })",
             errors: [{
@@ -81,8 +98,24 @@ ruleTester.run("no-useless-computed-key", rule, {
                 type: "Property"
             }]
         }, {
+            code: "var { [0]: a } = obj",
+            output: "var { 0: a } = obj",
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "0" },
+                type: "Property"
+            }]
+        }, {
             code: "({ ['x']: 0 })",
             output: "({ 'x': 0 })",
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "'x'" },
+                type: "Property"
+            }]
+        }, {
+            code: "var { ['x']: a } = obj",
+            output: "var { 'x': a } = obj",
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'x'" },
@@ -115,6 +148,14 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "({ [('x')]: 0 })",
             output: "({ 'x': 0 })",
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "'x'" },
+                type: "Property"
+            }]
+        }, {
+            code: "var { [('x')]: a } = obj",
+            output: "var { 'x': a } = obj",
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'x'" },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Closes #12048

#### What changes did you make? (Give an overview)

This PR documents that `no-useless-computed-key` also applies to object patterns. I added several tests to confirm the behavior.

#### Is there anything you'd like reviewers to focus on?

`['__proto__']` in object patterns is a false negative. Shall we fix it or leave the behavior as is?


<!-- markdownlint-disable-file MD004 -->
