### PR TITLE
docs: replace `var` with `let` and `const` in rule examples

### DIFF
--- a/docs/src/rules/no-caller.md
+++ b/docs/src/rules/no-caller.md
@@ -8,7 +8,7 @@ The use of `arguments.caller` and `arguments.callee` make several code optimizat
 
 ```js
 function foo() {
-    var callee = arguments.callee;
+    const callee = arguments.callee;
 }
 ```
 

--- a/docs/src/rules/no-delete-var.md
+++ b/docs/src/rules/no-delete-var.md
@@ -20,7 +20,7 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-delete-var: "error"*/
 
-var x;
+let x;
 delete x;
 ```
 

--- a/docs/src/rules/no-extend-native.md
+++ b/docs/src/rules/no-extend-native.md
@@ -15,13 +15,13 @@ For example here we are overriding a builtin method that will then affect all Ob
 Object.prototype.extra = 55;
 
 // loop through some userIds
-var users = {
+const users = {
     "123": "Stan",
     "456": "David"
 };
 
 // not what you'd expect
-for (var id in users) {
+for (const id in users) {
     console.log(id); // "123", "456", "extra"
 }
 ```
@@ -68,7 +68,7 @@ Object.prototype.a = "a";
 This rule *does not* report any of the following less obvious approaches to modify the prototype of builtin objects:
 
 ```js
-var x = Object;
+const x = Object;
 x.prototype.thing = a;
 
 eval("Array.prototype.forEach = 'muhahaha'");

--- a/docs/src/rules/no-extra-bind.md
+++ b/docs/src/rules/no-extra-bind.md
@@ -11,7 +11,7 @@ further_reading:
 The `bind()` method is used to create functions with specific `this` values and, optionally, binds arguments to specific values. When used to specify the value of `this`, it's important that the function actually uses `this` in its function body. For example:
 
 ```js
-var boundGetName = (function getName() {
+const boundGetName = (function getName() {
     return this.name;
 }).bind({ name: "ESLint" });
 
@@ -24,7 +24,7 @@ Sometimes during the course of code maintenance, the `this` value is removed fro
 
 ```js
 // useless bind
-var boundGetName = (function getName() {
+const boundGetName = (function getName() {
     return "ESLint";
 }).bind({ name: "ESLint" });
 
@@ -46,25 +46,25 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-extra-bind: "error"*/
 
-var x = function () {
+const x = function () {
     foo();
 }.bind(bar);
 
-var x = (() => {
+const y = (() => {
     foo();
 }).bind(bar);
 
-var x = (() => {
+const z = (() => {
     this.foo();
 }).bind(bar);
 
-var x = function () {
+const a = function () {
     (function () {
       this.foo();
     }());
 }.bind(bar);
 
-var x = function () {
+const b = function () {
     function foo() {
       this.bar();
     }
@@ -80,11 +80,11 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-extra-bind: "error"*/
 
-var x = function () {
+const x = function () {
     this.foo();
 }.bind(bar);
 
-var x = function (a) {
+const y = function (a) {
     return a + 1;
 }.bind(foo, bar);
 ```

--- a/docs/src/rules/no-global-assign.md
+++ b/docs/src/rules/no-global-assign.md
@@ -57,7 +57,7 @@ Examples of **correct** code for this rule:
 /*eslint no-global-assign: "error"*/
 
 a = 1
-var b = 1
+let b = 1
 b = 2
 ```
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Replaced `var` with `let` and `const` in following rule examples

`no-caller`
`no-delete-var`
`no-extend-native`
`no-extra-bind`
`no-global-assign`

#### Is there anything you'd like reviewers to focus on?
Refs #19240

<!-- markdownlint-disable-file MD004 -->
