### PR TITLE
docs: add missing backticks to `sort-imports`

### DIFF
--- a/docs/src/_data/rules_meta.json
+++ b/docs/src/_data/rules_meta.json
@@ -2894,7 +2894,7 @@
             }
         ],
         "docs": {
-            "description": "Enforce sorted import declarations within modules",
+            "description": "Enforce sorted `import` declarations within modules",
             "recommended": false,
             "frozen": true,
             "url": "https://eslint.org/docs/latest/rules/sort-imports"

--- a/docs/src/rules/sort-imports.md
+++ b/docs/src/rules/sort-imports.md
@@ -8,7 +8,7 @@ related_rules:
 
 
 
-The import statement is used to import members (functions, objects or primitives) that have been exported from an external module. Using a specific member syntax:
+The `import` statement is used to import members (functions, objects or primitives) that have been exported from an external module. Using a specific member syntax:
 
 ```js
 // single - Import single member.
@@ -22,18 +22,18 @@ import {foo, bar} from "my-module.js";
 import * as myModule from "my-module.js";
 ```
 
-The import statement can also import a module without exported bindings. Used when the module does not export anything, but runs it own code or changes the global context object.
+The `import` statement can also import a module without exported bindings. Used when the module does not export anything, but runs it own code or changes the global context object.
 
 ```js
 // none - Import module without exported bindings.
 import "my-module.js"
 ```
 
-When declaring multiple imports, a sorted list of import declarations make it easier for developers to read the code and find necessary imports later. This rule is purely a matter of style.
+When declaring multiple imports, a sorted list of `import` declarations make it easier for developers to read the code and find necessary imports later. This rule is purely a matter of style.
 
 ## Rule Details
 
-This rule checks all import declarations and verifies that all imports are first sorted by the used member syntax and then alphabetically by the first member or alias name.
+This rule checks all `import` declarations and verifies that all imports are first sorted by the used member syntax and then alphabetically by the first member or alias name.
 
 The `--fix` option on the command line automatically fixes some problems reported by this rule: multiple members on a single line are automatically sorted (e.g. `import { b, a } from 'foo.js'` is corrected to `import { a, b } from 'foo.js'`), but multiple lines are not reordered.
 

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rule to require sorting of import declarations
+ * @fileoverview Rule to enforce sorted `import` declarations within modules
  * @author Christian Schuller
  */
 
@@ -23,7 +23,7 @@ module.exports = {
         }],
 
         docs: {
-            description: "Enforce sorted import declarations within modules",
+            description: "Enforce sorted `import` declarations within modules",
             recommended: false,
             frozen: true,
             url: "https://eslint.org/docs/latest/rules/sort-imports"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,

I've added missing backticks to `sort-imports`.

I believe the word `import` should be wrapped in backticks, as it represents a declaration.

I've also updated `@fileoverview` to sync with the `description` property.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
