### PR TITLE
docs: add backtick in `-0` in `description` of `no-compare-neg-zero`

### DIFF
--- a/docs/src/_data/rules_meta.json
+++ b/docs/src/_data/rules_meta.json
@@ -950,7 +950,7 @@
     "no-compare-neg-zero": {
         "type": "problem",
         "docs": {
-            "description": "Disallow comparing against -0",
+            "description": "Disallow comparing against `-0`",
             "recommended": true,
             "url": "https://eslint.org/docs/latest/rules/no-compare-neg-zero"
         },

--- a/lib/rules/no-compare-neg-zero.js
+++ b/lib/rules/no-compare-neg-zero.js
@@ -14,7 +14,7 @@ module.exports = {
         type: "problem",
 
         docs: {
-            description: "Disallow comparing against -0",
+            description: "Disallow comparing against `-0`",
             recommended: true,
             url: "https://eslint.org/docs/latest/rules/no-compare-neg-zero"
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,

Although `-0` is wrapped in an inline code block using backticks in the official documentation, it is missing in the `description` property of the `no-compare-neg-zero.js` rule. So, I added it.

Here’s a screenshot of the official documentation.

https://eslint.org/docs/latest/rules/no-compare-neg-zero

![image](https://github.com/user-attachments/assets/f48d7d33-d22d-406a-8fc6-7fb276e146f9)

#### Is there anything you'd like reviewers to focus on?

It’s just a simple fix, and I am not sure if it should be categorized as a bug. so I didn’t use the bug template.

However, if I need to use the template, I’ll be happy to do so.

<!-- markdownlint-disable-file MD004 -->
