### PR TITLE
docs: fix double space in command

### DIFF
--- a/docs/src/use/configure/migration-guide.md
+++ b/docs/src/use/configure/migration-guide.md
@@ -24,8 +24,8 @@ For reference information on these configuration formats, refer to the following
 To get started, use the [configuration migrator](https://npmjs.com/package/@eslint/migrate-config) on your existing configuration file (`.eslintrc`, `.eslintrc.json`, `.eslintrc.yml`), like this:
 
 {{ npx_tabs({
-    package: null,
-    args: ["@eslint/migrate-config", ".eslintrc.json"]
+    package: "@eslint/migrate-config",
+    args: [".eslintrc.json"]
 }) }}
 
 This will create a starting point for your `eslint.config.js` file but is not guaranteed to work immediately without further modification. It will, however, do most of the conversion work mentioned in this guide automatically.

--- a/docs/src/use/configure/migration-guide.md
+++ b/docs/src/use/configure/migration-guide.md
@@ -16,8 +16,8 @@ To learn more about the flat config format, refer to [this blog post](https://es
 
 For reference information on these configuration formats, refer to the following documentation:
 
--   [eslintrc configuration files](configuration-files-deprecated)
--   [flat configuration files](configuration-files)
+- [eslintrc configuration files](configuration-files-deprecated)
+- [flat configuration files](configuration-files)
 
 ## Migrate Your Config File
 
@@ -44,10 +44,10 @@ To use flat config with ESLint v8, place a `eslint.config.js` file in the root o
 
 While the configuration file format has changed from eslintrc to flat config, the following has stayed the same:
 
--   Syntax for configuring rules.
--   Syntax for configuring processors.
--   The CLI, except for the flag changes noted in [CLI Flag Changes](#cli-flag-changes).
--   Global variables are configured the same way, but on a different property (see [Configuring Language Options](#configuring-language-options)).
+- Syntax for configuring rules.
+- Syntax for configuring processors.
+- The CLI, except for the flag changes noted in [CLI Flag Changes](#cli-flag-changes).
+- Global variables are configured the same way, but on a different property (see [Configuring Language Options](#configuring-language-options)).
 
 ## Key Differences between Configuration Formats
 
@@ -421,8 +421,8 @@ export default [
 
 In eslintrc files, use the `extends` property to use predefined and shareable configs. ESLint comes with two predefined configs that you can access as strings:
 
--   `"eslint:recommended"`: the rules recommended by ESLint.
--   `"eslint:all"`: all rules shipped with ESLint.
+- `"eslint:recommended"`: the rules recommended by ESLint.
+- `"eslint:all"`: all rules shipped with ESLint.
 
 You can also use the `extends` property to extend a shareable config. Shareable configs can either be paths to local config files or npm package names.
 
@@ -625,9 +625,9 @@ export default [
 
 The following CLI flags are no longer supported with the flat config file format:
 
--   `--rulesdir`
--   `--ext`
--   `--resolve-plugins-relative-to`
+- `--rulesdir`
+- `--ext`
+- `--resolve-plugins-relative-to`
 
 The flag `--no-eslintrc` has been replaced with `--no-config-lookup`.
 
@@ -691,9 +691,9 @@ With flat config, it's no longer possible to use a `package.json` file to config
 
 The following changes have been made from the eslintrc to the flat config file format:
 
--   The `root` option no longer exists. (Flat config files act as if `root: true` is set.)
--   The `files` option cannot be a single string anymore, it must be an array.
--   The `sourceType` option now supports the new value `"commonjs"` (`.eslintrc` supports it too, but it was never documented).
+- The `root` option no longer exists. (Flat config files act as if `root: true` is set.)
+- The `files` option cannot be a single string anymore, it must be an array.
+- The `sourceType` option now supports the new value `"commonjs"` (`.eslintrc` supports it too, but it was never documented).
 
 ## TypeScript Types for Flat Config Files
 
@@ -718,6 +718,6 @@ In a future version of the ESLint plugin, you will no longer need to enable this
 
 ## Further Reading
 
--   [Overview of the flat config file format blog post](https://eslint.org/blog/2022/08/new-config-system-part-2/)
--   [API usage of new configuration system blog post](https://eslint.org/blog/2022/08/new-config-system-part-3/)
--   [Background to new configuration system blog post](https://eslint.org/blog/2022/08/new-config-system-part-1/)
+- [Overview of the flat config file format blog post](https://eslint.org/blog/2022/08/new-config-system-part-2/)
+- [API usage of new configuration system blog post](https://eslint.org/blog/2022/08/new-config-system-part-3/)
+- [Background to new configuration system blog post](https://eslint.org/blog/2022/08/new-config-system-part-1/)


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
This PR removes a double space in the docs that was caused by incorrect usage of the `npx_tabs` macro.
<img width="836" alt="Screenshot 2025-04-25 at 4 10 03 pm" src="https://github.com/user-attachments/assets/5b1a4468-6b00-4d73-a7a9-fc8447b7a8b7" />


#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
