### PR TITLE
fix: allow `RuleTester` to test files inside `node_modules/`

### DIFF
--- a/lib/config/default-config.js
+++ b/lib/config/default-config.js
@@ -16,6 +16,7 @@ const Rules = require("../rules");
 //-----------------------------------------------------------------------------
 
 const sharedDefaultConfig = [
+
     // intentionally empty config to ensure these files are globbed by default
     {
         files: ["**/*.js", "**/*.mjs"]
@@ -69,11 +70,11 @@ exports.defaultConfig = Object.freeze([
         ]
     },
 
-    ...sharedDefaultConfig,
+    ...sharedDefaultConfig
 ]);
 
 exports.defaultRuleTesterConfig = Object.freeze([
     { files: ["**"] }, // Make sure the default config matches for all files
 
-    ...sharedDefaultConfig,
-])
+    ...sharedDefaultConfig
+]);

--- a/lib/config/default-config.js
+++ b/lib/config/default-config.js
@@ -15,6 +15,20 @@ const Rules = require("../rules");
 // Helpers
 //-----------------------------------------------------------------------------
 
+const sharedDefaultConfig = [
+    // intentionally empty config to ensure these files are globbed by default
+    {
+        files: ["**/*.js", "**/*.mjs"]
+    },
+    {
+        files: ["**/*.cjs"],
+        languageOptions: {
+            sourceType: "commonjs",
+            ecmaVersion: "latest"
+        }
+    }
+];
+
 exports.defaultConfig = Object.freeze([
     {
         plugins: {
@@ -55,15 +69,11 @@ exports.defaultConfig = Object.freeze([
         ]
     },
 
-    // intentionally empty config to ensure these files are globbed by default
-    {
-        files: ["**/*.js", "**/*.mjs"]
-    },
-    {
-        files: ["**/*.cjs"],
-        languageOptions: {
-            sourceType: "commonjs",
-            ecmaVersion: "latest"
-        }
-    }
+    ...sharedDefaultConfig,
 ]);
+
+exports.defaultRuleTesterConfig = Object.freeze([
+    { files: ["**"] }, // Make sure the default config matches for all files
+
+    ...sharedDefaultConfig,
+])

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -22,7 +22,7 @@ const
     stringify = require("json-stable-stringify-without-jsonify");
 
 const { FlatConfigArray } = require("../config/flat-config-array");
-const { defaultConfig } = require("../config/default-config");
+const { defaultConfig, defaultRuleTesterConfig } = require("../config/default-config");
 
 const ajv = require("../shared/ajv")({ strictDefaults: true });
 
@@ -577,7 +577,6 @@ class RuleTester {
         }
 
         const baseConfig = [
-            { files: ["**"] }, // Make sure the default config matches for all files
             {
                 plugins: {
 
@@ -622,7 +621,7 @@ class RuleTester {
                 },
                 language: defaultConfig[0].language
             },
-            ...defaultConfig.slice(1)
+            ...defaultRuleTesterConfig,
         ];
 
         /**

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -621,7 +621,7 @@ class RuleTester {
                 },
                 language: defaultConfig[0].language
             },
-            ...defaultRuleTesterConfig,
+            ...defaultRuleTesterConfig
         ];
 
         /**

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2223,8 +2223,15 @@ describe("RuleTester", () => {
         ];
 
         ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
-            valid: filenames.map(filename => ({code: 'foo', filename})),
-            invalid: filenames.map(filename => ({ code: "eval(foo)", errors: [{ message: "eval sucks.", type: "CallExpression" }] })),
+            valid: filenames.map((filename, index) => ({
+                code: `Eval(foo${index})`,
+                filename,
+            })),
+            invalid: filenames.map((filename, index) => ({
+                code: `eval(foo${index})`,
+                errors: [{ message: "eval sucks.", type: "CallExpression" }],
+                filename,
+            })),
         });
     })
 

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2211,26 +2211,22 @@ describe("RuleTester", () => {
         }, /Fixable rules must set the `meta\.fixable` property/u);
     });
 
-    // https://github.com/eslint/eslint/issues/17962
-    it("should not throw an error in case of absolute paths", () => {
+    it("should allow test any file", () => {
+        const filenames = [
+            // Ignored by default
+            'node_modules/foo.js',
+            '.git/foo.js',
+            // Absolute paths
+            // https://github.com/eslint/eslint/issues/17962
+            "/an-absolute-path/foo.js",
+            "C:\\an-absolute-path\\foo.js"
+        ];
+
         ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
-            valid: [
-                "Eval(foo)"
-            ],
-            invalid: [
-                {
-                    code: "eval(foo)",
-                    filename: "/an-absolute-path/foo.js",
-                    errors: [{ message: "eval sucks.", type: "CallExpression" }]
-                },
-                {
-                    code: "eval(bar)",
-                    filename: "C:\\an-absolute-path\\foo.js",
-                    errors: [{ message: "eval sucks.", type: "CallExpression" }]
-                }
-            ]
+            valid: filenames.map(filename => ({code: 'foo', filename})),
+            invalid: filenames.map(filename => ({ code: "eval(foo)", errors: [{ message: "eval sucks.", type: "CallExpression" }] })),
         });
-    });
+    })
 
     describe("suggestions", () => {
         it("should throw if suggestions are available but not specified", () => {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2213,11 +2213,15 @@ describe("RuleTester", () => {
 
     it("should allow test any file", () => {
         const filenames = [
+
             // Ignored by default
-            'node_modules/foo.js',
-            '.git/foo.js',
-            // Absolute paths
-            // https://github.com/eslint/eslint/issues/17962
+            "node_modules/foo.js",
+            ".git/foo.js",
+
+            /*
+             * Absolute paths
+             * https://github.com/eslint/eslint/issues/17962
+             */
             "/an-absolute-path/foo.js",
             "C:\\an-absolute-path\\foo.js"
         ];
@@ -2225,15 +2229,15 @@ describe("RuleTester", () => {
         ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
             valid: filenames.map((filename, index) => ({
                 code: `Eval(foo${index})`,
-                filename,
+                filename
             })),
             invalid: filenames.map((filename, index) => ({
                 code: `eval(foo${index})`,
                 errors: [{ message: "eval sucks.", type: "CallExpression" }],
-                filename,
-            })),
+                filename
+            }))
         });
-    })
+    });
 
     describe("suggestions", () => {
         it("should throw if suggestions are available but not specified", () => {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2211,10 +2211,13 @@ describe("RuleTester", () => {
         }, /Fixable rules must set the `meta\.fixable` property/u);
     });
 
-    it("should allow test any file", () => {
+    it("should allow testing of any file", () => {
         const filenames = [
 
-            // Ignored by default
+            /*
+             * Ignored by default
+             * https://github.com/eslint/eslint/issues/19471
+             */
             "node_modules/foo.js",
             ".git/foo.js",
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Stop applying default ignores to RuleTester.
Fixes #19471

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

No

