### PR TITLE
docs: rewrite var with const in rules examples

### DIFF
--- a/docs/src/rules/max-statements.md
+++ b/docs/src/rules/max-statements.md
@@ -16,9 +16,9 @@ The `max-statements` rule allows you to specify the maximum number of statements
 
 ```js
 function foo() {
-  var bar = 1; // one statement
-  var baz = 2; // two statements
-  var qux = 3; // three statements
+  const bar = 1; // one statement
+  const baz = 2; // two statements
+  const qux = 3; // three statements
 }
 ```
 
@@ -48,33 +48,33 @@ Examples of **incorrect** code for this rule with the default `{ "max": 10 }` op
 /*eslint max-statements: ["error", 10]*/
 
 function foo() {
-  var foo1 = 1;
-  var foo2 = 2;
-  var foo3 = 3;
-  var foo4 = 4;
-  var foo5 = 5;
-  var foo6 = 6;
-  var foo7 = 7;
-  var foo8 = 8;
-  var foo9 = 9;
-  var foo10 = 10;
+  const foo1 = 1;
+  const foo2 = 2;
+  const foo3 = 3;
+  const foo4 = 4;
+  const foo5 = 5;
+  const foo6 = 6;
+  const foo7 = 7;
+  const foo8 = 8;
+  const foo9 = 9;
+  const foo10 = 10;
 
-  var foo11 = 11; // Too many.
+  const foo11 = 11; // Too many.
 }
 
 let bar = () => {
-  var foo1 = 1;
-  var foo2 = 2;
-  var foo3 = 3;
-  var foo4 = 4;
-  var foo5 = 5;
-  var foo6 = 6;
-  var foo7 = 7;
-  var foo8 = 8;
-  var foo9 = 9;
-  var foo10 = 10;
+  const foo1 = 1;
+  const foo2 = 2;
+  const foo3 = 3;
+  const foo4 = 4;
+  const foo5 = 5;
+  const foo6 = 6;
+  const foo7 = 7;
+  const foo8 = 8;
+  const foo9 = 9;
+  const foo10 = 10;
 
-  var foo11 = 11; // Too many.
+  const foo11 = 11; // Too many.
 };
 ```
 
@@ -88,43 +88,43 @@ Examples of **correct** code for this rule with the default `{ "max": 10 }` opti
 /*eslint max-statements: ["error", 10]*/
 
 function foo() {
-  var foo1 = 1;
-  var foo2 = 2;
-  var foo3 = 3;
-  var foo4 = 4;
-  var foo5 = 5;
-  var foo6 = 6;
-  var foo7 = 7;
-  var foo8 = 8;
-  var foo9 = 9;
+  const foo1 = 1;
+  const foo2 = 2;
+  const foo3 = 3;
+  const foo4 = 4;
+  const foo5 = 5;
+  const foo6 = 6;
+  const foo7 = 7;
+  const foo8 = 8;
+  const foo9 = 9;
   return function () { // 10
 
     // The number of statements in the inner function does not count toward the
     // statement maximum.
 
-    var bar;
-    var baz;
+    const bar;
+    const baz;
     return 42;
   };
 }
 
 let bar = () => {
-  var foo1 = 1;
-  var foo2 = 2;
-  var foo3 = 3;
-  var foo4 = 4;
-  var foo5 = 5;
-  var foo6 = 6;
-  var foo7 = 7;
-  var foo8 = 8;
-  var foo9 = 9;
+  const foo1 = 1;
+  const foo2 = 2;
+  const foo3 = 3;
+  const foo4 = 4;
+  const foo5 = 5;
+  const foo6 = 6;
+  const foo7 = 7;
+  const foo8 = 8;
+  const foo9 = 9;
   return function () { // 10
 
     // The number of statements in the inner function does not count toward the
     // statement maximum.
 
-    var bar;
-    var baz;
+    const bar;
+    const baz;
     return 42;
   };
 }
@@ -170,17 +170,17 @@ Examples of additional **correct** code for this rule with the `{ "max": 10 }, {
 /*eslint max-statements: ["error", 10, { "ignoreTopLevelFunctions": true }]*/
 
 function foo() {
-  var foo1 = 1;
-  var foo2 = 2;
-  var foo3 = 3;
-  var foo4 = 4;
-  var foo5 = 5;
-  var foo6 = 6;
-  var foo7 = 7;
-  var foo8 = 8;
-  var foo9 = 9;
-  var foo10 = 10;
-  var foo11 = 11;
+  const foo1 = 1;
+  const foo2 = 2;
+  const foo3 = 3;
+  const foo4 = 4;
+  const foo5 = 5;
+  const foo6 = 6;
+  const foo7 = 7;
+  const foo8 = 8;
+  const foo9 = 9;
+  const foo10 = 10;
+  const foo11 = 11;
 }
 ```
 

--- a/docs/src/rules/new-cap.md
+++ b/docs/src/rules/new-cap.md
@@ -7,7 +7,7 @@ rule_type: suggestion
 The `new` operator in JavaScript creates a new instance of a particular type of object. That type of object is represented by a constructor function. Since constructor functions are just regular functions, the only defining characteristic is that `new` is being used as part of the call. Native JavaScript functions begin with an uppercase letter to distinguish those functions that are to be used as constructors from functions that are not. Many style guides recommend following this pattern to more easily determine which functions are to be used as constructors.
 
 ```js
-var friend = new Person();
+const friend = new Person();
 ```
 
 ## Rule Details
@@ -64,7 +64,7 @@ Examples of **incorrect** code for this rule with the default `{ "newIsCap": tru
 ```js
 /*eslint new-cap: ["error", { "newIsCap": true }]*/
 
-var friend = new person();
+const friend = new person();
 ```
 
 :::
@@ -76,7 +76,7 @@ Examples of **correct** code for this rule with the default `{ "newIsCap": true 
 ```js
 /*eslint new-cap: ["error", { "newIsCap": true }]*/
 
-var friend = new Person();
+const friend = new Person();
 ```
 
 :::
@@ -88,7 +88,7 @@ Examples of **correct** code for this rule with the `{ "newIsCap": false }` opti
 ```js
 /*eslint new-cap: ["error", { "newIsCap": false }]*/
 
-var friend = new person();
+const friend = new person();
 ```
 
 :::
@@ -102,7 +102,7 @@ Examples of **incorrect** code for this rule with the default `{ "capIsNew": tru
 ```js
 /*eslint new-cap: ["error", { "capIsNew": true }]*/
 
-var colleague = Person();
+const colleague = Person();
 ```
 
 :::
@@ -114,7 +114,7 @@ Examples of **correct** code for this rule with the default `{ "capIsNew": true 
 ```js
 /*eslint new-cap: ["error", { "capIsNew": true }]*/
 
-var colleague = new Person();
+const colleague = new Person();
 ```
 
 :::
@@ -126,7 +126,7 @@ Examples of **correct** code for this rule with the `{ "capIsNew": false }` opti
 ```js
 /*eslint new-cap: ["error", { "capIsNew": false }]*/
 
-var colleague = Person();
+const colleague = Person();
 ```
 
 :::
@@ -140,9 +140,9 @@ Examples of additional **correct** code for this rule with the `{ "newIsCapExcep
 ```js
 /*eslint new-cap: ["error", { "newIsCapExceptions": ["events"] }]*/
 
-var events = require('events');
+const events = require('events');
 
-var emitter = new events();
+const emitter = new events();
 ```
 
 :::
@@ -156,9 +156,9 @@ Examples of additional **correct** code for this rule with the `{ "newIsCapExcep
 ```js
 /*eslint new-cap: ["error", { "newIsCapExceptionPattern": "^person\\.." }]*/
 
-var friend = new person.acquaintance();
+const friend = new person.acquaintance();
 
-var bestFriend = new person.friend();
+const bestFriend = new person.friend();
 ```
 
 :::
@@ -170,7 +170,7 @@ Examples of additional **correct** code for this rule with the `{ "newIsCapExcep
 ```js
 /*eslint new-cap: ["error", { "newIsCapExceptionPattern": "\\.bar$" }]*/
 
-var friend = new person.bar();
+const friend = new person.bar();
 ```
 
 :::
@@ -200,8 +200,8 @@ Examples of additional **correct** code for this rule with the `{ "capIsNewExcep
 ```js
 /*eslint new-cap: ["error", { "capIsNewExceptionPattern": "^person\\.." }]*/
 
-var friend = person.Acquaintance();
-var bestFriend = person.Friend();
+const friend = person.Acquaintance();
+const bestFriend = person.Friend();
 ```
 
 :::
@@ -225,11 +225,11 @@ Examples of additional **correct** code for this rule with the `{ "capIsNewExcep
 ```js
 /*eslint new-cap: ["error", { "capIsNewExceptionPattern": "^Foo" }]*/
 
-var x = Foo(42);
+const x = Foo(42);
 
-var y = Foobar(42);
+const y = Foobar(42);
 
-var z = Foo.Bar(42);
+const z = Foo.Bar(42);
 ```
 
 :::
@@ -243,7 +243,7 @@ Examples of **incorrect** code for this rule with the default `{ "properties": t
 ```js
 /*eslint new-cap: ["error", { "properties": true }]*/
 
-var friend = new person.acquaintance();
+const friend = new person.acquaintance();
 ```
 
 :::
@@ -255,7 +255,7 @@ Examples of **correct** code for this rule with the default `{ "properties": tru
 ```js
 /*eslint new-cap: ["error", { "properties": true }]*/
 
-var friend = new person.Acquaintance();
+const friend = new person.Acquaintance();
 ```
 
 :::
@@ -267,7 +267,7 @@ Examples of **correct** code for this rule with the `{ "properties": false }` op
 ```js
 /*eslint new-cap: ["error", { "properties": false }]*/
 
-var friend = new person.acquaintance();
+const friend = new person.acquaintance();
 ```
 
 :::

--- a/docs/src/rules/no-alert.md
+++ b/docs/src/rules/no-alert.md
@@ -47,7 +47,7 @@ customConfirm("Are you sure?");
 customPrompt("Who are you?");
 
 function foo() {
-    var alert = myCustomLib.customAlert;
+    const alert = myCustomLib.customAlert;
     alert();
 }
 ```


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Rewrited var using const in following rule examples:

``new-cap``
``no-alert``
``max-statements``

Related Issue: #19240 

#### Is there anything you'd like reviewers to focus on?

I used ``const`` to replace ``var``, I believe it is the best solution for the issue

<!-- markdownlint-disable-file MD004 -->
