### PR TITLE
docs: don't pass filename when linting rule examples

### DIFF
--- a/docs/tools/prism-eslint-hook.js
+++ b/docs/tools/prism-eslint-hook.js
@@ -146,7 +146,6 @@ function installPrismESLintMarkerHook() {
 			// Remove trailing newline and presentational `⏎` characters
 			docsExampleCodeToParsableCode(code),
 			config,
-			{ filename: "code.js" },
 		);
 
 		if (lintMessages.some(m => m.fatal)) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

While reviewing https://github.com/eslint/eslint/pull/19493, I noticed that the docs site code that lints rule examples for the purpose of underlining errors gets a parsing error when checking TypeScript examples of correct code added in that PR. On the other hand, `tools/check-rule-examples.js` parses the same code successfully. The difference turned out to be that the former passes `filename: "code.js"` to `linter.verify()` whereas the latter doesn't.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed `filename: "code.js"` from the `linter.verify()` call used for underlining errors.

#### Is there anything you'd like reviewers to focus on?

This fixes the problem, though I don't understand why it makes a difference for the typescript-eslint parser.

<!-- markdownlint-disable-file MD004 -->
