### PR TITLE
docs: replace var with let and const in rules docs

### DIFF
--- a/docs/src/rules/no-eval.md
+++ b/docs/src/rules/no-eval.md
@@ -12,7 +12,7 @@ further_reading:
 JavaScript's `eval()` function is potentially dangerous and is often misused. Using `eval()` on untrusted code can open a program up to several different injection attacks. The use of `eval()` in most contexts can be substituted for a better, alternative approach to a problem.
 
 ```js
-var obj = { x: "foo" },
+const obj = { x: "foo" },
     key = "x",
     value = eval("obj." + key);
 ```
@@ -28,17 +28,17 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-eval: "error"*/
 
-var obj = { x: "foo" },
+const obj = { x: "foo" },
     key = "x",
     value = eval("obj." + key);
 
-(0, eval)("var a = 0");
+(0, eval)("const a = 0");
 
-var foo = eval;
-foo("var a = 0");
+const foo = eval;
+foo("const a = 0");
 
 // This `this` is the global object.
-this.eval("var a = 0");
+this.eval("const a = 0");
 ```
 
 :::
@@ -51,7 +51,7 @@ Example of additional **incorrect** code for this rule with `window` global vari
 /*eslint no-eval: "error"*/
 /*global window*/
 
-window.eval("var a = 0");
+window.eval("const a = 0");
 ```
 
 :::
@@ -64,7 +64,7 @@ Example of additional **incorrect** code for this rule with `global` global vari
 /*eslint no-eval: "error"*/
 /*global global*/
 
-global.eval("var a = 0");
+global.eval("const a = 0");
 ```
 
 :::
@@ -76,14 +76,14 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-eval: "error"*/
 
-var obj = { x: "foo" },
+const obj = { x: "foo" },
     key = "x",
     value = obj[key];
 
 class A {
     foo() {
         // This is a user-defined method.
-        this.eval("var a = 0");
+        this.eval("const a = 0");
     }
 
     eval() {
@@ -91,7 +91,7 @@ class A {
 
     static {
         // This is a user-defined static method.
-        this.eval("var a = 0");
+        this.eval("const a = 0");
     }
 
     static eval() {
@@ -121,7 +121,7 @@ Example of **incorrect** code for this rule with the `{"allowIndirect": true}` o
 ```js
 /*eslint no-eval: ["error", {"allowIndirect": true} ]*/
 
-var obj = { x: "foo" },
+const obj = { x: "foo" },
     key = "x",
     value = eval("obj." + key);
 ```
@@ -135,12 +135,12 @@ Examples of **correct** code for this rule with the `{"allowIndirect": true}` op
 ```js
 /*eslint no-eval: ["error", {"allowIndirect": true} ]*/
 
-(0, eval)("var a = 0");
+(0, eval)("const a = 0");
 
-var foo = eval;
-foo("var a = 0");
+const foo = eval;
+foo("const a = 0");
 
-this.eval("var a = 0");
+this.eval("const a = 0");
 ```
 
 :::
@@ -151,7 +151,7 @@ this.eval("var a = 0");
 /*eslint no-eval: ["error", {"allowIndirect": true} ]*/
 /*global window*/
 
-window.eval("var a = 0");
+window.eval("const a = 0");
 ```
 
 :::
@@ -162,7 +162,7 @@ window.eval("var a = 0");
 /*eslint no-eval: ["error", {"allowIndirect": true} ]*/
 /*global global*/
 
-global.eval("var a = 0");
+global.eval("const a = 0");
 ```
 
 :::
@@ -176,13 +176,13 @@ global.eval("var a = 0");
   module.exports = function(eval) {
       // If the value of this `eval` is built-in `eval` function, this is a
       // call of direct `eval`.
-      eval("var a = 0");
+      eval("const a = 0");
   };
   ```
 
 * This rule cannot catch renaming the global object. Such as:
 
   ```js
-  var foo = window;
-  foo.eval("var a = 0");
+  const foo = window;
+  foo.eval("const a = 0");
   ```

--- a/docs/src/rules/no-nested-ternary.md
+++ b/docs/src/rules/no-nested-ternary.md
@@ -10,7 +10,7 @@ related_rules:
 Nesting ternary expressions can make code more difficult to understand.
 
 ```js
-var foo = bar ? baz : qux === quxx ? bing : bam;
+const foo = bar ? baz : qux === quxx ? bing : bam;
 ```
 
 ## Rule Details
