### PR TITLE
docs: update getting-started config to match default generated config

### DIFF
--- a/docs/src/use/getting-started.md
+++ b/docs/src/use/getting-started.md
@@ -72,18 +72,18 @@ The `pluginJs.configs.recommended` object contains configuration to ensure that 
 You can configure rules individually by defining a new object with a `rules` key, as in this example:
 
 ```js
-   import pluginJs from "@eslint/js";
+import pluginJs from "@eslint/js";
 
-   export default [
-       pluginJs.configs.recommended,
+export default [
+    pluginJs.configs.recommended,
 
-      {
-          rules: {
-              "no-unused-vars": "warn",
-              "no-undef": "warn"
-          }
-      }
-   ];
+    {
+        rules: {
+            "no-unused-vars": "warn",
+            "no-undef": "warn"
+        }
+    }
+];
 ```
 
 The names `"no-unused-vars"` and `"no-undef"` are the names of [rules](../rules) in ESLint. The first value is the error level of the rule and can be one of these values:

--- a/docs/src/use/getting-started.md
+++ b/docs/src/use/getting-started.md
@@ -51,43 +51,19 @@ After that, you can run ESLint on any file or directory like this:
 
 **Note:** If you are coming from a version before 9.0.0 please see the [migration guide](configure/migration-guide).
 
