### PR TITLE
docs: delete unnecessary horizontal rule(`---`) in `nodejs-api`

### DIFF
--- a/docs/src/integrate/nodejs-api.md
+++ b/docs/src/integrate/nodejs-api.md
@@ -1001,8 +1001,6 @@ ruleTester.run("my-rule", myRule, {
 })
 ```
 
----
-
 [configuration object]: ../use/configure/
 [builtin-formatters]: ../use/formatters/
 [third-party-formatters]: https://www.npmjs.com/search?q=eslintformatter


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [ ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,  

I've removed an unnecessary horizontal rule (`---`) from `nodejs-api.md`.  

As shown in the screenshot below, the document contained redundant horizontal rules:  

![image](https://github.com/user-attachments/assets/318dd91e-2c89-44ed-a118-340de83e9f39)  

In contrast, other pages only include a single horizontal rule at the end of the document:  

![image](https://github.com/user-attachments/assets/b2e761f8-20e8-4e61-9379-0c3ceb0ada0f)

#### Is there anything you'd like reviewers to focus on?

I think the horizontal rule was added to separate the document from the comments section, but it doesn't seem to work as intended.  

If the purpose was to split the document and comments, I suggest using this instead: `<!-- --- -->`.  

- Before

    ```markdown
    ---
    
    [configuration object]: ../use/configure/
    [builtin-formatters]: ../use/formatters/
    [third-party-formatters]: https://www.npmjs.com/search?q=eslintformatter
    ```  

- After

    ```markdown
    <!-- --- -->
    
    [configuration object]: ../use/configure/
    [builtin-formatters]: ../use/formatters/
    [third-party-formatters]: https://www.npmjs.com/search?q=eslintformatter
    ```
<!-- markdownlint-disable-file MD004 -->
