### PR TITLE
docs: `require-unicode-regexp` add note for `i` flag and `\w` 

### DIFF
--- a/docs/src/rules/require-unicode-regexp.md
+++ b/docs/src/rules/require-unicode-regexp.md
@@ -73,6 +73,7 @@ const str = "\u017f\u212a"; // Example Unicode characters
 console.log(regexWithoutU.test(str)); // true
 console.log(regexWithU.test(str)); // false
 ```
+
 In such cases, this rule does not enforce adding the u flag, as it can lead to unintended changes in pattern matching.
 
 Examples of **incorrect** code for this rule:

--- a/docs/src/rules/require-unicode-regexp.md
+++ b/docs/src/rules/require-unicode-regexp.md
@@ -58,24 +58,6 @@ Therefore, the `u` and `v` flags let us work better with regular expressions.
 
 This rule aims to enforce the use of `u` or `v` flag on regular expressions.
 
-### Exception: When `i` flag and `\w` are used together
-
-If a regular expression uses both the `i` flag and the `\w` character class, adding the `u` flag may change its behavior due to Unicode case folding rules.
-
-For example:
-
-```js
-const regexWithoutU = /^\w+$/i;
-const regexWithU = /^\w+$/iu;
-
-const str = "\u017f\u212a"; // Example Unicode characters
-
-console.log(regexWithoutU.test(str)); // true
-console.log(regexWithU.test(str)); // false
-```
-
-In such cases, this rule does not enforce adding the u flag, as it can lead to unintended changes in pattern matching.
-
 Examples of **incorrect** code for this rule:
 
 ::: incorrect
@@ -200,3 +182,27 @@ const fooRegexp = new RegExp('foo', 'v');
 ## When Not To Use It
 
 If you don't want to warn on regular expressions without either a `u` or a `v` flag, then it's safe to disable this rule.
+
+### Note on `i` flag and `\w`
+
+In some cases, adding the `u` flag to a regular expression using both the `i` flag and the `\w` character class can change its behavior due to Unicode case folding.
+
+For example:
+
+```js
+const regexWithoutU = /^\w+$/i;
+const regexWithU = /^\w+$/iu;
+
+const str = "\u017f\u212a"; // Example Unicode characters
+
+console.log(regexWithoutU.test(str)); // true
+console.log(regexWithU.test(str)); // false
+```
+
+If you prefer to use a non-Unicode-aware regex in this specific case, you can disable this rule using an `eslint-disable` comment:
+
+```js
+/* eslint-disable require-unicode-regexp */
+const regex = /^\w+$/i;
+/* eslint-enable require-unicode-regexp */
+```

--- a/docs/src/rules/require-unicode-regexp.md
+++ b/docs/src/rules/require-unicode-regexp.md
@@ -58,6 +58,23 @@ Therefore, the `u` and `v` flags let us work better with regular expressions.
 
 This rule aims to enforce the use of `u` or `v` flag on regular expressions.
 
+### Exception: When `i` flag and `\w` are used together
+
+If a regular expression uses both the `i` flag and the `\w` character class, adding the `u` flag may change its behavior due to Unicode case folding rules.
+
+For example:
+
+```js
+const regexWithoutU = /^\w+$/i;
+const regexWithU = /^\w+$/iu;
+
+const str = "\u017f\u212a"; // Example Unicode characters
+
+console.log(regexWithoutU.test(str)); // true
+console.log(regexWithU.test(str)); // false
+```
+In such cases, this rule does not enforce adding the u flag, as it can lead to unintended changes in pattern matching.
+
 Examples of **incorrect** code for this rule:
 
 ::: incorrect

--- a/docs/src/rules/require-unicode-regexp.md
+++ b/docs/src/rules/require-unicode-regexp.md
@@ -195,8 +195,8 @@ const regexWithU = /^\w+$/iu;
 
 const str = "\u017f\u212a"; // Example Unicode characters
 
-console.log(regexWithoutU.test(str)); // true
-console.log(regexWithU.test(str)); // false
+console.log(regexWithoutU.test(str)); // false
+console.log(regexWithU.test(str)); // true
 ```
 
 If you prefer to use a non-Unicode-aware regex in this specific case, you can disable this rule using an `eslint-disable` comment:


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR updates the `require-unicode-regexp` documentation to clarify that when both the `i` flag and `\w` are used, adding the `u` flag may change behavior due to Unicode case folding. 

Closes #19474 

- Added an exception section explaining this case.
- Included an example demonstrating the difference in behavior.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

Please check to see if I missed anything.