-After running `npm init @eslint/config`, you'll have an `eslint.config.js` (or `eslint.config.mjs`) file in your directory. In it, you'll see some rules configured like this:
+When you run `npm init @eslint/config` , terminal would provide you different options to create a config file `eslint.config.js` (or `eslint.config.mjs`) as per your need .
+
+For example if you select *browser* and choose to install the *dependencies* , you will get a config like the one shown below .
 
 ```js
-// eslint.config.js
+import globals from "globals";
+import pluginJs from "@eslint/js";
+
+
+/** @type {import('eslint').Linter.Config[]} */
 export default [
-    {
-        rules: {
-            "no-unused-vars": "error",
-            "no-undef": "error"
-        }
-    }
-];
-```
-
-The names `"no-unused-vars"` and `"no-undef"` are the names of [rules](../rules) in ESLint. The first value is the error level of the rule and can be one of these values:
-
-* `"off"` or `0` - turn the rule off
-* `"warn"` or `1` - turn the rule on as a warning (doesn't affect exit code)
-* `"error"` or `2` - turn the rule on as an error (exit code will be 1)
-
-The three error levels allow you fine-grained control over how ESLint applies rules (for more configuration options and details, see the [configuration docs](configure/)).
-
-Your `eslint.config.js` configuration file will also include a recommended configuration, like this:
-
-```js
-// eslint.config.js
-import js from "@eslint/js";
-
-export default [
-    js.configs.recommended,
-
-    {
-        rules: {
-            "no-unused-vars": "warn",
-            "no-undef": "warn"
-        }
-    }
+  {languageOptions: { globals: globals.browser }},
+  pluginJs.configs.recommended,
 ];
 ```
 

--- a/docs/src/use/getting-started.md
+++ b/docs/src/use/getting-started.md
@@ -69,6 +69,30 @@ export default [
 
 The `pluginJs.configs.recommended` object contains configuration to ensure that all of the rules marked as recommended on the [rules page](../rules) will be turned on.  Alternatively, you can use configurations that others have created by searching for "eslint-config" on [npmjs.com](https://www.npmjs.com/search?q=eslint-config).  ESLint will not lint your code unless you extend from a shared configuration or explicitly turn rules on in your configuration.
 
+We can add `rules` as following:
+
+```js
+   import pluginJs from "@eslint/js";
+
+   export default [
+       pluginJs.configs.recommended,
+
+      {
+          rules: {
+              "no-unused-vars": "warn",
+              "no-undef": "warn"
+          }
+      }
+   ];
+```
+The names `"no-unused-vars"` and `"no-undef"` are the names of [rules](../rules) in ESLint. The first value is the error level of the rule and can be one of these values:
+
+- "off" or 0 - turn the rule off
+- "warn" or 1 - turn the rule on as a warning (doesn’t affect exit code)
+- "error" or 2 - turn the rule on as an error (exit code will be 1)
+
+The three error levels allow you fine-grained control over how ESLint applies rules (for more configuration options and details, see the configuration docs).
+
 ## Global Install
 
 It is also possible to install ESLint globally, rather than locally, using `npm install eslint --global`. However, this is not recommended, and any plugins or shareable configs that you use must still be installed locally if you install ESLint globally.

--- a/docs/src/use/getting-started.md
+++ b/docs/src/use/getting-started.md
@@ -69,7 +69,7 @@ export default [
 
 The `pluginJs.configs.recommended` object contains configuration to ensure that all of the rules marked as recommended on the [rules page](../rules) will be turned on.  Alternatively, you can use configurations that others have created by searching for "eslint-config" on [npmjs.com](https://www.npmjs.com/search?q=eslint-config).  ESLint will not lint your code unless you extend from a shared configuration or explicitly turn rules on in your configuration.
 
-We can add `rules` as following:
+You can configure rules individually by defining a new object with a `rules` key, as in this example:
 
 ```js
    import pluginJs from "@eslint/js";

--- a/docs/src/use/getting-started.md
+++ b/docs/src/use/getting-started.md
@@ -51,9 +51,9 @@ After that, you can run ESLint on any file or directory like this:
 
 **Note:** If you are coming from a version before 9.0.0 please see the [migration guide](configure/migration-guide).
 
-When you run `npm init @eslint/config` , terminal would provide you different options to create a config file `eslint.config.js` (or `eslint.config.mjs`) as per your need .
+When you run `npm init @eslint/config` ,terminal would provide you different options to create a config file `eslint.config.js` (or `eslint.config.mjs`) as per your need.
 
-For example if you select *browser* and choose to install the *dependencies* , you will get a config like the one shown below .
+For example if you select *browser` and choose to install the `dependencies` ,you will get a config like the one shown below.
 
 ```js
 import globals from "globals";

--- a/docs/src/use/getting-started.md
+++ b/docs/src/use/getting-started.md
@@ -51,9 +51,9 @@ After that, you can run ESLint on any file or directory like this:
 
 **Note:** If you are coming from a version before 9.0.0 please see the [migration guide](configure/migration-guide).
 
-When you run `npm init @eslint/config`, you'll be asked a series of questions to determine how you're using ESLint and what options should be included. After answering these questions, you'll have an `eslint.config.js` (or `eslint-config.mjs`) file created in your directory.
+When you run `npm init @eslint/config`, you'll be asked a series of questions to determine how you're using ESLint and what options should be included. After answering these questions, you'll have an `eslint.config.js` (or `eslint.config.mjs`) file created in your directory.
 
-For example,one of the questions is "Where does your code run?" If you select "Browser" then your configuration file will contain the definitions for global variables found in web browsers. Here's an example .
+For example, one of the questions is "Where does your code run?" If you select "Browser" then your configuration file will contain the definitions for global variables found in web browsers. Here's an example:
 
 ```js
 import globals from "globals";

--- a/docs/src/use/getting-started.md
+++ b/docs/src/use/getting-started.md
@@ -51,9 +51,9 @@ After that, you can run ESLint on any file or directory like this:
 
 **Note:** If you are coming from a version before 9.0.0 please see the [migration guide](configure/migration-guide).
 
-When you run `npm init @eslint/config`, terminal would provide you different options to create a config file `eslint.config.js` (or `eslint.config.mjs`) as per your need.
+When you run `npm init @eslint/config`, you'll be asked a series of questions to determine how you're using ESLint and what options should be included. After answering these questions, you'll have an `eslint.config.js` (or `eslint-config.mjs`) file created in your directory.
 
-For example if you select "browser" and choose to install the `dependencies`, you will get a config like the one shown below.
+For example,one of the questions is "Where does your code run?" If you select "Browser" then your configuration file will contain the definitions for global variables found in web browsers. Here's an example .
 
 ```js
 import globals from "globals";

--- a/docs/src/use/getting-started.md
+++ b/docs/src/use/getting-started.md
@@ -67,7 +67,7 @@ export default [
 ];
 ```
 
-The `js.configs.recommended` object contains configuration to ensure that all of the rules marked as recommended on the [rules page](../rules) will be turned on.  Alternatively, you can use configurations that others have created by searching for "eslint-config" on [npmjs.com](https://www.npmjs.com/search?q=eslint-config).  ESLint will not lint your code unless you extend from a shared configuration or explicitly turn rules on in your configuration.
+The `pluginJs.configs.recommended` object contains configuration to ensure that all of the rules marked as recommended on the [rules page](../rules) will be turned on.  Alternatively, you can use configurations that others have created by searching for "eslint-config" on [npmjs.com](https://www.npmjs.com/search?q=eslint-config).  ESLint will not lint your code unless you extend from a shared configuration or explicitly turn rules on in your configuration.
 
 ## Global Install
 
@@ -97,10 +97,10 @@ Before you begin, you must already have a `package.json` file. If you don't, mak
 1. Add configuration to the `eslint.config.js` file. Refer to the [Configure ESLint documentation](configure/) to learn how to add rules, custom configurations, plugins, and more.
 
    ```js
-   import js from "@eslint/js";
+   import pluginJs from "@eslint/js";
 
    export default [
-       js.configs.recommended,
+       pluginJs.configs.recommended,
 
       {
           rules: {

--- a/docs/src/use/getting-started.md
+++ b/docs/src/use/getting-started.md
@@ -53,7 +53,7 @@ After that, you can run ESLint on any file or directory like this:
 
 When you run `npm init @eslint/config`, terminal would provide you different options to create a config file `eslint.config.js` (or `eslint.config.mjs`) as per your need.
 
-For example if you select *browser` and choose to install the `dependencies`, you will get a config like the one shown below.
+For example if you select "browser" and choose to install the `dependencies`, you will get a config like the one shown below.
 
 ```js
 import globals from "globals";

--- a/docs/src/use/getting-started.md
+++ b/docs/src/use/getting-started.md
@@ -85,11 +85,12 @@ We can add `rules` as following:
       }
    ];
 ```
+
 The names `"no-unused-vars"` and `"no-undef"` are the names of [rules](../rules) in ESLint. The first value is the error level of the rule and can be one of these values:
 
-- "off" or 0 - turn the rule off
-- "warn" or 1 - turn the rule on as a warning (doesn’t affect exit code)
-- "error" or 2 - turn the rule on as an error (exit code will be 1)
+* "off" or 0 - turn the rule off
+* "warn" or 1 - turn the rule on as a warning (doesn’t affect exit code)
+* "error" or 2 - turn the rule on as an error (exit code will be 1)
 
 The three error levels allow you fine-grained control over how ESLint applies rules (for more configuration options and details, see the configuration docs).
 

--- a/docs/src/use/getting-started.md
+++ b/docs/src/use/getting-started.md
@@ -51,9 +51,9 @@ After that, you can run ESLint on any file or directory like this:
 
 **Note:** If you are coming from a version before 9.0.0 please see the [migration guide](configure/migration-guide).
 
-When you run `npm init @eslint/config` ,terminal would provide you different options to create a config file `eslint.config.js` (or `eslint.config.mjs`) as per your need.
+When you run `npm init @eslint/config`, terminal would provide you different options to create a config file `eslint.config.js` (or `eslint.config.mjs`) as per your need.
 
-For example if you select *browser` and choose to install the `dependencies` ,you will get a config like the one shown below.
+For example if you select *browser` and choose to install the `dependencies`, you will get a config like the one shown below.
 
 ```js
 import globals from "globals";


### PR DESCRIPTION
Updated the config example to make it almost match with default config .

#### Prerequisites checklist

- [ X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


#### What changes did you make? (Give an overview)

- The default generated config of eslint was very different from the one mentioned in the getting started section of doc.
- I replaced this with new config which minimizes the differences between the default config generated when the command ``npm init @eslint/config@latest`` is run . 

#### Is there anything you'd like reviewers to focus on?

- This is my first time contributing to eslint so feel free to guide me if I'm doing something wrong.

I wen't through contributing guide and I think It can be improved . Here is what I noticed

- It already assumes your repo has upstream url added which could be annoying for someone who's contributing for first time

Fixes #19283 


