### PR TITLE
docs: add missing messageId property and suggestion properties

### DIFF
--- a/docs/src/integrate/nodejs-api.md
+++ b/docs/src/integrate/nodejs-api.md
@@ -421,6 +421,8 @@ The `LintMessage` value is the information of each linting error. The `messages`
   `true` if this is a fatal error unrelated to a rule, like a parsing error.
 * `message` (`string`)<br>
   The error message.
+* `messageId` (`string | undefined`)<br>
+  The message id of the lint error. This property is undefined if the rule does not use message ids.
 * `line` (`number | undefined`)<br>
   The 1-based line number of the begin point of this message.
 * `column` (`number | undefined`)<br>
@@ -431,7 +433,7 @@ The `LintMessage` value is the information of each linting error. The `messages`
   The 1-based column number of the end point of this message. This property is undefined if this message is not a range.
 * `fix` (`EditInfo | undefined`)<br>
   The [EditInfo] object of autofix. This property is undefined if this message is not fixable.
-* `suggestions` (`{ desc: string; fix: EditInfo }[] | undefined`)<br>
+* `suggestions` (`{ desc: string; fix: EditInfo; messageId?: string; data?: object }[] | undefined`)<br>
   The list of suggestions. Each suggestion is the pair of a description and an [EditInfo] object to fix code. API users such as editor integrations can choose one of them to fix the problem of this message. This property is undefined if this message doesn't have any suggestions.
 
 ### ◆ SuppressedLintMessage type
@@ -446,6 +448,8 @@ The `SuppressedLintMessage` value is the information of each suppressed linting 
   Same as `fatal` in [LintMessage] type.
 * `message` (`string`)<br>
   Same as `message` in [LintMessage] type.
+* `messageId` (`string | undefined`)<br>
+  Same as `messageId` in [LintMessage] type.
 * `line` (`number | undefined`)<br>
   Same as `line` in [LintMessage] type.
 * `column` (`number | undefined`)<br>
@@ -456,7 +460,7 @@ The `SuppressedLintMessage` value is the information of each suppressed linting 
   Same as `endColumn` in [LintMessage] type.
 * `fix` (`EditInfo | undefined`)<br>
   Same as `fix` in [LintMessage] type.
-* `suggestions` (`{ desc: string; fix: EditInfo }[] | undefined`)<br>
+* `suggestions` (`{ desc: string; fix: EditInfo; messageId?: string; data?: object }[] | undefined`)<br>
   Same as `suggestions` in [LintMessage] type.
 * `suppressions` (`{ kind: string; justification: string}[]`)<br>
   The list of suppressions. Each suppression is the pair of a kind and a justification.
@@ -658,6 +662,7 @@ The information available for each linting message is:
 * `fatal` - usually omitted, but will be set to true if there's a parsing error (not related to a rule).
 * `line` - the line on which the error occurred.
 * `message` - the message that should be output.
+* `messageId` - the ID of the message used to generate the message (this property is omitted if the rule does not use message ids).
 * `nodeType` - (**Deprecated:** This property will be removed in a future version of ESLint.) the node or token type that was reported with the problem.
 * `ruleId` - the ID of the rule that triggered the messages (or null if `fatal` is true).
 * `severity` - either 1 or 2, depending on your configuration.

--- a/docs/src/integrate/nodejs-api.md
+++ b/docs/src/integrate/nodejs-api.md
@@ -422,7 +422,7 @@ The `LintMessage` value is the information of each linting error. The `messages`
 * `message` (`string`)<br>
   The error message.
 * `messageId` (`string | undefined`)<br>
-  The message id of the lint error. This property is undefined if the rule does not use message ids.
+  The message ID of the lint error. This property is undefined if the rule does not use message IDs.
 * `line` (`number | undefined`)<br>
   The 1-based line number of the begin point of this message.
 * `column` (`number | undefined`)<br>
@@ -662,7 +662,7 @@ The information available for each linting message is:
 * `fatal` - usually omitted, but will be set to true if there's a parsing error (not related to a rule).
 * `line` - the line on which the error occurred.
 * `message` - the message that should be output.
-* `messageId` - the ID of the message used to generate the message (this property is omitted if the rule does not use message ids).
+* `messageId` - the ID of the message used to generate the message (this property is omitted if the rule does not use message IDs).
 * `nodeType` - (**Deprecated:** This property will be removed in a future version of ESLint.) the node or token type that was reported with the problem.
 * `ruleId` - the ID of the rule that triggered the messages (or null if `fatal` is true).
 * `severity` - either 1 or 2, depending on your configuration.
@@ -842,7 +842,7 @@ In addition to the properties above, invalid test cases can also have the follow
 
 * `errors` (number or array, required): Asserts some properties of the errors that the rule is expected to produce when run on this code. If this is a number, asserts the number of errors produced. Otherwise, this should be a list of objects, each containing information about a single reported error. The following properties can be used for an error (all are optional unless otherwise noted):
     * `message` (string/regexp): The message for the error. Must provide this or `messageId`
-    * `messageId` (string): The Id for the error. Must provide this or `message`. See [testing errors with messageId](#testing-errors-with-messageid) for details
+    * `messageId` (string): The ID for the error. Must provide this or `message`. See [testing errors with messageId](#testing-errors-with-messageid) for details
     * `data` (object): Placeholder data which can be used in combination with `messageId`
     * `type` (string): (**Deprecated:** This property will be removed in a future version of ESLint.) The type of the reported AST node
     * `line` (number): The 1-based line number of the reported location


### PR DESCRIPTION

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
- Add `messageId` property to `LintMessage`, `SuppressedLintMessage` and `Linter.verify`
- Add optional `messageId` and `data` properties to suggestion types

Closes #19119

#### Is there anything you'd like reviewers to focus on?
No
<!-- markdownlint-disable-file MD004 -->
