### PR TITLE
feat: fix `no-useless-computed-key` false negative with `__proto__`

### DIFF
--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -58,7 +58,10 @@ function hasUselessComputedKey(node) {
 
     switch (node.type) {
         case "Property":
-            return value !== "__proto__";
+            if (node.parent.type === "ObjectExpression") {
+                return value !== "__proto__";
+            }
+            return true;
 
         case "PropertyDefinition":
             if (node.static) {

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -29,10 +29,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         "var { a } = obj;",
         "var { a: a } = obj;",
         "var { a: b } = obj;",
-
-        // ['__proto__'] is useless computed key in object patterns, but the rule doesn't report it for backwards compatibility since it's frozen
-        "var { ['__proto__']: a } = obj",
-
         { code: "class Foo { a() {} }", options: [{ enforceForClassMembers: true }] },
         { code: "class Foo { 'a'() {} }", options: [{ enforceForClassMembers: true }] },
         { code: "class Foo { [x]() {} }", options: [{ enforceForClassMembers: true }] },
@@ -119,6 +115,14 @@ ruleTester.run("no-useless-computed-key", rule, {
             errors: [{
                 messageId: "unnecessarilyComputedProperty",
                 data: { property: "'x'" },
+                type: "Property"
+            }]
+        }, {
+            code: "var { ['__proto__']: a } = obj",
+            output: "var { '__proto__': a } = obj",
+            errors: [{
+                messageId: "unnecessarilyComputedProperty",
+                data: { property: "'__proto__'" },
                 type: "Property"
             }]
         }, {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

* **Node version:** 20.12.0
* **npm version:** 10.5.0
* **Local ESLint version:** 9.14.0
* **Global ESLint version:** no
* **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = [];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint no-useless-computed-key: "error"*/

var { ['__proto__']: a } = obj
```

**What did you expect to happen?**

One `no-useless-computed-key` lint error on `['__proto__']`

**What actually happened? Please include the actual, raw output from ESLint.**

No lint errors.

[Playground demo](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tdXNlbGVzcy1jb21wdXRlZC1rZXk6IFwiZXJyb3JcIiovXG5cbnZhciB7IFsnX19wcm90b19fJ106IGEgfSA9IG9iaiIsIm9wdGlvbnMiOnsicnVsZXMiOnt9LCJsYW5ndWFnZU9wdGlvbnMiOnsic291cmNlVHlwZSI6Im1vZHVsZSIsInBhcnNlck9wdGlvbnMiOnsiZWNtYUZlYXR1cmVzIjp7fX19fX0=)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the logic that handles `__proto__` to apply to object expressions only.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
