### PR TITLE
test: avoid empty config warning in test output

### DIFF
--- a/tests/fixtures/cli/ignore-pattern-relative/eslint.config.js
+++ b/tests/fixtures/cli/ignore-pattern-relative/eslint.config.js
@@ -1,1 +1,1 @@
-module.exports = [];
+module.exports = [{}];

--- a/tests/fixtures/example-app/eslint.config.js
+++ b/tests/fixtures/example-app/eslint.config.js
@@ -1,1 +1,1 @@
-module.exports = [];
+module.exports = [{}];

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -4492,7 +4492,7 @@ describe("ESLint", () => {
                             "b.js": "",
                             "ab.js": "",
                             "[ab].js": "",
-                            "eslint.config.js": "module.exports = [];"
+                            "eslint.config.js": "module.exports = [{}];"
                         }
                     });
 
@@ -4513,7 +4513,7 @@ describe("ESLint", () => {
                             "a.js": "",
                             "b.js": "",
                             "ab.js": "",
-                            "eslint.config.js": "module.exports = [];"
+                            "eslint.config.js": "module.exports = [{}];"
                         }
                     });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Updates several fixture configs to avoid `ESLintEmptyConfigWarning` in the output of `npm test`.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Replaced `module.exports = []` with `module.exports = [{}]`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
