### PR TITLE
chore: add permissions: read-all to stale.yml workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,8 @@ on:
   schedule:
   - cron: '31 22 * * *'
 
+permissions: read-all
+
 jobs:
   stale:
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)


[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: internal GHA workflow work

#### What changes did you make? (Give an overview)

Added `permissions: read-all` to `.github/workflows/stale.yml` per https://github.com/eslint/eslint/issues/19356#issuecomment-2605433950.

#### Is there anything you'd like reviewers to focus on?

The individual `stale` job _should_ still have write permissions overriding the workflow setting. _Should_.