### PR TITLE
docs: `Edit this page` button link to different branches

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -37,6 +37,7 @@ module.exports = function(eleventyConfig) {
      */
 
     let pathPrefix = "/docs/head/";
+    const isNumberVersion = process.env.BRANCH && /^v\d+\.x$/u.test(process.env.BRANCH);
 
     if (process.env.CONTEXT === "deploy-preview") {
         pathPrefix = "/";
@@ -44,7 +45,7 @@ module.exports = function(eleventyConfig) {
         pathPrefix = "/docs/latest/";
     } else if (process.env.BRANCH === "next") {
         pathPrefix = "/docs/next/";
-    } else if (process.env.BRANCH && /^v\d+\.x$/u.test(process.env.BRANCH)) {
+    } else if (isNumberVersion) {
         pathPrefix = `/docs/${process.env.BRANCH}/`; // `/docs/v8.x/`, `/docs/v9.x/`, `/docs/v10.x/` ...
     }
 
@@ -56,10 +57,10 @@ module.exports = function(eleventyConfig) {
     const siteName = process.env.ESLINT_SITE_NAME || "en";
 
     /**
-     * Determines whether the given version is a prerelease.
-     * @returns {boolean} `true` if it is a prerelease, `false` otherwise.
+     * Determines whether we are in the prerelease phase.
+     * @returns {Promise<boolean>} `true` if there is a prerelease of the next major version, `false` otherwise.
      */
-    async function isPreRelease() {
+    async function isPrereleasePhase() {
         const eslintVersions = await require("./src/_data/eslintVersions")();
 
         return eslintVersions.items.some(item => item.branch === "next");
@@ -70,8 +71,8 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addGlobalData("HEAD", process.env.BRANCH === "main");
     eleventyConfig.addGlobalData("NOINDEX", process.env.BRANCH !== "latest");
     eleventyConfig.addGlobalData("PATH_PREFIX", pathPrefix);
-    eleventyConfig.addGlobalData("is_pre_release", isPreRelease);
-    eleventyConfig.addGlobalData("is_number_version", process.env.BRANCH && /^v\d+\.x$/u.test(process.env.BRANCH));
+    eleventyConfig.addGlobalData("is_prerelease_phase", isPrereleasePhase);
+    eleventyConfig.addGlobalData("is_number_version", isNumberVersion);
     eleventyConfig.addDataExtension("yml", contents => yaml.load(contents));
 
     //------------------------------------------------------------------------------

--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -56,22 +56,11 @@ module.exports = function(eleventyConfig) {
     // Load site-specific data
     const siteName = process.env.ESLINT_SITE_NAME || "en";
 
-    /**
-     * Determines whether we are in the prerelease phase.
-     * @returns {Promise<boolean>} `true` if there is a prerelease of the next major version, `false` otherwise.
-     */
-    async function isPrereleasePhase() {
-        const eslintVersions = await require("./src/_data/eslintVersions")();
-
-        return eslintVersions.items.some(item => item.branch === "next");
-    }
-
     eleventyConfig.addGlobalData("site_name", siteName);
     eleventyConfig.addGlobalData("GIT_BRANCH", process.env.BRANCH);
     eleventyConfig.addGlobalData("HEAD", process.env.BRANCH === "main");
     eleventyConfig.addGlobalData("NOINDEX", process.env.BRANCH !== "latest");
     eleventyConfig.addGlobalData("PATH_PREFIX", pathPrefix);
-    eleventyConfig.addGlobalData("is_prerelease_phase", isPrereleasePhase);
     eleventyConfig.addGlobalData("is_number_version", isNumberVersion);
     eleventyConfig.addDataExtension("yml", contents => yaml.load(contents));
 

--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -55,11 +55,24 @@ module.exports = function(eleventyConfig) {
     // Load site-specific data
     const siteName = process.env.ESLINT_SITE_NAME || "en";
 
+    // Current version of ESLint
+    const currentVersion = require("../package.json").version;
+
+    /**
+     * Determines whether the given version is a prerelease.
+     * @param {string} version The version to check.
+     * @returns {boolean} `true` if it is a prerelease, `false` otherwise.
+     */
+    function isPreRelease(version) {
+        return /[a-z]/u.test(version);
+    }
+
     eleventyConfig.addGlobalData("site_name", siteName);
     eleventyConfig.addGlobalData("GIT_BRANCH", process.env.BRANCH);
     eleventyConfig.addGlobalData("HEAD", process.env.BRANCH === "main");
     eleventyConfig.addGlobalData("NOINDEX", process.env.BRANCH !== "latest");
     eleventyConfig.addGlobalData("PATH_PREFIX", pathPrefix);
+    eleventyConfig.addGlobalData("is_pre_release", isPreRelease(currentVersion));
     eleventyConfig.addDataExtension("yml", contents => yaml.load(contents));
 
     //------------------------------------------------------------------------------

--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -55,16 +55,14 @@ module.exports = function(eleventyConfig) {
     // Load site-specific data
     const siteName = process.env.ESLINT_SITE_NAME || "en";
 
-    // Current version of ESLint
-    const currentVersion = require("../package.json").version;
-
     /**
      * Determines whether the given version is a prerelease.
-     * @param {string} version The version to check.
      * @returns {boolean} `true` if it is a prerelease, `false` otherwise.
      */
-    function isPreRelease(version) {
-        return /[a-z]/u.test(version);
+    async function isPreRelease() {
+        const eslintVersions = await require("./src/_data/eslintVersions")();
+
+        return eslintVersions.items.some(item => item.branch === "next");
     }
 
     eleventyConfig.addGlobalData("site_name", siteName);
@@ -72,7 +70,8 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addGlobalData("HEAD", process.env.BRANCH === "main");
     eleventyConfig.addGlobalData("NOINDEX", process.env.BRANCH !== "latest");
     eleventyConfig.addGlobalData("PATH_PREFIX", pathPrefix);
-    eleventyConfig.addGlobalData("is_pre_release", isPreRelease(currentVersion));
+    eleventyConfig.addGlobalData("is_pre_release", isPreRelease);
+    eleventyConfig.addGlobalData("is_number_version", process.env.BRANCH && /^v\d+\.x$/u.test(process.env.BRANCH));
     eleventyConfig.addDataExtension("yml", contents => yaml.load(contents));
 
     //------------------------------------------------------------------------------

--- a/docs/src/_data/eslintVersions.js
+++ b/docs/src/_data/eslintVersions.js
@@ -31,6 +31,7 @@ module.exports = async function() {
     const { items } = data;
 
     let foundItemForThisBranch = false;
+    let isPrereleasePhase = false;
 
     for (const item of items) {
         const isItemForThisBranch = item.branch === thisBranch;
@@ -54,6 +55,10 @@ module.exports = async function() {
         if (isItemForThisBranch) {
             item.selected = true;
         }
+
+        if (item.branch === "next") {
+            isPrereleasePhase = true;
+        }
     }
 
     // Add an empty item if this is not a production branch
@@ -66,6 +71,8 @@ module.exports = async function() {
             selected: true
         });
     }
+
+    data.isPrereleasePhase = isPrereleasePhase;
 
     return data;
 };

--- a/docs/src/_data/sites/en.yml
+++ b/docs/src/_data/sites/en.yml
@@ -117,4 +117,5 @@ footer:
 
 edit_link:
   start_with: https://github.com/eslint/eslint/edit/main/docs/
+  start_with_latest: https://github.com/eslint/eslint/edit/latest/docs/
   text: Edit this page

--- a/docs/src/_data/sites/zh-hans.yml
+++ b/docs/src/_data/sites/zh-hans.yml
@@ -114,4 +114,5 @@ footer:
 
 edit_link:
   start_with: https://github.com/eslint/eslint/edit/main/docs/
+  start_with_latest: https://github.com/eslint/eslint/edit/latest/docs/
   text: 编辑此页

--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -102,7 +102,7 @@ layout: base.html
                 {% if edit_link %}
                     {{ edit_link }}
                 {% else %}
-                    {% if is_pre_release and GIT_BRANCH === 'latest' %}
+                    {% if is_prerelease_phase and GIT_BRANCH === 'latest' %}
                         {{ site.edit_link.start_with_latest }}{{ page.inputPath }}
                     {% elseif is_number_version %}
                         https://github.com/eslint/eslint/edit/{{ GIT_BRANCH }}/docs/{{ page.inputPath }}

--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -102,12 +102,10 @@ layout: base.html
                 {% if edit_link %}
                     {{ edit_link }}
                 {% else %}
-                    {% if is_pre_release %}
-                        {% if PATH_PREFIX === '/docs/latest/' %}
-                            {{ site.edit_link.start_with_latest }}{{ page.inputPath }}
-                        {% else %}
-                            {{ site.edit_link.start_with }}{{ page.inputPath }}
-                        {% endif %}
+                    {% if is_pre_release and GIT_BRANCH === 'latest' %}
+                        {{ site.edit_link.start_with_latest }}{{ page.inputPath }}
+                    {% elseif is_number_version %}
+                        https://github.com/eslint/eslint/edit/{{ GIT_BRANCH }}/docs/{{ page.inputPath }}
                     {% else %}
                         {{ site.edit_link.start_with }}{{ page.inputPath }}
                     {% endif %}

--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -102,7 +102,15 @@ layout: base.html
                 {% if edit_link %}
                     {{ edit_link }}
                 {% else %}
-                    {{ site.edit_link.start_with }}{{ page.inputPath }}
+                    {% if is_pre_release %}
+                        {% if PATH_PREFIX === '/docs/latest/' %}
+                            {{ site.edit_link.start_with_latest }}{{ page.inputPath }}
+                        {% else %}
+                            {{ site.edit_link.start_with }}{{ page.inputPath }}
+                        {% endif %}
+                    {% else %}
+                        {{ site.edit_link.start_with }}{{ page.inputPath }}
+                    {% endif %}
                 {% endif %}
                 "
                 class="c-btn c-btn--secondary">{{ site.edit_link.text }}</a>

--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -102,7 +102,7 @@ layout: base.html
                 {% if edit_link %}
                     {{ edit_link }}
                 {% else %}
-                    {% if is_prerelease_phase and GIT_BRANCH === 'latest' %}
+                    {% if eslintVersions.isPrereleasePhase and GIT_BRANCH === 'latest' %}
                         {{ site.edit_link.start_with_latest }}{{ page.inputPath }}
                     {% elseif is_number_version %}
                         https://github.com/eslint/eslint/edit/{{ GIT_BRANCH }}/docs/{{ page.inputPath }}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Made the `Edit this page` to link to different branches according to the following data:

## When we are in prerelease

1. Docs at `/docs/latest` should point their edit buttons at the `latest` branch
2. Docs at `/docs/next` should point their edit buttons at the `main` branch
3. Docs at `/docs/head` should point their edit buttons at the `main` branch

## When we are not in prerelease

1. Docs at `/docs/latest` should point their edit buttons at the `main` branch
2. Docs at `/docs/head` should point their edit buttons at the `main` branch

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
Fixes #17965