### PR TITLE
chore: add type for `ignoreComputedKeys` option of `sort-keys`

### DIFF
--- a/lib/types/rules/stylistic-issues.d.ts
+++ b/lib/types/rules/stylistic-issues.d.ts
@@ -1854,6 +1854,10 @@ export interface StylisticIssues extends Linter.RulesRecord {
                  * @default false
                  */
                 allowLineSeparatedGroups: boolean;
+                /**
+                 * @default false
+                 */
+                ignoreComputedKeys: boolean;
             }>,
         ]
     >;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added type definition for `ignoreComputedKeys` option of `sort-keys` rule, that was added in #19162.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
