### PR TITLE
docs: replace `var` with `let` and `const` in rule example

### DIFF
--- a/docs/src/rules/no-continue.md
+++ b/docs/src/rules/no-continue.md
@@ -7,7 +7,7 @@ rule_type: suggestion
 The `continue` statement terminates execution of the statements in the current iteration of the current or labeled loop, and continues execution of the loop with the next iteration. When used incorrectly it makes code less testable, less readable and less maintainable. Structured control flow statements such as `if` should be used instead.
 
 ```js
-var sum = 0,
+let sum = 0,
     i;
 
 for(i = 0; i < 10; i++) {
@@ -30,7 +30,7 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-continue: "error"*/
 
-var sum = 0,
+let sum = 0,
     i;
 
 for(i = 0; i < 10; i++) {
@@ -49,7 +49,7 @@ for(i = 0; i < 10; i++) {
 ```js
 /*eslint no-continue: "error"*/
 
-var sum = 0,
+let sum = 0,
     i;
 
 labeledLoop: for(i = 0; i < 10; i++) {
@@ -70,7 +70,7 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-continue: "error"*/
 
-var sum = 0,
+let sum = 0,
     i;
 
 for(i = 0; i < 10; i++) {

--- a/docs/src/rules/no-labels.md
+++ b/docs/src/rules/no-labels.md
@@ -76,7 +76,7 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-labels: "error"*/
 
-var f = {
+const f = {
     label: "foo"
 };
 

--- a/docs/src/rules/no-magic-numbers.md
+++ b/docs/src/rules/no-magic-numbers.md
@@ -8,7 +8,7 @@ rule_type: suggestion
 They should preferably be replaced by named constants.
 
 ```js
-var now = Date.now(),
+const now = Date.now(),
     inOneHour = now + (60 * 60 * 1000);
 ```
 
@@ -24,7 +24,7 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-magic-numbers: "error"*/
 
-var dutyFreePrice = 100,
+const dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * 0.25);
 ```
 
@@ -35,9 +35,9 @@ var dutyFreePrice = 100,
 ```js
 /*eslint no-magic-numbers: "error"*/
 
-var data = ['foo', 'bar', 'baz'];
+const data = ['foo', 'bar', 'baz'];
 
-var dataLast = data[2];
+const dataLast = data[2];
 ```
 
 :::
@@ -47,7 +47,7 @@ var dataLast = data[2];
 ```js
 /*eslint no-magic-numbers: "error"*/
 
-var SECONDS;
+let SECONDS;
 
 SECONDS = 60;
 ```
@@ -61,9 +61,9 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-magic-numbers: "error"*/
 
-var TAX = 0.25;
+const TAX = 0.25;
 
-var dutyFreePrice = 100,
+const dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * TAX);
 ```
 
@@ -86,8 +86,8 @@ Examples of **correct** code for the sample `{ "ignore": [1] }` option:
 ```js
 /*eslint no-magic-numbers: ["error", { "ignore": [1] }]*/
 
-var data = ['foo', 'bar', 'baz'];
-var dataLast = data.length && data[data.length - 1];
+const data = ['foo', 'bar', 'baz'];
+const dataLast = data.length && data[data.length - 1];
 ```
 
 :::
@@ -121,7 +121,7 @@ Examples of **correct** code for the `{ "ignoreArrayIndexes": true }` option:
 ```js
 /*eslint no-magic-numbers: ["error", { "ignoreArrayIndexes": true }]*/
 
-var item = data[2];
+const item = data[2];
 
 data[100] = a;
 
@@ -243,9 +243,9 @@ Examples of **incorrect** code for the `{ "enforceConst": true }` option:
 ```js
 /*eslint no-magic-numbers: ["error", { "enforceConst": true }]*/
 
-var TAX = 0.25;
+let TAX = 0.25;
 
-var dutyFreePrice = 100,
+let dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * TAX);
 ```
 
@@ -262,11 +262,11 @@ Examples of **incorrect** code for the `{ "detectObjects": true }` option:
 ```js
 /*eslint no-magic-numbers: ["error", { "detectObjects": true }]*/
 
-var magic = {
+const magic = {
   tax: 0.25
 };
 
-var dutyFreePrice = 100,
+const dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * magic.tax);
 ```
 
@@ -279,13 +279,13 @@ Examples of **correct** code for the `{ "detectObjects": true }` option:
 ```js
 /*eslint no-magic-numbers: ["error", { "detectObjects": true }]*/
 
-var TAX = 0.25;
+const TAX = 0.25;
 
-var magic = {
+const magic = {
   tax: TAX
 };
 
-var dutyFreePrice = 100,
+const dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * magic.tax);
 ```
 

--- a/docs/src/rules/no-sequences.md
+++ b/docs/src/rules/no-sequences.md
@@ -7,7 +7,7 @@ rule_type: suggestion
 The comma operator includes multiple expressions where only one is expected. It evaluates each operand from left to right and returns the value of the last operand. However, this frequently obscures side effects, and its use is often an accident. Here are some examples of sequences:
 
 ```js
-var a = (3, 5); // a = 5
+let a = (3, 5); // a = 5
 
 a = b += 5, a + b;
 

--- a/docs/src/rules/unicode-bom.md
+++ b/docs/src/rules/unicode-bom.md
@@ -35,7 +35,7 @@ Example of **correct** code for this rule with the `"always"` option:
 
 /*eslint unicode-bom: ["error", "always"]*/
 
-var abc;
+let abc;
 ```
 
 :::
@@ -47,7 +47,7 @@ Example of **incorrect** code for this rule with the `"always"` option:
 ```js
 /*eslint unicode-bom: ["error", "always"]*/
 
-var abc;
+let abc;
 ```
 
 :::
@@ -61,7 +61,7 @@ Example of **correct** code for this rule with the default `"never"` option:
 ```js
 /*eslint unicode-bom: ["error", "never"]*/
 
-var abc;
+let abc;
 ```
 
 :::
@@ -75,7 +75,7 @@ Example of **incorrect** code for this rule with the `"never"` option:
 
 /*eslint unicode-bom: ["error", "never"]*/
 
-var abc;
+let abc;
 ```
 
 :::


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Replaced `var` with `let` and `const` in following rule examples

`no-continue`
`no-magic-numbers`
`no-labels`
`no-sequences`
`unicode-bom`

#### Is there anything you'd like reviewers to focus on?
refs #19240

similar as #19335

<!-- markdownlint-disable-file MD004 -->
