### PR TITLE
docs: support TypeScript language tags in rule documentation

### DIFF
--- a/tests/fixtures/bad-examples.md
+++ b/tests/fixtures/bad-examples.md
@@ -17,7 +17,7 @@ export default "foo";
 
 :::correct
 
-````ts
+````bad
 const foo = "bar";
 
 const foo = "baz";

--- a/tests/tools/check-rule-examples.js
+++ b/tests/tools/check-rule-examples.js
@@ -75,9 +75,9 @@ describe("check-rule-examples", () => {
                 const expectedStderr =
                 "\x1B[0m\x1B[0m\n" +
                 "\x1B[0m\x1B[4mbad-examples.md\x1B[24m\x1B[0m\n" +
-                "\x1B[0m   \x1B[2m11:4\x1B[22m  \x1B[31merror\x1B[39m  Missing language tag: use one of 'javascript', 'js' or 'jsx'\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m11:4\x1B[22m  \x1B[31merror\x1B[39m  Missing language tag: use one of 'javascript', 'js', 'jsx', 'typescript', 'ts' or 'tsx'\x1B[0m\n" +
                 "\x1B[0m   \x1B[2m12:1\x1B[22m  \x1B[31merror\x1B[39m  Unexpected lint error found: Parsing error: 'import' and 'export' may appear only with 'sourceType: module'\x1B[0m\n" +
-                "\x1B[0m   \x1B[2m20:5\x1B[22m  \x1B[31merror\x1B[39m  Nonstandard language tag 'ts': use one of 'javascript', 'js' or 'jsx'\x1B[0m\n" +
+                "\x1B[0m   \x1B[2m20:5\x1B[22m  \x1B[31merror\x1B[39m  Nonstandard language tag 'bad': use one of 'javascript', 'js', 'jsx', 'typescript', 'ts' or 'tsx'\x1B[0m\n" +
                 "\x1B[0m   \x1B[2m23:7\x1B[22m  \x1B[31merror\x1B[39m  Unexpected lint error found: Parsing error: Identifier 'foo' has already been declared\x1B[0m\n" +
                 "\x1B[0m   \x1B[2m31:1\x1B[22m  \x1B[31merror\x1B[39m  Example code should contain a configuration comment like /* eslint no-restricted-syntax: \"error\" */\x1B[0m\n" +
                 "\x1B[0m   \x1B[2m41:1\x1B[22m  \x1B[31merror\x1B[39m  Unexpected lint error found: Failed to parse JSON from 'doesn't allow this comment'\x1B[0m\n" +

--- a/tools/check-rule-examples.js
+++ b/tools/check-rule-examples.js
@@ -14,6 +14,7 @@ const { ConfigCommentParser } = require("@eslint/plugin-kit");
 const rules = require("../lib/rules");
 const { LATEST_ECMA_VERSION } = require("../conf/ecma-version");
 const { Linter } = require("../lib/linter");
+const tsParser = require("@typescript-eslint/parser");
 
 //------------------------------------------------------------------------------
 // Typedefs
@@ -27,7 +28,13 @@ const { Linter } = require("../lib/linter");
 // Helpers
 //------------------------------------------------------------------------------
 
-const STANDARD_LANGUAGE_TAGS = new Set(["javascript", "js", "jsx"]);
+const TYPESCRIPT_LANGUAGE_TAGS = new Set(["typescript", "ts", "tsx"]);
+const STANDARD_LANGUAGE_TAGS = new Set([
+    "javascript",
+    "js",
+    "jsx",
+    ...TYPESCRIPT_LANGUAGE_TAGS,
+]);
 
 const VALID_ECMA_VERSIONS = new Set([
     3,
@@ -57,9 +64,11 @@ async function findProblems(filename) {
                  * Missing language tags are also reported by Markdownlint rule MD040 for all code blocks,
                  * but the message we output here is more specific.
                  */
-                const message = `${languageTag
-                    ? `Nonstandard language tag '${languageTag}'`
-                    : "Missing language tag"}: use one of 'javascript', 'js' or 'jsx'`;
+                const message = `${
+                    languageTag
+                        ? `Nonstandard language tag '${languageTag}'`
+                        : "Missing language tag"
+                }: use one of 'javascript', 'js', 'jsx', 'typescript', 'ts' or 'tsx'`;
 
                 problems.push({
                     fatal: false,
@@ -93,6 +102,10 @@ async function findProblems(filename) {
 
                     return;
                 }
+            }
+
+            if (TYPESCRIPT_LANGUAGE_TAGS.has(languageTag)) {
+                languageOptions.parser = tsParser;
             }
 
             const linter = new Linter();


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Currently, the rule examples checker only allows JavaScript language tags ('js', 'javascript', 'jsx'), causing errors when TypeScript examples are present in rule documentation. This change adds support for TypeScript language tags.

#### Related Issues
#19527

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
