### PR TITLE
feat: Extend id-denylist to work with regular expressions as well

### DIFF
--- a/lib/rules/id-denylist.js
+++ b/lib/rules/id-denylist.js
@@ -95,6 +95,18 @@ function isPropertyNameInDestructuring(node) {
     );
 }
 
+/**
+ * Converts a String starting with a slash into a RegExp object.
+ * @param {string} string The string to convert.
+ * @returns {RegExp} The corresponding RegExp object.
+ */
+function string2RegExp(string) {
+    const match = string.match(/^\/(.*?)\/([gimy]*)$/u);
+
+    return new RegExp(match[1], match[2]);
+}
+
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -126,7 +138,15 @@ module.exports = {
     },
 
     create(context) {
-        const denyList = new Set(context.options);
+        const denyList = context.options.map(option => {
+            if (option.startsWith("/")) {
+
+                // treat as RegExp since identifiers can't start and end with a slash
+                return string2RegExp(option);
+            }
+
+            return option;
+        });
         const reportedNodes = new Set();
         const sourceCode = context.sourceCode;
 
@@ -139,7 +159,12 @@ module.exports = {
          * @private
          */
         function isRestricted(name) {
-            return denyList.has(name);
+            return denyList.some(deny => {
+                if (typeof deny === "object") {
+                    return deny.test(name);
+                }
+                return deny === name;
+            });
         }
 
         /**

--- a/tests/lib/rules/id-denylist.js
+++ b/tests/lib/rules/id-denylist.js
@@ -163,6 +163,12 @@ ruleTester.run("id-denylist", rule, {
             languageOptions: { ecmaVersion: 6 }
         },
 
+        // RegExp as option
+        {
+            code: "foo = \"bar\"",
+            options: ["/Foo/", "/fo$/", "/bar/"]
+        },
+
         // references to global variables
         {
             code: "Number.parseInt()",
@@ -1484,6 +1490,46 @@ ruleTester.run("id-denylist", rule, {
                 {
                     messageId: "restricted",
                     data: { name: "json" },
+                    type: "Identifier"
+                }
+            ]
+        },
+
+        // RegExp matches
+        {
+            code: "foo = \"bar\"",
+            options: ["/foo/"],
+            errors: [
+                {
+                    messageId: "restricted",
+                    data: { name: "foo" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "foo = \"bar\"",
+            options: ["/Foo/i"],
+            errors: [
+                {
+                    messageId: "restricted",
+                    data: { name: "foo" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "whiteList = blackList",
+            options: ["/(white|black)list/i"],
+            errors: [
+                {
+                    messageId: "restricted",
+                    data: { name: "whiteList" },
+                    type: "Identifier"
+                },
+                {
+                    messageId: "restricted",
+                    data: { name: "blackList" },
                     type: "Identifier"
                 }
             ]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

- [`id-denylist`](https://eslint.org/docs/latest/rules/id-denylist)
- Not sure if changes have to be backported to the deprecated [`id-blacklist`](https://eslint.org/docs/latest/rules/id-blacklist) as well.

**What change do you want to make (place an "X" next to just one item)?**

[X] Generate more warnings
[ ] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[ ] A new option
[ ] A new default behavior
[X] Other

In addition to simple strings, this change additionally handles strings starting with a slash as a regular expression. This is a backward-compatible change since identifiers are not allowed to start with a slash. I.e., we can treat and parse any option starting with a slash as a regular expression.

**Please provide some example code that this change will affect:**

```js
/*eslint id-denylist: ["error", "/(white|black)list/i"] */

var whiteList = [0, 1, 2];
```

**What does the rule currently do for this code?**

It does not throw an error.

**What will the rule do after it's changed?**

Throws an error: `Identifier 'whiteList' is restricted.`

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This rule extension has been proposed before in https://github.com/eslint/eslint/issues/6212. The proposal has been marked as accepted since it had "more than enough votes" (sic!). The issue was closed half a year later after having not yet been addressed by the community.

A community version of this rule extension has been published as `@susiandjames/eslint-plugin-id-denylist-regexp`: [GitHub](https://github.com/SUSIandJames/eslint-plugin-id-denylist-regexp) | [npm](https://www.npmjs.com/package/@susiandjames/eslint-plugin-id-denylist-regexp).

#### Is there anything you'd like reviewers to focus on?

I'll happily extend the documentation for the rule `id-denylist` as well once I got positive feedback about this rule extension proposal by the ESLint team.

<!-- markdownlint-disable-file MD004 -->

-----

The work on this PR was sponsored by [*SUSI&James GmbH*](https://susiandjames.com/).