### PR TITLE
fix: Clearer error message for wrong plugin format

### DIFF
--- a/messages/eslintrc-plugins.js
+++ b/messages/eslintrc-plugins.js
@@ -5,9 +5,14 @@ module.exports = function({ plugins }) {
     const isArrayOfStrings = typeof plugins[0] === "string";
 
     return `
-A config object has a "plugins" key defined as an array${isArrayOfStrings ? " of strings" : ""}.
+A config object has a "plugins" key defined as an array${isArrayOfStrings ? " of strings" : ""}. It
+looks something like this:
 
-Flat config requires "plugins" to be an object in this form:
+    {
+        "plugins": ${JSON.stringify(plugins)}
+    }
+
+Flat config requires "plugins" to be an object in this form, like this:
 
     {
         plugins: {

--- a/messages/eslintrc-plugins.js
+++ b/messages/eslintrc-plugins.js
@@ -12,7 +12,7 @@ looks something like this:
         "plugins": ${JSON.stringify(plugins)}
     }
 
-Flat config requires "plugins" to be an object in this form, like this:
+Flat config requires "plugins" to be an object, like this:
 
     {
         plugins: {

--- a/messages/eslintrc-plugins.js
+++ b/messages/eslintrc-plugins.js
@@ -5,8 +5,7 @@ module.exports = function({ plugins }) {
     const isArrayOfStrings = typeof plugins[0] === "string";
 
     return `
-A config object has a "plugins" key defined as an array${isArrayOfStrings ? " of strings" : ""}. It
-looks something like this:
+A config object has a "plugins" key defined as an array${isArrayOfStrings ? " of strings" : ""}. It looks something like this:
 
     {
         "plugins": ${JSON.stringify(plugins)}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the error message that's displayed when eslintrc-style plugins are found in a config. Hopefully this will give more of a clue of what to look for.

It turned out to be very difficult to get more information about the location of the error in the config array because this error is thrown during validation, which happens only when `getConfig()` is called. If we want a more robust solution, we'd need to change `ConfigArray` to validate upon normalization instead of lazily validating.

fixes #18926


#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
