### PR TITLE
docs: replace 'var' with 'const' Issue 19240

### DIFF
--- a/docs/src/rules/array-bracket-spacing.md
+++ b/docs/src/rules/array-bracket-spacing.md
@@ -10,11 +10,11 @@ A number of style guides require or disallow spaces between array brackets and o
 applies to both array literals and destructuring assignments (ECMAScript 6).
 
 ```js
-var arr = [ 'foo', 'bar' ];
-var [ x, y ] = z;
+const arr = [ 'foo', 'bar' ];
+const [ x, y ] = z;
 
-var arr = ['foo', 'bar'];
-var [x,y] = z;
+const arr = ['foo', 'bar'];
+const [x,y] = z;
 ```
 
 ## Rule Details
@@ -54,17 +54,17 @@ Examples of **incorrect** code for this rule with the default `"never"` option:
 ```js
 /*eslint array-bracket-spacing: ["error", "never"]*/
 
-var arr = [ 'foo', 'bar' ];
-var arr = ['foo', 'bar' ];
-var arr = [ ['foo'], 'bar'];
-var arr = [[ 'foo' ], 'bar'];
-var arr = [ 'foo',
+const arr = [ 'foo', 'bar' ];
+const arr = ['foo', 'bar' ];
+const arr = [ ['foo'], 'bar'];
+const arr = [[ 'foo' ], 'bar'];
+const arr = [ 'foo',
   'bar'
 ];
-var [ x, y ] = z;
-var [ x,y ] = z;
-var [ x, ...y ] = z;
-var [ ,,x, ] = z;
+const [ x, y ] = z;
+const [ x,y ] = z;
+const [ x, ...y ] = z;
+const [ ,,x, ] = z;
 ```
 
 :::
@@ -76,25 +76,25 @@ Examples of **correct** code for this rule with the default `"never"` option:
 ```js
 /*eslint array-bracket-spacing: ["error", "never"]*/
 
-var arr = [];
-var arr = ['foo', 'bar', 'baz'];
-var arr = [['foo'], 'bar', 'baz'];
-var arr = [
+const arr = [];
+const arr = ['foo', 'bar', 'baz'];
+const arr = [['foo'], 'bar', 'baz'];
+const arr = [
   'foo',
   'bar',
   'baz'
 ];
-var arr = ['foo',
+const arr = ['foo',
   'bar'
 ];
-var arr = [
+const arr = [
   'foo',
   'bar'];
 
-var [x, y] = z;
-var [x,y] = z;
-var [x, ...y] = z;
-var [,,x,] = z;
+const [x, y] = z;
+const [x,y] = z;
+const [x, ...y] = z;
+const [,,x,] = z;
 ```
 
 :::
@@ -108,20 +108,20 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 ```js
 /*eslint array-bracket-spacing: ["error", "always"]*/
 
-var arr = ['foo', 'bar'];
-var arr = ['foo', 'bar' ];
-var arr = [ ['foo'], 'bar' ];
-var arr = ['foo',
+const arr = ['foo', 'bar'];
+const arr = ['foo', 'bar' ];
+const arr = [ ['foo'], 'bar' ];
+const arr = ['foo',
   'bar'
 ];
-var arr = [
+const arr = [
   'foo',
   'bar'];
 
-var [x, y] = z;
-var [x,y] = z;
-var [x, ...y] = z;
-var [,,x,] = z;
+const [x, y] = z;
+const [x,y] = z;
+const [x, ...y] = z;
+const [,,x,] = z;
 ```
 
 :::
@@ -133,25 +133,25 @@ Examples of **correct** code for this rule with the `"always"` option:
 ```js
 /*eslint array-bracket-spacing: ["error", "always"]*/
 
-var arr = [];
-var arr = [ 'foo', 'bar', 'baz' ];
-var arr = [ [ 'foo' ], 'bar', 'baz' ];
-var arr = [ 'foo',
+const arr = [];
+const arr = [ 'foo', 'bar', 'baz' ];
+const arr = [ [ 'foo' ], 'bar', 'baz' ];
+const arr = [ 'foo',
   'bar'
 ];
-var arr = [
+const arr = [
   'foo',
   'bar' ];
-var arr = [
+const arr = [
   'foo',
   'bar',
   'baz'
 ];
 
-var [ x, y ] = z;
-var [ x,y ] = z;
-var [ x, ...y ] = z;
-var [ ,,x, ] = z;
+const [ x, y ] = z;
+const [ x,y ] = z;
+const [ x, ...y ] = z;
+const [ ,,x, ] = z;
 ```
 
 :::
