### PR TITLE
Add graceful handling of inactive flags

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1264,14 +1264,17 @@ class Linter {
      */
     constructor({ cwd, configType = "flat", flags = [] } = {}) {
 
-        flags.forEach(flag => {
+        flags = flags.filter(flag => {
             if (inactiveFlags.has(flag)) {
-                throw new Error(`The flag '${flag}' is inactive: ${inactiveFlags.get(flag)}`);
+                process.emitWarning(`The flag '${flag}' is inactive: ${inactiveFlags.get(flag)}. It is subject to removal in a future version of ESLint.`, "ESLintInactiveFlagWarning");
+                return false;
             }
 
             if (!activeFlags.has(flag)) {
                 throw new Error(`Unknown flag '${flag}'.`);
             }
+
+            return true;
         });
 
         internalSlotsMap.set(this, {

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -1907,14 +1907,20 @@ describe("cli", () => {
 
             describe("--flag option", () => {
 
-                it("should throw an error when an inactive flag is used", async () => {
+                it("should warn when an inactive flag is used", async () => {
+                    sinon.restore();
+                    const processStub = sinon.stub(process, "emitWarning");
+
                     const configPath = getFixturePath("eslint.config.js");
                     const filePath = getFixturePath("passing.js");
                     const input = `--flag test_only_old --config ${configPath} ${filePath}`;
+                    const exitCode = await cli.execute(input, null, true);
 
-                    await stdAssert.rejects(async () => {
-                        await cli.execute(input, null, true);
-                    }, /The flag 'test_only_old' is inactive: Used only for testing\./u);
+                    assert.strictEqual(exitCode, 0);
+                    assert.isAtLeast(processStub.callCount, 1, "calls `process.emitWarning()` at least once");
+                    assert.strictEqual(processStub.getCall(0).args[1], "ESLintInactiveFlagWarning");
+
+                    processStub.restore();
                 });
 
                 it("should error out when an unknown flag is used", async () => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -8043,11 +8043,20 @@ describe("Linter with FlatConfigArray", () => {
             );
         });
 
-        it("should throw an error if an inactive flag is present", () => {
-            assert.throws(() => {
-                // eslint-disable-next-line no-new -- needed for test
-                new Linter({ configType: "flat", flags: ["test_only_old"] });
-            }, /The flag 'test_only_old' is inactive: Used only for testing/u);
+        it("should warn if an inactive flag is present", () => {
+            sinon.restore();
+            const processStub = sinon.stub(process, "emitWarning");
+
+            assert.strictEqual(
+                new Linter({ configType: "flat", flags: ["test_only_old"] }).hasFlag("test_only_old"),
+                false
+            );
+
+            assert.strictEqual(processStub.callCount, 1, "calls `process.emitWarning()` once");
+            assert.strictEqual(processStub.getCall(0).args[0], "The flag 'test_only_old' is inactive: Used only for testing.. It is subject to removal in a future version of ESLint.");
+            assert.strictEqual(processStub.getCall(0).args[1], "ESLintInactiveFlagWarning");
+
+            processStub.restore();
         });
 
         it("should throw an error if an unknown flag is present", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Behavioral change to allow the use of inactive flags, which raise just a warning instead of erring out immediately. This allows people to gracefully migrate their code at their own convenience.

Alternatively flags could be split further into `inactiveFlags` and `removedFlags` for a more complete deprecation schema, although removing them from `inactiveFlags` in a next major also seems very reasonable to me.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Flags are now filtered, so that inactive flags are removed with a user-facing warning, instead of throwing an error and failing altogether.

Fixes #19337

#### Is there anything you'd like reviewers to focus on?

- API used to raise the warning
- Wording of the message

<!-- markdownlint-disable-file MD004 -->
