### PR TITLE
chore: add missing backticks to `flags.js`

### DIFF
--- a/lib/shared/flags.js
+++ b/lib/shared/flags.js
@@ -10,7 +10,7 @@
  */
 const activeFlags = new Map([
     ["test_only", "Used only for testing."],
-    ["unstable_config_lookup_from_file", "Look up eslint.config.js from the file being linted."],
+    ["unstable_config_lookup_from_file", "Look up `eslint.config.js` from the file being linted."],
     ["unstable_ts_config", "Enable TypeScript configuration files."]
 ]);
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello, I've added missing backticks to `flags.js`.

While `eslint.config.js` is consistently wrapped in backticks throughout the documentation, it was missing in `flags.js`.

![image](https://github.com/user-attachments/assets/e82cfe04-c06c-48b1-8865-94b0784363a5)

- E.g., `eslint.config.js` is wrapped in backticks throughout the documentation like the screenshot below.

    ![image](https://github.com/user-attachments/assets/947dd6fb-2b64-4042-943d-45208c9d6b07)

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
