### PR TITLE
test: fix an assertion failure

### DIFF
--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2042,15 +2042,11 @@ describe("RuleTester", () => {
     // Nominal message/messageId use cases
     it("should assert match if message provided in both test and result.", () => {
         assert.throws(() => {
-            try {
-                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
-                    valid: [],
-                    invalid: [{ code: "foo", errors: [{ message: "something" }] }]
-                });
-            } catch (error) {
-                throw new Error(`Expect message to be "${error.expected}", got "${error.actual}"`);
-            }
-        }, 'Expect message to be "something", got "Avoid using variables named \'foo\'."');
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
+                valid: [],
+                invalid: [{ code: "foo", errors: [{ message: "something" }] }]
+            });
+        }, assertErrorMatches("Avoid using variables named 'foo'.", "something"));
 
         ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
             valid: [],

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -2042,11 +2042,15 @@ describe("RuleTester", () => {
     // Nominal message/messageId use cases
     it("should assert match if message provided in both test and result.", () => {
         assert.throws(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
-                valid: [],
-                invalid: [{ code: "foo", errors: [{ message: "something" }] }]
-            });
-        }, /Avoid using variables named/u);
+            try {
+                ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
+                    valid: [],
+                    invalid: [{ code: "foo", errors: [{ message: "something" }] }]
+                });
+            } catch (error) {
+                throw new Error(`Expect message to be "${error.expected}", got "${error.actual}"`);
+            }
+        }, 'Expect message to be "something", got "Avoid using variables named \'foo\'."');
 
         ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
             valid: [],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

This test won't pass on local

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

When I work on #19499, I noticed this test won't pass.

The actual error is

```
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
actual expected

"Av'somethid using variables named 'foo'." (WITH COLORS)
```

I guess it passed because it's different on CI.


#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
No.
