### PR TITLE
feat: support TS syntax in `no-loss-of-precision`

### DIFF
--- a/lib/rules/no-loss-of-precision.js
+++ b/lib/rules/no-loss-of-precision.js
@@ -13,6 +13,8 @@
 module.exports = {
 	meta: {
 		type: "problem",
+		dialects: ["typescript", "javascript"],
+		language: "javascript",
 
 		docs: {
 			description: "Disallow literal numbers that lose precision",

--- a/tests/lib/rules/no-loss-of-precision.js
+++ b/tests/lib/rules/no-loss-of-precision.js
@@ -318,3 +318,39 @@ ruleTester.run("no-loss-of-precision", rule, {
 		},
 	],
 });
+
+const ruleTesterTypeScript = new RuleTester({
+	languageOptions: {
+		parser: require("@typescript-eslint/parser"),
+	},
+});
+
+ruleTesterTypeScript.run('no-loss-of-precision', rule, {
+	valid: [
+	  'const x = 12345;',
+	  'const x = 123.456;',
+	  'const x = -123.456;',
+	  'const x = 123_456;',
+	  'const x = 123_00_000_000_000_000_000_000_000;',
+	  'const x = 123.000_000_000_000_000_000_000_0;',
+	],
+	invalid: [
+	  {
+		code: 'const x = 9007199254740993;',
+		errors: [{ messageId: 'noLossOfPrecision' }],
+	  },
+	  {
+		code: 'const x = 9_007_199_254_740_993;',
+		errors: [{ messageId: 'noLossOfPrecision' }],
+	  },
+	  {
+		code: 'const x = 9_007_199_254_740.993e3;',
+		errors: [{ messageId: 'noLossOfPrecision' }],
+	  },
+	  {
+		code: 'const x = 0b100_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_001;',
+		errors: [{ messageId: 'noLossOfPrecision' }],
+	  },
+	],
+  });
+  

--- a/tests/lib/rules/no-loss-of-precision.js
+++ b/tests/lib/rules/no-loss-of-precision.js
@@ -325,32 +325,31 @@ const ruleTesterTypeScript = new RuleTester({
 	},
 });
 
-ruleTesterTypeScript.run('no-loss-of-precision', rule, {
+ruleTesterTypeScript.run("no-loss-of-precision", rule, {
 	valid: [
-	  'const x = 12345;',
-	  'const x = 123.456;',
-	  'const x = -123.456;',
-	  'const x = 123_456;',
-	  'const x = 123_00_000_000_000_000_000_000_000;',
-	  'const x = 123.000_000_000_000_000_000_000_0;',
+		"const x = 12345;",
+		"const x = 123.456;",
+		"const x = -123.456;",
+		"const x = 123_456;",
+		"const x = 123_00_000_000_000_000_000_000_000;",
+		"const x = 123.000_000_000_000_000_000_000_0;",
 	],
 	invalid: [
-	  {
-		code: 'const x = 9007199254740993;',
-		errors: [{ messageId: 'noLossOfPrecision' }],
-	  },
-	  {
-		code: 'const x = 9_007_199_254_740_993;',
-		errors: [{ messageId: 'noLossOfPrecision' }],
-	  },
-	  {
-		code: 'const x = 9_007_199_254_740.993e3;',
-		errors: [{ messageId: 'noLossOfPrecision' }],
-	  },
-	  {
-		code: 'const x = 0b100_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_001;',
-		errors: [{ messageId: 'noLossOfPrecision' }],
-	  },
+		{
+			code: "const x = 9007199254740993;",
+			errors: [{ messageId: "noLossOfPrecision" }],
+		},
+		{
+			code: "const x = 9_007_199_254_740_993;",
+			errors: [{ messageId: "noLossOfPrecision" }],
+		},
+		{
+			code: "const x = 9_007_199_254_740.993e3;",
+			errors: [{ messageId: "noLossOfPrecision" }],
+		},
+		{
+			code: "const x = 0b100_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_001;",
+			errors: [{ messageId: "noLossOfPrecision" }],
+		},
 	],
-  });
-  
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

[`@typescript-eslint/no-loss-of-precision/`](`https://typescript-eslint.io/rules/no-loss-of-precision/`) is already deprecated in favor of the core rule, just added test cases and updated the rule meta.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
