### PR TITLE
test: fix failing test in Node.js v22.13.0

### DIFF
--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -3064,13 +3064,13 @@ describe("ESLint", () => {
                         eslint = new ESLint({
                             flags,
                             overrideConfigFile: true,
-                            cwd: `${otherDriveLetter}:\\`
+                            cwd: `${otherDriveLetter}:\\files`
                         });
-                        const pattern = `${otherDriveLetter}:\\pa*ng.*`;
+                        const pattern = `${otherDriveLetter}:\\files\\???.*`;
                         const results = await eslint.lintFiles([pattern]);
 
                         assert.strictEqual(results.length, 1);
-                        assert.strictEqual(results[0].filePath, `${otherDriveLetter}:\\passing.js`);
+                        assert.strictEqual(results[0].filePath, `${otherDriveLetter}:\\files\\foo.js`);
                         assert.strictEqual(results[0].messages.length, 0);
                         assert.strictEqual(results[0].errorCount, 0);
                         assert.strictEqual(results[0].warningCount, 0);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fix tests

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR fixes a unit test that is failing in Node.js v22.13.0 on Windows. The failure can be observed for example in this CI run:

https://github.com/eslint/eslint/actions/runs/12757605004/job/35735176134

The error seems related to the handling of paths such as `B:\` (a drive's root directory) in certain file system calls in the new version of Node.js. It will be necessary to follow up this issue in the Node.js repo to get more insights, but to fix the failing test on our end I changed the `cwd` in the ESLint options of the test so it no longer points to the root directory. This fixed the failure on my machine.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
