### PR TITLE
test: ignore `package-lock.json` for `eslint-webpack-plugin`

### DIFF
--- a/.github/workflows/types-integration.yml
+++ b/.github/workflows/types-integration.yml
@@ -35,8 +35,7 @@ jobs:
             - name: Install Packages (eslint-webpack-plugin)
               working-directory: webpack
               run: |
-                  npm install
-                  npm install ../eslint
+                  npm install --no-package-lock ../eslint
 
             - name: Run TSC
               working-directory: webpack


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain: fix type integration tests

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

This PR fixes an error in type integration tests that has been occurring since the publishing of `@types/estree@1.0.7`, e.g.: https://github.com/eslint/eslint/actions/runs/14029899007/job/39275099400.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Changed a command in a CI workflow so that `eslint-webpack-plugin` gets installed with the `--no-package-lock` flag in the type integration tests. This causes `eslint-webpack-plugin` to use the same version of `@types/estree` as ESLint, i.e. the latest v1.0.7 instead of v1.0.6 specified in `package-lock.json`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
