### PR TITLE
fix: `nodeTypeKey` not being used in `NodeEventGenerator`

### DIFF
--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -346,11 +346,13 @@ class NodeEventGenerator {
 	 * @returns {void}
 	 */
 	applySelectors(node, isExit) {
+		const nodeTypeKey = this.esqueryOptions?.nodeTypeKey || "type";
+
 		const selectorsByNodeType =
 			(isExit
 				? this.exitSelectorsByNodeType
 				: this.enterSelectorsByNodeType
-			).get(node.type) || [];
+			).get(node[nodeTypeKey]) || [];
 		const anyTypeSelectors = isExit
 			? this.anyTypeExitSelectors
 			: this.anyTypeEnterSelectors;

--- a/tests/lib/linter/node-event-generator.js
+++ b/tests/lib/linter/node-event-generator.js
@@ -90,6 +90,31 @@ describe("NodeEventGenerator", () => {
 			assert(emitter.emit.calledWith("Foo > Bar", dummyNode));
 			assert(emitter.emit.calledWith("Bar", dummyNode));
 		});
+
+		it("should use `nodeTypeKey` if provided", () => {
+			generator = new NodeEventGenerator(emitter, {
+				...STANDARD_ESQUERY_OPTION,
+				nodeTypeKey: "kind",
+			});
+
+			const dummyNode = { kind: "Foo" };
+
+			generator.enterNode(dummyNode);
+
+			assert(emitter.emit.calledOnce);
+			assert(emitter.emit.calledWith("Foo", dummyNode));
+		});
+
+		it("should succeed without esqueryOptions", () => {
+			generator = new NodeEventGenerator(emitter);
+
+			const dummyNode = { type: "Foo" };
+
+			generator.enterNode(dummyNode);
+
+			assert(emitter.emit.calledOnce);
+			assert(emitter.emit.calledWith("Foo", dummyNode));
+		});
 	});
 
 	describe("traversing the entire AST", () => {


### PR DESCRIPTION
Closes #19630

