### PR TITLE
chore: format JSON files in Trunk

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -1,13 +1,5 @@
 {
-    "include": [
-        "bin/**/*.js",
-        "conf/**/*.js",
-        "lib/**/*.js"
-    ],
-    "reporter": [
-        "lcov",
-        "text-summary",
-        "cobertura"
-    ],
-    "sourceMap": true
+  "include": ["bin/**/*.js", "conf/**/*.js", "lib/**/*.js"],
+  "reporter": ["lcov", "text-summary", "cobertura"],
+  "sourceMap": true
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,37 +1,37 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:recommended",
-        ":approveMajorUpdates",
-        ":semanticCommitScopeDisabled"
-    ],
-    "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
-    "labels": ["dependencies"],
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:recommended",
+    ":approveMajorUpdates",
+    ":semanticCommitScopeDisabled",
+  ],
+  ignorePresets: [":semanticPrefixFixDepsChoreOthers"],
+  labels: ["dependencies"],
 
-    // Wait well over npm's three day window for any new package as a precaution against malicious publishes
-    // https://docs.npmjs.com/policies/unpublish/#packages-published-less-than-72-hours-ago
-    "minimumReleaseAge": "7 days",
+  // Wait well over npm's three day window for any new package as a precaution against malicious publishes
+  // https://docs.npmjs.com/policies/unpublish/#packages-published-less-than-72-hours-ago
+  minimumReleaseAge: "7 days",
 
