### PR TITLE
feat: convert no-array-constructor suggestions to autofixes

### DIFF
--- a/lib/rules/no-array-constructor.js
+++ b/lib/rules/no-array-constructor.js
@@ -140,7 +140,7 @@ module.exports = {
 				);
 
 				const shouldSuggest =
-					node.parent.type === "ChainExpression" ||
+					node.optional ||
 					(node.arguments.length > 0 && nonSpreadCount < 2) ||
 					hasCommentsInArrayConstructor(node);
 

--- a/tests/lib/rules/no-array-constructor.js
+++ b/tests/lib/rules/no-array-constructor.js
@@ -804,6 +804,21 @@ ruleTester.run("no-array-constructor", rule, {
 				},
 			],
 		},
+		{
+			code: "Array?.(0, 1, 2).forEach(doSomething);",
+			errors: [
+				{
+					messageId: "preferLiteral",
+					type: "CallExpression",
+					suggestions: [
+						{
+							messageId: "useLiteral",
+							output: "[0, 1, 2].forEach(doSomething);",
+						},
+					],
+				},
+			],
+		},
 	],
 });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Converted suggestions to automatic fixes, except for `Array(...args)` as we can't know if `args` might have only one element.
- Ensured that the autofix correctly preserves comments.

#### Is there anything you'd like reviewers to focus on?

Closes #19608

<!-- markdownlint-disable-file MD004 -->
