### PR TITLE
docs: add missing backticks to `eqeqeq`

### DIFF
--- a/docs/src/rules/eqeqeq.md
+++ b/docs/src/rules/eqeqeq.md
@@ -89,8 +89,8 @@ foo === null
 This rule optionally takes a second argument, which should be an object with the following supported properties:
 
 * `"null"`: Customize how this rule treats `null` literals. Possible values:
-    * `always` (default) - Always use === or !==.
-    * `never` - Never use === or !== with `null`.
+    * `always` (default) - Always use `===` or `!==`.
+    * `never` - Never use `===` or `!==` with `null`.
     * `ignore` - Do not apply this rule to `null`.
 
 ### smart


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,

I've added missing backticks to `eqeqeq.md`.

`===` and `!==` should be wrapped in backticks(inline code blocks) like the screenshot below.

![image](https://github.com/user-attachments/assets/770b6951-6af0-484c-9c7c-2f0a6eac1c08)

![image](https://github.com/user-attachments/assets/b981d95f-e11d-466e-853d-04ab85694d1e)

#### Is there anything you'd like reviewers to focus on?

Nothing.

<!-- markdownlint-disable-file MD004 -->
