### PR TITLE
fix: fix getting options in dot-notation rule

### DIFF
--- a/lib/rules/dot-notation.js
+++ b/lib/rules/dot-notation.js
@@ -60,7 +60,7 @@ module.exports = {
     },
 
     create(context) {
-        const [options] = context.options;
+        const options = context.options[0] ?? {};
         const allowKeywords = options.allowKeywords;
         const sourceCode = context.sourceCode;
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

- [ ] Documentation update
- [x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
- [ ] Add autofix to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In the latest version, an error appeared when trying to use the `dot-notation` rule.

```
Oops! Something went wrong! :(

ESLint: 9.15.0

TypeError: Error while loading rule '@typescript-eslint/dot-notation': Cannot read properties of undefined (reading 'allowKeywords')
Occurred while linting /Users/azat/Developer/eslint-config/environment.d.ts
    at Object.create (/Users/azat/Developer/eslint-config/node_modules/.pnpm/eslint@9.15.0_jiti@2.4.0/node_modules/eslint/lib/rules/dot-notation.js:64:39)
    at create (/Users/azat/Developer/eslint-config/node_modules/.pnpm/@typescript-eslint+eslint-plugin@8.14.0_@typescript-eslint+parser@8.14.0_eslint@9.15.0_jiti@2_s7scp74ser6rbpub4nqfgxuskq/node_modules/@typescript-eslint/eslint-plugin/dist/rules/dot-notation.js:89:32)
    at Object.create (/Users/azat/Developer/eslint-config/node_modules/.pnpm/@typescript-eslint+utils@8.14.0_eslint@9.15.0_jiti@2.4.0__typescript@5.6.3/node_modules/@typescript-eslint/utils/dist/eslint-utils/RuleCreator.js:31:20)
    at createRuleListeners (/Users/azat/Developer/eslint-config/node_modules/.pnpm/eslint@9.15.0_jiti@2.4.0/node_modules/eslint/lib/linter/linter.js:944:21)
    at /Users/azat/Developer/eslint-config/node_modules/.pnpm/eslint@9.15.0_jiti@2.4.0/node_modules/eslint/lib/linter/linter.js:1082:84
    at Array.forEach (<anonymous>)
    at runRules (/Users/azat/Developer/eslint-config/node_modules/.pnpm/eslint@9.15.0_jiti@2.4.0/node_modules/eslint/lib/linter/linter.js:1013:34)
    at #flatVerifyWithoutProcessors (/Users/azat/Developer/eslint-config/node_modules/.pnpm/eslint@9.15.0_jiti@2.4.0/node_modules/eslint/lib/linter/linter.js:1911:31)
    at Linter._verifyWithFlatConfigArrayAndWithoutProcessors (/Users/azat/Developer/eslint-config/node_modules/.pnpm/eslint@9.15.0_jiti@2.4.0/node_modules/eslint/lib/linter/linter.js:1993:49)
    at Linter._verifyWithFlatConfigArray (/Users/azat/Developer/eslint-config/node_modules/.pnpm/eslint@9.15.0_jiti@2.4.0/node_modules/eslint/lib/linter/linter.js:2082:21)
 ELIFECYCLE  Command failed with exit code 2.
```


#### Is there anything you'd like reviewers to focus on?

N/A.