@@ -24,7 +24,7 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-nested-ternary: "error"*/
 
-var thing = foo ? bar : baz === qux ? quxx : foobar;
+const thing = foo ? bar : baz === qux ? quxx : foobar;
 
 foo ? baz === qux ? quxx() : foobar() : bar();
 ```
@@ -38,16 +38,16 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-nested-ternary: "error"*/
 
-var thing = foo ? bar : foobar;
+const thing = foo ? bar : foobar;
 
-var thing;
+let otherThing;
 
 if (foo) {
-  thing = bar;
+  otherThing = bar;
 } else if (baz === qux) {
-  thing = quxx;
+  otherThing = quxx;
 } else {
-  thing = foobar;
+  otherThing = foobar;
 }
 ```
 

--- a/docs/src/rules/no-ternary.md
+++ b/docs/src/rules/no-ternary.md
@@ -10,7 +10,7 @@ related_rules:
 The ternary operator is used to conditionally assign a value to a variable. Some believe that the use of ternary operators leads to unclear code.
 
 ```js
-var foo = isBar ? baz : qux;
+const foo = isBar ? baz : qux;
 ```
 
 ## Rule Details
@@ -24,7 +24,7 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-ternary: "error"*/
 
-var foo = isBar ? baz : qux;
+const foo = isBar ? baz : qux;
 
 function quux() {
   return foo ? bar() : baz();
@@ -40,7 +40,7 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-ternary: "error"*/
 
-var foo;
+let foo;
 
 if (isBar) {
     foo = baz;

--- a/docs/src/rules/no-undefined.md
+++ b/docs/src/rules/no-undefined.md
@@ -17,7 +17,7 @@ The `undefined` variable in JavaScript is actually a property of the global obje
 
 ```js
 function doSomething(data) {
-    var undefined = "hi";
+    const undefined = "hi";
 
     // doesn't do what you think it does
     if (data === undefined) {
@@ -46,9 +46,9 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-undefined: "error"*/
 
-var foo = undefined;
+const foo = undefined;
 
-var undefined = "foo";
+const undefined = "foo";
 
 if (foo === undefined) {
     // ...
@@ -70,9 +70,9 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-undefined: "error"*/
 
-var foo = void 0;
+const foo = void 0;
 
-var Undefined = "foo";
+const Undefined = "foo";
 
 if (typeof foo === "undefined") {
     // ...

--- a/docs/src/rules/no-unneeded-ternary.md
+++ b/docs/src/rules/no-unneeded-ternary.md
@@ -13,16 +13,16 @@ Here are some examples:
 
 ```js
 // Bad
-var isYes = answer === 1 ? true : false;
+const isYes = answer === 1 ? true : false;
 
 // Good
-var isYes = answer === 1;
+const isYes = answer === 1;
 
 // Bad
-var isNo = answer === 1 ? false : true;
+const isNo = answer === 1 ? false : true;
 
 // Good
-var isNo = answer !== 1;
+const isNo = answer !== 1;
 ```
 
 Another common mistake is using a single variable as both the conditional test and the consequent. In such cases, the logical `OR` can be used to provide the same functionality.
@@ -47,9 +47,9 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-unneeded-ternary: "error"*/
 
-var a = x === 2 ? true : false;
+const a = x === 2 ? true : false;
 
-var a = x ? true : false;
+const b = x ? true : false;
 ```
 
 :::
@@ -61,13 +61,13 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-unneeded-ternary: "error"*/
 
-var a = x === 2 ? "Yes" : "No";
+const a = x === 2 ? "Yes" : "No";
 
-var a = x !== false;
+const b = x !== false;
 
-var a = x ? "Yes" : "No";
+const c = x ? "Yes" : "No";
 
-var a = x ? y : x;
+const d = x ? y : x;
 
 f(x ? x : 1); // default assignment - would be disallowed if defaultAssignment option set to false. See option details below.
 ```
@@ -92,7 +92,7 @@ Examples of additional **incorrect** code for this rule with the `{ "defaultAssi
 ```js
 /*eslint no-unneeded-ternary: ["error", { "defaultAssignment": false }]*/
 
-var a = x ? x : 1;
+const a = x ? x : 1;
 
 f(x ? x : 1);
 ```


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)
replaced var with const and let in rules examples
`no-eval`
`no-nested-ternary`
`no-ternary`
`no-undefined`
`no-unneeded-ternary`

#### Is there anything you'd like reviewers to focus on?
Refs https://github.com/eslint/eslint/issues/19240