### PR TITLE
feat: support TS syntax in `no-dupe-class-members`

### DIFF
--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -4,15 +4,17 @@ rule_type: problem
 handled_by_typescript: true
 ---
 
-
-
 If there are declarations of the same name in class members, the last declaration overwrites other declarations silently.
 It can cause unexpected behaviors.
 
 ```js
 class Foo {
-  bar() { console.log("hello"); }
-  bar() { console.log("goodbye"); }
+	bar() {
+		console.log("hello");
+	}
+	bar() {
+		console.log("goodbye");
+	}
 }
 
 const foo = new Foo();
@@ -33,28 +35,28 @@ Examples of **incorrect** code for this rule:
 /*eslint no-dupe-class-members: "error"*/
 
 class A {
-  bar() { }
-  bar() { }
+	bar() {}
+	bar() {}
 }
 
 class B {
-  bar() { }
-  get bar() { }
+	bar() {}
+	get bar() {}
 }
 
 class C {
-  bar;
-  bar;
+	bar;
+	bar;
 }
 
 class D {
-  bar;
-  bar() { }
+	bar;
+	bar() {}
 }
 
 class E {
-  static bar() { }
-  static bar() { }
+	static bar() {}
+	static bar() {}
 }
 ```
 
@@ -68,28 +70,44 @@ Examples of **correct** code for this rule:
 /*eslint no-dupe-class-members: "error"*/
 
 class A {
-  bar() { }
-  qux() { }
+	bar() {}
+	qux() {}
 }
 
 class B {
-  get bar() { }
-  set bar(value) { }
+	get bar() {}
+	set bar(value) {}
 }
 
 class C {
-  bar;
-  qux;
+	bar;
+	qux;
 }
 
 class D {
-  bar;
-  qux() { }
+	bar;
+	qux() {}
 }
 
 class E {
-  static bar() { }
-  bar() { }
+	static bar() {}
+	bar() {}
+}
+```
+
+:::
+
+This rule additionally supports TypeScript type syntax. It has support for TypeScript's method overload definitions.
+
+Examples of **correct** TypeScript code for this rule:
+
+::: correct
+
+```ts
+class A {
+	foo(value: string): void;
+	foo(value: number): void;
+	foo(value: string | number) {} // ✅ This is the actual implementation.
 }
 ```
 
@@ -100,3 +118,5 @@ class E {
 This rule should not be used in ES3/5 environments.
 
 In ES2015 (ES6) or later, if you don't want to be notified about duplicate names in class members, you can safely disable this rule.
+
+The TypeScript compiler already checks for the issues addressed by this ESLint rule. Therefore, enabling this rule in new TypeScript projects is generally unnecessary. You should only enable it if you prefer ESLint's error messages over the TypeScript compiler's or if you're using it to lint JavaScript code.

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -120,5 +120,3 @@ class A {
 This rule should not be used in ES3/5 environments.
 
 In ES2015 (ES6) or later, if you don't want to be notified about duplicate names in class members, you can safely disable this rule.
-
-The TypeScript compiler already checks for the issues addressed by this ESLint rule. Therefore, enabling this rule in new TypeScript projects is generally unnecessary. You should only enable it if you prefer ESLint's error messages over the TypeScript compiler's or if you're using it to lint JavaScript code.

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -4,17 +4,15 @@ rule_type: problem
 handled_by_typescript: true
 ---
 
+
+
 If there are declarations of the same name in class members, the last declaration overwrites other declarations silently.
 It can cause unexpected behaviors.
 
 ```js
 class Foo {
-	bar() {
-		console.log("hello");
-	}
-	bar() {
-		console.log("goodbye");
-	}
+  bar() { console.log("hello"); }
+  bar() { console.log("goodbye"); }
 }
 
 const foo = new Foo();
