### PR TITLE
docs: add missing backticks to `default-case-last`

### DIFF
--- a/docs/src/_data/rules_meta.json
+++ b/docs/src/_data/rules_meta.json
@@ -295,7 +295,7 @@
     "default-case-last": {
         "type": "suggestion",
         "docs": {
-            "description": "Enforce `default` clauses in switch statements to be last",
+            "description": "Enforce `default` clauses in `switch` statements to be last",
             "recommended": false,
             "url": "https://eslint.org/docs/latest/rules/default-case-last"
         }

--- a/lib/rules/default-case-last.js
+++ b/lib/rules/default-case-last.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rule to enforce `default` clauses in switch statements to be last
+ * @fileoverview Rule to enforce `default` clauses in `switch` statements to be last
  * @author Milos Djermanovic
  */
 
@@ -15,7 +15,7 @@ module.exports = {
         type: "suggestion",
 
         docs: {
-            description: "Enforce `default` clauses in switch statements to be last",
+            description: "Enforce `default` clauses in `switch` statements to be last",
             recommended: false,
             url: "https://eslint.org/docs/latest/rules/default-case-last"
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,

I've added missing backticks to `default-case-last.js`.

The `switch` statement is consistenly wrapped in backticks all around documentation.

![image](https://github.com/user-attachments/assets/2af6861d-24ed-44f1-b4a9-010e881d4920)


#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
