### PR TITLE
feat: deprecate `no-inline-comments` rule

### DIFF
--- a/docs/src/rules/no-inline-comments.md
+++ b/docs/src/rules/no-inline-comments.md
@@ -3,6 +3,7 @@ title: no-inline-comments
 rule_type: suggestion
 ---
 
+This rule was **deprecated** in ESLint v9.24.0. Please use [Prettier](https://prettier.io/) instead.
 
 Some style guides disallow comments on the same line as code. Code can become difficult to read if comments immediately follow the code on the same line.
 On the other hand, it is sometimes faster and more obvious to put comments immediately following code.

--- a/lib/rules/no-inline-comments.js
+++ b/lib/rules/no-inline-comments.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Enforces or disallows inline comments.
  * @author Greg Cochard
+ * @deprecated in ESLint v9.24.0
  */
 "use strict";
 
@@ -14,6 +15,8 @@ const astUtils = require("./utils/ast-utils");
 module.exports = {
 	meta: {
 		type: "suggestion",
+		deprecated: true,
+		replacedBy: [],
 
 		defaultOptions: [{}],
 

--- a/packages/js/src/configs/eslint-all.js
+++ b/packages/js/src/configs/eslint-all.js
@@ -97,7 +97,6 @@ module.exports = Object.freeze({
         "no-implicit-globals": "error",
         "no-implied-eval": "error",
         "no-import-assign": "error",
-        "no-inline-comments": "error",
         "no-inner-declarations": "error",
         "no-invalid-regexp": "error",
         "no-invalid-this": "error",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Fix https://github.com/eslint/eslint/issues/19350

Deprecate the `no-inline-comments` rule.
#### Is there anything you'd like reviewers to focus on?
No
<!-- markdownlint-disable-file MD004 -->
