### PR TITLE
docs: use higher contrast color tokens for code comments

### DIFF
--- a/docs/src/assets/scss/syntax-highlighter.scss
+++ b/docs/src/assets/scss/syntax-highlighter.scss
@@ -60,10 +60,10 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-    color: #6e7f8e;
+    color: var(--color-neutral-500);
 
     [data-theme="dark"] & {
-        color: #8e9fae;
+        color: var(--color-neutral-400);
     }
 }
 

--- a/docs/src/assets/scss/syntax-highlighter.scss
+++ b/docs/src/assets/scss/syntax-highlighter.scss
@@ -60,11 +60,7 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-    color: var(--color-neutral-500);
-
-    [data-theme="dark"] & {
-        color: var(--color-neutral-400);
-    }
+    color: var(--code-comments-color);
 }
 
 .token.namespace {

--- a/docs/src/assets/scss/tokens/themes.scss
+++ b/docs/src/assets/scss/tokens/themes.scss
@@ -74,6 +74,7 @@
     --color-brand: var(--color-primary-800);
     --body-background-color: #fff;
     --body-text-color: var(--color-neutral-500);
+    --code-comments-color: var(--color-neutral-500);
     --headings-color: var(--color-neutral-900);
 
     --border-color: var(--color-neutral-300);
@@ -95,6 +96,7 @@
     :root {
         --body-background-color: var(--color-neutral-900);
         --body-text-color: var(--color-neutral-300);
+        --code-comments-color: var(--color-neutral-400);
         --headings-color: #fff;
 
         --divider-color: var(--color-neutral-600);
@@ -116,6 +118,7 @@
 html[data-theme="light"] {
     --body-background-color: #fff;
     --body-text-color: var(--color-neutral-500);
+    --code-comments-color: var(--color-neutral-500);
     --headings-color: var(--color-neutral-900);
 
     --border-color: var(--color-neutral-300);
@@ -139,6 +142,7 @@ html[data-theme="dark"] {
 
     --body-background-color: var(--color-neutral-900);
     --body-text-color: var(--color-neutral-300);
+    --code-comments-color: var(--color-neutral-400);
     --headings-color: #fff;
 
     --divider-color: var(--color-neutral-600);


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes https://github.com/eslint/eslint.org/issues/665. Corresponds to https://github.com/eslint/eslint.org/pull/666.

#### What changes did you make? (Give an overview)

I swapped out the hardcoded comment colors with the closest theme tokens that had sufficient contrast.

<table>
<thead>
<tr>
<th>Mode
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>Light</td>
<td><img alt="'Before' screenshot in light mode of a code block with just barely too low contrast for code comments" src="https://github.com/user-attachments/assets/f464d4f2-e880-492e-81ac-7eec28de03c9" width="315px" /></td>
<td><img alt="'After' screenshot in light mode of a code block with just barely too low contrast for code comments" src="https://github.com/user-attachments/assets/9b59c73a-604a-43ce-a178-8babcdcd5b3c" width="315px" /></td>
</tr>
<tr>
<td>Dark</td>
<td><img alt="'Before' screenshot in dark mode of a code block with just barely too low contrast for code comments" src="https://github.com/user-attachments/assets/d9242313-0fb3-4bff-b61d-33c0c164851a" width="315px" /></td>
<td><img alt="'After' screenshot in dark mode of a code block with just barely enough contrast for code comments" src="https://github.com/user-attachments/assets/3a7f57e2-6107-4f52-be47-e3ab1d8e501a" width="315px" /></td>
</tr>
</tbody>
</table>

#### Is there anything you'd like reviewers to focus on?

If there are other ad-hoc colors just barely off from color tokens, I'd be happy to clean those up in a followup?
