### PR TITLE
docs: migrate sass to module system

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -48,7 +48,7 @@
         "postcss-cli": "^10.0.0",
         "postcss-html": "^1.5.0",
         "prismjs": "^1.29.0",
-        "sass": "^1.52.1",
+        "sass": "^1.85.1",
         "stylelint": "^14.13.0",
         "stylelint-config-html": "^1.1.0",
         "stylelint-config-standard": "^29.0.0",

--- a/docs/src/assets/scss/styles.scss
+++ b/docs/src/assets/scss/styles.scss
@@ -1,37 +1,37 @@
-@import "tokens/themes";
-@import "tokens/spacing";
-@import "tokens/typography";
-@import "tokens/ui";
-@import "tokens/opacity";
+@use "tokens/themes";
+@use "tokens/spacing";
+@use "tokens/typography";
+@use "tokens/ui";
+@use "tokens/opacity";
 
-@import "foundations";
-@import "syntax-highlighter";
-@import "docs-header";
-@import "docs-footer";
-@import "eslint-site-footer";
-@import "eslint-site-header";
-@import "forms";
-@import "docs";
-@import "versions";
-@import "languages";
+@use "foundations";
+@use "syntax-highlighter";
+@use "docs-header";
+@use "docs-footer";
+@use "eslint-site-footer";
+@use "eslint-site-header";
+@use "forms";
+@use "docs";
+@use "versions";
+@use "languages";
 
-@import "components/buttons";
-@import "components/docs-navigation";
-@import "components/toc";
-@import "components/search";
-@import "components/alert";
-@import "components/rules";
-@import "components/social-icons";
-@import "components/hero";
-@import "components/theme-switcher";
-@import "components/version-switcher";
-@import "components/language-switcher";
-@import "components/docs-index"; // docs index on the main docs pages
-@import "components/index"; // used in component library
-@import "components/tabs";
-@import "components/resources";
-@import "components/logo";
+@use "components/buttons";
+@use "components/docs-navigation";
+@use "components/toc";
+@use "components/search";
+@use "components/alert";
+@use "components/rules";
+@use "components/social-icons";
+@use "components/hero";
+@use "components/theme-switcher";
+@use "components/version-switcher";
+@use "components/language-switcher";
+@use "components/docs-index"; // docs index on the main docs pages
+@use "components/index"; // used in component library
+@use "components/tabs";
+@use "components/resources";
+@use "components/logo";
 
-@import "ads";
+@use "ads";
 
-@import "utilities";
+@use "utilities";


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR migrates the sass stylesheets from using the deprecated `@import` rules to the modern module system (`@use` ) and upgrades sass to the latest version.

This resolves deprecation warnings (`Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.`) encountered when starting or building the docs.

I verified that the output in _site is the same before and after.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
