### PR TITLE
chore: better error message for missing plugin in config

### DIFF
--- a/lib/config/rule-validator.js
+++ b/lib/config/rule-validator.js
@@ -36,7 +36,12 @@ function throwRuleNotFoundError({ pluginName, ruleName }, config) {
     const ruleId = pluginName === "@" ? ruleName : `${pluginName}/${ruleName}`;
 
     const errorMessageHeader = `Key "rules": Key "${ruleId}"`;
-    let errorMessage = `${errorMessageHeader}: Could not find plugin "${pluginName}".`;
+    const error = new TypeError(`${errorMessageHeader}: Could not find plugin "${pluginName}" in configuration.`);
+
+    error.messageTemplate = "config-plugin-missing";
+    error.messageData = { pluginName, ruleId };
+
+    let errorMessage = "";
 
     // if the plugin exists then we need to check if the rule exists
     if (config.plugins && config.plugins[pluginName]) {
@@ -63,7 +68,9 @@ function throwRuleNotFoundError({ pluginName, ruleName }, config) {
         // falls through to throw error
     }
 
-    throw new TypeError(errorMessage);
+    const finalError = errorMessage === "" ? error : new TypeError(errorMessage);
+
+    throw finalError;
 }
 
 /**

--- a/lib/config/rule-validator.js
+++ b/lib/config/rule-validator.js
@@ -39,7 +39,7 @@ function throwRuleNotFoundError({ pluginName, ruleName }, config) {
 
     let errorMessage = `${errorMessageHeader}: Could not find plugin "${pluginName}" in configuration.`;
 
-    const missingPluginError = errorMessage;
+    const missingPluginErrorMessage = errorMessage;
 
     // if the plugin exists then we need to check if the rule exists
     if (config.plugins && config.plugins[pluginName]) {
@@ -68,7 +68,7 @@ function throwRuleNotFoundError({ pluginName, ruleName }, config) {
 
     const error = new TypeError(errorMessage);
 
-    if (errorMessage === missingPluginError) {
+    if (errorMessage === missingPluginErrorMessage) {
         error.messageTemplate = "config-plugin-missing";
         error.messageData = { pluginName, ruleId };
     }

--- a/lib/config/rule-validator.js
+++ b/lib/config/rule-validator.js
@@ -36,12 +36,10 @@ function throwRuleNotFoundError({ pluginName, ruleName }, config) {
     const ruleId = pluginName === "@" ? ruleName : `${pluginName}/${ruleName}`;
 
     const errorMessageHeader = `Key "rules": Key "${ruleId}"`;
-    const error = new TypeError(`${errorMessageHeader}: Could not find plugin "${pluginName}" in configuration.`);
 
-    error.messageTemplate = "config-plugin-missing";
-    error.messageData = { pluginName, ruleId };
+    let errorMessage = `${errorMessageHeader}: Could not find plugin "${pluginName}" in configuration.`;
 
-    let errorMessage = "";
+    const missingPluginError = errorMessage;
 
     // if the plugin exists then we need to check if the rule exists
     if (config.plugins && config.plugins[pluginName]) {
@@ -68,9 +66,14 @@ function throwRuleNotFoundError({ pluginName, ruleName }, config) {
         // falls through to throw error
     }
 
-    const finalError = errorMessage === "" ? error : new TypeError(errorMessage);
+    const error = new TypeError(errorMessage);
 
-    throw finalError;
+    if (errorMessage === missingPluginError) {
+        error.messageTemplate = "config-plugin-missing";
+        error.messageData = { pluginName, ruleId };
+    }
+
+    throw error;
 }
 
 /**

--- a/messages/config-plugin-missing.js
+++ b/messages/config-plugin-missing.js
@@ -1,0 +1,12 @@
+"use strict";
+
+module.exports = function(it) {
+    const { pluginName, ruleId } = it;
+
+    return `
+Common causes of this problem include:
+
+1. The "${pluginName}" plugin is not defined in your configuration file.
+2. The "${pluginName}" plugin is not defined within the same configuration object in which the "${ruleId}" rule is applied.
+`.trimStart();
+};

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -2373,7 +2373,7 @@ describe("FlatConfigArray", () => {
                             "doesnt-exist/match": "error"
                         }
                     }
-                ], /Key "rules": Key "doesnt-exist\/match": Could not find plugin "doesnt-exist"\./u);
+                ], /Key "rules": Key "doesnt-exist\/match": Could not find plugin "doesnt-exist" in configuration\./u);
             });
 
             it("should error when rule options don't match schema", async () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
To modify the error message for missing plugin in config, created a new file `config-plugin-missing` to store message related to possible reasons of the error.

Message is kind of similar to what suggested in https://github.com/eslint/eslint/issues/19254#issuecomment-2598909936 which is
```
Oops! Something went wrong! :(

ESLint: 9.17.0

TypeError: Key "rules": Key "simple-import-sort/imports": Could not find plugin "simple-import-sort" in the configuration for file /path/to/file.js.

Common causes of this problem include:

1. The "simple-import-sort" plugin is not defined in your configuration file. 
2. "simple-import-sort" is defined in a configuration object that that doesn't match /path/to/file.js.

Use the Config Inspector (--inspect-config) to check your configuration file and which parts match path/to/file.js.
```

since it wasn't clear to me what `/path/to/file.js` exactly indicates in this error, so i tried to write something that can help to find issue, that is

```
Oops! Something went wrong! :(
ESLint: 9.17.0

TypeError: Key "rules": Key "simple-import-sort/imports": Could not find plugin "simple-import-sort" in the configuration.

Common causes of this problem include:

1. The "simple-import-sort" plugin is not defined in your configuration file.
2. The "simple-import-sort" plugin is not defined within the same configuration object in which the "simple-import-sort/imports" rule is applied.
```

#### Is there anything you'd like reviewers to focus on?
fixes #19254

<!-- markdownlint-disable-file MD004 -->
