### PR TITLE
docs: add limitation section in `no-loop-func`

### DIFF
--- a/docs/src/rules/no-loop-func.md
+++ b/docs/src/rules/no-loop-func.md
@@ -141,7 +141,7 @@ for (var i = 0; i < 5; i++) {
 
 :::
 
-## Limitation
+## Known Limitations
 
 The rule cannot identify whether the function instance is just immediately invoked and then discarded, or possibly stored for later use.
 

--- a/docs/src/rules/no-loop-func.md
+++ b/docs/src/rules/no-loop-func.md
@@ -140,3 +140,20 @@ for (var i = 0; i < 5; i++) {
 ```
 
 :::
+
+## Limitation
+
+The rule cannot identify whether the function instance is just immediately invoked and then discarded, or possibly stored for later use.
+
+```js
+const foo = [1, 2, 3, 4];
+var i = 0;
+
+while(foo.some(e => e > i)){
+    i += 1;
+}
+```
+
+Here the `some` method immediately executes the callback function for each element in the array and then discards the function instance. The function is not stored or reused beyond the scope of the loop iteration. So, this will work as intended.
+
+`eslint-disable` comments can be used in such cases.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added Limitation section in `no-loop-func` rule that stats: 
>The rule cannot identify whether the function instance is just immediately invoked and then discarded, or possibly stored for later use.

#### Is there anything you'd like reviewers to focus on?
Fixes #19120

<!-- markdownlint-disable-file MD004 -->
