### PR TITLE
docs: switch rule examples config format to `languageOptions`

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -197,9 +197,9 @@ module.exports = function(eleventyConfig) {
 
     // markdown-it plugin options for playground-linked code blocks in rule examples.
     const ruleExampleOptions = markdownItRuleExample({
-        open({ type, code, parserOptions, env, codeBlockToken }) {
+        open({ type, code, languageOptions, env, codeBlockToken }) {
 
-            prismESLintHook.addContentMustBeMarked(codeBlockToken.content, parserOptions);
+            prismESLintHook.addContentMustBeMarked(codeBlockToken.content, languageOptions);
 
             const isRuleRemoved = !Object.hasOwn(env.rules_meta, env.title);
 
@@ -207,10 +207,10 @@ module.exports = function(eleventyConfig) {
                 return `<div class="${type}">`;
             }
 
-            // See https://github.com/eslint/eslint.org/blob/ac38ab41f99b89a8798d374f74e2cce01171be8b/src/playground/App.js#L44
+            // See https://github.com/eslint/eslint.org/blob/29e1d8a000592245e4a30c1996e794643e9b263a/src/playground/App.js#L91-L105
             const state = encodeToBase64(
                 JSON.stringify({
-                    options: { parserOptions },
+                    options: languageOptions ? { languageOptions } : void 0,
                     text: code
                 })
             );

--- a/docs/src/rules/jsx-quotes.md
+++ b/docs/src/rules/jsx-quotes.md
@@ -37,7 +37,7 @@ This rule has a string option:
 
 Examples of **incorrect** code for this rule with the default `"prefer-double"` option:
 
-:::incorrect { "ecmaFeatures": { "jsx": true } }
+:::incorrect { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /*eslint jsx-quotes: ["error", "prefer-double"]*/
@@ -49,7 +49,7 @@ Examples of **incorrect** code for this rule with the default `"prefer-double"` 
 
 Examples of **correct** code for this rule with the default `"prefer-double"` option:
 
-:::correct { "ecmaFeatures": { "jsx": true } }
+:::correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /*eslint jsx-quotes: ["error", "prefer-double"]*/
@@ -64,7 +64,7 @@ Examples of **correct** code for this rule with the default `"prefer-double"` op
 
 Examples of **incorrect** code for this rule with the `"prefer-single"` option:
 
-:::incorrect { "ecmaFeatures": { "jsx": true } }
+:::incorrect { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /*eslint jsx-quotes: ["error", "prefer-single"]*/
@@ -76,7 +76,7 @@ Examples of **incorrect** code for this rule with the `"prefer-single"` option:
 
 Examples of **correct** code for this rule with the `"prefer-single"` option:
 
-:::correct { "ecmaFeatures": { "jsx": true } }
+:::correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /*eslint jsx-quotes: ["error", "prefer-single"]*/

--- a/docs/src/rules/keyword-spacing.md
+++ b/docs/src/rules/keyword-spacing.md
@@ -58,7 +58,7 @@ if (foo) {
 
 Examples of **correct** code for this rule with the default `{ "before": true }` option:
 
-::: correct { "ecmaFeatures": { "jsx": true } }
+::: correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /*eslint keyword-spacing: ["error", { "before": true }]*/
@@ -172,7 +172,7 @@ if(foo) {
 
 Examples of **correct** code for this rule with the default `{ "after": true }` option:
 
-::: correct { "ecmaFeatures": { "jsx": true } }
+::: correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /*eslint keyword-spacing: ["error", { "after": true }]*/

--- a/docs/src/rules/no-extra-parens.md
+++ b/docs/src/rules/no-extra-parens.md
@@ -212,7 +212,7 @@ foo ? bar : (baz || qux);
 
 Examples of **correct** code for this rule with the `all` and `{ "ignoreJSX": "all" }` options:
 
-::: correct { "ecmaFeatures": { "jsx": true } }
+::: correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "all" }] */
@@ -228,7 +228,7 @@ const ThatComponent = (
 
 Examples of **incorrect** code for this rule with the `all` and `{ "ignoreJSX": "multi-line" }` options:
 
-::: incorrect { "ecmaFeatures": { "jsx": true } }
+::: incorrect { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "multi-line" }] */
@@ -240,7 +240,7 @@ const ThatComponent = (<div><p /></div>)
 
 Examples of **correct** code for this rule with the `all` and `{ "ignoreJSX": "multi-line" }` options:
 
-::: correct { "ecmaFeatures": { "jsx": true } }
+::: correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "multi-line" }] */
@@ -260,7 +260,7 @@ const ThatComponent = (
 
 Examples of **incorrect** code for this rule with the `all` and `{ "ignoreJSX": "single-line" }` options:
 
-::: incorrect { "ecmaFeatures": { "jsx": true } }
+::: incorrect { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "single-line" }] */
@@ -280,7 +280,7 @@ const ThatComponent = (
 
 Examples of **correct** code for this rule with the `all` and `{ "ignoreJSX": "single-line" }` options:
 
-::: correct { "ecmaFeatures": { "jsx": true } }
+::: correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "single-line" }] */

--- a/docs/src/rules/no-inline-comments.md
+++ b/docs/src/rules/no-inline-comments.md
@@ -54,7 +54,7 @@ Comments inside the curly braces in JSX are allowed to be on the same line as th
 
 Examples of **incorrect** code for this rule:
 
-::: incorrect { "ecmaFeatures": { "jsx": true } }
+::: incorrect { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /*eslint no-inline-comments: "error"*/
@@ -74,7 +74,7 @@ var bar = (
 
 Examples of **correct** code for this rule:
 
-::: correct { "ecmaFeatures": { "jsx": true } }
+::: correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /*eslint no-inline-comments: "error"*/

--- a/docs/src/rules/no-irregular-whitespace.md
+++ b/docs/src/rules/no-irregular-whitespace.md
@@ -202,7 +202,7 @@ function thing() {
 
 Examples of additional **correct** code for this rule with the `{ "skipJSXText": true }` option:
 
-::: correct { "ecmaFeatures": { "jsx": true } }
+::: correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /*eslint no-irregular-whitespace: ["error", { "skipJSXText": true }]*/

--- a/docs/src/rules/no-unused-expressions.md
+++ b/docs/src/rules/no-unused-expressions.md
@@ -251,7 +251,7 @@ JSX is most-commonly used in the React ecosystem, where it is compiled to `React
 
 Examples of **incorrect** code for the `{ "enforceForJSX": true }` option:
 
-::: incorrect { "ecmaFeatures": { "jsx": true } }
+::: incorrect { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /*eslint no-unused-expressions: ["error", { "enforceForJSX": true }]*/
@@ -265,7 +265,7 @@ Examples of **incorrect** code for the `{ "enforceForJSX": true }` option:
 
 Examples of **correct** code for the `{ "enforceForJSX": true }` option:
 
-::: correct { "ecmaFeatures": { "jsx": true } }
+::: correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 /*eslint no-unused-expressions: ["error", { "enforceForJSX": true }]*/

--- a/docs/src/rules/space-before-keywords.md
+++ b/docs/src/rules/space-before-keywords.md
@@ -67,7 +67,7 @@ function bar() {
 
 Examples of **correct** code for this rule with the default `"always"` option:
 
-::: correct { "ecmaFeatures": { "jsx": true } }
+::: correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```js
 /*eslint space-before-keywords: ["error", "always"]*/

--- a/docs/tools/markdown-it-rule-example.js
+++ b/docs/tools/markdown-it-rule-example.js
@@ -10,7 +10,7 @@ const { docsExampleCodeToParsableCode } = require("./code-block-utils");
  * @param {Object} data Callback data.
  * @param {"correct" | "incorrect"} data.type The type of the example.
  * @param {string} data.code The example code.
- * @param {LanguageOptions} data.languageOptions The language options to be passed to the Playground.
+ * @param {LanguageOptions | undefined} data.languageOptions The language options to be passed to the Playground.
  * @param {Object} data.codeBlockToken The `markdown-it` token for the code block inside the container.
  * @param {Object} data.env Additional Eleventy metadata, if available.
  * @returns {string | undefined} If a text is returned, it will be appended to the rendered output

--- a/docs/tools/markdown-it-rule-example.js
+++ b/docs/tools/markdown-it-rule-example.js
@@ -2,7 +2,7 @@
 
 const { docsExampleCodeToParsableCode } = require("./code-block-utils");
 
-/** @typedef {import("../../lib/shared/types").ParserOptions} ParserOptions */
+/** @typedef {import("../../lib/shared/types").LanguageOptions} LanguageOptions */
 
 /**
  * A callback function to handle the opening of container blocks.
@@ -10,7 +10,7 @@ const { docsExampleCodeToParsableCode } = require("./code-block-utils");
  * @param {Object} data Callback data.
  * @param {"correct" | "incorrect"} data.type The type of the example.
  * @param {string} data.code The example code.
- * @param {ParserOptions} data.parserOptions The parser options to be passed to the Playground.
+ * @param {LanguageOptions} data.languageOptions The language options to be passed to the Playground.
  * @param {Object} data.codeBlockToken The `markdown-it` token for the code block inside the container.
  * @param {Object} data.env Additional Eleventy metadata, if available.
  * @returns {string | undefined} If a text is returned, it will be appended to the rendered output
@@ -31,7 +31,7 @@ const { docsExampleCodeToParsableCode } = require("./code-block-utils");
  *
  * - Ensure that the plugin instance only matches container blocks tagged with 'correct' or
  * 'incorrect'.
- * - Parse the optional `parserOptions` after the correct/incorrect tag.
+ * - Parse the optional `languageOptions` after the correct/incorrect tag.
  * - Apply common transformations to the code inside the code block, like stripping '⏎' at the end
  * of a line or the last newline character.
  *
@@ -47,7 +47,7 @@ const { docsExampleCodeToParsableCode } = require("./code-block-utils");
  *
  * markdownIt()
  *     .use(markdownItContainer, "rule-example", markdownItRuleExample({
- *         open({ type, code, parserOptions, codeBlockToken, env }) {
+ *         open({ type, code, languageOptions, codeBlockToken, env }) {
  *             // do something
  *         }
  *         close() {
@@ -72,14 +72,14 @@ function markdownItRuleExample({ open, close }) {
                 return typeof text === "string" ? text : "";
             }
 
-            const { type, parserOptionsJSON } = /^\s*(?<type>\S+)(\s+(?<parserOptionsJSON>\S.*?))?\s*$/u.exec(tagToken.info).groups;
-            const parserOptions = { sourceType: "module", ...(parserOptionsJSON && JSON.parse(parserOptionsJSON)) };
+            const { type, languageOptionsJSON } = /^\s*(?<type>\S+)(\s+(?<languageOptionsJSON>\S.*?))?\s*$/u.exec(tagToken.info).groups;
+            const languageOptions = languageOptionsJSON ? JSON.parse(languageOptionsJSON) : void 0;
             const codeBlockToken = tokens[index + 1];
 
             // Remove trailing newline and presentational `⏎` characters (https://github.com/eslint/eslint/issues/17627):
             const code = docsExampleCodeToParsableCode(codeBlockToken.content);
 
-            const text = open({ type, code, parserOptions, codeBlockToken, env });
+            const text = open({ type, code, languageOptions, codeBlockToken, env });
 
             // Return an empty string to avoid appending unexpected text to the output.
             return typeof text === "string" ? text : "";

--- a/docs/tools/prism-eslint-hook.js
+++ b/docs/tools/prism-eslint-hook.js
@@ -27,7 +27,7 @@ try {
     // ignore
 }
 
-/** @typedef {import("../../lib/shared/types").ParserOptions} ParserOptions */
+/** @typedef {import("../../lib/shared/types").LanguageOptions} LanguageOptions */
 
 /**
  * Content that needs to be marked with ESLint
@@ -37,19 +37,19 @@ let contentMustBeMarked;
 
 /**
  * Parser options received from the `::: incorrect` or `::: correct` container.
- * @type {ParserOptions|undefined}
+ * @type {LanguageOptions|undefined}
  */
-let contentParserOptions;
+let contentLanguageOptions;
 
 /**
  * Set content that needs to be marked.
  * @param {string} content Source code content that marks ESLint errors.
- * @param {ParserOptions} options The options used for validation.
+ * @param {LanguageOptions} options The options used for validation.
  * @returns {void}
  */
 function addContentMustBeMarked(content, options) {
     contentMustBeMarked = content;
-    contentParserOptions = options;
+    contentLanguageOptions = options;
 }
 
 /**
@@ -113,7 +113,7 @@ function installPrismESLintMarkerHook() {
             return;
         }
         contentMustBeMarked = void 0;
-        const parserOptions = contentParserOptions;
+        const config = contentLanguageOptions ? { languageOptions: contentLanguageOptions } : {};
 
         const code = env.code;
 
@@ -148,7 +148,7 @@ function installPrismESLintMarkerHook() {
 
             // Remove trailing newline and presentational `⏎` characters
             docsExampleCodeToParsableCode(code),
-            { languageOptions: { sourceType: parserOptions.sourceType, parserOptions } },
+            config,
             { filename: "code.js" }
         );
 

--- a/tests/fixtures/good-examples.md
+++ b/tests/fixtures/good-examples.md
@@ -19,7 +19,7 @@ const foo = <bar></bar>;
 
 A test with multiple spaces after 'correct':
 <!-- markdownlint-disable-next-line no-trailing-spaces -->
-:::correct
+:::correct  
 
 ```js
 ```

--- a/tests/fixtures/good-examples.md
+++ b/tests/fixtures/good-examples.md
@@ -9,7 +9,7 @@ export default⏎
 
 :::
 
-::: correct { "ecmaFeatures": { "jsx": true } }
+::: correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
 ```jsx
 const foo = <bar></bar>;
@@ -19,7 +19,7 @@ const foo = <bar></bar>;
 
 A test with multiple spaces after 'correct':
 <!-- markdownlint-disable-next-line no-trailing-spaces -->
-:::correct  
+:::correct
 
 ```js
 ```


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Updates docs site generator to treat configs after `::: correct`/`::: incorrect` as `languageOptions` instead of legacy `parserOptions`. This aligns rule example configs with the current config format and thus makes it easier to reason about them.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Updated code that underlines lint errors in rule examples accordingly.
* Updated tool that verifies rule examples accordingly.
* Updated code that generates Playground links to pass serialized configs in the current flat config format instead of legacy eslintrc config format.
* Optimized Playground links to not include serialized configs when there's no need for them (i.e. when the default config applies).

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
