### PR TITLE
fix: `no-dupe-keys` false positive with proto setter

### DIFF
--- a/docs/src/rules/no-dupe-keys.md
+++ b/docs/src/rules/no-dupe-keys.md
@@ -55,6 +55,11 @@ const foo = {
     bar: "baz",
     quxx: "qux"
 };
+
+const obj = {
+    "__proto__": baz, // defines object's prototype
+    ["__proto__"]: qux // defines a property named "__proto__"
+};
 ```
 
 :::

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -124,6 +124,30 @@ module.exports = {
                     return;
                 }
 
+                /*
+                 * Skip if the property node is a proto setter.
+                 * Proto setter is a special syntax that sets
+                 * object's prototype instead of creating a property.
+                 * It can be in one of the following forms:
+                 *
+                 *    __proto__: <expression>
+                 *    '__proto__': <expression>
+                 *    "__proto__": <expression>
+                 *
+                 * Duplicate proto setters produce parsing errors,
+                 * so we can just skip them to not interfere with
+                 * regular properties named "__proto__".
+                 */
+                if (
+                    name === "__proto__" &&
+                    node.kind === "init" &&
+                    !node.computed &&
+                    !node.shorthand &&
+                    !node.method
+                ) {
+                    return;
+                }
+
                 // Reports if the name is defined already.
                 if (info.isPropertyDefined(node)) {
                     context.report({

--- a/tests/lib/rules/no-dupe-keys.js
+++ b/tests/lib/rules/no-dupe-keys.js
@@ -40,7 +40,11 @@ ruleTester.run("no-dupe-keys", rule, {
         { code: "var x = ({ null: 1, [/(?<zero>0)/]: 2 })", languageOptions: { ecmaVersion: 2018 } },
         { code: "var {a, a} = obj", languageOptions: { ecmaVersion: 6 } },
         "var x = { 012: 1, 12: 2 };",
-        { code: "var x = { 1_0: 1, 1: 2 };", languageOptions: { ecmaVersion: 2021 } }
+        { code: "var x = { 1_0: 1, 1: 2 };", languageOptions: { ecmaVersion: 2021 } },
+        { code: "var x = { __proto__: null, ['__proto__']: null };", languageOptions: { ecmaVersion: 6 } },
+        { code: "var x = { ['__proto__']: null, __proto__: null };", languageOptions: { ecmaVersion: 6 } },
+        { code: "var x = { '__proto__': null, ['__proto__']: null };", languageOptions: { ecmaVersion: 6 } },
+        { code: "var x = { ['__proto__']: null, '__proto__': null };", languageOptions: { ecmaVersion: 6 } },
     ],
     invalid: [
         { code: "var x = { a: b, ['a']: b };", languageOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpected", data: { name: "a" }, type: "ObjectExpression" }] },
@@ -58,6 +62,12 @@ ruleTester.run("no-dupe-keys", rule, {
         { code: "var x = { a: 1, get a() {} };", languageOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpected", data: { name: "a" }, type: "ObjectExpression" }] },
         { code: "var x = { a: 1, set a(value) {} };", languageOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpected", data: { name: "a" }, type: "ObjectExpression" }] },
         { code: "var x = { a: 1, b: { a: 2 }, get b() {} };", languageOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpected", data: { name: "b" }, type: "ObjectExpression" }] },
-        { code: "var x = ({ '/(?<zero>0)/': 1, [/(?<zero>0)/]: 2 })", languageOptions: { ecmaVersion: 2018 }, errors: [{ messageId: "unexpected", data: { name: "/(?<zero>0)/" }, type: "ObjectExpression" }] }
+        { code: "var x = ({ '/(?<zero>0)/': 1, [/(?<zero>0)/]: 2 })", languageOptions: { ecmaVersion: 2018 }, errors: [{ messageId: "unexpected", data: { name: "/(?<zero>0)/" }, type: "ObjectExpression" }] },
+        { code: "var x = { ['__proto__']: null, ['__proto__']: null };", languageOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpected", data: { name: "__proto__" }, type: "ObjectExpression" }] },
+        { code: "var x = { ['__proto__']: null, __proto__ };", languageOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpected", data: { name: "__proto__" }, type: "ObjectExpression" }] },
+        { code: "var x = { ['__proto__']: null, __proto__() {} };", languageOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpected", data: { name: "__proto__" }, type: "ObjectExpression" }] },
+        { code: "var x = { ['__proto__']: null, get __proto__() {} };", languageOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpected", data: { name: "__proto__" }, type: "ObjectExpression" }] },
+        { code: "var x = { ['__proto__']: null, set __proto__(value) {} };", languageOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpected", data: { name: "__proto__" }, type: "ObjectExpression" }] },
+        { code: "var x = { __proto__: null, a: 5, a: 6 };", languageOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpected", data: { name: "a" }, type: "ObjectExpression" }] }
     ]
 });

--- a/tests/lib/rules/no-dupe-keys.js
+++ b/tests/lib/rules/no-dupe-keys.js
@@ -45,6 +45,14 @@ ruleTester.run("no-dupe-keys", rule, {
         { code: "var x = { ['__proto__']: null, __proto__: null };", languageOptions: { ecmaVersion: 6 } },
         { code: "var x = { '__proto__': null, ['__proto__']: null };", languageOptions: { ecmaVersion: 6 } },
         { code: "var x = { ['__proto__']: null, '__proto__': null };", languageOptions: { ecmaVersion: 6 } },
+        { code: "var x = { __proto__: null, __proto__ };", languageOptions: { ecmaVersion: 6 } },
+        { code: "var x = { __proto__, __proto__: null };", languageOptions: { ecmaVersion: 6 } },
+        { code: "var x = { __proto__: null, __proto__() {} };", languageOptions: { ecmaVersion: 6 } },
+        { code: "var x = { __proto__() {}, __proto__: null };", languageOptions: { ecmaVersion: 6 } },
+        { code: "var x = { __proto__: null, get __proto__() {} };", languageOptions: { ecmaVersion: 6 } },
+        { code: "var x = { get __proto__() {}, __proto__: null };", languageOptions: { ecmaVersion: 6 } },
+        { code: "var x = { __proto__: null, set __proto__(value) {} };", languageOptions: { ecmaVersion: 6 } },
+        { code: "var x = { set __proto__(value) {}, __proto__: null };", languageOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         { code: "var x = { a: b, ['a']: b };", languageOptions: { ecmaVersion: 6 }, errors: [{ messageId: "unexpected", data: { name: "a" }, type: "ObjectExpression" }] },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #19504

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `no-dupe-keys` rule to ignore proto setter syntax in object literals.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
