### PR TITLE
test: processors can return subpaths

### DIFF
--- a/tests/fixtures/processors/test/test-subpath.txt
+++ b/tests/fixtures/processors/test/test-subpath.txt
@@ -1,0 +1,1 @@
+foo bar baz

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -3876,6 +3876,75 @@ describe("ESLint", () => {
 
                 });
 
+                // https://github.com/eslint/markdown/blob/main/rfcs/configure-file-name-from-block-meta.md#name-uniqueness
+                it("should allow processors to return filenames with a slash and treat them as subpaths", async () => {
+                    eslint = new ESLint({
+                        flags,
+                        overrideConfigFile: true,
+                        overrideConfig: [
+                            {
+                                plugins: {
+                                    test: {
+                                        processors: {
+                                            txt: {
+                                                preprocess(input) {
+                                                    return input.split(" ").map((text, index) => ({
+                                                        filename: `example-${index}/a.js`,
+                                                        text
+                                                    }));
+                                                },
+                                                postprocess(messagesList) {
+                                                    return messagesList.flat();
+                                                }
+                                            }
+                                        },
+                                        rules: {
+                                            "test-rule": {
+                                                meta: {},
+                                                create(context) {
+                                                    return {
+                                                        Identifier(node) {
+                                                            context.report({
+                                                                node,
+                                                                message: `filename: ${context.filename} physicalFilename: ${context.physicalFilename} identifier: ${node.name}`
+                                                            });
+                                                        }
+                                                    };
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                files: ["**/*.txt"],
+                                processor: "test/txt"
+                            },
+                            {
+                                files: ["**/a.js"],
+                                rules: {
+                                    "test/test-rule": "error"
+                                }
+                            }
+                        ],
+                        cwd: path.join(fixtureDir, "..")
+                    });
+                    const filename = getFixturePath("processors", "test", "test-subpath.txt");
+                    const [result] = await eslint.lintFiles([filename]);
+
+                    assert.strictEqual(result.messages.length, 3);
+
+                    assert.strictEqual(result.messages[0].ruleId, "test/test-rule");
+                    assert.strictEqual(result.messages[0].message, `filename: ${path.join(filename, "0_example-0", "a.js")} physicalFilename: ${filename} identifier: foo`);
+                    assert.strictEqual(result.messages[1].ruleId, "test/test-rule");
+                    assert.strictEqual(result.messages[1].message, `filename: ${path.join(filename, "1_example-1", "a.js")} physicalFilename: ${filename} identifier: bar`);
+                    assert.strictEqual(result.messages[2].ruleId, "test/test-rule");
+                    assert.strictEqual(result.messages[2].message, `filename: ${path.join(filename, "2_example-2", "a.js")} physicalFilename: ${filename} identifier: baz`);
+
+                    assert.strictEqual(result.suppressedMessages.length, 0);
+
+                });
+
                 describe("autofixing with processors", () => {
                     const HTML_PROCESSOR = Object.freeze({
                         preprocess(text) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Refs https://github.com/eslint/markdown/blob/main/rfcs/configure-file-name-from-block-meta.md#name-uniqueness.

#### What changes did you make? (Give an overview)

Added tests that verify that processors can return slashes in the code block filename and that such filenames are treated as subpaths.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