@@ -165,14 +165,14 @@ Examples of **incorrect** code for this rule with the `"always", { "singleValue"
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "singleValue": false }]*/
 
-var foo = [ 'foo' ];
-var foo = [ 'foo'];
-var foo = ['foo' ];
-var foo = [ 1 ];
-var foo = [ 1];
-var foo = [1 ];
-var foo = [ [ 1, 2 ] ];
-var foo = [ { 'foo': 'bar' } ];
+const foo = [ 'foo' ];
+const foo = [ 'foo'];
+const foo = ['foo' ];
+const foo = [ 1 ];
+const foo = [ 1];
+const foo = [1 ];
+const foo = [ [ 1, 2 ] ];
+const foo = [ { 'foo': 'bar' } ];
 ```
 
 :::
@@ -184,10 +184,10 @@ Examples of **correct** code for this rule with the `"always", { "singleValue": 
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "singleValue": false }]*/
 
-var foo = ['foo'];
-var foo = [1];
-var foo = [[ 1, 1 ]];
-var foo = [{ 'foo': 'bar' }];
+const foo = ['foo'];
+const foo = [1];
+const foo = [[ 1, 1 ]];
+const foo = [{ 'foo': 'bar' }];
 ```
 
 :::
@@ -201,8 +201,8 @@ Examples of **incorrect** code for this rule with the `"always", { "objectsInArr
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "objectsInArrays": false }]*/
 
-var arr = [ { 'foo': 'bar' } ];
-var arr = [ {
+const arr = [ { 'foo': 'bar' } ];
+const arr = [ {
   'foo': 'bar'
 } ]
 ```
@@ -216,8 +216,8 @@ Examples of **correct** code for this rule with the `"always", { "objectsInArray
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "objectsInArrays": false }]*/
 
-var arr = [{ 'foo': 'bar' }];
-var arr = [{
+const arr = [{ 'foo': 'bar' }];
+const arr = [{
   'foo': 'bar'
 }];
 ```
@@ -233,8 +233,8 @@ Examples of **incorrect** code for this rule with the `"always", { "arraysInArra
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "arraysInArrays": false }]*/
 
-var arr = [ [ 1, 2 ], 2, 3, 4 ];
-var arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];
+const arr = [ [ 1, 2 ], 2, 3, 4 ];
+const arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];
 ```
 
 :::
@@ -246,8 +246,8 @@ Examples of **correct** code for this rule with the `"always", { "arraysInArrays
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "arraysInArrays": false }]*/
 
-var arr = [[ 1, 2 ], 2, 3, 4 ];
-var arr = [[ 1, 2 ], 2, [ 3, 4 ]];
+const arr = [[ 1, 2 ], 2, 3, 4 ];
+const arr = [[ 1, 2 ], 2, [ 3, 4 ]];
 ```
 
 :::

--- a/docs/src/rules/array-bracket-spacing.md
+++ b/docs/src/rules/array-bracket-spacing.md
@@ -54,11 +54,11 @@ Examples of **incorrect** code for this rule with the default `"never"` option:
 ```js
 /*eslint array-bracket-spacing: ["error", "never"]*/
 
-const arr = [ 'foo', 'bar' ];
-const arr = ['foo', 'bar' ];
-const arr = [ ['foo'], 'bar'];
-const arr = [[ 'foo' ], 'bar'];
-const arr = [ 'foo',
+let arr = [ 'foo', 'bar' ];
+let arr = ['foo', 'bar' ];
+let arr = [ ['foo'], 'bar'];
+let arr = [[ 'foo' ], 'bar'];
+let arr = [ 'foo',
   'bar'
 ];
 const [ x, y ] = z;
@@ -76,18 +76,18 @@ Examples of **correct** code for this rule with the default `"never"` option:
 ```js
 /*eslint array-bracket-spacing: ["error", "never"]*/
 
