### PR TITLE
refactor: One-shot ESQuery selector analysis

### DIFF
--- a/lib/linter/esquery.js
+++ b/lib/linter/esquery.js
@@ -256,7 +256,7 @@ function tryParseSelector(rawSelector) {
 /**
  * Parses a raw selector string, and returns the parsed selector along with specificity and type information.
  * @param {string} source A raw AST selector
- * @returns {ASTSelector} A selector descriptor
+ * @returns {ESQueryParsedSelector} A selector descriptor
  */
 function parse(source) {
 	if (selectorCache.has(source)) {

--- a/lib/linter/esquery.js
+++ b/lib/linter/esquery.js
@@ -231,14 +231,38 @@ function analyzeParsedSelector(parsedSelector) {
 }
 
 /**
+ * Tries to parse a simple selector string, such as a single identifier or wildcard.
+ * This saves time by avoiding the overhead of esquery parsing for simple cases.
+ * @param {string} selector The selector string to parse.
+ * @returns {Object|null} An object describing the selector if it is simple, or `null` if it is not.
+ */
+function trySimpleParseSelector(selector) {
+	if (selector === "*") {
+		return {
+			type: "wildcard",
+			value: "*",
+		};
+	}
+
+	if (/^[a-z]$/iu.test(selector)) {
+		return {
+			type: "identifier",
+			value: selector,
+		};
+	}
+
+	return null;
+}
+
+/**
  * Parses a raw selector string, and throws a useful error if parsing fails.
- * @param {string} rawSelector A raw AST selector
+ * @param {string} selector The selector string to parse.
  * @returns {Object} An object (from esquery) describing the matching behavior of this selector
  * @throws {Error} An error if the selector is invalid
  */
-function tryParseSelector(rawSelector) {
+function tryParseSelector(selector) {
 	try {
-		return esquery.parse(rawSelector.replace(/:exit$/u, ""));
+		return esquery.parse(selector);
 	} catch (err) {
 		if (
 			err.location &&
@@ -246,7 +270,7 @@ function tryParseSelector(rawSelector) {
 			typeof err.location.start.offset === "number"
 		) {
 			throw new SyntaxError(
-				`Syntax error in selector "${rawSelector}" at position ${err.location.start.offset}: ${err.message}`,
+				`Syntax error in selector "${selector}" at position ${err.location.start.offset}: ${err.message}`,
 			);
 		}
 		throw err;
@@ -263,7 +287,9 @@ function parse(source) {
 		return selectorCache.get(source);
 	}
 
-	const parsedSelector = tryParseSelector(source);
+	const cleanSource = source.replace(/:exit$/u, "");
+	const parsedSelector =
+		trySimpleParseSelector(cleanSource) ?? tryParseSelector(cleanSource);
 	const { nodeTypes, attributeCount, identifierCount } =
 		analyzeParsedSelector(parsedSelector);
 

--- a/lib/linter/esquery.js
+++ b/lib/linter/esquery.js
@@ -93,10 +93,10 @@ class ESQueryParsedSelector {
 	 * Compares this selector's specifity to another selector for sorting purposes.
 	 * @param {ESQueryParsedSelector} otherSelector The selector to compare against
 	 * @returns {number}
-	 * a value less than 0 if selectorA is less specific than selectorB
-	 * a value greater than 0 if selectorA is more specific than selectorB
-	 * a value less than 0 if selectorA and selectorB have the same specificity, and selectorA <= selectorB alphabetically
-	 * a value greater than 0 if selectorA and selectorB have the same specificity, and selectorA > selectorB alphabetically
+	 * a value less than 0 if this selector is less specific than otherSelector
+	 * a value greater than 0 if this selector is more specific than otherSelector
+	 * a value less than 0 if this selector and otherSelector have the same specificity, and this selector <= otherSelector alphabetically
+	 * a value greater than 0 if this selector and otherSelector have the same specificity, and this selector > otherSelector alphabetically
 	 */
 	compare(otherSelector) {
 		return (

--- a/lib/linter/esquery.js
+++ b/lib/linter/esquery.js
@@ -264,14 +264,14 @@ function parse(source) {
 	}
 
 	const parsedSelector = tryParseSelector(source);
-	const { listenerTypes, attributeCount, identifierCount } =
+	const { nodeTypes, attributeCount, identifierCount } =
 		analyzeParsedSelector(parsedSelector);
 
 	const result = new ESQueryParsedSelector(
 		source,
 		source.endsWith(":exit"),
 		parsedSelector,
-		listenerTypes,
+		nodeTypes,
 		attributeCount,
 		identifierCount,
 	);

--- a/lib/linter/esquery.js
+++ b/lib/linter/esquery.js
@@ -1,0 +1,303 @@
+/**
+ * @fileoverview ESQuery wrapper for ESLint.
+ * @author Nicholas C. Zakas
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const esquery = require("esquery");
+
+//-----------------------------------------------------------------------------
+// Typedefs
+//-----------------------------------------------------------------------------
+
+/**
+ * @typedef {import("esquery").Selector} ESQuerySelector
+ * @typedef {import("esquery").ESQueryOptions} ESQueryOptions
+ */
+
+//------------------------------------------------------------------------------
+// Classes
+//------------------------------------------------------------------------------
+
+/**
+ * The result of parsing and analyzing an ESQuery selector.
+ */
+class ESQueryParsedSelector {
+	/**
+	 * The raw selector string that was parsed
+	 * @type {string}
+	 */
+	source;
+
+	/**
+	 * Whether this selector is an exit selector
+	 * @type {boolean}
+	 */
+	isExit;
+
+	/**
+	 * An object (from esquery) describing the matching behavior of the selector
+	 * @type {ESQuerySelector}
+	 */
+	root;
+
+	/**
+	 * The node types that could possibly trigger this selector, or `null` if all node types could trigger it
+	 * @type {string[]|null}
+	 */
+	nodeTypes;
+
+	/**
+	 * The number of class, pseudo-class, and attribute queries in this selector
+	 * @type {number}
+	 */
+	attributeCount;
+
+	/**
+	 * The number of identifier queries in this selector
+	 * @type {number}
+	 */
+	identifierCount;
+
+	/**
+	 * Creates a new parsed selector.
+	 * @param {string} source The raw selector string that was parsed
+	 * @param {boolean} isExit Whether this selector is an exit selector
+	 * @param {ESQuerySelector} root An object (from esquery) describing the matching behavior of the selector
+	 * @param {string[]|null} nodeTypes The node types that could possibly trigger this selector, or `null` if all node types could trigger it
+	 * @param {number} attributeCount The number of class, pseudo-class, and attribute queries in this selector
+	 * @param {number} identifierCount The number of identifier queries in this selector
+	 */
+	constructor(
+		source,
+		isExit,
+		root,
+		nodeTypes,
+		attributeCount,
+		identifierCount,
+	) {
+		this.source = source;
+		this.isExit = isExit;
+		this.root = root;
+		this.nodeTypes = nodeTypes;
+		this.attributeCount = attributeCount;
+		this.identifierCount = identifierCount;
+	}
+
+	/**
+	 * Compares this selector's specifity to another selector for sorting purposes.
+	 * @param {ESQueryParsedSelector} otherSelector The selector to compare against
+	 * @returns {number}
+	 * a value less than 0 if selectorA is less specific than selectorB
+	 * a value greater than 0 if selectorA is more specific than selectorB
+	 * a value less than 0 if selectorA and selectorB have the same specificity, and selectorA <= selectorB alphabetically
+	 * a value greater than 0 if selectorA and selectorB have the same specificity, and selectorA > selectorB alphabetically
+	 */
+	compare(otherSelector) {
+		return (
+			this.attributeCount - otherSelector.attributeCount ||
+			this.identifierCount - otherSelector.identifierCount ||
+			(this.source <= otherSelector.source ? -1 : 1)
+		);
+	}
+}
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const selectorCache = new Map();
+
+/**
+ * Computes the union of one or more arrays
+ * @param {...any[]} arrays One or more arrays to union
+ * @returns {any[]} The union of the input arrays
+ */
+function union(...arrays) {
+	return [...new Set(arrays.flat())];
+}
+
+/**
+ * Computes the intersection of one or more arrays
+ * @param {...any[]} arrays One or more arrays to intersect
+ * @returns {any[]} The intersection of the input arrays
+ */
+function intersection(...arrays) {
+	if (arrays.length === 0) {
+		return [];
+	}
+
+	let result = [...new Set(arrays[0])];
+
+	for (const array of arrays.slice(1)) {
+		result = result.filter(x => array.includes(x));
+	}
+	return result;
+}
+
+/**
+ * Analyzes a parsed selector and returns combined data about it
+ * @param {ESQuerySelector} parsedSelector An object (from esquery) describing the matching behavior of the selector
+ * @returns {{nodeTypes:string[]|null, attributeCount:number, identifierCount:number}} Object containing selector data.
+ */
+function analyzeParsedSelector(parsedSelector) {
+	let attributeCount = 0;
+	let identifierCount = 0;
+
+	/**
+	 * Analyzes a selector and returns the node types that could possibly trigger it.
+	 * @param {ESQuerySelector} selector The selector to analyze.
+	 * @returns {string[]|null} The node types that could possibly trigger this selector, or `null` if all node types could trigger it
+	 */
+	function analyzeSelector(selector) {
+		switch (selector.type) {
+			case "identifier":
+				identifierCount++;
+				return [selector.value];
+
+			case "not":
+				selector.selectors.map(analyzeSelector);
+				return null;
+
+			case "matches": {
+				const typesForComponents =
+					selector.selectors.map(analyzeSelector);
+
+				if (typesForComponents.every(Boolean)) {
+					return union(...typesForComponents);
+				}
+				return null;
+			}
+
+			case "compound": {
+				const typesForComponents = selector.selectors
+					.map(analyzeSelector)
+					.filter(typesForComponent => typesForComponent);
+
+				// If all of the components could match any type, then the compound could also match any type.
+				if (!typesForComponents.length) {
+					return null;
+				}
+
+				/*
+				 * If at least one of the components could only match a particular type, the compound could only match
+				 * the intersection of those types.
+				 */
+				return intersection(...typesForComponents);
+			}
+
+			case "attribute":
+			case "field":
+			case "nth-child":
+			case "nth-last-child":
+				attributeCount++;
+				return null;
+
+			case "child":
+			case "descendant":
+			case "sibling":
+			case "adjacent":
+				analyzeSelector(selector.left);
+				return analyzeSelector(selector.right);
+
+			case "class":
+				// TODO: abstract into JSLanguage somehow
+				if (selector.name === "function") {
+					return [
+						"FunctionDeclaration",
+						"FunctionExpression",
+						"ArrowFunctionExpression",
+					];
+				}
+				return null;
+
+			default:
+				return null;
+		}
+	}
+
+	const nodeTypes = analyzeSelector(parsedSelector);
+
+	return {
+		nodeTypes,
+		attributeCount,
+		identifierCount,
+	};
+}
+
+/**
+ * Parses a raw selector string, and throws a useful error if parsing fails.
+ * @param {string} rawSelector A raw AST selector
+ * @returns {Object} An object (from esquery) describing the matching behavior of this selector
+ * @throws {Error} An error if the selector is invalid
+ */
+function tryParseSelector(rawSelector) {
+	try {
+		return esquery.parse(rawSelector.replace(/:exit$/u, ""));
+	} catch (err) {
+		if (
+			err.location &&
+			err.location.start &&
+			typeof err.location.start.offset === "number"
+		) {
+			throw new SyntaxError(
+				`Syntax error in selector "${rawSelector}" at position ${err.location.start.offset}: ${err.message}`,
+			);
+		}
+		throw err;
+	}
+}
+
+/**
+ * Parses a raw selector string, and returns the parsed selector along with specificity and type information.
+ * @param {string} source A raw AST selector
+ * @returns {ASTSelector} A selector descriptor
+ */
+function parse(source) {
+	if (selectorCache.has(source)) {
+		return selectorCache.get(source);
+	}
+
+	const parsedSelector = tryParseSelector(source);
+	const { listenerTypes, attributeCount, identifierCount } =
+		analyzeParsedSelector(parsedSelector);
+
+	const result = new ESQueryParsedSelector(
+		source,
+		source.endsWith(":exit"),
+		parsedSelector,
+		listenerTypes,
+		attributeCount,
+		identifierCount,
+	);
+
+	selectorCache.set(source, result);
+	return result;
+}
+
+/**
+ * Checks if a node matches a given selector.
+ * @param {Object} node The node to check against the selector.
+ * @param {ESQuerySelector} root The root of the selector to match against.
+ * @param {Object[]} ancestry The ancestry of the node being checked, which is an array of nodes from the root to the current node.
+ * @param {ESQueryOptions} options The options to use for matching.
+ * @returns {boolean} `true` if the node matches the selector, `false` otherwise.
+ */
+function matches(node, root, ancestry, options) {
+	return esquery.matches(node, root, ancestry, options);
+}
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+module.exports = {
+	parse,
+	matches,
+	ESQueryParsedSelector,
+};

--- a/lib/linter/esquery.js
+++ b/lib/linter/esquery.js
@@ -310,7 +310,7 @@ function parse(source) {
  * Checks if a node matches a given selector.
  * @param {Object} node The node to check against the selector.
  * @param {ESQuerySelector} root The root of the selector to match against.
- * @param {Object[]} ancestry The ancestry of the node being checked, which is an array of nodes from the root to the current node.
+ * @param {Object[]} ancestry The ancestry of the node being checked, which is an array of nodes from the current node to the root.
  * @param {ESQueryOptions} options The options to use for matching.
  * @returns {boolean} `true` if the node matches the selector, `false` otherwise.
  */

--- a/lib/linter/esquery.js
+++ b/lib/linter/esquery.js
@@ -244,7 +244,7 @@ function trySimpleParseSelector(selector) {
 		};
 	}
 
-	if (/^[a-z]$/iu.test(selector)) {
+	if (/^[a-z]+$/iu.test(selector)) {
 		return {
 			type: "identifier",
 			value: selector,

--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -70,12 +70,12 @@ class NodeEventGenerator {
 		emitter.eventNames().forEach(rawSelector => {
 			const selector = parse(rawSelector);
 
-			if (selector.listenerTypes) {
+			if (selector.nodeTypes) {
 				const typeMap = selector.isExit
 					? this.exitSelectorsByNodeType
 					: this.enterSelectorsByNodeType;
 
-				selector.listenerTypes.forEach(nodeType => {
+				selector.nodeTypes.forEach(nodeType => {
 					if (!typeMap.has(nodeType)) {
 						typeMap.set(nodeType, []);
 					}

--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -9,220 +9,28 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const esquery = require("esquery");
+const { parse, matches } = require("./esquery");
 
-//------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Typedefs
-//------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 /**
- * An object describing an AST selector
- * @typedef {Object} ASTSelector
- * @property {string} rawSelector The string that was parsed into this selector
- * @property {boolean} isExit `true` if this should be emitted when exiting the node rather than when entering
- * @property {Object} parsedSelector An object (from esquery) describing the matching behavior of the selector
- * @property {string[]|null} listenerTypes A list of node types that could possibly cause the selector to match,
- * or `null` if all node types could cause a match
- * @property {number} attributeCount The total number of classes, pseudo-classes, and attribute queries in this selector
- * @property {number} identifierCount The total number of identifier queries in this selector
+ * @import { ESQueryParsedSelector } from "./esquery.js";
  */
 
-//------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Helpers
-//------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 /**
- * Computes the union of one or more arrays
- * @param {...any[]} arrays One or more arrays to union
- * @returns {any[]} The union of the input arrays
+ * Compares two ESQuery selectors by specificity.
+ * @param {ESQueryParsedSelector} a The first selector to compare.
+ * @param {ESQueryParsedSelector} b The second selector to compare.
+ * @returns {number} A negative number if `a` is more specific than `b`, a positive number if `b` is more specific than `a`, or zero if they are equally specific.
  */
-function union(...arrays) {
-	return [...new Set(arrays.flat())];
-}
-
-/**
- * Computes the intersection of one or more arrays
- * @param {...any[]} arrays One or more arrays to intersect
- * @returns {any[]} The intersection of the input arrays
- */
-function intersection(...arrays) {
-	if (arrays.length === 0) {
-		return [];
-	}
-
-	let result = [...new Set(arrays[0])];
-
-	for (const array of arrays.slice(1)) {
-		result = result.filter(x => array.includes(x));
-	}
-	return result;
-}
-
-/**
- * Analyzes a parsed selector and returns combined data about it
- * @param {Object} parsedSelector An object (from esquery) describing the matching behavior of the selector
- * @returns {{listenerTypes:string[]|null,attributeCount:number, identifierCount:number}} Object containing selector data.
- */
-function analyzeParsedSelector(parsedSelector) {
-	let attributeCount = 0;
-	let identifierCount = 0;
-
-	/**
-	 * Analyzes a selector component and updates counters
-	 * @param {Object} selector A selector object from esquery
-	 * @returns {string[]|null} The node types that could match this selector, or null if all could match
-	 */
-	function analyzeSelector(selector) {
-		switch (selector.type) {
-			case "identifier": {
-				identifierCount++;
-				return [selector.value];
-			}
-
-			case "matches": {
-				const typesForComponents = selector.selectors.map(s => {
-					const result = analyzeSelector(s);
-					return result;
-				});
-
-				if (typesForComponents.every(Boolean)) {
-					return union(...typesForComponents);
-				}
-				return null;
-			}
-
-			case "compound": {
-				const typesForComponents = selector.selectors
-					.map(s => analyzeSelector(s))
-					.filter(Boolean);
-
-				// If all of the components could match any type, then the compound could also match any type.
-				if (!typesForComponents.length) {
-					return null;
-				}
-
-				/*
-				 * If at least one of the components could only match a particular type, the compound could only match
-				 * the intersection of those types.
-				 */
-				return intersection(...typesForComponents);
-			}
-
-			case "child":
-			case "descendant":
-			case "sibling":
-			case "adjacent": {
-				analyzeSelector(selector.left);
-				return analyzeSelector(selector.right);
-			}
-
-			case "class":
-				attributeCount++;
-				if (selector.name === "function") {
-					return [
-						"FunctionDeclaration",
-						"FunctionExpression",
-						"ArrowFunctionExpression",
-					];
-				}
-				return null;
-
-			case "attribute":
-			case "field":
-			case "nth-child":
-			case "nth-last-child":
-				attributeCount++;
-				return null;
-
-			case "not": {
-				selector.selectors.forEach(s => {
-					analyzeSelector(s);
-				});
-				return null;
-			}
-
-			default:
-				return null;
-		}
-	}
-
-	const listenerTypes = analyzeSelector(parsedSelector);
-
-	return {
-		listenerTypes,
-		attributeCount,
-		identifierCount,
-	};
-}
-
-/**
- * Compares the specificity of two selector objects, with CSS-like rules.
- * @param {ASTSelector} selectorA An AST selector descriptor
- * @param {ASTSelector} selectorB Another AST selector descriptor
- * @returns {number}
- * a value less than 0 if selectorA is less specific than selectorB
- * a value greater than 0 if selectorA is more specific than selectorB
- * a value less than 0 if selectorA and selectorB have the same specificity, and selectorA <= selectorB alphabetically
- * a value greater than 0 if selectorA and selectorB have the same specificity, and selectorA > selectorB alphabetically
- */
-function compareSpecificity(selectorA, selectorB) {
-	return (
-		selectorA.attributeCount - selectorB.attributeCount ||
-		selectorA.identifierCount - selectorB.identifierCount ||
-		(selectorA.rawSelector <= selectorB.rawSelector ? -1 : 1)
-	);
-}
-
-/**
- * Parses a raw selector string, and throws a useful error if parsing fails.
- * @param {string} rawSelector A raw AST selector
- * @returns {Object} An object (from esquery) describing the matching behavior of this selector
- * @throws {Error} An error if the selector is invalid
- */
-function tryParseSelector(rawSelector) {
-	try {
-		return esquery.parse(rawSelector.replace(/:exit$/u, ""));
-	} catch (err) {
-		if (
-			err.location &&
-			err.location.start &&
-			typeof err.location.start.offset === "number"
-		) {
-			throw new SyntaxError(
-				`Syntax error in selector "${rawSelector}" at position ${err.location.start.offset}: ${err.message}`,
-			);
-		}
-		throw err;
-	}
-}
-
-const selectorCache = new Map();
-
-/**
- * Parses a raw selector string, and returns the parsed selector along with specificity and type information.
- * @param {string} rawSelector A raw AST selector
- * @returns {ASTSelector} A selector descriptor
- */
-function parseSelector(rawSelector) {
-	if (selectorCache.has(rawSelector)) {
-		return selectorCache.get(rawSelector);
-	}
-
-	const parsedSelector = tryParseSelector(rawSelector);
-	const { listenerTypes, attributeCount, identifierCount } =
-		analyzeParsedSelector(parsedSelector);
-
-	const result = {
-		rawSelector,
-		isExit: rawSelector.endsWith(":exit"),
-		parsedSelector,
-		listenerTypes,
-		attributeCount,
-		identifierCount,
-	};
-
-	selectorCache.set(rawSelector, result);
-	return result;
+function compareSpecificity(a, b) {
+	return a.compare(b);
 }
 
 //------------------------------------------------------------------------------
@@ -260,7 +68,7 @@ class NodeEventGenerator {
 		this.anyTypeExitSelectors = [];
 
 		emitter.eventNames().forEach(rawSelector => {
-			const selector = parseSelector(rawSelector);
+			const selector = parse(rawSelector);
 
 			if (selector.listenerTypes) {
 				const typeMap = selector.isExit
@@ -295,19 +103,19 @@ class NodeEventGenerator {
 	/**
 	 * Checks a selector against a node, and emits it if it matches
 	 * @param {ASTNode} node The node to check
-	 * @param {ASTSelector} selector An AST selector descriptor
+	 * @param {ESQueryParsedSelector} selector An AST selector descriptor
 	 * @returns {void}
 	 */
 	applySelector(node, selector) {
 		if (
-			esquery.matches(
+			matches(
 				node,
-				selector.parsedSelector,
+				selector.root,
 				this.currentAncestry,
 				this.esqueryOptions,
 			)
 		) {
-			this.emitter.emit(selector.rawSelector, node);
+			this.emitter.emit(selector.source, node);
 		}
 	}
 
@@ -343,8 +151,7 @@ class NodeEventGenerator {
 			if (
 				selectorsByTypeIndex >= selectorsByNodeType.length ||
 				(anyTypeSelectorsIndex < anyTypeSelectors.length &&
-					compareSpecificity(
-						anyTypeSelectors[anyTypeSelectorsIndex],
+					anyTypeSelectors[anyTypeSelectorsIndex].compare(
 						selectorsByNodeType[selectorsByTypeIndex],
 					) < 0)
 			) {

--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -51,6 +51,52 @@ function compareSpecificity(a, b) {
  */
 class NodeEventGenerator {
 	/**
+	 * The emitter to use during traversal.
+	 * @type {SafeEmitter}
+	 */
+	emitter;
+
+	/**
+	 * The options for `esquery` to use during matching.
+	 * @type {ESQueryOptions}
+	 */
+	esqueryOptions;
+
+	/**
+	 * The ancestry of the currently visited node.
+	 * @type {ASTNode[]}
+	 */
+	currentAncestry = [];
+
+	/**
+	 * A map of node type to selectors targeting that node type on the
+	 * enter phase of traversal.
+	 * @type {Map<string, ESQueryParsedSelector[]>}
+	 */
+	enterSelectorsByNodeType = new Map();
+
+	/**
+	 * A map of node type to selectors targeting that node type on the
+	 * exit phase of traversal.
+	 * @type {Map<string, ESQueryParsedSelector[]>}
+	 */
+	exitSelectorsByNodeType = new Map();
+
+	/**
+	 * An array of selectors that match any node type on the
+	 * enter phase of traversal.
+	 * @type {ESQueryParsedSelector[]}
+	 */
+	anyTypeEnterSelectors = [];
+
+	/**
+	 * An array of selectors that match any node type on the
+	 * exit phase of traversal.
+	 * @type {ESQueryParsedSelector[]}
+	 */
+	anyTypeExitSelectors = [];
+
+	/**
 	 * @param {SafeEmitter} emitter
 	 * An SafeEmitter which is the destination of events. This emitter must already
 	 * have registered listeners for all of the events that it needs to listen for.
@@ -61,15 +107,14 @@ class NodeEventGenerator {
 	constructor(emitter, esqueryOptions) {
 		this.emitter = emitter;
 		this.esqueryOptions = esqueryOptions;
-		this.currentAncestry = [];
-		this.enterSelectorsByNodeType = new Map();
-		this.exitSelectorsByNodeType = new Map();
-		this.anyTypeEnterSelectors = [];
-		this.anyTypeExitSelectors = [];
 
 		emitter.eventNames().forEach(rawSelector => {
 			const selector = parse(rawSelector);
 
+			/*
+			 * If this selector has identified specific node types,
+			 * add it to the map for these node types for faster lookup.
+			 */
 			if (selector.nodeTypes) {
 				const typeMap = selector.isExit
 					? this.exitSelectorsByNodeType
@@ -83,6 +128,13 @@ class NodeEventGenerator {
 				});
 				return;
 			}
+
+			/*
+			 * All selectors are added to the "any type" selectors
+			 * list for the appropriate phase of traversal. This ensures
+			 * that all selectors will still be applied even if no
+			 * specific node type is matched.
+			 */
 			const selectors = selector.isExit
 				? this.anyTypeExitSelectors
 				: this.anyTypeEnterSelectors;
@@ -90,6 +142,7 @@ class NodeEventGenerator {
 			selectors.push(selector);
 		});
 
+		// sort all selectors by specificity for prioritizing call order
 		this.anyTypeEnterSelectors.sort(compareSpecificity);
 		this.anyTypeExitSelectors.sort(compareSpecificity);
 		this.enterSelectorsByNodeType.forEach(selectorList =>

--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -27,7 +27,7 @@ const { parse, matches } = require("./esquery");
  * Compares two ESQuery selectors by specificity.
  * @param {ESQueryParsedSelector} a The first selector to compare.
  * @param {ESQueryParsedSelector} b The second selector to compare.
- * @returns {number} A negative number if `a` is more specific than `b`, a positive number if `b` is more specific than `a`, or zero if they are equally specific.
+ * @returns {number} A negative number if `a` is less specific than `b` or they are equally specific and `a` <= `b` alphabetically, a positive number if `a` is more specific than `b`.
  */
 function compareSpecificity(a, b) {
 	return a.compare(b);

--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -181,6 +181,11 @@ class NodeEventGenerator {
 	applySelectors(node, isExit) {
 		const nodeTypeKey = this.esqueryOptions?.nodeTypeKey || "type";
 
+		/*
+		 * Get the selectors that may match this node. First, check
+		 * to see if the node type has specific selectors,
+		 * then gather the "any type" selectors.
+		 */
 		const selectorsByNodeType =
 			(isExit
 				? this.exitSelectorsByNodeType
@@ -194,18 +199,23 @@ class NodeEventGenerator {
 		 * selectorsByNodeType and anyTypeSelectors were already sorted by specificity in the constructor.
 		 * Iterate through each of them, applying selectors in the right order.
 		 */
-		let selectorsByTypeIndex = 0;
+		let selectorsByNodeTypeIndex = 0;
 		let anyTypeSelectorsIndex = 0;
 
 		while (
-			selectorsByTypeIndex < selectorsByNodeType.length ||
+			selectorsByNodeTypeIndex < selectorsByNodeType.length ||
 			anyTypeSelectorsIndex < anyTypeSelectors.length
 		) {
 			if (
-				selectorsByTypeIndex >= selectorsByNodeType.length ||
+				/*
+				 * If we've already exhausted the selectors for this node type,
+				 * or if the next any type selector is more specific than the
+				 * next selector for this node type, apply the any type selector.
+				 */
+				selectorsByNodeTypeIndex >= selectorsByNodeType.length ||
 				(anyTypeSelectorsIndex < anyTypeSelectors.length &&
 					anyTypeSelectors[anyTypeSelectorsIndex].compare(
-						selectorsByNodeType[selectorsByTypeIndex],
+						selectorsByNodeType[selectorsByNodeTypeIndex],
 					) < 0)
 			) {
 				this.applySelector(
@@ -213,9 +223,10 @@ class NodeEventGenerator {
 					anyTypeSelectors[anyTypeSelectorsIndex++],
 				);
 			} else {
+				// otherwise apply the node type selector
 				this.applySelector(
 					node,
-					selectorsByNodeType[selectorsByTypeIndex++],
+					selectorsByNodeType[selectorsByNodeTypeIndex++],
 				);
 			}
 		}

--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -130,7 +130,7 @@ class NodeEventGenerator {
 			}
 
 			/*
-			 * All selectors are added to the "any type" selectors
+			 * Remaining selectors are added to the "any type" selectors
 			 * list for the appropriate phase of traversal. This ensures
 			 * that all selectors will still be applied even if no
 			 * specific node type is matched.

--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -206,12 +206,12 @@ class NodeEventGenerator {
 			selectorsByNodeTypeIndex < selectorsByNodeType.length ||
 			anyTypeSelectorsIndex < anyTypeSelectors.length
 		) {
+			/*
+			 * If we've already exhausted the selectors for this node type,
+			 * or if the next any type selector is more specific than the
+			 * next selector for this node type, apply the any type selector.
+			 */
 			if (
-				/*
-				 * If we've already exhausted the selectors for this node type,
-				 * or if the next any type selector is more specific than the
-				 * next selector for this node type, apply the any type selector.
-				 */
 				selectorsByNodeTypeIndex >= selectorsByNodeType.length ||
 				(anyTypeSelectorsIndex < anyTypeSelectors.length &&
 					anyTypeSelectors[anyTypeSelectorsIndex].compare(

--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -59,130 +59,100 @@ function intersection(...arrays) {
 }
 
 /**
- * Gets the possible types of a selector
+ * Analyzes a parsed selector and returns combined data about it
  * @param {Object} parsedSelector An object (from esquery) describing the matching behavior of the selector
- * @returns {string[]|null} The node types that could possibly trigger this selector, or `null` if all node types could trigger it
+ * @returns {{listenerTypes:string[]|null,attributeCount:number, identifierCount:number}} Object containing selector data.
  */
-function getPossibleTypes(parsedSelector) {
-	switch (parsedSelector.type) {
-		case "identifier":
-			return [parsedSelector.value];
+function analyzeParsedSelector(parsedSelector) {
+	let attributeCount = 0;
+	let identifierCount = 0;
 
-		case "matches": {
-			const typesForComponents =
-				parsedSelector.selectors.map(getPossibleTypes);
-
-			if (typesForComponents.every(Boolean)) {
-				return union(...typesForComponents);
+	/**
+	 * Analyzes a selector component and updates counters
+	 * @param {Object} selector A selector object from esquery
+	 * @returns {string[]|null} The node types that could match this selector, or null if all could match
+	 */
+	function analyzeSelector(selector) {
+		switch (selector.type) {
+			case "identifier": {
+				identifierCount++;
+				return [selector.value];
 			}
-			return null;
-		}
 
-		case "compound": {
-			const typesForComponents = parsedSelector.selectors
-				.map(getPossibleTypes)
-				.filter(typesForComponent => typesForComponent);
+			case "matches": {
+				const typesForComponents = selector.selectors.map(s => {
+					const result = analyzeSelector(s);
+					return result;
+				});
 
-			// If all of the components could match any type, then the compound could also match any type.
-			if (!typesForComponents.length) {
+				if (typesForComponents.every(Boolean)) {
+					return union(...typesForComponents);
+				}
 				return null;
 			}
 
-			/*
-			 * If at least one of the components could only match a particular type, the compound could only match
-			 * the intersection of those types.
-			 */
-			return intersection(...typesForComponents);
-		}
+			case "compound": {
+				const typesForComponents = selector.selectors
+					.map(s => analyzeSelector(s))
+					.filter(Boolean);
 
-		case "child":
-		case "descendant":
-		case "sibling":
-		case "adjacent":
-			return getPossibleTypes(parsedSelector.right);
+				// If all of the components could match any type, then the compound could also match any type.
+				if (!typesForComponents.length) {
+					return null;
+				}
 
-		case "class":
-			if (parsedSelector.name === "function") {
-				return [
-					"FunctionDeclaration",
-					"FunctionExpression",
-					"ArrowFunctionExpression",
-				];
+				/*
+				 * If at least one of the components could only match a particular type, the compound could only match
+				 * the intersection of those types.
+				 */
+				return intersection(...typesForComponents);
 			}
 
-			return null;
+			case "child":
+			case "descendant":
+			case "sibling":
+			case "adjacent": {
+				analyzeSelector(selector.left);
+				return analyzeSelector(selector.right);
+			}
 
-		default:
-			return null;
+			case "class":
+				attributeCount++;
+				if (selector.name === "function") {
+					return [
+						"FunctionDeclaration",
+						"FunctionExpression",
+						"ArrowFunctionExpression",
+					];
+				}
+				return null;
+
+			case "attribute":
+			case "field":
+			case "nth-child":
+			case "nth-last-child":
+				attributeCount++;
+				return null;
+
+			case "not": {
+				selector.selectors.forEach(s => {
+					analyzeSelector(s);
+				});
+				return null;
+			}
+
+			default:
+				return null;
+		}
 	}
-}
 
-/**
- * Counts the number of class, pseudo-class, and attribute queries in this selector
- * @param {Object} parsedSelector An object (from esquery) describing the selector's matching behavior
- * @returns {number} The number of class, pseudo-class, and attribute queries in this selector
- */
-function countClassAttributes(parsedSelector) {
-	switch (parsedSelector.type) {
-		case "child":
-		case "descendant":
-		case "sibling":
-		case "adjacent":
-			return (
-				countClassAttributes(parsedSelector.left) +
-				countClassAttributes(parsedSelector.right)
-			);
+	const listenerTypes = analyzeSelector(parsedSelector);
 
-		case "compound":
-		case "not":
-		case "matches":
-			return parsedSelector.selectors.reduce(
-				(sum, childSelector) =>
-					sum + countClassAttributes(childSelector),
-				0,
-			);
-
-		case "attribute":
-		case "field":
-		case "nth-child":
-		case "nth-last-child":
-			return 1;
-
-		default:
-			return 0;
-	}
-}
-
-/**
- * Counts the number of identifier queries in this selector
- * @param {Object} parsedSelector An object (from esquery) describing the selector's matching behavior
- * @returns {number} The number of identifier queries
- */
-function countIdentifiers(parsedSelector) {
-	switch (parsedSelector.type) {
-		case "child":
-		case "descendant":
-		case "sibling":
-		case "adjacent":
-			return (
-				countIdentifiers(parsedSelector.left) +
-				countIdentifiers(parsedSelector.right)
-			);
-
-		case "compound":
-		case "not":
-		case "matches":
-			return parsedSelector.selectors.reduce(
-				(sum, childSelector) => sum + countIdentifiers(childSelector),
-				0,
-			);
-
-		case "identifier":
-			return 1;
-
-		default:
-			return 0;
-	}
+	return {
+		listenerTypes,
+		attributeCount,
+		identifierCount,
+	};
 }
 
 /**
@@ -239,14 +209,16 @@ function parseSelector(rawSelector) {
 	}
 
 	const parsedSelector = tryParseSelector(rawSelector);
+	const { listenerTypes, attributeCount, identifierCount } =
+		analyzeParsedSelector(parsedSelector);
 
 	const result = {
 		rawSelector,
 		isExit: rawSelector.endsWith(":exit"),
 		parsedSelector,
-		listenerTypes: getPossibleTypes(parsedSelector),
-		attributeCount: countClassAttributes(parsedSelector),
-		identifierCount: countIdentifiers(parsedSelector),
+		listenerTypes,
+		attributeCount,
+		identifierCount,
 	};
 
 	selectorCache.set(rawSelector, result);

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "@cypress/webpack-preprocessor": "^6.0.2",
     "@eslint/json": "^0.11.0",
     "@trunkio/launcher": "^1.3.4",
+    "@types/esquery": "^1.5.4",
     "@types/node": "^22.13.14",
     "@typescript-eslint/parser": "^8.4.0",
     "babel-loader": "^8.0.5",

--- a/tests/lib/linter/esquery.js
+++ b/tests/lib/linter/esquery.js
@@ -238,7 +238,7 @@ describe("esquery", () => {
 		});
 	});
 
-	describe("matches", () => {
+	describe("matches()", () => {
 		it("should delegate to esquery.matches", () => {
 			const matchesSpy = sinon.stub(esquery, "matches").returns(true);
 			const node = { type: "Identifier", name: "foo" };
@@ -255,6 +255,47 @@ describe("esquery", () => {
 			assert.strictEqual(result, true);
 
 			matchesSpy.restore();
+		});
+	});
+
+	describe("compare()", () => {
+		[
+			["Identifier", "Identifier", -1],
+			["Identifier", "Identifier:exit", -1],
+			["Identifier:exit", "Identifier", 1],
+			["Identifier:exit", "Identifier:exit", -1],
+			["Identifier", "Literal", -1],
+			["Literal", "Identifier", 1],
+			["Literal[name='foo']", "Literal[name='bar']", 1],
+			["Literal[name='bar']", "Literal[name='foo']", -1],
+			["Literal[name='foo']", "Literal[name='foo']", -1],
+			[
+				"FunctionDeclaration[id.name='foo']",
+				"FunctionDeclaration[id.name='bar']",
+				1,
+			],
+			[
+				"FunctionDeclaration[id.name='bar']",
+				"FunctionDeclaration[id.name='foo']",
+				-1,
+			],
+			[
+				"FunctionDeclaration[id.name='foo']",
+				"FunctionDeclaration[id.name='foo']",
+				-1,
+			],
+			["Identifier", "[name]", -1],
+			["Identifier", "Identifier[name]", -1],
+		].forEach(([selectorA, selectorB, expected]) => {
+			it(`compare "${selectorA}" to "${selectorB}" should return ${expected}`, () => {
+				const parsedSelectorA = parse(selectorA);
+				const parsedSelectorB = parse(selectorB);
+
+				assert.strictEqual(
+					parsedSelectorA.compare(parsedSelectorB),
+					expected,
+				);
+			});
 		});
 	});
 });

--- a/tests/lib/linter/esquery.js
+++ b/tests/lib/linter/esquery.js
@@ -1,0 +1,260 @@
+/**
+ * @fileoverview Tests for esquery
+ * @author Nicholas C. Zakas
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const assert = require("chai").assert;
+const sinon = require("sinon");
+const esquery = require("esquery");
+const {
+	parse,
+	matches,
+	ESQueryParsedSelector,
+} = require("../../../lib/linter/esquery");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("esquery", () => {
+	describe("ESQueryParsedSelector", () => {
+		describe("constructor", () => {
+			it("should store properties correctly", () => {
+				const selector = new ESQueryParsedSelector(
+					"Identifier",
+					false,
+					{ type: "identifier", value: "Identifier" },
+					["Identifier"],
+					1,
+					2,
+				);
+
+				assert.strictEqual(selector.source, "Identifier");
+				assert.strictEqual(selector.isExit, false);
+				assert.deepStrictEqual(selector.root, {
+					type: "identifier",
+					value: "Identifier",
+				});
+				assert.deepStrictEqual(selector.nodeTypes, ["Identifier"]);
+				assert.strictEqual(selector.attributeCount, 1);
+				assert.strictEqual(selector.identifierCount, 2);
+			});
+		});
+
+		describe("compare", () => {
+			it("should compare based on attributeCount first", () => {
+				const selector1 = new ESQueryParsedSelector(
+					"",
+					false,
+					{},
+					[],
+					2,
+					1,
+				);
+				const selector2 = new ESQueryParsedSelector(
+					"",
+					false,
+					{},
+					[],
+					1,
+					1,
+				);
+
+				assert.isAbove(selector1.compare(selector2), 0);
+				assert.isBelow(selector2.compare(selector1), 0);
+			});
+
+			it("should compare based on identifierCount if attributeCount is equal", () => {
+				const selector1 = new ESQueryParsedSelector(
+					"",
+					false,
+					{},
+					[],
+					1,
+					2,
+				);
+				const selector2 = new ESQueryParsedSelector(
+					"",
+					false,
+					{},
+					[],
+					1,
+					1,
+				);
+
+				assert.isAbove(selector1.compare(selector2), 0);
+				assert.isBelow(selector2.compare(selector1), 0);
+			});
+
+			it("should compare based on source if attributeCount and identifierCount are equal", () => {
+				const selector1 = new ESQueryParsedSelector(
+					"B",
+					false,
+					{},
+					[],
+					1,
+					1,
+				);
+				const selector2 = new ESQueryParsedSelector(
+					"A",
+					false,
+					{},
+					[],
+					1,
+					1,
+				);
+
+				assert.isAbove(selector1.compare(selector2), 0);
+				assert.isBelow(selector2.compare(selector1), 0);
+			});
+
+			it("should return -1 if sources are equal", () => {
+				const selector1 = new ESQueryParsedSelector(
+					"A",
+					false,
+					{},
+					[],
+					1,
+					1,
+				);
+				const selector2 = new ESQueryParsedSelector(
+					"A",
+					false,
+					{},
+					[],
+					1,
+					1,
+				);
+
+				assert.strictEqual(selector1.compare(selector2), -1);
+			});
+		});
+	});
+
+	describe("parse", () => {
+		it("should parse a simple selector", () => {
+			const result = parse("Identifier");
+
+			assert.instanceOf(result, ESQueryParsedSelector);
+			assert.strictEqual(result.source, "Identifier");
+			assert.strictEqual(result.isExit, false);
+			assert.deepStrictEqual(result.nodeTypes, ["Identifier"]);
+			assert.strictEqual(result.attributeCount, 0);
+			assert.strictEqual(result.identifierCount, 1);
+		});
+
+		it("should recognize exit selectors", () => {
+			const result = parse("Identifier:exit");
+
+			assert.strictEqual(result.isExit, true);
+			assert.deepStrictEqual(result.nodeTypes, ["Identifier"]);
+			assert.strictEqual(result.attributeCount, 0);
+			assert.strictEqual(result.identifierCount, 1);
+		});
+
+		it("should use cached results when parsing the same selector twice", () => {
+			const result1 = parse("Identifier");
+			const result2 = parse("Identifier");
+
+			assert.strictEqual(result1, result2);
+			assert.strictEqual(result1.attributeCount, 0);
+			assert.strictEqual(result1.identifierCount, 1);
+		});
+
+		it("should throw a useful error when parsing fails", () => {
+			assert.throws(
+				() => parse("[invalid"),
+				SyntaxError,
+				/Syntax error in selector/u,
+			);
+		});
+
+		it("should return null nodeTypes for selectors that match any type", () => {
+			const result = parse("[attr]");
+			assert.strictEqual(result.nodeTypes, null);
+			assert.strictEqual(result.attributeCount, 1);
+			assert.strictEqual(result.identifierCount, 0);
+		});
+
+		it("should handle compound selectors", () => {
+			const result = parse("FunctionDeclaration[id.name='foo']");
+			assert.deepStrictEqual(result.nodeTypes, ["FunctionDeclaration"]);
+			assert.strictEqual(result.attributeCount, 1);
+			assert.strictEqual(result.identifierCount, 1);
+		});
+
+		it("should handle class selectors for functions", () => {
+			const result = parse(":function");
+			assert.includeMembers(result.nodeTypes, [
+				"FunctionDeclaration",
+				"FunctionExpression",
+				"ArrowFunctionExpression",
+			]);
+			assert.strictEqual(result.attributeCount, 0);
+			assert.strictEqual(result.identifierCount, 0);
+		});
+
+		it("should handle class selectors for statements", () => {
+			const result = parse(":statement");
+
+			assert.strictEqual(result.nodeTypes, null);
+			assert.strictEqual(result.attributeCount, 0);
+			assert.strictEqual(result.identifierCount, 0);
+		});
+
+		it("should handle child selector with attribute selector", () => {
+			const result = parse("BinaryExpression > *[name='foo']");
+
+			assert.strictEqual(result.isExit, false);
+			assert.strictEqual(result.nodeTypes, null);
+			assert.strictEqual(result.attributeCount, 1);
+			assert.strictEqual(result.identifierCount, 1);
+		});
+
+		it("should handle not selector", () => {
+			const result = parse("*:not(ExpressionStatement)");
+
+			assert.strictEqual(result.isExit, false);
+			assert.strictEqual(result.nodeTypes, null);
+			assert.strictEqual(result.attributeCount, 0);
+			assert.strictEqual(result.identifierCount, 1);
+		});
+
+		it("should handle compound selector with matches", () => {
+			const result = parse(
+				":matches(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])",
+			);
+
+			assert.strictEqual(result.isExit, false);
+			assert.deepStrictEqual(result.nodeTypes, ["Identifier"]);
+			assert.strictEqual(result.attributeCount, 3);
+			assert.strictEqual(result.identifierCount, 3);
+		});
+	});
+
+	describe("matches", () => {
+		it("should delegate to esquery.matches", () => {
+			const matchesSpy = sinon.stub(esquery, "matches").returns(true);
+			const node = { type: "Identifier", name: "foo" };
+			const root = { type: "identifier", value: "Identifier" };
+			const ancestry = [];
+			const options = {};
+
+			const result = matches(node, root, ancestry, options);
+
+			assert.strictEqual(
+				matchesSpy.calledOnceWith(node, root, ancestry, options),
+				true,
+			);
+			assert.strictEqual(result, true);
+
+			matchesSpy.restore();
+		});
+	});
+});

--- a/tests/lib/linter/esquery.js
+++ b/tests/lib/linter/esquery.js
@@ -149,6 +149,16 @@ describe("esquery", () => {
 			assert.strictEqual(result.identifierCount, 1);
 		});
 
+		it("should parse a wildcard selector", () => {
+			const result = parse("*");
+			assert.instanceOf(result, ESQueryParsedSelector);
+			assert.strictEqual(result.source, "*");
+			assert.strictEqual(result.isExit, false);
+			assert.strictEqual(result.nodeTypes, null);
+			assert.strictEqual(result.attributeCount, 0);
+			assert.strictEqual(result.identifierCount, 0);
+		});
+
 		it("should recognize exit selectors", () => {
 			const result = parse("Identifier:exit");
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Refactor

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This refactors the ESQuery selector evaluation done by `NodeEventGenerator`. Previously, it would traverse the selector AST three times to collect different data. This refactor combines those three traversals into one to avoid extra work.

- Split out ESQuery logic into its own file (necessary as part of core rewrite work to avoid duplication)
- Added tests for ESQuery parsing and matching
- Refactored logic into a single-pass traversal

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
