### PR TITLE
fix: sync rule type header comments automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: node Makefile checkRuleExamples
 
       - name: Check Rule Types
-        run: node tools/update-rule-type-headers.js --check
+        run: npm run lint:rule-types
 
       - name: Lint Files, Dependencies, & Exports
         run: npm run lint:unused

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Check Rule Examples
         run: node Makefile checkRuleExamples
 
+      - name: Check Rule Types
+        run: node tools/update-rule-type-headers.js --check
+
       - name: Lint Files, Dependencies, & Exports
         run: npm run lint:unused
 

--- a/Makefile.js
+++ b/Makefile.js
@@ -324,6 +324,21 @@ function updateVersions(oldVersion, newVersion) {
 }
 
 /**
+ * Updates TSDoc header comments of all rule types.
+ * @returns {void}
+ */
+function updateRuleTypeHeaders() {
+    const { execFileSync } = require("node:child_process");
+
+    // We don't need the stack trace of execFileSync if the command fails.
+    try {
+        execFileSync(process.execPath, ["tools/update-rule-type-headers.js"], { stdio: "inherit" });
+    } catch {
+        exit(1);
+    }
+}
+
+/**
  * Updates the changelog, bumps the version number in package.json, creates a local git commit and tag,
  * and generates the site in an adjacent `website` folder.
  * @param {Object} options Release options.
@@ -356,8 +371,11 @@ function generateRelease({ prereleaseId, packageTag }) {
         updateVersions(oldVersion, releaseInfo.version);
     }
 
-    echo("Updating commit with docs data");
-    exec("git add docs/ && git commit --amend --no-edit");
+    echo("Updating rule type header comments");
+    updateRuleTypeHeaders();
+
+    echo("Updating commit with docs data and rule types");
+    exec("git add lib/types/rules/ docs/ && git commit --amend --no-edit");
     exec(`git tag -a -f v${releaseInfo.version} -m ${releaseInfo.version}`);
 }
 

--- a/lib/types/rules/best-practices.d.ts
+++ b/lib/types/rules/best-practices.d.ts
@@ -29,10 +29,10 @@ import { Linter } from "../index";
 
 export interface BestPractices extends Linter.RulesRecord {
     /**
-     * Rule to enforce getter and setter pairs in objects.
+     * Rule to enforce getter and setter pairs in objects and classes.
      *
      * @since 0.22.0
-     * @see https://eslint.org/docs/rules/accessor-pairs
+     * @see https://eslint.org/docs/latest/rules/accessor-pairs
      */
     "accessor-pairs": Linter.RuleEntry<
         [
@@ -57,7 +57,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to enforce `return` statements in callbacks of array methods.
      *
      * @since 2.0.0-alpha-1
-     * @see https://eslint.org/docs/rules/array-callback-return
+     * @see https://eslint.org/docs/latest/rules/array-callback-return
      */
     "array-callback-return": Linter.RuleEntry<
         [
@@ -82,7 +82,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to enforce the use of variables within the scope they are defined.
      *
      * @since 0.1.0
-     * @see https://eslint.org/docs/rules/block-scoped-var
+     * @see https://eslint.org/docs/latest/rules/block-scoped-var
      */
     "block-scoped-var": Linter.RuleEntry<[]>;
 
@@ -90,7 +90,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to enforce that class methods utilize `this`.
      *
      * @since 3.4.0
-     * @see https://eslint.org/docs/rules/class-methods-use-this
+     * @see https://eslint.org/docs/latest/rules/class-methods-use-this
      */
     "class-methods-use-this": Linter.RuleEntry<
         [
@@ -104,7 +104,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to enforce a maximum cyclomatic complexity allowed in a program.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/complexity
+     * @see https://eslint.org/docs/latest/rules/complexity
      */
     complexity: Linter.RuleEntry<
         [
@@ -132,7 +132,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to require `return` statements to either always or never specify values.
      *
      * @since 0.4.0
-     * @see https://eslint.org/docs/rules/consistent-return
+     * @see https://eslint.org/docs/latest/rules/consistent-return
      */
     "consistent-return": Linter.RuleEntry<
         [
@@ -149,7 +149,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to enforce consistent brace style for all control statements.
      *
      * @since 0.0.2
-     * @see https://eslint.org/docs/rules/curly
+     * @see https://eslint.org/docs/latest/rules/curly
      */
     curly: Linter.RuleEntry<["all" | "multi" | "multi-line" | "multi-or-nest" | "consistent"]>;
 
@@ -157,7 +157,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to require `default` cases in `switch` statements.
      *
      * @since 0.6.0
-     * @see https://eslint.org/docs/rules/default-case
+     * @see https://eslint.org/docs/latest/rules/default-case
      */
     "default-case": Linter.RuleEntry<
         [
@@ -171,15 +171,15 @@ export interface BestPractices extends Linter.RulesRecord {
     >;
 
     /**
-     * Rule to enforce default clauses in switch statements to be last
+     * Rule to enforce `default` clauses in `switch` statements to be last.
      *
-     * @since 7.0.0
+     * @since 7.0.0-alpha.0
      * @see https://eslint.org/docs/latest/rules/default-case-last
      */
     "default-case-last": Linter.RuleEntry<[]>;
 
     /**
-     * Enforce default parameters to be last
+     * Rule to enforce default parameters to be last.
      *
      * @since 6.4.0
      * @see https://eslint.org/docs/latest/rules/default-param-last
@@ -191,7 +191,7 @@ export interface BestPractices extends Linter.RulesRecord {
      *
      * @since 0.21.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/dot-location) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/dot-location
+     * @see https://eslint.org/docs/latest/rules/dot-location
      */
     "dot-location": Linter.RuleEntry<["object" | "property"]>;
 
@@ -199,7 +199,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to enforce dot notation whenever possible.
      *
      * @since 0.0.7
-     * @see https://eslint.org/docs/rules/dot-notation
+     * @see https://eslint.org/docs/latest/rules/dot-notation
      */
     "dot-notation": Linter.RuleEntry<
         [
@@ -217,7 +217,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to require the use of `===` and `!==`.
      *
      * @since 0.0.2
-     * @see https://eslint.org/docs/rules/eqeqeq
+     * @see https://eslint.org/docs/latest/rules/eqeqeq
      */
     eqeqeq:
         | Linter.RuleEntry<
@@ -234,7 +234,7 @@ export interface BestPractices extends Linter.RulesRecord {
         | Linter.RuleEntry<["smart" | "allow-null"]>;
 
     /**
-     * Require grouped accessor pairs in object literals and classes.
+     * Rule to require grouped accessor pairs in object literals and classes.
      *
      * @since 6.7.0
      * @see https://eslint.org/docs/latest/rules/grouped-accessor-pairs
@@ -245,7 +245,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to require `for-in` loops to include an `if` statement.
      *
      * @since 0.0.6
-     * @see https://eslint.org/docs/rules/guard-for-in
+     * @see https://eslint.org/docs/latest/rules/guard-for-in
      */
     "guard-for-in": Linter.RuleEntry<[]>;
 
@@ -253,7 +253,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to enforce a maximum number of classes per file.
      *
      * @since 5.0.0-alpha.3
-     * @see https://eslint.org/docs/rules/max-classes-per-file
+     * @see https://eslint.org/docs/latest/rules/max-classes-per-file
      */
     "max-classes-per-file": Linter.RuleEntry<[number]>;
 
@@ -261,7 +261,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow the use of `alert`, `confirm`, and `prompt`.
      *
      * @since 0.0.5
-     * @see https://eslint.org/docs/rules/no-alert
+     * @see https://eslint.org/docs/latest/rules/no-alert
      */
     "no-alert": Linter.RuleEntry<[]>;
 
@@ -269,7 +269,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow the use of `arguments.caller` or `arguments.callee`.
      *
      * @since 0.0.6
-     * @see https://eslint.org/docs/rules/no-caller
+     * @see https://eslint.org/docs/latest/rules/no-caller
      */
     "no-caller": Linter.RuleEntry<[]>;
 
@@ -280,15 +280,15 @@ export interface BestPractices extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 1.9.0
-     * @see https://eslint.org/docs/rules/no-case-declarations
+     * @see https://eslint.org/docs/latest/rules/no-case-declarations
      */
     "no-case-declarations": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to disallow division operators explicitly at the beginning of regular expressions.
+     * Rule to disallow equal signs explicitly at the beginning of regular expressions.
      *
      * @since 0.1.0
-     * @see https://eslint.org/docs/rules/no-div-regex
+     * @see https://eslint.org/docs/latest/rules/no-div-regex
      */
     "no-div-regex": Linter.RuleEntry<[]>;
 
@@ -296,7 +296,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow `else` blocks after `return` statements in `if` statements.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-else-return
+     * @see https://eslint.org/docs/latest/rules/no-else-return
      */
     "no-else-return": Linter.RuleEntry<
         [
@@ -313,7 +313,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow empty functions.
      *
      * @since 2.0.0
-     * @see https://eslint.org/docs/rules/no-empty-function
+     * @see https://eslint.org/docs/latest/rules/no-empty-function
      */
     "no-empty-function": Linter.RuleEntry<
         [
@@ -344,15 +344,26 @@ export interface BestPractices extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 1.7.0
-     * @see https://eslint.org/docs/rules/no-empty-pattern
+     * @see https://eslint.org/docs/latest/rules/no-empty-pattern
      */
     "no-empty-pattern": Linter.RuleEntry<[]>;
+
+    /**
+     * Rule to disallow empty static blocks.
+     *
+     * @remarks
+     * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
+     *
+     * @since 8.27.0
+     * @see https://eslint.org/docs/latest/rules/no-empty-static-block
+     */
+    "no-empty-static-block": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow `null` comparisons without type-checking operators.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-eq-null
+     * @see https://eslint.org/docs/latest/rules/no-eq-null
      */
     "no-eq-null": Linter.RuleEntry<[]>;
 
@@ -360,7 +371,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow the use of `eval()`.
      *
      * @since 0.0.2
-     * @see https://eslint.org/docs/rules/no-eval
+     * @see https://eslint.org/docs/latest/rules/no-eval
      */
     "no-eval": Linter.RuleEntry<
         [
@@ -377,7 +388,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow extending native types.
      *
      * @since 0.1.4
-     * @see https://eslint.org/docs/rules/no-extend-native
+     * @see https://eslint.org/docs/latest/rules/no-extend-native
      */
     "no-extend-native": Linter.RuleEntry<
         [
@@ -391,7 +402,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow unnecessary calls to `.bind()`.
      *
      * @since 0.8.0
-     * @see https://eslint.org/docs/rules/no-extra-bind
+     * @see https://eslint.org/docs/latest/rules/no-extra-bind
      */
     "no-extra-bind": Linter.RuleEntry<[]>;
 
@@ -399,7 +410,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow unnecessary labels.
      *
      * @since 2.0.0-rc.0
-     * @see https://eslint.org/docs/rules/no-extra-label
+     * @see https://eslint.org/docs/latest/rules/no-extra-label
      */
     "no-extra-label": Linter.RuleEntry<[]>;
 
@@ -410,7 +421,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.7
-     * @see https://eslint.org/docs/rules/no-fallthrough
+     * @see https://eslint.org/docs/latest/rules/no-fallthrough
      */
     "no-fallthrough": Linter.RuleEntry<
         [
@@ -436,7 +447,7 @@ export interface BestPractices extends Linter.RulesRecord {
      *
      * @since 0.0.6
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/no-floating-decimal) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/no-floating-decimal
+     * @see https://eslint.org/docs/latest/rules/no-floating-decimal
      */
     "no-floating-decimal": Linter.RuleEntry<[]>;
 
@@ -447,7 +458,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 3.3.0
-     * @see https://eslint.org/docs/rules/no-global-assign
+     * @see https://eslint.org/docs/latest/rules/no-global-assign
      */
     "no-global-assign": Linter.RuleEntry<
         [
@@ -461,7 +472,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow shorthand type conversions.
      *
      * @since 1.0.0-rc-2
-     * @see https://eslint.org/docs/rules/no-implicit-coercion
+     * @see https://eslint.org/docs/latest/rules/no-implicit-coercion
      */
     "no-implicit-coercion": Linter.RuleEntry<
         [
@@ -491,10 +502,10 @@ export interface BestPractices extends Linter.RulesRecord {
     >;
 
     /**
-     * Rule to disallow variable and `function` declarations in the global scope.
+     * Rule to disallow declarations in the global scope.
      *
      * @since 2.0.0-alpha-1
-     * @see https://eslint.org/docs/rules/no-implicit-globals
+     * @see https://eslint.org/docs/latest/rules/no-implicit-globals
      */
     "no-implicit-globals": Linter.RuleEntry<[]>;
 
@@ -502,12 +513,12 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow the use of `eval()`-like methods.
      *
      * @since 0.0.7
-     * @see https://eslint.org/docs/rules/no-implied-eval
+     * @see https://eslint.org/docs/latest/rules/no-implied-eval
      */
     "no-implied-eval": Linter.RuleEntry<[]>;
 
     /**
-     * Disallow assigning to imported bindings.
+     * Rule to disallow assigning to imported bindings.
      *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
@@ -518,10 +529,10 @@ export interface BestPractices extends Linter.RulesRecord {
     "no-import-assign": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to disallow `this` keywords outside of classes or class-like objects.
+     * Rule to disallow use of `this` in contexts where the value of `this` is `undefined`.
      *
      * @since 1.0.0-rc-2
-     * @see https://eslint.org/docs/rules/no-invalid-this
+     * @see https://eslint.org/docs/latest/rules/no-invalid-this
      */
     "no-invalid-this": Linter.RuleEntry<
         [
@@ -538,7 +549,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow the use of the `__iterator__` property.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-iterator
+     * @see https://eslint.org/docs/latest/rules/no-iterator
      */
     "no-iterator": Linter.RuleEntry<[]>;
 
@@ -546,7 +557,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow labeled statements.
      *
      * @since 0.4.0
-     * @see https://eslint.org/docs/rules/no-labels
+     * @see https://eslint.org/docs/latest/rules/no-labels
      */
     "no-labels": Linter.RuleEntry<
         [
@@ -567,7 +578,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow unnecessary nested blocks.
      *
      * @since 0.4.0
-     * @see https://eslint.org/docs/rules/no-lone-blocks
+     * @see https://eslint.org/docs/latest/rules/no-lone-blocks
      */
     "no-lone-blocks": Linter.RuleEntry<[]>;
 
@@ -575,7 +586,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow function declarations that contain unsafe references inside loop statements.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-loop-func
+     * @see https://eslint.org/docs/latest/rules/no-loop-func
      */
     "no-loop-func": Linter.RuleEntry<[]>;
 
@@ -583,7 +594,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow magic numbers.
      *
      * @since 1.7.0
-     * @see https://eslint.org/docs/rules/no-magic-numbers
+     * @see https://eslint.org/docs/latest/rules/no-magic-numbers
      */
     "no-magic-numbers": Linter.RuleEntry<
         [
@@ -613,7 +624,7 @@ export interface BestPractices extends Linter.RulesRecord {
      *
      * @since 0.9.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/no-multi-spaces) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/no-multi-spaces
+     * @see https://eslint.org/docs/latest/rules/no-multi-spaces
      */
     "no-multi-spaces": Linter.RuleEntry<
         [
@@ -634,7 +645,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow multiline strings.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-multi-str
+     * @see https://eslint.org/docs/latest/rules/no-multi-str
      */
     "no-multi-str": Linter.RuleEntry<[]>;
 
@@ -642,7 +653,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow `new` operators outside of assignments or comparisons.
      *
      * @since 0.0.7
-     * @see https://eslint.org/docs/rules/no-new
+     * @see https://eslint.org/docs/latest/rules/no-new
      */
     "no-new": Linter.RuleEntry<[]>;
 
@@ -650,7 +661,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow `new` operators with the `Function` object.
      *
      * @since 0.0.7
-     * @see https://eslint.org/docs/rules/no-new-func
+     * @see https://eslint.org/docs/latest/rules/no-new-func
      */
     "no-new-func": Linter.RuleEntry<[]>;
 
@@ -658,15 +669,18 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow `new` operators with the `String`, `Number`, and `Boolean` objects.
      *
      * @since 0.0.6
-     * @see https://eslint.org/docs/rules/no-new-wrappers
+     * @see https://eslint.org/docs/latest/rules/no-new-wrappers
      */
     "no-new-wrappers": Linter.RuleEntry<[]>;
 
     /**
-     * Disallow `\\8` and `\\9` escape sequences in string literals.
+     * Rule to disallow `\8` and `\9` escape sequences in string literals.
+     *
+     * @remarks
+     * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 7.14.0
-     * @see https://eslint.org/docs/rules/no-nonoctal-decimal-escape
+     * @see https://eslint.org/docs/latest/rules/no-nonoctal-decimal-escape
      */
     "no-nonoctal-decimal-escape": Linter.RuleEntry<[]>;
 
@@ -677,7 +691,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.6
-     * @see https://eslint.org/docs/rules/no-octal
+     * @see https://eslint.org/docs/latest/rules/no-octal
      */
     "no-octal": Linter.RuleEntry<[]>;
 
@@ -685,15 +699,15 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow octal escape sequences in string literals.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-octal-escape
+     * @see https://eslint.org/docs/latest/rules/no-octal-escape
      */
     "no-octal-escape": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to disallow reassigning `function` parameters.
+     * Rule to disallow reassigning function parameters.
      *
      * @since 0.18.0
-     * @see https://eslint.org/docs/rules/no-param-reassign
+     * @see https://eslint.org/docs/latest/rules/no-param-reassign
      */
     "no-param-reassign": Linter.RuleEntry<
         [
@@ -720,7 +734,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow the use of the `__proto__` property.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-proto
+     * @see https://eslint.org/docs/latest/rules/no-proto
      */
     "no-proto": Linter.RuleEntry<[]>;
 
@@ -731,7 +745,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-redeclare
+     * @see https://eslint.org/docs/latest/rules/no-redeclare
      */
     "no-redeclare": Linter.RuleEntry<
         [
@@ -748,7 +762,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow certain properties on certain objects.
      *
      * @since 3.5.0
-     * @see https://eslint.org/docs/rules/no-restricted-properties
+     * @see https://eslint.org/docs/latest/rules/no-restricted-properties
      */
     "no-restricted-properties": Linter.RuleEntry<
         [
@@ -770,7 +784,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow assignment operators in `return` statements.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-return-assign
+     * @see https://eslint.org/docs/latest/rules/no-return-assign
      */
     "no-return-assign": Linter.RuleEntry<["except-parens" | "always"]>;
 
@@ -778,15 +792,16 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow unnecessary `return await`.
      *
      * @since 3.10.0
-     * @see https://eslint.org/docs/rules/no-return-await
+     * @deprecated
+     * @see https://eslint.org/docs/latest/rules/no-return-await
      */
     "no-return-await": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to disallow `javascript:` urls.
+     * Rule to disallow `javascript:` URLs.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-script-url
+     * @see https://eslint.org/docs/latest/rules/no-script-url
      */
     "no-script-url": Linter.RuleEntry<[]>;
 
@@ -797,7 +812,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 2.0.0-rc.0
-     * @see https://eslint.org/docs/rules/no-self-assign
+     * @see https://eslint.org/docs/latest/rules/no-self-assign
      */
     "no-self-assign": Linter.RuleEntry<[]>;
 
@@ -805,7 +820,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow comparisons where both sides are exactly the same.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-self-compare
+     * @see https://eslint.org/docs/latest/rules/no-self-compare
      */
     "no-self-compare": Linter.RuleEntry<[]>;
 
@@ -813,7 +828,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow comma operators.
      *
      * @since 0.5.1
-     * @see https://eslint.org/docs/rules/no-sequences
+     * @see https://eslint.org/docs/latest/rules/no-sequences
      */
     "no-sequences": Linter.RuleEntry<
         [
@@ -831,7 +846,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow throwing literals as exceptions.
      *
      * @since 0.15.0
-     * @see https://eslint.org/docs/rules/no-throw-literal
+     * @see https://eslint.org/docs/latest/rules/no-throw-literal
      */
     "no-throw-literal": Linter.RuleEntry<[]>;
 
@@ -839,7 +854,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow unmodified loop conditions.
      *
      * @since 2.0.0-alpha-2
-     * @see https://eslint.org/docs/rules/no-unmodified-loop-condition
+     * @see https://eslint.org/docs/latest/rules/no-unmodified-loop-condition
      */
     "no-unmodified-loop-condition": Linter.RuleEntry<[]>;
 
@@ -847,7 +862,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow unused expressions.
      *
      * @since 0.1.0
-     * @see https://eslint.org/docs/rules/no-unused-expressions
+     * @see https://eslint.org/docs/latest/rules/no-unused-expressions
      */
     "no-unused-expressions": Linter.RuleEntry<
         [
@@ -880,13 +895,12 @@ export interface BestPractices extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 2.0.0-rc.0
-     * @see https://eslint.org/docs/rules/no-unused-labels
+     * @see https://eslint.org/docs/latest/rules/no-unused-labels
      */
     "no-unused-labels": Linter.RuleEntry<[]>;
 
     /**
-     * Disallow variable assignments when the value is not used
-     *
+     * Rule to disallow variable assignments when the value is not used.
      *
      * @since 9.0.0-alpha.1
      * @see https://eslint.org/docs/latest/rules/no-useless-assignment
@@ -894,7 +908,7 @@ export interface BestPractices extends Linter.RulesRecord {
     "no-useless-assignment": Linter.RuleEntry<[]>;
 
     /**
-     * Disallow useless backreferences in regular expressions
+     * Rule to disallow useless backreferences in regular expressions.
      *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
@@ -908,7 +922,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow unnecessary calls to `.call()` and `.apply()`.
      *
      * @since 1.0.0-rc-1
-     * @see https://eslint.org/docs/rules/no-useless-call
+     * @see https://eslint.org/docs/latest/rules/no-useless-call
      */
     "no-useless-call": Linter.RuleEntry<[]>;
 
@@ -919,7 +933,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 5.11.0
-     * @see https://eslint.org/docs/rules/no-useless-catch
+     * @see https://eslint.org/docs/latest/rules/no-useless-catch
      */
     "no-useless-catch": Linter.RuleEntry<[]>;
 
@@ -927,7 +941,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow unnecessary concatenation of literals or template literals.
      *
      * @since 1.3.0
-     * @see https://eslint.org/docs/rules/no-useless-concat
+     * @see https://eslint.org/docs/latest/rules/no-useless-concat
      */
     "no-useless-concat": Linter.RuleEntry<[]>;
 
@@ -938,7 +952,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 2.5.0
-     * @see https://eslint.org/docs/rules/no-useless-escape
+     * @see https://eslint.org/docs/latest/rules/no-useless-escape
      */
     "no-useless-escape": Linter.RuleEntry<[]>;
 
@@ -946,7 +960,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow redundant return statements.
      *
      * @since 3.9.0
-     * @see https://eslint.org/docs/rules/no-useless-return
+     * @see https://eslint.org/docs/latest/rules/no-useless-return
      */
     "no-useless-return": Linter.RuleEntry<[]>;
 
@@ -954,7 +968,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow `void` operators.
      *
      * @since 0.8.0
-     * @see https://eslint.org/docs/rules/no-void
+     * @see https://eslint.org/docs/latest/rules/no-void
      */
     "no-void": Linter.RuleEntry<
         [
@@ -971,7 +985,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow specified warning terms in comments.
      *
      * @since 0.4.4
-     * @see https://eslint.org/docs/rules/no-warning-comments
+     * @see https://eslint.org/docs/latest/rules/no-warning-comments
      */
     "no-warning-comments": Linter.RuleEntry<
         [
@@ -995,7 +1009,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.2
-     * @see https://eslint.org/docs/rules/no-with
+     * @see https://eslint.org/docs/latest/rules/no-with
      */
     "no-with": Linter.RuleEntry<[]>;
 
@@ -1003,15 +1017,15 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to enforce using named capture group in regular expression.
      *
      * @since 5.15.0
-     * @see https://eslint.org/docs/rules/prefer-named-capture-group
+     * @see https://eslint.org/docs/latest/rules/prefer-named-capture-group
      */
     "prefer-named-capture-group": Linter.RuleEntry<[]>;
 
     /**
-     * Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
+     * Rule to disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
      *
      * @since 8.5.0
-     * @see https://eslint.org/docs/rules/prefer-object-has-own
+     * @see https://eslint.org/docs/latest/rules/prefer-object-has-own
      */
     "prefer-object-has-own": Linter.RuleEntry<[]>;
 
@@ -1019,7 +1033,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to require using Error objects as Promise rejection reasons.
      *
      * @since 3.14.0
-     * @see https://eslint.org/docs/rules/prefer-promise-reject-errors
+     * @see https://eslint.org/docs/latest/rules/prefer-promise-reject-errors
      */
     "prefer-promise-reject-errors": Linter.RuleEntry<
         [
@@ -1033,7 +1047,7 @@ export interface BestPractices extends Linter.RulesRecord {
     >;
 
     /**
-     * Disallow use of the `RegExp` constructor in favor of regular expression literals.
+     * Rule to disallow use of the `RegExp` constructor in favor of regular expression literals.
      *
      * @since 6.4.0
      * @see https://eslint.org/docs/latest/rules/prefer-regex-literals
@@ -1053,7 +1067,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to enforce the consistent use of the radix argument when using `parseInt()`.
      *
      * @since 0.0.7
-     * @see https://eslint.org/docs/rules/radix
+     * @see https://eslint.org/docs/latest/rules/radix
      */
     radix: Linter.RuleEntry<["always" | "as-needed"]>;
 
@@ -1061,15 +1075,15 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to disallow async functions which have no `await` expression.
      *
      * @since 3.11.0
-     * @see https://eslint.org/docs/rules/require-await
+     * @see https://eslint.org/docs/latest/rules/require-await
      */
     "require-await": Linter.RuleEntry<[]>;
 
     /**
-     * Enforce the use of `u` or `v` flag on RegExp
+     * Rule to enforce the use of `u` or `v` flag on regular expressions.
      *
      * @since 5.3.0
-     * @see https://eslint.org/docs/rules/require-unicode-regexp
+     * @see https://eslint.org/docs/latest/rules/require-unicode-regexp
      */
     "require-unicode-regexp": Linter.RuleEntry<
         [
@@ -1086,7 +1100,7 @@ export interface BestPractices extends Linter.RulesRecord {
      * Rule to require `var` declarations be placed at the top of their containing scope.
      *
      * @since 0.8.0
-     * @see https://eslint.org/docs/rules/vars-on-top
+     * @see https://eslint.org/docs/latest/rules/vars-on-top
      */
     "vars-on-top": Linter.RuleEntry<[]>;
 
@@ -1095,7 +1109,7 @@ export interface BestPractices extends Linter.RulesRecord {
      *
      * @since 0.0.9
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/wrap-iife) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/wrap-iife
+     * @see https://eslint.org/docs/latest/rules/wrap-iife
      */
     "wrap-iife": Linter.RuleEntry<
         [
@@ -1110,10 +1124,10 @@ export interface BestPractices extends Linter.RulesRecord {
     >;
 
     /**
-     * Rule to require or disallow “Yoda” conditions.
+     * Rule to require or disallow "Yoda" conditions.
      *
      * @since 0.7.1
-     * @see https://eslint.org/docs/rules/yoda
+     * @see https://eslint.org/docs/latest/rules/yoda
      */
     yoda:
         | Linter.RuleEntry<

--- a/lib/types/rules/deprecated.d.ts
+++ b/lib/types/rules/deprecated.d.ts
@@ -28,12 +28,29 @@
 import { Linter } from "../index";
 
 export interface Deprecated extends Linter.RulesRecord {
+
+    /**
+     * Rule to enforce line breaks between arguments of a function call.
+     *
+     * @since 6.2.0
+     * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/function-call-argument-newline) in `@stylistic/eslint-plugin-js`.
+     * @see https://eslint.org/docs/latest/rules/function-call-argument-newline
+     */
+    "function-call-argument-newline": Linter.RuleEntry<
+        [
+            /**
+             * @default "always"
+             */
+            "always" | "never" | "consistent"
+        ]
+    >;
+
     /**
      * Rule to enforce consistent indentation.
      *
      * @since 4.0.0-alpha.0
      * @deprecated since 4.0.0, use [`indent`](https://eslint.org/docs/rules/indent) instead.
-     * @see https://eslint.org/docs/rules/indent-legacy
+     * @see https://eslint.org/docs/latest/rules/indent-legacy
      */
     "indent-legacy": Linter.RuleEntry<
         [
@@ -136,7 +153,7 @@ export interface Deprecated extends Linter.RulesRecord {
      *
      * @since 3.5.0
      * @deprecated since 4.0.0, use [`padding-line-between-statements`](https://eslint.org/docs/rules/padding-line-between-statements) instead.
-     * @see https://eslint.org/docs/rules/lines-around-directive
+     * @see https://eslint.org/docs/latest/rules/lines-around-directive
      */
     "lines-around-directive": Linter.RuleEntry<["always" | "never"]>;
 
@@ -145,7 +162,7 @@ export interface Deprecated extends Linter.RulesRecord {
      *
      * @since 0.18.0
      * @deprecated since 4.0.0, use [`padding-line-between-statements`](https://eslint.org/docs/rules/padding-line-between-statements) instead.
-     * @see https://eslint.org/docs/rules/newline-after-var
+     * @see https://eslint.org/docs/latest/rules/newline-after-var
      */
     "newline-after-var": Linter.RuleEntry<["always" | "never"]>;
 
@@ -154,25 +171,25 @@ export interface Deprecated extends Linter.RulesRecord {
      *
      * @since 2.3.0
      * @deprecated since 4.0.0, use [`padding-line-between-statements`](https://eslint.org/docs/rules/padding-line-between-statements) instead.
-     * @see https://eslint.org/docs/rules/newline-before-return
+     * @see https://eslint.org/docs/latest/rules/newline-before-return
      */
     "newline-before-return": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to disallow shadowing of variables inside of `catch`.
+     * Rule to disallow `catch` clause parameters from shadowing variables in the outer scope.
      *
      * @since 0.0.9
      * @deprecated since 5.1.0, use [`no-shadow`](https://eslint.org/docs/rules/no-shadow) instead.
-     * @see https://eslint.org/docs/rules/no-catch-shadow
+     * @see https://eslint.org/docs/latest/rules/no-catch-shadow
      */
     "no-catch-shadow": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to disallow reassignment of native objects.
+     * Rule to disallow assignments to native objects or read-only global variables.
      *
      * @since 0.0.9
      * @deprecated since 3.3.0, use [`no-global-assign`](https://eslint.org/docs/rules/no-global-assign) instead.
-     * @see https://eslint.org/docs/rules/no-native-reassign
+     * @see https://eslint.org/docs/latest/rules/no-native-reassign
      */
     "no-native-reassign": Linter.RuleEntry<
         [
@@ -187,7 +204,7 @@ export interface Deprecated extends Linter.RulesRecord {
      *
      * @since 0.1.2
      * @deprecated since 3.3.0, use [`no-unsafe-negation`](https://eslint.org/docs/rules/no-unsafe-negation) instead.
-     * @see https://eslint.org/docs/rules/no-negated-in-lhs
+     * @see https://eslint.org/docs/latest/rules/no-negated-in-lhs
      */
     "no-negated-in-lhs": Linter.RuleEntry<[]>;
 
@@ -196,7 +213,7 @@ export interface Deprecated extends Linter.RulesRecord {
      *
      * @since 0.0.9
      * @deprecated since 8.50.0, use [`no-object-constructor`](https://eslint.org/docs/rules/no-object-constructor) instead.
-     * @see https://eslint.org/docs/rules/no-object-constructor
+     * @see https://eslint.org/docs/latest/rules/no-new-object
      */
     "no-new-object": Linter.RuleEntry<[]>;
 
@@ -205,25 +222,25 @@ export interface Deprecated extends Linter.RulesRecord {
      *
      * @since 2.0.0-beta.1
      * @deprecated since 8.27.0, use [`no-new-native-nonconstructor`](https://eslint.org/docs/rules/no-new-native-nonconstructor) instead.
-     * @see https://eslint.org/docs/rules/no-new-symbol
+     * @see https://eslint.org/docs/latest/rules/no-new-symbol
      */
     "no-new-symbol": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to disallow spacing between function identifiers and their applications.
+     * Rule to disallow spacing between function identifiers and their applications (deprecated).
      *
      * @since 0.1.2
      * @deprecated since 3.3.0, use [`func-call-spacing`](https://eslint.org/docs/rules/func-call-spacing) instead.
-     * @see https://eslint.org/docs/rules/no-spaced-func
+     * @see https://eslint.org/docs/latest/rules/no-spaced-func
      */
     "no-spaced-func": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to suggest using `Reflect` methods where applicable.
+     * Rule to require `Reflect` methods where applicable.
      *
      * @since 1.0.0-rc-2
      * @deprecated since 3.9.0
-     * @see https://eslint.org/docs/rules/prefer-reflect
+     * @see https://eslint.org/docs/latest/rules/prefer-reflect
      */
     "prefer-reflect": Linter.RuleEntry<
         [

--- a/lib/types/rules/ecmascript-6.d.ts
+++ b/lib/types/rules/ecmascript-6.d.ts
@@ -63,7 +63,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to require braces around arrow function bodies.
      *
      * @since 1.8.0
-     * @see https://eslint.org/docs/rules/arrow-body-style
+     * @see https://eslint.org/docs/latest/rules/arrow-body-style
      */
     "arrow-body-style":
         | Linter.RuleEntry<
@@ -84,7 +84,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      *
      * @since 1.0.0-rc-1
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/arrow-parens) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/arrow-parens
+     * @see https://eslint.org/docs/latest/rules/arrow-parens
      */
     "arrow-parens":
         | Linter.RuleEntry<["always"]>
@@ -105,7 +105,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      *
      * @since 1.0.0-rc-1
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/arrow-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/arrow-spacing
+     * @see https://eslint.org/docs/latest/rules/arrow-spacing
      */
     "arrow-spacing": Linter.RuleEntry<[]>;
 
@@ -116,7 +116,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.24.0
-     * @see https://eslint.org/docs/rules/constructor-super
+     * @see https://eslint.org/docs/latest/rules/constructor-super
      */
     "constructor-super": Linter.RuleEntry<[]>;
 
@@ -125,7 +125,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      *
      * @since 0.17.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/generator-star-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/generator-star-spacing
+     * @see https://eslint.org/docs/latest/rules/generator-star-spacing
      */
     "generator-star-spacing": Linter.RuleEntry<
         [
@@ -168,10 +168,10 @@ export interface ECMAScript6 extends Linter.RulesRecord {
     >;
 
     /**
-     * Require or disallow logical assignment operator shorthand.
+     * Rule to require or disallow logical assignment operator shorthand.
      *
      * @since 8.24.0
-     * @see https://eslint.org/docs/rules/logical-assignment-operators
+     * @see https://eslint.org/docs/latest/rules/logical-assignment-operators
      */
     "logical-assignment-operators":
         | Linter.RuleEntry<
@@ -194,7 +194,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 1.0.0-rc-1
-     * @see https://eslint.org/docs/rules/no-class-assign
+     * @see https://eslint.org/docs/latest/rules/no-class-assign
      */
     "no-class-assign": Linter.RuleEntry<[]>;
 
@@ -203,7 +203,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      *
      * @since 2.0.0-alpha-2
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/no-confusing-arrow) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/no-confusing-arrow
+     * @see https://eslint.org/docs/latest/rules/no-confusing-arrow
      */
     "no-confusing-arrow": Linter.RuleEntry<
         [
@@ -223,7 +223,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 1.0.0-rc-1
-     * @see https://eslint.org/docs/rules/no-const-assign
+     * @see https://eslint.org/docs/latest/rules/no-const-assign
      */
     "no-const-assign": Linter.RuleEntry<[]>;
 
@@ -234,7 +234,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 1.2.0
-     * @see https://eslint.org/docs/rules/no-dupe-class-members
+     * @see https://eslint.org/docs/latest/rules/no-dupe-class-members
      */
     "no-dupe-class-members": Linter.RuleEntry<[]>;
 
@@ -242,7 +242,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to disallow duplicate module imports.
      *
      * @since 2.5.0
-     * @see https://eslint.org/docs/rules/no-duplicate-imports
+     * @see https://eslint.org/docs/latest/rules/no-duplicate-imports
      */
     "no-duplicate-imports": Linter.RuleEntry<
         [
@@ -256,13 +256,13 @@ export interface ECMAScript6 extends Linter.RulesRecord {
     >;
 
     /**
-     * Rule to disallow `new` operator with global non-constructor functions
-     * 
+     * Rule to disallow `new` operators with global non-constructor functions.
+     *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 8.27.0
-     * @see https://eslint.org/docs/rules/no-new-native-nonconstructor
+     * @see https://eslint.org/docs/latest/rules/no-new-native-nonconstructor
      */
     "no-new-native-nonconstructor": Linter.RuleEntry<[]>;
 
@@ -270,7 +270,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to disallow specified names in exports.
      *
      * @since 7.0.0-alpha.0
-     * @see https://eslint.org/docs/rules/no-restricted-exports
+     * @see https://eslint.org/docs/latest/rules/no-restricted-exports
      */
     "no-restricted-exports": Linter.RuleEntry<
         [
@@ -316,7 +316,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to disallow specified modules when loaded by `import`.
      *
      * @since 2.0.0-alpha-1
-     * @see https://eslint.org/docs/rules/no-restricted-imports
+     * @see https://eslint.org/docs/latest/rules/no-restricted-imports
      */
     "no-restricted-imports": Linter.RuleEntry<
         [
@@ -338,15 +338,15 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.24.0
-     * @see https://eslint.org/docs/rules/no-this-before-super
+     * @see https://eslint.org/docs/latest/rules/no-this-before-super
      */
     "no-this-before-super": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to disallow unnecessary computed property keys in object literals.
+     * Rule to disallow unnecessary computed property keys in objects and classes.
      *
      * @since 2.9.0
-     * @see https://eslint.org/docs/rules/no-useless-computed-key
+     * @see https://eslint.org/docs/latest/rules/no-useless-computed-key
      */
     "no-useless-computed-key": Linter.RuleEntry<
         [
@@ -363,7 +363,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to disallow unnecessary constructors.
      *
      * @since 2.0.0-beta.1
-     * @see https://eslint.org/docs/rules/no-useless-constructor
+     * @see https://eslint.org/docs/latest/rules/no-useless-constructor
      */
     "no-useless-constructor": Linter.RuleEntry<[]>;
 
@@ -371,7 +371,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to disallow renaming import, export, and destructured assignments to the same name.
      *
      * @since 2.11.0
-     * @see https://eslint.org/docs/rules/no-useless-rename
+     * @see https://eslint.org/docs/latest/rules/no-useless-rename
      */
     "no-useless-rename": Linter.RuleEntry<
         [
@@ -396,7 +396,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to require `let` or `const` instead of `var`.
      *
      * @since 0.12.0
-     * @see https://eslint.org/docs/rules/no-var
+     * @see https://eslint.org/docs/latest/rules/no-var
      */
     "no-var": Linter.RuleEntry<[]>;
 
@@ -404,7 +404,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to require or disallow method and property shorthand syntax for object literals.
      *
      * @since 0.20.0
-     * @see https://eslint.org/docs/rules/object-shorthand
+     * @see https://eslint.org/docs/latest/rules/object-shorthand
      */
     "object-shorthand":
         | Linter.RuleEntry<
@@ -447,7 +447,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to require using arrow functions for callbacks.
      *
      * @since 1.2.0
-     * @see https://eslint.org/docs/rules/prefer-arrow-callback
+     * @see https://eslint.org/docs/latest/rules/prefer-arrow-callback
      */
     "prefer-arrow-callback": Linter.RuleEntry<
         [
@@ -468,7 +468,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to require `const` declarations for variables that are never reassigned after declared.
      *
      * @since 0.23.0
-     * @see https://eslint.org/docs/rules/prefer-const
+     * @see https://eslint.org/docs/latest/rules/prefer-const
      */
     "prefer-const": Linter.RuleEntry<
         [
@@ -489,7 +489,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to require destructuring from arrays and/or objects.
      *
      * @since 3.13.0
-     * @see https://eslint.org/docs/rules/prefer-destructuring
+     * @see https://eslint.org/docs/latest/rules/prefer-destructuring
      */
     "prefer-destructuring": Linter.RuleEntry<
         [
@@ -516,7 +516,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
     >;
 
     /**
-     * Disallow the use of `Math.pow` in favor of the `**` operator.
+     * Rule to disallow the use of `Math.pow` in favor of the `**` operator.
      *
      * @since 6.7.0
      * @see https://eslint.org/docs/latest/rules/prefer-exponentiation-operator
@@ -527,7 +527,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to disallow `parseInt()` and `Number.parseInt()` in favor of binary, octal, and hexadecimal literals.
      *
      * @since 3.5.0
-     * @see https://eslint.org/docs/rules/prefer-numeric-literals
+     * @see https://eslint.org/docs/latest/rules/prefer-numeric-literals
      */
     "prefer-numeric-literals": Linter.RuleEntry<[]>;
 
@@ -535,7 +535,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to require rest parameters instead of `arguments`.
      *
      * @since 2.0.0-alpha-1
-     * @see https://eslint.org/docs/rules/prefer-rest-params
+     * @see https://eslint.org/docs/latest/rules/prefer-rest-params
      */
     "prefer-rest-params": Linter.RuleEntry<[]>;
 
@@ -543,7 +543,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to require spread operators instead of `.apply()`.
      *
      * @since 1.0.0-rc-1
-     * @see https://eslint.org/docs/rules/prefer-spread
+     * @see https://eslint.org/docs/latest/rules/prefer-spread
      */
     "prefer-spread": Linter.RuleEntry<[]>;
 
@@ -551,7 +551,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to require template literals instead of string concatenation.
      *
      * @since 1.2.0
-     * @see https://eslint.org/docs/rules/prefer-template
+     * @see https://eslint.org/docs/latest/rules/prefer-template
      */
     "prefer-template": Linter.RuleEntry<[]>;
 
@@ -562,7 +562,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 1.0.0-rc-1
-     * @see https://eslint.org/docs/rules/require-yield
+     * @see https://eslint.org/docs/latest/rules/require-yield
      */
     "require-yield": Linter.RuleEntry<[]>;
 
@@ -571,15 +571,15 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      *
      * @since 2.12.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/rest-spread-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/rest-spread-spacing
+     * @see https://eslint.org/docs/latest/rules/rest-spread-spacing
      */
     "rest-spread-spacing": Linter.RuleEntry<["never" | "always"]>;
 
     /**
-     * Rule to enforce sorted import declarations within modules.
+     * Rule to enforce sorted `import` declarations within modules.
      *
      * @since 2.0.0-beta.1
-     * @see https://eslint.org/docs/rules/sort-imports
+     * @see https://eslint.org/docs/latest/rules/sort-imports
      */
     "sort-imports": Linter.RuleEntry<
         [
@@ -612,7 +612,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to require symbol descriptions.
      *
      * @since 3.4.0
-     * @see https://eslint.org/docs/rules/symbol-description
+     * @see https://eslint.org/docs/latest/rules/symbol-description
      */
     "symbol-description": Linter.RuleEntry<[]>;
 
@@ -621,7 +621,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      *
      * @since 2.0.0-rc.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/template-curly-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/template-curly-spacing
+     * @see https://eslint.org/docs/latest/rules/template-curly-spacing
      */
     "template-curly-spacing": Linter.RuleEntry<["never" | "always"]>;
 
@@ -630,7 +630,7 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      *
      * @since 2.0.0-alpha-1
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/yield-star-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/yield-star-spacing
+     * @see https://eslint.org/docs/latest/rules/yield-star-spacing
      */
     "yield-star-spacing": Linter.RuleEntry<
         [

--- a/lib/types/rules/node-commonjs.d.ts
+++ b/lib/types/rules/node-commonjs.d.ts
@@ -32,7 +32,8 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * Rule to require `return` statements after callbacks.
      *
      * @since 1.0.0-rc-1
-     * @see https://eslint.org/docs/rules/callback-return
+     * @deprecated
+     * @see https://eslint.org/docs/latest/rules/callback-return
      */
     "callback-return": Linter.RuleEntry<[string[]]>;
 
@@ -40,7 +41,8 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * Rule to require `require()` calls to be placed at top-level module scope.
      *
      * @since 1.4.0
-     * @see https://eslint.org/docs/rules/global-require
+     * @deprecated
+     * @see https://eslint.org/docs/latest/rules/global-require
      */
     "global-require": Linter.RuleEntry<[]>;
 
@@ -48,7 +50,8 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * Rule to require error handling in callbacks.
      *
      * @since 0.4.5
-     * @see https://eslint.org/docs/rules/handle-callback-err
+     * @deprecated
+     * @see https://eslint.org/docs/latest/rules/handle-callback-err
      */
     "handle-callback-err": Linter.RuleEntry<[string]>;
 
@@ -56,7 +59,8 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * Rule to disallow use of the `Buffer()` constructor.
      *
      * @since 4.0.0-alpha.0
-     * @see https://eslint.org/docs/rules/no-buffer-constructor
+     * @deprecated
+     * @see https://eslint.org/docs/latest/rules/no-buffer-constructor
      */
     "no-buffer-constructor": Linter.RuleEntry<[]>;
 
@@ -64,7 +68,8 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * Rule to disallow `require` calls to be mixed with regular variable declarations.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-mixed-requires
+     * @deprecated
+     * @see https://eslint.org/docs/latest/rules/no-mixed-requires
      */
     "no-mixed-requires": Linter.RuleEntry<
         [
@@ -85,15 +90,17 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * Rule to disallow `new` operators with calls to `require`.
      *
      * @since 0.6.0
-     * @see https://eslint.org/docs/rules/no-new-require
+     * @deprecated
+     * @see https://eslint.org/docs/latest/rules/no-new-require
      */
     "no-new-require": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to disallow string concatenation when using `__dirname` and `__filename`.
+     * Rule to disallow string concatenation with `__dirname` and `__filename`.
      *
      * @since 0.4.0
-     * @see https://eslint.org/docs/rules/no-path-concat
+     * @deprecated
+     * @see https://eslint.org/docs/latest/rules/no-path-concat
      */
     "no-path-concat": Linter.RuleEntry<[]>;
 
@@ -101,7 +108,8 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * Rule to disallow the use of `process.env`.
      *
      * @since 0.9.0
-     * @see https://eslint.org/docs/rules/no-process-env
+     * @deprecated
+     * @see https://eslint.org/docs/latest/rules/no-process-env
      */
     "no-process-env": Linter.RuleEntry<[]>;
 
@@ -109,7 +117,8 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * Rule to disallow the use of `process.exit()`.
      *
      * @since 0.4.0
-     * @see https://eslint.org/docs/rules/no-process-exit
+     * @deprecated
+     * @see https://eslint.org/docs/latest/rules/no-process-exit
      */
     "no-process-exit": Linter.RuleEntry<[]>;
 
@@ -117,7 +126,8 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * Rule to disallow specified modules when loaded by `require`.
      *
      * @since 0.6.0
-     * @see https://eslint.org/docs/rules/no-restricted-modules
+     * @deprecated
+     * @see https://eslint.org/docs/latest/rules/no-restricted-modules
      */
     "no-restricted-modules": Linter.RuleEntry<
         [
@@ -145,7 +155,8 @@ export interface NodeJSAndCommonJS extends Linter.RulesRecord {
      * Rule to disallow synchronous methods.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-sync
+     * @deprecated
+     * @see https://eslint.org/docs/latest/rules/no-sync
      */
     "no-sync": Linter.RuleEntry<
         [

--- a/lib/types/rules/possible-errors.d.ts
+++ b/lib/types/rules/possible-errors.d.ts
@@ -35,7 +35,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 4.0.0-beta.0
-     * @see https://eslint.org/docs/rules/for-direction
+     * @see https://eslint.org/docs/latest/rules/for-direction
      */
     "for-direction": Linter.RuleEntry<[]>;
 
@@ -46,7 +46,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 4.2.0
-     * @see https://eslint.org/docs/rules/getter-return
+     * @see https://eslint.org/docs/latest/rules/getter-return
      */
     "getter-return": Linter.RuleEntry<
         [
@@ -60,13 +60,13 @@ export interface PossibleErrors extends Linter.RulesRecord {
     >;
 
     /**
-     * Rule to disallow using an async function as a `Promise` executor.
+     * Rule to disallow using an async function as a Promise executor.
      *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 5.3.0
-     * @see https://eslint.org/docs/rules/no-async-promise-executor
+     * @see https://eslint.org/docs/latest/rules/no-async-promise-executor
      */
     "no-async-promise-executor": Linter.RuleEntry<[]>;
 
@@ -74,7 +74,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Rule to disallow `await` inside of loops.
      *
      * @since 3.12.0
-     * @see https://eslint.org/docs/rules/no-await-in-loop
+     * @see https://eslint.org/docs/latest/rules/no-await-in-loop
      */
     "no-await-in-loop": Linter.RuleEntry<[]>;
 
@@ -85,18 +85,18 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 3.17.0
-     * @see https://eslint.org/docs/rules/no-compare-neg-zero
+     * @see https://eslint.org/docs/latest/rules/no-compare-neg-zero
      */
     "no-compare-neg-zero": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to disallow assignment operators in conditional statements.
+     * Rule to disallow assignment operators in conditional expressions.
      *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-cond-assign
+     * @see https://eslint.org/docs/latest/rules/no-cond-assign
      */
     "no-cond-assign": Linter.RuleEntry<["except-parens" | "always"]>;
 
@@ -104,7 +104,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Rule to disallow the use of `console`.
      *
      * @since 0.0.2
-     * @see https://eslint.org/docs/rules/no-console
+     * @see https://eslint.org/docs/latest/rules/no-console
      */
     "no-console": Linter.RuleEntry<
         [
@@ -115,13 +115,24 @@ export interface PossibleErrors extends Linter.RulesRecord {
     >;
 
     /**
+     * Rule to disallow expressions where the operation doesn't affect the value.
+     *
+     * @remarks
+     * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
+     *
+     * @since 8.14.0
+     * @see https://eslint.org/docs/latest/rules/no-constant-binary-expression
+     */
+    "no-constant-binary-expression": Linter.RuleEntry<[]>;
+
+    /**
      * Rule to disallow constant expressions in conditions.
      *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.4.1
-     * @see https://eslint.org/docs/rules/no-constant-condition
+     * @see https://eslint.org/docs/latest/rules/no-constant-condition
      */
     "no-constant-condition": Linter.RuleEntry<
         [
@@ -135,13 +146,21 @@ export interface PossibleErrors extends Linter.RulesRecord {
     >;
 
     /**
+     * Rule to disallow returning value from constructor.
+     *
+     * @since 6.7.0
+     * @see https://eslint.org/docs/latest/rules/no-constructor-return
+     */
+    "no-constructor-return": Linter.RuleEntry<[]>;
+
+    /**
      * Rule to disallow control characters in regular expressions.
      *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.1.0
-     * @see https://eslint.org/docs/rules/no-control-regex
+     * @see https://eslint.org/docs/latest/rules/no-control-regex
      */
     "no-control-regex": Linter.RuleEntry<[]>;
 
@@ -152,7 +171,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.2
-     * @see https://eslint.org/docs/rules/no-debugger
+     * @see https://eslint.org/docs/latest/rules/no-debugger
      */
     "no-debugger": Linter.RuleEntry<[]>;
 
@@ -163,18 +182,18 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.16.0
-     * @see https://eslint.org/docs/rules/no-dupe-args
+     * @see https://eslint.org/docs/latest/rules/no-dupe-args
      */
     "no-dupe-args": Linter.RuleEntry<[]>;
 
     /**
-     * Disallow duplicate conditions in if-else-if chains.
+     * Rule to disallow duplicate conditions in if-else-if chains.
      *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 6.7.0
-     * @see https://eslint.org/docs/rules/no-dupe-else-if
+     * @see https://eslint.org/docs/latest/rules/no-dupe-else-if
      */
     "no-dupe-else-if": Linter.RuleEntry<[]>;
 
@@ -185,18 +204,18 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-dupe-keys
+     * @see https://eslint.org/docs/latest/rules/no-dupe-keys
      */
     "no-dupe-keys": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to disallow a duplicate case label.
+     * Rule to disallow duplicate case labels.
      *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.17.0
-     * @see https://eslint.org/docs/rules/no-duplicate-case
+     * @see https://eslint.org/docs/latest/rules/no-duplicate-case
      */
     "no-duplicate-case": Linter.RuleEntry<[]>;
 
@@ -207,7 +226,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.2
-     * @see https://eslint.org/docs/rules/no-empty
+     * @see https://eslint.org/docs/latest/rules/no-empty
      */
     "no-empty": Linter.RuleEntry<
         [
@@ -227,7 +246,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.22.0
-     * @see https://eslint.org/docs/rules/no-empty-character-class
+     * @see https://eslint.org/docs/latest/rules/no-empty-character-class
      */
     "no-empty-character-class": Linter.RuleEntry<[]>;
 
@@ -238,7 +257,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-ex-assign
+     * @see https://eslint.org/docs/latest/rules/no-ex-assign
      */
     "no-ex-assign": Linter.RuleEntry<[]>;
 
@@ -249,7 +268,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.4.0
-     * @see https://eslint.org/docs/rules/no-extra-boolean-cast
+     * @see https://eslint.org/docs/latest/rules/no-extra-boolean-cast
      */
     "no-extra-boolean-cast": Linter.RuleEntry<
         [
@@ -281,7 +300,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      *
      * @since 0.1.4
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/no-extra-parens) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/no-extra-parens
+     * @see https://eslint.org/docs/latest/rules/no-extra-parens
      */
     "no-extra-parens":
         | Linter.RuleEntry<
@@ -316,12 +335,9 @@ export interface PossibleErrors extends Linter.RulesRecord {
     /**
      * Rule to disallow unnecessary semicolons.
      *
-     * @remarks
-     * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
-     *
      * @since 0.0.9
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/no-extra-semi) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/no-extra-semi
+     * @see https://eslint.org/docs/latest/rules/no-extra-semi
      */
     "no-extra-semi": Linter.RuleEntry<[]>;
 
@@ -332,18 +348,15 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-func-assign
+     * @see https://eslint.org/docs/latest/rules/no-func-assign
      */
     "no-func-assign": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow variable or `function` declarations in nested blocks.
      *
-     * @remarks
-     * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
-     *
      * @since 0.6.0
-     * @see https://eslint.org/docs/rules/no-inner-declarations
+     * @see https://eslint.org/docs/latest/rules/no-inner-declarations
      */
     "no-inner-declarations": Linter.RuleEntry<["functions" | "both"]>;
 
@@ -354,7 +367,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.1.4
-     * @see https://eslint.org/docs/rules/no-invalid-regexp
+     * @see https://eslint.org/docs/latest/rules/no-invalid-regexp
      */
     "no-invalid-regexp": Linter.RuleEntry<
         [
@@ -371,7 +384,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.9.0
-     * @see https://eslint.org/docs/rules/no-irregular-whitespace
+     * @see https://eslint.org/docs/latest/rules/no-irregular-whitespace
      */
     "no-irregular-whitespace": Linter.RuleEntry<
         [
@@ -397,7 +410,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
     >;
 
     /**
-     * Disallow literal numbers that lose precision.
+     * Rule to disallow literal numbers that lose precision.
      *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
@@ -414,7 +427,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 5.3.0
-     * @see https://eslint.org/docs/rules/no-misleading-character-class
+     * @see https://eslint.org/docs/latest/rules/no-misleading-character-class
      */
     "no-misleading-character-class": Linter.RuleEntry<
         [
@@ -435,7 +448,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-obj-calls
+     * @see https://eslint.org/docs/latest/rules/no-obj-calls
      */
     "no-obj-calls": Linter.RuleEntry<[]>;
 
@@ -443,7 +456,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Rule to disallow returning values from Promise executor functions.
      *
      * @since 7.3.0
-     * @see https://eslint.org/docs/rules/no-promise-executor-return
+     * @see https://eslint.org/docs/latest/rules/no-promise-executor-return
      */
     "no-promise-executor-return": Linter.RuleEntry<[
         {
@@ -455,13 +468,13 @@ export interface PossibleErrors extends Linter.RulesRecord {
     ]>;
 
     /**
-     * Rule to disallow use of `Object.prototypes` builtins directly.
+     * Rule to disallow calling some `Object.prototype` methods directly on objects.
      *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 2.11.0
-     * @see https://eslint.org/docs/rules/no-prototype-builtins
+     * @see https://eslint.org/docs/latest/rules/no-prototype-builtins
      */
     "no-prototype-builtins": Linter.RuleEntry<[]>;
 
@@ -472,9 +485,20 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.4.0
-     * @see https://eslint.org/docs/rules/no-regex-spaces
+     * @see https://eslint.org/docs/latest/rules/no-regex-spaces
      */
     "no-regex-spaces": Linter.RuleEntry<[]>;
+
+    /**
+     * Rule to disallow returning values from setters.
+     *
+     * @remarks
+     * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
+     *
+     * @since 6.7.0
+     * @see https://eslint.org/docs/latest/rules/no-setter-return
+     */
+    "no-setter-return": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow sparse arrays.
@@ -483,7 +507,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.4.0
-     * @see https://eslint.org/docs/rules/no-sparse-arrays
+     * @see https://eslint.org/docs/latest/rules/no-sparse-arrays
      */
     "no-sparse-arrays": Linter.RuleEntry<[]>;
 
@@ -491,7 +515,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Rule to disallow template literal placeholder syntax in regular strings.
      *
      * @since 3.3.0
-     * @see https://eslint.org/docs/rules/no-template-curly-in-string
+     * @see https://eslint.org/docs/latest/rules/no-template-curly-in-string
      */
     "no-template-curly-in-string": Linter.RuleEntry<[]>;
 
@@ -502,7 +526,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.24.0
-     * @see https://eslint.org/docs/rules/no-unexpected-multiline
+     * @see https://eslint.org/docs/latest/rules/no-unexpected-multiline
      */
     "no-unexpected-multiline": Linter.RuleEntry<[]>;
 
@@ -513,12 +537,12 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.6
-     * @see https://eslint.org/docs/rules/no-unreachable
+     * @see https://eslint.org/docs/latest/rules/no-unreachable
      */
     "no-unreachable": Linter.RuleEntry<[]>;
 
     /**
-     * Disallow loops with a body that allows only one iteration.
+     * Rule to disallow loops with a body that allows only one iteration.
      *
      * @since 7.3.0
      * @see https://eslint.org/docs/latest/rules/no-unreachable-loop
@@ -541,7 +565,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 2.9.0
-     * @see https://eslint.org/docs/rules/no-unsafe-finally
+     * @see https://eslint.org/docs/latest/rules/no-unsafe-finally
      */
     "no-unsafe-finally": Linter.RuleEntry<[]>;
 
@@ -552,7 +576,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 3.3.0
-     * @see https://eslint.org/docs/rules/no-unsafe-negation
+     * @see https://eslint.org/docs/latest/rules/no-unsafe-negation
      */
     "no-unsafe-negation": Linter.RuleEntry<
         [
@@ -567,13 +591,13 @@ export interface PossibleErrors extends Linter.RulesRecord {
     >;
 
     /**
-     * Disallow use of optional chaining in contexts where the `undefined` value is not allowed.
+     * Rule to disallow use of optional chaining in contexts where the `undefined` value is not allowed.
      *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 7.15.0
-     * @see https://eslint.org/docs/rules/no-unsafe-optional-chaining
+     * @see https://eslint.org/docs/latest/rules/no-unsafe-optional-chaining
      */
     "no-unsafe-optional-chaining": Linter.RuleEntry<
         [
@@ -587,13 +611,21 @@ export interface PossibleErrors extends Linter.RulesRecord {
     >;
 
     /**
-     * Rule to disallow assignments that can lead to race conditions due to usage of `await` or `yield`.
+     * Rule to disallow unused private class members.
      *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
+     * @since 8.1.0
+     * @see https://eslint.org/docs/latest/rules/no-unused-private-class-members
+     */
+    "no-unused-private-class-members": Linter.RuleEntry<[]>;
+
+    /**
+     * Rule to disallow assignments that can lead to race conditions due to usage of `await` or `yield`.
+     *
      * @since 5.3.0
-     * @see https://eslint.org/docs/rules/require-atomic-updates
+     * @see https://eslint.org/docs/latest/rules/require-atomic-updates
      */
     "require-atomic-updates": Linter.RuleEntry<
         [
@@ -614,7 +646,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.6
-     * @see https://eslint.org/docs/rules/use-isnan
+     * @see https://eslint.org/docs/latest/rules/use-isnan
      */
     "use-isnan": Linter.RuleEntry<
         [
@@ -638,7 +670,7 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.5.0
-     * @see https://eslint.org/docs/rules/valid-typeof
+     * @see https://eslint.org/docs/latest/rules/valid-typeof
      */
     "valid-typeof": Linter.RuleEntry<
         [

--- a/lib/types/rules/strict-mode.d.ts
+++ b/lib/types/rules/strict-mode.d.ts
@@ -32,7 +32,7 @@ export interface StrictMode extends Linter.RulesRecord {
      * Rule to require or disallow strict mode directives.
      *
      * @since 0.1.0
-     * @see https://eslint.org/docs/rules/strict
+     * @see https://eslint.org/docs/latest/rules/strict
      */
     strict: Linter.RuleEntry<["safe" | "global" | "function" | "never"]>;
 }

--- a/lib/types/rules/stylistic-issues.d.ts
+++ b/lib/types/rules/stylistic-issues.d.ts
@@ -33,7 +33,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 4.0.0-alpha.1
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/array-bracket-newline) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/array-bracket-newline
+     * @see https://eslint.org/docs/latest/rules/array-bracket-newline
      */
     "array-bracket-newline": Linter.RuleEntry<
         [
@@ -58,7 +58,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.24.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/array-bracket-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/array-bracket-spacing
+     * @see https://eslint.org/docs/latest/rules/array-bracket-spacing
      */
     "array-bracket-spacing":
         | Linter.RuleEntry<
@@ -105,7 +105,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 4.0.0-rc.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/array-element-newline) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/array-element-newline
+     * @see https://eslint.org/docs/latest/rules/array-element-newline
      */
     "array-element-newline": Linter.RuleEntry<
         [
@@ -130,7 +130,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 1.2.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/block-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/block-spacing
+     * @see https://eslint.org/docs/latest/rules/block-spacing
      */
     "block-spacing": Linter.RuleEntry<["always" | "never"]>;
 
@@ -139,7 +139,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.0.7
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/brace-style) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/brace-style
+     * @see https://eslint.org/docs/latest/rules/brace-style
      */
     "brace-style": Linter.RuleEntry<
         [
@@ -157,7 +157,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to enforce camelcase naming convention.
      *
      * @since 0.0.2
-     * @see https://eslint.org/docs/rules/camelcase
+     * @see https://eslint.org/docs/latest/rules/camelcase
      */
     camelcase: Linter.RuleEntry<
         [
@@ -193,7 +193,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to enforce or disallow capitalization of the first letter of a comment.
      *
      * @since 3.11.0
-     * @see https://eslint.org/docs/rules/capitalized-comments
+     * @see https://eslint.org/docs/latest/rules/capitalized-comments
      */
     "capitalized-comments": Linter.RuleEntry<
         [
@@ -217,7 +217,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.16.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/comma-dangle) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/comma-dangle
+     * @see https://eslint.org/docs/latest/rules/comma-dangle
      */
     "comma-dangle": Linter.RuleEntry<
         [
@@ -255,7 +255,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.9.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/comma-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/comma-spacing
+     * @see https://eslint.org/docs/latest/rules/comma-spacing
      */
     "comma-spacing": Linter.RuleEntry<
         [
@@ -277,7 +277,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.9.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/comma-style) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/comma-style
+     * @see https://eslint.org/docs/latest/rules/comma-style
      */
     "comma-style": Linter.RuleEntry<
         [
@@ -293,7 +293,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.23.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/computed-property-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/computed-property-spacing
+     * @see https://eslint.org/docs/latest/rules/computed-property-spacing
      */
     "computed-property-spacing": Linter.RuleEntry<["never" | "always"]>;
 
@@ -301,7 +301,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to enforce consistent naming when capturing the current execution context.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/consistent-this
+     * @see https://eslint.org/docs/latest/rules/consistent-this
      */
     "consistent-this": Linter.RuleEntry<[...string[]]>;
 
@@ -310,7 +310,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.7.1
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/eol-last) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/eol-last
+     * @see https://eslint.org/docs/latest/rules/eol-last
      */
     "eol-last": Linter.RuleEntry<
         [
@@ -323,7 +323,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 3.3.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/function-call-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/func-call-spacing
+     * @see https://eslint.org/docs/latest/rules/func-call-spacing
      */
     "func-call-spacing": Linter.RuleEntry<["never" | "always"]>;
 
@@ -331,7 +331,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to require function names to match the name of the variable or property to which they are assigned.
      *
      * @since 3.8.0
-     * @see https://eslint.org/docs/rules/func-name-matching
+     * @see https://eslint.org/docs/latest/rules/func-name-matching
      */
     "func-name-matching":
         | Linter.RuleEntry<
@@ -368,7 +368,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to require or disallow named `function` expressions.
      *
      * @since 0.4.0
-     * @see https://eslint.org/docs/rules/func-names
+     * @see https://eslint.org/docs/latest/rules/func-names
      */
     "func-names": Linter.RuleEntry<
         [
@@ -380,10 +380,10 @@ export interface StylisticIssues extends Linter.RulesRecord {
     >;
 
     /**
-     * Rule to enforce the consistent use of either `function` declarations or expressions.
+     * Rule to enforce the consistent use of either `function` declarations or expressions assigned to variables.
      *
      * @since 0.2.0
-     * @see https://eslint.org/docs/rules/func-style
+     * @see https://eslint.org/docs/latest/rules/func-style
      */
     "func-style": Linter.RuleEntry<
         [
@@ -405,7 +405,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 4.6.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/function-paren-newline) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/function-paren-newline
+     * @see https://eslint.org/docs/latest/rules/function-paren-newline
      */
     "function-paren-newline": Linter.RuleEntry<
         [
@@ -424,15 +424,24 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow specified identifiers.
      *
      * @since 2.0.0-beta.2
-     * @see https://eslint.org/docs/rules/id-blacklist
+     * @deprecated please use [`id-denylist`](https://eslint.org/docs/latest/rules/id-denylist).
+     * @see https://eslint.org/docs/latest/rules/id-blacklist
      */
     "id-blacklist": Linter.RuleEntry<[...string[]]>;
+
+    /**
+     * Rule to disallow specified identifiers.
+     *
+     * @since 7.4.0
+     * @see https://eslint.org/docs/latest/rules/id-denylist
+     */
+    "id-denylist": Linter.RuleEntry<string[]>;
 
     /**
      * Rule to enforce minimum and maximum identifier lengths.
      *
      * @since 1.0.0
-     * @see https://eslint.org/docs/rules/id-length
+     * @see https://eslint.org/docs/latest/rules/id-length
      */
     "id-length": Linter.RuleEntry<
         [
@@ -458,7 +467,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to require identifiers to match a specified regular expression.
      *
      * @since 1.0.0
-     * @see https://eslint.org/docs/rules/id-match
+     * @see https://eslint.org/docs/latest/rules/id-match
      */
     "id-match": Linter.RuleEntry<
         [
@@ -485,7 +494,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 4.12.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/implicit-arrow-linebreak) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/implicit-arrow-linebreak
+     * @see https://eslint.org/docs/latest/rules/implicit-arrow-linebreak
      */
     "implicit-arrow-linebreak": Linter.RuleEntry<["beside" | "below"]>;
 
@@ -494,7 +503,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.14.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/indent) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/indent
+     * @see https://eslint.org/docs/latest/rules/indent
      */
     indent: Linter.RuleEntry<
         [
@@ -597,7 +606,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 1.4.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/jsx-quotes) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/jsx-quotes
+     * @see https://eslint.org/docs/latest/rules/jsx-quotes
      */
     "jsx-quotes": Linter.RuleEntry<["prefer-double" | "prefer-single"]>;
 
@@ -606,7 +615,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.9.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/key-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/key-spacing
+     * @see https://eslint.org/docs/latest/rules/key-spacing
      */
     "key-spacing": Linter.RuleEntry<
         [
@@ -762,7 +771,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 2.0.0-beta.1
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/keyword-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/keyword-spacing
+     * @see https://eslint.org/docs/latest/rules/keyword-spacing
      */
     "keyword-spacing": Linter.RuleEntry<
         [
@@ -791,7 +800,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 3.5.0
      * @deprecated since 9.3.0, please use the [corresponding rule](https://eslint.style/rules/js/line-comment-position) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/line-comment-position
+     * @see https://eslint.org/docs/latest/rules/line-comment-position
      */
     "line-comment-position": Linter.RuleEntry<
         [
@@ -814,7 +823,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.21.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/linebreak-style) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/linebreak-style
+     * @see https://eslint.org/docs/latest/rules/linebreak-style
      */
     "linebreak-style": Linter.RuleEntry<["unix" | "windows"]>;
 
@@ -823,7 +832,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.22.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/lines-around-comment) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/lines-around-comment
+     * @see https://eslint.org/docs/latest/rules/lines-around-comment
      */
     "lines-around-comment": Linter.RuleEntry<
         [
@@ -890,7 +899,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 4.9.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/lines-between-class-members) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/lines-between-class-members
+     * @see https://eslint.org/docs/latest/rules/lines-between-class-members
      */
     "lines-between-class-members": Linter.RuleEntry<
         [
@@ -916,7 +925,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to enforce a maximum depth that blocks can be nested.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/max-depth
+     * @see https://eslint.org/docs/latest/rules/max-depth
      */
     "max-depth": Linter.RuleEntry<
         [
@@ -934,7 +943,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.0.9
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/max-len) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/max-len
+     * @see https://eslint.org/docs/latest/rules/max-len
      */
     "max-len": Linter.RuleEntry<
         [
@@ -981,7 +990,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to enforce a maximum number of lines per file.
      *
      * @since 2.12.0
-     * @see https://eslint.org/docs/rules/max-lines
+     * @see https://eslint.org/docs/latest/rules/max-lines
      */
     "max-lines": Linter.RuleEntry<
         [
@@ -1004,10 +1013,10 @@ export interface StylisticIssues extends Linter.RulesRecord {
     >;
 
     /**
-     * Rule to enforce a maximum number of line of code in a function.
+     * Rule to enforce a maximum number of lines of code in a function.
      *
      * @since 5.0.0
-     * @see https://eslint.org/docs/rules/max-lines-per-function
+     * @see https://eslint.org/docs/latest/rules/max-lines-per-function
      */
     "max-lines-per-function": Linter.RuleEntry<
         [
@@ -1036,7 +1045,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to enforce a maximum depth that callbacks can be nested.
      *
      * @since 0.2.0
-     * @see https://eslint.org/docs/rules/max-nested-callbacks
+     * @see https://eslint.org/docs/latest/rules/max-nested-callbacks
      */
     "max-nested-callbacks": Linter.RuleEntry<
         [
@@ -1054,7 +1063,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to enforce a maximum number of parameters in function definitions.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/max-params
+     * @see https://eslint.org/docs/latest/rules/max-params
      */
     "max-params": Linter.RuleEntry<
         [
@@ -1072,7 +1081,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to enforce a maximum number of statements allowed in function blocks.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/max-statements
+     * @see https://eslint.org/docs/latest/rules/max-statements
      */
     "max-statements": Linter.RuleEntry<
         [
@@ -1095,7 +1104,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 2.5.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/max-statements-per-line) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/max-statements-per-line
+     * @see https://eslint.org/docs/latest/rules/max-statements-per-line
      */
     "max-statements-per-line": Linter.RuleEntry<
         [
@@ -1114,7 +1123,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 4.10.0
      * @deprecated since 9.3.0, please use the [corresponding rule](https://eslint.style/rules/js/multiline-comment-style) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/multiline-comment-style
+     * @see https://eslint.org/docs/latest/rules/multiline-comment-style
      */
     "multiline-comment-style": Linter.RuleEntry<["starred-block" | "bare-block" | "separate-lines"]>;
 
@@ -1123,7 +1132,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 3.1.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/multiline-ternary) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/multiline-ternary
+     * @see https://eslint.org/docs/latest/rules/multiline-ternary
      */
     "multiline-ternary": Linter.RuleEntry<["always" | "always-multiline" | "never"]>;
 
@@ -1131,7 +1140,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to require constructor names to begin with a capital letter.
      *
      * @since 0.0.3-0
-     * @see https://eslint.org/docs/rules/new-cap
+     * @see https://eslint.org/docs/latest/rules/new-cap
      */
     "new-cap": Linter.RuleEntry<
         [
@@ -1161,7 +1170,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.0.6
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/new-parens) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/new-parens
+     * @see https://eslint.org/docs/latest/rules/new-parens
      */
     "new-parens": Linter.RuleEntry<["always" | "never"]>;
 
@@ -1170,7 +1179,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 2.0.0-rc.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/newline-per-chained-call) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/newline-per-chained-call
+     * @see https://eslint.org/docs/latest/rules/newline-per-chained-call
      */
     "newline-per-chained-call": Linter.RuleEntry<
         [
@@ -1187,7 +1196,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow `Array` constructors.
      *
      * @since 0.4.0
-     * @see https://eslint.org/docs/rules/no-array-constructor
+     * @see https://eslint.org/docs/latest/rules/no-array-constructor
      */
     "no-array-constructor": Linter.RuleEntry<[]>;
 
@@ -1195,7 +1204,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow bitwise operators.
      *
      * @since 0.0.2
-     * @see https://eslint.org/docs/rules/no-bitwise
+     * @see https://eslint.org/docs/latest/rules/no-bitwise
      */
     "no-bitwise": Linter.RuleEntry<
         [
@@ -1213,7 +1222,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow `continue` statements.
      *
      * @since 0.19.0
-     * @see https://eslint.org/docs/rules/no-continue
+     * @see https://eslint.org/docs/latest/rules/no-continue
      */
     "no-continue": Linter.RuleEntry<[]>;
 
@@ -1221,7 +1230,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow inline comments after code.
      *
      * @since 0.10.0
-     * @see https://eslint.org/docs/rules/no-inline-comments
+     * @see https://eslint.org/docs/latest/rules/no-inline-comments
      */
     "no-inline-comments": Linter.RuleEntry<[]>;
 
@@ -1229,7 +1238,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow `if` statements as the only statement in `else` blocks.
      *
      * @since 0.6.0
-     * @see https://eslint.org/docs/rules/no-lonely-if
+     * @see https://eslint.org/docs/latest/rules/no-lonely-if
      */
     "no-lonely-if": Linter.RuleEntry<[]>;
 
@@ -1238,7 +1247,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 2.12.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/no-mixed-operators) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/no-mixed-operators
+     * @see https://eslint.org/docs/latest/rules/no-mixed-operators
      */
     "no-mixed-operators": Linter.RuleEntry<
         [
@@ -1265,12 +1274,9 @@ export interface StylisticIssues extends Linter.RulesRecord {
     /**
      * Rule to disallow mixed spaces and tabs for indentation.
      *
-     * @remarks
-     * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
-     *
      * @since 0.7.1
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/no-mixed-spaces-and-tabs) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/no-mixed-spaces-and-tabs
+     * @see https://eslint.org/docs/latest/rules/no-mixed-spaces-and-tabs
      */
     "no-mixed-spaces-and-tabs": Linter.RuleEntry<["smart-tabs"]>;
 
@@ -1278,7 +1284,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow use of chained assignment expressions.
      *
      * @since 3.14.0
-     * @see https://eslint.org/docs/rules/no-multi-assign
+     * @see https://eslint.org/docs/latest/rules/no-multi-assign
      */
     "no-multi-assign": Linter.RuleEntry<[]>;
 
@@ -1287,7 +1293,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.9.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/no-multiple-empty-lines) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/no-multiple-empty-lines
+     * @see https://eslint.org/docs/latest/rules/no-multiple-empty-lines
      */
     "no-multiple-empty-lines": Linter.RuleEntry<
         [
@@ -1307,7 +1313,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow negated conditions.
      *
      * @since 1.6.0
-     * @see https://eslint.org/docs/rules/no-negated-condition
+     * @see https://eslint.org/docs/latest/rules/no-negated-condition
      */
     "no-negated-condition": Linter.RuleEntry<[]>;
 
@@ -1315,15 +1321,15 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow nested ternary expressions.
      *
      * @since 0.2.0
-     * @see https://eslint.org/docs/rules/no-nested-ternary
+     * @see https://eslint.org/docs/latest/rules/no-nested-ternary
      */
     "no-nested-ternary": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to disallow calls to the `Object` constructor without an argument
+     * Rule to disallow calls to the `Object` constructor without an argument.
      *
      * @since 8.50.0
-     * @see https://eslint.org/docs/rules/no-object-constructor
+     * @see https://eslint.org/docs/latest/rules/no-object-constructor
      */
     "no-object-constructor": Linter.RuleEntry<[]>;
 
@@ -1331,7 +1337,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow the unary operators `++` and `--`.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-plusplus
+     * @see https://eslint.org/docs/latest/rules/no-plusplus
      */
     "no-plusplus": Linter.RuleEntry<
         [
@@ -1348,7 +1354,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow specified syntax.
      *
      * @since 1.4.0
-     * @see https://eslint.org/docs/rules/no-restricted-syntax
+     * @see https://eslint.org/docs/latest/rules/no-restricted-syntax
      */
     "no-restricted-syntax": Linter.RuleEntry<
         [
@@ -1367,7 +1373,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 3.2.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/no-tabs) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/no-tabs
+     * @see https://eslint.org/docs/latest/rules/no-tabs
      */
     "no-tabs": Linter.RuleEntry<
         [
@@ -1384,7 +1390,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow ternary operators.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-ternary
+     * @see https://eslint.org/docs/latest/rules/no-ternary
      */
     "no-ternary": Linter.RuleEntry<[]>;
 
@@ -1393,7 +1399,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.7.1
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/no-trailing-spaces) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/no-trailing-spaces
+     * @see https://eslint.org/docs/latest/rules/no-trailing-spaces
      */
     "no-trailing-spaces": Linter.RuleEntry<
         [
@@ -1414,7 +1420,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow dangling underscores in identifiers.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-underscore-dangle
+     * @see https://eslint.org/docs/latest/rules/no-underscore-dangle
      */
     "no-underscore-dangle": Linter.RuleEntry<
         [
@@ -1465,7 +1471,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to disallow ternary operators when simpler alternatives exist.
      *
      * @since 0.21.0
-     * @see https://eslint.org/docs/rules/no-unneeded-ternary
+     * @see https://eslint.org/docs/latest/rules/no-unneeded-ternary
      */
     "no-unneeded-ternary": Linter.RuleEntry<
         [
@@ -1483,7 +1489,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 2.0.0-beta.1
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/no-whitespace-before-property) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/no-whitespace-before-property
+     * @see https://eslint.org/docs/latest/rules/no-whitespace-before-property
      */
     "no-whitespace-before-property": Linter.RuleEntry<[]>;
 
@@ -1492,7 +1498,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 3.17.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/nonblock-statement-body-position) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/nonblock-statement-body-position
+     * @see https://eslint.org/docs/latest/rules/nonblock-statement-body-position
      */
     "nonblock-statement-body-position": Linter.RuleEntry<
         [
@@ -1504,11 +1510,11 @@ export interface StylisticIssues extends Linter.RulesRecord {
     >;
 
     /**
-     * Rule to enforce consistent line breaks inside braces.
+     * Rule to enforce consistent line breaks after opening and before closing braces.
      *
      * @since 2.12.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/object-curly-newline) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/object-curly-newline
+     * @see https://eslint.org/docs/latest/rules/object-curly-newline
      */
     "object-curly-newline": Linter.RuleEntry<
         [
@@ -1551,7 +1557,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.22.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/object-curly-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/object-curly-spacing
+     * @see https://eslint.org/docs/latest/rules/object-curly-spacing
      */
     "object-curly-spacing":
         | Linter.RuleEntry<
@@ -1590,7 +1596,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 2.10.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/object-property-newline) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/object-property-newline
+     * @see https://eslint.org/docs/latest/rules/object-property-newline
      */
     "object-property-newline": Linter.RuleEntry<
         [
@@ -1607,7 +1613,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to enforce variables to be declared either together or separately in functions.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/one-var
+     * @see https://eslint.org/docs/latest/rules/one-var
      */
     "one-var": Linter.RuleEntry<
         [
@@ -1631,7 +1637,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 2.0.0-beta.3
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/one-var-declaration-per-line) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/one-var-declaration-per-line
+     * @see https://eslint.org/docs/latest/rules/one-var-declaration-per-line
      */
     "one-var-declaration-per-line": Linter.RuleEntry<["initializations" | "always"]>;
 
@@ -1639,7 +1645,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to require or disallow assignment operator shorthand where possible.
      *
      * @since 0.10.0
-     * @see https://eslint.org/docs/rules/operator-assignment
+     * @see https://eslint.org/docs/latest/rules/operator-assignment
      */
     "operator-assignment": Linter.RuleEntry<["always" | "never"]>;
 
@@ -1648,7 +1654,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.19.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/operator-linebreak) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/operator-linebreak
+     * @see https://eslint.org/docs/latest/rules/operator-linebreak
      */
     "operator-linebreak": Linter.RuleEntry<
         [
@@ -1664,7 +1670,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.9.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/padded-blocks) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/padded-blocks
+     * @see https://eslint.org/docs/latest/rules/padded-blocks
      */
     "padded-blocks": Linter.RuleEntry<
         [
@@ -1683,7 +1689,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 4.0.0-beta.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/padding-line-between-statements) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/padding-line-between-statements
+     * @see https://eslint.org/docs/latest/rules/padding-line-between-statements
      */
     "padding-line-between-statements": Linter.RuleEntry<
         [
@@ -1696,10 +1702,10 @@ export interface StylisticIssues extends Linter.RulesRecord {
     >;
 
     /**
-     * Rule to disallow using Object.assign with an object literal as the first argument and prefer the use of object spread instead.
+     * Rule to disallow using `Object.assign` with an object literal as the first argument and prefer the use of object spread instead.
      *
      * @since 5.0.0-alpha.3
-     * @see https://eslint.org/docs/rules/prefer-object-spread
+     * @see https://eslint.org/docs/latest/rules/prefer-object-spread
      */
     "prefer-object-spread": Linter.RuleEntry<[]>;
 
@@ -1708,7 +1714,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.0.6
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/quote-props) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/quote-props
+     * @see https://eslint.org/docs/latest/rules/quote-props
      */
     "quote-props":
         | Linter.RuleEntry<["always" | "consistent"]>
@@ -1748,7 +1754,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.0.7
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/quotes) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/quotes
+     * @see https://eslint.org/docs/latest/rules/quotes
      */
     quotes: Linter.RuleEntry<
         [
@@ -1771,7 +1777,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.0.6
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/semi) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/semi
+     * @see https://eslint.org/docs/latest/rules/semi
      */
     semi:
         | Linter.RuleEntry<
@@ -1802,7 +1808,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.16.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/semi-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/semi-spacing
+     * @see https://eslint.org/docs/latest/rules/semi-spacing
      */
     "semi-spacing": Linter.RuleEntry<
         [
@@ -1824,7 +1830,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 4.0.0-beta.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/semi-style) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/semi-style
+     * @see https://eslint.org/docs/latest/rules/semi-style
      */
     "semi-style": Linter.RuleEntry<["last" | "first"]>;
 
@@ -1832,7 +1838,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to require object keys to be sorted.
      *
      * @since 3.3.0
-     * @see https://eslint.org/docs/rules/sort-keys
+     * @see https://eslint.org/docs/latest/rules/sort-keys
      */
     "sort-keys": Linter.RuleEntry<
         [
@@ -1866,7 +1872,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to require variables within the same declaration block to be sorted.
      *
      * @since 0.2.0
-     * @see https://eslint.org/docs/rules/sort-vars
+     * @see https://eslint.org/docs/latest/rules/sort-vars
      */
     "sort-vars": Linter.RuleEntry<
         [
@@ -1884,7 +1890,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.9.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/space-before-blocks) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/space-before-blocks
+     * @see https://eslint.org/docs/latest/rules/space-before-blocks
      */
     "space-before-blocks": Linter.RuleEntry<
         ["always" | "never" | Partial<Record<"functions" | "keywords" | "classes", "always" | "never" | "off">>]
@@ -1895,7 +1901,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.18.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/space-before-function-paren) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/space-before-function-paren
+     * @see https://eslint.org/docs/latest/rules/space-before-function-paren
      */
     "space-before-function-paren": Linter.RuleEntry<
         ["always" | "never" | Partial<Record<"anonymous" | "named" | "asyncArrow", "always" | "never" | "ignore">>]
@@ -1906,7 +1912,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.8.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/space-in-parens) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/space-in-parens
+     * @see https://eslint.org/docs/latest/rules/space-in-parens
      */
     "space-in-parens": Linter.RuleEntry<
         [
@@ -1922,7 +1928,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.2.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/space-infix-ops) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/space-infix-ops
+     * @see https://eslint.org/docs/latest/rules/space-infix-ops
      */
     "space-infix-ops": Linter.RuleEntry<
         [
@@ -1940,7 +1946,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.10.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/space-unary-ops) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/space-unary-ops
+     * @see https://eslint.org/docs/latest/rules/space-unary-ops
      */
     "space-unary-ops": Linter.RuleEntry<
         [
@@ -1963,7 +1969,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.23.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/spaced-comment) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/spaced-comment
+     * @see https://eslint.org/docs/latest/rules/spaced-comment
      */
     "spaced-comment": Linter.RuleEntry<
         [
@@ -1992,7 +1998,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 4.0.0-beta.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/switch-colon-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/switch-colon-spacing
+     * @see https://eslint.org/docs/latest/rules/switch-colon-spacing
      */
     "switch-colon-spacing": Linter.RuleEntry<
         [
@@ -2014,7 +2020,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 3.15.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/template-tag-spacing) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/template-tag-spacing
+     * @see https://eslint.org/docs/latest/rules/template-tag-spacing
      */
     "template-tag-spacing": Linter.RuleEntry<["never" | "always"]>;
 
@@ -2022,7 +2028,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      * Rule to require or disallow Unicode byte order mark (BOM).
      *
      * @since 2.11.0
-     * @see https://eslint.org/docs/rules/unicode-bom
+     * @see https://eslint.org/docs/latest/rules/unicode-bom
      */
     "unicode-bom": Linter.RuleEntry<["never" | "always"]>;
 
@@ -2031,7 +2037,7 @@ export interface StylisticIssues extends Linter.RulesRecord {
      *
      * @since 0.1.0
      * @deprecated since 8.53.0, please use the [corresponding rule](https://eslint.style/rules/js/wrap-regex) in `@stylistic/eslint-plugin-js`.
-     * @see https://eslint.org/docs/rules/wrap-regex
+     * @see https://eslint.org/docs/latest/rules/wrap-regex
      */
     "wrap-regex": Linter.RuleEntry<[]>;
 }

--- a/lib/types/rules/variables.d.ts
+++ b/lib/types/rules/variables.d.ts
@@ -32,7 +32,7 @@ export interface Variables extends Linter.RulesRecord {
      * Rule to require or disallow initialization in variable declarations.
      *
      * @since 1.0.0-rc-1
-     * @see https://eslint.org/docs/rules/init-declarations
+     * @see https://eslint.org/docs/latest/rules/init-declarations
      */
     "init-declarations":
         | Linter.RuleEntry<["always"]>
@@ -52,7 +52,7 @@ export interface Variables extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-delete-var
+     * @see https://eslint.org/docs/latest/rules/no-delete-var
      */
     "no-delete-var": Linter.RuleEntry<[]>;
 
@@ -60,7 +60,7 @@ export interface Variables extends Linter.RulesRecord {
      * Rule to disallow labels that share a name with a variable.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-label-var
+     * @see https://eslint.org/docs/latest/rules/no-label-var
      */
     "no-label-var": Linter.RuleEntry<[]>;
 
@@ -68,7 +68,7 @@ export interface Variables extends Linter.RulesRecord {
      * Rule to disallow specified global variables.
      *
      * @since 2.3.0
-     * @see https://eslint.org/docs/rules/no-restricted-globals
+     * @see https://eslint.org/docs/latest/rules/no-restricted-globals
      */
     "no-restricted-globals": Linter.RuleEntry<
         [
@@ -86,7 +86,7 @@ export interface Variables extends Linter.RulesRecord {
      * Rule to disallow variable declarations from shadowing variables declared in the outer scope.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-shadow
+     * @see https://eslint.org/docs/latest/rules/no-shadow
      */
     "no-shadow": Linter.RuleEntry<
         [
@@ -116,18 +116,18 @@ export interface Variables extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.1.4
-     * @see https://eslint.org/docs/rules/no-shadow-restricted-names
+     * @see https://eslint.org/docs/latest/rules/no-shadow-restricted-names
      */
     "no-shadow-restricted-names": Linter.RuleEntry<[]>;
 
     /**
-     * Rule to disallow the use of undeclared variables unless mentioned in `global` comments.
+     * Rule to disallow the use of undeclared variables unless mentioned in \/*global *\/ comments.
      *
      * @remarks
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-undef
+     * @see https://eslint.org/docs/latest/rules/no-undef
      */
     "no-undef": Linter.RuleEntry<
         [
@@ -144,7 +144,7 @@ export interface Variables extends Linter.RulesRecord {
      * Rule to disallow initializing variables to `undefined`.
      *
      * @since 0.0.6
-     * @see https://eslint.org/docs/rules/no-undef-init
+     * @see https://eslint.org/docs/latest/rules/no-undef-init
      */
     "no-undef-init": Linter.RuleEntry<[]>;
 
@@ -152,7 +152,7 @@ export interface Variables extends Linter.RulesRecord {
      * Rule to disallow the use of `undefined` as an identifier.
      *
      * @since 0.7.1
-     * @see https://eslint.org/docs/rules/no-undefined
+     * @see https://eslint.org/docs/latest/rules/no-undefined
      */
     "no-undefined": Linter.RuleEntry<[]>;
 
@@ -163,7 +163,7 @@ export interface Variables extends Linter.RulesRecord {
      * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-unused-vars
+     * @see https://eslint.org/docs/latest/rules/no-unused-vars
      */
     "no-unused-vars": Linter.RuleEntry<
         [
@@ -206,7 +206,7 @@ export interface Variables extends Linter.RulesRecord {
      * Rule to disallow the use of variables before they are defined.
      *
      * @since 0.0.9
-     * @see https://eslint.org/docs/rules/no-use-before-define
+     * @see https://eslint.org/docs/latest/rules/no-use-before-define
      */
     "no-use-before-define": Linter.RuleEntry<
         [

--- a/package.json
+++ b/package.json
@@ -82,7 +82,11 @@
       "node tools/fetch-docs-links.js",
       "git add docs/src/_data/further_reading_links.json"
     ],
-    "docs/**/*.svg": "trunk check --fix --filter=svgo"
+    "docs/**/*.svg": "trunk check --fix --filter=svgo",
+    "docs/src/_data/{rules_meta,rule_versions}.json": [
+      "node tools/update-rule-type-headers.js",
+      "git add lib/types/rules/*.ts"
+    ]
   },
   "files": [
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
       "git add docs/src/_data/further_reading_links.json"
     ],
     "docs/**/*.svg": "trunk check --fix --filter=svgo",
-    "docs/src/_data/{rules_meta,rule_versions}.json": [
+    "{lib/rules/*.js,docs/src/_data/rule_versions.json}": [
       "node tools/update-rule-type-headers.js",
       "git add lib/types/rules/*.ts"
     ]

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "lint:unused": "knip",
     "lint:fix": "trunk check -y --ignore=docs/**/*.js -a --filter=eslint && trunk check -y --ignore=docs/**/*.js",
     "lint:fix:docs:js": "trunk check -y --ignore=** --ignore=!docs/**/*.js -a --flter=eslint && trunk check -y --ignore=** --ignore=!docs/**/*.js",
+    "lint:rule-types": "node tools/update-rule-type-headers.js --check",
     "lint:types": "attw --pack",
     "release:generate:alpha": "node Makefile.js generatePrerelease -- alpha",
     "release:generate:beta": "node Makefile.js generatePrerelease -- beta",
@@ -75,18 +76,15 @@
     "*.md": "trunk check --fix --filter=markdownlint",
     "lib/rules/*.js": [
       "node tools/update-eslint-all.js",
-      "git add packages/js/src/configs/eslint-all.js"
+      "node tools/update-rule-type-headers.js",
+      "git add packages/js/src/configs/eslint-all.js \"lib/types/rules/*.ts\""
     ],
     "docs/src/rules/*.md": [
       "node tools/check-rule-examples.js",
       "node tools/fetch-docs-links.js",
       "git add docs/src/_data/further_reading_links.json"
     ],
-    "docs/**/*.svg": "trunk check --fix --filter=svgo",
-    "{lib/rules/*.js,docs/src/_data/rule_versions.json}": [
-      "node tools/update-rule-type-headers.js",
-      "git add lib/types/rules/*.ts"
-    ]
+    "docs/**/*.svg": "trunk check --fix --filter=svgo"
   },
   "files": [
     "LICENSE",

--- a/packages/eslint-config-eslint/base.js
+++ b/packages/eslint-config-eslint/base.js
@@ -60,14 +60,6 @@ const jsConfigs = [js.configs.recommended, {
         "no-process-exit": "off",
         "no-restricted-properties": ["error",
             {
-                property: "substring",
-                message: "Use .slice instead of .substring."
-            },
-            {
-                property: "substr",
-                message: "Use .slice instead of .substr."
-            },
-            {
                 object: "assert",
                 property: "equal",
                 message: "Use assert.strictEqual instead of assert.equal."
@@ -255,6 +247,7 @@ const unicornConfigs = [{
         "unicorn/prefer-at": "error",
         "unicorn/prefer-includes": "error",
         "unicorn/prefer-set-has": "error",
+        "unicorn/prefer-string-slice": "error",
         "unicorn/prefer-string-starts-ends-with": "error",
         "unicorn/prefer-string-trim-start-end": "error"
     }

--- a/packages/eslint-config-eslint/base.js
+++ b/packages/eslint-config-eslint/base.js
@@ -255,7 +255,6 @@ const unicornConfigs = [{
         "unicorn/prefer-at": "error",
         "unicorn/prefer-includes": "error",
         "unicorn/prefer-set-has": "error",
-        "unicorn/prefer-string-slice": "error",
         "unicorn/prefer-string-starts-ends-with": "error",
         "unicorn/prefer-string-trim-start-end": "error"
     }

--- a/tools/update-rule-type-headers.js
+++ b/tools/update-rule-type-headers.js
@@ -66,7 +66,7 @@ function escapeForMultilineComment(line) {
             // In a TSDoc comment, the sequence `*/` ("*" + "/") must be escaped as `*\/`.
             // But escaping inside a markdown code block is not possible, so discard the backticks.
             if (capture.includes("*/")) {
-                return capture.replaceAll(/\//gu, "\\/");
+                return capture.replaceAll("/", "\\/");
             }
             return substring;
         }

--- a/tools/update-rule-type-headers.js
+++ b/tools/update-rule-type-headers.js
@@ -1,0 +1,288 @@
+/**
+ * @fileoverview Script to update the TSDoc header comments of rule types.
+ * This script should be run after `docs/src/_data/rules_meta.json` and `docs/src/_data/rule_versions.json` have been updated.
+ *
+ * @author Francesco Trotta
+ */
+
+"use strict";
+
+//-----------------------------------------------------------------------------
+// Requirements
+//-----------------------------------------------------------------------------
+
+const { readdir, readFile, writeFile } = require("node:fs/promises");
+const { extname, join } = require("node:path");
+const rulesMeta = require("../docs/src/_data/rules_meta.json");
+const { added } = require("../docs/src/_data/rule_versions.json");
+const ts = require("typescript");
+
+//------------------------------------------------------------------------------
+// Typedefs
+//------------------------------------------------------------------------------
+
+/** @typedef {import("eslint").AST.Range} Range */
+/** @typedef {import("eslint").Rule.RuleMetaData} RuleMetaData */
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+/**
+ * Returns the deprecation notice for a rule.
+ * If the provided TSDoc comment contains a `@deprecated` tag followed by some text, the deprecation notice is extracted from there;
+ * otherwise, a standard notice will be created from the name of the replacement rule, if one exists.
+ * @param {string} tsDoc The text of the existing TSDoc comment.
+ * @param {RuleMetaData} ruleMeta The rule's `meta` object.
+ * @returns {string} The deprecation notice for the specified rule.
+ */
+function createDeprecationNotice(tsDoc, ruleMeta) {
+    const match = /\n *\* *@deprecated +(?<notice>.+)\n/u.exec(tsDoc);
+
+    if (match) {
+        return match.groups.notice;
+    }
+    const { replacedBy } = ruleMeta;
+
+    if (replacedBy && replacedBy.length === 1) {
+        const replacement = replacedBy[0];
+        const replacementURL = rulesMeta[replacement].docs.url;
+
+        return `please use [\`${replacement}\`](${replacementURL}).`;
+    }
+    return "";
+}
+
+/**
+ * Escapes a line of markdown text so it can be safely inserted into a TSDoc comment.
+ * @param {string} line A line of markdown text.
+ * @returns {string} The escaped text.
+ */
+function escapeForMultilineComment(line) {
+    return line.replaceAll(
+        /(`*)([^`]+)\1/gu,
+        (substring, backticks, capture) => {
+
+            // In a TSDoc comment, the sequence `*/` ("*" + "/") must be escaped as `*\/`.
+            // But escaping inside a markdown code block is not possible, so discard the backticks.
+            if (capture.includes("*/")) {
+                return capture.replaceAll(/\//gu, "\\/");
+            }
+            return substring;
+        }
+    );
+}
+
+/**
+ * Checks if a declared interface extends `Linter.RulesRecord`.
+ * @param {ts.InterfaceDeclaration} node An `InterfaceDeclaration` node.
+ * @returns {boolean} A boolean value indicating whether the specified interface extends `Linter.RulesRecord`.
+ */
+function extendsRulesRecord(node) {
+    const { heritageClauses } = node;
+
+    if (!heritageClauses) {
+        return false;
+    }
+    for (const heritageClause of heritageClauses) {
+        for (const { expression } of heritageClause.types) {
+            if (expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
+                if (
+                    expression.expression.kind === ts.SyntaxKind.Identifier &&
+                    expression.expression.text === "Linter" &&
+                    expression.name.kind === ts.SyntaxKind.Identifier &&
+                    expression.name.text === "RulesRecord"
+                ) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Creates a TSDoc comment from a list of lines.
+ * @param {ReadonlyArray<string>} lines The lines of the TSDoc comments.
+ * @returns {string} The formatted text of the TSDoc comment.
+ */
+function formatTSDoc(lines) {
+    const formattedLines = ["/**"];
+
+    for (const line of lines) {
+        formattedLines.push(`     *${line ? ` ${line}` : ""}`);
+    }
+    formattedLines.push("     */");
+    return formattedLines.join("\n");
+}
+
+/**
+ * Returns the locations of the TSDoc header comments for each rule in a type declaration file.
+ * If a rule has no header comment the location returned is the start position of the rule name.
+ * @param {string} sourceText The source text of the type declaration file.
+ * @returns {Map<string, Range>} A map of rule names to ranges.
+ * The ranges indicate the locations of the TSDoc header comments in the source.
+ */
+function getTSDocRangeMap(sourceText) {
+    const tsDocRangeMap = new Map();
+    const ast = ts.createSourceFile("", sourceText);
+
+    for (const statement of ast.statements) {
+        if (statement.kind === ts.SyntaxKind.InterfaceDeclaration && extendsRulesRecord(statement)) {
+            const { members } = statement;
+
+            for (const member of members) {
+                if (member.kind === ts.SyntaxKind.PropertySignature) {
+                    const ruleId = member.name.text;
+                    let tsDocRange;
+
+                    // Only the last TSDoc comment is regarded.
+                    const tsDoc = member.jsDoc?.at(-1);
+
+                    if (tsDoc) {
+                        tsDocRange = [tsDoc.pos, tsDoc.end];
+                    } else {
+                        const regExp = /\S/gu;
+
+                        regExp.lastIndex = member.pos;
+                        const { index } = regExp.exec(sourceText);
+
+                        tsDocRange = [index, index];
+                    }
+                    tsDocRangeMap.set(ruleId, tsDocRange);
+                }
+            }
+        }
+    }
+    return tsDocRangeMap;
+}
+
+/**
+ * Rewords a rule description to match the existing conventions for TSDoc header comments.
+ * For example "Require foobar" becomes "Rule to require foobar."
+ * @param {string} description The original rule description.
+ * @returns {string} The reworded rule description.
+ */
+function paraphraseDescription(description) {
+    let newDescription;
+    const match = /^(Disallow|Enforce|Require) /u.exec(description);
+
+    if (match) {
+        newDescription = `Rule to ${description[0].toLowerCase()}${description.slice(1)}`;
+    } else {
+        newDescription = description;
+    }
+    if (!newDescription.endsWith(".")) {
+        newDescription += ".";
+    }
+    return newDescription;
+}
+
+/**
+ * Creates the TSDoc header comment for a rule.
+ * @param {string} ruleId The rule name.
+ * @param {string} currentTSDoc The current TSDoc comment, if any.
+ * @returns {string} The updated TSDoc comment.
+ */
+function createTSDoc(ruleId, currentTSDoc) {
+    const ruleMeta = rulesMeta[ruleId];
+    const ruleDocs = ruleMeta.docs;
+    const since = added[ruleId];
+    const lines = [escapeForMultilineComment(paraphraseDescription(ruleDocs.description)), ""];
+
+    if (ruleDocs.recommended) {
+        lines.push(
+            "@remarks",
+            "Recommended by ESLint, the rule was enabled in `eslint:recommended`.",
+            ""
+        );
+    }
+    if (since) {
+        lines.push(`@since ${since}`);
+    }
+    if (ruleMeta.deprecated) {
+        const deprecationNotice = createDeprecationNotice(currentTSDoc, ruleMeta);
+
+        lines.push(`@deprecated${deprecationNotice ? ` ${deprecationNotice}` : ""}`);
+    }
+    lines.push(`@see ${ruleDocs.url}`);
+    const newTSDoc = formatTSDoc(lines);
+
+    return newTSDoc;
+}
+
+/**
+ * Updates rule header comments in a `.d.ts` file.
+ * @param {string} filePath Pathname of the `.d.ts` file.
+ * @returns {Promise<Iterable<string>>} The names of the rules found in the `.d.ts` file.
+ */
+async function updateTypeDeclaration(filePath) {
+    const sourceText = await readFile(filePath, "utf-8");
+    const tsDocRangeMap = getTSDocRangeMap(sourceText);
+    const chunks = [];
+    let lastPos = 0;
+
+    for (const [ruleId, [tsDocStart, tsDocEnd]] of tsDocRangeMap) {
+        const textBeforeTSDoc = sourceText.slice(lastPos, tsDocStart);
+        const currentTSDoc = sourceText.slice(tsDocStart, tsDocEnd);
+        const newTSDoc = createTSDoc(ruleId, currentTSDoc);
+
+        chunks.push(textBeforeTSDoc, newTSDoc);
+        if (sourceText[tsDocEnd] !== "\n") {
+            chunks.push("\n    ");
+        }
+        lastPos = tsDocEnd;
+    }
+    chunks.push(sourceText.slice(Math.max(0, lastPos)));
+    const newText = chunks.join("");
+
+    await writeFile(filePath, newText);
+    return tsDocRangeMap.keys();
+}
+
+//-----------------------------------------------------------------------------
+// Main
+//-----------------------------------------------------------------------------
+
+(async () => {
+    const dirPath = join(__dirname, "../lib/types/rules");
+    const fileNames = (await readdir(dirPath)).filter(fileName => extname(fileName) === ".ts");
+    const typedRuleIds = new Set();
+    const repeatedRuleIds = new Set();
+    const untypedRuleIds = [];
+
+    await Promise.all(
+        fileNames.map(
+            async fileName => {
+                const ruleIds = await updateTypeDeclaration(join(dirPath, fileName));
+
+                for (const ruleId of ruleIds) {
+                    if (typedRuleIds.has(ruleId)) {
+                        repeatedRuleIds.add(ruleId);
+                    } else {
+                        typedRuleIds.add(ruleId);
+                    }
+                }
+            }
+        )
+    );
+    for (const ruleId of Object.keys(rulesMeta)) {
+        if (!typedRuleIds.has(ruleId)) {
+            untypedRuleIds.push(ruleId);
+        }
+    }
+    if (repeatedRuleIds.size) {
+        console.warn(
+            "The following rules have multiple type definition:%s",
+            [...repeatedRuleIds].map(ruleId => `\n* ${ruleId}`).join("")
+        );
+        process.exitCode = 1;
+    }
+    if (untypedRuleIds.length) {
+        console.warn(
+            "The following rules have no type definition:%s",
+            untypedRuleIds.map(ruleId => `\n* ${ruleId}`).join("")
+        );
+        process.exitCode = 1;
+    }
+})();


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [ ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Fix types

Refs #18912

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Added a script to keep the TSDoc comments on top of rule type declarations in sync with the rule metadata. The script will automatically update the rule description, the recommended notice, `@since` and `@see` tags, and it will add a deprecation notice if not already present. It will throw an error if the types for a rule are missing. Note that the script does not update the rule type itself. This must be still entered manually.
* Some rules were missing types. Manually added types for the following rules:
  * `function-call-argument-newline`
  * `id-denylist`
  * `no-constant-binary-expression`
  * `no-constructor-return`
  * `no-empty-static-block`
  * `no-setter-return`
  * `no-unused-private-class-members`
* Updated lint-staged config to ensure that rule type header comments are updated automatically when a rule source file is updated.
* Updated the CI workflow to run the script in check-only mode when a commit is pushed, making sure that the commit hook is not bypassed.
* Updated `Makefile.js` to run the script during release. This ensures that new rules types are tagged with `@since`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
