### PR TITLE
fix: move deprecated `RuleContext` methods to subtype

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -41,27 +41,6 @@ import type {
 import { JSONSchema4 } from "json-schema";
 import { LegacyESLint } from "./use-at-your-own-risk.js";
 
-/*
- * Need to extend the `RuleContext` interface to include the
- * deprecated methods that have not yet been removed.
- * TODO: Remove in v10.0.0.
- */
-declare module "@eslint/core" {
-	interface RuleContext {
-		/** @deprecated Use `sourceCode.getAncestors()` instead */
-		getAncestors(): ESTree.Node[];
-
-		/** @deprecated Use `sourceCode.getDeclaredVariables()` instead */
-		getDeclaredVariables(node: ESTree.Node): Scope.Variable[];
-
-		/** @deprecated Use `sourceCode.getScope()` instead */
-		getScope(): Scope.Scope;
-
-		/** @deprecated Use `sourceCode.markVariableAsUsed()` instead */
-		markVariableAsUsed(name: string): boolean;
-	}
-}
-
 export namespace AST {
 	type TokenType =
 		| "Boolean"
@@ -607,15 +586,18 @@ export namespace SourceCode {
 // #endregion
 
 export namespace Rule {
-	type RuleModule = RuleDefinition<{
-		LangOptions: Linter.LanguageOptions;
-		Code: SourceCode;
-		RuleOptions: any[];
-		Visitor: NodeListener;
-		Node: ESTree.Node;
-		MessageIds: string;
-		ExtRuleDocs: {};
-	}>;
+	interface RuleModule
+		extends RuleDefinition<{
+			LangOptions: Linter.LanguageOptions;
+			Code: SourceCode;
+			RuleOptions: any[];
+			Visitor: NodeListener;
+			Node: ESTree.Node;
+			MessageIds: string;
+			ExtRuleDocs: {};
+		}> {
+		create(context: RuleContext): NodeListener;
+	}
 
 	type NodeTypes = ESTree.Node["type"];
 	interface NodeListener extends RuleVisitor {
@@ -1199,7 +1181,23 @@ export namespace Rule {
 				Node: ESTree.Node;
 			}
 		> {
-		// report(descriptor: ReportDescriptor): void;
+		/*
+		 * Need to extend the `RuleContext` interface to include the
+		 * deprecated methods that have not yet been removed.
+		 * TODO: Remove in v10.0.0.
+		 */
+
+		/** @deprecated Use `sourceCode.getAncestors()` instead */
+		getAncestors(): ESTree.Node[];
+
+		/** @deprecated Use `sourceCode.getDeclaredVariables()` instead */
+		getDeclaredVariables(node: ESTree.Node): Scope.Variable[];
+
+		/** @deprecated Use `sourceCode.getScope()` instead */
+		getScope(): Scope.Scope;
+
+		/** @deprecated Use `sourceCode.markVariableAsUsed()` instead */
+		markVariableAsUsed(name: string): boolean;
 	}
 
 	type ReportFixer = (

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -52,7 +52,7 @@ import {
 	StaticBlock,
 	WhileStatement,
 } from "estree";
-import { Language } from "@eslint/core";
+import { Language, RuleDefinition } from "@eslint/core";
 
 const SOURCE = `var foo = bar;`;
 
@@ -782,6 +782,23 @@ rule = {
 		};
 	},
 };
+
+type DeprecatedRuleContextKeys =
+	| "getAncestors"
+	| "getDeclaredVariables"
+	| "getScope"
+	| "markVariableAsUsed";
+(): RuleDefinition => ({
+	create(context) {
+		// Ensure that deprecated RuleContext methods are not defined when using RuleDefinition
+		context satisfies {
+			[Key in keyof typeof context]: Key extends DeprecatedRuleContextKeys
+				? never
+				: (typeof context)[Key];
+		};
+		return {};
+	},
+});
 
 // #endregion
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Currently, the types of plugins such as `@eslint/json` are not compatible with `ESLint.Plugin` because of a [module augmentation](https://github.com/eslint/eslint/blob/v9.22.0/lib/types/index.d.ts#L49-L64) on `"@eslint/core"` that defines additional deprecated methods on the `RuleContext` type. The additional methods modify all types that reference `RuleContext` inside ESLint, hence also `ESLint.Plugin`, but not the types of plugins like `@eslint/json` that use the core types directly.

This means that the `context` of rules defined in `@eslint/json` does not have the deprecated methods `getAncestors`, `getDeclaredVariables`, `getScope` and  `markVariableAsUsed`, and this results in an incompatibility between the plugin and the `ESLint.Plugin` type. 

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v22.14.0
npm version: v10.9.2
Local ESLint version: v9.22.0 (Currently used)
Global ESLint version: v9.22.0
Operating System: darwin 24.3.0

</details>

**What did you do? Please include the actual source code causing the issue.**

```ts
import json from '@eslint/json';
import type { ESLint } from 'eslint';

const plugin: ESLint.Plugin = json;
```

**What did you expect to happen?**

The code should compile without errros.

**What actually happened? Please include the actual, raw output from ESLint.**

An error occurs.

```plain
Type 'typeof plugin' is not assignable to type 'Plugin'.
  Types of property 'rules' are incompatible.
    Type '{ "no-duplicate-keys": NoDuplicateKeysRuleDefinition; "no-empty-keys": NoEmptyKeysRuleDefinition; "no-unsafe-values": NoUnsafeValuesRuleDefinition; "no-unnormalized-keys": NoUnnormalizedKeysRuleDefinition; "sort-keys": SortKeysRuleDefinition; "top-level-interop": TopLevelInteropRuleDefinition; }' is not assignable to type 'Record<string, RuleDefinition<RuleDefinitionTypeOptions>>'.
      Property '"no-duplicate-keys"' is incompatible with index signature.
        Type 'NoDuplicateKeysRuleDefinition' is not assignable to type 'RuleDefinition<RuleDefinitionTypeOptions>'.
          Types of property 'create' are incompatible.
            Type '(context: RuleContext<{ LangOptions: JSONLanguageOptions; Code: IJSONSourceCode; RuleOptions: []; Node: AnyNode; MessageIds: "duplicateKey"; }>) => JSONRuleVisitor' is not assignable to type '(context: RuleContext<{ LangOptions: LanguageOptions; Code: SourceCode<{ LangOptions: LanguageOptions; RootNode: unknown; SyntaxElementWithLoc: unknown; ConfigNode: unknown; }>; RuleOptions: unknown[]; Node: unknown; MessageIds: string; }>) => RuleVisitor'.
              Types of parameters 'context' and 'context' are incompatible.
                Type 'RuleContext<{ LangOptions: LanguageOptions; Code: SourceCode<{ LangOptions: LanguageOptions; RootNode: unknown; SyntaxElementWithLoc: unknown; ConfigNode: unknown; }>; RuleOptions: unknown[]; Node: unknown; MessageIds: string; }>' is not assignable to type 'RuleContext<{ LangOptions: JSONLanguageOptions; Code: IJSONSourceCode; RuleOptions: []; Node: AnyNode; MessageIds: "duplicateKey"; }>'.
                  Types of property 'sourceCode' are incompatible.
                    Type 'SourceCode<{ LangOptions: LanguageOptions; RootNode: unknown; SyntaxElementWithLoc: unknown; ConfigNode: unknown; }>' is not assignable to type 'IJSONSourceCode'.
                      Type 'TextSourceCode<{ LangOptions: LanguageOptions; RootNode: unknown; SyntaxElementWithLoc: unknown; ConfigNode: unknown; }>' is missing the following properties from type 'IJSONSourceCode': getText, comments, lines(2322)
```

[**StackBlitz Repro**](https://stackblitz.com/edit/94nnwfu1?file=index.ts)

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Moved the deprecated methods out of the core type's `RuleContext` augmentation into ESLint's `Rule.RuleContext` type.
* Updated `Rule.RuleModule` so that the `create()` method accepts an argument of type `Rule.RuleContext`. This ensures that the deprecated methods are available to legacy code that uses the `Rule.RuleModule` type.
* Added a test to ensure that the deprecated context methods are not defined on the `context` of a `RuleDefinition`.
* Verified that `@eslint/json`'s main export is assignable to `ESLint.Plugin` after this change.

#### Is there anything you'd like reviewers to focus on?

See the discussion at https://github.com/eslint/markdown/pull/324#discussion_r1995447199.

<!-- markdownlint-disable-file MD004 -->
