### PR TITLE
docs: additional checks for rule examples

### DIFF
--- a/docs/src/rules/capitalized-comments.md
+++ b/docs/src/rules/capitalized-comments.md
@@ -41,18 +41,21 @@ Examples of **correct** code for this rule:
 
 // 丈 Non-Latin character at beginning of comment
 
-/* eslint semi:off */
-/* eslint-disable */
-/* eslint-enable */
 /* istanbul ignore next */
 /* jscs:enable */
 /* jshint asi:true */
 /* global foo */
 /* globals foo */
 /* exported myVar */
-// eslint-disable-line
-// eslint-disable-next-line
 // https://github.com
+
+/* eslint semi:2 */
+/* eslint-disable */
+foo
+/* eslint-enable */
+// eslint-disable-next-line
+baz
+bar // eslint-disable-line
 
 ```
 
@@ -116,18 +119,21 @@ Examples of **correct** code for this rule:
 
 // 丈 Non-Latin character at beginning of comment
 
-/* eslint semi:off */
-/* eslint-disable */
-/* eslint-enable */
 /* istanbul ignore next */
 /* jscs:enable */
 /* jshint asi:true */
 /* global foo */
 /* globals foo */
 /* exported myVar */
-// eslint-disable-line
-// eslint-disable-next-line
 // https://github.com
+
+/* eslint semi:2 */
+/* eslint-disable */
+foo
+/* eslint-enable */
+// eslint-disable-next-line
+baz
+bar // eslint-disable-line
 
 ```
 

--- a/docs/src/rules/comma-dangle.md
+++ b/docs/src/rules/comma-dangle.md
@@ -161,7 +161,7 @@ var arr = [1,2,];
 foo({
   bar: "baz",
   qux: "quux",
-});
+},);
 ```
 
 :::

--- a/docs/src/rules/consistent-this.md
+++ b/docs/src/rules/consistent-this.md
@@ -69,7 +69,7 @@ foo.bar = this;
 
 Examples of **incorrect** code for this rule with the default `"that"` option, if the variable is not initialized:
 
-::: incorrect
+::: incorrect { "sourceType": "script" }
 
 ```js
 /*eslint consistent-this: ["error", "that"]*/

--- a/docs/src/rules/indent-legacy.md
+++ b/docs/src/rules/indent-legacy.md
@@ -316,7 +316,7 @@ function foo(x) {
 })();
 
 if(y) {
-   console.log('foo');
+  console.log('foo');
 }
 ```
 

--- a/tests/fixtures/bad-examples.md
+++ b/tests/fixtures/bad-examples.md
@@ -28,7 +28,7 @@ const foo = "baz";
 :::correct
 
 ```js
-/* eslint another-rule: error */
+/* eslint no-undef: error */
 ```
 
 :::
@@ -77,6 +77,44 @@ const foo = "baz";
 
 /*eslint-env node */
 /*eslint-env*/
+```
+
+:::
+
+:::correct { "foo": 6 }
+
+```js
+/* eslint no-restricted-syntax: ["error", "ArrayPattern"] */
+```
+
+:::
+
+:::correct
+
+```js
+/* eslint no-restricted-syntax: ["error", "ArrayPattern"] */
+
+const [foo] = bar;
+```
+
+:::
+
+:::incorrect
+
+```js
+/* eslint no-restricted-syntax: ["error", "ArrayPattern"] */
+
+const foo = [bar];
+```
+
+:::
+
+:::incorrect
+
+```js
+/* eslint no-restricted-syntax: ["errorr", "ArrayPattern"] */
+
+const foo = [bar];
 ```
 
 :::