@@ -35,28 +33,28 @@ Examples of **incorrect** code for this rule:
 /*eslint no-dupe-class-members: "error"*/
 
 class A {
-	bar() {}
-	bar() {}
+  bar() { }
+  bar() { }
 }
 
 class B {
-	bar() {}
-	get bar() {}
+  bar() { }
+  get bar() { }
 }
 
 class C {
-	bar;
-	bar;
+  bar;
+  bar;
 }
 
 class D {
-	bar;
-	bar() {}
+  bar;
+  bar() { }
 }
 
 class E {
-	static bar() {}
-	static bar() {}
+  static bar() { }
+  static bar() { }
 }
 ```
 
@@ -70,46 +68,28 @@ Examples of **correct** code for this rule:
 /*eslint no-dupe-class-members: "error"*/
 
 class A {
-	bar() {}
-	qux() {}
+  bar() { }
+  qux() { }
 }
 
 class B {
-	get bar() {}
-	set bar(value) {}
+  get bar() { }
+  set bar(value) { }
 }
 
 class C {
-	bar;
-	qux;
+  bar;
+  qux;
 }
 
 class D {
-	bar;
-	qux() {}
+  bar;
+  qux() { }
 }
 
 class E {
-	static bar() {}
-	bar() {}
-}
-```
-
-:::
-
-This rule additionally supports TypeScript type syntax. It has support for TypeScript's method overload definitions.
-
-Examples of **correct** TypeScript code for this rule:
-
-::: correct
-
-```ts
-/* eslint no-dupe-class-members: "error" */
-
-class A {
-	foo(value: string): void;
-	foo(value: number): void;
-	foo(value: string | number) {} // ✅ This is the actual implementation.
+  static bar() { }
+  bar() { }
 }
 ```
 

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -104,6 +104,8 @@ Examples of **correct** TypeScript code for this rule:
 ::: correct
 
 ```ts
+/* eslint no-dupe-class-members: "error" */
+
 class A {
 	foo(value: string): void;
 	foo(value: number): void;

--- a/docs/src/rules/no-dupe-class-members.md
+++ b/docs/src/rules/no-dupe-class-members.md
@@ -115,6 +115,24 @@ class A {
 
 :::
 
+This rule additionally supports TypeScript type syntax. It has support for TypeScript's method overload definitions.
+
+Examples of **correct** TypeScript code for this rule:
+
+::: correct
+
+```ts
+/* eslint no-dupe-class-members: "error" */
+
+class A {
+	foo(value: string): void;
+	foo(value: number): void;
+	foo(value: string | number) {} // ✅ This is the actual implementation.
+}
+```
+
+:::
+
 ## When Not To Use It
 
 This rule should not be used in ES3/5 environments.

--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -15,6 +15,8 @@ const astUtils = require("./utils/ast-utils");
 module.exports = {
 	meta: {
 		type: "problem",
+		dialects: ["javascript", "typescript"],
+		language: "javascript",
 
 		docs: {
 			description: "Disallow duplicate class members",
@@ -73,6 +75,13 @@ module.exports = {
 
 			// Reports the node if its name has been declared already.
 			"MethodDefinition, PropertyDefinition"(node) {
+				if (
+					node.value &&
+					node.value.type === "TSEmptyBodyFunctionExpression"
+				) {
+					return;
+				}
+
 				const name = astUtils.getStaticPropertyName(node);
 				const kind =
 					node.type === "MethodDefinition" ? node.kind : "field";

--- a/tests/lib/rules/no-dupe-class-members.js
+++ b/tests/lib/rules/no-dupe-class-members.js
@@ -410,3 +410,256 @@ ruleTester.run("no-dupe-class-members", rule, {
 		 */
 	],
 });
+
+const ruleTesterTypeScript = new RuleTester({
+	languageOptions: {
+		parser: require("@typescript-eslint/parser"),
+	},
+});
+
+ruleTesterTypeScript.run("no-dupe-class-members", rule, {
+	valid: [
+		`
+		  class A {
+			foo() {}
+			bar() {}
+		  }
+			  `,
+		`
+		  class A {
+			static foo() {}
+			foo() {}
+		  }
+			  `,
+		`
+		  class A {
+			get foo() {}
+			set foo(value) {}
+		  }
+			  `,
+		`
+		  class A {
+			static foo() {}
+			get foo() {}
+			set foo(value) {}
+		  }
+			  `,
+		`
+		  class A {
+			foo() {}
+		  }
+		  class B {
+			foo() {}
+		  }
+			  `,
+		`
+		  class A {
+			[foo]() {}
+			foo() {}
+		  }
+			  `,
+		`
+		  class A {
+			foo() {}
+			bar() {}
+			baz() {}
+		  }
+			  `,
+		`
+		  class A {
+			*foo() {}
+			*bar() {}
+			*baz() {}
+		  }
+			  `,
+		`
+		  class A {
+			get foo() {}
+			get bar() {}
+			get baz() {}
+		  }
+			  `,
+		`
+		  class A {
+			1() {}
+			2() {}
+		  }
+			  `,
+		`
+		class Foo {
+		  foo(a: string): string;
+		  foo(a: number): number;
+		  foo(a: any): any {}
+		}
+	  `,
+	],
+	invalid: [
+		{
+			code: `
+  class A {
+	foo() {}
+    foo() {}
+  }
+		`,
+			errors: [
+				{
+					column: 5,
+					data: { name: "foo" },
+					line: 4,
+					messageId: "unexpected",
+				},
+			],
+		},
+		{
+			code: `
+		  !class A {
+			foo() {}
+			foo() {}
+		  };
+				`,
+			errors: [
+				{
+					column: 4,
+					data: { name: "foo" },
+					line: 4,
+					messageId: "unexpected",
+				},
+			],
+		},
+		{
+			code: `
+		  class A {
+			'foo'() {}
+			'foo'() {}
+		  }
+				`,
+			errors: [
+				{
+					column: 4,
+					data: { name: "foo" },
+					line: 4,
+					messageId: "unexpected",
+				},
+			],
+		},
+		{
+			code: `
+		  class A {
+			10() {}
+			1e1() {}
+		  }
+				`,
+			errors: [
+				{
+					column: 4,
+					data: { name: "10" },
+					line: 4,
+					messageId: "unexpected",
+				},
+			],
+		},
+		{
+			code: `
+		  class A {
+			foo() {}
+			foo() {}
+			foo() {}
+		  }
+				`,
+			errors: [
+				{
+					column: 4,
+					data: { name: "foo" },
+					line: 4,
+					messageId: "unexpected",
+				},
+				{
+					column: 4,
+					data: { name: "foo" },
+					line: 5,
+					messageId: "unexpected",
+				},
+			],
+		},
+		{
+			code: `
+		  class A {
+			static foo() {}
+			static foo() {}
+		  }
+				`,
+			errors: [
+				{
+					column: 4,
+					data: { name: "foo" },
+					line: 4,
+					messageId: "unexpected",
+				},
+			],
+		},
+		{
+			code: `
+		  class A {
+			foo() {}
+			get foo() {}
+		  }
+				`,
+			errors: [
+				{
+					column: 4,
+					data: { name: "foo" },
+					line: 4,
+					messageId: "unexpected",
+				},
+			],
+		},
+		{
+			code: `
+		  class A {
+			set foo(value) {}
+			foo() {}
+		  }
+				`,
+			errors: [
+				{
+					column: 4,
+					data: { name: "foo" },
+					line: 4,
+					messageId: "unexpected",
+				},
+			],
+		},
+		{
+			code: `
+		  class A {
+			foo;
+			foo = 42;
+		  }
+				`,
+			errors: [
+				{
+					column: 4,
+					data: { name: "foo" },
+					line: 4,
+					messageId: "unexpected",
+				},
+			],
+		},
+		{
+			code: `
+		  class A {
+			foo;
+			foo() {}
+		  }
+				`,
+			errors: [
+				{
+					column: 4,
+					data: { name: "foo" },
+					line: 4,
+					messageId: "unexpected",
+				},
+			],
+		},
+	],
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refs #19173 

- [Rule Reference](https://typescript-eslint.io/rules/no-dupe-class-members/)
- TypeScript allows method overloads, where multiple method signatures can be declared but only one implementation exists.

    ```ts
    class A {
      foo(value: string): void;
      foo(value: number): void;
      foo(value: string | number) {} // ✅ This is the actual implementation.
    }
    ```



#### Is there anything you'd like reviewers to focus on?
No
<!-- markdownlint-disable-file MD004 -->
