### PR TITLE
feat: circular autofix/conflicting rules detection

### DIFF
--- a/docs/src/use/troubleshooting/circular-fixes.md
+++ b/docs/src/use/troubleshooting/circular-fixes.md
@@ -1,0 +1,38 @@
+---
+title: Circular fixes detected …
+eleventyNavigation:
+    key: circular fixes
+    parent: troubleshooting
+    title: Circular fixes detected …
+---
+
+## Symptoms
+
+When running ESLint with the `--fix` option, you may see the following warning:
+
+```plaintext
+ESLintCircularFixesWarning: Circular fixes detected while fixing path/to/file. It is likely that you have conflicting rules in your configuration.
+```
+
+## Cause
+
+You have conflicting fixable rules in your configuration. ESLint autofixes code in mulitple passes. In one pass, one of the rules changes the code, and in the following pass, another rule changes the new code back to the previous version. ESLint detects that autofix is going in circles and emits this warning.
+
+## Resolution
+
+Common resolutions for this issue include:
+
+* Remove or reconfigure one of the conflicting rules in your configuration file.
+
+How to find the conflicting rules:
+
+1. Open the file specified in the warning in an editor that supports applying individual fixes (for example, VS Code).
+1. In the list of lint problems, find a fixable rule. That is one of the conflicting rules.
+1. Apply the fix ("Fix this rule-name problem" action in VS Code).
+1. Check what new lint problem has appeared in the list. That is the other conflicting rule.
+
+## Resources
+
+For more information, see:
+
+* [Configure Rules](../configure/rules) for documentation on how to configure rules

--- a/docs/src/use/troubleshooting/circular-fixes.md
+++ b/docs/src/use/troubleshooting/circular-fixes.md
@@ -28,7 +28,7 @@ How to find the conflicting rules:
 
 1. Open the file specified in the warning in an editor that supports applying individual fixes (for example, VS Code).
 1. In the list of lint problems, find a fixable rule. That is one of the conflicting rules.
-1. Apply the fix ("Fix this rule-name problem" action in VS Code).
+1. Apply the fix ("Fix this (rule-name) problem" action in VS Code).
 1. Check what new lint problem has appeared in the list. That is the other conflicting rule.
 
 ## Resources

--- a/docs/src/use/troubleshooting/circular-fixes.md
+++ b/docs/src/use/troubleshooting/circular-fixes.md
@@ -16,7 +16,7 @@ ESLintCircularFixesWarning: Circular fixes detected while fixing path/to/file. I
 
 ## Cause
 
-You have conflicting fixable rules in your configuration. ESLint autofixes code in mulitple passes. In one pass, one of the rules changes the code, and in the following pass, another rule changes the new code back to the previous version. ESLint detects that autofix is going in circles and emits this warning.
+You have conflicting fixable rules in your configuration. ESLint autofixes code in multiple passes, meaning it's possible that a fix in one pass is undone in a subsequent pass. For example, in the first pass a rules removes a trailing comma and in the following pass a different rule adds a trailing comma in the same place, effectively changing the code back to the previous version. ESLint emits a warning when it detects cycles like this.
 
 ## Resolution
 

--- a/docs/src/use/troubleshooting/circular-fixes.md
+++ b/docs/src/use/troubleshooting/circular-fixes.md
@@ -16,7 +16,7 @@ ESLintCircularFixesWarning: Circular fixes detected while fixing path/to/file. I
 
 ## Cause
 
-You have conflicting fixable rules in your configuration. ESLint autofixes code in multiple passes, meaning it's possible that a fix in one pass is undone in a subsequent pass. For example, in the first pass a rules removes a trailing comma and in the following pass a different rule adds a trailing comma in the same place, effectively changing the code back to the previous version. ESLint emits a warning when it detects cycles like this.
+You have conflicting fixable rules in your configuration. ESLint autofixes code in multiple passes, meaning it's possible that a fix in one pass is undone in a subsequent pass. For example, in the first pass a rule removes a trailing comma and in the following pass a different rule adds a trailing comma in the same place, effectively changing the code back to the previous version. ESLint emits a warning when it detects cycles like this.
 
 ## Resolution
 

--- a/docs/src/use/troubleshooting/index.md
+++ b/docs/src/use/troubleshooting/index.md
@@ -11,6 +11,7 @@ This page serves as a reference for common issues working with ESLint.
 
 ## Configuration
 
+* [`Circular fixes detected …`](./circular-fixes)
 * [`TypeError: context.getScope is not a function`](./v9-rule-api-changes)
 
 ## Legacy (eslintrc) Configuration

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -2432,7 +2432,7 @@ class Linter {
             }
 
             // Stop if we've made a circular fix
