### PR TITLE
docs: fix a typo in `debug.md`

### DIFF
--- a/docs/src/use/configure/debug.md
+++ b/docs/src/use/configure/debug.md
@@ -20,7 +20,7 @@ ESLint creates a configuration for each file that is linted based on your config
 npx eslint --debug file.js
 ```
 
-This outputs all of ESLint's debugging information onto the console. You should copy this output to a file and then search for "eslint.config.js` to see which file is loaded. Here's some example output:
+This outputs all of ESLint's debugging information onto the console. You should copy this output to a file and then search for `eslint.config.js` to see which file is loaded. Here's some example output:
 
 ```text
 eslint:eslint Using file patterns: bin/eslint.js +0ms


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello, I've fixed a typo in `debug.md`.

I think `"` is a typo. It should be <code>`</code>.

![image](https://github.com/user-attachments/assets/3cc89add-2d87-4099-bb57-d4704a8becf7)

#### Is there anything you'd like reviewers to focus on?

Nope!

<!-- markdownlint-disable-file MD004 -->
