### PR TITLE
feat: add allowObjects option to no-restricted-properties

### DIFF
--- a/docs/src/rules/no-restricted-properties.md
+++ b/docs/src/rules/no-restricted-properties.md
@@ -71,6 +71,22 @@ If the property name is omitted, accessing any property of the given object is d
 }
 ```
 
+If you want to globally restrict a property but allow specific objects to use it, you can use the `allowObjects` option:
+
+```json
+{
+    "rules": {
+        "no-restricted-properties": [2, {
+            "property": "push",
+            "allowObjects": ["router"],
+            "message": "Prefer [...array, newValue] because it does not mutate the array in place."
+        }]
+    }
+}
+```
+
+Note that the `allowObjects` option cannot be used together with the `object` option since they are mutually exclusive.
+
 Examples of **incorrect** code for this rule:
 
 ::: incorrect
@@ -116,6 +132,19 @@ require.resolve('foo');
 
 :::
 
+::: incorrect
+
+```js
+/* eslint no-restricted-properties: [2, {
+    "property": "push",
+    "allowObjects": ["router"],
+}] */
+
+myArray.push(5);
+```
+
+:::
+
 Examples of **correct** code for this rule:
 
 ::: correct
@@ -141,6 +170,20 @@ allowedObjectName.disallowedPropertyName();
 }] */
 
 require('foo');
+```
+
+:::
+
+::: correct
+
+```js
+/* eslint no-restricted-properties: [2, {
+    "property": "push",
+    "allowObjects": ["router", "history"],
+}] */
+
+router.push('/home');
+history.push('/about');
 ```
 
 :::

