### PR TITLE
docs: replace var with const in rule examples

### DIFF
--- a/docs/src/rules/object-shorthand.md
+++ b/docs/src/rules/object-shorthand.md
@@ -16,14 +16,14 @@ Here are a few common examples using the ES5 syntax:
 
 ```js
 // properties
-var foo = {
+const foo = {
     x: x,
     y: y,
     z: z,
 };
 
 // methods
-var foo = {
+const foo = {
     a: function() {},
     b: function() {}
 };
@@ -33,10 +33,10 @@ Now here are ES6 equivalents:
 
 ```js
 // properties
-var foo = {x, y, z};
+const foo = {x, y, z};
 
 // methods
-var foo = {
+const foo = {
     a() {},
     b() {}
 };
@@ -53,7 +53,7 @@ Each of the following properties would warn:
 ```js
 /*eslint object-shorthand: "error"*/
 
-var foo = {
+const foo = {
     w: function() {},
     x: function *() {},
     [y]: function() {},
@@ -66,7 +66,7 @@ In that case the expected syntax would have been:
 ```js
 /*eslint object-shorthand: "error"*/
 
-var foo = {
+const foo = {
     w() {},
     *x() {},
     [y]() {},
@@ -80,7 +80,7 @@ The following will *not* warn:
 ```js
 /*eslint object-shorthand: "error"*/
 
-var foo = {
+const foo = {
     x: (y) => y
 };
 ```
@@ -126,7 +126,7 @@ Example of **incorrect** code for this rule with the `"always", { "avoidQuotes":
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidQuotes": true }]*/
 
-var foo = {
+const foo = {
     "bar-baz"() {}
 };
 ```
@@ -140,7 +140,7 @@ Example of **correct** code for this rule with the `"always", { "avoidQuotes": t
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidQuotes": true }]*/
 
-var foo = {
+const foo = {
     "bar-baz": function() {},
     "qux": qux
 };
@@ -163,7 +163,7 @@ Example of **correct** code for this rule with the `"always", { "ignoreConstruct
 ```js
 /*eslint object-shorthand: ["error", "always", { "ignoreConstructors": true }]*/
 
-var foo = {
+const foo = {
     ConstructorFunction: function() {}
 };
 ```
@@ -179,7 +179,7 @@ Example of **correct** code for this rule with the `"always", { "methodsIgnorePa
 ```js
 /*eslint object-shorthand: ["error", "always", { "methodsIgnorePattern": "^bar$" }]*/
 
-var foo = {
+const foo = {
     bar: function() {}
 };
 ```
@@ -201,7 +201,7 @@ Example of **incorrect** code for this rule with the `"always", { "avoidExplicit
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidExplicitReturnArrows": true }]*/
 
-var foo = {
+const foo = {
   foo: (bar, baz) => {
     return bar + baz;
   },
@@ -221,7 +221,7 @@ Example of **correct** code for this rule with the `"always", { "avoidExplicitRe
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidExplicitReturnArrows": true }]*/
 
-var foo = {
+const foo = {
   foo(bar, baz) {
     return bar + baz;
   },
@@ -239,7 +239,7 @@ Example of **incorrect** code for this rule with the `"consistent"` option:
 ```js
 /*eslint object-shorthand: [2, "consistent"]*/
 
-var foo = {
+const foo = {
     a,
     b: "foo",
 };
@@ -254,12 +254,12 @@ Examples of **correct** code for this rule with the `"consistent"` option:
 ```js
 /*eslint object-shorthand: [2, "consistent"]*/
 
-var foo = {
+const foo = {
     a: a,
     b: "foo"
 };
 
-var bar = {
+const bar = {
     a,
     b,
 };
@@ -274,7 +274,7 @@ Example of **incorrect** code with the `"consistent-as-needed"` option, which is
 ```js
 /*eslint object-shorthand: [2, "consistent-as-needed"]*/
 
-var foo = {
+const foo = {
     a: a,
     b: b,
 };

--- a/docs/src/rules/object-shorthand.md
+++ b/docs/src/rules/object-shorthand.md
@@ -23,7 +23,7 @@ const foo = {
 };
 
 // methods
-const foo = {
+const bar = {
     a: function() {},
     b: function() {}
 };
@@ -36,7 +36,7 @@ Now here are ES6 equivalents:
 const foo = {x, y, z};
 
 // methods
-const foo = {
+const bar = {
     a() {},
     b() {}
 };

--- a/docs/src/rules/prefer-promise-reject-errors.md
+++ b/docs/src/rules/prefer-promise-reject-errors.md
@@ -60,7 +60,7 @@ new Promise(function(resolve, reject) {
   reject(new Error("something bad happened"));
 });
 
-var foo = getUnknownValue();
+const foo = getUnknownValue();
 Promise.reject(foo);
 ```
 

--- a/docs/src/rules/prefer-rest-params.md
+++ b/docs/src/rules/prefer-rest-params.md
@@ -29,12 +29,12 @@ function foo() {
 }
 
 function foo(action) {
-    var args = Array.prototype.slice.call(arguments, 1);
+    const args = Array.prototype.slice.call(arguments, 1);
     action.apply(null, args);
 }
 
 function foo(action) {
-    var args = [].slice.call(arguments, 1);
+    const args = [].slice.call(arguments, 1);
     action.apply(null, args);
 }
 ```
@@ -61,7 +61,7 @@ function foo(arguments) {
     console.log(arguments); // This is the first argument.
 }
 function foo() {
-    var arguments = 0;
+    const arguments = 0;
     console.log(arguments); // This is a local variable.
 }
 ```

--- a/docs/src/rules/prefer-spread.md
+++ b/docs/src/rules/prefer-spread.md
@@ -9,14 +9,14 @@ related_rules:
 Before ES2015, one must use `Function.prototype.apply()` to call variadic functions.
 
 ```js
-var args = [1, 2, 3, 4];
+const args = [1, 2, 3, 4];
 Math.max.apply(Math, args);
 ```
 
 In ES2015, one can use spread syntax to call variadic functions.
 
 ```js
-var args = [1, 2, 3, 4];
+const args = [1, 2, 3, 4];
 Math.max(...args);
 ```
 

--- a/docs/src/rules/prefer-template.md
+++ b/docs/src/rules/prefer-template.md
@@ -11,11 +11,11 @@ related_rules:
 In ES2015 (ES6), we can use template literals instead of string concatenation.
 
 ```js
-var str = "Hello, " + name + "!";
+const str = "Hello, " + name + "!";
 ```
 
 ```js
-var str = `Hello, ${name}!`;
+const str = `Hello, ${name}!`;
 ```
 
 ## Rule Details
@@ -31,8 +31,8 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint prefer-template: "error"*/
 
-var str = "Hello, " + name + "!";
-var str = "Time: " + (12 * 60 * 60 * 1000);
+const str = "Hello, " + name + "!";
+const str1 = "Time: " + (12 * 60 * 60 * 1000);
 ```
 
 :::
@@ -44,12 +44,12 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint prefer-template: "error"*/
 
-var str = "Hello World!";
-var str = `Hello, ${name}!`;
-var str = `Time: ${12 * 60 * 60 * 1000}`;
+const str = "Hello World!";
+const str1 = `Hello, ${name}!`;
+const str2 = `Time: ${12 * 60 * 60 * 1000}`;
 
 // This is reported by `no-useless-concat`.
-var str = "Hello, " + "World!";
+const str4 = "Hello, " + "World!";
 ```
 
 :::


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Replaced `var` with const in following rules examples:
`object-shorthand.md`
`prefer-promise-reject-errors.md`
`prefer-rest-params.md`
`prefer-spread.md`
`prefer-template.md`

#### Is there anything you'd like reviewers to focus on?
Refs https://github.com/eslint/eslint/issues/19240
<!-- markdownlint-disable-file MD004 -->
