### PR TITLE
docs: Refactor search result handling with better event listener cleanup

### DIFF
--- a/docs/src/assets/js/search.js
+++ b/docs/src/assets/js/search.js
@@ -146,10 +146,18 @@ function debounce(callback, delay) {
     }
 }
 
+/**
+ * Debounced function to fetch search results after 300ms of inactivity.
+ * Calls `fetchSearchResults` to retrieve data and `displaySearchResults` to show them.
+ * If an error occurs, clears the search results.
+ * @param {string} query - The search query.
+ * @returns {void} - No return value.
+ * @see debounce - Limits the number of requests during rapid typing.
+ */
 const debouncedFetchSearchResults = debounce((query) => {
     fetchSearchResults(query)
         .then(displaySearchResults)
-        .catch(()=>{clearSearchResults(true)});
+        .catch(() => { clearSearchResults(true) });
 }, 300);
 
 

--- a/docs/src/assets/js/search.js
+++ b/docs/src/assets/js/search.js
@@ -41,13 +41,36 @@ function fetchSearchResults(query) {
 }
 
 /**
- * Removes any current search results from the display.
- * @returns {void}
+ * Clears the search results from the display.
+ * If the removeEventListener flag is true, removes the click event listener from the document.
+ * @param {boolean} [removeEventListener=false] - Optional flag to indicate if the click event listener should be removed. Default is false.
+ * @returns {void} - This function doesn't return anything.
  */
-function clearSearchResults() {
-    while (resultsElement.firstChild) {
-        resultsElement.removeChild(resultsElement.firstChild);
+function clearSearchResults(removeEventListener = false) {
+    resultsElement.innerHTML = "";
+    if (removeEventListener && document.clickEventAdded) {
+        document.removeEventListener('click', handleDocumentClick);
+        document.clickEventAdded = false;
     }
+}
+
+/**
+ * Displays a "No results found" message in both the live region and results display area.
+ * This is typically used when no matching results are found in the search.
+ * @returns {void} - This function doesn't return anything.
+ */
+function showNoResults() {
+    resultsLiveRegion.innerHTML = "No results found.";
+    resultsElement.innerHTML = "No results found.";
+    resultsElement.setAttribute('data-results', 'false');
+}
+
+/**
+ * Clears any "No results found" message from the live region and results display area.
+ * @returns {void} - This function doesn't return anything.
+ */
+function clearNoResults() {
+    resultsLiveRegion.innerHTML = "";
     resultsElement.innerHTML = "";
 }
 
@@ -81,9 +104,7 @@ function displaySearchResults(results) {
         }
 
     } else {
-        resultsLiveRegion.innerHTML = "No results found.";
-        resultsElement.innerHTML = "No results found.";
-        resultsElement.setAttribute('data-results', 'false');
+        showNoResults();
     }
 
 }
@@ -128,8 +149,21 @@ function debounce(callback, delay) {
 const debouncedFetchSearchResults = debounce((query) => {
     fetchSearchResults(query)
         .then(displaySearchResults)
-        .catch(clearSearchResults);
+        .catch(()=>{clearSearchResults(true)});
 }, 300);
+
+
+/**
+ * Handles the document click event to clear search results if the user clicks outside of the search input or results element.
+ * @param {MouseEvent} e - The event object representing the click event.
+ * @returns {void} - This function does not return any value. It directly interacts with the UI by clearing search results.
+ */
+const handleDocumentClick = (e) => {
+    if (e.target !== resultsElement && e.target !== searchInput) {
+        clearSearchResults(true);
+    }
+}
+
 
 //-----------------------------------------------------------------------------
 // Event Handlers
@@ -146,14 +180,13 @@ if (searchInput)
         else searchClearBtn.setAttribute('hidden', '');
 
         if (query.length > 2) {
-
             debouncedFetchSearchResults(query);
-
-            document.addEventListener('click', function (e) {
-                if (e.target !== resultsElement) clearSearchResults();
-            });
+            if (!document.clickEventAdded) {
+                document.addEventListener('click', handleDocumentClick);
+                document.clickEventAdded = true;
+            }
         } else {
-            clearSearchResults();
+            clearSearchResults(true);
         }
 
         searchQuery = query
@@ -165,7 +198,7 @@ if (searchClearBtn)
     searchClearBtn.addEventListener('click', function (e) {
         searchInput.value = '';
         searchInput.focus();
-        clearSearchResults();
+        clearSearchResults(true);
         searchClearBtn.setAttribute('hidden', '');
     });
 
@@ -175,10 +208,8 @@ document.addEventListener('keydown', function (e) {
 
     if (e.key === 'Escape') {
         e.preventDefault();
-        if (searchResults.length) {
-            clearSearchResults();
-            searchInput.focus();
-        }
+        searchResults.length ? clearSearchResults(true) : clearNoResults();
+        searchInput.focus();
     }
 
     if ((e.metaKey || e.ctrlKey) && e.key === 'k') {

--- a/docs/src/assets/js/search.js
+++ b/docs/src/assets/js/search.js
@@ -214,10 +214,17 @@ document.addEventListener('keydown', function (e) {
 
     const searchResults = Array.from(document.querySelectorAll('.search-results__item'));
 
-    if (e.key === 'Escape') {
+    if (e.key === "Escape") {
         e.preventDefault();
-        searchResults.length ? clearSearchResults(true) : clearNoResults();
-        searchInput.focus();
+        if (searchResults.length) {
+            clearSearchResults(true);
+            searchInput.focus();
+        } else if (
+            document.activeElement === searchInput
+        ) {
+            clearNoResults();
+            searchInput.blur();
+        }
     }
 
     if ((e.metaKey || e.ctrlKey) && e.key === 'k') {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
1. The `clearSearchResults` function was being triggered when clicking on the input field, which was unnecessary. A check has been added to prevent this.

| **Before** | **After** |
|------------|-----------|
| `if (e.target !== resultsElement) clearSearchResults();` | ```if (e.target !== resultsElement && e.target !== searchInput) { clearSearchResults(true); }``` |

2. Previously, the click listener was not removed when it was no longer required. In this change, we ensure the listener is removed when it's no longer needed, such as when the results section is closed.

3. Pressing Escape cleared the results when there were search results, but if no results were found, the section remained unchanged. In this update, I've ensured that the results section is cleared even when no results are found upon pressing Escape.

#### Is there anything you'd like reviewers to focus on?

Ensure that the existing functionality remains unaffected

<!-- markdownlint-disable-file MD004 -->