### PR TITLE
feat: change behavior of inactive flags

### DIFF
--- a/docs/src/_data/flags.js
+++ b/docs/src/_data/flags.js
@@ -6,6 +6,19 @@
 "use strict";
 
 //-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+/**
+ * Determines whether the flag is used for test purposes only.
+ * @param {string} flag The flag to check.
+ * @returns {boolean} `true` if the flag is used for test purposes only.
+ */
+function isTestOnlyFlag(flag) {
+    return flag.startsWith("test_only");
+}
+
+//-----------------------------------------------------------------------------
 // Exports
 //-----------------------------------------------------------------------------
 
@@ -14,7 +27,7 @@ module.exports = function() {
     const { activeFlags, inactiveFlags } = require("../../../lib/shared/flags");
 
     return {
-        active: Object.fromEntries([...activeFlags]),
-        inactive: Object.fromEntries([...inactiveFlags])
+        active: Object.fromEntries([...activeFlags].filter(([name]) => !isTestOnlyFlag(name))),
+        inactive: Object.fromEntries([...inactiveFlags].filter(([name]) => !isTestOnlyFlag(name)))
     };
 };

--- a/docs/src/_data/flags.js
+++ b/docs/src/_data/flags.js
@@ -11,11 +11,11 @@
 
 /**
  * Determines whether the flag is used for test purposes only.
- * @param {string} flag The flag to check.
+ * @param {string} name The flag name to check.
  * @returns {boolean} `true` if the flag is used for test purposes only.
  */
