### PR TITLE
chore: temporarily disable prettier in trunk

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -45,7 +45,6 @@ lint:
         - checkov@3.2.228
         - markdownlint@0.41.0
         - oxipng@9.1.2
-        - prettier@3.3.3
         - renovate@38.37.1
         - shellcheck@0.10.0
         - shfmt@3.6.0
@@ -57,10 +56,6 @@ lint:
         - linters: [markdownlint]
           paths:
               - CHANGELOG.md
-        - linters: [prettier]
-          paths:
-              - "**" # Ignore all files
-              - "!conf/**/*.json" # Except for json files in conf/
 actions:
     disabled:
         - trunk-announce


### PR DESCRIPTION
Quick fix for #19355's failures:

```plaintext
conf/replacements.json
 -:-  fmt  Incorrect formatting, autoformat by running 'trunk fmt'  prettier

conf/rule-type-list.json
 -:-  fmt  Incorrect formatting, autoformat by running 'trunk fmt'  prettier
```

Trunk is still configured to run on specifically those files on `main`, so it's using its default settings. But we're going with a different set of customizations in #19354.

This PR disables Prettier in Trunk altogether (i.e. removing the _"un-ignore the `conf/*.json` files"_ line). Prettier will be re-enabled in #19354.