### PR TITLE
fix: check cache file existence before deletion

### DIFF
--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -707,13 +707,7 @@ class ESLint {
 					await fs.unlink(cacheFilePath);
 				}
 			} catch (error) {
-				const errorCode = error && error.code;
-
-				// Ignore errors when no such file exists or file system is read only (and cache file does not exist)
-				if (
-					errorCode !== "ENOENT" &&
-					!(errorCode === "EROFS" && !existsSync(cacheFilePath))
-				) {
+				if (existsSync(cacheFilePath)) {
 					throw error;
 				}
 			}

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -703,7 +703,9 @@ class ESLint {
 			debug(`Deleting cache file at ${cacheFilePath}`);
 
 			try {
-				await fs.unlink(cacheFilePath);
+				if (existsSync(cacheFilePath)) {
+					await fs.unlink(cacheFilePath);
+				}
 			} catch (error) {
 				const errorCode = error && error.code;
 

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -12541,7 +12541,7 @@ describe("ESLint", () => {
 			await eslint.lintFiles([file]);
 
 			assert(
-				!fsp.unlink.called,
+				fsp.unlink.notCalled,
 				"Expected attempt to delete the cache was not made.",
 			);
 		});

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -12541,7 +12541,7 @@ describe("ESLint", () => {
 			await eslint.lintFiles([file]);
 
 			assert(
-				fsp.unlink.calledWithExactly(cacheFilePath),
+				!fsp.unlink.called,
 				"Expected attempt to delete the cache was not made.",
 			);
 		});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR modifies the cache file deletion logic to check if the cache file exists before attempting to delete it.

Closes #19647

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
