### PR TITLE
docs: refactor from 'var' to 'let' in rule examples

### DIFF
--- a/docs/src/rules/array-bracket-spacing.md
+++ b/docs/src/rules/array-bracket-spacing.md
@@ -10,11 +10,11 @@ A number of style guides require or disallow spaces between array brackets and o
 applies to both array literals and destructuring assignments (ECMAScript 6).
 
 ```js
-var arr = [ 'foo', 'bar' ];
-var [ x, y ] = z;
+let arr = [ 'foo', 'bar' ];
+let [ x, y ] = z;
 
-var arr = ['foo', 'bar'];
-var [x,y] = z;
+let arr = ['foo', 'bar'];
+let [x,y] = z;
 ```
 
 ## Rule Details
@@ -54,17 +54,17 @@ Examples of **incorrect** code for this rule with the default `"never"` option:
 ```js
 /*eslint array-bracket-spacing: ["error", "never"]*/
 
-var arr = [ 'foo', 'bar' ];
-var arr = ['foo', 'bar' ];
-var arr = [ ['foo'], 'bar'];
-var arr = [[ 'foo' ], 'bar'];
-var arr = [ 'foo',
+let arr = [ 'foo', 'bar' ];
+let arr = ['foo', 'bar' ];
+let arr = [ ['foo'], 'bar'];
+let arr = [[ 'foo' ], 'bar'];
+let arr = [ 'foo',
   'bar'
 ];
-var [ x, y ] = z;
-var [ x,y ] = z;
-var [ x, ...y ] = z;
-var [ ,,x, ] = z;
+let [ x, y ] = z;
+let [ x,y ] = z;
+let [ x, ...y ] = z;
+let [ ,,x, ] = z;
 ```
 
 :::
@@ -76,25 +76,25 @@ Examples of **correct** code for this rule with the default `"never"` option:
 ```js
 /*eslint array-bracket-spacing: ["error", "never"]*/
 
-var arr = [];
-var arr = ['foo', 'bar', 'baz'];
-var arr = [['foo'], 'bar', 'baz'];
-var arr = [
+let arr = [];
+let arr = ['foo', 'bar', 'baz'];
+let arr = [['foo'], 'bar', 'baz'];
+let arr = [
   'foo',
   'bar',
   'baz'
 ];
-var arr = ['foo',
+let arr = ['foo',
   'bar'
 ];
-var arr = [
+let arr = [
   'foo',
   'bar'];
 
-var [x, y] = z;
-var [x,y] = z;
-var [x, ...y] = z;
-var [,,x,] = z;
+let [x, y] = z;
+let [x,y] = z;
+let [x, ...y] = z;
+let [,,x,] = z;
 ```
 
 :::
@@ -108,20 +108,20 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 ```js
 /*eslint array-bracket-spacing: ["error", "always"]*/
 
-var arr = ['foo', 'bar'];
-var arr = ['foo', 'bar' ];
-var arr = [ ['foo'], 'bar' ];
-var arr = ['foo',
+let arr = ['foo', 'bar'];
+let arr = ['foo', 'bar' ];
+let arr = [ ['foo'], 'bar' ];
+let arr = ['foo',
   'bar'
 ];
-var arr = [
+let arr = [
   'foo',
   'bar'];
 
-var [x, y] = z;
-var [x,y] = z;
-var [x, ...y] = z;
-var [,,x,] = z;
+let [x, y] = z;
+let [x,y] = z;
+let [x, ...y] = z;
+let [,,x,] = z;
 ```
 
 :::
@@ -133,25 +133,25 @@ Examples of **correct** code for this rule with the `"always"` option:
 ```js
 /*eslint array-bracket-spacing: ["error", "always"]*/
 
-var arr = [];
-var arr = [ 'foo', 'bar', 'baz' ];
-var arr = [ [ 'foo' ], 'bar', 'baz' ];
-var arr = [ 'foo',
+let arr = [];
+let arr = [ 'foo', 'bar', 'baz' ];
+let arr = [ [ 'foo' ], 'bar', 'baz' ];
+let arr = [ 'foo',
   'bar'
 ];
-var arr = [
+let arr = [
   'foo',
   'bar' ];
-var arr = [
+let arr = [
   'foo',
   'bar',
   'baz'
 ];
 
-var [ x, y ] = z;
-var [ x,y ] = z;
-var [ x, ...y ] = z;
-var [ ,,x, ] = z;
+let [ x, y ] = z;
+let [ x,y ] = z;
+let [ x, ...y ] = z;
+let [ ,,x, ] = z;
 ```
 
 :::