--- a/docs/src/rules/no-restricted-properties.md
+++ b/docs/src/rules/no-restricted-properties.md
@@ -71,7 +71,7 @@ If the property name is omitted, accessing any property of the given object is d
 }
 ```
 
-If you want to globally restrict a property but allow specific objects to use it, you can use the `allowObjects` option:
+If you want to restrict a property globally but allow specific objects to use it, you can use the `allowObjects` option:
 
 ```json
 {

--- a/lib/rules/no-restricted-properties.js
+++ b/lib/rules/no-restricted-properties.js
@@ -108,7 +108,7 @@ module.exports = {
 		/**
 		 * Checks if an object name is in the allowed objects list.
 		 * @param {string} objectName The name of the object to check
-		 * @param {string[]} allowObjects The list of objects to allow
+		 * @param {string[]} [allowObjects] The list of objects to allow
 		 * @returns {boolean} True if the object is allowed, false otherwise
 		 */
 		function isAllowedObject(objectName, allowObjects) {

--- a/lib/rules/no-restricted-properties.js
+++ b/lib/rules/no-restricted-properties.js
@@ -25,41 +25,37 @@ module.exports = {
 		schema: {
 			type: "array",
 			items: {
-				anyOf: [
-					// `object` and `property` are both optional, but at least one of them must be provided.
-					{
-						type: "object",
-						properties: {
-							object: {
-								type: "string",
-							},
-							property: {
-								type: "string",
-							},
-							message: {
-								type: "string",
-							},
+				type: "object",
+				properties: {
+					object: {
+						type: "string",
+					},
+					property: {
+						type: "string",
+					},
+					allowObjects: {
+						type: "array",
+						items: {
+							type: "string",
 						},
-						additionalProperties: false,
+						uniqueItems: true,
+					},
+					message: {
+						type: "string",
+					},
+				},
+				anyOf: [
+					{
 						required: ["object"],
 					},
 					{
-						type: "object",
-						properties: {
-							object: {
-								type: "string",
-							},
-							property: {
-								type: "string",
-							},
-							message: {
-								type: "string",
-							},
-						},
-						additionalProperties: false,
 						required: ["property"],
 					},
 				],
+				not: {
+					required: ["allowObjects", "object"],
+				},
+				additionalProperties: false,
 			},
 			uniqueItems: true,
 		},
@@ -91,6 +87,7 @@ module.exports = {
 
 			if (typeof objectName === "undefined") {
 				globallyRestrictedProperties.set(propertyName, {
+					allowObjects: option.allowObjects,
 					message: option.message,
 				});
 			} else if (typeof propertyName === "undefined") {
@@ -107,6 +104,20 @@ module.exports = {
 				});
 			}
 		});
+
+		/**
+		 * Checks if an object name is in the allowed objects list.
+		 * @param {string} objectName The name of the object to check
+		 * @param {string[]} allowObjects The list of objects to allow
+		 * @returns {boolean} True if the object is allowed, false otherwise
+		 */
+		function isAllowedObject(objectName, allowObjects) {
+			if (!allowObjects) {
+				return false;
+			}
+
+			return allowObjects.includes(objectName);
+		}
 
 		/**
 		 * Checks to see whether a property access is restricted, and reports it if so.
@@ -140,7 +151,10 @@ module.exports = {
 						message,
 					},
 				});
-			} else if (globalMatchedProperty) {
+			} else if (
+				globalMatchedProperty &&
+				!isAllowedObject(objectName, globalMatchedProperty.allowObjects)
+			) {
 				const message = globalMatchedProperty.message
 					? ` ${globalMatchedProperty.message}`
 					: "";

--- a/tests/lib/rules/no-restricted-properties.js
+++ b/tests/lib/rules/no-restricted-properties.js
@@ -929,7 +929,6 @@ ruleTester.run("no-restricted-properties", rule, {
 				{
 					messageId: "restrictedProperty",
 					data: {
-						objectName: "someObject",
 						propertyName: "disallowedProperty",
 						message: "",
 					},
@@ -950,7 +949,6 @@ ruleTester.run("no-restricted-properties", rule, {
 				{
 					messageId: "restrictedProperty",
 					data: {
-						objectName: "someObject",
 						propertyName: "disallowedProperty",
 						message:
 							" Please use someObject.allowedProperty instead.",
@@ -975,7 +973,6 @@ ruleTester.run("no-restricted-properties", rule, {
 				{
 					messageId: "restrictedProperty",
 					data: {
-						objectName: "someObject",
 						propertyName: "disallowedProperty",
 						message: "",
 					},
@@ -984,7 +981,6 @@ ruleTester.run("no-restricted-properties", rule, {
 				{
 					messageId: "restrictedProperty",
 					data: {
-						objectName: "anotherObject",
 						propertyName: "anotherDisallowedProperty",
 						message: "",
 					},

--- a/tests/lib/rules/no-restricted-properties.js
+++ b/tests/lib/rules/no-restricted-properties.js
@@ -233,6 +233,52 @@ ruleTester.run("no-restricted-properties", rule, {
 			options: [{ property: "#foo" }],
 			languageOptions: { ecmaVersion: 2022 },
 		},
+		{
+			code: "someObject.disallowedProperty",
+			options: [
+				{
+					property: "disallowedProperty",
+					allowObjects: ["someObject"],
+				},
+			],
+		},
+		{
+			code: "someObject.disallowedProperty; anotherObject.disallowedProperty();",
+			options: [
+				{
+					property: "disallowedProperty",
+					allowObjects: ["someObject", "anotherObject"],
+				},
+			],
+		},
+		{
+			code: "someObject.disallowedProperty()",
+			options: [
+				{
+					property: "disallowedProperty",
+					allowObjects: ["someObject"],
+				},
+			],
+		},
+		{
+			code: "someObject['disallowedProperty']()",
+			options: [
+				{
+					property: "disallowedProperty",
+					allowObjects: ["someObject"],
+				},
+			],
+		},
+		{
+			code: "let {bar} = foo;",
+			options: [{ property: "bar", allowObjects: ["foo"] }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "let {baz: bar} = foo;",
+			options: [{ property: "baz", allowObjects: ["foo"] }],
+			languageOptions: { ecmaVersion: 6 },
+		},
 	],
 
 	invalid: [
@@ -868,6 +914,81 @@ ruleTester.run("no-restricted-properties", rule, {
 						propertyName: "bad",
 						message: "",
 					},
+				},
+			],
+		},
+		{
+			code: "someObject.disallowedProperty",
+			options: [
+				{
+					property: "disallowedProperty",
+					allowObjects: ["anotherObject"],
+				},
+			],
+			errors: [
+				{
+					messageId: "restrictedProperty",
+					data: {
+						objectName: "someObject",
+						propertyName: "disallowedProperty",
+						message: "",
+					},
+					type: "MemberExpression",
+				},
+			],
+		},
+		{
+			code: "someObject.disallowedProperty",
+			options: [
+				{
+					property: "disallowedProperty",
+					allowObjects: ["anotherObject"],
+					message: "Please use someObject.allowedProperty instead.",
+				},
+			],
+			errors: [
+				{
+					messageId: "restrictedProperty",
+					data: {
+						objectName: "someObject",
+						propertyName: "disallowedProperty",
+						message:
+							" Please use someObject.allowedProperty instead.",
+					},
+					type: "MemberExpression",
+				},
+			],
+		},
+		{
+			code: "someObject.disallowedProperty; anotherObject.anotherDisallowedProperty()",
+			options: [
+				{
+					property: "disallowedProperty",
+					allowObjects: ["anotherObject"],
+				},
+				{
+					property: "anotherDisallowedProperty",
+					allowObjects: ["someObject"],
+				},
+			],
+			errors: [
+				{
+					messageId: "restrictedProperty",
+					data: {
+						objectName: "someObject",
+						propertyName: "disallowedProperty",
+						message: "",
+					},
+					type: "MemberExpression",
+				},
+				{
+					messageId: "restrictedProperty",
+					data: {
+						objectName: "anotherObject",
+						propertyName: "anotherDisallowedProperty",
+						message: "",
+					},
+					type: "MemberExpression",
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds a new `allowObjects` option to the `no-restricted-properties` rule, allowing users to globally restrict a property while making exceptions for specific objects.

Closes #19348

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
