### PR TITLE
fix: Emit warning when empty config file is used

### DIFF
--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -512,7 +512,7 @@ class ConfigLoader {
 
             debug(`Config file ${configFilePath} is ${emptyConfig ? "empty" : "not empty"}`);
 
-            if (fileConfig) {
+            if (!emptyConfig) {
                 if (Array.isArray(fileConfig)) {
                     if (fileConfig.length === 0) {
                         debug(`Config file ${configFilePath} is an empty array`);
@@ -521,7 +521,7 @@ class ConfigLoader {
                         configs.push(...fileConfig);
                     }
                 } else {
-                    if (Object.keys(fileConfig).length === 0) {
+                    if (typeof fileConfig === "object" && fileConfig !== null && Object.keys(fileConfig).length === 0) {
                         debug(`Config file ${configFilePath} is an empty object`);
                         emptyConfig = true;
                     } else {

--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -531,7 +531,7 @@ class ConfigLoader {
             }
 
             if (emptyConfig) {
-                globalThis.process?.emitWarning?.(`Running ESLint with an empty config (from ${configFilePath}). Please double-check that this is what you want.`, "ESLintEmptyConfigWarning");
+                globalThis.process?.emitWarning?.(`Running ESLint with an empty config (from ${configFilePath}). Please double-check that this is what you want. If you want to run ESLint with an empty config, export [{}] to remove this warning.`, "ESLintEmptyConfigWarning");
             }
 
         }

--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -499,11 +499,41 @@ class ConfigLoader {
             debug(`Loading config file ${configFilePath}`);
             const fileConfig = await loadConfigFile(configFilePath);
 
-            if (Array.isArray(fileConfig)) {
-                configs.push(...fileConfig);
-            } else {
-                configs.push(fileConfig);
+            /*
+             * It's possible that a config file could be empty or else
+             * have an empty object or array. In this case, we want to
+             * warn the user that they have an empty config.
+             *
+             * An empty CommonJS file exports an empty object while
+             * an empty ESM file exports undefined.
+             */
+
+            let emptyConfig = typeof fileConfig === "undefined";
+
+            debug(`Config file ${configFilePath} is ${emptyConfig ? "empty" : "not empty"}`);
+
+            if (fileConfig) {
+                if (Array.isArray(fileConfig)) {
+                    if (fileConfig.length === 0) {
+                        debug(`Config file ${configFilePath} is an empty array`);
+                        emptyConfig = true;
+                    } else {
+                        configs.push(...fileConfig);
+                    }
+                } else {
+                    if (Object.keys(fileConfig).length === 0) {
+                        debug(`Config file ${configFilePath} is an empty object`);
+                        emptyConfig = true;
+                    } else {
+                        configs.push(fileConfig);
+                    }
+                }
             }
+
+            if (emptyConfig) {
+                globalThis.process?.emitWarning?.(`Running ESLint with an empty config (from ${configFilePath}). Please double-check that this is what you want.`, "ESLintEmptyConfigWarning");
+            }
+
         }
 
         // add in any configured defaults

--- a/tests/fixtures/empty-config-file/cjs/eslint.config.cjs
+++ b/tests/fixtures/empty-config-file/cjs/eslint.config.cjs
@@ -1,0 +1,1 @@
+// intentionally empty

--- a/tests/fixtures/empty-config-file/cjs/foo.js
+++ b/tests/fixtures/empty-config-file/cjs/foo.js
@@ -1,0 +1,1 @@
+let foo = "bar";

--- a/tests/fixtures/empty-config-file/esm/eslint.config.empty-array.mjs
+++ b/tests/fixtures/empty-config-file/esm/eslint.config.empty-array.mjs
@@ -1,0 +1,1 @@
+export default [];

--- a/tests/fixtures/empty-config-file/esm/eslint.config.mjs
+++ b/tests/fixtures/empty-config-file/esm/eslint.config.mjs
@@ -1,0 +1,1 @@
+// intentionally empty

--- a/tests/fixtures/empty-config-file/esm/eslint.config.null.mjs
+++ b/tests/fixtures/empty-config-file/esm/eslint.config.null.mjs
@@ -1,0 +1,1 @@
+export default null;

--- a/tests/fixtures/empty-config-file/esm/eslint.config.zero.mjs
+++ b/tests/fixtures/empty-config-file/esm/eslint.config.zero.mjs
@@ -1,0 +1,1 @@
+export default 0;

--- a/tests/fixtures/empty-config-file/esm/foo.js
+++ b/tests/fixtures/empty-config-file/esm/foo.js
@@ -1,0 +1,1 @@
+let foo = "bar";

--- a/tests/lib/config/config-loader.js
+++ b/tests/lib/config/config-loader.js
@@ -134,6 +134,48 @@ describe("Config loaders", () => {
                     assert(emitWarning.called, "Expected `process.emitWarning` to be called");
                     assert.strictEqual(emitWarning.args[0][1], "ESLintEmptyConfigWarning", "Expected `process.emitWarning` to be called with 'ESLintEmptyConfigWarning' as the second argument");
                 });
+
+                it("should throw an error when loading an ESM config file with null", async () => {
+                    const cwd = path.resolve(fixtureDir, "empty-config-file");
+
+                    const configLoader = new ConfigLoaderClass({
+                        cwd,
+                        ignoreEnabled: true,
+                        configFile: "esm/eslint.config.null.mjs"
+                    });
+
+                    let error;
+
+                    try {
+                        await configLoader.loadConfigArrayForFile(path.resolve(cwd, "mjs/foo.js"));
+                    } catch (err) {
+                        error = err;
+                    }
+
+                    assert(error);
+                    assert.strictEqual(error.message, "Config (unnamed): Unexpected null config at user-defined index 0.");
+                });
+
+                it("should throw an error when loading an ESM config with 0", async () => {
+                    const cwd = path.resolve(fixtureDir, "empty-config-file");
+
+                    const configLoader = new ConfigLoaderClass({
+                        cwd,
+                        ignoreEnabled: true,
+                        configFile: "esm/eslint.config.zero.mjs"
+                    });
+
+                    let error;
+
+                    try {
+                        await configLoader.loadConfigArrayForFile(path.resolve(cwd, "mjs/foo.js"));
+                    } catch (err) {
+                        error = err;
+                    }
+
+                    assert(error);
+                    assert.strictEqual(error.message, "Config (unnamed): Unexpected non-object config at user-defined index 0.");
+                });
             });
 
             describe("getCachedConfigArrayForFile()", () => {

--- a/tests/lib/config/config-loader.js
+++ b/tests/lib/config/config-loader.js
@@ -83,6 +83,57 @@ describe("Config loaders", () => {
                     assert.strictEqual(locateConfigFileToUse.callCount, 1, "Expected `ConfigLoader.locateConfigFileToUse` to be called exactly once");
                     assert.strictEqual(calculateConfigArray.callCount, 1, "Expected `ConfigLoader.calculateConfigArray` to be called exactly once");
                 });
+
+                it("should not error when loading an empty CommonJS config file", async () => {
+                    const cwd = path.resolve(fixtureDir, "empty-config-file");
+
+                    const configLoader = new ConfigLoaderClass({
+                        cwd,
+                        ignoreEnabled: true,
+                        configFile: "cjs/eslint.config.cjs"
+                    });
+
+                    const emitWarning = sinon.stub(process, "emitWarning");
+                    const configArray = await configLoader.loadConfigArrayForFile(path.resolve(cwd, "cjs/foo.js"));
+
+                    assert(Array.isArray(configArray), "Expected `loadConfigArrayForFile()` to return a config array");
+                    assert(emitWarning.called, "Expected `process.emitWarning` to be called");
+                    assert.strictEqual(emitWarning.args[0][1], "ESLintEmptyConfigWarning", "Expected `process.emitWarning` to be called with 'ESLintEmptyConfigWarning' as the second argument");
+                });
+
+                it("should not error when loading an empty ESM config file", async () => {
+                    const cwd = path.resolve(fixtureDir, "empty-config-file");
+
+                    const configLoader = new ConfigLoaderClass({
+                        cwd,
+                        ignoreEnabled: true,
+                        configFile: "esm/eslint.config.mjs"
+                    });
+
+                    const emitWarning = sinon.stub(process, "emitWarning");
+                    const configArray = await configLoader.loadConfigArrayForFile(path.resolve(cwd, "esm/foo.js"));
+
+                    assert(Array.isArray(configArray), "Expected `loadConfigArrayForFile()` to return a config array");
+                    assert(emitWarning.called, "Expected `process.emitWarning` to be called");
+                    assert.strictEqual(emitWarning.args[0][1], "ESLintEmptyConfigWarning", "Expected `process.emitWarning` to be called with 'ESLintEmptyConfigWarning' as the second argument");
+                });
+
+                it("should not error when loading an ESM config file with an empty array", async () => {
+                    const cwd = path.resolve(fixtureDir, "empty-config-file");
+
+                    const configLoader = new ConfigLoaderClass({
+                        cwd,
+                        ignoreEnabled: true,
+                        configFile: "esm/eslint.config.empty-array.mjs"
+                    });
+
+                    const emitWarning = sinon.stub(process, "emitWarning");
+                    const configArray = await configLoader.loadConfigArrayForFile(path.resolve(cwd, "mjs/foo.js"));
+
+                    assert(Array.isArray(configArray), "Expected `loadConfigArrayForFile()` to return a config array");
+                    assert(emitWarning.called, "Expected `process.emitWarning` to be called");
+                    assert.strictEqual(emitWarning.args[0][1], "ESLintEmptyConfigWarning", "Expected `process.emitWarning` to be called with 'ESLintEmptyConfigWarning' as the second argument");
+                });
             });
 
             describe("getCachedConfigArrayForFile()", () => {

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -1389,9 +1389,12 @@ describe("ESLint", () => {
                     );
                 });
 
-                it("should fail to load a CommonJS TS config file that exports undefined with a helpful error message", async () => {
+                it("should fail to load a CommonJS TS config file that exports undefined with a helpful warning message", async () => {
+
+                    sinon.restore();
 
                     const cwd = getFixturePath("ts-config-files", "ts");
+                    const processStub = sinon.stub(process, "emitWarning");
 
                     eslint = new ESLint({
                         cwd,
@@ -1399,10 +1402,10 @@ describe("ESLint", () => {
                         overrideConfigFile: "eslint.undefined.config.ts"
                     });
 
-                    await assert.rejects(
-                        eslint.lintText("foo"),
-                        { message: "Config (unnamed): Unexpected undefined config at user-defined index 0." }
-                    );
+                    await eslint.lintText("foo");
+
+                    assert.strictEqual(processStub.callCount, 1, "calls `process.emitWarning()` once");
+                    assert.strictEqual(processStub.getCall(0).args[1], "ESLintEmptyConfigWarning");
 
                 });
 
@@ -5975,9 +5978,12 @@ describe("ESLint", () => {
                     );
                 });
 
-                it("should fail to load a CommonJS TS config file that exports undefined with a helpful error message", async () => {
+                it("should fail to load a CommonJS TS config file that exports undefined with a helpful warning message", async () => {
+
+                    sinon.restore();
 
                     const cwd = getFixturePath("ts-config-files", "ts");
+                    const processStub = sinon.stub(process, "emitWarning");
 
                     eslint = new ESLint({
                         cwd,
@@ -5985,10 +5991,11 @@ describe("ESLint", () => {
                         overrideConfigFile: "eslint.undefined.config.ts"
                     });
 
-                    await assert.rejects(
-                        eslint.lintFiles("foo.js"),
-                        { message: "Config (unnamed): Unexpected undefined config at user-defined index 0." }
-                    );
+                    await eslint.lintFiles("foo.js");
+
+                    assert.strictEqual(processStub.callCount, 1, "calls `process.emitWarning()` once");
+                    assert.strictEqual(processStub.getCall(0).args[1], "ESLintEmptyConfigWarning");
+
 
                 });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Ensured consistent behavior when an empty CJS config file is loaded vs. an empty ESM config file. It now no longer throws an error in any situation and instead emits a warning.

fixes #19044

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
