### PR TITLE
fix: Better error message for unserializable parser

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -110,7 +110,12 @@ function languageOptionsToJSON(languageOptions, objectKey = "languageOptions") {
             }
 
             if (typeof value === "function") {
-                throw new TypeError(`Cannot serialize key "${key}" in ${objectKey}: Function values are not supported.`);
+                const error = new TypeError(`Cannot serialize key "${key}" in ${objectKey}: Function values are not supported.`);
+
+                error.messageTemplate = "config-serialize-function";
+                error.messageData = { key, objectKey };
+
+                throw error;
             }
 
         }

--- a/messages/config-serialize-function.js
+++ b/messages/config-serialize-function.js
@@ -11,7 +11,7 @@ representation. Please open an issue with the maintainer of the custom parser
 and share this link:
 
 https://eslint.org/docs/latest/extend/custom-parsers#meta-data-in-custom-parsers
-`.trimStart();
+`.trim();
 
     return `
 The requested operation requires ESLint to serialize configuration data,

--- a/messages/config-serialize-function.js
+++ b/messages/config-serialize-function.js
@@ -1,0 +1,28 @@
+"use strict";
+
+module.exports = function({ key, objectKey }) {
+
+    // special case for parsers
+    const isParser = objectKey === "parser" && key === "parse";
+    const parserMessage = `
+    This typically happens when you're using a custom parser that does not
+provide a "meta" property, which is how ESLint determines the serialized
+representation. Please open an issue with the maintainer of the custom parser
+and share this link:
+
+https://eslint.org/docs/latest/extend/custom-parsers#meta-data-in-custom-parsers
+`.trimStart();
+
+    return `
+The requested operation requires ESLint to serialize configuration data,
+but the configuration key "${objectKey}.${key}" contains a function value,
+which cannot be serialized.
+
+${
+    isParser ? parserMessage : "Please double-check your configuration for errors."
+}
+
+If you still have problems, please stop by https://eslint.org/chat/help to chat
+with the team.
+`.trimStart();
+};

--- a/messages/config-serialize-function.js
+++ b/messages/config-serialize-function.js
@@ -3,7 +3,7 @@
 module.exports = function({ key, objectKey }) {
 
     // special case for parsers
-    const isParser = objectKey === "parser" && key === "parse";
+    const isParser = objectKey === "parser" && (key === "parse" || key === "parseForESLint");
     const parserMessage = `
     This typically happens when you're using a custom parser that does not
 provide a "meta" property, which is how ESLint determines the serialized


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the error message that is displayed when a function value can't be serialized. There's a special message when it's a parser vs. any other key.

fixes #19322

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