-    "packageRules": [
-        {
-            "description": "Use the deps:actions label for github-action manager updates (this means Renovate's github-action manager).",
-            "addLabels": ["deps:actions"],
-            "matchManagers": ["github-actions"]
-        },
-        {
-            "description": "Use the deps:npm label for npm manager packages (this means Renovate's npm manager).",
-            "addLabels": ["deps:npm"],
-            "matchManagers": ["npm"]
-        },
-        {
-            "description": "Group Babel packages into a single PR.",
-            "groupName": "babel",
-            "matchPackagePrefixes": ["@babel", "babel-"]
-        },
-        {
-            "description": "Group metascraper packages into a single PR.",
-            "groupName": "metascraper",
-            "matchPackagePrefixes": ["metascraper"]
-        }
-    ]
+  packageRules: [
+    {
+      description: "Use the deps:actions label for github-action manager updates (this means Renovate's github-action manager).",
+      addLabels: ["deps:actions"],
+      matchManagers: ["github-actions"],
+    },
+    {
+      description: "Use the deps:npm label for npm manager packages (this means Renovate's npm manager).",
+      addLabels: ["deps:npm"],
+      matchManagers: ["npm"],
+    },
+    {
+      description: "Group Babel packages into a single PR.",
+      groupName: "babel",
+      matchPackagePrefixes: ["@babel", "babel-"],
+    },
+    {
+      description: "Group metascraper packages into a single PR.",
+      groupName: "metascraper",
+      matchPackagePrefixes: ["metascraper"],
+    },
+  ],
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,7 +5,7 @@
 
   "overrides": [
     {
-      "files": ["*.json"],
+      "files": ["*.{json,jsonc,json5}", ".c8rc"],
       "options": {
         "tabWidth": 2,
         "useTabs": false

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -26,9 +26,16 @@ tools:
 
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
+    files:
+        - name: json
+          extensions:
+              - json
+              - jsonc
+              - json5
+              - c8rc
     definitions:
         - name: eslint
-          files: [typescript, javascript, yaml] # Add YAML to default files.
+          files: [typescript, javascript, yaml, json] # Add YAML and JSON to default files.
           hold_the_line: false
           commands:
               - name: lint

--- a/docs/package.json
+++ b/docs/package.json
@@ -51,10 +51,9 @@
     "sass": "^1.85.1",
     "stylelint": "^14.13.0",
     "stylelint-config-html": "^1.1.0",
+    "stylelint-config-prettier": "^9.0.5",
     "stylelint-config-standard": "^29.0.0",
-    "stylelint-config-prettier": "^9.0.5",
     "stylelint-config-standard-scss": "^5.0.0",
-    "stylelint-config-prettier": "^9.0.5",
     "tap-spot": "^1.1.2"
   },
   "engines": {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -202,6 +202,7 @@ module.exports = defineConfig([
 		files: ["knip.jsonc"],
 		plugins: { json },
 		language: "json/jsonc",
+		languageOptions: { allowTrailingCommas: true },
 		extends: ["json/recommended"],
 	},
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,41 +1,41 @@
 {
-	"workspaces": {
-		".": {
-			// These entries are complementary to the ones found in package.json
-			"entry": ["lib/rules/index.js", "tools/internal-rules/*.js"],
-			"project": ["{conf,lib,tools}/**/*.js"],
-			"mocha": {
-				"entry": [
-					"tests/{bin,conf,lib,tools}/**/*.js", // see Makefile.js
-					"tests/_utils/test-lazy-loading-rules.js",
-				],
-				"project": ["tests/**/*.js"],
-			},
-			"ignore": [
-				// If Knip would consider exports as named, their usage is too dynamic: globals[`es${ecmaVersion}`]
-				// An alternative is to add `__esModule: true` to the export and we can remove it here from the ignores:
-				"conf/globals.js",
-				// These contain unresolved imports and other oddities:
-				"tests/bench/large.js",
-				"tests/lib/rule-tester/rule-tester.js",
-				"tests/performance/jshint.js",
-				// Many are required using dynamic paths such as `fs.readFileSync(path.join())`:
-				"tests/fixtures/**",
-			],
-			"ignoreDependencies": [
-				"c8",
-				// Optional peer dependency used for loading TypeScript configuration files
-				"jiti",
-			],
-		},
-		"docs": {
-			"ignore": ["src/assets/js/search.js", "_examples/**"],
-		},
-		// Workspaces with default configs:
-		"packages/*": {
-			"ignore": ["tests/types/**"],
-			"ignoreDependencies": ["eslint"],
-		},
-		"tools/internal-rules": {},
-	},
+  "workspaces": {
+    ".": {
+      // These entries are complementary to the ones found in package.json
+      "entry": ["lib/rules/index.js", "tools/internal-rules/*.js"],
+      "project": ["{conf,lib,tools}/**/*.js"],
+      "mocha": {
+        "entry": [
+          "tests/{bin,conf,lib,tools}/**/*.js", // see Makefile.js
+          "tests/_utils/test-lazy-loading-rules.js",
+        ],
+        "project": ["tests/**/*.js"],
+      },
+      "ignore": [
+        // If Knip would consider exports as named, their usage is too dynamic: globals[`es${ecmaVersion}`]
+        // An alternative is to add `__esModule: true` to the export and we can remove it here from the ignores:
+        "conf/globals.js",
+        // These contain unresolved imports and other oddities:
+        "tests/bench/large.js",
+        "tests/lib/rule-tester/rule-tester.js",
+        "tests/performance/jshint.js",
+        // Many are required using dynamic paths such as `fs.readFileSync(path.join())`:
+        "tests/fixtures/**",
+      ],
+      "ignoreDependencies": [
+        "c8",
+        // Optional peer dependency used for loading TypeScript configuration files
+        "jiti",
+      ],
+    },
+    "docs": {
+      "ignore": ["src/assets/js/search.js", "_examples/**"],
+    },
+    // Workspaces with default configs:
+    "packages/*": {
+      "ignore": ["tests/types/**"],
+      "ignoreDependencies": ["eslint"],
+    },
+    "tools/internal-rules": {},
+  },
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Update the build

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I noticed that after #19354 running `node bin/eslint` was reporting errors for `.json` files that were not caught by Trunk in CI, so I updated the Trunk config to lint and auto-format JSON files as well. I also updated the Prettier config to apply the same formatting rules for `.json` files also to `.jsonc` and `.json5` files and to the `.c8rc` file, and I updated the ESLint config so that `.jsonc` files with trailing commas can be parsed. Then I fixed the lint problem in`docs/package.json` and let Prettier do the rest.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
