### PR TITLE
docs: revert accidental changes in TS config files docs

### DIFF
--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -325,7 +325,7 @@ For example:
 
 {{ npx_tabs ({
     package: "eslint",
-    args: ["--config", "~/personal-eslintrc.js", "\\", "--resolve-plugins-relative-to", "/usr/local/lib/"]
+    args: ["--config", "~/personal-eslintrc.js", "--resolve-plugins-relative-to", "/usr/local/lib/"]
 }) }}
 
 ### Specify Rules and Plugins
@@ -384,7 +384,7 @@ To ignore rules in `.eslintrc` configuration files and only run rules specified 
 
 {{ npx_tabs ({
     package: "eslint",
-    args: ["--rule", "\'quotes: [error, double]\'", "-no-eslintrc"],
+    args: ["--rule", "\'quotes: [error, double]\'", "--no-eslintrc"],
     comment: "Only apply rule from the command line"
 }) }}
 

--- a/docs/src/use/configure/configuration-files.md
+++ b/docs/src/use/configure/configuration-files.md
@@ -521,19 +521,6 @@ For more information about using feature flags, see [Feature Flags](../../flags/
 
 ## TypeScript Configuration Files
 
-::: warning
-This feature is currently experimental and may change in future versions.
-:::
-
-You need to enable this feature through the `unstable_ts_config` feature flag:
-
-{{ npx_tabs({
-    package: "eslint",
-    args: ["--flag", "unstable_ts_config"]
-}) }}
-
-For more information about using feature flags, see [Feature Flags](../../flags/).
-
 For Deno and Bun, TypeScript configuration files are natively supported; for Node.js, you must install the optional dev dependency [`jiti`](https://github.com/unjs/jiti) in version 2.0.0 or later in your project (this dependency is not automatically installed by ESLint):
 
 {{ npm_tabs({


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR reverts an accidental change in #18784 that reintroduced a removed part in the documentation about TypeScript Configuration Files.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
