### PR TITLE
fix: correct `overrideConfigFile` type

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1484,7 +1484,7 @@ export namespace ESLint {
         allowInlineConfig?: boolean | undefined;
         baseConfig?: Linter.Config | Linter.Config[] | null | undefined;
         overrideConfig?: Linter.Config | Linter.Config[] | null | undefined;
-        overrideConfigFile?: string | boolean | undefined;
+        overrideConfigFile?: string | true | null | undefined;
         plugins?: Record<string, Plugin> | null | undefined;
         ruleFilter?: ((arg: { ruleId: string; severity: Exclude<Linter.Severity, 0> }) => boolean) | undefined;
         stats?: boolean | undefined;

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -927,8 +927,6 @@ linterWithEslintrcConfig.getRules();
     eslint = new ESLint();
     eslint = new ESLint({ allowInlineConfig: false });
     eslint = new ESLint({ baseConfig: {} });
-    eslint = new ESLint({ overrideConfig: {} });
-    eslint = new ESLint({ overrideConfigFile: "foo" });
     eslint = new ESLint({ cache: true });
     eslint = new ESLint({ cacheLocation: "foo" });
     eslint = new ESLint({ cacheStrategy: "content" });
@@ -941,6 +939,14 @@ linterWithEslintrcConfig.getRules();
     eslint = new ESLint({ globInputPaths: true });
     eslint = new ESLint({ ignore: true });
     eslint = new ESLint({ ignorePatterns: ["foo", "bar"] });
+    eslint = new ESLint({ overrideConfig: {} });
+
+    eslint = new ESLint({ overrideConfigFile: "foo" });
+    eslint = new ESLint({ overrideConfigFile: true });
+    eslint = new ESLint({ overrideConfigFile: null });
+    // @ts-expect-error `overrideConfigFile` cannot be `false`
+    eslint = new ESLint({ overrideConfigFile: false });
+
     eslint = new ESLint({ plugins: { foo: {} } });
     eslint = new ESLint({
         ruleFilter({ severity }) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v22.12.0
npm version: v10.9.0
Local ESLint version: v9.17.0 (Currently used)
Global ESLint version: Not found
Operating System: darwin 24.1.0

**What parser are you using (place an "X" next to just one item)?**

[X] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

no configuration

**What did you do? Please include the actual source code causing the issue.**

```ts
// index.ts
import { ESLint } from "eslint";

const eslint = new ESLint({ overrideConfigFile: false });
```

**What did you expect to happen?**

A TypeScript compiler error since `overrideConfigFile` can be only `string`, `true`, `null` or `undefined`.

**What actually happened? Please include the actual, raw output from ESLint.**

No error.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed `overrideConfigFile` type to disallow a value of `false` and allow `null`.

After this change, `overrideConfigFile: false` in the `ESLint` constructor options will be recognized as a type error.

![image](https://github.com/user-attachments/assets/9c88d216-0e88-496e-acd4-ba55e154df03)

#### Is there anything you'd like reviewers to focus on?

Refs #19262

<!-- markdownlint-disable-file MD004 -->
