### PR TITLE
docs: add missing backtick to `no-async-promise-executor`

### DIFF
--- a/docs/src/rules/no-async-promise-executor.md
+++ b/docs/src/rules/no-async-promise-executor.md
@@ -76,4 +76,4 @@ const result = Promise.resolve(foo);
 
 ## When Not To Use It
 
-If your codebase doesn't support async function syntax, there's no need to enable this rule.
+If your codebase doesn't support `async function` syntax, there's no need to enable this rule.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,

I've added a missing backtick for the inline code block in `no-async-promise-executor.md`.

It was included in the paragraph above but was missing in the one below. (Please refer to the screenshot below.)

![image](https://github.com/user-attachments/assets/157b7c2f-28e6-4a5e-8038-85f5e54acec9)

#### Is there anything you'd like reviewers to focus on?

Nope!

<!-- markdownlint-disable-file MD004 -->
