### PR TITLE
fix: improve error message for falsy parsed JS AST

### DIFF
--- a/lib/languages/js/source-code/source-code.js
+++ b/lib/languages/js/source-code/source-code.js
@@ -59,7 +59,7 @@ const CODE_PATH_EVENTS = [
  */
 function validate(ast) {
     if (!ast) {
-        throw new Error(`AST is ${ast}.`);
+        throw new TypeError(`Unexpected empty AST. (${ast})`);
     }
 
     if (!ast.tokens) {

--- a/lib/languages/js/source-code/source-code.js
+++ b/lib/languages/js/source-code/source-code.js
@@ -63,19 +63,19 @@ function validate(ast) {
     }
 
     if (!ast.tokens) {
-        throw new Error("AST is missing the tokens array.");
+        throw new TypeError("AST is missing the tokens array.");
     }
 
     if (!ast.comments) {
-        throw new Error("AST is missing the comments array.");
+        throw new TypeError("AST is missing the comments array.");
     }
 
     if (!ast.loc) {
-        throw new Error("AST is missing location information.");
+        throw new TypeError("AST is missing location information.");
     }
 
     if (!ast.range) {
-        throw new Error("AST is missing range information");
+        throw new TypeError("AST is missing range information");
     }
 }
 
@@ -208,16 +208,16 @@ function isSpaceBetween(sourceCode, first, second, checkInsideOfJSXText) {
         if (
             currentToken.range[1] !== nextToken.range[0] ||
 
-                /*
-                 * For backward compatibility, check spaces in JSXText.
-                 * https://github.com/eslint/eslint/issues/12614
-                 */
-                (
-                    checkInsideOfJSXText &&
-                    nextToken !== finalToken &&
-                    nextToken.type === "JSXText" &&
-                    /\s/u.test(nextToken.value)
-                )
+            /*
+             * For backward compatibility, check spaces in JSXText.
+             * https://github.com/eslint/eslint/issues/12614
+             */
+            (
+                checkInsideOfJSXText &&
+                nextToken !== finalToken &&
+                nextToken.type === "JSXText" &&
+                /\s/u.test(nextToken.value)
+            )
         ) {
             return true;
         }

--- a/lib/languages/js/source-code/source-code.js
+++ b/lib/languages/js/source-code/source-code.js
@@ -58,6 +58,10 @@ const CODE_PATH_EVENTS = [
  * @private
  */
 function validate(ast) {
+    if (!ast) {
+        throw new Error(`AST is ${ast}.`);
+    }
+
     if (!ast.tokens) {
         throw new Error("AST is missing the tokens array.");
     }

--- a/tests/lib/languages/js/source-code/source-code.js
+++ b/tests/lib/languages/js/source-code/source-code.js
@@ -90,6 +90,33 @@ describe("SourceCode", () => {
             assert.strictEqual(sourceCode.lines[1], "bar;");
         });
 
+        it("should throw an error when called with a false AST", () => {
+
+            assert.throws(
+                () => new SourceCode("foo;", false),
+                /AST is false/u
+            );
+
+        });
+
+        it("should throw an error when called with a null AST", () => {
+
+            assert.throws(
+                () => new SourceCode("foo;", null),
+                /AST is null/u
+            );
+
+        });
+
+        it("should throw an error when called with a undefined AST", () => {
+
+            assert.throws(
+                () => new SourceCode("foo;", void 0),
+                /AST is undefined/u
+            );
+
+        });
+
         it("should throw an error when called with an AST that's missing tokens", () => {
 
             assert.throws(

--- a/tests/lib/languages/js/source-code/source-code.js
+++ b/tests/lib/languages/js/source-code/source-code.js
@@ -94,7 +94,7 @@ describe("SourceCode", () => {
 
             assert.throws(
                 () => new SourceCode("foo;", false),
-                /AST is false/u
+                /Unexpected empty AST\. \(false\)/u
             );
 
         });
@@ -103,7 +103,7 @@ describe("SourceCode", () => {
 
             assert.throws(
                 () => new SourceCode("foo;", null),
-                /AST is null/u
+                /Unexpected empty AST\. \(null\)/u
             );
 
         });
@@ -112,7 +112,7 @@ describe("SourceCode", () => {
 
             assert.throws(
                 () => new SourceCode("foo;", void 0),
-                /AST is undefined/u
+                /Unexpected empty AST\. \(undefined\)/u
             );
 
         });


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Adds an `if` for the case of a falsy AST in `JS`'s `SourceCode` > `validate` function.

Uses a more generalized, succinct error message than what I originally suggested in the issue. I found this one to align more with the rest of them.

#### Is there anything you'd like reviewers to focus on?

