### PR TITLE
fix: update missing plugin message template

### DIFF
--- a/messages/config-plugin-missing.js
+++ b/messages/config-plugin-missing.js
@@ -4,6 +4,8 @@ module.exports = function(it) {
     const { pluginName, ruleId } = it;
 
     return `
+A configuration object specifies rule "${ruleId}", but could not find plugin "${pluginName}".
+
 Common causes of this problem include:
 
 1. The "${pluginName}" plugin is not defined in your configuration file.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Follow-up to https://github.com/eslint/eslint/pull/19402.

The output lists common causes of the problem, but doesn't say what the problem is:

```
Oops! Something went wrong! :(

ESLint: 9.20.1

Common causes of this problem include:

1. The "foo" plugin is not defined in your configuration file.
2. The "foo" plugin is not defined within the same configuration object in which the "foo/bar" rule is applied.
```

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added a line describing the problem:

```
Oops! Something went wrong! :(

ESLint: 9.20.1

A configuration object specifies rule "foo/bar", but could not find plugin "foo".

Common causes of this problem include:

1. The "foo" plugin is not defined in your configuration file.
2. The "foo" plugin is not defined within the same configuration object in which the "foo/bar" rule is applied.
```

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
