### PR TITLE
docs: replace `var` with `let` and `const` in rule example

### DIFF
--- a/docs/src/rules/no-ex-assign.md
+++ b/docs/src/rules/no-ex-assign.md
@@ -40,7 +40,7 @@ Examples of **correct** code for this rule:
 try {
     // code
 } catch (e) {
-    var foo = 10;
+    const foo = 10;
 }
 ```
 

--- a/docs/src/rules/no-func-assign.md
+++ b/docs/src/rules/no-func-assign.md
@@ -6,7 +6,7 @@ handled_by_typescript: true
 
 
 
-JavaScript functions can be written as a FunctionDeclaration `function foo() { ... }` or as a FunctionExpression `var foo = function() { ... };`. While a JavaScript interpreter might tolerate it, overwriting/reassigning a function written as a FunctionDeclaration is often indicative of a mistake or issue.
+JavaScript functions can be written as a FunctionDeclaration `function foo() { ... }` or as a FunctionExpression `const foo = function() { ... };`. While a JavaScript interpreter might tolerate it, overwriting/reassigning a function written as a FunctionDeclaration is often indicative of a mistake or issue.
 
 ```js
 function foo() {}
@@ -66,7 +66,7 @@ function baz(baz) { // `baz` is shadowed.
 }
 
 function qux() {
-    var qux = bar;  // `qux` is shadowed.
+    const qux = bar;  // `qux` is shadowed.
 }
 ```
 

--- a/docs/src/rules/no-func-assign.md
+++ b/docs/src/rules/no-func-assign.md
@@ -31,7 +31,7 @@ function baz() {
     baz = bar;
 }
 
-var a = function hello() {
+let a = function hello() {
   hello = 123;
 };
 ```
@@ -58,7 +58,7 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-func-assign: "error"*/
 
-var foo = function () {}
+let foo = function () {}
 foo = bar;
 
 function baz(baz) { // `baz` is shadowed.

--- a/docs/src/rules/no-irregular-whitespace.md
+++ b/docs/src/rules/no-irregular-whitespace.md
@@ -81,31 +81,31 @@ Examples of **incorrect** code for this rule with the default `{ "skipStrings": 
 ```js
 /*eslint no-irregular-whitespace: "error"*/
 
-var thing = function() /*<NBSP>*/{
+const thing = function() /*<NBSP>*/{
     return 'test';
 }
 
-var thing = function( /*<NBSP>*/){
+const foo = function( /*<NBSP>*/){
     return 'test';
 }
 
-var thing = function /*<NBSP>*/(){
+const bar = function /*<NBSP>*/(){
     return 'test';
 }
 
-var thing = function /*<Ogham Space Mark>*/(){
+const baz = function /*<Ogham Space Mark>*/(){
     return 'test';
 }
 
-var thing = function() {
+const qux = function() {
     return 'test'; /*<ENSP>*/
 }
 
-var thing = function() {
+const quux = function() {
     return 'test'; /*<NBSP>*/
 }
 
-var thing = function() {
+const item = function() {
     // Description <NBSP>: some descriptive text
 }
 
@@ -113,11 +113,11 @@ var thing = function() {
 Description <NBSP>: some descriptive text
 */
 
-var thing = function() {
+const func = function() {
     return / <NBSP>regexp/;
 }
 
-var thing = function() {
+const myFunc = function() {
     return `template <NBSP>string`;
 }
 ```
@@ -131,15 +131,15 @@ Examples of **correct** code for this rule with the default `{ "skipStrings": tr
 ```js
 /*eslint no-irregular-whitespace: "error"*/
 
-var thing = function() {
+const thing = function() {
     return ' <NBSP>thing';
 }
 
-var thing = function() {
+const foo = function() {
     return '​<ZWSP>thing';
 }
 
-var thing = function() {
+const bar = function() {
     return 'th <NBSP>ing';
 }
 ```

--- a/docs/src/rules/no-new-native-nonconstructor.md
+++ b/docs/src/rules/no-new-native-nonconstructor.md
@@ -16,10 +16,10 @@ It is a convention in JavaScript that global variables beginning with an upperca
 
 ```js
 // throws a TypeError
-let foo = new Symbol("foo");
+const foo = new Symbol("foo");
 
 // throws a TypeError
-let result = new BigInt(9007199254740991);
+const result = new BigInt(9007199254740991);
 ```
 
 Both `new Symbol` and `new BigInt` throw a type error because they are functions and not classes. It is easy to make this mistake by assuming the uppercase letters indicate classes.
@@ -40,8 +40,8 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-new-native-nonconstructor: "error"*/
 
-var foo = new Symbol('foo');
-var bar = new BigInt(9007199254740991);
+const foo = new Symbol('foo');
+const bar = new BigInt(9007199254740991);
 ```
 
 :::
@@ -53,8 +53,8 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-new-native-nonconstructor: "error"*/
 
-var foo = Symbol('foo');
-var bar = BigInt(9007199254740991);
+const foo = Symbol('foo');
+const bar = BigInt(9007199254740991);
 
 // Ignores shadowed Symbol.
 function baz(Symbol) {

--- a/docs/src/rules/no-obj-calls.md
+++ b/docs/src/rules/no-obj-calls.md
@@ -39,25 +39,25 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-obj-calls: "error"*/
 
-var math = Math();
+const math = Math();
 
-var newMath = new Math();
+const newMath = new Math();
 
-var json = JSON();
+const json = JSON();
 
-var newJSON = new JSON();
+const newJSON = new JSON();
 
-var reflect = Reflect();
+const reflect = Reflect();
 
-var newReflect = new Reflect();
+const newReflect = new Reflect();
 
-var atomics = Atomics();
+const atomics = Atomics();
 
-var newAtomics = new Atomics();
+const newAtomics = new Atomics();
 
-var intl = Intl();
+const intl = Intl();
 
-var newIntl = new Intl();
+const newIntl = new Intl();
 ```
 
 :::
@@ -73,13 +73,13 @@ function area(r) {
     return Math.PI * r * r;
 }
 
-var object = JSON.parse("{}");
+const object = JSON.parse("{}");
 
-var value = Reflect.get({ x: 1, y: 2 }, "x");
+const value = Reflect.get({ x: 1, y: 2 }, "x");
 
-var first = Atomics.load(foo, 0);
+const first = Atomics.load(foo, 0);
 
-var segmenterFr = new Intl.Segmenter("fr", { granularity: "word" });
+const segmenterFr = new Intl.Segmenter("fr", { granularity: "word" });
 ```
 
 :::


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Replaced `var` with `let` and `const` in following rule examples:
`no-ex-assign`
`no-func-assign`
`no-irregular-whitespace`
`no-new-native-nonconstructor`
`no-obj-calls`

#### Is there anything you'd like reviewers to focus on?
Ref #19240

<!-- markdownlint-disable-file MD004 -->