@@ -165,14 +165,14 @@ Examples of **incorrect** code for this rule with the `"always", { "singleValue"
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "singleValue": false }]*/
 
-var foo = [ 'foo' ];
-var foo = [ 'foo'];
-var foo = ['foo' ];
-var foo = [ 1 ];
-var foo = [ 1];
-var foo = [1 ];
-var foo = [ [ 1, 2 ] ];
-var foo = [ { 'foo': 'bar' } ];
+let foo = [ 'foo' ];
+let foo = [ 'foo'];
+let foo = ['foo' ];
+let foo = [ 1 ];
+let foo = [ 1];
+let foo = [1 ];
+let foo = [ [ 1, 2 ] ];
+let foo = [ { 'foo': 'bar' } ];
 ```
 
 :::
@@ -184,10 +184,10 @@ Examples of **correct** code for this rule with the `"always", { "singleValue": 
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "singleValue": false }]*/
 
-var foo = ['foo'];
-var foo = [1];
-var foo = [[ 1, 1 ]];
-var foo = [{ 'foo': 'bar' }];
+let foo = ['foo'];
+let foo = [1];
+let foo = [[ 1, 1 ]];
+let foo = [{ 'foo': 'bar' }];
 ```
 
 :::
@@ -201,8 +201,8 @@ Examples of **incorrect** code for this rule with the `"always", { "objectsInArr
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "objectsInArrays": false }]*/
 
-var arr = [ { 'foo': 'bar' } ];
-var arr = [ {
+let arr = [ { 'foo': 'bar' } ];
+let arr = [ {
   'foo': 'bar'
 } ]
 ```
@@ -216,8 +216,8 @@ Examples of **correct** code for this rule with the `"always", { "objectsInArray
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "objectsInArrays": false }]*/
 
-var arr = [{ 'foo': 'bar' }];
-var arr = [{
+let arr = [{ 'foo': 'bar' }];
+let arr = [{
   'foo': 'bar'
 }];
 ```
@@ -233,8 +233,8 @@ Examples of **incorrect** code for this rule with the `"always", { "arraysInArra
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "arraysInArrays": false }]*/
 
-var arr = [ [ 1, 2 ], 2, 3, 4 ];
-var arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];
+let arr = [ [ 1, 2 ], 2, 3, 4 ];
+let arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];
 ```
 
 :::
@@ -246,8 +246,8 @@ Examples of **correct** code for this rule with the `"always", { "arraysInArrays
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "arraysInArrays": false }]*/
 
-var arr = [[ 1, 2 ], 2, 3, 4 ];
-var arr = [[ 1, 2 ], 2, [ 3, 4 ]];
+let arr = [[ 1, 2 ], 2, 3, 4 ];
+let arr = [[ 1, 2 ], 2, [ 3, 4 ]];
 ```
 
 :::

--- a/docs/src/rules/array-element-newline.md
+++ b/docs/src/rules/array-element-newline.md
@@ -53,14 +53,14 @@ Examples of **incorrect** code for this rule with the default `"always"` option:
 ```js
 /*eslint array-element-newline: ["error", "always"]*/
 
-var c = [1, 2];
-var d = [1, 2, 3];
-var e = [1, 2, 3
+let c = [1, 2];
+let d = [1, 2, 3];
+let e = [1, 2, 3
 ];
-var f = [
+let f = [
   1, 2, 3
 ];
-var g = [
+let g = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -78,19 +78,19 @@ Examples of **correct** code for this rule with the default `"always"` option:
 ```js
 /*eslint array-element-newline: ["error", "always"]*/
 
