### PR TITLE
fix: fix crash when `message.fix` is nullish

### DIFF
--- a/lib/linter/source-code-fixer.js
+++ b/lib/linter/source-code-fixer.js
@@ -107,7 +107,7 @@ SourceCodeFixer.applyFixes = function(sourceText, messages, shouldFix) {
     }
 
     messages.forEach(problem => {
-        if (Object.hasOwn(problem, "fix")) {
+        if (Object.hasOwn(problem, "fix") && problem.fix) {
             fixes.push(problem);
         } else {
             remainingMessages.push(problem);

--- a/tests/lib/linter/source-code-fixer.js
+++ b/tests/lib/linter/source-code-fixer.js
@@ -429,15 +429,15 @@ describe("SourceCodeFixer", () => {
 
         });
 
-        describe("Nil fix", () => {
-            it("should not throw if fix equal null", () => {
+        describe("Nullish fixes", () => {
+            it("should not throw if fix is null", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [NULL_FIX]);
 
                 assert.isFalse(result.fixed);
                 assert.strictEqual(result.output, TEST_CODE);
             });
 
-            it("should not throw if fix equal undefined", () => {
+            it("should not throw if fix is undefined", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [UNDEFINED_FIX]);
 
                 assert.isFalse(result.fixed);

--- a/tests/lib/linter/source-code-fixer.js
+++ b/tests/lib/linter/source-code-fixer.js
@@ -435,6 +435,8 @@ describe("SourceCodeFixer", () => {
 
                 assert.isFalse(result.fixed);
                 assert.strictEqual(result.output, TEST_CODE);
+                assert.strictEqual(result.messages.length, 1);
+                assert.strictEqual(result.messages[0].message, "null");
             });
 
             it("should not throw if fix is undefined", () => {
@@ -442,6 +444,8 @@ describe("SourceCodeFixer", () => {
 
                 assert.isFalse(result.fixed);
                 assert.strictEqual(result.output, TEST_CODE);
+                assert.strictEqual(result.messages.length, 1);
+                assert.strictEqual(result.messages[0].message, "undefined");
             });
         });
 

--- a/tests/lib/linter/source-code-fixer.js
+++ b/tests/lib/linter/source-code-fixer.js
@@ -127,6 +127,14 @@ const INSERT_AT_END = {
             range: [3, 0],
             text: " "
         }
+    },
+    UNDEFINED_FIX = {
+        message: "undefined",
+        fix: void 0
+    },
+    NULL_FIX = {
+        message: "null",
+        fix: null
     };
 
 //------------------------------------------------------------------------------
@@ -419,6 +427,22 @@ describe("SourceCodeFixer", () => {
                 assert.strictEqual(result.messages.length, 0);
             });
 
+        });
+
+        describe("Nil fix", () => {
+            it("should not throw if fix equal null", () => {
+                const result = SourceCodeFixer.applyFixes(TEST_CODE, [NULL_FIX]);
+
+                assert.isFalse(result.fixed);
+                assert.strictEqual(result.output, TEST_CODE);
+            });
+
+            it("should not throw if fix equal undefined", () => {
+                const result = SourceCodeFixer.applyFixes(TEST_CODE, [UNDEFINED_FIX]);
+
+                assert.isFalse(result.fixed);
+                assert.strictEqual(result.output, TEST_CODE);
+            });
         });
 
     });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

No need for providing the template. So I skipped it.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds a simple check in `linter.source-code-fixer` incasing `message.fix` equals to `null` or `undefined` which might cause the linter throw. 

#### Is there anything you'd like reviewers to focus on?

There is a reproduction repo https://github.com/pany-ang/issue-eslint-config.

Or you can just remove the check, run the tests added.

<!-- markdownlint-disable-file MD004 -->