-function isTestOnlyFlag(flag) {
-    return flag.startsWith("test_only");
+function isTestOnlyFlag(name) {
+    return name.startsWith("test_only");
 }
 
 //-----------------------------------------------------------------------------
@@ -24,10 +24,23 @@ function isTestOnlyFlag(flag) {
 
 module.exports = function() {
 
-    const { activeFlags, inactiveFlags } = require("../../../lib/shared/flags");
+    const { activeFlags, inactiveFlags, getInactivityReasonMessage } = require("../../../lib/shared/flags");
 
     return {
-        active: Object.fromEntries([...activeFlags].filter(([name]) => !isTestOnlyFlag(name))),
-        inactive: Object.fromEntries([...inactiveFlags].filter(([name]) => !isTestOnlyFlag(name)))
+        active: Object.fromEntries(
+            [...activeFlags]
+                .filter(([name]) => !isTestOnlyFlag(name))
+        ),
+        inactive: Object.fromEntries(
+            [...inactiveFlags]
+                .filter(([name]) => !isTestOnlyFlag(name))
+                .map(([name, inactiveFlagData]) => [
+                    name,
+                    {
+                        ...inactiveFlagData,
+                        inactivityReason: getInactivityReasonMessage(inactiveFlagData)
+                    }
+                ])
+        )
     };
 };

--- a/docs/src/pages/flags.md
+++ b/docs/src/pages/flags.md
@@ -59,11 +59,12 @@ The following flags were once used but are no longer active.
         <tr>
             <th>Flag</th>
             <th>Description</th>
+            <th>Inactivity Reason</th>
         </tr>
     </thead>
     <tbody>
 {%- for name, data in flags.inactive -%}
-        <tr><td><code>{{name}}</code></td><td>{{data.description}}</td></tr>
+        <tr><td><code>{{name}}</code></td><td>{{data.description}}</td><td>{{data.inactivityReason}}</td></tr>
 {%- endfor -%}
     </tbody>
 </table>

--- a/docs/src/pages/flags.md
+++ b/docs/src/pages/flags.md
@@ -20,9 +20,17 @@ ESLint ships experimental and future breaking changes behind feature flags to le
 The prefix of a flag indicates its status:
 
 * `unstable_` indicates that the feature is experimental and the implementation may change before the feature is stabilized. This is a "use at your own risk" feature.
-* `v##_` indicates that the feature is stabilized and will be available in the next major release. For example, `v10_some_feature` indicates that this is a breaking change that will be formally released in ESLint v10.0.0. These flags are removed each major release.
+* `v##_` indicates that the feature is stabilized and will be available in the next major release. For example, `v10_some_feature` indicates that this is a breaking change that will be formally released in ESLint v10.0.0. These flags are removed each major release, and further use of them throws an error.
 
-A feature may move from unstable to stable without a major release if it is a non-breaking change.
+A feature may move from unstable to being enabled by default without a major release if it is a non-breaking change.
+
+The following policies apply to `unstable_` flags.
+
+* When the feature is stabilized
+    * If enabling the feature by default would be a breaking change, a new `v##_` flag is added as active, and the `unstable_` flag becomes inactive. Further use of the `unstable_` flag automatically enables the `v##_` flag but emits a warning.
+    * Otherwise, the feature is enabled by default, and the `unstable_` flag becomes inactive. Further use of the `unstable_` flag emits a warning.
+* If the feature is abandoned, the `unstable_` flag becomes inactive. Further use of it throws an error.
+* All inactive `unstable_` flags are removed each major release, and further use of them throws an error.
 
 ## Active Flags
 
@@ -54,8 +62,8 @@ The following flags were once used but are no longer active.
         </tr>
     </thead>
     <tbody>
-{%- for name, desc in flags.inactive -%}
-        <tr><td><code>{{name}}</code></td><td>{{desc}}</td></tr>
+{%- for name, data in flags.inactive -%}
+        <tr><td><code>{{name}}</code></td><td>{{data.description}}</td></tr>
 {%- endfor -%}
     </tbody>
 </table>

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -470,7 +470,7 @@ class ESLint {
             defaultConfigs
         };
 
-        this.#configLoader = processedOptions.flags.includes("unstable_config_lookup_from_file")
+        this.#configLoader = linter.hasFlag("unstable_config_lookup_from_file")
             ? new ConfigLoader(configLoaderOptions)
             : new LegacyConfigLoader(configLoaderOptions);
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1337,6 +1337,7 @@ class Linter {
                     throw new Error(`The flag '${flag}' is inactive: ${inactivityReason}`);
                 }
 
+                // if there's a replacement, enable it instead of original
                 if (typeof inactiveFlagData.replacedBy === "string") {
                     processedFlags.push(inactiveFlagData.replacedBy);
                 }

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -43,7 +43,7 @@ const { assertIsRuleSeverity } = require("../config/flat-config-schema");
 const { normalizeSeverityToString, normalizeSeverityToNumber } = require("../shared/severity");
 const { deepMergeArrays } = require("../shared/deep-merge-arrays");
 const jslang = require("../languages/js");
-const { activeFlags, inactiveFlags } = require("../shared/flags");
+const { activeFlags, inactiveFlags, getInactivityReasonMessage } = require("../shared/flags");
 const debug = require("debug")("eslint:linter");
 const MAX_AUTOFIX_PASSES = 10;
 const DEFAULT_PARSER_NAME = "espree";
@@ -1330,18 +1330,19 @@ class Linter {
 
         flags.forEach(flag => {
             if (inactiveFlags.has(flag)) {
-                const { description, replacedBy } = inactiveFlags.get(flag);
+                const inactiveFlagData = inactiveFlags.get(flag);
+                const inactivityReason = getInactivityReasonMessage(inactiveFlagData);
 
-                if (typeof replacedBy === "undefined") {
-                    throw new Error(`The flag '${flag}' is inactive: ${description}`);
+                if (typeof inactiveFlagData.replacedBy === "undefined") {
+                    throw new Error(`The flag '${flag}' is inactive: ${inactivityReason}`);
                 }
 
-                if (typeof replacedBy === "string") {
-                    processedFlags.push(replacedBy);
+                if (typeof inactiveFlagData.replacedBy === "string") {
+                    processedFlags.push(inactiveFlagData.replacedBy);
                 }
 
                 globalThis.process?.emitWarning?.(
-                    `The flag '${flag}' is inactive: ${description}`,
+                    `The flag '${flag}' is inactive: ${inactivityReason}`,
                     `ESLintInactiveFlag_${flag}`
                 );
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1326,19 +1326,38 @@ class Linter {
      */
     constructor({ cwd, configType = "flat", flags = [] } = {}) {
 
+        const processedFlags = [];
+
         flags.forEach(flag => {
             if (inactiveFlags.has(flag)) {
-                throw new Error(`The flag '${flag}' is inactive: ${inactiveFlags.get(flag)}`);
+                const { description, replacedBy } = inactiveFlags.get(flag);
+
+                if (typeof replacedBy === "undefined") {
+                    throw new Error(`The flag '${flag}' is inactive: ${description}`);
+                }
+
+                if (typeof replacedBy === "string") {
+                    processedFlags.push(replacedBy);
+                }
+
+                globalThis.process?.emitWarning?.(
+                    `The flag '${flag}' is inactive: ${description}`,
+                    `ESLintInactiveFlag_${flag}`
+                );
+
+                return;
             }
 
             if (!activeFlags.has(flag)) {
                 throw new Error(`Unknown flag '${flag}'.`);
             }
+
+            processedFlags.push(flag);
         });
 
         internalSlotsMap.set(this, {
             cwd: normalizeCwd(cwd),
-            flags,
+            flags: processedFlags,
             lastConfigArray: null,
             lastSourceCode: null,
             lastSuppressedMessages: [],

--- a/lib/shared/flags.js
+++ b/lib/shared/flags.js
@@ -4,6 +4,23 @@
 
 "use strict";
 
+//------------------------------------------------------------------------------
+// Typedefs
+//------------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} InactiveFlagData
+ * @property {string} description Flag description
+ * @property {string | null} [replacedBy] Can be either:
+ *   - An active flag (string) that enables the same feature.
+ *   - `null` if the feature is now enabled by default.
+ *   - Omitted if the feature has been abandoned.
+ */
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
 /**
  * The set of flags that change ESLint behavior with a description.
  * @type {Map<string, string>}
@@ -15,21 +32,35 @@ const activeFlags = new Map([
 
 /**
  * The set of flags that used to be active.
- *
- * `replacedBy` can be either:
- *   - An active flag (string) that enables the same feature.
- *   - `null` if the feature is now enabled by default.
- *   - Omitted if the feature has been abandoned.
- * @type {Map<string, {description: string, replacedBy?: string | null}>}
+ * @type {Map<string, InactiveFlagData>}
  */
 const inactiveFlags = new Map([
     ["test_only_replaced", { description: "Used only for testing flags that have been replaced by other flags.", replacedBy: "test_only" }],
     ["test_only_enabled_by_default", { description: "Used only for testing flags whose features have been enabled by default.", replacedBy: null }],
     ["test_only_abandoned", { description: "Used only for testing flags whose features have been abandoned." }],
-    ["unstable_ts_config", { description: "This flag is no longer required to enable TypeScript configuration files.", replacedBy: null }]
+    ["unstable_ts_config", { description: "Enable TypeScript configuration files.", replacedBy: null }]
 ]);
+
+/**
+ * Creates a message that describes the reason the flag is inactive.
+ * @param {InactiveFlagData} inactiveFlagData Data for the inactive flag.
+ * @returns {string} Message describing the reason the flag is inactive.
+ */
+function getInactivityReasonMessage({ replacedBy }) {
+    if (typeof replacedBy === "undefined") {
+        return "This feature has been abandoned.";
+    }
+
+    if (typeof replacedBy === "string") {
+        return `This flag has been renamed '${replacedBy}' to reflect its stabilization. Please use '${replacedBy}' instead.`;
+    }
+
+    // null
+    return "This feature is now enabled by default.";
+}
 
 module.exports = {
     activeFlags,
-    inactiveFlags
+    inactiveFlags,
+    getInactivityReasonMessage
 };

--- a/lib/shared/flags.js
+++ b/lib/shared/flags.js
@@ -14,12 +14,19 @@ const activeFlags = new Map([
 ]);
 
 /**
- * The set of flags that used to be active but no longer have an effect.
- * @type {Map<string, string>}
+ * The set of flags that used to be active.
+ *
+ * `replacedBy` can be either:
+ *   - An active flag (string) that enables the same feature.
+ *   - `null` if the feature is now enabled by default.
+ *   - Omitted if the feature has been abandoned.
+ * @type {Map<string, {description: string, replacedBy?: string | null}>}
  */
 const inactiveFlags = new Map([
-    ["test_only_old", "Used only for testing."],
-    ["unstable_ts_config", "This flag is no longer required to enable TypeScript configuration files."]
+    ["test_only_replaced", { description: "Used only for testing flags that have been replaced by other flags.", replacedBy: "test_only" }],
+    ["test_only_enabled_by_default", { description: "Used only for testing flags whose features have been enabled by default.", replacedBy: null }],
+    ["test_only_abandoned", { description: "Used only for testing flags whose features have been abandoned." }],
+    ["unstable_ts_config", { description: "This flag is no longer required to enable TypeScript configuration files.", replacedBy: null }]
 ]);
 
 module.exports = {

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -1921,7 +1921,7 @@ describe("cli", () => {
 
                     await stdAssert.rejects(async () => {
                         await cli.execute(input, null, true);
-                    }, /The flag 'test_only_abandoned' is inactive: Used only for testing flags whose features have been abandoned\./u);
+                    }, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned\./u);
                 });
 
                 it("should error out when an unknown flag is used", async () => {
@@ -1944,7 +1944,7 @@ describe("cli", () => {
                     assert.deepStrictEqual(
                         processStub.getCall(0).args,
                         [
-                            "The flag 'test_only_replaced' is inactive: Used only for testing flags that have been replaced by other flags.",
+                            "The flag 'test_only_replaced' is inactive: This flag has been renamed 'test_only' to reflect its stabilization. Please use 'test_only' instead.",
                             "ESLintInactiveFlag_test_only_replaced"
                         ]
                     );
@@ -1962,7 +1962,7 @@ describe("cli", () => {
                     assert.deepStrictEqual(
                         processStub.getCall(0).args,
                         [
-                            "The flag 'test_only_enabled_by_default' is inactive: Used only for testing flags whose features have been enabled by default.",
+                            "The flag 'test_only_enabled_by_default' is inactive: This feature is now enabled by default.",
                             "ESLintInactiveFlag_test_only_enabled_by_default"
                         ]
                     );

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -335,15 +335,6 @@ describe("ESLint", () => {
 
                 processStub.restore();
             });
-
-            it("should throw an error if the flag 'unstable_ts_config' is used", () => {
-                assert.throws(
-                    () => new ESLint({
-                        flags: [...flags, "unstable_ts_config"]
-                    }),
-                    { message: "The flag 'unstable_ts_config' is inactive: This flag is no longer required to enable TypeScript configuration files." }
-                );
-            });
         });
 
         describe("hasFlag", () => {
@@ -351,17 +342,60 @@ describe("ESLint", () => {
             /** @type {InstanceType<ESLint>} */
             let eslint;
 
+            let processStub;
+
+            beforeEach(() => {
+                sinon.restore();
+                processStub = sinon.stub(process, "emitWarning").withArgs(sinon.match.any, sinon.match(/^ESLintInactiveFlag_/u)).returns();
+            });
+
             it("should return true if the flag is present and active", () => {
                 eslint = new ESLint({ cwd: getFixturePath(), flags: ["test_only"] });
 
                 assert.strictEqual(eslint.hasFlag("test_only"), true);
             });
 
-            it("should throw an error if the flag is inactive", () => {
+            it("should return true for the replacement flag if an inactive flag that has been replaced is used", () => {
+                eslint = new ESLint({ cwd: getFixturePath(), flags: ["test_only_replaced"] });
+
+                assert.strictEqual(eslint.hasFlag("test_only"), true);
+                assert.strictEqual(processStub.callCount, 1, "calls `process.emitWarning()` for flags once");
+                assert.deepStrictEqual(
+                    processStub.getCall(0).args,
+                    [
+                        "The flag 'test_only_replaced' is inactive: Used only for testing flags that have been replaced by other flags.",
+                        "ESLintInactiveFlag_test_only_replaced"
+                    ]
+                );
+            });
+
+            it("should return false if an inactive flag whose feature is enabled by default is used", () => {
+                eslint = new ESLint({ cwd: getFixturePath(), flags: ["test_only_enabled_by_default"] });
+
+                assert.strictEqual(eslint.hasFlag("test_only_enabled_by_default"), false);
+                assert.strictEqual(processStub.callCount, 1, "calls `process.emitWarning()` for flags once");
+                assert.deepStrictEqual(
+                    processStub.getCall(0).args,
+                    [
+                        "The flag 'test_only_enabled_by_default' is inactive: Used only for testing flags whose features have been enabled by default.",
+                        "ESLintInactiveFlag_test_only_enabled_by_default"
+                    ]
+                );
+            });
+
+            it("should throw an error if an inactive flag whose feature has been abandoned is used", () => {
 
                 assert.throws(() => {
-                    eslint = new ESLint({ cwd: getFixturePath(), flags: ["test_only_old"] });
-                }, /The flag 'test_only_old' is inactive/u);
+                    eslint = new ESLint({ cwd: getFixturePath(), flags: ["test_only_abandoned"] });
+                }, /The flag 'test_only_abandoned' is inactive: Used only for testing flags whose features have been abandoned/u);
+
+            });
+
+            it("should throw an error if the flag is unknown", () => {
+
+                assert.throws(() => {
+                    eslint = new ESLint({ cwd: getFixturePath(), flags: ["foo_bar"] });
+                }, /Unknown flag 'foo_bar'/u);
 
             });
 
@@ -369,6 +403,23 @@ describe("ESLint", () => {
                 eslint = new ESLint({ cwd: getFixturePath() });
 
                 assert.strictEqual(eslint.hasFlag("x_feature"), false);
+            });
+
+            // TODO: Remove in ESLint v10 when the flag is removed
+            it("should not throw an error if the flag 'unstable_ts_config' is used", () => {
+                eslint = new ESLint({
+                    flags: [...flags, "unstable_ts_config"]
+                });
+
+                assert.strictEqual(eslint.hasFlag("unstable_ts_config"), false);
+                assert.strictEqual(processStub.callCount, 1, "calls `process.emitWarning()` for flags once");
+                assert.deepStrictEqual(
+                    processStub.getCall(0).args,
+                    [
+                        "The flag 'unstable_ts_config' is inactive: This flag is no longer required to enable TypeScript configuration files.",
+                        "ESLintInactiveFlag_unstable_ts_config"
+                    ]
+                );
             });
         });
 

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -363,7 +363,7 @@ describe("ESLint", () => {
                 assert.deepStrictEqual(
                     processStub.getCall(0).args,
                     [
-                        "The flag 'test_only_replaced' is inactive: Used only for testing flags that have been replaced by other flags.",
+                        "The flag 'test_only_replaced' is inactive: This flag has been renamed 'test_only' to reflect its stabilization. Please use 'test_only' instead.",
                         "ESLintInactiveFlag_test_only_replaced"
                     ]
                 );
@@ -377,7 +377,7 @@ describe("ESLint", () => {
                 assert.deepStrictEqual(
                     processStub.getCall(0).args,
                     [
-                        "The flag 'test_only_enabled_by_default' is inactive: Used only for testing flags whose features have been enabled by default.",
+                        "The flag 'test_only_enabled_by_default' is inactive: This feature is now enabled by default.",
                         "ESLintInactiveFlag_test_only_enabled_by_default"
                     ]
                 );
@@ -387,7 +387,7 @@ describe("ESLint", () => {
 
                 assert.throws(() => {
                     eslint = new ESLint({ cwd: getFixturePath(), flags: ["test_only_abandoned"] });
-                }, /The flag 'test_only_abandoned' is inactive: Used only for testing flags whose features have been abandoned/u);
+                }, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned/u);
 
             });
 
@@ -416,7 +416,7 @@ describe("ESLint", () => {
                 assert.deepStrictEqual(
                     processStub.getCall(0).args,
                     [
-                        "The flag 'unstable_ts_config' is inactive: This flag is no longer required to enable TypeScript configuration files.",
+                        "The flag 'unstable_ts_config' is inactive: This feature is now enabled by default.",
                         "ESLintInactiveFlag_unstable_ts_config"
                     ]
                 );

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -8067,7 +8067,7 @@ describe("Linter with FlatConfigArray", () => {
                 assert.deepStrictEqual(
                     processStub.getCall(0).args,
                     [
-                        "The flag 'test_only_replaced' is inactive: Used only for testing flags that have been replaced by other flags.",
+                        "The flag 'test_only_replaced' is inactive: This flag has been renamed 'test_only' to reflect its stabilization. Please use 'test_only' instead.",
                         "ESLintInactiveFlag_test_only_replaced"
                     ]
                 );
@@ -8085,7 +8085,7 @@ describe("Linter with FlatConfigArray", () => {
                 assert.deepStrictEqual(
                     processStub.getCall(0).args,
                     [
-                        "The flag 'test_only_enabled_by_default' is inactive: Used only for testing flags whose features have been enabled by default.",
+                        "The flag 'test_only_enabled_by_default' is inactive: This feature is now enabled by default.",
                         "ESLintInactiveFlag_test_only_enabled_by_default"
                     ]
                 );
@@ -8096,7 +8096,7 @@ describe("Linter with FlatConfigArray", () => {
             assert.throws(() => {
                 // eslint-disable-next-line no-new -- needed for test
                 new Linter({ configType: "flat", flags: ["test_only_abandoned"] });
-            }, /The flag 'test_only_abandoned' is inactive: Used only for testing flags whose features have been abandoned/u);
+            }, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned/u);
         });
 
         it("should throw an error if an unknown flag is present", () => {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -8035,6 +8035,20 @@ describe("Linter with FlatConfigArray", () => {
 
     describe("hasFlag()", () => {
 
+        let processStub;
+
+        beforeEach(() => {
+
+            // in the browser test, `process.emitWarning` is not defined
+            if (typeof process !== "undefined" && typeof process.emitWarning !== "undefined") {
+                processStub = sinon.stub(process, "emitWarning").withArgs(sinon.match.any, sinon.match(/^ESLintInactiveFlag_/u)).returns();
+            }
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
         it("should return true if an active flag is present", () => {
             assert.strictEqual(
                 new Linter({ configType: "flat", flags: ["test_only"] }).hasFlag("test_only"),
@@ -8042,11 +8056,47 @@ describe("Linter with FlatConfigArray", () => {
             );
         });
 
-        it("should throw an error if an inactive flag is present", () => {
+        it("should return true for the replacement flag if an inactive flag that has been replaced is used", () => {
+            assert.strictEqual(
+                new Linter({ configType: "flat", flags: ["test_only_replaced"] }).hasFlag("test_only"),
+                true
+            );
+
+            if (processStub) {
+                assert.strictEqual(processStub.callCount, 1, "calls `process.emitWarning()` for flags once");
+                assert.deepStrictEqual(
+                    processStub.getCall(0).args,
+                    [
+                        "The flag 'test_only_replaced' is inactive: Used only for testing flags that have been replaced by other flags.",
+                        "ESLintInactiveFlag_test_only_replaced"
+                    ]
+                );
+            }
+        });
+
+        it("should return false if an inactive flag whose feature is enabled by default is used", () => {
+            assert.strictEqual(
+                new Linter({ configType: "flat", flags: ["test_only_enabled_by_default"] }).hasFlag("test_only_enabled_by_default"),
+                false
+            );
+
+            if (processStub) {
+                assert.strictEqual(processStub.callCount, 1, "calls `process.emitWarning()` for flags once");
+                assert.deepStrictEqual(
+                    processStub.getCall(0).args,
+                    [
+                        "The flag 'test_only_enabled_by_default' is inactive: Used only for testing flags whose features have been enabled by default.",
+                        "ESLintInactiveFlag_test_only_enabled_by_default"
+                    ]
+                );
+            }
+        });
+
+        it("should throw an error if an inactive flag whose feature has been abandoned is used", () => {
             assert.throws(() => {
                 // eslint-disable-next-line no-new -- needed for test
-                new Linter({ configType: "flat", flags: ["test_only_old"] });
-            }, /The flag 'test_only_old' is inactive: Used only for testing/u);
+                new Linter({ configType: "flat", flags: ["test_only_abandoned"] });
+            }, /The flag 'test_only_abandoned' is inactive: Used only for testing flags whose features have been abandoned/u);
         });
 
         it("should throw an error if an unknown flag is present", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

Fixes #19337

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Updated behavior of inactive flags as per https://github.com/eslint/eslint/issues/19337#issuecomment-2608050058.
* Added CLI, ESLint class, and Linter class tests for all scenarios.
* Updated docs with the flags policies.
* Updated data for the list of flags on the flags docs page to filter out test-only ones as it feels there are too many of those now.

#### Is there anything you'd like reviewers to focus on?

The implementation deviates slightly from the proposal we agreed on regarding flags for features that have been abandoned. Instead of removing the flag in a minor version, which would produce a generic "unknown flag" error message, we can make it inactive. An attempt to use it will still result in throwing an error, but we can provide a message like "the feature to ... has been abandoned".

<!-- markdownlint-disable-file MD004 -->
