### PR TITLE
fix: Ensure module scope is checked for references in `consistent-this`

### DIFF
--- a/lib/rules/consistent-this.js
+++ b/lib/rules/consistent-this.js
@@ -119,8 +119,17 @@ module.exports = {
         function ensureWasAssigned(node) {
             const scope = sourceCode.getScope(node);
 
+            // if this is program scope we also need to check module scope
+            const extraScope = node.type === "Program" && node.sourceType === "module"
+                ? scope.childScopes[0]
+                : null;
+
             aliases.forEach(alias => {
                 checkWasAssigned(alias, scope);
+
+                if (extraScope) {
+                    checkWasAssigned(alias, extraScope);
+                }
             });
         }
 

--- a/tests/lib/rules/consistent-this.js
+++ b/tests/lib/rules/consistent-this.js
@@ -68,6 +68,7 @@ ruleTester.run("consistent-this", rule, {
         { code: "that = this", options: ["self"], errors: [{ messageId: "unexpectedAlias", data: { name: "that" }, type: "AssignmentExpression" }] },
         { code: "self = this", options: ["that"], errors: [{ messageId: "unexpectedAlias", data: { name: "self" }, type: "AssignmentExpression" }] },
         { code: "self += this", options: ["self"], errors: [{ messageId: "aliasNotAssignedToThis", data: { name: "self" }, type: "AssignmentExpression" }] },
-        { code: "var self; (function() { self = this; }())", options: ["self"], errors: [{ messageId: "aliasNotAssignedToThis", data: { name: "self" }, type: "VariableDeclarator" }] }
+        { code: "var self; (function() { self = this; }())", options: ["self"], errors: [{ messageId: "aliasNotAssignedToThis", data: { name: "self" }, type: "VariableDeclarator" }] },
+        { code: "var self; (function() { self = this; }())", options: ["self"], languageOptions: { ecmaVersion: 6, sourceType: "module" }, errors: [{ messageId: "aliasNotAssignedToThis", data: { name: "self" }, type: "VariableDeclarator" }] }
     ]
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Ensure that the module scope is checked for references.

fixes #19244

#### Is there anything you'd like reviewers to focus on?

This is a little quick-and-dirty to fix the bug. I think this rule could use a larger refactor because this seems like an inefficient way to check for these references, but I don't have time to dig too deep at the moment.

<!-- markdownlint-disable-file MD004 -->
