### PR TITLE
feat: circular autofix/conflicting rules detection

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -2344,9 +2344,9 @@ class Linter {
             // Stop if we've made a circular fix
             if (recentOutputs.length === 2 && fixedResult.output === recentOutputs[0]) {
                 debug(`Circular fixes detected after pass ${passNumber}. Exiting fix loop.`);
-                process.emitWarning(
-                    "Warning: Circular fixes detected in your configuration.",
-                    "ESLINT_CIRCULAR_FIXES"
+                globalThis?.process?.emitWarning?.(
+                    `Circular fixes detected while fixing ${options?.filename ?? "text"}. It is likely that you have conflicting rules in your configuration.`,
+                    "ESLintCircularFixesWarning"
                 );
                 fixedResult.output = currentText;
                 break;

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -2342,7 +2342,7 @@ class Linter {
             }
 
             // Stop if we've made a circular fix
-            if (recentOutputs.length === 2 && fixedResult.output === recentOutputs[0]) {
+            if (recentOutputs.length === 2 && fixedResult.output.length === recentOutputs[0].length && fixedResult.output === recentOutputs[0]) {
                 debug(`Circular fixes detected after pass ${passNumber}. Exiting fix loop.`);
                 globalThis?.process?.emitWarning?.(
                     `Circular fixes detected while fixing ${options?.filename ?? "text"}. It is likely that you have conflicting rules in your configuration.`,

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -2290,6 +2290,7 @@ class Linter {
         const debugTextDescription = options && options.filename || `${text.slice(0, 10)}...`;
         const shouldFix = options && typeof options.fix !== "undefined" ? options.fix : true;
         const stats = options?.stats;
+        const recentOutputs = [];
 
         /**
          * This loop continues until one of the following is true:
@@ -2338,6 +2339,23 @@ class Linter {
                 } else {
                     storeTime(0, { type: "fix" }, slots);
                 }
+            }
+
+            // Stop if we've made a circular fix
+            if (recentOutputs.length === 2 && fixedResult.output === recentOutputs[0]) {
+                debug(`Circular fixes detected after pass ${passNumber}. Exiting fix loop.`);
+                process.emitWarning(
+                    "Warning: Circular fixes detected in your configuration.",
+                    "ESLINT_CIRCULAR_FIXES"
+                );
+                fixedResult.output = currentText;
+                break;
+            }
+
+            // Update the recent outputs buffer
+            recentOutputs.push(fixedResult.output);
+            if (recentOutputs.length > 2) {
+                recentOutputs.shift();
             }
 
             /*

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7607,10 +7607,10 @@ var a = "test2";
                                 message: "Adding leading hyphen",
                                 fix(fixer) {
                                     if (hasLeadingHyphen) {
-                                        return;
+                                        return fixer;
                                     }
 
-                                    fixer.insertTextBefore(node, "-");
+                                    return fixer.insertTextBefore(node, "-");
                                 }
                             });
                         }
@@ -7632,10 +7632,10 @@ var a = "test2";
                                 message: "Removing leading hyphen",
                                 fix(fixer) {
                                     if (!hasLeadingHyphen) {
-                                        return;
+                                        return fixer;
                                     }
 
-                                    fixer.removeRange([0, 1]);
+                                    return fixer.removeRange([0, 1]);
                                 }
                             });
                         }
@@ -16523,10 +16523,10 @@ var a = "test2";
                                                 message: "Adding leading hyphen",
                                                 fix(fixer) {
                                                     if (hasLeadingHyphen) {
-                                                        return;
+                                                        return fixer;
                                                     }
 
-                                                    fixer.insertTextBefore(node, "-");
+                                                    return fixer.insertTextBefore(node, "-");
                                                 }
                                             });
                                         }
@@ -16548,10 +16548,10 @@ var a = "test2";
                                                 message: "Removing leading hyphen",
                                                 fix(fixer) {
                                                     if (!hasLeadingHyphen) {
-                                                        return;
+                                                        return fixer;
                                                     }
 
-                                                    fixer.removeRange([0, 1]);
+                                                    return fixer.removeRange([0, 1]);
                                                 }
                                             });
                                         }

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -8092,6 +8092,17 @@ describe("Linter with FlatConfigArray", () => {
         return new FlatConfigArray(value, options);
     }
 
+    let processStub;
+
+    beforeEach(() => {
+        sinon.restore();
+        processStub = sinon.stub(process, "emitWarning");
+    });
+
+    afterEach(() => {
+        processStub.restore();
+    });
+
     beforeEach(() => {
         linter = new Linter({ configType: "flat" });
     });
@@ -16563,6 +16574,14 @@ var a = "test2";
             assert.strictEqual(fixResult.output, "-a", "Output should match the original input due to circular fixes.");
             assert.strictEqual(fixResult.messages.length, 2, "There should be two remaining lint messages after detecting circular fixes.");
             assert.strictEqual(fixResult.messages[0].message, "Adding leading hyphen", "Message should match the last fix attempt.");
+
+            // Verify the warning was emitted
+            assert.strictEqual(processStub.callCount, 1, "calls `process.emitWarning()` once");
+            assert.strictEqual(
+                processStub.firstCall.args[0],
+                "Circular fixes detected while fixing text. It is likely that you have conflicting rules in your configuration."
+            );
+            assert.strictEqual(processStub.firstCall.args[1], "ESLintCircularFixesWarning");
 
             const suppressedMessages = linter.getSuppressedMessages();
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7592,24 +7592,51 @@ var a = "test2";
         });
 
         it("should stop fixing if a circular fix is detected", () => {
-            linter.defineRule("circular-fix", {
+            linter.defineRule("add-leading-hyphen", {
                 meta: {
                     fixable: "whitespace"
                 },
                 create(context) {
                     return {
                         Program(node) {
-
-                            // Alternate between adding and removing a hyphen.
                             const sourceCode = context.getSourceCode();
                             const hasLeadingHyphen = sourceCode.getText(node).startsWith("-");
 
                             context.report({
                                 node,
-                                message: "Circular fix detected",
-                                fix: fixer => (hasLeadingHyphen
-                                    ? fixer.removeRange([0, 1])
-                                    : fixer.insertTextBefore(node, "-"))
+                                message: "Adding leading hyphen",
+                                fix(fixer) {
+                                    if (hasLeadingHyphen) {
+                                        return;
+                                    }
+
+                                    fixer.insertTextBefore(node, "-");
+                                }
+                            });
+                        }
+                    };
+                }
+            });
+            linter.defineRule("remove-leading-hyphen", {
+                meta: {
+                    fixable: "whitespace"
+                },
+                create(context) {
+                    return {
+                        Program(node) {
+                            const sourceCode = context.getSourceCode();
+                            const hasLeadingHyphen = sourceCode.getText(node).startsWith("-");
+
+                            context.report({
+                                node,
+                                message: "Removing leading hyphen",
+                                fix(fixer) {
+                                    if (!hasLeadingHyphen) {
+                                        return;
+                                    }
+
+                                    fixer.removeRange([0, 1]);
+                                }
                             });
                         }
                     };
@@ -7617,12 +7644,17 @@ var a = "test2";
             });
 
             const initialCode = "-a";
-            const fixResult = linter.verifyAndFix(initialCode, { rules: { "circular-fix": "error" } });
+            const fixResult = linter.verifyAndFix(initialCode, {
+                rules: {
+                    "add-leading-hyphen": "error",
+                    "remove-leading-hyphen": "error"
+                }
+            });
 
-            assert.strictEqual(fixResult.fixed, true, "Fixing should have been applied but stopped due to circular fixes.");
+            assert.strictEqual(fixResult.fixed, false, "Fixing was not applied due to circular fixes.");
             assert.strictEqual(fixResult.output, "-a", "Output should match the original input due to circular fixes.");
-            assert.strictEqual(fixResult.messages.length, 1, "There should be one remaining lint message after detecting circular fixes.");
-            assert.strictEqual(fixResult.messages[0].message, "Circular fix detected", "Message should match the last fix attempt.");
+            assert.strictEqual(fixResult.messages.length, 2, "There should be two remaining lint messages after detecting circular fixes.");
+            assert.strictEqual(fixResult.messages[0].message, "Adding leading hyphen", "Message should match the last fix attempt.");
 
             const suppressedMessages = linter.getSuppressedMessages();
 
@@ -16465,24 +16497,51 @@ var a = "test2";
                 plugins: {
                     test: {
                         rules: {
-                            "circular-fix": {
+                            "add-leading-hyphen": {
                                 meta: {
                                     fixable: "whitespace"
                                 },
                                 create(context) {
                                     return {
                                         Program(node) {
-
-                                            // Alternate between adding and removing a hyphen.
                                             const sourceCode = context.getSourceCode();
                                             const hasLeadingHyphen = sourceCode.getText(node).startsWith("-");
 
                                             context.report({
                                                 node,
-                                                message: "Circular fix detected",
-                                                fix: fixer => (hasLeadingHyphen
-                                                    ? fixer.removeRange([0, 1])
-                                                    : fixer.insertTextBefore(node, "-"))
+                                                message: "Adding leading hyphen",
+                                                fix(fixer) {
+                                                    if (hasLeadingHyphen) {
+                                                        return;
+                                                    }
+
+                                                    fixer.insertTextBefore(node, "-");
+                                                }
+                                            });
+                                        }
+                                    };
+                                }
+                            },
+                            "remove-leading-hyphen": {
+                                meta: {
+                                    fixable: "whitespace"
+                                },
+                                create(context) {
+                                    return {
+                                        Program(node) {
+                                            const sourceCode = context.getSourceCode();
+                                            const hasLeadingHyphen = sourceCode.getText(node).startsWith("-");
+
+                                            context.report({
+                                                node,
+                                                message: "Removing leading hyphen",
+                                                fix(fixer) {
+                                                    if (!hasLeadingHyphen) {
+                                                        return;
+                                                    }
+
+                                                    fixer.removeRange([0, 1]);
+                                                }
                                             });
                                         }
                                     };
@@ -16492,17 +16551,18 @@ var a = "test2";
                     }
                 },
                 rules: {
-                    "test/circular-fix": "error"
+                    "test/add-leading-hyphen": "error",
+                    "test/remove-leading-hyphen": "error"
                 }
             };
 
             const initialCode = "-a";
             const fixResult = linter.verifyAndFix(initialCode, config);
 
-            assert.strictEqual(fixResult.fixed, true, "Fixing should have been applied but stopped due to circular fixes.");
+            assert.strictEqual(fixResult.fixed, false, "Fixing was not applied due to circular fixes.");
             assert.strictEqual(fixResult.output, "-a", "Output should match the original input due to circular fixes.");
-            assert.strictEqual(fixResult.messages.length, 1, "There should be one remaining lint message after detecting circular fixes.");
-            assert.strictEqual(fixResult.messages[0].message, "Circular fix detected", "Message should match the last fix attempt.");
+            assert.strictEqual(fixResult.messages.length, 2, "There should be two remaining lint messages after detecting circular fixes.");
+            assert.strictEqual(fixResult.messages[0].message, "Adding leading hyphen", "Message should match the last fix attempt.");
 
             const suppressedMessages = linter.getSuppressedMessages();
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7590,6 +7590,44 @@ var a = "test2";
                 linter.verify("0", { rules: { "test-rule": "error" } });
             }, /Fixable rules must set the `meta\.fixable` property/u);
         });
+
+        it("should stop fixing if a circular fix is detected", () => {
+            linter.defineRule("circular-fix", {
+                meta: {
+                    fixable: "whitespace"
+                },
+                create(context) {
+                    return {
+                        Program(node) {
+
+                            // Alternate between adding and removing a hyphen.
+                            const sourceCode = context.getSourceCode();
+                            const hasLeadingHyphen = sourceCode.getText(node).startsWith("-");
+
+                            context.report({
+                                node,
+                                message: "Circular fix detected",
+                                fix: fixer => (hasLeadingHyphen
+                                    ? fixer.removeRange([0, 1])
+                                    : fixer.insertTextBefore(node, "-"))
+                            });
+                        }
+                    };
+                }
+            });
+
+            const initialCode = "-a";
+            const fixResult = linter.verifyAndFix(initialCode, { rules: { "circular-fix": "error" } });
+
+            assert.strictEqual(fixResult.fixed, true, "Fixing should have been applied but stopped due to circular fixes.");
+            assert.strictEqual(fixResult.output, "-a", "Output should match the original input due to circular fixes.");
+            assert.strictEqual(fixResult.messages.length, 1, "There should be one remaining lint message after detecting circular fixes.");
+            assert.strictEqual(fixResult.messages[0].message, "Circular fix detected", "Message should match the last fix attempt.");
+
+            const suppressedMessages = linter.getSuppressedMessages();
+
+            assert.strictEqual(suppressedMessages.length, 0, "No suppressed messages should exist.");
+        });
     });
 
     describe("Edge cases", () => {
@@ -16420,6 +16458,55 @@ var a = "test2";
             assert.throws(() => {
                 linter.verify("0", config);
             }, /Fixable rules must set the `meta\.fixable` property/u);
+        });
+
+        it("should stop fixing if a circular fix is detected", () => {
+            const config = {
+                plugins: {
+                    test: {
+                        rules: {
+                            "circular-fix": {
+                                meta: {
+                                    fixable: "whitespace"
+                                },
+                                create(context) {
+                                    return {
+                                        Program(node) {
+
+                                            // Alternate between adding and removing a hyphen.
+                                            const sourceCode = context.getSourceCode();
+                                            const hasLeadingHyphen = sourceCode.getText(node).startsWith("-");
+
+                                            context.report({
+                                                node,
+                                                message: "Circular fix detected",
+                                                fix: fixer => (hasLeadingHyphen
+                                                    ? fixer.removeRange([0, 1])
+                                                    : fixer.insertTextBefore(node, "-"))
+                                            });
+                                        }
+                                    };
+                                }
+                            }
+                        }
+                    }
+                },
+                rules: {
+                    "test/circular-fix": "error"
+                }
+            };
+
+            const initialCode = "-a";
+            const fixResult = linter.verifyAndFix(initialCode, config);
+
+            assert.strictEqual(fixResult.fixed, true, "Fixing should have been applied but stopped due to circular fixes.");
+            assert.strictEqual(fixResult.output, "-a", "Output should match the original input due to circular fixes.");
+            assert.strictEqual(fixResult.messages.length, 1, "There should be one remaining lint message after detecting circular fixes.");
+            assert.strictEqual(fixResult.messages[0].message, "Circular fix detected", "Message should match the last fix attempt.");
+
+            const suppressedMessages = linter.getSuppressedMessages();
+
+            assert.strictEqual(suppressedMessages.length, 0, "No suppressed messages should exist.");
         });
     });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: #17609

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This addresses an issue with ESLint's autofix mechanism, where it could enter a loop in cases of conflicting rules/circular fixes (e.g., alternating fixes that add and remove the same text).

The fix ensures that the verifyAndFix method detects circular fixes by comparing the output of the current fix pass to the output two passes ago. If a circular pattern is detected, the autofix process halts and shows a warning.

Both the Flat Config and legacy Config tests are updated to handle this.

Fixes #17609.

#### Is there anything you'd like reviewers to focus on?

1. Review how the circular fix warning is handled. I implemented it using `process.emitWarning` similar to [@snitin315's suggestion](https://github.com/eslint/eslint/issues/17609#issuecomment-2412979714). This includes emitting a warning and adding a `debug` log message. Let me know if this aligns with ESLint's best practices.  

2. Verify the new test cases added under the `verifyAndFix` namespace for both Flat Config (`FlatConfigArray`) and legacy Config setups.

<!-- markdownlint-disable-file MD004 -->
