### PR TITLE
feat: support TypeScript syntax in `class-methods-use-this`

### DIFF
--- a/lib/rules/class-methods-use-this.js
+++ b/lib/rules/class-methods-use-this.js
@@ -18,6 +18,8 @@ const astUtils = require("./utils/ast-utils");
 /** @type {import('../shared/types').Rule} */
 module.exports = {
     meta: {
+        dialects: ["javascript", "typescript"],
+        language: "javascript",
         type: "suggestion",
 
         defaultOptions: [{

--- a/tests/lib/rules/class-methods-use-this.js
+++ b/tests/lib/rules/class-methods-use-this.js
@@ -214,3 +214,236 @@ ruleTester.run("class-methods-use-this", rule, {
         }
     ]
 });
+
+const ruleTesterTypeScript = new RuleTester({
+    languageOptions: {
+        parser: require("@typescript-eslint/parser")
+    }
+});
+
+ruleTesterTypeScript.run("class-methods-use-this", rule, {
+    valid: [
+        "class A { constructor() {} }",
+        "class A { foo() {this} }",
+        "class A { foo() {this.bar = 'bar';} }",
+        "class A { foo() {bar(this);} }",
+        "class A extends B { foo() {super.foo();} }",
+        "class A { foo() { if(true) { return this; } } }",
+        "class A { static foo() {} }",
+        "({ a(){} });",
+        "class A { foo() { () => this; } }",
+        "({ a: function () {} });",
+        { code: "class A { foo() {this} bar() {} }", options: [{ exceptMethods: ["bar"] }] },
+        { code: "class A { \"foo\"() { } }", options: [{ exceptMethods: ["foo"] }] },
+        { code: "class A { 42() { } }", options: [{ exceptMethods: ["42"] }] },
+        "class A { foo = function() {this} }",
+        "class A { foo = () => {this} }",
+        "class A { foo = () => {super.toString} }",
+        "class A { static foo = function() {} }",
+        "class A { static foo = () => {} }",
+        { code: "class A { #bar() {} }", options: [{ exceptMethods: ["#bar"] }] },
+        { code: "class A { foo = function () {} }", options: [{ enforceForClassFields: false }] },
+        { code: "class A { foo = () => {} }", options: [{ enforceForClassFields: false }] },
+        "class A { foo() { return class { [this.foo] = 1 }; } }",
+        "class A { static {} }"
+    ],
+    invalid: [
+        {
+            code: `
+  class Foo {
+    method() {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Foo {
+    private method() {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Foo {
+    protected method() {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Derived extends Base {
+    override method() {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Derived extends Base {
+    property = () => {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Derived extends Base {
+    public property = () => {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Derived extends Base {
+    override property = () => {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Foo {
+    #method() {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Foo {
+    get getter(): number {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Foo {
+    private get getter(): number {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Foo {
+    protected get getter(): number {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Foo {
+    get #getter(): number {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Foo {
+    private set setter(b: number) {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Foo {
+    protected set setter(b: number) {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+        {
+            code: `
+  class Foo {
+    set #setter(b: number) {}
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        },
+
+        {
+            code: `
+  function fn() {
+    this.foo = 303;
+
+    class Foo {
+      method() {}
+    }
+  }
+        `,
+            errors: [
+                {
+                    messageId: "missingThis"
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Continues #19431.

Adds tests to show that `class-methods-use-this` works with TypeScript syntax. Interestingly, there weren't any code changes in the rule itself needed besides `meta.(dialects,language)`. It doesn't support any of typescript-eslint's TypeScript-syntax-specific options and so the core logic is still the same. Nifty.

#### Is there anything you'd like reviewers to focus on?

I propose leaving the added options from https://typescript-eslint.io/rules/class-methods-use-this/#options for followup issues.

<!-- markdownlint-disable-file MD004 -->
