### PR TITLE
fix: use `any[]` type for `context.options`

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1174,13 +1174,13 @@ export namespace Rule {
 	}
 
 	interface RuleContext
-		extends CoreRuleContext<
-			RuleContextTypeOptions & {
-				LangOptions: Linter.LanguageOptions;
-				Code: SourceCode;
-				Node: ESTree.Node;
-			}
-		> {
+		extends CoreRuleContext<{
+			LangOptions: Linter.LanguageOptions;
+			Code: SourceCode;
+			RuleOptions: any[];
+			Node: ESTree.Node;
+			MessageIds: string;
+		}> {
 		/*
 		 * Need to extend the `RuleContext` interface to include the
 		 * deprecated methods that have not yet been removed.

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -613,6 +613,13 @@ rule = {
 		hasSuggestions: true,
 	},
 };
+rule = {
+	create(context) {
+		const foo: string = context.options[0];
+		const baz: number = context.options[1]?.baz ?? false;
+		return {};
+	},
+};
 
 rule = {
 	create(context: Rule.RuleContext) {
@@ -635,6 +642,8 @@ rule = {
 		context.languageOptions;
 		context.languageOptions
 			.ecmaVersion satisfies Linter.LanguageOptions["ecmaVersion"];
+
+		context.options; // $ExpectType any[]
 
 		context.sourceCode;
 		context.sourceCode.getLocFromIndex(42);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

This pull request changes the type of the `options` property in `Rule.RuleContext` from `unknown[]` to `any[]`. I checked the `@types/eslint` types and the `options` property was specified to have type `any[]` in [the original definition](https://app.unpkg.com/@types/eslint@9.6.1/files/index.d.ts#L739).

The issue has become apparent in ESLint v9.23.0 as a result of the changes made to `Rule.RuleModule` in #19531, where the `create` method was explicitly defined to accept an argument of type `Rule.RuleContext`.

Fixes #19579

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated type definition for `Rule.RuleContext` and added tests.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