-const arr = [];
-const arr = ['foo', 'bar', 'baz'];
-const arr = [['foo'], 'bar', 'baz'];
-const arr = [
+let arr = [];
+let arr = ['foo', 'bar', 'baz'];
+let arr = [['foo'], 'bar', 'baz'];
+let arr = [
   'foo',
   'bar',
   'baz'
 ];
-const arr = ['foo',
+let arr = ['foo',
   'bar'
 ];
-const arr = [
+let arr = [
   'foo',
   'bar'];
 
@@ -108,13 +108,13 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 ```js
 /*eslint array-bracket-spacing: ["error", "always"]*/
 
-const arr = ['foo', 'bar'];
-const arr = ['foo', 'bar' ];
-const arr = [ ['foo'], 'bar' ];
-const arr = ['foo',
+let arr = ['foo', 'bar'];
+let arr = ['foo', 'bar' ];
+let arr = [ ['foo'], 'bar' ];
+let arr = ['foo',
   'bar'
 ];
-const arr = [
+let arr = [
   'foo',
   'bar'];
 
@@ -133,16 +133,16 @@ Examples of **correct** code for this rule with the `"always"` option:
 ```js
 /*eslint array-bracket-spacing: ["error", "always"]*/
 
-const arr = [];
-const arr = [ 'foo', 'bar', 'baz' ];
-const arr = [ [ 'foo' ], 'bar', 'baz' ];
-const arr = [ 'foo',
+let arr = [];
+let arr = [ 'foo', 'bar', 'baz' ];
+let arr = [ [ 'foo' ], 'bar', 'baz' ];
+let arr = [ 'foo',
   'bar'
 ];
-const arr = [
+let arr = [
   'foo',
   'bar' ];
-const arr = [
+let arr = [
   'foo',
   'bar',
   'baz'
@@ -165,14 +165,14 @@ Examples of **incorrect** code for this rule with the `"always", { "singleValue"
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "singleValue": false }]*/
 
-const foo = [ 'foo' ];
-const foo = [ 'foo'];
-const foo = ['foo' ];
-const foo = [ 1 ];
-const foo = [ 1];
-const foo = [1 ];
-const foo = [ [ 1, 2 ] ];
-const foo = [ { 'foo': 'bar' } ];
+let foo = [ 'foo' ];
+let foo = [ 'foo'];
+let foo = ['foo' ];
+let foo = [ 1 ];
+let foo = [ 1];
+let foo = [1 ];
+let foo = [ [ 1, 2 ] ];
+let foo = [ { 'foo': 'bar' } ];
 ```
 
 :::
@@ -184,10 +184,10 @@ Examples of **correct** code for this rule with the `"always", { "singleValue": 
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "singleValue": false }]*/
 
-const foo = ['foo'];
-const foo = [1];
-const foo = [[ 1, 1 ]];
-const foo = [{ 'foo': 'bar' }];
+let foo = ['foo'];
+let foo = [1];
+let foo = [[ 1, 1 ]];
+let foo = [{ 'foo': 'bar' }];
 ```
 
 :::
@@ -201,8 +201,8 @@ Examples of **incorrect** code for this rule with the `"always", { "objectsInArr
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "objectsInArrays": false }]*/
 
-const arr = [ { 'foo': 'bar' } ];
-const arr = [ {
+let arr = [ { 'foo': 'bar' } ];
+let arr = [ {
   'foo': 'bar'
 } ]
 ```
@@ -216,8 +216,8 @@ Examples of **correct** code for this rule with the `"always", { "objectsInArray
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "objectsInArrays": false }]*/
 
-const arr = [{ 'foo': 'bar' }];
-const arr = [{
+let arr = [{ 'foo': 'bar' }];
+let arr = [{
   'foo': 'bar'
 }];
 ```
@@ -233,8 +233,8 @@ Examples of **incorrect** code for this rule with the `"always", { "arraysInArra
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "arraysInArrays": false }]*/
 
-const arr = [ [ 1, 2 ], 2, 3, 4 ];
-const arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];
+let arr = [ [ 1, 2 ], 2, 3, 4 ];
+let arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];
 ```
 
 :::
@@ -246,8 +246,8 @@ Examples of **correct** code for this rule with the `"always", { "arraysInArrays
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "arraysInArrays": false }]*/
 
-const arr = [[ 1, 2 ], 2, 3, 4 ];
-const arr = [[ 1, 2 ], 2, [ 3, 4 ]];
+let arr = [[ 1, 2 ], 2, 3, 4 ];
+let arr = [[ 1, 2 ], 2, [ 3, 4 ]];
 ```
 
 :::

--- a/docs/src/rules/array-element-newline.md
+++ b/docs/src/rules/array-element-newline.md
@@ -53,14 +53,14 @@ Examples of **incorrect** code for this rule with the default `"always"` option:
 ```js
 /*eslint array-element-newline: ["error", "always"]*/
 
-var c = [1, 2];
-var d = [1, 2, 3];
-var e = [1, 2, 3
+const c = [1, 2];
+const d = [1, 2, 3];
+const e = [1, 2, 3
 ];
-var f = [
+const f = [
   1, 2, 3
 ];
-var g = [
+const g = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -78,19 +78,19 @@ Examples of **correct** code for this rule with the default `"always"` option:
 ```js
 /*eslint array-element-newline: ["error", "always"]*/
 
-var a = [];
-var b = [1];
-var c = [1,
+const a = [];
+const b = [1];
+const c = [1,
     2];
-var d = [1,
+const d = [1,
     2,
     3];
-var d = [
+const d = [
   1, 
   2, 
   3
 ];
-var e = [
+const e = [
     function foo() {
         dosomething();
     },
@@ -111,16 +111,16 @@ Examples of **incorrect** code for this rule with the `"never"` option:
 ```js
 /*eslint array-element-newline: ["error", "never"]*/
 
-var c = [
+const c = [
     1,
     2
 ];
-var d = [
+const d = [
     1,
     2,
     3
 ];
-var e = [
+const e = [
     function foo() {
         dosomething();
     },
@@ -139,16 +139,16 @@ Examples of **correct** code for this rule with the `"never"` option:
 ```js
 /*eslint array-element-newline: ["error", "never"]*/
 
-var a = [];
-var b = [1];
-var c = [1, 2];
-var d = [1, 2, 3];
-var e = [
+const a = [];
+const b = [1];
+const c = [1, 2];
+const d = [1, 2, 3];
+const e = [
     1, 2, 3];
-var f = [
+const f = [
   1, 2, 3
 ];
-var g = [
+const g = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -168,11 +168,11 @@ Examples of **incorrect** code for this rule with the `"consistent"` option:
 ```js
 /*eslint array-element-newline: ["error", "consistent"]*/
 
-var a = [
+const a = [
     1, 2,
     3
 ];
-var b = [
+const b = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -193,20 +193,20 @@ Examples of **correct** code for this rule with the `"consistent"` option:
 ```js
 /*eslint array-element-newline: ["error", "consistent"]*/
 
-var a = [];
-var b = [1];
-var c = [1, 2];
-var d = [1, 2, 3];
-var e = [
+const a = [];
+const b = [1];
+const c = [1, 2];
+const d = [1, 2, 3];
+const e = [
     1,
     2
 ];
-var f = [
+const f = [
     1,
     2,
     3
 ];
-var g = [
+const g = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -215,7 +215,7 @@ var g = [
         dosomething();
     }
 ];
-var h = [
+const h = [
     function foo() {
         dosomething();
     },
@@ -239,9 +239,9 @@ Examples of **incorrect** code for this rule with the `{ "multiline": true }` op
 ```js
 /*eslint array-element-newline: ["error", { "multiline": true }]*/
 
-var d = [1,
+const d = [1,
     2, 3];
-var e = [
+const e = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -259,11 +259,11 @@ Examples of **correct** code for this rule with the `{ "multiline": true }` opti
 ```js
 /*eslint array-element-newline: ["error", { "multiline": true }]*/
 
-var a = [];
-var b = [1];
-var c = [1, 2];
-var d = [1, 2, 3];
-var e = [
+const a = [];
+const b = [1];
+const c = [1, 2];
+const d = [1, 2, 3];
+const e = [
     function foo() {
         dosomething();
     },
@@ -284,10 +284,10 @@ Examples of **incorrect** code for this rule with the `{ "minItems": 3 }` option
 ```js
 /*eslint array-element-newline: ["error", { "minItems": 3 }]*/
 
-var c = [1,
+const c = [1,
     2];
-var d = [1, 2, 3];
-var e = [
+const d = [1, 2, 3];
+const e = [
     function foo() {
         dosomething();
     },
@@ -306,13 +306,13 @@ Examples of **correct** code for this rule with the `{ "minItems": 3 }` option:
 ```js
 /*eslint array-element-newline: ["error", { "minItems": 3 }]*/
 
-var a = [];
-var b = [1];
-var c = [1, 2];
-var d = [1,
+const a = [];
+const b = [1];
+const c = [1, 2];
+const d = [1,
     2,
     3];
-var e = [
+const e = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -332,10 +332,10 @@ Examples of **incorrect** code for this rule with the `{ "multiline": true, "min
 ```js
 /*eslint array-element-newline: ["error", { "multiline": true, "minItems": 3 }]*/
 
-var c = [1,
+const c = [1,
 2];
-var d = [1, 2, 3];
-var e = [
+const d = [1, 2, 3];
+const e = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -353,13 +353,13 @@ Examples of **correct** code for this rule with the `{ "multiline": true, "minIt
 ```js
 /*eslint array-element-newline: ["error", { "multiline": true, "minItems": 3 }]*/
 
-var a = [];
-var b = [1];
-var c = [1, 2];
-var d = [1,
+const a = [];
+const b = [1];
+const c = [1, 2];
+const d = [1,
     2,
     3];
-var e = [
+const e = [
     function foo() {
         dosomething();
     },
@@ -380,9 +380,9 @@ Examples of **incorrect** code for this rule with the `{ "ArrayExpression": "alw
 ```js
 /*eslint array-element-newline: ["error", { "ArrayExpression": "always", "ArrayPattern": "never" }]*/
 
-var a = [1, 2];
-var b = [1, 2, 3];
-var c = [
+const a = [1, 2];
+const b = [1, 2, 3];
+const c = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -390,12 +390,12 @@ var c = [
     }
 ];
 
-var [d,
+const [d,
     e] = arr;
-var [f,
+const [f,
     g,
     h] = arr;
-var [i = function foo() {
+const [i = function foo() {
   dosomething()
 },
 j = function bar() {
@@ -412,12 +412,12 @@ Examples of **correct** code for this rule with the `{ "ArrayExpression": "alway
 ```js
 /*eslint array-element-newline: ["error", { "ArrayExpression": "always", "ArrayPattern": "never" }]*/
 
-var a = [1,
+const a = [1,
     2];
-var b = [1,
+const b = [1,
     2,
     3];
-var c = [
+const c = [
     function foo() {
         dosomething();
     },
@@ -426,9 +426,9 @@ var c = [
     }
 ];
 
-var [d, e] = arr
-var [f, g, h] = arr
-var [i = function foo() {
+const [d, e] = arr
+const [f, g, h] = arr
+const [i = function foo() {
     dosomething()
 }, j = function bar() {
     dosomething()

--- a/docs/src/rules/array-element-newline.md
+++ b/docs/src/rules/array-element-newline.md
@@ -85,12 +85,12 @@ const c = [1,
 const d = [1,
     2,
     3];
-const d = [
+const e = [
   1, 
   2, 
   3
 ];
-const e = [
+const f = [
     function foo() {
         dosomething();
     },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)

https://github.com/eslint/eslint/issues/19240
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
replaced **'var'** with **'const'** in 
* array-bracket-spacing.md
* array-element-newline.md

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