-            if (recentOutputs.length === 2 && fixedResult.output === recentOutputs[0]) {
+            if (recentOutputs.length === 2 && fixedResult.output.length === recentOutputs[0].length && fixedResult.output === recentOutputs[0]) {
                 debug(`Circular fixes detected after pass ${passNumber}. Exiting fix loop.`);
                 globalThis?.process?.emitWarning?.(
                     `Circular fixes detected while fixing ${options?.filename ?? "text"}. It is likely that you have conflicting rules in your configuration.`,

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -2380,6 +2380,7 @@ class Linter {
         const debugTextDescription = options && options.filename || `${text.slice(0, 10)}...`;
         const shouldFix = options && typeof options.fix !== "undefined" ? options.fix : true;
         const stats = options?.stats;
+        const recentOutputs = [];
 
         /**
          * This loop continues until one of the following is true:
@@ -2428,6 +2429,23 @@ class Linter {
                 } else {
                     storeTime(0, { type: "fix" }, slots);
                 }
+            }
+
+            // Stop if we've made a circular fix
+            if (recentOutputs.length === 2 && fixedResult.output === recentOutputs[0]) {
+                debug(`Circular fixes detected after pass ${passNumber}. Exiting fix loop.`);
+                process.emitWarning(
+                    "Warning: Circular fixes detected in your configuration.",
+                    "ESLINT_CIRCULAR_FIXES"
+                );
+                fixedResult.output = currentText;
+                break;
+            }
+
+            // Update the recent outputs buffer
+            recentOutputs.push(fixedResult.output);
+            if (recentOutputs.length > 2) {
+                recentOutputs.shift();
             }
 
             /*

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -2376,11 +2376,12 @@ class Linter {
             fixedResult,
             fixed = false,
             passNumber = 0,
-            currentText = text;
+            currentText = text,
+            secondPreviousText,
+            previousText;
         const debugTextDescription = options && options.filename || `${text.slice(0, 10)}...`;
         const shouldFix = options && typeof options.fix !== "undefined" ? options.fix : true;
         const stats = options?.stats;
-        const recentOutputs = [];
 
         /**
          * This loop continues until one of the following is true:
@@ -2431,23 +2432,6 @@ class Linter {
                 }
             }
 
-            // Stop if we've made a circular fix
-            if (recentOutputs.length === 2 && fixedResult.output.length === recentOutputs[0].length && fixedResult.output === recentOutputs[0]) {
-                debug(`Circular fixes detected after pass ${passNumber}. Exiting fix loop.`);
-                globalThis?.process?.emitWarning?.(
-                    `Circular fixes detected while fixing ${options?.filename ?? "text"}. It is likely that you have conflicting rules in your configuration.`,
-                    "ESLintCircularFixesWarning"
-                );
-                fixedResult.output = currentText;
-                break;
-            }
-
-            // Update the recent outputs buffer
-            recentOutputs.push(fixedResult.output);
-            if (recentOutputs.length > 2) {
-                recentOutputs.shift();
-            }
-
             /*
              * stop if there are any syntax errors.
              * 'fixedResult.output' is a empty string.
@@ -2460,6 +2444,8 @@ class Linter {
             fixed = fixed || fixedResult.fixed;
 
             // update to use the fixed output instead of the original text
+            secondPreviousText = previousText;
+            previousText = currentText;
             currentText = fixedResult.output;
 
             if (stats) {
@@ -2467,6 +2453,20 @@ class Linter {
                 const passIndex = slots.times.passes.length - 1;
 
                 slots.times.passes[passIndex].total = tTotal;
+            }
+
+            // Stop if we've made a circular fix
+            if (
+                passNumber > 1 &&
+                currentText.length === secondPreviousText.length &&
+                currentText === secondPreviousText
+            ) {
+                debug(`Circular fixes detected after pass ${passNumber}. Exiting fix loop.`);
+                globalThis?.process?.emitWarning?.(
+                    `Circular fixes detected while fixing ${options?.filename ?? "text"}. It is likely that you have conflicting rules in your configuration.`,
+                    "ESLintCircularFixesWarning"
+                );
+                break;
             }
 
         } while (

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -2434,9 +2434,9 @@ class Linter {
             // Stop if we've made a circular fix
             if (recentOutputs.length === 2 && fixedResult.output === recentOutputs[0]) {
                 debug(`Circular fixes detected after pass ${passNumber}. Exiting fix loop.`);
-                process.emitWarning(
-                    "Warning: Circular fixes detected in your configuration.",
-                    "ESLINT_CIRCULAR_FIXES"
+                globalThis?.process?.emitWarning?.(
+                    `Circular fixes detected while fixing ${options?.filename ?? "text"}. It is likely that you have conflicting rules in your configuration.`,
+                    "ESLintCircularFixesWarning"
                 );
                 fixedResult.output = currentText;
                 break;

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -8091,6 +8091,17 @@ describe("Linter with FlatConfigArray", () => {
         return new FlatConfigArray(value, options);
     }
 
+    let processStub;
+
+    beforeEach(() => {
+        sinon.restore();
+        processStub = sinon.stub(process, "emitWarning");
+    });
+
+    afterEach(() => {
+        processStub.restore();
+    });
+
     beforeEach(() => {
         linter = new Linter({ configType: "flat" });
     });
@@ -16750,6 +16761,14 @@ var a = "test2";
             assert.strictEqual(fixResult.output, "-a", "Output should match the original input due to circular fixes.");
             assert.strictEqual(fixResult.messages.length, 2, "There should be two remaining lint messages after detecting circular fixes.");
             assert.strictEqual(fixResult.messages[0].message, "Adding leading hyphen", "Message should match the last fix attempt.");
+
+            // Verify the warning was emitted
+            assert.strictEqual(processStub.callCount, 1, "calls `process.emitWarning()` once");
+            assert.strictEqual(
+                processStub.firstCall.args[0],
+                "Circular fixes detected while fixing text. It is likely that you have conflicting rules in your configuration."
+            );
+            assert.strictEqual(processStub.firstCall.args[1], "ESLintCircularFixesWarning");
 
             const suppressedMessages = linter.getSuppressedMessages();
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7591,24 +7591,51 @@ var a = "test2";
         });
 
         it("should stop fixing if a circular fix is detected", () => {
-            linter.defineRule("circular-fix", {
+            linter.defineRule("add-leading-hyphen", {
                 meta: {
                     fixable: "whitespace"
                 },
                 create(context) {
                     return {
                         Program(node) {
-
-                            // Alternate between adding and removing a hyphen.
                             const sourceCode = context.getSourceCode();
                             const hasLeadingHyphen = sourceCode.getText(node).startsWith("-");
 
                             context.report({
                                 node,
-                                message: "Circular fix detected",
-                                fix: fixer => (hasLeadingHyphen
-                                    ? fixer.removeRange([0, 1])
-                                    : fixer.insertTextBefore(node, "-"))
+                                message: "Adding leading hyphen",
+                                fix(fixer) {
+                                    if (hasLeadingHyphen) {
+                                        return;
+                                    }
+
+                                    fixer.insertTextBefore(node, "-");
+                                }
+                            });
+                        }
+                    };
+                }
+            });
+            linter.defineRule("remove-leading-hyphen", {
+                meta: {
+                    fixable: "whitespace"
+                },
+                create(context) {
+                    return {
+                        Program(node) {
+                            const sourceCode = context.getSourceCode();
+                            const hasLeadingHyphen = sourceCode.getText(node).startsWith("-");
+
+                            context.report({
+                                node,
+                                message: "Removing leading hyphen",
+                                fix(fixer) {
+                                    if (!hasLeadingHyphen) {
+                                        return;
+                                    }
+
+                                    fixer.removeRange([0, 1]);
+                                }
                             });
                         }
                     };
@@ -7616,12 +7643,17 @@ var a = "test2";
             });
 
             const initialCode = "-a";
-            const fixResult = linter.verifyAndFix(initialCode, { rules: { "circular-fix": "error" } });
+            const fixResult = linter.verifyAndFix(initialCode, {
+                rules: {
+                    "add-leading-hyphen": "error",
+                    "remove-leading-hyphen": "error"
+                }
+            });
 
-            assert.strictEqual(fixResult.fixed, true, "Fixing should have been applied but stopped due to circular fixes.");
+            assert.strictEqual(fixResult.fixed, false, "Fixing was not applied due to circular fixes.");
             assert.strictEqual(fixResult.output, "-a", "Output should match the original input due to circular fixes.");
-            assert.strictEqual(fixResult.messages.length, 1, "There should be one remaining lint message after detecting circular fixes.");
-            assert.strictEqual(fixResult.messages[0].message, "Circular fix detected", "Message should match the last fix attempt.");
+            assert.strictEqual(fixResult.messages.length, 2, "There should be two remaining lint messages after detecting circular fixes.");
+            assert.strictEqual(fixResult.messages[0].message, "Adding leading hyphen", "Message should match the last fix attempt.");
 
             const suppressedMessages = linter.getSuppressedMessages();
 
@@ -16652,24 +16684,51 @@ var a = "test2";
                 plugins: {
                     test: {
                         rules: {
-                            "circular-fix": {
+                            "add-leading-hyphen": {
                                 meta: {
                                     fixable: "whitespace"
                                 },
                                 create(context) {
                                     return {
                                         Program(node) {
-
-                                            // Alternate between adding and removing a hyphen.
                                             const sourceCode = context.getSourceCode();
                                             const hasLeadingHyphen = sourceCode.getText(node).startsWith("-");
 
                                             context.report({
                                                 node,
-                                                message: "Circular fix detected",
-                                                fix: fixer => (hasLeadingHyphen
-                                                    ? fixer.removeRange([0, 1])
-                                                    : fixer.insertTextBefore(node, "-"))
+                                                message: "Adding leading hyphen",
+                                                fix(fixer) {
+                                                    if (hasLeadingHyphen) {
+                                                        return;
+                                                    }
+
+                                                    fixer.insertTextBefore(node, "-");
+                                                }
+                                            });
+                                        }
+                                    };
+                                }
+                            },
+                            "remove-leading-hyphen": {
+                                meta: {
+                                    fixable: "whitespace"
+                                },
+                                create(context) {
+                                    return {
+                                        Program(node) {
+                                            const sourceCode = context.getSourceCode();
+                                            const hasLeadingHyphen = sourceCode.getText(node).startsWith("-");
+
+                                            context.report({
+                                                node,
+                                                message: "Removing leading hyphen",
+                                                fix(fixer) {
+                                                    if (!hasLeadingHyphen) {
+                                                        return;
+                                                    }
+
+                                                    fixer.removeRange([0, 1]);
+                                                }
                                             });
                                         }
                                     };
@@ -16679,17 +16738,18 @@ var a = "test2";
                     }
                 },
                 rules: {
-                    "test/circular-fix": "error"
+                    "test/add-leading-hyphen": "error",
+                    "test/remove-leading-hyphen": "error"
                 }
             };
 
             const initialCode = "-a";
             const fixResult = linter.verifyAndFix(initialCode, config);
 
-            assert.strictEqual(fixResult.fixed, true, "Fixing should have been applied but stopped due to circular fixes.");
+            assert.strictEqual(fixResult.fixed, false, "Fixing was not applied due to circular fixes.");
             assert.strictEqual(fixResult.output, "-a", "Output should match the original input due to circular fixes.");
-            assert.strictEqual(fixResult.messages.length, 1, "There should be one remaining lint message after detecting circular fixes.");
-            assert.strictEqual(fixResult.messages[0].message, "Circular fix detected", "Message should match the last fix attempt.");
+            assert.strictEqual(fixResult.messages.length, 2, "There should be two remaining lint messages after detecting circular fixes.");
+            assert.strictEqual(fixResult.messages[0].message, "Adding leading hyphen", "Message should match the last fix attempt.");
 
             const suppressedMessages = linter.getSuppressedMessages();
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -7606,10 +7606,10 @@ var a = "test2";
                                 message: "Adding leading hyphen",
                                 fix(fixer) {
                                     if (hasLeadingHyphen) {
-                                        return;
+                                        return fixer;
                                     }
 
-                                    fixer.insertTextBefore(node, "-");
+                                    return fixer.insertTextBefore(node, "-");
                                 }
                             });
                         }
@@ -7631,10 +7631,10 @@ var a = "test2";
                                 message: "Removing leading hyphen",
                                 fix(fixer) {
                                     if (!hasLeadingHyphen) {
-                                        return;
+                                        return fixer;
                                     }
 
-                                    fixer.removeRange([0, 1]);
+                                    return fixer.removeRange([0, 1]);
                                 }
                             });
                         }
@@ -16710,10 +16710,10 @@ var a = "test2";
                                                 message: "Adding leading hyphen",
                                                 fix(fixer) {
                                                     if (hasLeadingHyphen) {
-                                                        return;
+                                                        return fixer;
                                                     }
 
-                                                    fixer.insertTextBefore(node, "-");
+                                                    return fixer.insertTextBefore(node, "-");
                                                 }
                                             });
                                         }
@@ -16735,10 +16735,10 @@ var a = "test2";
                                                 message: "Removing leading hyphen",
                                                 fix(fixer) {
                                                     if (!hasLeadingHyphen) {
-                                                        return;
+                                                        return fixer;
                                                     }
 
-                                                    fixer.removeRange([0, 1]);
+                                                    return fixer.removeRange([0, 1]);
                                                 }
                                             });
                                         }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

Fixes https://github.com/eslint/eslint/issues/17609.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `Linter#verifyAndFix()` to check if the produced fix in a pass is the same as in the second previous pass, and in that case stop and emit a warning about conflicting rules.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
