### PR TITLE
fix: don't crash on tests with circular references in `RuleTester`

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -192,16 +192,24 @@ function cloneDeeplyExcludesParent(x) {
 /**
  * Freezes a given value deeply.
  * @param {any} x A value to freeze.
+ * @param {Set<Object>} seenObjects Objects already seen during the traversal.
  * @returns {void}
  */
-function freezeDeeply(x) {
+function freezeDeeply(x, seenObjects = new Set()) {
 	if (typeof x === "object" && x !== null) {
+		if (seenObjects.has(x)) {
+			return; // skip to avoid infinite recursion
+		}
+		seenObjects.add(x);
+
 		if (Array.isArray(x)) {
-			x.forEach(freezeDeeply);
+			x.forEach(element => {
+				freezeDeeply(element, seenObjects);
+			});
 		} else {
 			for (const key in x) {
 				if (key !== "parent" && hasOwnProperty(x, key)) {
-					freezeDeeply(x[key]);
+					freezeDeeply(x[key], seenObjects);
 				}
 			}
 		}

--- a/lib/shared/serialization.js
+++ b/lib/shared/serialization.js
@@ -26,21 +26,44 @@ function isSerializablePrimitiveOrPlainObject(val) {
  * Check if a value is serializable.
  * Functions or objects like RegExp cannot be serialized by JSON.stringify().
  * Inspired by: https://stackoverflow.com/questions/30579940/reliable-way-to-check-if-objects-is-serializable-in-javascript
- * @param {any} val the value
- * @returns {boolean} true if the value is serializable
+ * @param {any} val The value
+ * @param {Set<Object>} seenObjects Objects already seen in this path from the root object.
+ * @returns {boolean} `true` if the value is serializable
  */
-function isSerializable(val) {
+function isSerializable(val, seenObjects = new Set()) {
 	if (!isSerializablePrimitiveOrPlainObject(val)) {
 		return false;
 	}
-	if (typeof val === "object") {
+	if (typeof val === "object" && val !== null) {
+		if (seenObjects.has(val)) {
+			/*
+			 * Since this is a depth-first traversal, encountering
+			 * the same object again means there is a circular reference.
+			 * Objects with circular references are not serializable.
+			 */
+			return false;
+		}
 		for (const property in val) {
 			if (Object.hasOwn(val, property)) {
 				if (!isSerializablePrimitiveOrPlainObject(val[property])) {
 					return false;
 				}
-				if (typeof val[property] === "object") {
-					if (!isSerializable(val[property])) {
+				if (
+					typeof val[property] === "object" &&
+					val[property] !== null
+				) {
+					if (
+						/*
+						 * We're creating a new Set of seen objects because we want to
+						 * ensure that `val` doesn't appear again in this path, but it can appear
+						 * in other paths. This allows for resuing objects in the graph, as long as
+						 * there are no cycles.
+						 */
+						!isSerializable(
+							val[property],
+							new Set([...seenObjects, val]),
+						)
+					) {
 						return false;
 					}
 				}

--- a/tests/lib/shared/serialization.js
+++ b/tests/lib/shared/serialization.js
@@ -68,6 +68,32 @@ describe("serialization", () => {
 				assert.isFalse(isSerializable({ a: /abc/u }));
 				assert.isFalse(isSerializable({ a: { b: /abc/u } }));
 			});
+
+			it("circular references", () => {
+				const obj1 = {};
+				obj1.circular = obj1;
+				assert.isFalse(isSerializable(obj1));
+				assert.isFalse(isSerializable({ a: obj1 }));
+
+				const obj2 = {};
+				obj2.a = { circular: obj2 };
+				assert.isFalse(isSerializable(obj2));
+				assert.isFalse(isSerializable({ b: obj2 }));
+
+				const obj3 = { foo: { bar: "baz" } };
+				assert.isTrue(
+					isSerializable({
+						a: obj3,
+						b: obj3,
+						c: {
+							d: obj3,
+							e: {
+								f: obj3,
+							},
+						},
+					}),
+				);
+			});
 		});
 
 		describe("array", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #19646

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `isSerializable` (`lib/shared/serialization.js`) to not cause a stack overflow error when the passed object has circular references, and in that case return `false` because objects with circular references are not JSON-serializable.

Also updated `freezeDeeply` (in `lib/rule-tester/rule-tester.js`) to to not cause a stack overflow error when the passed object has circular references.

#### Is there anything you'd like reviewers to focus on?

This is a very edge case, so I was more concerned if it would affect performance. By my performance testing, which was to run all core rules tests, it doesn't seem to significantly affect execution time.

Before:

```
$ time node node_modules/mocha/bin/_mocha -R min "tests/lib/rules/*.js"


  31860 passing (21s)


real    0m22.923s
user    0m0.015s 
sys     0m0.045s 
```

After:

```
$ time node node_modules/mocha/bin/_mocha -R min "tests/lib/rules/*.js"


  31860 passing (21s)


real    0m22.946s
user    0m0.000s 
sys     0m0.030s 
```

<!-- markdownlint-disable-file MD004 -->