-var a = [];
-var b = [1];
-var c = [1,
+let a = [];
+let b = [1];
+let c = [1,
     2];
-var d = [1,
+let d = [1,
     2,
     3];
-var d = [
+let d = [
   1, 
   2, 
   3
 ];
-var e = [
+let e = [
     function foo() {
         dosomething();
     },
@@ -111,16 +111,16 @@ Examples of **incorrect** code for this rule with the `"never"` option:
 ```js
 /*eslint array-element-newline: ["error", "never"]*/
 
-var c = [
+let c = [
     1,
     2
 ];
-var d = [
+let d = [
     1,
     2,
     3
 ];
-var e = [
+let e = [
     function foo() {
         dosomething();
     },
@@ -139,16 +139,16 @@ Examples of **correct** code for this rule with the `"never"` option:
 ```js
 /*eslint array-element-newline: ["error", "never"]*/
 
-var a = [];
-var b = [1];
-var c = [1, 2];
-var d = [1, 2, 3];
-var e = [
+let a = [];
+let b = [1];
+let c = [1, 2];
+let d = [1, 2, 3];
+let e = [
     1, 2, 3];
-var f = [
+let f = [
   1, 2, 3
 ];
-var g = [
+let g = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -168,11 +168,11 @@ Examples of **incorrect** code for this rule with the `"consistent"` option:
 ```js
 /*eslint array-element-newline: ["error", "consistent"]*/
 
-var a = [
+let a = [
     1, 2,
     3
 ];
-var b = [
+let b = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -193,20 +193,20 @@ Examples of **correct** code for this rule with the `"consistent"` option:
 ```js
 /*eslint array-element-newline: ["error", "consistent"]*/
 
-var a = [];
-var b = [1];
-var c = [1, 2];
-var d = [1, 2, 3];
-var e = [
+let a = [];
+let b = [1];
+let c = [1, 2];
+let d = [1, 2, 3];
+let e = [
     1,
     2
 ];
-var f = [
+let f = [
     1,
     2,
     3
 ];
-var g = [
+let g = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -215,7 +215,7 @@ var g = [
         dosomething();
     }
 ];
-var h = [
+let h = [
     function foo() {
         dosomething();
     },
@@ -239,9 +239,9 @@ Examples of **incorrect** code for this rule with the `{ "multiline": true }` op
 ```js
 /*eslint array-element-newline: ["error", { "multiline": true }]*/
 
-var d = [1,
+let d = [1,
     2, 3];
-var e = [
+let e = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -259,11 +259,11 @@ Examples of **correct** code for this rule with the `{ "multiline": true }` opti
 ```js
 /*eslint array-element-newline: ["error", { "multiline": true }]*/
 
-var a = [];
-var b = [1];
-var c = [1, 2];
-var d = [1, 2, 3];
-var e = [
+let a = [];
+let b = [1];
+let c = [1, 2];
+let d = [1, 2, 3];
+let e = [
     function foo() {
         dosomething();
     },
@@ -284,10 +284,10 @@ Examples of **incorrect** code for this rule with the `{ "minItems": 3 }` option
 ```js
 /*eslint array-element-newline: ["error", { "minItems": 3 }]*/
 
-var c = [1,
+let c = [1,
     2];
-var d = [1, 2, 3];
-var e = [
+let d = [1, 2, 3];
+let e = [
     function foo() {
         dosomething();
     },
@@ -306,13 +306,13 @@ Examples of **correct** code for this rule with the `{ "minItems": 3 }` option:
 ```js
 /*eslint array-element-newline: ["error", { "minItems": 3 }]*/
 
-var a = [];
-var b = [1];
-var c = [1, 2];
-var d = [1,
+let a = [];
+let b = [1];
+let c = [1, 2];
+let d = [1,
     2,
     3];
-var e = [
+let e = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -332,10 +332,10 @@ Examples of **incorrect** code for this rule with the `{ "multiline": true, "min
 ```js
 /*eslint array-element-newline: ["error", { "multiline": true, "minItems": 3 }]*/
 
-var c = [1,
+let c = [1,
 2];
-var d = [1, 2, 3];
-var e = [
+let d = [1, 2, 3];
+let e = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -353,13 +353,13 @@ Examples of **correct** code for this rule with the `{ "multiline": true, "minIt
 ```js
 /*eslint array-element-newline: ["error", { "multiline": true, "minItems": 3 }]*/
 
-var a = [];
-var b = [1];
-var c = [1, 2];
-var d = [1,
+let a = [];
+let b = [1];
+let c = [1, 2];
+let d = [1,
     2,
     3];
-var e = [
+let e = [
     function foo() {
         dosomething();
     },
@@ -380,9 +380,9 @@ Examples of **incorrect** code for this rule with the `{ "ArrayExpression": "alw
 ```js
 /*eslint array-element-newline: ["error", { "ArrayExpression": "always", "ArrayPattern": "never" }]*/
 
-var a = [1, 2];
-var b = [1, 2, 3];
-var c = [
+let a = [1, 2];
+let b = [1, 2, 3];
+let c = [
     function foo() {
         dosomething();
     }, function bar() {
@@ -390,12 +390,12 @@ var c = [
     }
 ];
 
-var [d,
+let [d,
     e] = arr;
-var [f,
+let [f,
     g,
     h] = arr;
-var [i = function foo() {
+let [i = function foo() {
   dosomething()
 },
 j = function bar() {
@@ -412,12 +412,12 @@ Examples of **correct** code for this rule with the `{ "ArrayExpression": "alway
 ```js
 /*eslint array-element-newline: ["error", { "ArrayExpression": "always", "ArrayPattern": "never" }]*/
 
-var a = [1,
+let a = [1,
     2];
-var b = [1,
+let b = [1,
     2,
     3];
-var c = [
+let c = [
     function foo() {
         dosomething();
     },
@@ -426,9 +426,9 @@ var c = [
     }
 ];
 
-var [d, e] = arr
-var [f, g, h] = arr
-var [i = function foo() {
+let [d, e] = arr
+let [f, g, h] = arr
+let [i = function foo() {
     dosomething()
 }, j = function bar() {
     dosomething()

--- a/docs/src/rules/arrow-parens.md
+++ b/docs/src/rules/arrow-parens.md
@@ -96,8 +96,8 @@ a.then((foo) => { if (true) {} });
 One of the benefits of this option is that it prevents the incorrect use of arrow functions in conditionals:
 
 ```js
-var a = 1;
-var b = 2;
+let a = 1;
+let b = 2;
 // ...
 if (a => b) {
  console.log('bigger');
@@ -112,8 +112,8 @@ The contents of the `if` statement is an arrow function, not a comparison.
 If the arrow function is intentional, it should be wrapped in parens to remove ambiguity.
 
 ```js
-var a = 1;
-var b = 0;
+let a = 1;
+let b = 0;
 // ...
 if ((a) => b) {
  console.log('truthy value returned');
@@ -126,8 +126,8 @@ if ((a) => b) {
 The following is another example of this behavior:
 
 ```js
-var a = 1, b = 2, c = 3, d = 4;
-var f = a => b ? c: d;
+let a = 1, b = 2, c = 3, d = 4;
+let f = a => b ? c: d;
 // f = ?
 ```
 
@@ -136,8 +136,8 @@ var f = a => b ? c: d;
 This should be rewritten like so:
 
 ```js
-var a = 1, b = 2, c = 3, d = 4;
-var f = (a) => b ? c: d;
+let a = 1, b = 2, c = 3, d = 4;
+let f = (a) => b ? c: d;
 ```
 
 ### as-needed

--- a/docs/src/rules/comma-dangle.md
+++ b/docs/src/rules/comma-dangle.md
@@ -5,7 +5,7 @@ rule_type: layout
 Trailing commas in object literals are valid according to the ECMAScript 5 (and ECMAScript 3!) spec. However, IE8 (when not in IE8 document mode) and below will throw an error when it encounters trailing commas in JavaScript.
 
 ```js
-var foo = {
+let foo = {
     bar: "baz",
     qux: "quux",
 };
@@ -17,7 +17,7 @@ Another argument in favor of trailing commas is that it improves the clarity of 
 Less clear:
 
 ```diff
- var foo = {
+ let foo = {
 -    bar: "baz",
 -    qux: "quux"
 +    bar: "baz"
@@ -27,7 +27,7 @@ Less clear:
 More clear:
 
 ```diff
- var foo = {
+ let foo = {
      bar: "baz",
 -    qux: "quux",
  };
@@ -80,12 +80,12 @@ Examples of **incorrect** code for this rule with the default `"never"` option:
 ```js
 /*eslint comma-dangle: ["error", "never"]*/
 
-var foo = {
+let foo = {
     bar: "baz",
     qux: "quux",
 };
 
-var arr = [1,2,];
+let arr = [1,2,];
 
 foo({
   bar: "baz",
@@ -102,12 +102,12 @@ Examples of **correct** code for this rule with the default `"never"` option:
 ```js
 /*eslint comma-dangle: ["error", "never"]*/
 
-var foo = {
+let foo = {
     bar: "baz",
     qux: "quux"
 };
 
-var arr = [1,2];
+let arr = [1,2];
 
 foo({
   bar: "baz",
@@ -126,12 +126,12 @@ Examples of **incorrect** code for this rule with the `"always"` option:
 ```js
 /*eslint comma-dangle: ["error", "always"]*/
 
-var foo = {
+let foo = {
     bar: "baz",
     qux: "quux"
 };
 
-var arr = [1,2];
+let arr = [1,2];
 
 foo({
   bar: "baz",
@@ -148,12 +148,12 @@ Examples of **correct** code for this rule with the `"always"` option:
 ```js
 /*eslint comma-dangle: ["error", "always"]*/
 
-var foo = {
+let foo = {
     bar: "baz",
     qux: "quux",
 };
 
-var arr = [1,2,];
+let arr = [1,2,];
 
 foo({
   bar: "baz",
@@ -172,19 +172,19 @@ Examples of **incorrect** code for this rule with the `"always-multiline"` optio
 ```js
 /*eslint comma-dangle: ["error", "always-multiline"]*/
 
-var foo = {
+let foo = {
     bar: "baz",
     qux: "quux"
 };
 
-var foo = { bar: "baz", qux: "quux", };
+let foo = { bar: "baz", qux: "quux", };
 
-var arr = [1,2,];
+let arr = [1,2,];
 
-var arr = [1,
+let arr = [1,
     2,];
 
-var arr = [
+let arr = [
     1,
     2
 ];
@@ -204,18 +204,18 @@ Examples of **correct** code for this rule with the `"always-multiline"` option:
 ```js
 /*eslint comma-dangle: ["error", "always-multiline"]*/
 
-var foo = {
+let foo = {
     bar: "baz",
     qux: "quux",
 };
 
-var foo = {bar: "baz", qux: "quux"};
-var arr = [1,2];
+let foo = {bar: "baz", qux: "quux"};
+let arr = [1,2];
 
-var arr = [1,
+let arr = [1,
     2];
 
-var arr = [
+let arr = [
     1,
     2,
 ];
@@ -237,11 +237,11 @@ Examples of **incorrect** code for this rule with the `"only-multiline"` option:
 ```js
 /*eslint comma-dangle: ["error", "only-multiline"]*/
 
-var foo = { bar: "baz", qux: "quux", };
+let foo = { bar: "baz", qux: "quux", };
 
-var arr = [1,2,];
+let arr = [1,2,];
 
-var arr = [1,
+let arr = [1,
     2,];
 
 ```
@@ -255,28 +255,28 @@ Examples of **correct** code for this rule with the `"only-multiline"` option:
 ```js
 /*eslint comma-dangle: ["error", "only-multiline"]*/
 
-var foo = {
+let foo = {
     bar: "baz",
     qux: "quux",
 };
 
-var foo = {
+let foo = {
     bar: "baz",
     qux: "quux"
 };
 
-var foo = {bar: "baz", qux: "quux"};
-var arr = [1,2];
+let foo = {bar: "baz", qux: "quux"};
+let arr = [1,2];
 
-var arr = [1,
+let arr = [1,
     2];
 
-var arr = [
+let arr = [
     1,
     2,
 ];
 
-var arr = [
+let arr = [
     1,
     2
 ];


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Replaced var with let in following rule examples
`array-bracket-spacing`
`array-element-newline`
`arrow-parens`
`comma-dangle`

#### Is there anything you'd like reviewers to focus on?
Refs https://github.com/eslint/eslint/issues/19240

<!-- markdownlint-disable-file MD004 -->
