### PR TITLE
feat: support TypeScript syntax in `default-param-last`

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -201,6 +201,14 @@ module.exports = function(eleventyConfig) {
     const ruleExampleOptions = markdownItRuleExample({
         open({ type, code, languageOptions, env, codeBlockToken }) {
 
+            /*
+             * TypeScript isn't yet supported on the playground:
+             * https://github.com/eslint/eslint.org/issues/709
+             */
+            if (codeBlockToken.info === "ts") {
+                return `<div class="${type}">`;
+            }
+
             prismESLintHook.addContentMustBeMarked(codeBlockToken.content, languageOptions);
 
             const isRuleRemoved = !Object.hasOwn(env.rules_meta, env.title);

--- a/docs/src/rules/default-param-last.md
+++ b/docs/src/rules/default-param-last.md
@@ -41,6 +41,34 @@ Examples of **correct** code for this rule:
 /* eslint default-param-last: ["error"] */
 
 function f(a, b = 0) {}
+
+function g(a, b = 0, c = 0) {}
+```
+
+:::
+
+This rule additionally supports TypeScript type syntax.
+
+Examples of **incorrect** TypeScript code for this rule:
+
+::: incorrect
+
+```ts
+/* eslint default-param-last: ["error"] */
+
+function h(a = 0, b: number) {}
+```
+
+:::
+
+Examples of **correct** TypeScript code for this rule:
+
+::: correct
+
+```ts
+/* eslint default-param-last: ["error"] */
+
+function h(a = 0, b?: number) {}
 ```
 
 :::

--- a/lib/rules/default-param-last.js
+++ b/lib/rules/default-param-last.js
@@ -5,6 +5,35 @@
 
 "use strict";
 
+/**
+ * checks if node is optional parameter
+ * @param {ASTNode} node the node to be evaluated
+ * @returns {boolean} whether the node is optional
+ */
+function isOptionalParam(node) {
+    return (
+        (node.type === "ArrayPattern" ||
+            node.type === "AssignmentPattern" ||
+            node.type === "Identifier" ||
+            node.type === "ObjectPattern" ||
+            node.type === "RestElement") &&
+        node.optional
+    );
+}
+
+/**
+ * checks if node is plain parameter
+ * @param {ASTNode} node the node to be evaluated
+ * @returns {boolean} whether the node is plain
+ */
+function isPlainParam(node) {
+    return !(
+        node.type === "AssignmentPattern" ||
+        node.type === "RestElement" ||
+        isOptionalParam(node)
+    );
+}
+
 /** @type {import('../shared/types').Rule} */
 module.exports = {
     meta: {
@@ -35,19 +64,24 @@ module.exports = {
             let hasSeenPlainParam = false;
 
             for (let i = node.params.length - 1; i >= 0; i -= 1) {
-                const param = node.params[i];
+                const current = node.params[i];
+                const param =
+                    current.type === "TSParameterProperty"
+                        ? current.parameter
+                        : current;
 
-                if (
-                    param.type !== "AssignmentPattern" &&
-                    param.type !== "RestElement"
-                ) {
+                if (isPlainParam(param)) {
                     hasSeenPlainParam = true;
                     continue;
                 }
 
-                if (hasSeenPlainParam && param.type === "AssignmentPattern") {
+                if (
+                    hasSeenPlainParam &&
+                    (isOptionalParam(param) ||
+                    param.type === "AssignmentPattern")
+                ) {
                     context.report({
-                        node: param,
+                        node: current,
                         messageId: "shouldBeLast"
                     });
                 }

--- a/lib/rules/default-param-last.js
+++ b/lib/rules/default-param-last.js
@@ -6,9 +6,9 @@
 "use strict";
 
 /**
- * checks if node is optional parameter
+ * Checks if node is a TypeScript-optional parameter.
  * @param {ASTNode} node the node to be evaluated
- * @returns {boolean} whether the node is optional
+ * @returns {boolean} true if the node is optional, false if not.
  */
 function isOptionalParam(node) {
     return (

--- a/lib/rules/default-param-last.js
+++ b/lib/rules/default-param-last.js
@@ -27,7 +27,8 @@ module.exports = {
             description: "Enforce default parameters to be last",
             recommended: false,
             frozen: true,
-            url: "https://eslint.org/docs/latest/rules/default-param-last"
+            url: "https://eslint.org/docs/latest/rules/default-param-last",
+            typescript: "syntax"
         },
 
         schema: [],

--- a/lib/rules/default-param-last.js
+++ b/lib/rules/default-param-last.js
@@ -6,31 +6,15 @@
 "use strict";
 
 /**
- * Checks if node is a TypeScript-optional parameter.
+ * Checks if node is required: i.e. does not have a default value or ? optional indicator.
  * @param {ASTNode} node the node to be evaluated
- * @returns {boolean} true if the node is optional, false if not.
+ * @returns {boolean} true if the node is required, false if not.
  */
-function isOptionalParam(node) {
-    return (
-        (node.type === "ArrayPattern" ||
-            node.type === "AssignmentPattern" ||
-            node.type === "Identifier" ||
-            node.type === "ObjectPattern" ||
-            node.type === "RestElement") &&
-        node.optional
-    );
-}
-
-/**
- * checks if node is plain parameter
- * @param {ASTNode} node the node to be evaluated
- * @returns {boolean} whether the node is plain
- */
-function isPlainParam(node) {
+function isRequiredParameter(node) {
     return !(
         node.type === "AssignmentPattern" ||
         node.type === "RestElement" ||
-        isOptionalParam(node)
+        node.optional
     );
 }
 
@@ -61,7 +45,7 @@ module.exports = {
          * @returns {void}
          */
         function handleFunction(node) {
-            let hasSeenPlainParam = false;
+            let hasSeenRequiredParameter = false;
 
             for (let i = node.params.length - 1; i >= 0; i -= 1) {
                 const current = node.params[i];
@@ -70,16 +54,12 @@ module.exports = {
                         ? current.parameter
                         : current;
 
-                if (isPlainParam(param)) {
-                    hasSeenPlainParam = true;
+                if (isRequiredParameter(param)) {
+                    hasSeenRequiredParameter = true;
                     continue;
                 }
 
-                if (
-                    hasSeenPlainParam &&
-                    (isOptionalParam(param) ||
-                    param.type === "AssignmentPattern")
-                ) {
+                if (hasSeenRequiredParameter) {
                     context.report({
                         node: current,
                         messageId: "shouldBeLast"

--- a/lib/rules/default-param-last.js
+++ b/lib/rules/default-param-last.js
@@ -29,8 +29,7 @@ module.exports = {
             description: "Enforce default parameters to be last",
             recommended: false,
             frozen: true,
-            url: "https://eslint.org/docs/latest/rules/default-param-last",
-            typescript: "syntax"
+            url: "https://eslint.org/docs/latest/rules/default-param-last"
         },
 
         schema: [],

--- a/lib/rules/default-param-last.js
+++ b/lib/rules/default-param-last.js
@@ -21,6 +21,8 @@ function isRequiredParameter(node) {
 /** @type {import('../shared/types').Rule} */
 module.exports = {
     meta: {
+        dialects: ["javascript", "typescript"],
+        language: "javascript",
         type: "suggestion",
 
         docs: {

--- a/tests/fixtures/bad-examples.md
+++ b/tests/fixtures/bad-examples.md
@@ -17,7 +17,7 @@ export default "foo";
 
 :::correct
 
-````ts
+````rs
 const foo = "bar";
 
 const foo = "baz";

--- a/tests/lib/rules/default-param-last.js
+++ b/tests/lib/rules/default-param-last.js
@@ -112,3 +112,542 @@ ruleTester.run("default-param-last", rule, {
         }
     ]
 });
+
+const ruleTesterTypeScript = new RuleTester({
+    languageOptions: {
+        parser: require("@typescript-eslint/parser")
+    }
+});
+
+ruleTesterTypeScript.run("default-param-last", rule, {
+    valid: [
+        "function foo() {}",
+        "function foo(a: number) {}",
+        "function foo(a = 1) {}",
+        "function foo(a?: number) {}",
+        "function foo(a: number, b: number) {}",
+        "function foo(a: number, b: number, c?: number) {}",
+        "function foo(a: number, b = 1) {}",
+        "function foo(a: number, b = 1, c = 1) {}",
+        "function foo(a: number, b = 1, c?: number) {}",
+        "function foo(a: number, b?: number, c = 1) {}",
+        "function foo(a: number, b = 1, ...c) {}",
+
+        "const foo = function () {};",
+        "const foo = function (a: number) {};",
+        "const foo = function (a = 1) {};",
+        "const foo = function (a?: number) {};",
+        "const foo = function (a: number, b: number) {};",
+        "const foo = function (a: number, b: number, c?: number) {};",
+        "const foo = function (a: number, b = 1) {};",
+        "const foo = function (a: number, b = 1, c = 1) {};",
+        "const foo = function (a: number, b = 1, c?: number) {};",
+        "const foo = function (a: number, b?: number, c = 1) {};",
+        "const foo = function (a: number, b = 1, ...c) {};",
+
+        "const foo = () => {};",
+        "const foo = (a: number) => {};",
+        "const foo = (a = 1) => {};",
+        "const foo = (a?: number) => {};",
+        "const foo = (a: number, b: number) => {};",
+        "const foo = (a: number, b: number, c?: number) => {};",
+        "const foo = (a: number, b = 1) => {};",
+        "const foo = (a: number, b = 1, c = 1) => {};",
+        "const foo = (a: number, b = 1, c?: number) => {};",
+        "const foo = (a: number, b?: number, c = 1) => {};",
+        "const foo = (a: number, b = 1, ...c) => {};",
+        `
+    class Foo {
+      constructor(a: number, b: number, c: number) {}
+    }
+        `,
+        `
+    class Foo {
+      constructor(a: number, b?: number, c = 1) {}
+    }
+        `,
+        `
+    class Foo {
+      constructor(a: number, b = 1, c?: number) {}
+    }
+        `,
+        `
+    class Foo {
+      constructor(
+        public a: number,
+        protected b: number,
+        private c: number,
+      ) {}
+    }
+        `,
+        `
+    class Foo {
+      constructor(
+        public a: number,
+        protected b?: number,
+        private c = 10,
+      ) {}
+    }
+        `,
+        `
+    class Foo {
+      constructor(
+        public a: number,
+        protected b = 10,
+        private c?: number,
+      ) {}
+    }
+        `,
+        `
+    class Foo {
+      constructor(
+        a: number,
+        protected b?: number,
+        private c = 0,
+      ) {}
+    }
+        `,
+        `
+    class Foo {
+      constructor(
+        a: number,
+        b?: number,
+        private c = 0,
+      ) {}
+    }
+        `,
+        `
+    class Foo {
+      constructor(
+        a: number,
+        private b?: number,
+        c = 0,
+      ) {}
+    }
+        `
+    ],
+    invalid: [
+        {
+            code: "function foo(a = 1, b: number) {}",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 19
+                }
+            ]
+        },
+        {
+            code: "function foo(a = 1, b = 2, c: number) {}",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 19
+                },
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 21,
+                    endColumn: 26
+                }
+            ]
+        },
+        {
+            code: "function foo(a = 1, b: number, c = 2, d: number) {}",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 19
+                },
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 32,
+                    endColumn: 37
+                }
+            ]
+        },
+        {
+            code: "function foo(a = 1, b: number, c = 2) {}",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 19
+                }
+            ]
+        },
+        {
+            code: "function foo(a = 1, b: number, ...c) {}",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 19
+                }
+            ]
+        },
+        {
+            code: "function foo(a?: number, b: number) {}",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 24
+                }
+            ]
+        },
+        {
+            code: "function foo(a: number, b?: number, c: number) {}",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 25,
+                    endColumn: 35
+                }
+            ]
+        },
+        {
+            code: "function foo(a = 1, b?: number, c: number) {}",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 19
+                },
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 21,
+                    endColumn: 31
+                }
+            ]
+        },
+        {
+            code: "const foo = function (a = 1, b: number) {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 23,
+                    endColumn: 28
+                }
+            ]
+        },
+        {
+            code: "const foo = function (a = 1, b = 2, c: number) {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 23,
+                    endColumn: 28
+                },
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 30,
+                    endColumn: 35
+                }
+            ]
+        },
+        {
+            code: "const foo = function (a = 1, b: number, c = 2, d: number) {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 23,
+                    endColumn: 28
+                },
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 41,
+                    endColumn: 46
+                }
+            ]
+        },
+        {
+            code: "const foo = function (a = 1, b: number, c = 2) {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 23,
+                    endColumn: 28
+                }
+            ]
+        },
+        {
+            code: "const foo = function (a = 1, b: number, ...c) {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 23,
+                    endColumn: 28
+                }
+            ]
+        },
+        {
+            code: "const foo = function (a?: number, b: number) {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 23,
+                    endColumn: 33
+                }
+            ]
+        },
+        {
+            code: "const foo = function (a: number, b?: number, c: number) {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 34,
+                    endColumn: 44
+                }
+            ]
+        },
+        {
+            code: "const foo = function (a = 1, b?: number, c: number) {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 23,
+                    endColumn: 28
+                },
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 30,
+                    endColumn: 40
+                }
+            ]
+        },
+        {
+            code: "const foo = (a = 1, b: number) => {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 19
+                }
+            ]
+        },
+        {
+            code: "const foo = (a = 1, b = 2, c: number) => {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 19
+                },
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 21,
+                    endColumn: 26
+                }
+            ]
+        },
+        {
+            code: "const foo = (a = 1, b: number, c = 2, d: number) => {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 19
+                },
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 32,
+                    endColumn: 37
+                }
+            ]
+        },
+        {
+            code: "const foo = (a = 1, b: number, c = 2) => {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 19
+                }
+            ]
+        },
+        {
+            code: "const foo = (a = 1, b: number, ...c) => {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 19
+                }
+            ]
+        },
+        {
+            code: "const foo = (a?: number, b: number) => {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 24
+                }
+            ]
+        },
+        {
+            code: "const foo = (a: number, b?: number, c: number) => {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 25,
+                    endColumn: 35
+                }
+            ]
+        },
+        {
+            code: "const foo = (a = 1, b?: number, c: number) => {};",
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 14,
+                    endColumn: 19
+                },
+                {
+                    messageId: "shouldBeLast",
+                    line: 1,
+                    column: 21,
+                    endColumn: 31
+                }
+            ]
+        },
+        {
+            code: `
+    class Foo {
+      constructor(
+        public a: number,
+        protected b?: number,
+        private c: number,
+      ) {}
+    }
+          `,
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 5,
+                    column: 9,
+                    endColumn: 29
+                }
+            ]
+        },
+        {
+            code: `
+    class Foo {
+      constructor(
+        public a: number,
+        protected b = 0,
+        private c: number,
+      ) {}
+    }
+          `,
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 5,
+                    column: 9,
+                    endColumn: 24
+                }
+            ]
+        },
+        {
+            code: `
+    class Foo {
+      constructor(
+        public a?: number,
+        private b: number,
+      ) {}
+    }
+          `,
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 4,
+                    column: 9,
+                    endColumn: 26
+                }
+            ]
+        },
+        {
+            code: `
+    class Foo {
+      constructor(
+        public a = 0,
+        private b: number,
+      ) {}
+    }
+          `,
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 4,
+                    column: 9,
+                    endColumn: 21
+                }
+            ]
+        },
+        {
+            code: `
+    class Foo {
+      constructor(a = 0, b: number) {}
+    }
+          `,
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 3,
+                    column: 19,
+                    endColumn: 24
+                }
+            ]
+        },
+        {
+            code: `
+    class Foo {
+      constructor(a?: number, b: number) {}
+    }
+          `,
+            errors: [
+                {
+                    messageId: "shouldBeLast",
+                    line: 3,
+                    column: 19,
+                    endColumn: 29
+                }
+            ]
+        }
+    ]
+});

--- a/tests/tools/check-rule-examples.js
+++ b/tests/tools/check-rule-examples.js
@@ -75,9 +75,9 @@ describe("check-rule-examples", () => {
                 const expectedStderr =
                 "\x1B[0m\x1B[0m\n" +
                 "\x1B[0m\x1B[4mbad-examples.md\x1B[24m\x1B[0m\n" +
-                "\x1B[0m   \x1B[2m11:4\x1B[22m  \x1B[31merror\x1B[39m  Missing language tag: use one of 'javascript', 'js' or 'jsx'\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m11:4\x1B[22m  \x1B[31merror\x1B[39m  Missing language tag: use one of 'javascript', 'js', 'jsx', 'ts', or 'tsx'\x1B[0m\n" +
                 "\x1B[0m   \x1B[2m12:1\x1B[22m  \x1B[31merror\x1B[39m  Unexpected lint error found: Parsing error: 'import' and 'export' may appear only with 'sourceType: module'\x1B[0m\n" +
-                "\x1B[0m   \x1B[2m20:5\x1B[22m  \x1B[31merror\x1B[39m  Nonstandard language tag 'ts': use one of 'javascript', 'js' or 'jsx'\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m20:5\x1B[22m  \x1B[31merror\x1B[39m  Nonstandard language tag 'rs': use one of 'javascript', 'js', 'jsx', 'ts', or 'tsx'\x1B[0m\n" +
                 "\x1B[0m   \x1B[2m23:7\x1B[22m  \x1B[31merror\x1B[39m  Unexpected lint error found: Parsing error: Identifier 'foo' has already been declared\x1B[0m\n" +
                 "\x1B[0m   \x1B[2m31:1\x1B[22m  \x1B[31merror\x1B[39m  Example code should contain a configuration comment like /* eslint no-restricted-syntax: \"error\" */\x1B[0m\n" +
                 "\x1B[0m   \x1B[2m41:1\x1B[22m  \x1B[31merror\x1B[39m  Unexpected lint error found: Failed to parse JSON from 'doesn't allow this comment'\x1B[0m\n" +

--- a/tools/check-rule-examples.js
+++ b/tools/check-rule-examples.js
@@ -14,6 +14,7 @@ const { ConfigCommentParser } = require("@eslint/plugin-kit");
 const rules = require("../lib/rules");
 const { LATEST_ECMA_VERSION } = require("../conf/ecma-version");
 const { Linter } = require("../lib/linter");
+const tseslint = require("@typescript-eslint/parser");
 
 //------------------------------------------------------------------------------
 // Typedefs
@@ -27,7 +28,9 @@ const { Linter } = require("../lib/linter");
 // Helpers
 //------------------------------------------------------------------------------
 
-const STANDARD_LANGUAGE_TAGS = new Set(["javascript", "js", "jsx"]);
+const TYPESCRIPT_LANGUAGE_TAGS = new Set(["ts", "tsx"]);
+const STANDARD_LANGUAGE_TAGS = new Set(["javascript", "js", "jsx", ...TYPESCRIPT_LANGUAGE_TAGS]);
+
 
 const VALID_ECMA_VERSIONS = new Set([
     3,
@@ -93,6 +96,10 @@ async function findProblems(filename) {
 
                     return;
                 }
+            }
+
+            if (TYPESCRIPT_LANGUAGE_TAGS.has(languageTag)) {
+                languageOptions.parser = tseslint;
             }
 
             const linter = new Linter();

--- a/tools/check-rule-examples.js
+++ b/tools/check-rule-examples.js
@@ -62,7 +62,7 @@ async function findProblems(filename) {
                  */
                 const message = `${languageTag
                     ? `Nonstandard language tag '${languageTag}'`
-                    : "Missing language tag"}: use one of 'javascript', 'js' or 'jsx'`;
+                    : "Missing language tag"}: use one of 'javascript', 'js', 'jsx', 'ts', or 'tsx'`;
 
                 problems.push({
                     fatal: false,

--- a/tools/check-rule-examples.js
+++ b/tools/check-rule-examples.js
@@ -11,10 +11,10 @@ const markdownIt = require("markdown-it");
 const markdownItContainer = require("markdown-it-container");
 const markdownItRuleExample = require("../docs/tools/markdown-it-rule-example");
 const { ConfigCommentParser } = require("@eslint/plugin-kit");
+const tsParser = require("@typescript-eslint/parser");
 const rules = require("../lib/rules");
 const { LATEST_ECMA_VERSION } = require("../conf/ecma-version");
 const { Linter } = require("../lib/linter");
-const tseslint = require("@typescript-eslint/parser");
 
 //------------------------------------------------------------------------------
 // Typedefs
@@ -99,7 +99,7 @@ async function findProblems(filename) {
             }
 
             if (TYPESCRIPT_LANGUAGE_TAGS.has(languageTag)) {
-                languageOptions.parser = tseslint;
+                languageOptions.parser = tsParser;
             }
 
             const linter = new Linter();


### PR DESCRIPTION
#### Prerequisites checklist

- [ ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Starts on #19173.

Updates `default-param-last` to account for TypeScript syntax features as handled in the [`@typescript-eslint/default-param-last`](https://typescript-eslint.io/rules/default-param-last) extension rule:

* Class parameter properties
* Type annotations

Includes tests equivalent to what the extension rule currently tests that's exclusive to TypeScript. They're in a separate `ruleTesterTypeScript` instance that uses `@typescript-eslint/parser`.

Also updates `tools/check-rule-examples.js` to allow TypeScript code block. Previously it only allowed JavaScript.

#### Is there anything you'd like reviewers to focus on?

Should we also update documentation?

<!-- markdownlint-disable-file MD004 -->