--- a/tests/tools/check-rule-examples.js
+++ b/tests/tools/check-rule-examples.js
@@ -65,27 +65,38 @@ describe("check-rule-examples", () => {
                     .replace(/(?<=\x1B\[4m).*(?=bad-examples\.md)/u, "")
 
                     // Remove runtime-specific error message part (different in Node.js 18, 20 and 21).
-                    .replace(/(?<='doesn't allow this comment'):.*(?=\x1B\[0m)/u, "");
+                    .replace(/(?<='doesn't allow this comment'):.*(?=\x1B\[0m)/u, "")
+
+                    // Remove multiple whitespace before rule name in lint errors
+                    .replaceAll(/\s+(?=\S*no-restricted-syntax\S*\n)/gu, " ");
 
                 /* eslint-enable no-control-regex -- re-enable rule */
 
                 const expectedStderr =
                 "\x1B[0m\x1B[0m\n" +
                 "\x1B[0m\x1B[4mbad-examples.md\x1B[24m\x1B[0m\n" +
-                "\x1B[0m  \x1B[2m11:4\x1B[22m  \x1B[31merror\x1B[39m  Missing language tag: use one of 'javascript', 'js' or 'jsx'\x1B[0m\n" +
-                "\x1B[0m  \x1B[2m12:1\x1B[22m  \x1B[31merror\x1B[39m  Syntax error: 'import' and 'export' may appear only with 'sourceType: module'\x1B[0m\n" +
-                "\x1B[0m  \x1B[2m20:5\x1B[22m  \x1B[31merror\x1B[39m  Nonstandard language tag 'ts': use one of 'javascript', 'js' or 'jsx'\x1B[0m\n" +
-                "\x1B[0m  \x1B[2m23:7\x1B[22m  \x1B[31merror\x1B[39m  Syntax error: Identifier 'foo' has already been declared\x1B[0m\n" +
-                "\x1B[0m  \x1B[2m31:1\x1B[22m  \x1B[31merror\x1B[39m  Example code should contain a configuration comment like /* eslint no-restricted-syntax: \"error\" */\x1B[0m\n" +
-                "\x1B[0m  \x1B[2m41:1\x1B[22m  \x1B[31merror\x1B[39m  Failed to parse JSON from 'doesn't allow this comment'\x1B[0m\n" +
-                "\x1B[0m  \x1B[2m51:1\x1B[22m  \x1B[31merror\x1B[39m  Duplicate /* eslint no-restricted-syntax */ configuration comment. Each example should contain only one. Split this example into multiple examples\x1B[0m\n" +
-                "\x1B[0m  \x1B[2m56:1\x1B[22m  \x1B[31merror\x1B[39m  Remove unnecessary \"ecmaVersion\":\"latest\"\x1B[0m\n" +
-                `\x1B[0m  \x1B[2m64:1\x1B[22m  \x1B[31merror\x1B[39m  "ecmaVersion" must be one of ${[3, 5, ...Array.from({ length: LATEST_ECMA_VERSION - 2015 + 1 }, (_, index) => index + 2015)].join(", ")}\x1B[0m\n` +
-                "\x1B[0m  \x1B[2m76:1\x1B[22m  \x1B[31merror\x1B[39m  /* eslint-env */ comments are no longer supported. Remove the comment\x1B[0m\n" +
-                "\x1B[0m  \x1B[2m78:1\x1B[22m  \x1B[31merror\x1B[39m  /* eslint-env */ comments are no longer supported. Remove the comment\x1B[0m\n" +
-                "\x1B[0m  \x1B[2m79:1\x1B[22m  \x1B[31merror\x1B[39m  /* eslint-env */ comments are no longer supported. Remove the comment\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m11:4\x1B[22m  \x1B[31merror\x1B[39m  Missing language tag: use one of 'javascript', 'js' or 'jsx'\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m12:1\x1B[22m  \x1B[31merror\x1B[39m  Unexpected lint error found: Parsing error: 'import' and 'export' may appear only with 'sourceType: module'\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m20:5\x1B[22m  \x1B[31merror\x1B[39m  Nonstandard language tag 'ts': use one of 'javascript', 'js' or 'jsx'\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m23:7\x1B[22m  \x1B[31merror\x1B[39m  Unexpected lint error found: Parsing error: Identifier 'foo' has already been declared\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m31:1\x1B[22m  \x1B[31merror\x1B[39m  Example code should contain a configuration comment like /* eslint no-restricted-syntax: \"error\" */\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m41:1\x1B[22m  \x1B[31merror\x1B[39m  Unexpected lint error found: Failed to parse JSON from 'doesn't allow this comment'\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m51:1\x1B[22m  \x1B[31merror\x1B[39m  Unexpected lint error found: Rule \"no-restricted-syntax\" is already configured by another configuration comment in the preceding code. This configuration is ignored\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m51:1\x1B[22m  \x1B[31merror\x1B[39m  Duplicate /* eslint no-restricted-syntax */ configuration comment. Each example should contain only one. Split this example into multiple examples\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m56:1\x1B[22m  \x1B[31merror\x1B[39m  Remove unnecessary \"ecmaVersion\":\"latest\"\x1B[0m\n" +
+                `\x1B[0m   \x1B[2m64:1\x1B[22m  \x1B[31merror\x1B[39m  "ecmaVersion" must be one of ${[3, 5, ...Array.from({ length: LATEST_ECMA_VERSION - 2015 + 1 }, (_, index) => index + 2015)].join(", ")}\x1B[0m\n` +
+                "\x1B[0m   \x1B[2m76:1\x1B[22m  \x1B[31merror\x1B[39m  /* eslint-env */ comments are no longer supported. Remove the comment\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m78:1\x1B[22m  \x1B[31merror\x1B[39m  /* eslint-env */ comments are no longer supported. Remove the comment\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m79:1\x1B[22m  \x1B[31merror\x1B[39m  /* eslint-env */ comments are no longer supported. Remove the comment\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m84:1\x1B[22m  \x1B[31merror\x1B[39m  Configuration error: Key \"languageOptions\": Unexpected key \"foo\" found\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m97:7\x1B[22m  \x1B[31merror\x1B[39m  Unexpected lint error found: Using 'ArrayPattern' is not allowed \x1B[2mno-restricted-syntax\x1B[22m\x1B[0m\n" +
+                "\x1B[0m  \x1B[2m105:1\x1B[22m  \x1B[31merror\x1B[39m  Incorrect examples should have at least one error reported by the rule\x1B[0m\n" +
+                "\x1B[0m  \x1B[2m115:1\x1B[22m  \x1B[31merror\x1B[39m  Incorrect examples should have at least one error reported by the rule\x1B[0m\n" +
+                "\x1B[0m  \x1B[2m115:1\x1B[22m  \x1B[31merror\x1B[39m  Unexpected lint error found: Inline configuration for rule \"no-restricted-syntax\" is invalid:\x1B[0m\n" +
+                    "\x1B[0m\tExpected severity of \"off\", 0, \"warn\", 1, \"error\", or 2. You passed \"errorr,ArrayPattern\".\x1B[0m\n" +
+                    "\x1B[0m \x1B[2mno-restricted-syntax\x1B[22m\x1B[0m\n" +
                 "\x1B[0m\x1B[0m\n" +
-                "\x1B[0m\x1B[31m\x1B[1m✖ 12 problems (12 errors, 0 warnings)\x1B[22m\x1B[39m\x1B[0m\n" +
+                "\x1B[0m\x1B[31m\x1B[1m✖ 18 problems (18 errors, 0 warnings)\x1B[22m\x1B[39m\x1B[0m\n" +
                 "\x1B[0m\x1B[31m\x1B[1m\x1B[22m\x1B[39m\x1B[0m\n";
 
                 assert.strictEqual(normalizedStderr, expectedStderr);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Adds more checks for rule examples:

* `correct` examples should have no lint errors.
* `incorrect` examples should have one or more lint errors reported by the rule, and no other errors.
* Inline configurations (`/* eslint */`) should have valid options for the rule.
* `languageOptions` configurations after `:::correct`/`:::incorrect` should be valid.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Updated `tools/check-rule-examples.js` to run `Linter#verify()` instead of just parsing and added the checks listed above.
* Updated several rule docs files that failed with the new checks.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
