### PR TITLE
feat: handle 'void 0' shortcut of 'undefined' in `valid-typeof` rule

### DIFF
--- a/docs/src/rules/valid-typeof.md
+++ b/docs/src/rules/valid-typeof.md
@@ -26,6 +26,8 @@ typeof foo === "strnig"
 typeof foo == "undefimed"
 typeof bar != "nunber"
 typeof bar !== "fucntion"
+typeof baz === undefined
+typeof baz !== void 0
 ```
 
 :::

--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -45,7 +45,9 @@ module.exports = {
         messages: {
             invalidValue: "Invalid typeof comparison value.",
             notString: "Typeof comparisons should be to string literals.",
-            suggestString: 'Use `"{{type}}"` instead of `{{type}}`.'
+            suggestString: 'Use `"{{type}}"` instead of `{{type}}`.',
+            usingVoidOperator: 'Invalid use of "void" operator.',
+            suggestStringOnVoid: 'Use `"{{type}}"` instead of `{{invalidOperation}}`.'
         }
     },
 
@@ -102,6 +104,25 @@ module.exports = {
                             if (!VALID_TYPES.has(value)) {
                                 context.report({ node: sibling, messageId: "invalidValue" });
                             }
+                        } else if (
+                            sibling.type === "UnaryExpression" &&
+                            sibling.operator === 'void' &&
+                            sibling.argument.type === 'Literal' &&
+                            sibling.argument.value === 0
+                        ) {
+                            context.report({
+                                node: sibling,
+                                messageId: "usingVoidOperator",
+                                suggest: [
+                                    {
+                                        messageId: "suggestStringOnVoid",
+                                        data: { type: "undefined", invalidOperation: sourceCode.getText(sibling) },
+                                        fix(fixer) {
+                                            return fixer.replaceText(sibling, '"undefined"');
+                                        }
+                                    }
+                                ]
+                            });
                         } else if (sibling.type === "Identifier" && sibling.name === "undefined" && isReferenceToGlobalVariable(sibling)) {
                             context.report({
                                 node: sibling,

--- a/tests/lib/rules/valid-typeof.js
+++ b/tests/lib/rules/valid-typeof.js
@@ -216,6 +216,36 @@ ruleTester.run("valid-typeof", rule, {
             options: [{ requireStringLiterals: true }],
             languageOptions: { ecmaVersion: 6 },
             errors: [{ messageId: "notString", type: "TemplateLiteral" }]
+        },
+        {
+            code: "typeof foo === void 0",
+            errors: [
+                {
+                    messageId: "usingVoidOperator",
+                    type: "UnaryExpression",
+                    suggestions: [
+                        {
+                            messageId: "suggestStringOnVoid",
+                            data: { type: "undefined", invalidOperation: "void 0" },
+                            output: 'typeof foo === "undefined"'
+                        }
+                    ]
+                }]
+        },
+        {
+            code: "void 0 === typeof foo",
+            errors: [
+                {
+                    messageId: "usingVoidOperator",
+                    type: "UnaryExpression",
+                    suggestions: [
+                        {
+                            messageId: "suggestStringOnVoid",
+                            data: { type: "undefined", invalidOperation: "void 0" },
+                            output: '"undefined" === typeof foo'
+                        }
+                    ]
+                }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**What rule do you want to change?**
`valid-typeof`

**What change do you want to make (place an "X" next to just one item)?**

[x] Generate more warnings
[ ] Generate fewer warnings
[x] Implement autofix
[x] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[ ] A new option
[x] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
// this is the same as 'typeof baz !== undefined'
typeof baz !== void 0
```

**What does the rule currently do for this code?**
Nothing and this is invalid.

**What will the rule do after it's changed?**
Handle `void 0` in a same way as `undefined` global value.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
The `void 0` is well-using shortcut for `undefined` global value.
Rule `valid-typeof` handle `undefined` global value but ignored `void 0`.
This changes is focused to handle this two things the same.

#### Is there anything you'd like reviewers to focus on?
1. Note that `void 0` should be handled without `{ "requireStringLiterals": true }` option, just like `undefined` global value.
2. I deliberately ignore all the others cases with `void` (`void 1`, `void func()` and others) to keep the implementation simple and prevent unintentional loss of user code when applying fixes. There might be a new option that would warnings for such usage of `void`. But this is out of scope of this PR.
3. There was a bug in current version of documentation: not mentioned that `typeof baz === undefined` is incorrect by default without `{ "requireStringLiterals": true }` option. I fixed that.

<!-- markdownlint-disable-file MD004 -->
