### PR TITLE
docs: add missing backticks in various parts of the documentation

### DIFF
--- a/docs/src/extend/plugins.md
+++ b/docs/src/extend/plugins.md
@@ -40,7 +40,7 @@ If you plan to distribute your plugin as an npm package, make sure that the modu
 
 ### Meta Data in Plugins
 
-For easier debugging and more effective caching of plugins, it's recommended to provide a name and version in a `meta` object at the root of your plugin, like this:
+For easier debugging and more effective caching of plugins, it's recommended to provide a `name` and `version` in a `meta` object at the root of your plugin, like this:
 
 ```js
 const plugin = {

--- a/docs/src/rules/id-match.md
+++ b/docs/src/rules/id-match.md
@@ -9,7 +9,7 @@ rule_type: suggestion
 Naming things consistently in a project is an often underestimated aspect of code creation.
 When done correctly, it can save your team hours of unnecessary head scratching and misdirections.
 This rule allows you to precisely define and enforce the variables and function names on your team should use.
-No more limiting yourself to camelCase, snake_case, PascalCase, or HungarianNotation. Id-match has all your needs covered!
+No more limiting yourself to camelCase, snake_case, PascalCase, or HungarianNotation. `id-match` has all your needs covered!
 
 ## Rule Details
 

--- a/docs/src/rules/no-array-constructor.md
+++ b/docs/src/rules/no-array-constructor.md
@@ -10,7 +10,7 @@ related_rules:
 Use of the `Array` constructor to construct a new array is generally
 discouraged in favor of array literal notation because of the single-argument
 pitfall and because the `Array` global may be redefined. The exception is when
-the Array constructor is used to intentionally create sparse arrays of a
+the `Array` constructor is used to intentionally create sparse arrays of a
 specified size by giving the constructor a single numeric argument.
 
 ## Rule Details

--- a/docs/src/rules/no-console.md
+++ b/docs/src/rules/no-console.md
@@ -69,7 +69,7 @@ console.error("Log an error level message.");
 
 If you're using Node.js, however, `console` is used to output information to the user and so is not strictly used for debugging purposes. If you are developing for Node.js then you most likely do not want this rule enabled.
 
-Another case where you might not use this rule is if you want to enforce console calls and not console overwrites. For example:
+Another case where you might not use this rule is if you want to enforce `console` calls and not `console` overwrites. For example:
 
 ```js
 /* eslint no-console: ["error", { allow: ["warn"] }] */


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello, 

I've added missing backticks in various parts of the documentation.

Here is the list of changes I've made:

1. **`docs/src/extend/plugins.md`**  
   The properties `name` and `version` are part of an object, so they need backticks.

2. **`docs/src/rules/id-match.md`**  
   `id-match` is also a property and requires backticks.

3. **`docs/src/rules/no-array-constructor.md`**  
   `Array` represents a constructor, so it needs backticks.

4. **`docs/src/rules/no-console.md`**  
   `console` represents a global object, so it needs backticks.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
