### PR TITLE
chore: add `repository.directory` property to `package.json`

### DIFF
--- a/packages/eslint-config-eslint/package.json
+++ b/packages/eslint-config-eslint/package.json
@@ -25,7 +25,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/eslint/eslint"
+    "url": "https://github.com/eslint/eslint",
+    "directory": "packages/eslint-config-eslint"
   },
   "homepage": "https://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,  

I’ve added the `repository.directory` property to `eslint-config-eslint/package.json`.  

This property is already exist in `js/package.json` but it's missing in `eslint-config-eslint/package.json`.

https://github.com/eslint/eslint/blob/d46059410a0e02b98067aa31975c25fd8d0d1c2b/packages/js/package.json#L19-L22

Additionally, This property is mentioned in the [npm documentation](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository) and can be useful for maintaining a monorepo.  

It helps tools like npm and GitHub identify the specific directory within the repository where the package is located, which is especially beneficial in monorepo setups.

![image](https://github.com/user-attachments/assets/8231d415-c56b-4981-91f5-10c58c88402f)

#### Is there anything you'd like reviewers to focus on?

Nope!
