### PR TITLE
fix: regression in `no-warnings-comments`

### DIFF
--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -64,7 +64,7 @@ module.exports = {
 
     create(context) {
         const sourceCode = context.sourceCode;
-        const [{ decoration, location, terms: warningTerms }] = context.options;
+        const [{ decoration, location, terms: warningTerms } = {}] = context.options || [];
         const escapedDecoration = escapeRegExp(decoration ? decoration.join("") : "");
         const selfConfigRegEx = /\bno-warning-comments\b/u;
 


### PR DESCRIPTION
Seems like #17656 introduced an unintended change in `no-warnings-comments.js` where before it roughly looked like:

```js
var configuration = context.options[0] || {};
var decoration = [...configuration.decoration || []].join("");
```

And afterwards it looks like:

```js
const [{ decoration, location, terms: warningTerms }] = context.options;
```

Which unintentionally(?) removes the `context.options[0] || {}` default, which eg. causes `eslint-plugin-unicorn@<15.0.1` to fail (see https://github.com/sindresorhus/eslint-plugin-unicorn/pull/2497)

Since this happened in a minor `eslint` release but the fix for `eslint-plugin-unicorn` is only available as a patch to its latest major, this is causing me some issues.

My guess is that you won't be wanting to merge this though as `eslint-plugin-unicorn` is [extending that rule](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/8b7c5fcf5c9743db4afde0bb9c90cc51782d47ef/rules/utils/get-builtin-rule.js#L4) through:

```js
require('eslint/use-at-your-own-risk').builtinRules.get('no-warning-comments')
```

And as discussed in #19013 you don't consider that a good practise:

> It's in unstable APIs because rule APIs are indeed not stable

> Core rules are not intended to extended any you do so at your own risk

Perhaps #19013 or similar can suggest an alternative for eg. `eslint-plugin-unicorn` to avoid this happening again in the future, but my guess is you consider such suggestions to be out of scope of `eslint` and as such to not be something you ant to get involved in.

Here's a PR fixing the regression at least, you decide if you want to accept it or reject it 🤷‍♂️

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Restored the default that existed prior to #17656

#### Is there anything you'd like reviewers to focus on?

Using this version of ESLint with the `^14.0.0` 

<!-- markdownlint-disable-file MD004 -->
