### PR TITLE
chore: replace chai with node.js assert

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "@typescript-eslint/parser": "^8.4.0",
     "babel-loader": "^8.0.5",
     "c8": "^7.12.0",
-    "chai": "^4.0.1",
     "cheerio": "^0.22.0",
     "common-tags": "^1.8.0",
     "core-js": "^3.1.3",

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -11,7 +11,7 @@
 
 const childProcess = require("node:child_process");
 const fs = require("node:fs");
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const path = require("node:path");
 
 //------------------------------------------------------------------------------
@@ -389,8 +389,9 @@ describe("bin/eslint.js", () => {
 				const child = runESLint(ARGS_WITH_CACHE);
 
 				return assertExitCode(child, 0).then(() => {
-					assert.isTrue(
+					assert.strictEqual(
 						fs.existsSync(CACHE_PATH),
+						true,
 						"Cache file should exist at the given location",
 					);
 
@@ -405,8 +406,9 @@ describe("bin/eslint.js", () => {
 				const child = runESLint(ARGS_WITH_CACHE);
 
 				return assertExitCode(child, 0).then(() => {
-					assert.isTrue(
+					assert.strictEqual(
 						fs.existsSync(CACHE_PATH),
+						true,
 						"Cache file should exist at the given location",
 					);
 				});
@@ -416,8 +418,9 @@ describe("bin/eslint.js", () => {
 
 				return assertExitCode(child, 0).then(() => {
 					// Note: This doesn't actually verify that the cache file is used for anything.
-					assert.isTrue(
+					assert.strictEqual(
 						fs.existsSync(CACHE_PATH),
+						true,
 						"Cache file should still exist after linting with --cache",
 					);
 				});
@@ -447,8 +450,9 @@ describe("bin/eslint.js", () => {
 				const child = runESLint(ARGS_WITHOUT_CACHE);
 
 				return assertExitCode(child, 0).then(() => {
-					assert.isFalse(
+					assert.strictEqual(
 						fs.existsSync(CACHE_PATH),
+						false,
 						"Cache file should be deleted after running ESLint without the --cache argument",
 					);
 				});
@@ -473,8 +477,9 @@ describe("bin/eslint.js", () => {
 				const child = runESLint(ARGS_WITH_CACHE);
 
 				return assertExitCode(child, 0).then(() => {
-					assert.isTrue(
+					assert.strictEqual(
 						fs.existsSync(CACHE_PATH),
+						true,
 						"Cache file should exist at the given location",
 					);
 
@@ -487,8 +492,9 @@ describe("bin/eslint.js", () => {
 				const child = runESLint(ARGS_WITHOUT_CACHE);
 
 				return assertExitCode(child, 0).then(() => {
-					assert.isFalse(
+					assert.strictEqual(
 						fs.existsSync(CACHE_PATH),
+						false,
 						"Cache file should be deleted after running ESLint without the --cache argument",
 					);
 				});
@@ -570,9 +576,10 @@ describe("bin/eslint.js", () => {
 
 				const exitCodeAssertion = assertExitCode(child, 2);
 				const outputAssertion = getOutput(child).then(output => {
-					assert.include(
-						output.stderr,
-						"The --suppress-all option and the --suppress-rule option cannot be used together.",
+					assert.ok(
+						output.stderr.includes(
+							"The --suppress-all option and the --suppress-rule option cannot be used together.",
+						),
 					);
 				});
 
@@ -586,9 +593,10 @@ describe("bin/eslint.js", () => {
 
 				const exitCodeAssertion = assertExitCode(child, 2);
 				const outputAssertion = getOutput(child).then(output => {
-					assert.include(
-						output.stderr,
-						"The --suppress-all option and the --prune-suppressions option cannot be used together.",
+					assert.ok(
+						output.stderr.includes(
+							"The --suppress-all option and the --prune-suppressions option cannot be used together.",
+						),
 					);
 				});
 
@@ -604,9 +612,10 @@ describe("bin/eslint.js", () => {
 
 				const exitCodeAssertion = assertExitCode(child, 2);
 				const outputAssertion = getOutput(child).then(output => {
-					assert.include(
-						output.stderr,
-						"The --suppress-rule option and the --prune-suppressions option cannot be used together.",
+					assert.ok(
+						output.stderr.includes(
+							"The --suppress-rule option and the --prune-suppressions option cannot be used together.",
+						),
 					);
 				});
 
@@ -627,9 +636,10 @@ describe("bin/eslint.js", () => {
 
 				const exitCodeAssertion = assertExitCode(child, 2);
 				const outputAssertion = getOutput(child).then(output => {
-					assert.include(
-						output.stderr,
-						"The --suppress-all, --suppress-rule, and --prune-suppressions options cannot be used with piped-in code.",
+					assert.ok(
+						output.stderr.includes(
+							"The --suppress-all, --suppress-rule, and --prune-suppressions options cannot be used with piped-in code.",
+						),
 					);
 				});
 
@@ -649,9 +659,10 @@ describe("bin/eslint.js", () => {
 
 				const exitCodeAssertion = assertExitCode(child, 2);
 				const outputAssertion = getOutput(child).then(output => {
-					assert.include(
-						output.stderr,
-						"The --suppress-all, --suppress-rule, and --prune-suppressions options cannot be used with piped-in code.",
+					assert.ok(
+						output.stderr.includes(
+							"The --suppress-all, --suppress-rule, and --prune-suppressions options cannot be used with piped-in code.",
+						),
 					);
 				});
 
@@ -670,9 +681,10 @@ describe("bin/eslint.js", () => {
 
 				const exitCodeAssertion = assertExitCode(child, 2);
 				const outputAssertion = getOutput(child).then(output => {
-					assert.include(
-						output.stderr,
-						"The --suppress-all, --suppress-rule, and --prune-suppressions options cannot be used with piped-in code.",
+					assert.ok(
+						output.stderr.includes(
+							"The --suppress-all, --suppress-rule, and --prune-suppressions options cannot be used with piped-in code.",
+						),
 					);
 				});
 
@@ -683,8 +695,9 @@ describe("bin/eslint.js", () => {
 		describe("when no suppression file exists", () => {
 			beforeEach(() => {
 				fs.rmSync(SUPPRESSIONS_PATH, { force: true });
-				assert.isFalse(
+				assert.strictEqual(
 					fs.existsSync(SUPPRESSIONS_PATH),
+					false,
 					"Suppressions file should not exist at the start",
 				);
 			});
@@ -692,8 +705,9 @@ describe("bin/eslint.js", () => {
 				const child = runESLint(ARGS_WITH_SUPPRESS_ALL);
 
 				const exitCodeAssertion = assertExitCode(child, 0).then(() => {
-					assert.isTrue(
+					assert.strictEqual(
 						fs.existsSync(SUPPRESSIONS_PATH),
+						true,
 						"Suppressions file should exist at the given location",
 					);
 					JSON.parse(fs.readFileSync(SUPPRESSIONS_PATH, "utf8"));
@@ -701,20 +715,23 @@ describe("bin/eslint.js", () => {
 
 				const outputAssertion = getOutput(child).then(output => {
 					// Warnings
-					assert.include(
-						output.stdout,
-						"'e' is assigned a value but never used",
+					assert.ok(
+						output.stdout.includes(
+							"'e' is assigned a value but never used",
+						),
 					);
 
 					// Suppressed errors
-					assert.notInclude(output.stdout, "is not defined");
-					assert.notInclude(
-						output.stdout,
-						"Expected indentation of 2 spaces but found 4",
+					assert.ok(!output.stdout.includes("is not defined"));
+					assert.ok(
+						!output.stdout.includes(
+							"Expected indentation of 2 spaces but found 4",
+						),
 					);
-					assert.notInclude(
-						output.stdout,
-						"Unexpected comma in middle of array",
+					assert.ok(
+						!output.stdout.includes(
+							"Unexpected comma in middle of array",
+						),
 					);
 				});
 
@@ -724,8 +741,9 @@ describe("bin/eslint.js", () => {
 				const child = runESLint(ARGS_WITH_SUPPRESS_RULE_INDENT);
 
 				const exitCodeAssertion = assertExitCode(child, 1).then(() => {
-					assert.isTrue(
+					assert.strictEqual(
 						fs.existsSync(SUPPRESSIONS_PATH),
+						true,
 						"Suppressions file should exist at the given location",
 					);
 					assert.deepStrictEqual(
@@ -736,22 +754,25 @@ describe("bin/eslint.js", () => {
 				});
 				const outputAssertion = getOutput(child).then(output => {
 					// Warnings
-					assert.include(
-						output.stdout,
-						"'e' is assigned a value but never used",
+					assert.ok(
+						output.stdout.includes(
+							"'e' is assigned a value but never used",
+						),
 					);
 
 					// Un-suppressed errors
-					assert.include(output.stdout, "is not defined");
-					assert.include(
-						output.stdout,
-						"Unexpected comma in middle of array",
+					assert.ok(output.stdout.includes("is not defined"));
+					assert.ok(
+						output.stdout.includes(
+							"Unexpected comma in middle of array",
+						),
 					);
 
 					// Suppressed errors
-					assert.notInclude(
-						output.stdout,
-						"Expected indentation of 2 spaces but found 4",
+					assert.ok(
+						!output.stdout.includes(
+							"Expected indentation of 2 spaces but found 4",
+						),
 					);
 				});
 
@@ -763,8 +784,9 @@ describe("bin/eslint.js", () => {
 				);
 
 				const exitCodeAssertion = assertExitCode(child, 1).then(() => {
-					assert.isTrue(
+					assert.strictEqual(
 						fs.existsSync(SUPPRESSIONS_PATH),
+						true,
 						"Suppressions file should exist at the given location",
 					);
 					assert.deepStrictEqual(
@@ -775,22 +797,25 @@ describe("bin/eslint.js", () => {
 				});
 				const outputAssertion = getOutput(child).then(output => {
 					// Warnings
-					assert.include(
-						output.stdout,
-						"'e' is assigned a value but never used",
+					assert.ok(
+						output.stdout.includes(
+							"'e' is assigned a value but never used",
+						),
 					);
 
 					// Un-suppressed errors
-					assert.include(output.stdout, "is not defined");
+					assert.ok(output.stdout.includes("is not defined"));
 
 					// Suppressed errors
-					assert.notInclude(
-						output.stdout,
-						"Expected indentation of 2 spaces but found 4",
+					assert.ok(
+						!output.stdout.includes(
+							"Expected indentation of 2 spaces but found 4",
+						),
 					);
-					assert.notInclude(
-						output.stdout,
-						"Unexpected comma in middle of array",
+					assert.ok(
+						!output.stdout.includes(
+							"Unexpected comma in middle of array",
+						),
 					);
 				});
 
@@ -799,15 +824,17 @@ describe("bin/eslint.js", () => {
 			it("displays an error when the suppressions file doesn't exist", () => {
 				const child = runESLint(ARGS_WITHOUT_SUPPRESSIONS);
 				const exitCodeAssertion = assertExitCode(child, 2).then(() => {
-					assert.isTrue(
+					assert.strictEqual(
 						!fs.existsSync(SUPPRESSIONS_PATH),
+						true,
 						"Suppressions file must not exist at the given location",
 					);
 				});
 				const outputAssertion = getOutput(child).then(output => {
-					assert.include(
-						output.stderr,
-						"The suppressions file does not exist",
+					assert.ok(
+						output.stderr.includes(
+							"The suppressions file does not exist",
+						),
 					);
 				});
 
@@ -816,15 +843,17 @@ describe("bin/eslint.js", () => {
 			it("displays an error when the --prune-suppressions flag used, and the suppressions file doesn't exist", () => {
 				const child = runESLint(ARGS_WITH_PRUNE_SUPPRESSIONS);
 				const exitCodeAssertion = assertExitCode(child, 2).then(() => {
-					assert.isTrue(
+					assert.strictEqual(
 						!fs.existsSync(SUPPRESSIONS_PATH),
+						true,
 						"Suppressions file must not exist at the given location",
 					);
 				});
 				const outputAssertion = getOutput(child).then(output => {
-					assert.include(
-						output.stderr,
-						"The suppressions file does not exist",
+					assert.ok(
+						output.stderr.includes(
+							"The suppressions file does not exist",
+						),
 					);
 				});
 
@@ -846,8 +875,9 @@ describe("bin/eslint.js", () => {
 				]);
 
 				return assertExitCode(child, 0).then(() => {
-					assert.isTrue(
+					assert.strictEqual(
 						fs.existsSync(SUPPRESSIONS_PATH),
+						true,
 						"Suppressions file should exist at the given location",
 					);
 
@@ -855,8 +885,10 @@ describe("bin/eslint.js", () => {
 						fs.readFileSync(SUPPRESSIONS_PATH, "utf8"),
 					);
 
-					assert.notExists(
-						suppressionsFiles[tempFilePath].indent,
+					assert.ok(
+						suppressionsFiles[tempFilePath].indent === null ||
+							typeof suppressionsFiles[tempFilePath].indent ===
+								"undefined",
 						"Suppressions file should not contain any suppressions for indent",
 					);
 				});
@@ -887,9 +919,10 @@ describe("bin/eslint.js", () => {
 
 				const exitCodeAssertion = assertExitCode(child, 2);
 				const outputAssertion = getOutput(child).then(output => {
-					assert.include(
-						output.stderr,
-						"Failed to parse suppressions file at",
+					assert.ok(
+						output.stderr.includes(
+							"Failed to parse suppressions file at",
+						),
 					);
 				});
 
@@ -901,9 +934,10 @@ describe("bin/eslint.js", () => {
 
 				const exitCodeAssertion = assertExitCode(child, 2);
 				const outputAssertion = getOutput(child).then(output => {
-					assert.include(
-						output.stderr,
-						"Failed to parse suppressions file at",
+					assert.ok(
+						output.stderr.includes(
+							"Failed to parse suppressions file at",
+						),
 					);
 				});
 
@@ -915,9 +949,10 @@ describe("bin/eslint.js", () => {
 
 				const exitCodeAssertion = assertExitCode(child, 2);
 				const outputAssertion = getOutput(child).then(output => {
-					assert.include(
-						output.stderr,
-						"Failed to parse suppressions file at",
+					assert.ok(
+						output.stderr.includes(
+							"Failed to parse suppressions file at",
+						),
 					);
 				});
 
@@ -929,9 +964,10 @@ describe("bin/eslint.js", () => {
 
 				const exitCodeAssertion = assertExitCode(child, 2);
 				const outputAssertion = getOutput(child).then(output => {
-					assert.include(
-						output.stderr,
-						"Failed to parse suppressions file at",
+					assert.ok(
+						output.stderr.includes(
+							"Failed to parse suppressions file at",
+						),
 					);
 				});
 
@@ -956,28 +992,31 @@ describe("bin/eslint.js", () => {
 						fs.readFileSync(SUPPRESSIONS_PATH, "utf8"),
 					);
 
-					assert.property(
-						suppressions,
-						"tests/fixtures/suppressions/extra-file.js",
+					assert.ok(
+						"tests/fixtures/suppressions/extra-file.js" in
+							suppressions,
 					);
 				});
 
 				const outputAssertion = getOutput(child).then(output => {
 					// Warnings
-					assert.include(
-						output.stdout,
-						"'e' is assigned a value but never used",
+					assert.ok(
+						output.stdout.includes(
+							"'e' is assigned a value but never used",
+						),
 					);
 
 					// Suppressed errors
-					assert.notInclude(output.stdout, "is not defined");
-					assert.notInclude(
-						output.stdout,
-						"Unexpected comma in middle of array",
+					assert.ok(!output.stdout.includes("is not defined"));
+					assert.ok(
+						!output.stdout.includes(
+							"Unexpected comma in middle of array",
+						),
 					);
-					assert.notInclude(
-						output.stdout,
-						"Expected indentation of 2 spaces but found 4",
+					assert.ok(
+						!output.stdout.includes(
+							"Expected indentation of 2 spaces but found 4",
+						),
 					);
 				});
 
@@ -996,20 +1035,23 @@ describe("bin/eslint.js", () => {
 
 				const outputAssertion = getOutput(child).then(output => {
 					// Warnings
-					assert.include(
-						output.stdout,
-						"'e' is assigned a value but never used",
+					assert.ok(
+						output.stdout.includes(
+							"'e' is assigned a value but never used",
+						),
 					);
 
 					// Suppressed errors
-					assert.notInclude(output.stdout, "is not defined");
-					assert.notInclude(
-						output.stdout,
-						"Unexpected comma in middle of array",
+					assert.ok(!output.stdout.includes("is not defined"));
+					assert.ok(
+						!output.stdout.includes(
+							"Unexpected comma in middle of array",
+						),
 					);
-					assert.notInclude(
-						output.stdout,
-						"Expected indentation of 2 spaces but found 4",
+					assert.ok(
+						!output.stdout.includes(
+							"Expected indentation of 2 spaces but found 4",
+						),
 					);
 				});
 
@@ -1032,22 +1074,25 @@ describe("bin/eslint.js", () => {
 				const exitCodeAssertion = assertExitCode(child, 1);
 				const outputAssertion = getOutput(child).then(output => {
 					// Warnings
-					assert.include(
-						output.stdout,
-						"'e' is assigned a value but never used",
+					assert.ok(
+						output.stdout.includes(
+							"'e' is assigned a value but never used",
+						),
 					);
 
 					// Suppressed errors (but displayed because there is at least one left unmatched)
-					assert.include(output.stdout, "is not defined");
+					assert.ok(output.stdout.includes("is not defined"));
 
 					// Suppressed errors
-					assert.notInclude(
-						output.stdout,
-						"Unexpected comma in middle of array",
+					assert.ok(
+						!output.stdout.includes(
+							"Unexpected comma in middle of array",
+						),
 					);
-					assert.notInclude(
-						output.stdout,
-						"Expected indentation of 2 spaces but found 4",
+					assert.ok(
+						!output.stdout.includes(
+							"Expected indentation of 2 spaces but found 4",
+						),
 					);
 				});
 
@@ -1107,7 +1152,7 @@ describe("bin/eslint.js", () => {
 				const expectedSubstring = "Syntax error in selector";
 
 				assert.strictEqual(output.stdout, "");
-				assert.include(output.stderr, expectedSubstring);
+				assert.ok(output.stderr.includes(expectedSubstring));
 			});
 
 			return Promise.all([exitCodeAssertion, outputAssertion]);
@@ -1124,7 +1169,7 @@ describe("bin/eslint.js", () => {
 				const expectedSubstring = "Syntax error in selector";
 
 				assert.strictEqual(output.stdout, "");
-				assert.include(output.stderr, expectedSubstring);
+				assert.ok(output.stderr.includes(expectedSubstring));
 
 				// The message should appear exactly once in stderr
 				assert.strictEqual(
@@ -1146,11 +1191,11 @@ describe("bin/eslint.js", () => {
 			const exitCodeAssertion = assertExitCode(child, 2);
 			const outputAssertion = getOutput(child).then(output => {
 				// ensure the expected error was printed
-				assert.include(output.stderr, "test_error_stack");
+				assert.ok(output.stderr.includes("test_error_stack"));
 
 				// ensure that linting the file did not cause an error
-				assert.notInclude(output.stderr, "empty.js");
-				assert.notInclude(output.stdout, "empty.js");
+				assert.ok(!output.stderr.includes("empty.js"));
+				assert.ok(!output.stdout.includes("empty.js"));
 			});
 
 			return Promise.all([exitCodeAssertion, outputAssertion]);
@@ -1207,9 +1252,10 @@ describe("bin/eslint.js", () => {
 			const child = runESLint(["--config", config, "conf", "tools"]);
 			const exitCodeAssertion = assertExitCode(child, 2);
 			const outputAssertion = getOutput(child).then(output => {
-				assert.include(
-					output.stderr,
-					'Key "linterOptions": Key "reportUnusedDisableDirectives"',
+				assert.ok(
+					output.stderr.includes(
+						'Key "linterOptions": Key "reportUnusedDisableDirectives"',
+					),
 				);
 			});
 

--- a/tests/conf/eslint-all.js
+++ b/tests/conf/eslint-all.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const eslintAll = require("../../packages/js").configs.all;
 const rules = eslintAll.rules;
 
@@ -21,7 +21,7 @@ describe("eslint-all", () => {
 	it("should only include rules", () => {
 		const ruleNames = Object.keys(rules);
 
-		assert.notInclude(ruleNames, ".eslintrc.yml");
+		assert.ok(!ruleNames.includes(".eslintrc.yml"));
 	});
 
 	it("should return all rules", () => {
@@ -29,8 +29,8 @@ describe("eslint-all", () => {
 		const count = ruleNames.length;
 		const someRule = "yoda";
 
-		assert.include(ruleNames, someRule);
-		assert.isBelow(count, 200);
+		assert.ok(ruleNames.includes(someRule));
+		assert.ok(count < 200);
 	});
 
 	it("should configure all rules as errors", () => {

--- a/tests/conf/eslint-recommended.js
+++ b/tests/conf/eslint-recommended.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const eslintRecommended = require("../../packages/js").configs.recommended;
 const rules = eslintRecommended.rules;
 
@@ -23,6 +23,6 @@ describe("eslint-recommended", () => {
 	});
 
 	it("should not configure non-recommended rules", () => {
-		assert.notProperty(rules, "camelcase");
+		assert.ok(!("camelcase" in rules));
 	});
 });

--- a/tests/lib/api.js
+++ b/tests/lib/api.js
@@ -9,7 +9,7 @@
 // Requirements
 //-----------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	api = require("../../lib/api"),
 	{ LegacyESLint } = require("../../lib/eslint/legacy-eslint");
 
@@ -19,27 +19,27 @@ const assert = require("chai").assert,
 
 describe("api", () => {
 	it("should have ESLint exposed", () => {
-		assert.isFunction(api.ESLint);
+		assert.strictEqual(typeof api.ESLint, "function");
 	});
 
 	it("should have RuleTester exposed", () => {
-		assert.isFunction(api.RuleTester);
+		assert.strictEqual(typeof api.RuleTester, "function");
 	});
 
 	it("should not have CLIEngine exposed", () => {
-		assert.isUndefined(api.CLIEngine);
+		assert.strictEqual(typeof api.CLIEngine, "undefined");
 	});
 
 	it("should not have linter exposed", () => {
-		assert.isUndefined(api.linter);
+		assert.strictEqual(typeof api.linter, "undefined");
 	});
 
 	it("should have Linter exposed", () => {
-		assert.isFunction(api.Linter);
+		assert.strictEqual(typeof api.Linter, "function");
 	});
 
 	it("should have SourceCode exposed", () => {
-		assert.isFunction(api.SourceCode);
+		assert.strictEqual(typeof api.SourceCode, "function");
 	});
 
 	describe("loadESLint", () => {
@@ -48,11 +48,11 @@ describe("api", () => {
 		});
 
 		it("should be a function", () => {
-			assert.isFunction(api.loadESLint);
+			assert.strictEqual(typeof api.loadESLint, "function");
 		});
 
 		it("should return a Promise", () => {
-			assert.instanceOf(api.loadESLint(), Promise);
+			assert.ok(api.loadESLint() instanceof Promise);
 		});
 
 		it("should return ESLint when useFlatConfig is true", async () => {

--- a/tests/lib/cli-engine/file-enumerator.js
+++ b/tests/lib/cli-engine/file-enumerator.js
@@ -11,7 +11,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const os = require("node:os");
-const { assert } = require("chai");
+const assert = require("node:assert");
 const sh = require("shelljs");
 const sinon = require("sinon");
 const {
@@ -19,6 +19,7 @@ const {
 } = require("@eslint/eslintrc");
 const { createCustomTeardown } = require("../../_utils");
 const { FileEnumerator } = require("../../../lib/cli-engine/file-enumerator");
+const escapeRegExp = require("escape-string-regexp");
 
 //------------------------------------------------------------------------------
 // Tests
@@ -379,7 +380,7 @@ describe("FileEnumerator", () => {
 						"baz.js",
 					);
 
-					assert.isArray(result);
+					assert.ok(Array.isArray(result));
 					assert.deepStrictEqual(result, [
 						{ filename: file1, ignored: false },
 					]);
@@ -449,11 +450,17 @@ describe("FileEnumerator", () => {
 						getFixturePath("glob-util", "hidden", "**/*.js"),
 					];
 
-					assert.throws(() => {
-						listFiles(patterns, {
-							cwd: getFixturePath(),
-						});
-					}, `All files matched by '${patterns[0]}' are ignored.`);
+					assert.throws(
+						() => {
+							listFiles(patterns, {
+								cwd: getFixturePath(),
+							});
+						},
+						new RegExp(
+							`All files matched by '${escapeRegExp(patterns[0])}' are ignored.`,
+							"u",
+						),
+					);
 				});
 
 				it("should return hidden files if included in glob pattern", () => {
@@ -480,11 +487,17 @@ describe("FileEnumerator", () => {
 					const directory = getFixturePath("glob-util", "hidden");
 					const patterns = [directory];
 
-					assert.throws(() => {
-						listFiles(patterns, {
-							cwd: getFixturePath(),
-						});
-					}, `All files matched by '${directory}' are ignored.`);
+					assert.throws(
+						() => {
+							listFiles(patterns, {
+								cwd: getFixturePath(),
+							});
+						},
+						new RegExp(
+							`All files matched by '${escapeRegExp(directory)}' are ignored.`,
+							"u",
+						),
+					);
 				});
 
 				it("should ignore and warn for default ignored files when passed explicitly", () => {
@@ -509,12 +522,18 @@ describe("FileEnumerator", () => {
 					const directory = getFixturePath("glob-util", "hidden");
 					const patterns = [directory];
 
-					assert.throws(() => {
-						listFiles(patterns, {
-							cwd: getFixturePath(),
-							ignore: false,
-						});
-					}, `All files matched by '${directory}' are ignored.`);
+					assert.throws(
+						() => {
+							listFiles(patterns, {
+								cwd: getFixturePath(),
+								ignore: false,
+							});
+						},
+						new RegExp(
+							`All files matched by '${escapeRegExp(directory)}' are ignored.`,
+							"u",
+						),
+					);
 				});
 
 				it("should not ignore default ignored files when passed explicitly if ignore is false", () => {
@@ -544,23 +563,35 @@ describe("FileEnumerator", () => {
 					);
 					const patterns = [filename];
 
-					assert.throws(() => {
-						listFiles(patterns, {
-							cwd: getFixturePath(),
-							allowMissingGlobs: true,
-						});
-					}, `No files matching '${filename}' were found.`);
+					assert.throws(
+						() => {
+							listFiles(patterns, {
+								cwd: getFixturePath(),
+								allowMissingGlobs: true,
+							});
+						},
+						new RegExp(
+							`No files matching '${escapeRegExp(filename)}' were found.`,
+							"u",
+						),
+					);
 				});
 
 				it("should throw if a folder that does not have any applicable files is linted", () => {
 					const filename = getFixturePath("glob-util", "empty");
 					const patterns = [filename];
 
-					assert.throws(() => {
-						listFiles(patterns, {
-							cwd: getFixturePath(),
-						});
-					}, `No files matching '${filename}' were found.`);
+					assert.throws(
+						() => {
+							listFiles(patterns, {
+								cwd: getFixturePath(),
+							});
+						},
+						new RegExp(
+							`No files matching '${escapeRegExp(filename)}' were found.`,
+							"u",
+						),
+					);
 				});
 
 				it("should throw if only ignored files match a glob", () => {
@@ -574,19 +605,31 @@ describe("FileEnumerator", () => {
 						),
 					};
 
-					assert.throws(() => {
-						listFiles([pattern], options);
-					}, `All files matched by '${pattern}' are ignored.`);
+					assert.throws(
+						() => {
+							listFiles([pattern], options);
+						},
+						new RegExp(
+							`All files matched by '${escapeRegExp(pattern)}' are ignored.`,
+							"u",
+						),
+					);
 				});
 
 				it("should throw an error if no files match a glob", () => {
 					const patterns = ["dir-does-not-exist/**/*.js"];
 
-					assert.throws(() => {
-						listFiles(patterns, {
-							cwd: getFixturePath("ignored-paths"),
-						});
-					}, `No files matching '${patterns[0]}' were found.`);
+					assert.throws(
+						() => {
+							listFiles(patterns, {
+								cwd: getFixturePath("ignored-paths"),
+							});
+						},
+						new RegExp(
+							`No files matching '${escapeRegExp(patterns[0])}' were found.`,
+							"u",
+						),
+					);
 				});
 
 				it("should return an ignored file, if ignore option is turned off", () => {
@@ -612,9 +655,15 @@ describe("FileEnumerator", () => {
 						getFixturePath("glob-util", "ignored", "**/*.js"),
 					];
 
-					assert.throws(() => {
-						listFiles(patterns, options);
-					}, `All files matched by '${patterns[0]}' are ignored.`);
+					assert.throws(
+						() => {
+							listFiles(patterns, options);
+						},
+						new RegExp(
+							`All files matched by '${escapeRegExp(patterns[0])}' are ignored.`,
+							"u",
+						),
+					);
 				});
 
 				it("should ignore a file from a glob if matching a specified ignore pattern", () => {
@@ -627,9 +676,15 @@ describe("FileEnumerator", () => {
 						getFixturePath("glob-util", "ignored", "**/*.js"),
 					];
 
-					assert.throws(() => {
-						listFiles(patterns, options);
-					}, `All files matched by '${patterns[0]}' are ignored.`);
+					assert.throws(
+						() => {
+							listFiles(patterns, options);
+						},
+						new RegExp(
+							`All files matched by '${escapeRegExp(patterns[0])}' are ignored.`,
+							"u",
+						),
+					);
 				});
 
 				it("should return a file only once if listed in more than 1 pattern", () => {
@@ -647,7 +702,7 @@ describe("FileEnumerator", () => {
 						"baz.js",
 					);
 
-					assert.isArray(result);
+					assert.ok(Array.isArray(result));
 					assert.deepStrictEqual(result, [
 						{ filename: file1, ignored: false },
 					]);
@@ -682,12 +737,13 @@ describe("FileEnumerator", () => {
 						resultObj => resultObj.filename,
 					);
 
-					assert.notInclude(
-						resultFilenames,
-						getFixturePath(
-							"glob-util",
-							"node_modules",
-							"dependency.js",
+					assert.ok(
+						!resultFilenames.includes(
+							getFixturePath(
+								"glob-util",
+								"node_modules",
+								"dependency.js",
+							),
 						),
 					);
 				});
@@ -708,9 +764,16 @@ describe("FileEnumerator", () => {
 						"dependency.js",
 					);
 
-					assert.includeDeepMembers(result, [
-						{ filename: unignoredFilename, ignored: false },
-					]);
+					const expectedObject = {
+						filename: unignoredFilename,
+						ignored: false,
+					};
+					const found = result.some(
+						item =>
+							item.filename === expectedObject.filename &&
+							item.ignored === expectedObject.ignored,
+					);
+					assert.strictEqual(found, true);
 				});
 
 				it("should return unignored files from folders unignored in .eslintignore", () => {

--- a/tests/lib/cli-engine/formatters/html.js
+++ b/tests/lib/cli-engine/formatters/html.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const formatter = require("../../../../lib/cli-engine/formatters/html");
 const cheerio = require("cheerio");
 
@@ -24,7 +24,10 @@ const cheerio = require("cheerio");
  * @returns {void}
  */
 function checkOverview($, args) {
-	assert($("#overview").hasClass(args.bgColor), "Check if color is correct");
+	assert.ok(
+		$("#overview").hasClass(args.bgColor),
+		"Check if color is correct",
+	);
 	assert.strictEqual(
 		$("#overview span").text(),
 		args.problems,
@@ -42,7 +45,7 @@ function checkOverview($, args) {
 function checkHeaderRow($, rowObject, args) {
 	const row = $(rowObject);
 
-	assert(
+	assert.ok(
 		row.hasClass(args.bgColor),
 		"Check that background color is correct",
 	);
@@ -78,13 +81,13 @@ function checkHeaderRow($, rowObject, args) {
 function checkContentRow($, rowObject, args) {
 	const row = $(rowObject);
 
-	assert(row.hasClass(args.group), "Check that linked to correct header");
+	assert.ok(row.hasClass(args.group), "Check that linked to correct header");
 	assert.strictEqual(
 		$(row.find("td")[0]).text(),
 		args.lineCol,
 		"Check that line:column is correct",
 	);
-	assert(
+	assert.ok(
 		$(row.find("td")[1]).hasClass(args.color),
 		"Check that severity color is correct",
 	);

--- a/tests/lib/cli-engine/formatters/json-with-metadata.js
+++ b/tests/lib/cli-engine/formatters/json-with-metadata.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	formatter = require("../../../../lib/cli-engine/formatters/json-with-metadata");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/cli-engine/formatters/json.js
+++ b/tests/lib/cli-engine/formatters/json.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	formatter = require("../../../../lib/cli-engine/formatters/json");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/cli-engine/formatters/stylish.js
+++ b/tests/lib/cli-engine/formatters/stylish.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	chalk = require("chalk"),
 	proxyquire = require("proxyquire"),
 	sinon = require("sinon");
@@ -423,7 +423,7 @@ describe("formatter:stylish", () => {
 
 			const result = formatter(code);
 
-			assert.notInclude(result, "potentially fixable");
+			assert.ok(!result.includes("potentially fixable"));
 		});
 
 		it("should output the fixable problems message when errors are fixable", () => {
@@ -448,9 +448,10 @@ describe("formatter:stylish", () => {
 
 			const result = formatter(code);
 
-			assert.include(
-				result,
-				"  1 error and 0 warnings potentially fixable with the `--fix` option.\n",
+			assert.ok(
+				result.includes(
+					"  1 error and 0 warnings potentially fixable with the `--fix` option.\n",
+				),
 			);
 		});
 
@@ -472,9 +473,10 @@ describe("formatter:stylish", () => {
 
 			const result = formatter(code);
 
-			assert.include(
-				result,
-				"  0 errors and 2 warnings potentially fixable with the `--fix` option.\n",
+			assert.ok(
+				result.includes(
+					"  0 errors and 2 warnings potentially fixable with the `--fix` option.\n",
+				),
 			);
 		});
 
@@ -508,9 +510,10 @@ describe("formatter:stylish", () => {
 
 			const result = formatter(code);
 
-			assert.include(
-				result,
-				"  9 errors and 3 warnings potentially fixable with the `--fix` option.\n",
+			assert.ok(
+				result.includes(
+					"  9 errors and 3 warnings potentially fixable with the `--fix` option.\n",
+				),
 			);
 		});
 	});

--- a/tests/lib/cli-engine/lint-result-cache.js
+++ b/tests/lib/cli-engine/lint-result-cache.js
@@ -8,7 +8,7 @@
 // Requirements
 //-----------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	{ CLIEngine } = require("../../../lib/cli-engine"),
 	fs = require("node:fs"),
 	path = require("node:path"),
@@ -218,7 +218,7 @@ describe("LintResultCache", () => {
 				);
 
 				assert.ok(getFileDescriptorStub.calledOnce);
-				assert.isNull(result);
+				assert.strictEqual(result, null);
 			});
 		});
 
@@ -234,7 +234,7 @@ describe("LintResultCache", () => {
 				);
 
 				assert.ok(getFileDescriptorStub.calledOnce);
-				assert.isNull(result);
+				assert.strictEqual(result, null);
 			});
 		});
 
@@ -251,7 +251,7 @@ describe("LintResultCache", () => {
 				);
 
 				assert.ok(getFileDescriptorStub.calledOnce);
-				assert.isNull(result);
+				assert.strictEqual(result, null);
 			});
 		});
 
@@ -318,8 +318,8 @@ describe("LintResultCache", () => {
 					fakeErrorResultsAutofix,
 				);
 
-				assert.notProperty(cacheEntry.meta, "results");
-				assert.notProperty(cacheEntry.meta, "hashOfConfig");
+				assert.ok(!("results" in cacheEntry.meta));
+				assert.ok(!("hashOfConfig" in cacheEntry.meta));
 			});
 		});
 
@@ -335,8 +335,8 @@ describe("LintResultCache", () => {
 					fakeErrorResults,
 				);
 
-				assert.notProperty(cacheEntry.meta, "results");
-				assert.notProperty(cacheEntry.meta, "hashOfConfig");
+				assert.ok(!("results" in cacheEntry.meta));
+				assert.ok(!("hashOfConfig" in cacheEntry.meta));
 			});
 		});
 
@@ -424,7 +424,7 @@ describe("LintResultCache", () => {
 		it("calls reconcile on the underlying cache", () => {
 			lintResultsCache.reconcile();
 
-			assert.isTrue(reconcileStub.calledOnce);
+			assert.strictEqual(reconcileStub.calledOnce, true);
 		});
 	});
 });

--- a/tests/lib/cli-engine/load-rules.js
+++ b/tests/lib/cli-engine/load-rules.js
@@ -9,7 +9,7 @@
 // Requirements
 //-----------------------------------------------------------------------------
 
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const loadRules = require("../../../lib/cli-engine/load-rules");
 
 //-----------------------------------------------------------------------------

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -14,8 +14,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
-	stdAssert = require("node:assert"),
+const assert = require("node:assert"),
 	{ ESLint, LegacyESLint } = require("../../lib/eslint"),
 	BuiltinRules = require("../../lib/rules"),
 	path = require("node:path"),
@@ -205,7 +204,7 @@ describe("cli", () => {
 					);
 
 					assert.strictEqual(result, 0);
-					assert.isTrue(log.info.notCalled);
+					assert.strictEqual(log.info.notCalled, true);
 				});
 
 				it(`should exit with console error when passed unsupported arguments with configType:${configType}`, async () => {
@@ -465,7 +464,7 @@ describe("cli", () => {
 								log.info.args[0][0],
 							);
 
-							assert.notProperty(metadata, "maxWarningsExceeded");
+							assert.ok(!("maxWarningsExceeded" in metadata));
 						});
 					});
 				});
@@ -655,8 +654,9 @@ describe("cli", () => {
 						useFlatConfig,
 					);
 
-					assert.isTrue(
+					assert.strictEqual(
 						log.info.called,
+						true,
 						"Log should have been called.",
 					);
 
@@ -667,7 +667,7 @@ describe("cli", () => {
 						null,
 						useFlatConfig,
 					);
-					assert.isTrue(log.info.notCalled);
+					assert.strictEqual(log.info.notCalled, true);
 				});
 			});
 
@@ -779,7 +779,7 @@ describe("cli", () => {
 							useFlatConfig,
 						);
 
-						assert.isTrue(log.info.calledOnce);
+						assert.strictEqual(log.info.calledOnce, true);
 						assert.strictEqual(exit, 1);
 					});
 
@@ -791,7 +791,7 @@ describe("cli", () => {
 							useFlatConfig,
 						);
 
-						assert.isTrue(log.info.notCalled);
+						assert.strictEqual(log.info.notCalled, true);
 						assert.strictEqual(exit, 0);
 					});
 
@@ -803,7 +803,7 @@ describe("cli", () => {
 							useFlatConfig,
 						);
 
-						assert.isTrue(log.info.notCalled);
+						assert.strictEqual(log.info.notCalled, true);
 						assert.strictEqual(exit, 0);
 					});
 				});
@@ -833,9 +833,8 @@ describe("cli", () => {
 
 						const formattedOutput = log.info.firstCall.args[0];
 
-						assert.include(
-							formattedOutput,
-							"(1 error, 0 warnings)",
+						assert.ok(
+							formattedOutput.includes("(1 error, 0 warnings)"),
 						);
 					});
 
@@ -872,7 +871,7 @@ describe("cli", () => {
 							);
 							const cliArgs = `--quiet --max-warnings=1 --config ${configPath}' ${filePath}`;
 
-							await stdAssert.rejects(async () => {
+							await assert.rejects(async () => {
 								await cli.execute(cliArgs, null, useFlatConfig);
 							});
 						});
@@ -889,7 +888,7 @@ describe("cli", () => {
 								filePath = filePath.replace(/\\/gu, "/");
 							}
 
-							await stdAssert.rejects(
+							await assert.rejects(
 								async () => {
 									await cli.execute(
 										`"${filePath}/${globPattern}"`,
@@ -1041,9 +1040,12 @@ describe("cli", () => {
 
 						assert.strictEqual(exitCode, 1);
 						assert.ok(log.error.calledOnce);
-						assert.include(
-							log.error.getCall(0).args[0],
-							"ESLint found too many warnings",
+						assert.ok(
+							log.error
+								.getCall(0)
+								.args[0].includes(
+									"ESLint found too many warnings",
+								),
 						);
 					});
 
@@ -1056,9 +1058,12 @@ describe("cli", () => {
 
 						assert.strictEqual(exitCode, 1);
 						assert.ok(log.error.calledOnce);
-						assert.include(
-							log.error.getCall(0).args[0],
-							"ESLint found too many warnings",
+						assert.ok(
+							log.error
+								.getCall(0)
+								.args[0].includes(
+									"ESLint found too many warnings",
+								),
 						);
 						assert.ok(log.info.notCalled); // didn't print warnings
 					});
@@ -1150,7 +1155,7 @@ describe("cli", () => {
 								? `All files matched by '${filePath.replace(/\\/gu, "/")}' are ignored.`
 								: `All files matched by '${filePath}' are ignored.`;
 
-							await stdAssert.rejects(async () => {
+							await assert.rejects(async () => {
 								await cli.execute(
 									`${options} ${filePath}`,
 									null,
@@ -1173,7 +1178,7 @@ describe("cli", () => {
 							);
 
 							// a warning about the ignored file
-							assert.isTrue(log.info.called);
+							assert.strictEqual(log.info.called, true);
 							assert.strictEqual(exit, 0);
 						});
 
@@ -1189,7 +1194,7 @@ describe("cli", () => {
 							);
 
 							// no warnings
-							assert.isFalse(log.info.called);
+							assert.strictEqual(log.info.called, false);
 							assert.strictEqual(exit, 0);
 						});
 
@@ -1204,7 +1209,7 @@ describe("cli", () => {
 								useFlatConfig,
 							);
 
-							assert.isFalse(log.info.called);
+							assert.strictEqual(log.info.called, false);
 
 							// When eslintrc is used, we get an exit code of 2 because the --no-warn-ignored option is unrecognized.
 							assert.strictEqual(exit, useFlatConfig ? 0 : 2);
@@ -1217,7 +1222,7 @@ describe("cli", () => {
 								useFlatConfig,
 							);
 
-							assert.isFalse(log.info.called);
+							assert.strictEqual(log.info.called, false);
 							assert.strictEqual(exit, 0);
 						});
 
@@ -1232,7 +1237,7 @@ describe("cli", () => {
 								useFlatConfig,
 							);
 
-							assert.isFalse(log.info.called);
+							assert.strictEqual(log.info.called, false);
 
 							// When eslintrc is used, we get an exit code of 2 because the --no-warn-ignored option is unrecognized.
 							assert.strictEqual(exit, useFlatConfig ? 0 : 2);
@@ -1258,7 +1263,7 @@ describe("cli", () => {
 							);
 
 							// warnings about the ignored files
-							assert.isTrue(log.info.called);
+							assert.strictEqual(log.info.called, true);
 							assert.strictEqual(exit, 0);
 						});
 
@@ -1280,7 +1285,7 @@ describe("cli", () => {
 
 							assert.strictEqual(exit, 0);
 
-							await stdAssert.rejects(
+							await assert.rejects(
 								async () =>
 									await cli.execute(
 										"**/*.js --ignore-pattern subsubdir/*.js",
@@ -1297,7 +1302,7 @@ describe("cli", () => {
 									"cli/ignore-pattern-relative/subdir/subsubdir",
 								);
 
-							await stdAssert.rejects(
+							await assert.rejects(
 								async () =>
 									await cli.execute(
 										"**/*.js --ignore-pattern *.js",
@@ -1320,7 +1325,7 @@ describe("cli", () => {
 								);
 
 								// parsing error causes exit code 1
-								assert.isTrue(log.info.called);
+								assert.strictEqual(log.info.called, true);
 								assert.strictEqual(exit, 0);
 							});
 
@@ -1335,7 +1340,7 @@ describe("cli", () => {
 								);
 
 								// parsing error causes exit code 1
-								assert.isTrue(log.info.called);
+								assert.strictEqual(log.info.called, true);
 								assert.strictEqual(exit, 0);
 							});
 						}
@@ -1347,7 +1352,7 @@ describe("cli", () => {
 				it(`should exit with a fatal error if parser is invalid with configType:${configType}`, async () => {
 					const filePath = getFixturePath("passing.js");
 
-					await stdAssert.rejects(
+					await assert.rejects(
 						async () =>
 							await cli.execute(
 								`--no-ignore --parser test111 ${filePath}`,
@@ -1388,14 +1393,15 @@ describe("cli", () => {
 
 					await cli.execute(code, null, useFlatConfig);
 
-					assert.include(
-						fs.readFileSync(
-							"tests/output/eslint-output.txt",
-							"utf8",
-						),
-						filePath,
+					assert.ok(
+						fs
+							.readFileSync(
+								"tests/output/eslint-output.txt",
+								"utf8",
+							)
+							.includes(filePath),
 					);
-					assert.isTrue(log.info.notCalled);
+					assert.strictEqual(log.info.notCalled, true);
 				});
 
 				// https://github.com/eslint/eslint/issues/17660
@@ -1406,8 +1412,9 @@ describe("cli", () => {
 					// TODO: fix this test to: await cli.execute(code, null, useFlatConfig);
 					await cli.execute(code, "var a = 'b'", useFlatConfig);
 
-					assert.isTrue(
+					assert.strictEqual(
 						fs.existsSync("tests/output/eslint-output.txt"),
+						true,
 					);
 					assert.strictEqual(
 						fs.readFileSync(
@@ -1416,7 +1423,7 @@ describe("cli", () => {
 						),
 						"",
 					);
-					assert.isTrue(log.info.notCalled);
+					assert.strictEqual(log.info.notCalled, true);
 				});
 
 				it(`should return an error if the path is a directory with configType:${configType}`, async () => {
@@ -1428,8 +1435,8 @@ describe("cli", () => {
 					const exit = await cli.execute(code, null, useFlatConfig);
 
 					assert.strictEqual(exit, 2);
-					assert.isTrue(log.info.notCalled);
-					assert.isTrue(log.error.calledOnce);
+					assert.strictEqual(log.info.notCalled, true);
+					assert.strictEqual(log.error.calledOnce, true);
 				});
 
 				it(`should return an error if the path could not be written to with configType:${configType}`, async () => {
@@ -1441,8 +1448,8 @@ describe("cli", () => {
 					const exit = await cli.execute(code, null, useFlatConfig);
 
 					assert.strictEqual(exit, 2);
-					assert.isTrue(log.info.notCalled);
-					assert.isTrue(log.error.calledOnce);
+					assert.strictEqual(log.info.notCalled, true);
+					assert.strictEqual(log.error.calledOnce, true);
 				});
 			});
 
@@ -2018,7 +2025,7 @@ describe("cli", () => {
 						useFlatConfig,
 					);
 
-					assert.isTrue(log.info.calledOnce);
+					assert.strictEqual(log.info.calledOnce, true);
 					assert.strictEqual(exitCode, 0);
 				});
 
@@ -2032,8 +2039,8 @@ describe("cli", () => {
 						useFlatConfig,
 					);
 
-					assert.isTrue(log.info.notCalled);
-					assert.isTrue(log.error.calledOnce);
+					assert.strictEqual(log.info.notCalled, true);
+					assert.strictEqual(log.error.calledOnce, true);
 					assert.strictEqual(exitCode, 2);
 				});
 
@@ -2044,8 +2051,8 @@ describe("cli", () => {
 						useFlatConfig,
 					);
 
-					assert.isTrue(log.info.notCalled);
-					assert.isTrue(log.error.calledOnce);
+					assert.strictEqual(log.info.notCalled, true);
+					assert.strictEqual(log.error.calledOnce, true);
 					assert.strictEqual(exitCode, 2);
 				});
 			});
@@ -2494,7 +2501,7 @@ describe("cli", () => {
 					);
 					const code = `--rulesdir ${rulesPath} --config ${configPath} --no-ignore ${filePath}`;
 
-					await stdAssert.rejects(async () => {
+					await assert.rejects(async () => {
 						const exit = await cli.execute(code, null, false);
 
 						assert.strictEqual(exit, 2);
@@ -2513,8 +2520,8 @@ describe("cli", () => {
 
 					await cli.execute(code, null, false);
 
-					assert.isTrue(log.info.calledOnce);
-					assert.isTrue(log.info.neverCalledWith(""));
+					assert.strictEqual(log.info.calledOnce, true);
+					assert.strictEqual(log.info.neverCalledWith(""), true);
 				});
 
 				it("should return warnings from multiple rules in different directories", async () => {
@@ -2533,11 +2540,14 @@ describe("cli", () => {
 
 					const call = log.info.getCall(0);
 
-					assert.isTrue(log.info.calledOnce);
-					assert.isTrue(call.args[0].includes("String!"));
-					assert.isTrue(call.args[0].includes("Literal!"));
-					assert.isTrue(call.args[0].includes("2 problems"));
-					assert.isTrue(log.info.neverCalledWith(""));
+					assert.strictEqual(log.info.calledOnce, true);
+					assert.strictEqual(call.args[0].includes("String!"), true);
+					assert.strictEqual(call.args[0].includes("Literal!"), true);
+					assert.strictEqual(
+						call.args[0].includes("2 problems"),
+						true,
+					);
+					assert.strictEqual(log.info.neverCalledWith(""), true);
 					assert.strictEqual(exit, 1);
 				});
 			});
@@ -2551,7 +2561,7 @@ describe("cli", () => {
 						false,
 					);
 
-					assert.isTrue(log.info.notCalled);
+					assert.strictEqual(log.info.notCalled, true);
 					assert.strictEqual(exit, 0);
 				});
 			});
@@ -2565,7 +2575,7 @@ describe("cli", () => {
 						false,
 					);
 
-					assert.isTrue(log.info.calledOnce);
+					assert.strictEqual(log.info.calledOnce, true);
 					assert.strictEqual(exit, 1);
 				});
 			});
@@ -2641,9 +2651,8 @@ describe("cli", () => {
 
 					assert.strictEqual(exitCode, 1);
 					assert.ok(log.info.calledOnce);
-					assert.include(
-						log.info.firstCall.firstArg,
-						"Hello CommonJS!",
+					assert.ok(
+						log.info.firstCall.firstArg.includes("Hello CommonJS!"),
 					);
 				});
 
@@ -2655,7 +2664,9 @@ describe("cli", () => {
 
 					assert.strictEqual(exitCode, 1);
 					assert.ok(log.info.calledOnce);
-					assert.include(log.info.firstCall.firstArg, "Hello ESM!");
+					assert.ok(
+						log.info.firstCall.firstArg.includes("Hello ESM!"),
+					);
 				});
 
 				it("should load multiple plugins", async () => {
@@ -2666,11 +2677,12 @@ describe("cli", () => {
 
 					assert.strictEqual(exitCode, 1);
 					assert.ok(log.info.calledOnce);
-					assert.include(
-						log.info.firstCall.firstArg,
-						"Hello CommonJS!",
+					assert.ok(
+						log.info.firstCall.firstArg.includes("Hello CommonJS!"),
 					);
-					assert.include(log.info.firstCall.firstArg, "Hello ESM!");
+					assert.ok(
+						log.info.firstCall.firstArg.includes("Hello ESM!"),
+					);
 				});
 
 				it("should resolve plugins specified with 'eslint-plugin-'", async () => {
@@ -2695,10 +2707,10 @@ describe("cli", () => {
 					const code =
 						"--plugin 'example, no-such-plugin' ../passing.js";
 
-					await stdAssert.rejects(
+					await assert.rejects(
 						cli.execute(code, null, true),
 						({ message }) => {
-							assert(
+							assert.ok(
 								message.startsWith(
 									"Cannot find module 'eslint-plugin-no-such-plugin'\n",
 								),
@@ -2713,7 +2725,7 @@ describe("cli", () => {
 					const code =
 						"--plugin 'example, throws-on-load' ../passing.js";
 
-					await stdAssert.rejects(cli.execute(code, null, true), {
+					await assert.rejects(cli.execute(code, null, true), {
 						message: "error thrown while loading this module",
 					});
 				});
@@ -2722,7 +2734,7 @@ describe("cli", () => {
 					const code =
 						"--plugin 'example, no-default-export' ../passing.js";
 
-					await stdAssert.rejects(cli.execute(code, null, true), {
+					await assert.rejects(cli.execute(code, null, true), {
 						message:
 							'"eslint-plugin-no-default-export" cannot be used with the `--plugin` option because its default module does not provide a `default` export',
 					});
@@ -2748,7 +2760,7 @@ describe("cli", () => {
 					const filePath = getFixturePath("passing.js");
 					const input = `--flag test_only_abandoned --config ${configPath} ${filePath}`;
 
-					await stdAssert.rejects(async () => {
+					await assert.rejects(async () => {
 						await cli.execute(input, null, true);
 					}, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned\./u);
 				});
@@ -2758,7 +2770,7 @@ describe("cli", () => {
 					const filePath = getFixturePath("passing.js");
 					const input = `--flag test_only_oldx --config ${configPath} ${filePath}`;
 
-					await stdAssert.rejects(async () => {
+					await assert.rejects(async () => {
 						await cli.execute(input, null, true);
 					}, /Unknown flag 'test_only_oldx'\./u);
 				});
@@ -3125,7 +3137,7 @@ describe("cli", () => {
 				const flag = "unstable_config_lookup_from_file";
 
 				it("should throw an error when text is passed and no config file is found", async () => {
-					await stdAssert.rejects(
+					await assert.rejects(
 						() =>
 							cli.execute(
 								`--flag ${flag} --stdin --stdin-filename /foo.js"`,

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -10,7 +10,7 @@
 //-----------------------------------------------------------------------------
 
 const { FlatConfigArray } = require("../../../lib/config/flat-config-array");
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const stringify = require("json-stable-stringify-without-jsonify");
 const espree = require("espree");
 const jslang = require("../../../lib/languages/js");
@@ -194,13 +194,13 @@ async function assertMergedResult(values, result) {
 		);
 	}
 
-	assert.deepStrictEqual(config, result);
+	assert.deepStrictEqual({ ...config }, result);
 }
 
 /**
  * Asserts that a given set of configs results in an invalid config.
  * @param {*[]} values An array of configs to use in the config array.
- * @param {string|RegExp} message The expected error message.
+ * @param {RegExp} message The expected error message.
  * @returns {void}
  * @throws {AssertionError} If the config is valid or if the error
  *      has an unexpected message.
@@ -887,14 +887,14 @@ describe("FlatConfigArray", () => {
 		it("should error on 'eslint:recommended' string config", async () => {
 			await assertInvalidConfig(
 				["eslint:recommended"],
-				"Config (unnamed): Unexpected non-object config at original index 0.",
+				/Config \(unnamed\): Unexpected non-object config at original index 0./u,
 			);
 		});
 
 		it("should error on 'eslint:all' string config", async () => {
 			await assertInvalidConfig(
 				["eslint:all"],
-				"Config (unnamed): Unexpected non-object config at original index 0.",
+				/Config \(unnamed\): Unexpected non-object config at original index 0./u,
 			);
 		});
 
@@ -903,7 +903,7 @@ describe("FlatConfigArray", () => {
 
 			assert.throws(() => {
 				configs.normalizeSync();
-			}, "Config (unnamed): Unexpected undefined config at original index 0.");
+			}, /Config \(unnamed\): Unexpected undefined config at original index 0./u);
 		});
 
 		it("should throw an error when undefined original config is normalized asynchronously", async () => {
@@ -925,7 +925,7 @@ describe("FlatConfigArray", () => {
 
 			assert.throws(() => {
 				configs.normalizeSync();
-			}, "Config (unnamed): Unexpected null config at original index 0.");
+			}, /Config \(unnamed\): Unexpected null config at original index 0./u);
 		});
 
 		it("should throw an error when null original config is normalized asynchronously", async () => {
@@ -947,7 +947,7 @@ describe("FlatConfigArray", () => {
 
 			assert.throws(() => {
 				configs.normalizeSync();
-			}, "Config (unnamed): Unexpected undefined config at base index 0.");
+			}, /Config \(unnamed\): Unexpected undefined config at base index 0./u);
 		});
 
 		it("should throw an error when undefined base config is normalized asynchronously", async () => {
@@ -969,7 +969,7 @@ describe("FlatConfigArray", () => {
 
 			assert.throws(() => {
 				configs.normalizeSync();
-			}, "Config (unnamed): Unexpected null config at base index 0.");
+			}, /Config \(unnamed\): Unexpected null config at base index 0./u);
 		});
 
 		it("should throw an error when null base config is normalized asynchronously", async () => {
@@ -993,7 +993,7 @@ describe("FlatConfigArray", () => {
 
 			assert.throws(() => {
 				configs.normalizeSync();
-			}, "Config (unnamed): Unexpected undefined config at user-defined index 0.");
+			}, /Config \(unnamed\): Unexpected undefined config at user-defined index 0./u);
 		});
 
 		it("should throw an error when undefined user-defined config is normalized asynchronously", async () => {
@@ -1019,7 +1019,7 @@ describe("FlatConfigArray", () => {
 
 			assert.throws(() => {
 				configs.normalizeSync();
-			}, "Config (unnamed): Unexpected null config at user-defined index 0.");
+			}, /Config \(unnamed\): Unexpected null config at user-defined index 0./u);
 		});
 
 		it("should throw an error when null user-defined config is normalized asynchronously", async () => {
@@ -1242,7 +1242,7 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					],
-					'Cannot redefine plugin "a".',
+					/Cannot redefine plugin "a"./u,
 				);
 			});
 
@@ -1255,7 +1255,7 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					],
-					'Key "a": Expected an object.',
+					/Key "a": Expected an object./u,
 				);
 			});
 		});
@@ -1330,7 +1330,7 @@ describe("FlatConfigArray", () => {
 							processor: "foo",
 						},
 					],
-					"pluginName/objectName",
+					/pluginName\/objectName/u,
 				);
 			});
 
@@ -1341,7 +1341,7 @@ describe("FlatConfigArray", () => {
 							processor: "",
 						},
 					],
-					"pluginName/objectName",
+					/pluginName\/objectName/u,
 				);
 			});
 
@@ -1352,7 +1352,7 @@ describe("FlatConfigArray", () => {
 							processor: {},
 						},
 					],
-					"Object must have a preprocess() and a postprocess() method.",
+					/Object must have a preprocess\(\) and a postprocess\(\) method./u,
 				);
 			});
 
@@ -1381,7 +1381,7 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					],
-					'Unexpected key "foo" found.',
+					/Unexpected key "foo" found./u,
 				);
 			});
 
@@ -1395,7 +1395,7 @@ describe("FlatConfigArray", () => {
 								},
 							},
 						],
-						"Expected a Boolean.",
+						/Expected a Boolean./u,
 					);
 				});
 
@@ -1586,7 +1586,7 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					],
-					'Unexpected key "foo" found.',
+					/Unexpected key "foo" found./u,
 				);
 			});
 
@@ -1728,7 +1728,10 @@ describe("FlatConfigArray", () => {
 
 				const config = configs.getConfig("file.my");
 
-				assert.isObject(config.languageOptions);
+				assert.ok(
+					config.languageOptions !== null &&
+						typeof config.languageOptions === "object",
+				);
 				assert.strictEqual(
 					Object.keys(config.languageOptions).length,
 					0,
@@ -1829,7 +1832,7 @@ describe("FlatConfigArray", () => {
 								},
 							},
 						],
-						'Expected "script", "module", or "commonjs".',
+						/Expected "script", "module", or "commonjs"./u,
 					);
 				});
 
@@ -1918,7 +1921,7 @@ describe("FlatConfigArray", () => {
 								},
 							},
 						],
-						"Expected an object.",
+						/Expected an object./u,
 					);
 				});
 
@@ -1934,7 +1937,7 @@ describe("FlatConfigArray", () => {
 								},
 							},
 						],
-						'Key "foo": Expected "readonly", "writable", or "off".',
+						/Key "foo": Expected "readonly", "writable", or "off"./u,
 					);
 				});
 
@@ -2124,7 +2127,7 @@ describe("FlatConfigArray", () => {
 								},
 							},
 						],
-						'Key "languageOptions": Key "parser": Expected object with parse() or parseForESLint() method.',
+						/Key "languageOptions": Key "parser": Expected object with parse\(\) or parseForESLint\(\) method./u,
 					);
 				});
 
@@ -2138,7 +2141,7 @@ describe("FlatConfigArray", () => {
 								},
 							},
 						],
-						'Key "languageOptions": Key "parser": Expected object with parse() or parseForESLint() method.',
+						/Key "languageOptions": Key "parser": Expected object with parse\(\) or parseForESLint\(\) method./u,
 					);
 				});
 
@@ -2152,7 +2155,7 @@ describe("FlatConfigArray", () => {
 								},
 							},
 						],
-						'Key "languageOptions": Key "parser": Expected object with parse() or parseForESLint() method.',
+						/Key "languageOptions": Key "parser": Expected object with parse\(\) or parseForESLint\(\) method./u,
 					);
 				});
 
@@ -2166,7 +2169,7 @@ describe("FlatConfigArray", () => {
 								},
 							},
 						],
-						'Key "languageOptions": Key "parser": Expected object with parse() or parseForESLint() method.',
+						/Key "languageOptions": Key "parser": Expected object with parse\(\) or parseForESLint\(\) method./u,
 					);
 				});
 
@@ -2265,7 +2268,7 @@ describe("FlatConfigArray", () => {
 								},
 							},
 						],
-						"Expected an object.",
+						/Expected an object./u,
 					);
 				});
 
@@ -2470,7 +2473,7 @@ describe("FlatConfigArray", () => {
 							rules: true,
 						},
 					],
-					"Expected an object.",
+					/Expected an object./u,
 				);
 			});
 
@@ -2483,7 +2486,7 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					],
-					'Key "rules": Key "foo": Expected severity of "off", 0, "warn", 1, "error", or 2.',
+					/Key "rules": Key "foo": Expected severity of "off", 0, "warn", 1, "error", or 2./u,
 				);
 			});
 
@@ -2496,7 +2499,7 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					],
-					'Key "rules": Key "foo": Expected severity of "off", 0, "warn", 1, "error", or 2.',
+					/Key "rules": Key "foo": Expected severity of "off", 0, "warn", 1, "error", or 2./u,
 				);
 			});
 
@@ -2509,7 +2512,7 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					],
-					'Key "rules": Key "foo": Expected severity of "off", 0, "warn", 1, "error", or 2.',
+					/Key "rules": Key "foo": Expected severity of "off", 0, "warn", 1, "error", or 2./u,
 				);
 			});
 
@@ -2522,7 +2525,7 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					],
-					'Key "rules": Key "foo": Expected severity of "off", 0, "warn", 1, "error", or 2.',
+					/Key "rules": Key "foo": Expected severity of "off", 0, "warn", 1, "error", or 2./u,
 				);
 			});
 
@@ -2612,7 +2615,7 @@ describe("FlatConfigArray", () => {
 								},
 							},
 						],
-						"Error while processing options validation schema of rule 'foo/bar': Rule's `meta.schema` must be an array or object",
+						/Error while processing options validation schema of rule 'foo\/bar': Rule's `meta.schema` must be an array or object/u,
 					);
 				});
 			});
@@ -2637,7 +2640,7 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					],
-					"Error while processing options validation schema of rule 'foo/bar': minItems must be number",
+					/Error while processing options validation schema of rule 'foo\/bar': minItems must be number/u,
 				);
 			});
 
@@ -2980,7 +2983,7 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					],
-					'Unexpected property "destruct". Expected properties: "destructuring", "ignoreReadBeforeAssign"',
+					/Unexpected property "destruct". Expected properties: "destructuring", "ignoreReadBeforeAssign"/u,
 				);
 
 				await assertInvalidConfig(
@@ -2994,7 +2997,7 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					],
-					'Unexpected property "obj". Expected properties: "VariableDeclarator", "AssignmentExpression"',
+					/Unexpected property "obj". Expected properties: "VariableDeclarator", "AssignmentExpression"/u,
 				);
 
 				await assertInvalidConfig(
@@ -3008,7 +3011,7 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					],
-					'Unexpected property "obj". Expected properties: "array", "object"',
+					/Unexpected property "obj". Expected properties: "array", "object"/u,
 				);
 
 				await assertInvalidConfig(
@@ -3023,7 +3026,7 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					],
-					'Unexpected property "enforceRenamedProperties". Expected properties: "enforceForRenamedProperties"',
+					/Unexpected property "enforceRenamedProperties". Expected properties: "enforceForRenamedProperties"/u,
 				);
 			});
 		});
@@ -3048,7 +3051,10 @@ describe("FlatConfigArray", () => {
 								[key]: "foo",
 							},
 						],
-						`Key "${key}": This appears to be in eslintrc format rather than flat config format.`,
+						new RegExp(
+							`Key "${key}": This appears to be in eslintrc format rather than flat config format.`,
+							"u",
+						),
 					);
 				});
 			});
@@ -3060,7 +3066,7 @@ describe("FlatConfigArray", () => {
 							plugins: ["foo"],
 						},
 					],
-					'Key "plugins": This appears to be in eslintrc format (array of strings) rather than flat config format (object).',
+					/Key "plugins": This appears to be in eslintrc format \(array of strings\) rather than flat config format \(object\)./u,
 				);
 			});
 		});

--- a/tests/lib/config/flat-config-helpers.js
+++ b/tests/lib/config/flat-config-helpers.js
@@ -14,7 +14,7 @@ const {
 	getRuleFromConfig,
 	getRuleOptionsSchema,
 } = require("../../../lib/config/flat-config-helpers");
-const assert = require("chai").assert;
+const assert = require("node:assert");
 
 //-----------------------------------------------------------------------------
 // Tests
@@ -173,7 +173,7 @@ describe("Config Helpers", () => {
 
 				assert.throws(() => {
 					getRuleOptionsSchema(rule);
-				}, "Rule's `meta.schema` must be an array or object");
+				}, /Rule's `meta.schema` must be an array or object/u);
 			});
 		});
 

--- a/tests/lib/config/flat-config-schema.js
+++ b/tests/lib/config/flat-config-schema.js
@@ -6,7 +6,7 @@
 "use strict";
 
 const { flatConfigSchema } = require("../../../lib/config/flat-config-schema");
-const { assert } = require("chai");
+const assert = require("node:assert");
 const {
 	Legacy: { ConfigArray },
 } = require("@eslint/eslintrc");
@@ -178,7 +178,7 @@ describe("merge", () => {
 		const result = merge(first, second);
 
 		assert.deepStrictEqual(result, second);
-		assert.notProperty(result.someProperty, "foo");
+		assert.ok(!("foo" in result.someProperty));
 		confirmLegacyMergeResult(first, second, result);
 	});
 
@@ -188,7 +188,7 @@ describe("merge", () => {
 		const result = merge(first, second);
 
 		assert.deepStrictEqual(result, second);
-		assert.notProperty(result.someProperty, "foo");
+		assert.ok(!("foo" in result.someProperty));
 		confirmLegacyMergeResult(first, second, result);
 	});
 

--- a/tests/lib/languages/js/source-code/source-code.js
+++ b/tests/lib/languages/js/source-code/source-code.js
@@ -10,7 +10,7 @@
 
 const fs = require("node:fs"),
 	path = require("node:path"),
-	assert = require("chai").assert,
+	assert = require("node:assert"),
 	espree = require("espree"),
 	eslintScope = require("eslint-scope"),
 	sinon = require("sinon"),
@@ -57,7 +57,7 @@ describe("SourceCode", () => {
 			const ast = { comments: [], tokens: [], loc: {}, range: [] };
 			const sourceCode = new SourceCode("foo;", ast);
 
-			assert.isObject(sourceCode);
+			assert.ok(sourceCode !== null && typeof sourceCode === "object");
 			assert.strictEqual(sourceCode.text, "foo;");
 			assert.strictEqual(sourceCode.ast, ast);
 		});
@@ -75,7 +75,7 @@ describe("SourceCode", () => {
 				visitorKeys,
 			});
 
-			assert.isObject(sourceCode);
+			assert.ok(sourceCode !== null && typeof sourceCode === "object");
 			assert.strictEqual(sourceCode.text, "foo;");
 			assert.strictEqual(sourceCode.ast, ast);
 			assert.strictEqual(sourceCode.parserServices, parserServices);
@@ -87,7 +87,7 @@ describe("SourceCode", () => {
 			const ast = { comments: [], tokens: [], loc: {}, range: [] };
 			const sourceCode = new SourceCode("foo;\nbar;", ast);
 
-			assert.isObject(sourceCode);
+			assert.ok(sourceCode !== null && typeof sourceCode === "object");
 			assert.strictEqual(sourceCode.lines.length, 2);
 			assert.strictEqual(sourceCode.lines[0], "foo;");
 			assert.strictEqual(sourceCode.lines[1], "bar;");
@@ -338,7 +338,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should not take a JSDoc comment from a VariableDeclaration parent node when the node is a FunctionExpression inside a NewExpression", () => {
@@ -369,7 +373,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should not take a JSDoc comment from a FunctionExpression parent node when the node is a FunctionExpression", () => {
@@ -403,8 +411,9 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(
+			assert.strictEqual(
 				spy.calledTwice,
+				true,
 				"Event handler should be called twice.",
 			);
 		});
@@ -443,7 +452,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should get JSDoc comment for node when the node is a FunctionDeclaration", () => {
@@ -473,7 +486,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should get JSDoc comment for node when the node is a FunctionDeclaration but its parent is an export", () => {
@@ -506,7 +523,11 @@ describe("SourceCode", () => {
 				rules: { checker: "error" },
 				parserOptions: { ecmaVersion: 6, sourceType: "module" },
 			});
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should get JSDoc comment for node when the node is a FunctionDeclaration but not the first statement", () => {
@@ -540,7 +561,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should not get JSDoc comment for node when the node is a FunctionDeclaration inside of an IIFE without a JSDoc comment", () => {
@@ -561,7 +586,7 @@ describe("SourceCode", () => {
 				const sourceCode = linter.getSourceCode();
 				const jsdoc = sourceCode.getJSDocComment(node);
 
-				assert.isNull(jsdoc);
+				assert.strictEqual(jsdoc, null);
 			}
 
 			const spy = sinon.spy(assertJSDoc);
@@ -574,7 +599,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should get JSDoc comment for node when the node is a FunctionDeclaration and there are multiple comments", () => {
@@ -608,7 +637,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should get JSDoc comment for node when the node is a FunctionDeclaration inside of an IIFE", () => {
@@ -644,7 +677,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should get JSDoc comment for node when the node is a FunctionExpression inside of an object literal", () => {
@@ -680,7 +717,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should get JSDoc comment for node when the node is a ArrowFunctionExpression inside of an object literal", () => {
@@ -719,7 +760,11 @@ describe("SourceCode", () => {
 				rules: { checker: "error" },
 				parserOptions: { ecmaVersion: 6 },
 			});
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should get JSDoc comment for node when the node is a FunctionExpression in an assignment", () => {
@@ -753,7 +798,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE", () => {
@@ -791,7 +840,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledTwice, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledTwice,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should not get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE without a JSDoc comment", () => {
@@ -814,7 +867,7 @@ describe("SourceCode", () => {
 					const sourceCode = linter.getSourceCode();
 					const jsdoc = sourceCode.getJSDocComment(node);
 
-					assert.isNull(jsdoc);
+					assert.strictEqual(jsdoc, null);
 				}
 			}
 
@@ -828,7 +881,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledTwice, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledTwice,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should not get JSDoc comment for node when the node is a FunctionExpression inside of a CallExpression", () => {
@@ -849,7 +906,7 @@ describe("SourceCode", () => {
 					const sourceCode = linter.getSourceCode();
 					const jsdoc = sourceCode.getJSDocComment(node);
 
-					assert.isNull(jsdoc);
+					assert.strictEqual(jsdoc, null);
 				}
 			}
 
@@ -863,7 +920,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should not get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE without a JSDoc comment", () => {
@@ -892,7 +953,7 @@ describe("SourceCode", () => {
 					const sourceCode = linter.getSourceCode();
 					const jsdoc = sourceCode.getJSDocComment(node);
 
-					assert.isNull(jsdoc);
+					assert.strictEqual(jsdoc, null);
 				}
 			}
 
@@ -906,7 +967,11 @@ describe("SourceCode", () => {
 				},
 			});
 			linter.verify(code, { rules: { checker: "error" } });
-			assert.isTrue(spy.calledTwice, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledTwice,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should get JSDoc comment for node when the node is a ClassExpression", () => {
@@ -946,7 +1011,11 @@ describe("SourceCode", () => {
 				rules: { checker: "error" },
 				parserOptions: { ecmaVersion: 6 },
 			});
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should get JSDoc comment for node when the node is a ClassDeclaration", () => {
@@ -986,7 +1055,11 @@ describe("SourceCode", () => {
 				rules: { checker: "error" },
 				parserOptions: { ecmaVersion: 6 },
 			});
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should not get JSDoc comment for class method even if the class has jsdoc present", () => {
@@ -1007,7 +1080,7 @@ describe("SourceCode", () => {
 				const sourceCode = linter.getSourceCode();
 				const jsdoc = sourceCode.getJSDocComment(node);
 
-				assert.isNull(jsdoc);
+				assert.strictEqual(jsdoc, null);
 			}
 
 			const spy = sinon.spy(assertJSDoc);
@@ -1023,7 +1096,11 @@ describe("SourceCode", () => {
 				rules: { checker: "error" },
 				parserOptions: { ecmaVersion: 6 },
 			});
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should get JSDoc comment for function expression even if function has blank lines on top", () => {
@@ -1067,7 +1144,11 @@ describe("SourceCode", () => {
 				rules: { checker: "error" },
 				parserOptions: { ecmaVersion: 6 },
 			});
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 
 		it("should not get JSDoc comment for function declaration when the function has blank lines on top", () => {
@@ -1090,7 +1171,7 @@ describe("SourceCode", () => {
 				const sourceCode = linter.getSourceCode();
 				const jsdoc = sourceCode.getJSDocComment(node);
 
-				assert.isNull(jsdoc);
+				assert.strictEqual(jsdoc, null);
 			}
 
 			const spy = sinon.spy(assertJSDoc);
@@ -1106,7 +1187,11 @@ describe("SourceCode", () => {
 				rules: { checker: "error" },
 				parserOptions: { ecmaVersion: 6 },
 			});
-			assert.isTrue(spy.calledOnce, "Event handler should be called.");
+			assert.strictEqual(
+				spy.calledOnce,
+				true,
+				"Event handler should be called.",
+			);
 		});
 	});
 
@@ -1287,9 +1372,9 @@ describe("SourceCode", () => {
 		it("should return null if the index is outside the range of any node", () => {
 			let node = sourceCode.getNodeByRangeIndex(-1);
 
-			assert.isNull(node);
+			assert.strictEqual(node, null);
 			node = sourceCode.getNodeByRangeIndex(-99);
-			assert.isNull(node);
+			assert.strictEqual(node, null);
 		});
 	});
 
@@ -2827,7 +2912,7 @@ describe("SourceCode", () => {
 			};
 
 			flatLinter.verify(code, config, filename);
-			assert(spy && spy.calledOnce, "Spy was not called.");
+			assert.ok(spy && spy.calledOnce, "Spy was not called.");
 		});
 
 		it("should retrieve empty ancestors for root node", () => {
@@ -2857,7 +2942,7 @@ describe("SourceCode", () => {
 			};
 
 			flatLinter.verify(code, config);
-			assert(spy && spy.calledOnce, "Spy was not called.");
+			assert.ok(spy && spy.calledOnce, "Spy was not called.");
 		});
 
 		it("should throw an error when the argument is missing", () => {
@@ -2887,7 +2972,7 @@ describe("SourceCode", () => {
 			};
 
 			flatLinter.verify(code, config);
-			assert(spy && spy.calledOnce, "Spy was not called.");
+			assert.ok(spy && spy.calledOnce, "Spy was not called.");
 		});
 	});
 
@@ -2971,8 +3056,8 @@ describe("SourceCode", () => {
 							const variables =
 								sourceCode.getDeclaredVariables(node);
 
-							assert(Array.isArray(expectedNames));
-							assert(Array.isArray(variables));
+							assert.ok(Array.isArray(expectedNames));
+							assert.ok(Array.isArray(variables));
 							assert.strictEqual(
 								expectedNames.length,
 								variables.length,
@@ -3144,12 +3229,18 @@ describe("SourceCode", () => {
 					const sourceCode = context.sourceCode;
 
 					spy = sinon.spy(node => {
-						assert.isTrue(sourceCode.markVariableAsUsed("a"));
+						assert.strictEqual(
+							sourceCode.markVariableAsUsed("a"),
+							true,
+						);
 
 						const scope = sourceCode.getScope(node);
 
-						assert.isTrue(getVariable(scope, "a").eslintUsed);
-						assert.notOk(getVariable(scope, "b").eslintUsed);
+						assert.strictEqual(
+							getVariable(scope, "a").eslintUsed,
+							true,
+						);
+						assert.ok(!getVariable(scope, "b").eslintUsed);
 					});
 
 					return { "Program:exit": spy };
@@ -3157,7 +3248,7 @@ describe("SourceCode", () => {
 			});
 
 			linter.verify(code, { rules: { checker: "error" } });
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("should mark variables in function args as used", () => {
@@ -3169,12 +3260,18 @@ describe("SourceCode", () => {
 					const sourceCode = context.sourceCode;
 
 					spy = sinon.spy(node => {
-						assert.isTrue(sourceCode.markVariableAsUsed("a", node));
+						assert.strictEqual(
+							sourceCode.markVariableAsUsed("a", node),
+							true,
+						);
 
 						const scope = sourceCode.getScope(node);
 
-						assert.isTrue(getVariable(scope, "a").eslintUsed);
-						assert.notOk(getVariable(scope, "b").eslintUsed);
+						assert.strictEqual(
+							getVariable(scope, "a").eslintUsed,
+							true,
+						);
+						assert.ok(!getVariable(scope, "b").eslintUsed);
 					});
 
 					return { ReturnStatement: spy };
@@ -3182,7 +3279,7 @@ describe("SourceCode", () => {
 			});
 
 			linter.verify(code, { rules: { checker: "error" } });
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("should mark variables in higher scopes as used", () => {
@@ -3194,13 +3291,19 @@ describe("SourceCode", () => {
 					const sourceCode = context.sourceCode;
 
 					returnSpy = sinon.spy(node => {
-						assert.isTrue(sourceCode.markVariableAsUsed("a", node));
+						assert.strictEqual(
+							sourceCode.markVariableAsUsed("a", node),
+							true,
+						);
 					});
 					exitSpy = sinon.spy(node => {
 						const scope = sourceCode.getScope(node);
 
-						assert.isTrue(getVariable(scope, "a").eslintUsed);
-						assert.notOk(getVariable(scope, "b").eslintUsed);
+						assert.strictEqual(
+							getVariable(scope, "a").eslintUsed,
+							true,
+						);
+						assert.ok(!getVariable(scope, "b").eslintUsed);
 					});
 
 					return {
@@ -3211,8 +3314,8 @@ describe("SourceCode", () => {
 			});
 
 			linter.verify(code, { rules: { checker: "error" } });
-			assert(returnSpy && returnSpy.calledOnce);
-			assert(exitSpy && exitSpy.calledOnce);
+			assert.ok(returnSpy && returnSpy.calledOnce);
+			assert.ok(exitSpy && exitSpy.calledOnce);
 		});
 
 		it("should mark variables in Node.js environment as used", () => {
@@ -3227,11 +3330,18 @@ describe("SourceCode", () => {
 						const globalScope = sourceCode.getScope(node),
 							childScope = globalScope.childScopes[0];
 
-						assert.isTrue(sourceCode.markVariableAsUsed("a"));
+						assert.strictEqual(
+							sourceCode.markVariableAsUsed("a"),
+							true,
+						);
 
-						assert.isTrue(getVariable(childScope, "a").eslintUsed);
-						assert.isUndefined(
-							getVariable(childScope, "b").eslintUsed,
+						assert.strictEqual(
+							getVariable(childScope, "a").eslintUsed,
+							true,
+						);
+						assert.strictEqual(
+							typeof getVariable(childScope, "b").eslintUsed,
+							"undefined",
 						);
 					});
 
@@ -3243,7 +3353,7 @@ describe("SourceCode", () => {
 				rules: { checker: "error" },
 				env: { node: true },
 			});
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("should mark variables in modules as used", () => {
@@ -3258,11 +3368,18 @@ describe("SourceCode", () => {
 						const globalScope = sourceCode.getScope(node),
 							childScope = globalScope.childScopes[0];
 
-						assert.isTrue(sourceCode.markVariableAsUsed("a"));
+						assert.strictEqual(
+							sourceCode.markVariableAsUsed("a"),
+							true,
+						);
 
-						assert.isTrue(getVariable(childScope, "a").eslintUsed);
-						assert.isUndefined(
-							getVariable(childScope, "b").eslintUsed,
+						assert.strictEqual(
+							getVariable(childScope, "a").eslintUsed,
+							true,
+						);
+						assert.strictEqual(
+							typeof getVariable(childScope, "b").eslintUsed,
+							"undefined",
 						);
 					});
 
@@ -3278,7 +3395,7 @@ describe("SourceCode", () => {
 				},
 				filename,
 			);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("should return false if the given variable is not found", () => {
@@ -3290,7 +3407,10 @@ describe("SourceCode", () => {
 					const sourceCode = context.sourceCode;
 
 					spy = sinon.spy(() => {
-						assert.isFalse(sourceCode.markVariableAsUsed("c"));
+						assert.strictEqual(
+							sourceCode.markVariableAsUsed("c"),
+							false,
+						);
 					});
 
 					return { "Program:exit": spy };
@@ -3298,7 +3418,7 @@ describe("SourceCode", () => {
 			});
 
 			linter.verify(code, { rules: { checker: "error" } });
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 	});
 
@@ -3390,7 +3510,7 @@ describe("SourceCode", () => {
 			const globalScope = sourceCode.scopeManager.scopes[0];
 			const variable = globalScope.set.get("Promise");
 
-			assert.isDefined(variable);
+			assert.ok(typeof variable !== "undefined");
 		});
 
 		it("should add custom globals", () => {
@@ -3418,8 +3538,8 @@ describe("SourceCode", () => {
 			const globalScope = sourceCode.scopeManager.scopes[0];
 			const variable = globalScope.set.get("FOO");
 
-			assert.isDefined(variable);
-			assert.isTrue(variable.writeable);
+			assert.ok(typeof variable !== "undefined");
+			assert.strictEqual(variable.writeable, true);
 		});
 
 		it("should add commonjs globals", () => {
@@ -3446,7 +3566,7 @@ describe("SourceCode", () => {
 			const globalScope = sourceCode.scopeManager.scopes[0];
 			const variable = globalScope.set.get("require");
 
-			assert.isDefined(variable);
+			assert.ok(typeof variable !== "undefined");
 		});
 	});
 
@@ -3470,8 +3590,8 @@ describe("SourceCode", () => {
 			const globalScope = sourceCode.scopeManager.scopes[0];
 			const variable = globalScope.set.get("bar");
 
-			assert.isDefined(variable);
-			assert.isTrue(variable.writeable);
+			assert.ok(typeof variable !== "undefined");
+			assert.strictEqual(variable.writeable, true);
 		});
 
 		describe("exported variables", () => {
@@ -3505,9 +3625,9 @@ describe("SourceCode", () => {
 				const globalScope = loadGlobalScope(code);
 				const variable = globalScope.get("foo");
 
-				assert.isDefined(variable);
-				assert.isTrue(variable.eslintUsed);
-				assert.isTrue(variable.eslintExported);
+				assert.ok(typeof variable !== "undefined");
+				assert.strictEqual(variable.eslintUsed, true);
+				assert.strictEqual(variable.eslintExported, true);
 			});
 
 			it("should not mark exported variable with `key: value` pair", () => {
@@ -3515,9 +3635,9 @@ describe("SourceCode", () => {
 				const globalScope = loadGlobalScope(code);
 				const variable = globalScope.get("foo");
 
-				assert.isDefined(variable);
-				assert.notOk(variable.eslintUsed);
-				assert.notOk(variable.eslintExported);
+				assert.ok(typeof variable !== "undefined");
+				assert.ok(!variable.eslintUsed);
+				assert.ok(!variable.eslintExported);
 			});
 
 			it("should mark exported variables with comma", () => {
@@ -3527,9 +3647,9 @@ describe("SourceCode", () => {
 				["foo", "bar"].forEach(name => {
 					const variable = globalScope.get(name);
 
-					assert.isDefined(variable);
-					assert.isTrue(variable.eslintUsed);
-					assert.isTrue(variable.eslintExported);
+					assert.ok(typeof variable !== "undefined");
+					assert.strictEqual(variable.eslintUsed, true);
+					assert.strictEqual(variable.eslintExported, true);
 				});
 			});
 
@@ -3540,9 +3660,9 @@ describe("SourceCode", () => {
 				["foo", "bar"].forEach(name => {
 					const variable = globalScope.get(name);
 
-					assert.isDefined(variable);
-					assert.notOk(variable.eslintUsed);
-					assert.notOk(variable.eslintExported);
+					assert.ok(typeof variable !== "undefined");
+					assert.ok(!variable.eslintUsed);
+					assert.ok(!variable.eslintExported);
 				});
 			});
 		});
@@ -3603,7 +3723,7 @@ describe("SourceCode", () => {
 				problem.message,
 				/Failed to parse JSON from '"some-rule"::,': Unexpected token '?:'?/u,
 			);
-			assert.isNull(problem.ruleId);
+			assert.strictEqual(problem.ruleId, null);
 		});
 	});
 });

--- a/tests/lib/languages/js/source-code/token-store.js
+++ b/tests/lib/languages/js/source-code/token-store.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	espree = require("espree"),
 	TokenStore = require("../../../../../lib/languages/js/source-code/token-store");
 
@@ -1534,7 +1534,7 @@ describe("TokenStore", () => {
 		it("should return null when token doesn't exist", () => {
 			const result = store.getTokenByRangeStart(10);
 
-			assert.isNull(result);
+			assert.strictEqual(result, null);
 		});
 
 		it("should return a comment token when includeComments is true", () => {
@@ -1551,13 +1551,13 @@ describe("TokenStore", () => {
 				includeComments: false,
 			});
 
-			assert.isNull(result);
+			assert.strictEqual(result, null);
 		});
 
 		it("should not return comment tokens by default", () => {
 			const result = store.getTokenByRangeStart(15);
 
-			assert.isNull(result);
+			assert.strictEqual(result, null);
 		});
 	});
 
@@ -1743,14 +1743,16 @@ describe("TokenStore", () => {
 
 	describe("when calling commentsExistBetween", () => {
 		it("should retrieve false if comments don't exist", () => {
-			assert.isFalse(
+			assert.strictEqual(
 				store.commentsExistBetween(AST.tokens[0], AST.tokens[1]),
+				false,
 			);
 		});
 
 		it("should retrieve true if comments exist", () => {
-			assert.isTrue(
+			assert.strictEqual(
 				store.commentsExistBetween(AST.tokens[1], AST.tokens[2]),
+				true,
 			);
 		});
 	});

--- a/tests/lib/linter/apply-disable-directives.js
+++ b/tests/lib/linter/apply-disable-directives.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const applyDisableDirectives = require("../../../lib/linter/apply-disable-directives");
 const jslang = require("../../../lib/languages/js");
 
@@ -1148,7 +1148,7 @@ describe("apply-disable-directives", () => {
 						],
 						problems: [],
 					}),
-				"Unrecognized directive type 'foo'",
+				/Unrecognized directive type 'foo'/u,
 			);
 		});
 	});

--- a/tests/lib/linter/esquery.js
+++ b/tests/lib/linter/esquery.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const sinon = require("sinon");
 const esquery = require("esquery");
 const {
@@ -66,8 +66,8 @@ describe("esquery", () => {
 					1,
 				);
 
-				assert.isAbove(selector1.compare(selector2), 0);
-				assert.isBelow(selector2.compare(selector1), 0);
+				assert.ok(selector1.compare(selector2) > 0);
+				assert.ok(selector2.compare(selector1) < 0);
 			});
 
 			it("should compare based on identifierCount if attributeCount is equal", () => {
@@ -88,8 +88,8 @@ describe("esquery", () => {
 					1,
 				);
 
-				assert.isAbove(selector1.compare(selector2), 0);
-				assert.isBelow(selector2.compare(selector1), 0);
+				assert.ok(selector1.compare(selector2) > 0);
+				assert.ok(selector2.compare(selector1) < 0);
 			});
 
 			it("should compare based on source if attributeCount and identifierCount are equal", () => {
@@ -110,8 +110,8 @@ describe("esquery", () => {
 					1,
 				);
 
-				assert.isAbove(selector1.compare(selector2), 0);
-				assert.isBelow(selector2.compare(selector1), 0);
+				assert.ok(selector1.compare(selector2) > 0);
+				assert.ok(selector2.compare(selector1) < 0);
 			});
 
 			it("should return -1 if sources are equal", () => {
@@ -141,7 +141,7 @@ describe("esquery", () => {
 		it("should parse a simple selector", () => {
 			const result = parse("Identifier");
 
-			assert.instanceOf(result, ESQueryParsedSelector);
+			assert.ok(result instanceof ESQueryParsedSelector);
 			assert.strictEqual(result.source, "Identifier");
 			assert.strictEqual(result.isExit, false);
 			assert.deepStrictEqual(result.nodeTypes, ["Identifier"]);
@@ -151,7 +151,7 @@ describe("esquery", () => {
 
 		it("should parse a wildcard selector", () => {
 			const result = parse("*");
-			assert.instanceOf(result, ESQueryParsedSelector);
+			assert.ok(result instanceof ESQueryParsedSelector);
 			assert.strictEqual(result.source, "*");
 			assert.strictEqual(result.isExit, false);
 			assert.strictEqual(result.nodeTypes, null);
@@ -201,11 +201,9 @@ describe("esquery", () => {
 
 		it("should handle class selectors for functions", () => {
 			const result = parse(":function");
-			assert.includeMembers(result.nodeTypes, [
-				"FunctionDeclaration",
-				"FunctionExpression",
-				"ArrowFunctionExpression",
-			]);
+			assert.ok(result.nodeTypes.includes("FunctionDeclaration"));
+			assert.ok(result.nodeTypes.includes("FunctionExpression"));
+			assert.ok(result.nodeTypes.includes("ArrowFunctionExpression"));
 			assert.strictEqual(result.attributeCount, 0);
 			assert.strictEqual(result.identifierCount, 0);
 		});

--- a/tests/lib/linter/interpolate.js
+++ b/tests/lib/linter/interpolate.js
@@ -4,7 +4,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const {
 	getPlaceholderMatcher,
 	interpolate,
@@ -30,13 +30,16 @@ describe("getPlaceholderMatcher", () => {
 	it("does not match text without placeholders", () => {
 		const matcher = getPlaceholderMatcher();
 
-		assert.notMatch("no placeholders in sight", matcher);
+		assert.doesNotMatch("no placeholders in sight", matcher);
 	});
 
 	it("captures the text inside the placeholder", () => {
 		const matcher = getPlaceholderMatcher();
 		const text = "{{ placeholder }}";
-		const matches = Array.from(text.matchAll(matcher));
+		const matches = Array.from(text.matchAll(matcher)).map(match => [
+			match[0],
+			match[1],
+		]);
 
 		assert.deepStrictEqual(matches, [[text, " placeholder "]]);
 	});

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const { assert } = require("chai"),
+const assert = require("node:assert"),
 	sinon = require("sinon"),
 	espree = require("espree"),
 	esprima = require("esprima"),
@@ -96,9 +96,15 @@ describe("Linter", () => {
 				}),
 			});
 
-			assert.throws(() => {
-				linter.verify(code, config, filename);
-			}, `Intentional error.\nOccurred while linting ${filename}:1\nRule: "checker"`);
+			assert.throws(
+				() => {
+					linter.verify(code, config, filename);
+				},
+				new RegExp(
+					`Intentional error.\nOccurred while linting ${filename}:1\nRule: "checker"`,
+					"u",
+				),
+			);
 		});
 
 		it("does not call rule listeners with a `this` value", () => {
@@ -108,7 +114,7 @@ describe("Linter", () => {
 				create: () => ({ Program: spy }),
 			});
 			linter.verify("foo", { rules: { checker: "error" } });
-			assert(spy.calledOnce, "Rule should have been called");
+			assert.ok(spy.calledOnce, "Rule should have been called");
 			assert.strictEqual(
 				spy.firstCall.thisValue,
 				void 0,
@@ -125,7 +131,7 @@ describe("Linter", () => {
 			linter.verify("foo", {
 				rules: { checker: "error", "no-undef": "error" },
 			});
-			assert(spy.notCalled);
+			assert.ok(spy.notCalled);
 		});
 
 		it("has all the `parent` properties on nodes when the rule listeners are created", () => {
@@ -150,7 +156,7 @@ describe("Linter", () => {
 			linter.defineRule("checker", { create: spy });
 
 			linter.verify("foo + bar", { rules: { checker: "error" } });
-			assert(spy.calledOnce);
+			assert.ok(spy.calledOnce);
 		});
 	});
 
@@ -162,9 +168,11 @@ describe("Linter", () => {
 
 			const sourceCode = linter.getSourceCode();
 
-			assert.isObject(sourceCode);
+			assert.ok(sourceCode !== null && typeof sourceCode === "object");
 			assert.strictEqual(sourceCode.text, code);
-			assert.isObject(sourceCode.ast);
+			assert.ok(
+				sourceCode.ast !== null && typeof sourceCode.ast === "object",
+			);
 		});
 
 		it("should retrieve SourceCode object without reset", () => {
@@ -172,9 +180,11 @@ describe("Linter", () => {
 
 			const sourceCode = linter.getSourceCode();
 
-			assert.isObject(sourceCode);
+			assert.ok(sourceCode !== null && typeof sourceCode === "object");
 			assert.strictEqual(sourceCode.text, code);
-			assert.isObject(sourceCode.ast);
+			assert.ok(
+				sourceCode.ast !== null && typeof sourceCode.ast === "object",
+			);
 		});
 	});
 
@@ -350,7 +360,7 @@ describe("Linter", () => {
 						rules: { "function-style-rule": "error" },
 					}),
 				TypeError,
-				"Error while loading rule 'function-style-rule': Rule must be an object with a `create` method",
+				/Error while loading rule 'function-style-rule': Rule must be an object with a `create` method/u,
 			);
 		});
 
@@ -373,7 +383,7 @@ describe("Linter", () => {
 						rules: { "object-rule-without-create": "error" },
 					}),
 				TypeError,
-				"Error while loading rule 'object-rule-without-create': Rule must be an object with a `create` method",
+				/Error while loading rule 'object-rule-without-create': Rule must be an object with a `create` method/u,
 			);
 		});
 
@@ -391,7 +401,7 @@ describe("Linter", () => {
 
 			assert.throws(
 				() => linter.verify("/* eslint rule-with-invalid-schema: 2 */"),
-				"Error while processing options validation schema of rule 'rule-with-invalid-schema': Rule's `meta.schema` must be an array or object",
+				/Error while processing options validation schema of rule 'rule-with-invalid-schema': Rule's `meta.schema` must be an array or object/u,
 			);
 		});
 
@@ -410,7 +420,7 @@ describe("Linter", () => {
 						rules: { "invalid-report": "error" },
 					}),
 				TypeError,
-				"Missing `message` property in report() call; add a message that describes the linting problem.",
+				/Missing `message` property in report\(\) call; add a message that describes the linting problem./u,
 			);
 		});
 	});
@@ -776,7 +786,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 	});
 
@@ -808,7 +818,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 	});
 
@@ -844,7 +854,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("variables should be available in global scope with quoted items", () => {
@@ -870,7 +880,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 	});
 
@@ -897,7 +907,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 	});
 
@@ -920,7 +930,7 @@ describe("Linter", () => {
 						const scope = context.sourceCode.getScope(node),
 							horse = getVariable(scope, "horse");
 
-						assert.isTrue(horse.eslintUsed);
+						assert.strictEqual(horse.eslintUsed, true);
 					});
 
 					return { Program: spy };
@@ -928,7 +938,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("`key: value` pair variable should not be exported", () => {
@@ -942,7 +952,7 @@ describe("Linter", () => {
 						const scope = context.sourceCode.getScope(node),
 							horse = getVariable(scope, "horse");
 
-						assert.notOk(horse.eslintUsed);
+						assert.ok(!horse.eslintUsed);
 					});
 
 					return { Program: spy };
@@ -950,7 +960,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("variables with comma should be exported", () => {
@@ -964,7 +974,10 @@ describe("Linter", () => {
 						const scope = context.sourceCode.getScope(node);
 
 						["horse", "dog"].forEach(name => {
-							assert.isTrue(getVariable(scope, name).eslintUsed);
+							assert.strictEqual(
+								getVariable(scope, name).eslintUsed,
+								true,
+							);
 						});
 					});
 
@@ -973,7 +986,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("variables without comma should not be exported", () => {
@@ -987,7 +1000,7 @@ describe("Linter", () => {
 						const scope = context.sourceCode.getScope(node);
 
 						["horse", "dog"].forEach(name => {
-							assert.notOk(getVariable(scope, name).eslintUsed);
+							assert.ok(!getVariable(scope, name).eslintUsed);
 						});
 					});
 
@@ -996,7 +1009,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("variables should be exported", () => {
@@ -1018,7 +1031,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("undefined variables should not be exported", () => {
@@ -1040,7 +1053,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("variables should be exported in strict mode", () => {
@@ -1063,7 +1076,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("variables should not be exported in the es6 module environment", () => {
@@ -1088,7 +1101,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("variables should not be exported when in the node environment", () => {
@@ -1110,7 +1123,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 	});
 
@@ -1134,7 +1147,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 	});
 
@@ -1161,7 +1174,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 	});
 
@@ -1196,7 +1209,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("ES6 global variables should not be available by default", () => {
@@ -1218,7 +1231,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("ES6 global variables should be available in the es6 environment", () => {
@@ -1249,7 +1262,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("ES6 global variables can be disabled when the es6 environment is enabled", () => {
@@ -1275,7 +1288,7 @@ describe("Linter", () => {
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 	});
 
@@ -1429,7 +1442,7 @@ describe("Linter", () => {
 			assert.strictEqual(messages.length, 1);
 			assert.strictEqual(messages[0].ruleId, "no-alert");
 			assert.strictEqual(messages[0].message, "Unexpected alert.");
-			assert.include(messages[0].nodeType, "CallExpression");
+			assert.ok(messages[0].nodeType.includes("CallExpression"));
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
@@ -1445,7 +1458,7 @@ describe("Linter", () => {
 			assert.strictEqual(messages[0].ruleId, "no-alert");
 			assert.strictEqual(messages[0].severity, 2);
 			assert.strictEqual(messages[0].message, "Unexpected alert.");
-			assert.include(messages[0].nodeType, "CallExpression");
+			assert.ok(messages[0].nodeType.includes("CallExpression"));
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
@@ -1925,11 +1938,11 @@ describe("Linter", () => {
 				/Failed to parse JSON from '"no-unused-vars": \['/u,
 			);
 			assert.strictEqual(messages[0].severity, 2);
-			assert.isTrue(messages[0].fatal);
-			assert.isNull(messages[0].ruleId);
+			assert.strictEqual(messages[0].fatal, true);
+			assert.strictEqual(messages[0].ruleId, null);
 			assert.strictEqual(messages[0].line, 1);
 			assert.strictEqual(messages[0].column, 1);
-			assert.isNull(messages[0].nodeType);
+			assert.strictEqual(messages[0].nodeType, null);
 
 			assert.deepStrictEqual(messages[1], {
 				severity: 2,
@@ -2050,7 +2063,7 @@ describe("Linter", () => {
 			assert.strictEqual(messages.length, 2);
 			assert.strictEqual(messages[0].ruleId, "no-alert");
 			assert.strictEqual(messages[0].message, "Unexpected alert.");
-			assert.include(messages[0].nodeType, "CallExpression");
+			assert.ok(messages[0].nodeType.includes("CallExpression"));
 			assert.strictEqual(messages[1].ruleId, "no-console");
 
 			assert.strictEqual(suppressedMessages.length, 0);
@@ -2070,7 +2083,7 @@ describe("Linter", () => {
 			assert.strictEqual(messages.length, 1);
 			assert.strictEqual(messages[0].ruleId, "no-alert");
 			assert.strictEqual(messages[0].message, "Unexpected alert.");
-			assert.include(messages[0].nodeType, "CallExpression");
+			assert.ok(messages[0].nodeType.includes("CallExpression"));
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
@@ -2332,9 +2345,10 @@ describe("Linter", () => {
 			const suppressedMessages = linter.getSuppressedMessages();
 
 			assert.strictEqual(messages.length, 2);
-			assert.include(
-				messages[0].message,
-				'Configuration for rule "no-foo" is invalid',
+			assert.ok(
+				messages[0].message.includes(
+					'Configuration for rule "no-foo" is invalid',
+				),
 			);
 			assert.strictEqual(
 				messages[1].message,
@@ -2380,7 +2394,7 @@ describe("Linter", () => {
 			assert.strictEqual(messages.length, 1);
 			assert.strictEqual(messages[0].ruleId, "no-alert");
 			assert.strictEqual(messages[0].message, "Unexpected alert.");
-			assert.include(messages[0].nodeType, "CallExpression");
+			assert.ok(messages[0].nodeType.includes("CallExpression"));
 			assert.strictEqual(messages[0].line, 4);
 
 			assert.strictEqual(suppressedMessages.length, 1);
@@ -3453,7 +3467,7 @@ describe("Linter", () => {
 			assert.strictEqual(messages.length, 1);
 			assert.strictEqual(messages[0].ruleId, "no-alert");
 			assert.strictEqual(messages[0].message, "Unexpected alert.");
-			assert.include(messages[0].nodeType, "CallExpression");
+			assert.ok(messages[0].nodeType.includes("CallExpression"));
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
@@ -3474,7 +3488,7 @@ describe("Linter", () => {
 				messages[0].message,
 				"Strings must use doublequote.",
 			);
-			assert.include(messages[0].nodeType, "Literal");
+			assert.ok(messages[0].nodeType.includes("Literal"));
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
@@ -3495,7 +3509,7 @@ describe("Linter", () => {
 				messages[0].message,
 				"Strings must use doublequote.",
 			);
-			assert.include(messages[0].nodeType, "Literal");
+			assert.ok(messages[0].nodeType.includes("Literal"));
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
@@ -3534,7 +3548,7 @@ describe("Linter", () => {
 
 			assert.strictEqual(messages[1].ruleId, "no-alert");
 			assert.strictEqual(messages[1].message, "Unexpected alert.");
-			assert.include(messages[1].nodeType, "CallExpression");
+			assert.ok(messages[1].nodeType.includes("CallExpression"));
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
@@ -3571,7 +3585,7 @@ describe("Linter", () => {
 
 			assert.strictEqual(messages[1].ruleId, "no-alert");
 			assert.strictEqual(messages[1].message, "Unexpected alert.");
-			assert.include(messages[1].nodeType, "CallExpression");
+			assert.ok(messages[1].nodeType.includes("CallExpression"));
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
@@ -3608,7 +3622,7 @@ describe("Linter", () => {
 
 			assert.strictEqual(messages[1].ruleId, "no-alert");
 			assert.strictEqual(messages[1].message, "Unexpected alert.");
-			assert.include(messages[1].nodeType, "CallExpression");
+			assert.ok(messages[1].nodeType.includes("CallExpression"));
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
@@ -3630,7 +3644,7 @@ alert('test');
 				messages[0].message,
 				"This line has a length of 129. Maximum allowed is 100.",
 			);
-			assert.include(messages[0].nodeType, "Program");
+			assert.ok(messages[0].nodeType.includes("Program"));
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
@@ -3658,7 +3672,7 @@ var a = "test2";
 			);
 			assert.strictEqual(message1.line, 4);
 			assert.strictEqual(message1.column, 1);
-			assert.include(message1.nodeType, "Program");
+			assert.ok(message1.nodeType.includes("Program"));
 			assert.strictEqual(message2.ruleId, "max-len");
 			assert.strictEqual(
 				message2.message,
@@ -3666,7 +3680,7 @@ var a = "test2";
 			);
 			assert.strictEqual(message2.line, 5);
 			assert.strictEqual(message2.column, 1);
-			assert.include(message2.nodeType, "Program");
+			assert.ok(message2.nodeType.includes("Program"));
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
@@ -3700,7 +3714,7 @@ var a = "test2";
 
 			linter.defineRule("checker", { create: spy });
 			linter.verify(code, config);
-			assert(spy.calledOnce);
+			assert.ok(spy.calledOnce);
 		});
 
 		it("should comment hashbang without breaking offset", () => {
@@ -3721,7 +3735,7 @@ var a = "test2";
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 	});
 
@@ -3734,10 +3748,10 @@ var a = "test2";
 
 			assert.strictEqual(messages.length, 1);
 			assert.strictEqual(messages[0].severity, 2);
-			assert.isNull(messages[0].ruleId);
+			assert.strictEqual(messages[0].ruleId, null);
 			assert.strictEqual(messages[0].line, 1);
 			assert.strictEqual(messages[0].column, 4);
-			assert.isTrue(messages[0].fatal);
+			assert.strictEqual(messages[0].fatal, true);
 			assert.match(messages[0].message, /^Parsing error:/u);
 
 			assert.strictEqual(suppressedMessages.length, 0);
@@ -3750,7 +3764,7 @@ var a = "test2";
 
 			assert.strictEqual(messages.length, 1);
 			assert.strictEqual(messages[0].severity, 2);
-			assert.isTrue(messages[0].fatal);
+			assert.strictEqual(messages[0].fatal, true);
 			assert.match(messages[0].message, /^Parsing error:/u);
 
 			assert.strictEqual(suppressedMessages.length, 0);
@@ -3782,15 +3796,15 @@ var a = "test2";
 		});
 
 		it("should report a problem", () => {
-			assert.isNotNull(result);
-			assert.isArray(results);
-			assert.isObject(result);
-			assert.property(result, "ruleId");
+			assert.notStrictEqual(result, null);
+			assert.ok(Array.isArray(results));
+			assert.ok(result !== null && typeof result === "object");
+			assert.ok("ruleId" in result);
 			assert.strictEqual(result.ruleId, "foobar");
 		});
 
 		it("should report that the rule does not exist", () => {
-			assert.property(result, "message");
+			assert.ok("message" in result);
 			assert.strictEqual(
 				result.message,
 				"Definition for rule 'foobar' was not found.",
@@ -3798,18 +3812,24 @@ var a = "test2";
 		});
 
 		it("should report at the correct severity", () => {
-			assert.property(result, "severity");
+			assert.ok("severity" in result);
 			assert.strictEqual(result.severity, 2);
 			assert.strictEqual(warningResult.severity, 2); // this is 2, since the rulename is very likely to be wrong
 		});
 
 		it("should accept any valid rule configuration", () => {
-			assert.isObject(arrayOptionResults[0]);
-			assert.isObject(objectOptionResults[0]);
+			assert.ok(
+				arrayOptionResults[0] !== null &&
+					typeof arrayOptionResults[0] === "object",
+			);
+			assert.ok(
+				objectOptionResults[0] !== null &&
+					typeof objectOptionResults[0] === "object",
+			);
 		});
 
 		it("should report multiple missing rules", () => {
-			assert.isArray(resultsMultiple);
+			assert.ok(Array.isArray(resultsMultiple));
 
 			assert.deepStrictEqual(resultsMultiple[1], {
 				ruleId: "barfoo",
@@ -3847,8 +3867,11 @@ var a = "test2";
 		it("should return all loaded rules", () => {
 			const rules = linter.getRules();
 
-			assert.isAbove(rules.size, 230);
-			assert.isObject(rules.get("no-alert"));
+			assert.ok(rules.size > 230);
+			assert.ok(
+				rules.get("no-alert") !== null &&
+					typeof rules.get("no-alert") === "object",
+			);
 		});
 	});
 
@@ -3856,8 +3879,8 @@ var a = "test2";
 		it("should return current version number", () => {
 			const version = linter.version;
 
-			assert.isString(version);
-			assert.isTrue(parseInt(version[0], 10) >= 3);
+			assert.strictEqual(typeof version, "string");
+			assert.strictEqual(parseInt(version[0], 10) >= 3, true);
 		});
 	});
 
@@ -4087,7 +4110,7 @@ var a = "test2";
 
 							const foo = getVariable(scope, "foo");
 
-							assert.notOk(foo);
+							assert.ok(!foo);
 
 							ok = true;
 						},
@@ -4096,7 +4119,7 @@ var a = "test2";
 			});
 
 			linter.verify(code, config, { allowInlineConfig: false });
-			assert(ok);
+			assert.ok(ok);
 		});
 
 		it("should report a violation for eslint-disable", () => {
@@ -4268,7 +4291,7 @@ var a = "test2";
 			});
 
 			linterWithOption.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("should assign process.cwd() to it if cwd is undefined", () => {
@@ -4286,7 +4309,7 @@ var a = "test2";
 			});
 
 			linterWithOption.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 
 		it("should assign process.cwd() to it if the option is undefined", () => {
@@ -4303,7 +4326,7 @@ var a = "test2";
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 	});
 
@@ -5936,7 +5959,7 @@ var a = "test2";
 			});
 
 			linter.verify(code, config);
-			assert(spy && spy.calledOnce);
+			assert.ok(spy && spy.calledOnce);
 		});
 	});
 
@@ -5954,7 +5977,7 @@ var a = "test2";
 					{ rules: { checker: "error" } },
 					{ filename: "foo.js" },
 				);
-				assert(filenameChecker.calledOnce);
+				assert.ok(filenameChecker.calledOnce);
 			});
 
 			it("should allow filename to be passed as third argument", () => {
@@ -5969,7 +5992,7 @@ var a = "test2";
 					{ rules: { checker: "error" } },
 					"bar.js",
 				);
-				assert(filenameChecker.calledOnce);
+				assert.ok(filenameChecker.calledOnce);
 			});
 
 			it("should default filename to <input> when options object doesn't have filename", () => {
@@ -5980,7 +6003,7 @@ var a = "test2";
 
 				linter.defineRule("checker", { create: filenameChecker });
 				linter.verify("foo;", { rules: { checker: "error" } }, {});
-				assert(filenameChecker.calledOnce);
+				assert.ok(filenameChecker.calledOnce);
 			});
 
 			it("should default filename to <input> when only two arguments are passed", () => {
@@ -5991,7 +6014,7 @@ var a = "test2";
 
 				linter.defineRule("checker", { create: filenameChecker });
 				linter.verify("foo;", { rules: { checker: "error" } });
-				assert(filenameChecker.calledOnce);
+				assert.ok(filenameChecker.calledOnce);
 			});
 		});
 
@@ -6014,7 +6037,7 @@ var a = "test2";
 					{ rules: { checker: "error" } },
 					{ filename: "foo.js" },
 				);
-				assert(physicalFilenameChecker.calledOnce);
+				assert.ok(physicalFilenameChecker.calledOnce);
 			});
 
 			it("should default physicalFilename to <input> when options object doesn't have filename", () => {
@@ -6031,7 +6054,7 @@ var a = "test2";
 					create: physicalFilenameChecker,
 				});
 				linter.verify("foo;", { rules: { checker: "error" } }, {});
-				assert(physicalFilenameChecker.calledOnce);
+				assert.ok(physicalFilenameChecker.calledOnce);
 			});
 
 			it("should default physicalFilename to <input> when only two arguments are passed", () => {
@@ -6048,7 +6071,7 @@ var a = "test2";
 					create: physicalFilenameChecker,
 				});
 				linter.verify("foo;", { rules: { checker: "error" } });
-				assert(physicalFilenameChecker.calledOnce);
+				assert.ok(physicalFilenameChecker.calledOnce);
 			});
 		});
 
@@ -6536,7 +6559,7 @@ var a = "test2";
 
 			assert.strictEqual(messages.length, 1);
 			assert.strictEqual(messages[0].severity, 2);
-			assert.isTrue(messages[0].fatal);
+			assert.strictEqual(messages[0].fatal, true);
 			assert.match(messages[0].message, /^Parsing error:.*'char'/u);
 
 			assert.strictEqual(suppressedMessages.length, 0);
@@ -6553,7 +6576,7 @@ var a = "test2";
 
 			assert.strictEqual(messages.length, 1);
 			assert.strictEqual(messages[0].severity, 2);
-			assert.isTrue(messages[0].fatal);
+			assert.strictEqual(messages[0].fatal, true);
 			assert.match(messages[0].message, /^Parsing error:.*'char'/u);
 
 			assert.strictEqual(suppressedMessages.length, 0);
@@ -6570,7 +6593,7 @@ var a = "test2";
 
 			assert.strictEqual(messages.length, 1);
 			assert.strictEqual(messages[0].severity, 2);
-			assert.isTrue(messages[0].fatal);
+			assert.strictEqual(messages[0].fatal, true);
 			assert.match(messages[0].message, /^Parsing error:.*'char'/u);
 
 			assert.strictEqual(suppressedMessages.length, 0);
@@ -6608,7 +6631,7 @@ var a = "test2";
 
 				assert.strictEqual(messages.length, 1);
 				assert.strictEqual(messages[0].severity, 2);
-				assert.isTrue(messages[0].fatal);
+				assert.strictEqual(messages[0].fatal, true);
 				assert.match(messages[0].message, /^Parsing error:.*'enum'/u);
 
 				assert.strictEqual(suppressedMessages.length, 0);
@@ -6657,7 +6680,7 @@ var a = "test2";
 
 				assert.strictEqual(messages.length, 1);
 				assert.strictEqual(messages[0].severity, 2);
-				assert.isTrue(messages[0].fatal);
+				assert.strictEqual(messages[0].fatal, true);
 				assert.match(
 					messages[0].message,
 					/^Parsing error:.*allowReserved/u,
@@ -6759,7 +6782,7 @@ var a = "test2";
 			});
 
 			linter.verify(code, { rules: { test: 2 } });
-			assert(ok);
+			assert.ok(ok);
 		});
 
 		it("should report a linting error when a global is set to an invalid value", () => {
@@ -6888,9 +6911,9 @@ var a = "test2";
 				rules: { "save-ast2": 2 },
 			});
 
-			assert(ast1 !== null);
-			assert(ast2 !== null);
-			assert(ast1 === ast2);
+			assert.ok(ast1 !== null);
+			assert.ok(ast2 !== null);
+			assert.ok(ast1 === ast2);
 		});
 
 		it("should allow 'await' as a property name in modules", () => {
@@ -6899,7 +6922,7 @@ var a = "test2";
 			});
 			const suppressedMessages = linter.getSuppressedMessages();
 
-			assert(result.length === 0);
+			assert.ok(result.length === 0);
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
 
@@ -6918,7 +6941,7 @@ var a = "test2";
 
 			linter.defineRule("foo-bar-baz", { create: spy });
 			linter.verify("x", { rules: { "foo-bar-baz": "error" } });
-			assert(spy.calledOnce);
+			assert.ok(spy.calledOnce);
 		});
 
 		describe("descriptions in directive comments", () => {
@@ -7497,7 +7520,7 @@ var a = "test2";
 				rules: { test: 2 },
 				globals: { e: true, f: false },
 			});
-			assert(ok);
+			assert.ok(ok);
 		});
 
 		afterEach(() => {
@@ -7515,21 +7538,21 @@ var a = "test2";
 		});
 
 		it("Scope#variables should contain global variables", () => {
-			assert(scope.variables.some(v => v.name === "Object"));
-			assert(scope.variables.some(v => v.name === "foo"));
-			assert(scope.variables.some(v => v.name === "c"));
-			assert(scope.variables.some(v => v.name === "d"));
-			assert(scope.variables.some(v => v.name === "e"));
-			assert(scope.variables.some(v => v.name === "f"));
+			assert.ok(scope.variables.some(v => v.name === "Object"));
+			assert.ok(scope.variables.some(v => v.name === "foo"));
+			assert.ok(scope.variables.some(v => v.name === "c"));
+			assert.ok(scope.variables.some(v => v.name === "d"));
+			assert.ok(scope.variables.some(v => v.name === "e"));
+			assert.ok(scope.variables.some(v => v.name === "f"));
 		});
 
 		it("Scope#set should contain global variables", () => {
-			assert(scope.set.get("Object"));
-			assert(scope.set.get("foo"));
-			assert(scope.set.get("c"));
-			assert(scope.set.get("d"));
-			assert(scope.set.get("e"));
-			assert(scope.set.get("f"));
+			assert.ok(scope.set.get("Object"));
+			assert.ok(scope.set.get("foo"));
+			assert.ok(scope.set.get("c"));
+			assert.ok(scope.set.get("d"));
+			assert.ok(scope.set.get("e"));
+			assert.ok(scope.set.get("f"));
 		});
 
 		it("Variables#references should contain their references", () => {
@@ -7774,7 +7797,7 @@ var a = "test2";
 				linter.verify("0", {
 					rules: { "rule-with-suggestions": "error" },
 				});
-			}, "Rules with suggestions must set the `meta.hasSuggestions` property to `true`.");
+			}, /Rules with suggestions must set the `meta.hasSuggestions` property to `true`./u);
 		});
 
 		it("should throw an error if suggestion is passed but `meta.hasSuggestions` property is not enabled and the rule has the obsolete `meta.docs.suggestion` property", () => {
@@ -7801,7 +7824,7 @@ var a = "test2";
 				linter.verify("0", {
 					rules: { "rule-with-meta-docs-suggestion": "error" },
 				});
-			}, "Rules with suggestions must set the `meta.hasSuggestions` property to `true`. `meta.docs.suggestion` is ignored by ESLint.");
+			}, /Rules with suggestions must set the `meta.hasSuggestions` property to `true`. `meta.docs.suggestion` is ignored by ESLint./u);
 		});
 	});
 
@@ -7816,7 +7839,7 @@ var a = "test2";
 
 		describe("rules", () => {
 			it("with no changes, same rules are loaded", () => {
-				assert.sameDeepMembers(
+				assert.deepStrictEqual(
 					Array.from(linter1.getRules().keys()),
 					Array.from(linter2.getRules().keys()),
 				);
@@ -7827,12 +7850,14 @@ var a = "test2";
 					create: () => ({}),
 				});
 
-				assert.isTrue(
+				assert.strictEqual(
 					linter1.getRules().has("mock-rule"),
+					true,
 					"mock rule is present",
 				);
-				assert.isFalse(
+				assert.strictEqual(
 					linter2.getRules().has("mock-rule"),
+					false,
 					"mock rule is not present",
 				);
 			});
@@ -7982,13 +8007,13 @@ var a = "test2";
 
 				// filename
 				assert.strictEqual(receivedFilenames.length, 3);
-				assert(
+				assert.ok(
 					/^filename\.js[/\\]0_block\.js/u.test(receivedFilenames[0]),
 				);
-				assert(
+				assert.ok(
 					/^filename\.js[/\\]1_block\.js/u.test(receivedFilenames[1]),
 				);
-				assert(
+				assert.ok(
 					/^filename\.js[/\\]2_block\.js/u.test(receivedFilenames[2]),
 				);
 
@@ -8200,7 +8225,7 @@ var a = "test2";
 				"var a;",
 				"Fixes were applied correctly",
 			);
-			assert.isTrue(messages.fixed);
+			assert.strictEqual(messages.fixed, true);
 		});
 
 		it("does not require a third argument", () => {
@@ -8584,7 +8609,7 @@ var a = "test2";
 
 			linter.defineRule("test", {
 				create(context) {
-					assert(
+					assert.ok(
 						context.parserOptions.ecmaFeatures.globalReturn,
 						"`ecmaFeatures.globalReturn` of the node environment should not be modified.",
 					);
@@ -8597,7 +8622,7 @@ var a = "test2";
 				rules: { test: 2 },
 			});
 
-			assert(ok);
+			assert.ok(ok);
 		});
 
 		it("should throw when rule's create() function does not return an object", () => {
@@ -8609,7 +8634,7 @@ var a = "test2";
 
 			assert.throws(() => {
 				linter.verify("abc", config, filename);
-			}, "The create() function for rule 'checker' did not return an object.");
+			}, /The create\(\) function for rule 'checker' did not return an object./u);
 
 			linter.defineRule("checker", {
 				create() {},
@@ -8617,7 +8642,7 @@ var a = "test2";
 
 			assert.throws(() => {
 				linter.verify("abc", config, filename);
-			}, "The create() function for rule 'checker' did not return an object.");
+			}, /The create\(\) function for rule 'checker' did not return an object./u);
 		});
 	});
 
@@ -8738,7 +8763,7 @@ var a = "test2";
 			const suppressedMessages = linter.getSuppressedMessages();
 
 			assert.strictEqual(messages.length, 0);
-			assert.isTrue(nodes.length > 0);
+			assert.strictEqual(nodes.length > 0, true);
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
@@ -8927,8 +8952,8 @@ var a = "test2";
 					"test.js",
 				);
 
-				assert(scope2 !== null);
-				assert(scope2 === scope);
+				assert.ok(scope2 !== null);
+				assert.ok(scope2 === scope);
 			});
 		});
 
@@ -9497,7 +9522,7 @@ describe("Linter with FlatConfigArray", () => {
 					});
 					const suppressedMessages = linter.getSuppressedMessages();
 
-					assert(result.length === 0);
+					assert.ok(result.length === 0);
 					assert.strictEqual(suppressedMessages.length, 0);
 				});
 			});
@@ -9690,7 +9715,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify("0", config, filename);
-					assert.isTrue(spy.calledOnce);
+					assert.strictEqual(spy.calledOnce, true);
 				});
 
 				describe("Custom Parsers", () => {
@@ -9796,7 +9821,7 @@ describe("Linter with FlatConfigArray", () => {
 							linter.getSuppressedMessages();
 
 						assert.strictEqual(messages.length, 0);
-						assert.isTrue(nodes.length > 0);
+						assert.strictEqual(nodes.length > 0, true);
 						assert.strictEqual(suppressedMessages.length, 0);
 					});
 
@@ -10038,8 +10063,8 @@ describe("Linter with FlatConfigArray", () => {
 
 							linter.verify(sourceCode, config, "test.js");
 
-							assert(scope2 !== null);
-							assert(scope2 === scope);
+							assert.ok(scope2 !== null);
+							assert.ok(scope2 === scope);
 						});
 					});
 
@@ -10060,7 +10085,7 @@ describe("Linter with FlatConfigArray", () => {
 							"filename.js",
 						);
 
-						assert(
+						assert.ok(
 							spy.calledWithMatch(";", {
 								ecmaVersion: LATEST_ECMA_VERSION,
 								sourceType: "module",
@@ -10287,7 +10312,7 @@ describe("Linter with FlatConfigArray", () => {
 
 					assert.strictEqual(messages.length, 1);
 					assert.strictEqual(messages[0].severity, 2);
-					assert.isTrue(messages[0].fatal);
+					assert.strictEqual(messages[0].fatal, true);
 					assert.match(
 						messages[0].message,
 						/^Parsing error:.*'char'/u,
@@ -10309,7 +10334,7 @@ describe("Linter with FlatConfigArray", () => {
 
 					assert.strictEqual(messages.length, 1);
 					assert.strictEqual(messages[0].severity, 2);
-					assert.isTrue(messages[0].fatal);
+					assert.strictEqual(messages[0].fatal, true);
 					assert.match(
 						messages[0].message,
 						/^Parsing error:.*'char'/u,
@@ -10331,7 +10356,7 @@ describe("Linter with FlatConfigArray", () => {
 
 					assert.strictEqual(messages.length, 1);
 					assert.strictEqual(messages[0].severity, 2);
-					assert.isTrue(messages[0].fatal);
+					assert.strictEqual(messages[0].fatal, true);
 					assert.match(
 						messages[0].message,
 						/^Parsing error:.*'char'/u,
@@ -10380,7 +10405,7 @@ describe("Linter with FlatConfigArray", () => {
 
 						assert.strictEqual(messages.length, 1);
 						assert.strictEqual(messages[0].severity, 2);
-						assert.isTrue(messages[0].fatal);
+						assert.strictEqual(messages[0].fatal, true);
 						assert.match(
 							messages[0].message,
 							/^Parsing error:.*'enum'/u,
@@ -10440,7 +10465,7 @@ describe("Linter with FlatConfigArray", () => {
 
 						assert.strictEqual(messages.length, 1);
 						assert.strictEqual(messages[0].severity, 2);
-						assert.isTrue(messages[0].fatal);
+						assert.strictEqual(messages[0].fatal, true);
 						assert.match(
 							messages[0].message,
 							/^Parsing error:.*allowReserved/u,
@@ -10970,8 +10995,9 @@ describe("Linter with FlatConfigArray", () => {
 				};
 
 				linter.verify("code", config, filename);
-				assert.isTrue(
+				assert.strictEqual(
 					spy.notCalled,
+					true,
 					"Rule should not have been called",
 				);
 			});
@@ -11000,9 +11026,15 @@ describe("Linter with FlatConfigArray", () => {
 					rules: { "test/checker": "error" },
 				};
 
-				assert.throws(() => {
-					linter.verify(code, config, filename);
-				}, `Intentional error.\nOccurred while linting ${filename}:1\nRule: "test/checker"`);
+				assert.throws(
+					() => {
+						linter.verify(code, config, filename);
+					},
+					new RegExp(
+						`Intentional error.\nOccurred while linting ${filename}:1\nRule: "test/checker"`,
+						"u",
+					),
+				);
 			});
 
 			it("should not call rule visitor with a `this` value", () => {
@@ -11023,7 +11055,7 @@ describe("Linter with FlatConfigArray", () => {
 				};
 
 				linter.verify("foo", config);
-				assert(spy.calledOnce);
+				assert.ok(spy.calledOnce);
 				assert.strictEqual(spy.firstCall.thisValue, void 0);
 			});
 
@@ -11048,7 +11080,7 @@ describe("Linter with FlatConfigArray", () => {
 				};
 
 				linter.verify("foo", config);
-				assert(spy.notCalled);
+				assert.ok(spy.notCalled);
 			});
 
 			it("should have all the `parent` properties on nodes when the rule visitors are created", () => {
@@ -11088,7 +11120,7 @@ describe("Linter with FlatConfigArray", () => {
 				};
 
 				linter.verify("foo + bar", config);
-				assert(spy.calledOnce);
+				assert.ok(spy.calledOnce);
 			});
 
 			it("events for each node type should fire", () => {
@@ -11164,7 +11196,7 @@ describe("Linter with FlatConfigArray", () => {
 				assert.throws(
 					() => linter.verify("foo", config),
 					TypeError,
-					"Error while loading rule 'test/function-style-rule': Rule must be an object with a `create` method",
+					/Error while loading rule 'test\/function-style-rule': Rule must be an object with a `create` method/u,
 				);
 			});
 
@@ -11193,7 +11225,7 @@ describe("Linter with FlatConfigArray", () => {
 				assert.throws(
 					() => linter.verify("foo", config),
 					TypeError,
-					"Error while loading rule 'test/object-rule-without-create': Rule must be an object with a `create` method",
+					/Error while loading rule 'test\/object-rule-without-create': Rule must be an object with a `create` method/u,
 				);
 			});
 
@@ -11222,7 +11254,7 @@ describe("Linter with FlatConfigArray", () => {
 
 				assert.throws(
 					() => linter.verify("foo", config),
-					"Error while processing options validation schema of rule 'test/rule-with-invalid-schema': Rule's `meta.schema` must be an array or object",
+					/Error while processing options validation schema of rule 'test\/rule-with-invalid-schema': Rule's `meta.schema` must be an array or object/u,
 				);
 			});
 
@@ -11252,7 +11284,7 @@ describe("Linter with FlatConfigArray", () => {
 							"/* eslint test/rule-with-invalid-schema: 2 */",
 							config,
 						),
-					"Error while processing options validation schema of rule 'test/rule-with-invalid-schema': Rule's `meta.schema` must be an array or object",
+					/Error while processing options validation schema of rule 'test\/rule-with-invalid-schema': Rule's `meta.schema` must be an array or object/u,
 				);
 			});
 
@@ -11277,7 +11309,7 @@ describe("Linter with FlatConfigArray", () => {
 				assert.throws(
 					() => linter.verify("foo", config),
 					TypeError,
-					"Missing `message` property in report() call; add a message that describes the linting problem.",
+					/Missing `message` property in report() call; add a message that describes the linting problem./u,
 				);
 			});
 		});
@@ -11524,7 +11556,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linterWithOption.verify(code, config, `${cwd}/file.js`);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 
 				it("should assign process.cwd() to it if cwd is undefined", () => {
@@ -11552,7 +11584,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linterWithOption.verify(code, config);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 
 				it("should assign process.cwd() to it if the option is undefined", () => {
@@ -11579,7 +11611,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify(code, config);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 			});
 
@@ -11616,7 +11648,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linterWithOption.verify(code, config, `${cwd}/file.js`);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 
 				it("should assign process.cwd() to it if cwd is undefined", () => {
@@ -11648,7 +11680,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linterWithOption.verify(code, config);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 
 				it("should assign process.cwd() to it if the option is undefined", () => {
@@ -11679,7 +11711,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify(code, config);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 			});
 		});
@@ -11794,7 +11826,7 @@ describe("Linter with FlatConfigArray", () => {
 				};
 
 				linter.verify(code, config);
-				assert(spy.calledOnce);
+				assert.ok(spy.calledOnce);
 			});
 		});
 
@@ -11820,7 +11852,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify("foo;", config, { filename: "foo.js" });
-					assert(filenameChecker.calledOnce);
+					assert.ok(filenameChecker.calledOnce);
 				});
 
 				it("should allow filename to be passed as third argument", () => {
@@ -11843,7 +11875,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify("foo;", config, "bar.js");
-					assert(filenameChecker.calledOnce);
+					assert.ok(filenameChecker.calledOnce);
 				});
 
 				it("should default filename to <input> when options object doesn't have filename", () => {
@@ -11866,7 +11898,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify("foo;", config, {});
-					assert(filenameChecker.calledOnce);
+					assert.ok(filenameChecker.calledOnce);
 				});
 
 				it("should default filename to <input> when only two arguments are passed", () => {
@@ -11889,7 +11921,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify("foo;", config);
-					assert(filenameChecker.calledOnce);
+					assert.ok(filenameChecker.calledOnce);
 				});
 			});
 
@@ -11920,7 +11952,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify("foo;", config, { filename: "foo.js" });
-					assert(physicalFilenameChecker.calledOnce);
+					assert.ok(physicalFilenameChecker.calledOnce);
 				});
 
 				it("should default physicalFilename to <input> when options object doesn't have filename", () => {
@@ -11949,7 +11981,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify("foo;", config, {});
-					assert(physicalFilenameChecker.calledOnce);
+					assert.ok(physicalFilenameChecker.calledOnce);
 				});
 
 				it("should default physicalFilename to <input> when only two arguments are passed", () => {
@@ -11978,7 +12010,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify("foo;", config);
-					assert(physicalFilenameChecker.calledOnce);
+					assert.ok(physicalFilenameChecker.calledOnce);
 				});
 			});
 
@@ -12168,7 +12200,7 @@ describe("Linter with FlatConfigArray", () => {
 						}
 
 						linter.verify(code, config);
-						assert(spy && spy.calledOnce);
+						assert.ok(spy && spy.calledOnce);
 					}
 
 					it("variables should be available in global scope", () => {
@@ -12313,7 +12345,7 @@ describe("Linter with FlatConfigArray", () => {
 						};
 
 						linter.verify(code, config);
-						assert(spy && spy.calledOnce);
+						assert.ok(spy && spy.calledOnce);
 					});
 
 					// https://github.com/eslint/eslint/issues/18363
@@ -12411,7 +12443,7 @@ describe("Linter with FlatConfigArray", () => {
 						};
 
 						linter.verify(code, config);
-						assert(spy && spy.calledOnce);
+						assert.ok(spy && spy.calledOnce);
 					});
 				});
 
@@ -12449,7 +12481,7 @@ describe("Linter with FlatConfigArray", () => {
 						};
 
 						linter.verify(code, config);
-						assert(spy && spy.calledOnce);
+						assert.ok(spy && spy.calledOnce);
 					});
 				});
 
@@ -12502,7 +12534,7 @@ describe("Linter with FlatConfigArray", () => {
 						};
 
 						linter.verify(code, config);
-						assert(spy && spy.calledOnce);
+						assert.ok(spy && spy.calledOnce);
 					});
 				});
 
@@ -12590,7 +12622,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify(code, config);
-					assert(ok);
+					assert.ok(ok);
 				});
 
 				it("should report a linting error when a global is set to an invalid value", () => {
@@ -12657,7 +12689,10 @@ describe("Linter with FlatConfigArray", () => {
 														"horse",
 													);
 
-												assert.isTrue(horse.eslintUsed);
+												assert.strictEqual(
+													horse.eslintUsed,
+													true,
+												);
 											});
 
 											return { Program: spy };
@@ -12673,7 +12708,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify(code, config);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 
 				it("`key: value` pair variable should not be exported", () => {
@@ -12695,7 +12730,7 @@ describe("Linter with FlatConfigArray", () => {
 														"horse",
 													);
 
-												assert.notOk(horse.eslintUsed);
+												assert.ok(!horse.eslintUsed);
 											});
 
 											return { Program: spy };
@@ -12711,7 +12746,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify(code, config);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 
 				it("variables with comma should be exported", () => {
@@ -12731,11 +12766,12 @@ describe("Linter with FlatConfigArray", () => {
 
 												["horse", "dog"].forEach(
 													name => {
-														assert.isTrue(
+														assert.strictEqual(
 															getVariable(
 																scope,
 																name,
 															).eslintUsed,
+															true,
 														);
 													},
 												);
@@ -12754,7 +12790,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify(code, config);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 
 				it("variables without comma should not be exported", () => {
@@ -12774,8 +12810,8 @@ describe("Linter with FlatConfigArray", () => {
 
 												["horse", "dog"].forEach(
 													name => {
-														assert.notOk(
-															getVariable(
+														assert.ok(
+															!getVariable(
 																scope,
 																name,
 															).eslintUsed,
@@ -12797,7 +12833,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify(code, config);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 
 				it("variables should be exported", () => {
@@ -12839,7 +12875,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify(code, config);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 
 				it("undefined variables should not be exported", () => {
@@ -12877,7 +12913,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify(code, config);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 
 				it("variables should be exported in strict mode", () => {
@@ -12919,7 +12955,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify(code, config);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 
 				it("variables should not be exported in the es6 module environment", () => {
@@ -12958,7 +12994,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify(code, config);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 
 				it("variables should not be exported when in a commonjs file", () => {
@@ -12996,7 +13032,7 @@ describe("Linter with FlatConfigArray", () => {
 					};
 
 					linter.verify(code, config);
-					assert(spy && spy.calledOnce);
+					assert.ok(spy && spy.calledOnce);
 				});
 			});
 
@@ -13020,7 +13056,9 @@ describe("Linter with FlatConfigArray", () => {
 							messages[0].message,
 							"Unexpected alert.",
 						);
-						assert.include(messages[0].nodeType, "CallExpression");
+						assert.ok(
+							messages[0].nodeType.includes("CallExpression"),
+						);
 
 						assert.strictEqual(
 							suppressedMessages.length,
@@ -13661,11 +13699,11 @@ describe("Linter with FlatConfigArray", () => {
 							/Failed to parse JSON from '"no-unused-vars": \['/u,
 						);
 						assert.strictEqual(messages[0].severity, 2);
-						assert.isTrue(messages[0].fatal);
-						assert.isNull(messages[0].ruleId);
+						assert.strictEqual(messages[0].fatal, true);
+						assert.strictEqual(messages[0].ruleId, null);
 						assert.strictEqual(messages[0].line, 1);
 						assert.strictEqual(messages[0].column, 1);
-						assert.isNull(messages[0].nodeType);
+						assert.strictEqual(messages[0].nodeType, null);
 
 						assert.deepStrictEqual(messages[1], {
 							severity: 2,
@@ -13798,7 +13836,9 @@ describe("Linter with FlatConfigArray", () => {
 							messages[0].message,
 							"Unexpected alert.",
 						);
-						assert.include(messages[0].nodeType, "CallExpression");
+						assert.ok(
+							messages[0].nodeType.includes("CallExpression"),
+						);
 						assert.strictEqual(messages[1].ruleId, "no-console");
 
 						assert.strictEqual(suppressedMessages.length, 0);
@@ -13824,7 +13864,9 @@ describe("Linter with FlatConfigArray", () => {
 							messages[0].message,
 							"Unexpected alert.",
 						);
-						assert.include(messages[0].nodeType, "CallExpression");
+						assert.ok(
+							messages[0].nodeType.includes("CallExpression"),
+						);
 
 						assert.strictEqual(suppressedMessages.length, 0);
 					});
@@ -14162,9 +14204,10 @@ describe("Linter with FlatConfigArray", () => {
 							linter.getSuppressedMessages();
 
 						assert.strictEqual(messages.length, 2);
-						assert.include(
-							messages[0].message,
-							'Inline configuration for rule "test-plugin/no-foo" is invalid',
+						assert.ok(
+							messages[0].message.includes(
+								'Inline configuration for rule "test-plugin/no-foo" is invalid',
+							),
 						);
 						assert.strictEqual(
 							messages[1].message,
@@ -14215,7 +14258,9 @@ describe("Linter with FlatConfigArray", () => {
 							messages[0].message,
 							"Unexpected alert.",
 						);
-						assert.include(messages[0].nodeType, "CallExpression");
+						assert.ok(
+							messages[0].nodeType.includes("CallExpression"),
+						);
 						assert.strictEqual(messages[0].line, 4);
 
 						assert.strictEqual(suppressedMessages.length, 1);
@@ -14351,7 +14396,9 @@ describe("Linter with FlatConfigArray", () => {
 							messages[0].message,
 							"Unexpected alert.",
 						);
-						assert.include(messages[0].nodeType, "CallExpression");
+						assert.ok(
+							messages[0].nodeType.includes("CallExpression"),
+						);
 
 						assert.strictEqual(suppressedMessages.length, 0);
 					});
@@ -14374,7 +14421,7 @@ describe("Linter with FlatConfigArray", () => {
 							messages[0].message,
 							"Strings must use doublequote.",
 						);
-						assert.include(messages[0].nodeType, "Literal");
+						assert.ok(messages[0].nodeType.includes("Literal"));
 
 						assert.strictEqual(suppressedMessages.length, 0);
 					});
@@ -14397,7 +14444,7 @@ describe("Linter with FlatConfigArray", () => {
 							messages[0].message,
 							"Strings must use doublequote.",
 						);
-						assert.include(messages[0].nodeType, "Literal");
+						assert.ok(messages[0].nodeType.includes("Literal"));
 
 						assert.strictEqual(suppressedMessages.length, 0);
 					});
@@ -14440,7 +14487,9 @@ describe("Linter with FlatConfigArray", () => {
 							messages[1].message,
 							"Unexpected alert.",
 						);
-						assert.include(messages[1].nodeType, "CallExpression");
+						assert.ok(
+							messages[1].nodeType.includes("CallExpression"),
+						);
 
 						assert.strictEqual(suppressedMessages.length, 0);
 					});
@@ -14481,7 +14530,9 @@ describe("Linter with FlatConfigArray", () => {
 							messages[1].message,
 							"Unexpected alert.",
 						);
-						assert.include(messages[1].nodeType, "CallExpression");
+						assert.ok(
+							messages[1].nodeType.includes("CallExpression"),
+						);
 
 						assert.strictEqual(suppressedMessages.length, 0);
 					});
@@ -14523,7 +14574,9 @@ describe("Linter with FlatConfigArray", () => {
 							messages[1].message,
 							"Unexpected alert.",
 						);
-						assert.include(messages[1].nodeType, "CallExpression");
+						assert.ok(
+							messages[1].nodeType.includes("CallExpression"),
+						);
 
 						assert.strictEqual(suppressedMessages.length, 0);
 					});
@@ -14546,7 +14599,7 @@ alert('test');
 							messages[0].message,
 							"This line has a length of 129. Maximum allowed is 100.",
 						);
-						assert.include(messages[0].nodeType, "Program");
+						assert.ok(messages[0].nodeType.includes("Program"));
 
 						assert.strictEqual(suppressedMessages.length, 0);
 					});
@@ -14575,7 +14628,7 @@ var a = "test2";
 						);
 						assert.strictEqual(message1.line, 4);
 						assert.strictEqual(message1.column, 1);
-						assert.include(message1.nodeType, "Program");
+						assert.ok(message1.nodeType.includes("Program"));
 						assert.strictEqual(message2.ruleId, "max-len");
 						assert.strictEqual(
 							message2.message,
@@ -14583,7 +14636,7 @@ var a = "test2";
 						);
 						assert.strictEqual(message2.line, 5);
 						assert.strictEqual(message2.column, 1);
-						assert.include(message2.nodeType, "Program");
+						assert.ok(message2.nodeType.includes("Program"));
 
 						assert.strictEqual(suppressedMessages.length, 0);
 					});
@@ -16328,7 +16381,7 @@ var a = "test2";
 														"foo",
 													);
 
-													assert.notOk(foo);
+													assert.ok(!foo);
 
 													ok = true;
 												},
@@ -16345,7 +16398,7 @@ var a = "test2";
 						linter.verify(code, config, {
 							allowInlineConfig: false,
 						});
-						assert(ok);
+						assert.ok(ok);
 					});
 
 					it("should report a violation for eslint-disable", () => {
@@ -16869,7 +16922,7 @@ var a = "test2";
 									reportUnusedDisableDirectives: "foo",
 								},
 							}),
-						'Key "linterOptions": Key "reportUnusedDisableDirectives": Expected one of: "error", "warn", "off", 0, 1, 2, or a boolean.',
+						/Key "linterOptions": Key "reportUnusedDisableDirectives": Expected one of: "error", "warn", "off", 0, 1, 2, or a boolean./u,
 					);
 				});
 
@@ -16881,7 +16934,7 @@ var a = "test2";
 									reportUnusedDisableDirectives: {},
 								},
 							}),
-						'Key "linterOptions": Key "reportUnusedDisableDirectives": Expected one of: "error", "warn", "off", 0, 1, 2, or a boolean.',
+						/Key "linterOptions": Key "reportUnusedDisableDirectives": Expected one of: "error", "warn", "off", 0, 1, 2, or a boolean./u,
 					);
 				});
 
@@ -18355,7 +18408,10 @@ var a = "test2";
 				};
 
 				linter.verify(code, config);
-				assert(spy && spy.calledOnce, "Rule should have been called.");
+				assert.ok(
+					spy && spy.calledOnce,
+					"Rule should have been called.",
+				);
 			});
 
 			it("ES6 global variables should be available by default", () => {
@@ -18401,7 +18457,7 @@ var a = "test2";
 				};
 
 				linter.verify(code, config);
-				assert(spy && spy.calledOnce);
+				assert.ok(spy && spy.calledOnce);
 			});
 		});
 
@@ -18584,7 +18640,7 @@ var a = "test2";
 
 				assert.throws(() => {
 					linter.verify("0", config);
-				}, "Rules with suggestions must set the `meta.hasSuggestions` property to `true`.");
+				}, /Rules with suggestions must set the `meta.hasSuggestions` property to `true`./u);
 			});
 
 			it("should throw an error if suggestion is passed but `meta.hasSuggestions` property is not enabled and the rule has the obsolete `meta.docs.suggestion` property", () => {
@@ -18626,7 +18682,7 @@ var a = "test2";
 
 				assert.throws(() => {
 					linter.verify("0", config);
-				}, "Rules with suggestions must set the `meta.hasSuggestions` property to `true`. `meta.docs.suggestion` is ignored by ESLint.");
+				}, /Rules with suggestions must set the `meta.hasSuggestions` property to `true`. `meta.docs.suggestion` is ignored by ESLint./u);
 			});
 		});
 
@@ -18640,10 +18696,10 @@ var a = "test2";
 
 					assert.strictEqual(messages.length, 1);
 					assert.strictEqual(messages[0].severity, 2);
-					assert.isNull(messages[0].ruleId);
+					assert.strictEqual(messages[0].ruleId, null);
 					assert.strictEqual(messages[0].line, 1);
 					assert.strictEqual(messages[0].column, 4);
-					assert.isTrue(messages[0].fatal);
+					assert.strictEqual(messages[0].fatal, true);
 					assert.match(messages[0].message, /^Parsing error:/u);
 
 					assert.strictEqual(suppressedMessages.length, 0);
@@ -18661,7 +18717,7 @@ var a = "test2";
 
 					assert.strictEqual(messages.length, 1);
 					assert.strictEqual(messages[0].severity, 2);
-					assert.isTrue(messages[0].fatal);
+					assert.strictEqual(messages[0].fatal, true);
 					assert.match(messages[0].message, /^Parsing error:/u);
 
 					assert.strictEqual(suppressedMessages.length, 0);
@@ -18753,9 +18809,11 @@ var a = "test2";
 
 			const sourceCode = linter.getSourceCode();
 
-			assert.isObject(sourceCode);
+			assert.ok(sourceCode !== null && typeof sourceCode === "object");
 			assert.strictEqual(sourceCode.text, code);
-			assert.isObject(sourceCode.ast);
+			assert.ok(
+				sourceCode.ast !== null && typeof sourceCode.ast === "object",
+			);
 		});
 
 		it("should retrieve SourceCode object without reset", () => {
@@ -18763,9 +18821,11 @@ var a = "test2";
 
 			const sourceCode = linter.getSourceCode();
 
-			assert.isObject(sourceCode);
+			assert.ok(sourceCode !== null && typeof sourceCode === "object");
 			assert.strictEqual(sourceCode.text, code);
-			assert.isObject(sourceCode.ast);
+			assert.ok(
+				sourceCode.ast !== null && typeof sourceCode.ast === "object",
+			);
 		});
 	});
 
@@ -18855,8 +18915,8 @@ var a = "test2";
 		it("should return current version number", () => {
 			const version = linter.version;
 
-			assert.isString(version);
-			assert.isTrue(parseInt(version[0], 10) >= 3);
+			assert.strictEqual(typeof version, "string");
+			assert.strictEqual(parseInt(version[0], 10) >= 3, true);
 		});
 	});
 
@@ -18878,7 +18938,7 @@ var a = "test2";
 				"var a;",
 				"Fixes were applied correctly",
 			);
-			assert.isTrue(messages.fixed);
+			assert.strictEqual(messages.fixed, true);
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
@@ -19515,13 +19575,13 @@ var a = "test2";
 
 				// filename
 				assert.strictEqual(receivedFilenames.length, 3);
-				assert(
+				assert.ok(
 					/^filename\.js[/\\]0_block\.js/u.test(receivedFilenames[0]),
 				);
-				assert(
+				assert.ok(
 					/^filename\.js[/\\]1_block\.js/u.test(receivedFilenames[1]),
 				);
-				assert(
+				assert.ok(
 					/^filename\.js[/\\]2_block\.js/u.test(receivedFilenames[2]),
 				);
 
@@ -20183,9 +20243,9 @@ var a = "test2";
 				rules: { "test/save-ast2": "error" },
 			});
 
-			assert(ast1 !== null);
-			assert(ast2 !== null);
-			assert(ast1 === ast2);
+			assert.ok(ast1 !== null);
+			assert.ok(ast2 !== null);
+			assert.ok(ast1 === ast2);
 		});
 
 		it("should not modify config object passed as argument", () => {
@@ -20215,7 +20275,7 @@ var a = "test2";
 			};
 
 			linter.verify("x", config);
-			assert(spy.calledOnce);
+			assert.ok(spy.calledOnce);
 		});
 
 		describe("when evaluating an empty string", () => {

--- a/tests/lib/linter/report-translator.js
+++ b/tests/lib/linter/report-translator.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const { SourceCode } = require("../../../lib/languages/js/source-code");
 const espree = require("espree");
 const createReportTranslator = require("../../../lib/linter/report-translator");
@@ -495,7 +495,7 @@ describe("createReportTranslator", () => {
 
 			assert.throws(
 				translateReport.bind(null, reportDescriptor),
-				"Fix objects must not be overlapped in a report.",
+				/Fix objects must not be overlapped in a report./u,
 			);
 		});
 
@@ -1078,7 +1078,7 @@ describe("createReportTranslator", () => {
 		it("should throw an error if node is not an object", () => {
 			assert.throws(
 				() => translateReport("not a node", "hello world"),
-				"Node must be an object",
+				/Node must be an object/u,
 			);
 		});
 
@@ -1116,7 +1116,7 @@ describe("createReportTranslator", () => {
 		it("should throw an error if neither node nor location is provided", () => {
 			assert.throws(
 				() => translateReport(null, "hello world"),
-				"Node must be provided when reporting error if location is not provided",
+				/Node must be provided when reporting error if location is not provided/u,
 			);
 		});
 

--- a/tests/lib/linter/rule-fixer.js
+++ b/tests/lib/linter/rule-fixer.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	{ RuleFixer } = require("../../../lib/linter/rule-fixer");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/linter/rules.js
+++ b/tests/lib/linter/rules.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	Rules = require("../../../lib/linter/rules"),
 	{ Linter } = require("../../../lib/linter");
 
@@ -72,8 +72,11 @@ describe("rules", () => {
 		it("should iterate all rules", () => {
 			const allRules = new Map(rules);
 
-			assert.isAbove(allRules.size, 230);
-			assert.isObject(allRules.get("no-alert"));
+			assert.ok(allRules.size > 230);
+			assert.ok(
+				allRules.get("no-alert") !== null &&
+					typeof allRules.get("no-alert") === "object",
+			);
 		});
 	});
 });

--- a/tests/lib/linter/safe-emitter.js
+++ b/tests/lib/linter/safe-emitter.js
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 const createEmitter = require("../../../lib/linter/safe-emitter");
-const assert = require("chai").assert;
+const assert = require("node:assert");
 
 //------------------------------------------------------------------------------
 // Tests
@@ -45,7 +45,7 @@ describe("safe-emitter", () => {
 			});
 
 			emitter.emit("foo");
-			assert(called);
+			assert.ok(called);
 		});
 	});
 });

--- a/tests/lib/linter/source-code-fixer.js
+++ b/tests/lib/linter/source-code-fixer.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	sinon = require("sinon"),
 	SourceCodeFixer = require("../../../lib/linter/source-code-fixer");
 
@@ -161,7 +161,7 @@ describe("SourceCodeFixer", () => {
 					false,
 				);
 
-				assert.isFalse(result.fixed);
+				assert.strictEqual(result.fixed, false);
 				assert.strictEqual(result.output, TEST_CODE);
 			});
 
@@ -170,7 +170,7 @@ describe("SourceCodeFixer", () => {
 					INSERT_AT_END,
 				]);
 
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should call a function provided as 'shouldFix' for each message", () => {
@@ -181,7 +181,7 @@ describe("SourceCodeFixer", () => {
 					[INSERT_IN_MIDDLE, INSERT_AT_START, INSERT_AT_END],
 					shouldFixSpy,
 				);
-				assert.isTrue(shouldFixSpy.calledThrice);
+				assert.strictEqual(shouldFixSpy.calledThrice, true);
 			});
 
 			it("should provide a message object as an argument to 'shouldFix'", () => {
@@ -206,7 +206,7 @@ describe("SourceCodeFixer", () => {
 					shouldFixSpy,
 				);
 
-				assert.isFalse(result.fixed);
+				assert.strictEqual(result.fixed, false);
 			});
 
 			it("should return original text as output if 'shouldFix' function prevents all fixes", () => {
@@ -242,7 +242,10 @@ describe("SourceCodeFixer", () => {
 					shouldFixSpy,
 				);
 
-				assert.isUndefined(shouldFixSpy.thisValues[0]);
+				assert.strictEqual(
+					typeof shouldFixSpy.thisValues[0],
+					"undefined",
+				);
 			});
 		});
 
@@ -322,7 +325,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					TEST_CODE.replace("var", "let"),
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should replace text at the beginning of the code", () => {
@@ -335,7 +338,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					TEST_CODE.replace("answer", "foo"),
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should replace text in the middle of the code", () => {
@@ -345,7 +348,7 @@ describe("SourceCodeFixer", () => {
 
 				assert.strictEqual(result.messages.length, 0);
 				assert.strictEqual(result.output, TEST_CODE.replace("6", "5"));
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should replace text at the beginning and end of the code", () => {
@@ -357,7 +360,7 @@ describe("SourceCodeFixer", () => {
 
 				assert.strictEqual(result.messages.length, 0);
 				assert.strictEqual(result.output, "let foo = 5 * 7;");
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 		});
 
@@ -372,7 +375,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					TEST_CODE.replace("var ", ""),
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should remove text in the middle of the code", () => {
@@ -385,7 +388,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					TEST_CODE.replace("answer", "a"),
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should remove text towards the end of the code", () => {
@@ -398,7 +401,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					TEST_CODE.replace(" * 7", ""),
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should remove text at the beginning, middle, and end of the code", () => {
@@ -410,7 +413,7 @@ describe("SourceCodeFixer", () => {
 
 				assert.strictEqual(result.messages.length, 0);
 				assert.strictEqual(result.output, "a = 6;");
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 		});
 
@@ -423,7 +426,7 @@ describe("SourceCodeFixer", () => {
 				]);
 
 				assert.strictEqual(result.output, "let answer = 6;// end");
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 				assert.strictEqual(result.messages.length, 0);
 			});
 
@@ -439,7 +442,7 @@ describe("SourceCodeFixer", () => {
 				);
 				assert.strictEqual(result.messages.length, 1);
 				assert.strictEqual(result.messages[0].message, "removemiddle");
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should apply one fix when the end of one range is the same as the start of a previous range overlap", () => {
@@ -454,7 +457,7 @@ describe("SourceCodeFixer", () => {
 				);
 				assert.strictEqual(result.messages.length, 1);
 				assert.strictEqual(result.messages[0].message, "foo");
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should only apply one fix when ranges overlap and one message has no fix", () => {
@@ -471,7 +474,7 @@ describe("SourceCodeFixer", () => {
 				assert.strictEqual(result.messages.length, 2);
 				assert.strictEqual(result.messages[0].message, "nofix");
 				assert.strictEqual(result.messages[1].message, "removemiddle");
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should apply the same fix when ranges overlap regardless of order", () => {
@@ -495,7 +498,7 @@ describe("SourceCodeFixer", () => {
 				assert.strictEqual(result.output, TEST_CODE);
 				assert.strictEqual(result.messages.length, 1);
 				assert.strictEqual(result.messages[0].message, "nofix");
-				assert.isFalse(result.fixed);
+				assert.strictEqual(result.fixed, false);
 			});
 
 			it("should sort the no fix messages correctly", () => {
@@ -512,7 +515,7 @@ describe("SourceCodeFixer", () => {
 				assert.strictEqual(result.messages.length, 2);
 				assert.strictEqual(result.messages[0].message, "nofix1");
 				assert.strictEqual(result.messages[1].message, "nofix2");
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 		});
 
@@ -523,7 +526,7 @@ describe("SourceCodeFixer", () => {
 				]);
 
 				assert.strictEqual(result.output, `\uFEFF${TEST_CODE}`);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 				assert.strictEqual(result.messages.length, 0);
 			});
 
@@ -536,7 +539,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					`\uFEFF// start\n${TEST_CODE}`,
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 				assert.strictEqual(result.messages.length, 0);
 			});
 
@@ -546,7 +549,7 @@ describe("SourceCodeFixer", () => {
 				]);
 
 				assert.strictEqual(result.output, TEST_CODE);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 				assert.strictEqual(result.messages.length, 0);
 			});
 
@@ -556,7 +559,7 @@ describe("SourceCodeFixer", () => {
 				]);
 
 				assert.strictEqual(result.output, `// start\n${TEST_CODE}`);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 				assert.strictEqual(result.messages.length, 0);
 			});
 		});
@@ -567,7 +570,7 @@ describe("SourceCodeFixer", () => {
 					NULL_FIX,
 				]);
 
-				assert.isFalse(result.fixed);
+				assert.strictEqual(result.fixed, false);
 				assert.strictEqual(result.output, TEST_CODE);
 				assert.strictEqual(result.messages.length, 1);
 				assert.strictEqual(result.messages[0].message, "null");
@@ -578,7 +581,7 @@ describe("SourceCodeFixer", () => {
 					UNDEFINED_FIX,
 				]);
 
-				assert.isFalse(result.fixed);
+				assert.strictEqual(result.fixed, false);
 				assert.strictEqual(result.output, TEST_CODE);
 				assert.strictEqual(result.messages.length, 1);
 				assert.strictEqual(result.messages[0].message, "undefined");
@@ -668,7 +671,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					`\uFEFF${TEST_CODE.replace("var", "let")}`,
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should replace text at the beginning of the code", () => {
@@ -681,7 +684,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					`\uFEFF${TEST_CODE.replace("answer", "foo")}`,
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should replace text in the middle of the code", () => {
@@ -694,7 +697,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					`\uFEFF${TEST_CODE.replace("6", "5")}`,
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should replace text at the beginning and end of the code", () => {
@@ -706,7 +709,7 @@ describe("SourceCodeFixer", () => {
 
 				assert.strictEqual(result.messages.length, 0);
 				assert.strictEqual(result.output, "\uFEFFlet foo = 5 * 7;");
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 		});
 
@@ -721,7 +724,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					`\uFEFF${TEST_CODE.replace("var ", "")}`,
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should remove text in the middle of the code", () => {
@@ -734,7 +737,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					`\uFEFF${TEST_CODE.replace("answer", "a")}`,
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should remove text towards the end of the code", () => {
@@ -747,7 +750,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					`\uFEFF${TEST_CODE.replace(" * 7", "")}`,
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should remove text at the beginning, middle, and end of the code", () => {
@@ -759,7 +762,7 @@ describe("SourceCodeFixer", () => {
 
 				assert.strictEqual(result.messages.length, 0);
 				assert.strictEqual(result.output, "\uFEFFa = 6;");
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 		});
 
@@ -775,7 +778,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					"\uFEFFlet answer = 6;// end",
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 				assert.strictEqual(result.messages.length, 0);
 			});
 
@@ -791,7 +794,7 @@ describe("SourceCodeFixer", () => {
 				);
 				assert.strictEqual(result.messages.length, 1);
 				assert.strictEqual(result.messages[0].message, "removemiddle");
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should apply one fix when the end of one range is the same as the start of a previous range overlap", () => {
@@ -806,7 +809,7 @@ describe("SourceCodeFixer", () => {
 				);
 				assert.strictEqual(result.messages.length, 1);
 				assert.strictEqual(result.messages[0].message, "foo");
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should only apply one fix when ranges overlap and one message has no fix", () => {
@@ -823,7 +826,7 @@ describe("SourceCodeFixer", () => {
 				assert.strictEqual(result.messages.length, 2);
 				assert.strictEqual(result.messages[0].message, "nofix");
 				assert.strictEqual(result.messages[1].message, "removemiddle");
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 			});
 
 			it("should apply the same fix when ranges overlap regardless of order", () => {
@@ -849,7 +852,7 @@ describe("SourceCodeFixer", () => {
 				assert.strictEqual(result.output, `\uFEFF${TEST_CODE}`);
 				assert.strictEqual(result.messages.length, 1);
 				assert.strictEqual(result.messages[0].message, "nofix");
-				assert.isFalse(result.fixed);
+				assert.strictEqual(result.fixed, false);
 			});
 		});
 
@@ -860,7 +863,7 @@ describe("SourceCodeFixer", () => {
 				]);
 
 				assert.strictEqual(result.output, `\uFEFF${TEST_CODE}`);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 				assert.strictEqual(result.messages.length, 0);
 			});
 
@@ -873,7 +876,7 @@ describe("SourceCodeFixer", () => {
 					result.output,
 					`\uFEFF// start\n${TEST_CODE}`,
 				);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 				assert.strictEqual(result.messages.length, 0);
 			});
 
@@ -883,7 +886,7 @@ describe("SourceCodeFixer", () => {
 				]);
 
 				assert.strictEqual(result.output, TEST_CODE);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 				assert.strictEqual(result.messages.length, 0);
 			});
 
@@ -893,7 +896,7 @@ describe("SourceCodeFixer", () => {
 				]);
 
 				assert.strictEqual(result.output, `// start\n${TEST_CODE}`);
-				assert.isTrue(result.fixed);
+				assert.strictEqual(result.fixed, true);
 				assert.strictEqual(result.messages.length, 0);
 			});
 		});

--- a/tests/lib/linter/timing.js
+++ b/tests/lib/linter/timing.js
@@ -5,7 +5,7 @@
 //------------------------------------------------------------------------------
 
 const { getListSize } = require("../../../lib/linter/timing");
-const assert = require("chai").assert;
+const assert = require("node:assert");
 
 //------------------------------------------------------------------------------
 // Tests

--- a/tests/lib/linter/vfile.js
+++ b/tests/lib/linter/vfile.js
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 const { VFile } = require("../../../lib/linter/vfile");
-const assert = require("chai").assert;
+const assert = require("node:assert");
 
 //------------------------------------------------------------------------------
 // Tests
@@ -25,7 +25,7 @@ describe("VFile", () => {
 			assert.strictEqual(vfile.physicalPath, "foo.js");
 			assert.strictEqual(vfile.body, "var foo = bar;");
 			assert.strictEqual(vfile.rawBody, "var foo = bar;");
-			assert.isFalse(vfile.bom);
+			assert.strictEqual(vfile.bom, false);
 		});
 
 		it("should create a new instance with a BOM", () => {
@@ -35,7 +35,7 @@ describe("VFile", () => {
 			assert.strictEqual(vfile.physicalPath, "foo.js");
 			assert.strictEqual(vfile.body, "var foo = bar;");
 			assert.strictEqual(vfile.rawBody, "\uFEFFvar foo = bar;");
-			assert.isTrue(vfile.bom);
+			assert.strictEqual(vfile.bom, true);
 		});
 
 		it("should create a new instance with a physicalPath", () => {
@@ -47,7 +47,7 @@ describe("VFile", () => {
 			assert.strictEqual(vfile.physicalPath, "foo/bar");
 			assert.strictEqual(vfile.body, "var foo = bar;");
 			assert.strictEqual(vfile.rawBody, "var foo = bar;");
-			assert.isFalse(vfile.bom);
+			assert.strictEqual(vfile.bom, false);
 		});
 
 		it("should create a new instance with a Uint8Array", () => {
@@ -59,7 +59,7 @@ describe("VFile", () => {
 			assert.strictEqual(vfile.physicalPath, "foo.js");
 			assert.deepStrictEqual(vfile.body, body);
 			assert.deepStrictEqual(vfile.rawBody, body);
-			assert.isFalse(vfile.bom);
+			assert.strictEqual(vfile.bom, false);
 		});
 
 		it("should create a new instance with a BOM in a Uint8Array", () => {
@@ -71,7 +71,7 @@ describe("VFile", () => {
 			assert.strictEqual(vfile.physicalPath, "foo.js");
 			assert.deepStrictEqual(vfile.body, body.slice(3));
 			assert.deepStrictEqual(vfile.rawBody, body);
-			assert.isTrue(vfile.bom);
+			assert.strictEqual(vfile.bom, true);
 		});
 	});
 });

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	createOptions = require("../../lib/options");
 
 //-----------------------------------------------------------------------------
@@ -34,7 +34,7 @@ describe("options", () => {
 				it("should return true for .help when passed", () => {
 					const currentOptions = options.parse("--help");
 
-					assert.isTrue(currentOptions.help);
+					assert.strictEqual(currentOptions.help, true);
 				});
 			});
 
@@ -42,7 +42,7 @@ describe("options", () => {
 				it("should return true for .help when passed", () => {
 					const currentOptions = options.parse("-h");
 
-					assert.isTrue(currentOptions.help);
+					assert.strictEqual(currentOptions.help, true);
 				});
 			});
 
@@ -50,7 +50,7 @@ describe("options", () => {
 				it("should return a string for .config when passed a string", () => {
 					const currentOptions = options.parse("--config file");
 
-					assert.isString(currentOptions.config);
+					assert.strictEqual(typeof currentOptions.config, "string");
 					assert.strictEqual(currentOptions.config, "file");
 				});
 			});
@@ -59,7 +59,7 @@ describe("options", () => {
 				it("should return a string for .config when passed a string", () => {
 					const currentOptions = options.parse("-c file");
 
-					assert.isString(currentOptions.config);
+					assert.strictEqual(typeof currentOptions.config, "string");
 					assert.strictEqual(currentOptions.config, "file");
 				});
 			});
@@ -68,14 +68,14 @@ describe("options", () => {
 				it("should return a string for .format when passed a string", () => {
 					const currentOptions = options.parse("--format json");
 
-					assert.isString(currentOptions.format);
+					assert.strictEqual(typeof currentOptions.format, "string");
 					assert.strictEqual(currentOptions.format, "json");
 				});
 
 				it("should return stylish for .format when not passed", () => {
 					const currentOptions = options.parse("");
 
-					assert.isString(currentOptions.format);
+					assert.strictEqual(typeof currentOptions.format, "string");
 					assert.strictEqual(currentOptions.format, "stylish");
 				});
 			});
@@ -84,7 +84,7 @@ describe("options", () => {
 				it("should return a string for .format when passed a string", () => {
 					const currentOptions = options.parse("-f json");
 
-					assert.isString(currentOptions.format);
+					assert.strictEqual(typeof currentOptions.format, "string");
 					assert.strictEqual(currentOptions.format, "json");
 				});
 			});
@@ -93,7 +93,7 @@ describe("options", () => {
 				it("should return true for .version when passed", () => {
 					const currentOptions = options.parse("--version");
 
-					assert.isTrue(currentOptions.version);
+					assert.strictEqual(currentOptions.version, true);
 				});
 			});
 
@@ -101,7 +101,7 @@ describe("options", () => {
 				it("should return true for .version when passed", () => {
 					const currentOptions = options.parse("-v");
 
-					assert.isTrue(currentOptions.version);
+					assert.strictEqual(currentOptions.version, true);
 				});
 			});
 
@@ -109,7 +109,7 @@ describe("options", () => {
 				it("should return string of help text when called", () => {
 					const helpText = options.generateHelp();
 
-					assert.isString(helpText);
+					assert.strictEqual(typeof helpText, "string");
 				});
 			});
 
@@ -117,7 +117,7 @@ describe("options", () => {
 				it("should return false for .ignore when passed", () => {
 					const currentOptions = options.parse("--no-ignore");
 
-					assert.isFalse(currentOptions.ignore);
+					assert.strictEqual(currentOptions.ignore, false);
 				});
 			});
 
@@ -162,13 +162,13 @@ describe("options", () => {
 				it("should return true for .color when passed --color", () => {
 					const currentOptions = options.parse("--color");
 
-					assert.isTrue(currentOptions.color);
+					assert.strictEqual(currentOptions.color, true);
 				});
 
 				it("should return false for .color when passed --no-color", () => {
 					const currentOptions = options.parse("--no-color");
 
-					assert.isFalse(currentOptions.color);
+					assert.strictEqual(currentOptions.color, false);
 				});
 			});
 
@@ -176,7 +176,7 @@ describe("options", () => {
 				it("should return true for .stdin when passed", () => {
 					const currentOptions = options.parse("--stdin");
 
-					assert.isTrue(currentOptions.stdin);
+					assert.strictEqual(currentOptions.stdin, true);
 				});
 			});
 
@@ -194,7 +194,7 @@ describe("options", () => {
 				it("should return an array for a single occurrence", () => {
 					const currentOptions = options.parse("--global foo");
 
-					assert.isArray(currentOptions.global);
+					assert.ok(Array.isArray(currentOptions.global));
 					assert.strictEqual(currentOptions.global.length, 1);
 					assert.strictEqual(currentOptions.global[0], "foo");
 				});
@@ -202,7 +202,7 @@ describe("options", () => {
 				it("should split variable names using commas", () => {
 					const currentOptions = options.parse("--global foo,bar");
 
-					assert.isArray(currentOptions.global);
+					assert.ok(Array.isArray(currentOptions.global));
 					assert.strictEqual(currentOptions.global.length, 2);
 					assert.strictEqual(currentOptions.global[0], "foo");
 					assert.strictEqual(currentOptions.global[1], "bar");
@@ -213,7 +213,7 @@ describe("options", () => {
 						"--global foo:false,bar:true",
 					);
 
-					assert.isArray(currentOptions.global);
+					assert.ok(Array.isArray(currentOptions.global));
 					assert.strictEqual(currentOptions.global.length, 2);
 					assert.strictEqual(currentOptions.global[0], "foo:false");
 					assert.strictEqual(currentOptions.global[1], "bar:true");
@@ -224,7 +224,7 @@ describe("options", () => {
 						"--global foo:true --global bar:false",
 					);
 
-					assert.isArray(currentOptions.global);
+					assert.ok(Array.isArray(currentOptions.global));
 					assert.strictEqual(currentOptions.global.length, 2);
 					assert.strictEqual(currentOptions.global[0], "foo:true");
 					assert.strictEqual(currentOptions.global[1], "bar:false");
@@ -235,7 +235,7 @@ describe("options", () => {
 				it("should return true for .quiet when passed", () => {
 					const currentOptions = options.parse("--quiet");
 
-					assert.isTrue(currentOptions.quiet);
+					assert.strictEqual(currentOptions.quiet, true);
 				});
 			});
 
@@ -263,7 +263,7 @@ describe("options", () => {
 				it("should return true for --init when passed", () => {
 					const currentOptions = options.parse("--init");
 
-					assert.isTrue(currentOptions.init);
+					assert.strictEqual(currentOptions.init, true);
 				});
 			});
 
@@ -271,7 +271,7 @@ describe("options", () => {
 				it("should return true for --fix when passed", () => {
 					const currentOptions = options.parse("--fix");
 
-					assert.isTrue(currentOptions.fix);
+					assert.strictEqual(currentOptions.fix, true);
 				});
 			});
 
@@ -308,7 +308,7 @@ describe("options", () => {
 				it("should return true for --debug when passed", () => {
 					const currentOptions = options.parse("--debug");
 
-					assert.isTrue(currentOptions.debug);
+					assert.strictEqual(currentOptions.debug, true);
 				});
 			});
 
@@ -316,13 +316,13 @@ describe("options", () => {
 				it("should return false when passed --no-inline-config", () => {
 					const currentOptions = options.parse("--no-inline-config");
 
-					assert.isFalse(currentOptions.inlineConfig);
+					assert.strictEqual(currentOptions.inlineConfig, false);
 				});
 
 				it("should return true for --inline-config when empty", () => {
 					const currentOptions = options.parse("");
 
-					assert.isTrue(currentOptions.inlineConfig);
+					assert.strictEqual(currentOptions.inlineConfig, true);
 				});
 			});
 
@@ -340,7 +340,7 @@ describe("options", () => {
 				it("should return an array with one item when passed .jsx", () => {
 					const currentOptions = options.parse("--ext .jsx");
 
-					assert.isArray(currentOptions.ext);
+					assert.ok(Array.isArray(currentOptions.ext));
 					assert.strictEqual(currentOptions.ext[0], ".jsx");
 				});
 
@@ -349,7 +349,7 @@ describe("options", () => {
 						"--ext .jsx --ext .js",
 					);
 
-					assert.isArray(currentOptions.ext);
+					assert.ok(Array.isArray(currentOptions.ext));
 					assert.strictEqual(currentOptions.ext[0], ".jsx");
 					assert.strictEqual(currentOptions.ext[1], ".js");
 				});
@@ -357,7 +357,7 @@ describe("options", () => {
 				it("should return an array with two items when passed .jsx,.js", () => {
 					const currentOptions = options.parse("--ext .jsx,.js");
 
-					assert.isArray(currentOptions.ext);
+					assert.ok(Array.isArray(currentOptions.ext));
 					assert.strictEqual(currentOptions.ext[0], ".jsx");
 					assert.strictEqual(currentOptions.ext[1], ".js");
 				});
@@ -365,7 +365,7 @@ describe("options", () => {
 				it("should not exist when not passed", () => {
 					const currentOptions = options.parse("");
 
-					assert.notProperty(currentOptions, "ext");
+					assert.ok(!("ext" in currentOptions));
 				});
 			});
 		});
@@ -377,7 +377,7 @@ describe("options", () => {
 				"--rulesdir /morerules",
 			);
 
-			assert.isArray(currentOptions.rulesdir);
+			assert.ok(Array.isArray(currentOptions.rulesdir));
 			assert.deepStrictEqual(currentOptions.rulesdir, ["/morerules"]);
 		});
 	});
@@ -404,7 +404,7 @@ describe("options", () => {
 		it("should return an array when passed a single occurrence", () => {
 			const currentOptions = eslintrcOptions.parse("--plugin single");
 
-			assert.isArray(currentOptions.plugin);
+			assert.ok(Array.isArray(currentOptions.plugin));
 			assert.strictEqual(currentOptions.plugin.length, 1);
 			assert.strictEqual(currentOptions.plugin[0], "single");
 		});
@@ -412,7 +412,7 @@ describe("options", () => {
 		it("should return an array when passed a comma-delimited string", () => {
 			const currentOptions = eslintrcOptions.parse("--plugin foo,bar");
 
-			assert.isArray(currentOptions.plugin);
+			assert.ok(Array.isArray(currentOptions.plugin));
 			assert.strictEqual(currentOptions.plugin.length, 2);
 			assert.strictEqual(currentOptions.plugin[0], "foo");
 			assert.strictEqual(currentOptions.plugin[1], "bar");
@@ -423,7 +423,7 @@ describe("options", () => {
 				"--plugin foo --plugin bar",
 			);
 
-			assert.isArray(currentOptions.plugin);
+			assert.ok(Array.isArray(currentOptions.plugin));
 			assert.strictEqual(currentOptions.plugin.length, 2);
 			assert.strictEqual(currentOptions.plugin[0], "foo");
 			assert.strictEqual(currentOptions.plugin[1], "bar");
@@ -436,7 +436,7 @@ describe("options", () => {
 				"--no-config-lookup foo.js",
 			);
 
-			assert.isFalse(currentOptions.configLookup);
+			assert.strictEqual(currentOptions.configLookup, false);
 		});
 	});
 
@@ -444,7 +444,7 @@ describe("options", () => {
 		it("should return a boolean for .passOnNoPatterns when passed a string", () => {
 			const currentOptions = flatOptions.parse("--pass-on-no-patterns");
 
-			assert.isTrue(currentOptions.passOnNoPatterns);
+			assert.strictEqual(currentOptions.passOnNoPatterns, true);
 		});
 	});
 
@@ -452,13 +452,13 @@ describe("options", () => {
 		it("should return false when --no-warn-ignored is passed", () => {
 			const currentOptions = flatOptions.parse("--no-warn-ignored");
 
-			assert.isFalse(currentOptions.warnIgnored);
+			assert.strictEqual(currentOptions.warnIgnored, false);
 		});
 
 		it("should return true when --warn-ignored is passed", () => {
 			const currentOptions = flatOptions.parse("--warn-ignored");
 
-			assert.isTrue(currentOptions.warnIgnored);
+			assert.strictEqual(currentOptions.warnIgnored, true);
 		});
 	});
 
@@ -466,7 +466,7 @@ describe("options", () => {
 		it("should return true --stats is passed", () => {
 			const currentOptions = flatOptions.parse("--stats");
 
-			assert.isTrue(currentOptions.stats);
+			assert.strictEqual(currentOptions.stats, true);
 		});
 	});
 
@@ -474,7 +474,7 @@ describe("options", () => {
 		it("should return true when --inspect-config is passed", () => {
 			const currentOptions = flatOptions.parse("--inspect-config");
 
-			assert.isTrue(currentOptions.inspectConfig);
+			assert.strictEqual(currentOptions.inspectConfig, true);
 		});
 	});
 

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -10,8 +10,7 @@
 const sinon = require("sinon"),
 	EventEmitter = require("node:events"),
 	{ RuleTester } = require("../../../lib/rule-tester"),
-	assert = require("chai").assert,
-	nodeAssert = require("node:assert");
+	assert = require("node:assert");
 
 const jsonPlugin = require("@eslint/json").default;
 
@@ -21,7 +20,7 @@ const jsonPlugin = require("@eslint/json").default;
 
 const NODE_ASSERT_STRICT_EQUAL_OPERATOR = (() => {
 	try {
-		nodeAssert.strictEqual(1, 2);
+		assert.strictEqual(1, 2);
 	} catch (err) {
 		return err.operator;
 	}
@@ -30,13 +29,13 @@ const NODE_ASSERT_STRICT_EQUAL_OPERATOR = (() => {
 
 /**
  * A helper function to verify Node.js core error messages.
- * @param {string} actual The actual input
- * @param {string} expected The expected input
+ * @param {RegExp} actual The actual input
+ * @param {RegExp} expected The expected input
  * @returns {Function} Error callback to verify that the message is correct
  *                     for the actual and expected input.
  */
 function assertErrorMatches(actual, expected) {
-	const err = new nodeAssert.AssertionError({
+	const err = new assert.AssertionError({
 		actual,
 		expected,
 		operator: NODE_ASSERT_STRICT_EQUAL_OPERATOR,
@@ -110,7 +109,7 @@ describe("RuleTester", () => {
 			const config = { languageOptions: { globals: { test: true } } };
 
 			RuleTester.setDefaultConfig(config);
-			assert(
+			assert.ok(
 				RuleTester.getDefaultConfig().languageOptions.globals.test,
 				"The default config object is incorrect",
 			);
@@ -141,14 +140,14 @@ describe("RuleTester", () => {
 				};
 			}
 			const errorMessage =
-				"RuleTester.setDefaultConfig: config must be an object";
+				/RuleTester.setDefaultConfig: config must be an object/u;
 
-			assert.throw(setConfig(), errorMessage);
-			assert.throw(setConfig(1), errorMessage);
-			assert.throw(setConfig(3.14), errorMessage);
-			assert.throw(setConfig("foo"), errorMessage);
-			assert.throw(setConfig(null), errorMessage);
-			assert.throw(setConfig(true), errorMessage);
+			assert.throws(setConfig(), errorMessage);
+			assert.throws(setConfig(1), errorMessage);
+			assert.throws(setConfig(3.14), errorMessage);
+			assert.throws(setConfig("foo"), errorMessage);
+			assert.throws(setConfig(null), errorMessage);
+			assert.throws(setConfig(true), errorMessage);
 		});
 
 		it("should pass-through the globals config to the tester then to the to rule", () => {
@@ -208,7 +207,7 @@ describe("RuleTester", () => {
 					valid: ["foo(a, b)"],
 					invalid: [],
 				});
-			}, "Use node.range[0] instead of node.start");
+			}, /Use node.range\[0\] instead of node.start/u);
 		});
 	});
 
@@ -357,7 +356,7 @@ describe("RuleTester", () => {
 								invalid: [],
 							},
 						);
-					}, "Set `RuleTester.itOnly` to use `only` with a custom test framework.");
+					}, /Set `RuleTester.itOnly` to use `only` with a custom test framework./u);
 				});
 			});
 
@@ -406,7 +405,7 @@ describe("RuleTester", () => {
 								invalid: [],
 							},
 						);
-					}, "The current test framework does not support exclusive tests with `only`.");
+					}, /The current test framework does not support exclusive tests with `only`./u);
 				});
 			});
 		});
@@ -557,7 +556,7 @@ describe("RuleTester", () => {
 							],
 							invalid: [],
 						}),
-					"Something happened",
+					/Something happened/u,
 				);
 				assert.throws(
 					() =>
@@ -572,7 +571,7 @@ describe("RuleTester", () => {
 								},
 							],
 						}),
-					"Something happened",
+					/Something happened/u,
 				);
 			});
 
@@ -589,7 +588,10 @@ describe("RuleTester", () => {
 							],
 							invalid: [],
 						}),
-					`Optional test case property '${hookName}' must be a function`,
+					new RegExp(
+						`Optional test case property '${hookName}' must be a function`,
+						"u",
+					),
 				);
 				assert.throws(
 					() =>
@@ -604,7 +606,10 @@ describe("RuleTester", () => {
 								},
 							],
 						}),
-					`Optional test case property '${hookName}' must be a function`,
+					new RegExp(
+						`Optional test case property '${hookName}' must be a function`,
+						"u",
+					),
 				);
 			});
 		});
@@ -706,7 +711,7 @@ describe("RuleTester", () => {
 						],
 						invalid: [],
 					}),
-				"Something happened in before()",
+				/Something happened in before\(\)/u,
 			);
 			sinon.assert.calledOnce(hookBefore);
 			sinon.assert.calledOnce(hookAfter);
@@ -724,7 +729,7 @@ describe("RuleTester", () => {
 							},
 						],
 					}),
-				"Something happened in before()",
+				/Something happened in before\(\)/u,
 			);
 			sinon.assert.calledTwice(hookBefore);
 			sinon.assert.calledTwice(hookAfter);
@@ -859,7 +864,7 @@ describe("RuleTester", () => {
 					},
 				);
 			},
-			assertErrorMatches("Bad var.", "Bad error message."),
+			assertErrorMatches(/Bad var./u, /Bad error message./u),
 		);
 	});
 
@@ -938,7 +943,7 @@ describe("RuleTester", () => {
 					},
 				);
 			},
-			assertErrorMatches("Bad var.", "Bad error message."),
+			assertErrorMatches(/Bad var./u, /Bad error message./u),
 		);
 	});
 
@@ -1022,7 +1027,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "Error at index 0 has suggestions. Please convert the test error into an object and specify 'suggestions' property on it to test suggestions.");
+		}, /Error at index 0 has suggestions. Please convert the test error into an object and specify 'suggestions' property on it to test suggestions./u);
 	});
 
 	it("should throw an error when the error is an object with an unknown property name", () => {
@@ -1232,7 +1237,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "Test property 'output' matches 'code'. If no autofix is expected, then omit the 'output' property or set it to null.");
+		}, /Test property 'output' matches 'code'. If no autofix is expected, then omit the 'output' property or set it to null./u);
 	});
 
 	it("should throw an error when the expected output isn't specified and problems produce output", () => {
@@ -1245,7 +1250,7 @@ describe("RuleTester", () => {
 					invalid: [{ code: "var foo = bar;", errors: 1 }],
 				},
 			);
-		}, "The rule fixed the code. Please add 'output' property.");
+		}, /The rule fixed the code. Please add 'output' property./u);
 	});
 
 	it("should throw an error if invalid code specifies wrong type", () => {
@@ -1321,7 +1326,7 @@ describe("RuleTester", () => {
 
 	it("should throw an error if invalid code specifies wrong column", () => {
 		const wrongColumn = 10,
-			expectedErrorMessage = "Error column should be 1";
+			expectedErrorMessage = /Error column should be 1/u;
 
 		assert.throws(() => {
 			ruleTester.run(
@@ -1423,7 +1428,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "Error endLine should be 10");
+		}, /Error endLine should be 10/u);
 	});
 
 	it("should throw an error if invalid code specifies wrong endColumn", () => {
@@ -1448,7 +1453,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "Error endColumn should be 10");
+		}, /Error endColumn should be 10/u);
 	});
 
 	it("should throw an error if invalid code has the wrong number of errors", () => {
@@ -1578,7 +1583,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "Test error must specify either a 'messageId' or 'message'.");
+		}, /Test error must specify either a 'messageId' or 'message'./u);
 	});
 
 	it("should throw an error if an error has a property besides message or messageId", () => {
@@ -1596,7 +1601,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "Test error must specify either a 'messageId' or 'message'.");
+		}, /Test error must specify either a 'messageId' or 'message'./u);
 	});
 
 	it("should pass-through the globals config of valid tests to the to rule", () => {
@@ -2013,7 +2018,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "Schema for rule no-invalid-schema is invalid:,\titems: should be object\n\titems[0].enum: should NOT have fewer than 1 items\n\titems: should match some schema in anyOf");
+		}, /Schema for rule no-invalid-schema is invalid:,\titems: should be object\n\titems\[0\].enum: should NOT have fewer than 1 items\n\titems: should match some schema in anyOf/u);
 	});
 
 	it("should throw an error if rule schema is `{}`", () => {
@@ -2165,7 +2170,7 @@ describe("RuleTester", () => {
 					invalid: [],
 				},
 			);
-		}, /ESLint configuration in rule-tester is invalid./u);
+		}, /ConfigError: ESLint configuration in rule-tester is invalid./u);
 	});
 
 	it("throw an error when env is included in config", () => {
@@ -2214,7 +2219,7 @@ describe("RuleTester", () => {
 					invalid: [],
 				},
 			);
-		}, "Rule should not modify AST.");
+		}, /Rule should not modify AST./u);
 		assert.throws(() => {
 			ruleTester.run(
 				"foo",
@@ -2224,7 +2229,7 @@ describe("RuleTester", () => {
 					invalid: [{ code: "var bar = 0;", errors: ["error"] }],
 				},
 			);
-		}, "Rule should not modify AST.");
+		}, /Rule should not modify AST./u);
 	});
 
 	it("should throw an error node.start is accessed with custom parser", () => {
@@ -2256,7 +2261,7 @@ describe("RuleTester", () => {
 				valid: ["foo(a, b)"],
 				invalid: [],
 			});
-		}, "Use node.range[0] instead of node.start");
+		}, /Use node.range\[0\] instead of node.start/u);
 	});
 
 	it("should throw an error if AST was modified (at Program)", () => {
@@ -2269,7 +2274,7 @@ describe("RuleTester", () => {
 					invalid: [],
 				},
 			);
-		}, "Rule should not modify AST.");
+		}, /Rule should not modify AST./u);
 		assert.throws(() => {
 			ruleTester.run(
 				"foo",
@@ -2279,7 +2284,7 @@ describe("RuleTester", () => {
 					invalid: [{ code: "var bar = 0;", errors: ["error"] }],
 				},
 			);
-		}, "Rule should not modify AST.");
+		}, /Rule should not modify AST./u);
 	});
 
 	it("should throw an error if AST was modified (at Program:exit)", () => {
@@ -2292,7 +2297,7 @@ describe("RuleTester", () => {
 					invalid: [],
 				},
 			);
-		}, "Rule should not modify AST.");
+		}, /Rule should not modify AST./u);
 		assert.throws(() => {
 			ruleTester.run(
 				"foo",
@@ -2302,7 +2307,7 @@ describe("RuleTester", () => {
 					invalid: [{ code: "var bar = 0;", errors: ["error"] }],
 				},
 			);
-		}, "Rule should not modify AST.");
+		}, /Rule should not modify AST./u);
 	});
 
 	it("should throw an error if rule uses start and end properties on nodes, tokens or comments", () => {
@@ -2341,31 +2346,31 @@ describe("RuleTester", () => {
 				valid: ["foo(a, b)"],
 				invalid: [],
 			});
-		}, "Use node.range[0] instead of node.start");
+		}, /Use node.range\[0\] instead of node.start/u);
 		assert.throws(() => {
 			ruleTester.run("uses-start-end", usesStartEndRule, {
 				valid: [],
 				invalid: [{ code: "var a = b * (c + d) / e;", errors: 1 }],
 			});
-		}, "Use node.range[1] instead of node.end");
+		}, /Use node.range\[1\] instead of node.end/u);
 		assert.throws(() => {
 			ruleTester.run("uses-start-end", usesStartEndRule, {
 				valid: [],
 				invalid: [{ code: "var a = -b * c;", errors: 1 }],
 			});
-		}, "Use token.range[0] instead of token.start");
+		}, /Use token.range\[0\] instead of token.start/u);
 		assert.throws(() => {
 			ruleTester.run("uses-start-end", usesStartEndRule, {
 				valid: ["var a = b ? c : d;"],
 				invalid: [],
 			});
-		}, "Use token.range[1] instead of token.end");
+		}, /Use token.range\[1\] instead of token.end/u);
 		assert.throws(() => {
 			ruleTester.run("uses-start-end", usesStartEndRule, {
 				valid: ["function f() { /* comment */ }"],
 				invalid: [],
 			});
-		}, "Use token.range[0] instead of token.start");
+		}, /Use token.range\[0\] instead of token.start/u);
 		assert.throws(() => {
 			ruleTester.run("uses-start-end", usesStartEndRule, {
 				valid: [],
@@ -2373,7 +2378,7 @@ describe("RuleTester", () => {
 					{ code: "var x = //\n {\n //comment\n //\n}", errors: 1 },
 				],
 			});
-		}, "Use token.range[1] instead of token.end");
+		}, /Use token.range\[1\] instead of token.end/u);
 
 		const enhancedParser = require("../../fixtures/parsers/enhanced-parser");
 
@@ -2387,7 +2392,7 @@ describe("RuleTester", () => {
 				],
 				invalid: [],
 			});
-		}, "Use node.range[0] instead of node.start");
+		}, /Use node.range\[0\] instead of node.start/u);
 		assert.throws(() => {
 			ruleTester.run("uses-start-end", usesStartEndRule, {
 				valid: [],
@@ -2399,7 +2404,7 @@ describe("RuleTester", () => {
 					},
 				],
 			});
-		}, "Use node.range[1] instead of node.end");
+		}, /Use node.range\[1\] instead of node.end/u);
 		assert.throws(() => {
 			ruleTester.run("uses-start-end", usesStartEndRule, {
 				valid: [],
@@ -2411,7 +2416,7 @@ describe("RuleTester", () => {
 					},
 				],
 			});
-		}, "Use token.range[0] instead of token.start");
+		}, /Use token.range\[0\] instead of token.start/u);
 		assert.throws(() => {
 			ruleTester.run("uses-start-end", usesStartEndRule, {
 				valid: [
@@ -2422,7 +2427,7 @@ describe("RuleTester", () => {
 				],
 				invalid: [],
 			});
-		}, "Use token.range[1] instead of token.end");
+		}, /Use token.range\[1\] instead of token.end/u);
 		assert.throws(() => {
 			ruleTester.run("uses-start-end", usesStartEndRule, {
 				valid: [
@@ -2433,7 +2438,7 @@ describe("RuleTester", () => {
 				],
 				invalid: [],
 			});
-		}, "Use token.range[0] instead of token.start");
+		}, /Use token.range\[0\] instead of token.start/u);
 		assert.throws(() => {
 			ruleTester.run("uses-start-end", usesStartEndRule, {
 				valid: [],
@@ -2445,7 +2450,7 @@ describe("RuleTester", () => {
 					},
 				],
 			});
-		}, "Use token.range[1] instead of token.end");
+		}, /Use token.range\[1\] instead of token.end/u);
 
 		assert.throws(() => {
 			ruleTester.run("uses-start-end", usesStartEndRule, {
@@ -2459,7 +2464,7 @@ describe("RuleTester", () => {
 				],
 				invalid: [],
 			});
-		}, "Use node.range[0] instead of node.start");
+		}, /Use node.range\[0\] instead of node.start/u);
 	});
 
 	it("should throw an error if rule is a function", () => {
@@ -2481,7 +2486,7 @@ describe("RuleTester", () => {
 				valid: [],
 				invalid: [{ code: "var foo = bar;", errors: 1 }],
 			});
-		}, "Rule must be an object with a `create` method");
+		}, /Rule must be an object with a `create` method/u);
 	});
 
 	it("should throw an error if rule is an object without 'create' method", () => {
@@ -2500,7 +2505,7 @@ describe("RuleTester", () => {
 				valid: [],
 				invalid: [{ code: "var foo = bar;", errors: 1 }],
 			});
-		}, "Rule must be an object with a `create` method");
+		}, /Rule must be an object with a `create` method/u);
 	});
 
 	it("should throw an error if no test scenarios given", () => {
@@ -2509,7 +2514,7 @@ describe("RuleTester", () => {
 				"foo",
 				require("../../fixtures/testers/rule-tester/modify-ast-at-last"),
 			);
-		}, "Test Scenarios for rule foo : Could not find test scenario object");
+		}, /Test Scenarios for rule foo : Could not find test scenario object/u);
 	});
 
 	it("should throw an error if no acceptable test scenario object is given", () => {
@@ -2519,28 +2524,28 @@ describe("RuleTester", () => {
 				require("../../fixtures/testers/rule-tester/modify-ast-at-last"),
 				[],
 			);
-		}, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios");
+		}, /Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios/u);
 		assert.throws(() => {
 			ruleTester.run(
 				"foo",
 				require("../../fixtures/testers/rule-tester/modify-ast-at-last"),
 				"",
 			);
-		}, "Test Scenarios for rule foo : Could not find test scenario object");
+		}, /Test Scenarios for rule foo : Could not find test scenario object/u);
 		assert.throws(() => {
 			ruleTester.run(
 				"foo",
 				require("../../fixtures/testers/rule-tester/modify-ast-at-last"),
 				2,
 			);
-		}, "Test Scenarios for rule foo : Could not find test scenario object");
+		}, /Test Scenarios for rule foo : Could not find test scenario object/u);
 		assert.throws(() => {
 			ruleTester.run(
 				"foo",
 				require("../../fixtures/testers/rule-tester/modify-ast-at-last"),
 				{},
 			);
-		}, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios");
+		}, /Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios/u);
 		assert.throws(() => {
 			ruleTester.run(
 				"foo",
@@ -2549,7 +2554,7 @@ describe("RuleTester", () => {
 					valid: [],
 				},
 			);
-		}, "Test Scenarios for rule foo is invalid:\nCould not find any invalid test scenarios");
+		}, /Test Scenarios for rule foo is invalid:\nCould not find any invalid test scenarios/u);
 		assert.throws(() => {
 			ruleTester.run(
 				"foo",
@@ -2558,7 +2563,7 @@ describe("RuleTester", () => {
 					invalid: [],
 				},
 			);
-		}, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios");
+		}, /Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios/u);
 	});
 
 	// Nominal message/messageId use cases
@@ -2578,8 +2583,8 @@ describe("RuleTester", () => {
 				);
 			},
 			assertErrorMatches(
-				"Avoid using variables named 'foo'.",
-				"something",
+				/Avoid using variables named 'foo'./u,
+				/something/u,
 			),
 		);
 
@@ -2614,7 +2619,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "messageId 'avoidFoo' does not match expected messageId 'unused'.");
+		}, /messageId 'avoidFoo' does not match expected messageId 'unused'./u);
 
 		ruleTester.run(
 			"foo",
@@ -2648,7 +2653,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "Hydrated message \"Avoid using variables named 'notFoo'.\" does not match \"Avoid using variables named 'foo'.\"");
+		}, /Hydrated message "Avoid using variables named 'notFoo'." does not match "Avoid using variables named 'foo'./u);
 	});
 
 	it("should throw if the message has a single unsubstituted placeholder when data is not specified", () => {
@@ -2664,7 +2669,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "The reported message has an unsubstituted placeholder 'name'. Please provide the missing value via the 'data' property in the context.report() call.");
+		}, /The reported message has an unsubstituted placeholder 'name'. Please provide the missing value via the 'data' property in the context.report\(\) call./u);
 	});
 
 	it("should throw if the message has a single unsubstituted placeholders when data is specified", () => {
@@ -2688,7 +2693,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "Hydrated message \"Avoid using variables named 'name'.\" does not match \"Avoid using variables named '{{ name }}'.");
+		}, /Hydrated message "Avoid using variables named 'name'." does not match "Avoid using variables named '\{\{ name \}\}'./u);
 	});
 
 	it("should throw if the message has multiple unsubstituted placeholders when data is not specified", () => {
@@ -2704,7 +2709,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "The reported message has unsubstituted placeholders: 'type', 'name'. Please provide the missing values via the 'data' property in the context.report() call.");
+		}, /The reported message has unsubstituted placeholders: 'type', 'name'. Please provide the missing values via the 'data' property in the context.report\(\) call./u);
 	});
 
 	it("should not throw if the data in the message contains placeholders not present in the raw message", () => {
@@ -2732,7 +2737,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "The reported message has an unsubstituted placeholder 'name'. Please provide the missing value via the 'data' property in the context.report() call.");
+		}, /The reported message has an unsubstituted placeholder 'name'. Please provide the missing value via the 'data' property in the context.report\(\) call./u);
 	});
 
 	it("should not throw if the data in the message contains the same placeholder and data is specified", () => {
@@ -2793,7 +2798,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "Error should not specify both 'message' and a 'messageId'.");
+		}, /Error should not specify both 'message' and a 'messageId'./u);
 	});
 	it("should throw if user tests for messageId but the rule doesn't use the messageId meta syntax.", () => {
 		assert.throws(() => {
@@ -2808,7 +2813,7 @@ describe("RuleTester", () => {
 					],
 				},
 			);
-		}, "Error can not use 'messageId' if rule under test doesn't define 'meta.messages'");
+		}, /Error can not use 'messageId' if rule under test doesn't define 'meta.messages'/u);
 	});
 	it("should throw if user tests for messageId not listed in the rule's meta syntax.", () => {
 		assert.throws(() => {
@@ -2836,7 +2841,7 @@ describe("RuleTester", () => {
 					invalid: [{ code: "foo", errors: [{ data: "something" }] }],
 				},
 			);
-		}, "Test error must specify either a 'messageId' or 'message'.");
+		}, /Test error must specify either a 'messageId' or 'message'./u);
 	});
 
 	// fixable rules with or without `meta` property
@@ -2924,7 +2929,7 @@ describe("RuleTester", () => {
 
 	describe("suggestions", () => {
 		it("should throw if suggestions are available but not specified", () => {
-			assert.throw(() => {
+			assert.throws(() => {
 				ruleTester.run(
 					"suggestions-basic",
 					require("../../fixtures/testers/rule-tester/suggestions")
@@ -2944,7 +2949,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Error at index 0 has suggestions. Please specify 'suggestions' property on the test error object.");
+			}, /Error at index 0 has suggestions. Please specify 'suggestions' property on the test error object./u);
 		});
 
 		it("should pass with valid suggestions (tested using desc)", () => {
@@ -3074,7 +3079,7 @@ describe("RuleTester", () => {
 		});
 
 		it("should fail with valid suggestions when testing using both desc and messageIds for the same suggestion", () => {
-			assert.throw(() => {
+			assert.throws(() => {
 				ruleTester.run(
 					"suggestions-messageIds",
 					require("../../fixtures/testers/rule-tester/suggestions")
@@ -3105,7 +3110,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Error Suggestion at index 0: Test should not specify both 'desc' and 'messageId'.");
+			}, /Error Suggestion at index 0: Test should not specify both 'desc' and 'messageId'./u);
 		});
 
 		it("should pass with valid suggestions (tested using only desc on a rule that utilizes meta.messages)", () => {
@@ -3198,7 +3203,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "The message of the suggestion has an unsubstituted placeholder 'newName'. Please provide the missing value via the 'data' property for the suggestion in the context.report() call.");
+			}, /The message of the suggestion has an unsubstituted placeholder 'newName'. Please provide the missing value via the 'data' property for the suggestion in the context.report\(\) call./u);
 		});
 
 		it("should fail with a single missing data placeholder when data is specified", () => {
@@ -3228,7 +3233,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "The message of the suggestion has an unsubstituted placeholder 'newName'. Please provide the missing value via the 'data' property for the suggestion in the context.report() call.");
+			}, /The message of the suggestion has an unsubstituted placeholder 'newName'. Please provide the missing value via the 'data' property for the suggestion in the context.report\(\) call./u);
 		});
 
 		it("should fail with multiple missing data placeholders when data is not specified", () => {
@@ -3257,11 +3262,11 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "The message of the suggestion has unsubstituted placeholders: 'currentName', 'newName'. Please provide the missing values via the 'data' property for the suggestion in the context.report() call.");
+			}, /The message of the suggestion has unsubstituted placeholders: 'currentName', 'newName'. Please provide the missing values via the 'data' property for the suggestion in the context.report\(\) call./u);
 		});
 
 		it("should fail when tested using empty suggestion test objects even if the array length is correct", () => {
-			assert.throw(() => {
+			assert.throws(() => {
 				ruleTester.run(
 					"suggestions-messageIds",
 					require("../../fixtures/testers/rule-tester/suggestions")
@@ -3285,7 +3290,7 @@ describe("RuleTester", () => {
 		});
 
 		it("should fail when tested using non-empty suggestion test objects without an output property", () => {
-			assert.throw(() => {
+			assert.throws(() => {
 				ruleTester.run(
 					"suggestions-messageIds",
 					require("../../fixtures/testers/rule-tester/suggestions")
@@ -3308,7 +3313,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, 'Error Suggestion at index 0: The "output" property is required.');
+			}, /Error Suggestion at index 0: The "output" property is required./u);
 		});
 
 		it("should support explicitly expecting no suggestions", () => {
@@ -3357,7 +3362,7 @@ describe("RuleTester", () => {
 							],
 						},
 					);
-				}, "Error should have no suggestions on error with message: \"Avoid using identifiers named 'foo'.\"");
+				}, /Error should have no suggestions on error with message: "Avoid using identifiers named 'foo'."/u);
 			});
 		});
 
@@ -3386,7 +3391,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, 'Error should have suggestions on error with message: "Bad var."');
+			}, /Error should have suggestions on error with message: "Bad var."/u);
 		});
 
 		it("should support specifying only the amount of suggestions", () => {
@@ -3433,7 +3438,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Error should have 2 suggestions. Instead found 1 suggestions");
+			}, /Error should have 2 suggestions. Instead found 1 suggestions/u);
 		});
 
 		it("should fail when there are a different number of suggestions for arrays", () => {
@@ -3467,7 +3472,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Error should have 2 suggestions. Instead found 1 suggestions");
+			}, /Error should have 2 suggestions. Instead found 1 suggestions/u);
 		});
 
 		it("should fail when the suggestion property is neither a number nor an array", () => {
@@ -3492,11 +3497,11 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Test error object property 'suggestions' should be an array or a number");
+			}, /Test error object property 'suggestions' should be an array or a number/u);
 		});
 
 		it("should throw if suggestion fix made a syntax error.", () => {
-			assert.throw(() => {
+			assert.throws(() => {
 				ruleTester.run(
 					"foo",
 					{
@@ -3573,7 +3578,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Error Suggestion at index 0: desc should be \"not right\" but got \"Rename identifier 'foo' to 'bar'\" instead.");
+			}, /Error Suggestion at index 0: desc should be "not right" but got "Rename identifier 'foo' to 'bar'" instead./u);
 		});
 
 		it("should pass when different suggestion matchers use desc and messageId", () => {
@@ -3637,7 +3642,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Error Suggestion at index 0: messageId should be 'unused' but got 'renameFoo' instead.");
+			}, /Error Suggestion at index 0: messageId should be 'unused' but got 'renameFoo' instead./u);
 		});
 
 		it("should throw if test specifies messageId for a rule that doesn't have meta.messages", () => {
@@ -3667,7 +3672,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Error Suggestion at index 0: Test can not use 'messageId' if rule under test doesn't define 'meta.messages'.");
+			}, /Error Suggestion at index 0: Test can not use 'messageId' if rule under test doesn't define 'meta.messages'./u);
 		});
 
 		it("should throw if test specifies messageId that doesn't exist in the rule's meta.messages", () => {
@@ -3700,7 +3705,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Error Suggestion at index 1: Test has invalid messageId 'removeFoo', the rule under test allows only one of ['avoidFoo', 'unused', 'renameFoo'].");
+			}, /Error Suggestion at index 1: Test has invalid messageId 'removeFoo', the rule under test allows only one of \['avoidFoo', 'unused', 'renameFoo'\]./u);
 		});
 
 		it("should throw if hydrated desc doesn't match (wrong data value)", () => {
@@ -3735,7 +3740,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Error Suggestion at index 0: Hydrated test desc \"Rename identifier 'foo' to 'car'\" does not match received desc \"Rename identifier 'foo' to 'bar'\".");
+			}, /Error Suggestion at index 0: Hydrated test desc "Rename identifier 'foo' to 'car'" does not match received desc "Rename identifier 'foo' to 'bar'"./u);
 		});
 
 		it("should throw if hydrated desc doesn't match (wrong data key)", () => {
@@ -3770,7 +3775,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Error Suggestion at index 1: Hydrated test desc \"Rename identifier 'foo' to '{{ newName }}'\" does not match received desc \"Rename identifier 'foo' to 'baz'\".");
+			}, /Error Suggestion at index 1: Hydrated test desc "Rename identifier 'foo' to '\{\{ newName \}\}'" does not match received desc "Rename identifier 'foo' to 'baz'"./u);
 		});
 
 		it("should throw if test specifies both desc and data", () => {
@@ -3806,7 +3811,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Error Suggestion at index 0: Test should not specify both 'desc' and 'data'.");
+			}, /Error Suggestion at index 0: Test should not specify both 'desc' and 'data'./u);
 		});
 
 		it("should throw if test uses data but doesn't specify messageId", () => {
@@ -3840,7 +3845,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Error Suggestion at index 1: Test must specify 'messageId' if 'data' is used.");
+			}, /Error Suggestion at index 1: Test must specify 'messageId' if 'data' is used./u);
 		});
 
 		it("should throw if the resulting suggestion output doesn't match", () => {
@@ -3870,7 +3875,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Expected the applied suggestion fix to match the test suggestion output");
+			}, /Expected the applied suggestion fix to match the test suggestion output/u);
 		});
 
 		it("should throw if the resulting suggestion output is the same as the original source code", () => {
@@ -3900,7 +3905,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "The output of a suggestion should differ from the original source code for suggestion at index: 0 on error with message: \"Avoid using identifiers named 'foo'.\"");
+			}, /The output of a suggestion should differ from the original source code for suggestion at index: 0 on error with message: "Avoid using identifiers named 'foo'."/u);
 		});
 
 		it("should fail when specified suggestion isn't an object", () => {
@@ -3925,7 +3930,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Test suggestion in 'suggestions' array must be an object.");
+			}, /Test suggestion in 'suggestions' array must be an object./u);
 
 			assert.throws(() => {
 				ruleTester.run(
@@ -3953,7 +3958,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Test suggestion in 'suggestions' array must be an object.");
+			}, /Test suggestion in 'suggestions' array must be an object./u);
 		});
 
 		it("should fail when the suggestion is an object with an unknown property name", () => {
@@ -4030,7 +4035,7 @@ describe("RuleTester", () => {
 						invalid: [{ code: "var foo = bar;", errors: 1 }],
 					},
 				);
-			}, "Suggestion message 'Rename 'foo' to 'bar'' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");
+			}, /Suggestion message 'Rename 'foo' to 'bar'' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error./u);
 		});
 
 		it("should fail if a rule produces two suggestions with the same messageId without data", () => {
@@ -4044,7 +4049,7 @@ describe("RuleTester", () => {
 						invalid: [{ code: "var foo = bar;", errors: 1 }],
 					},
 				);
-			}, "Suggestion message 'Rename identifier' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");
+			}, /Suggestion message 'Rename identifier' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error./u);
 		});
 
 		it("should fail if a rule produces two suggestions with the same messageId with data", () => {
@@ -4058,7 +4063,7 @@ describe("RuleTester", () => {
 						invalid: [{ code: "var foo = bar;", errors: 1 }],
 					},
 				);
-			}, "Suggestion message 'Rename identifier 'foo' to 'bar'' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error.");
+			}, /Suggestion message 'Rename identifier 'foo' to 'bar'' reported from suggestion 1 was previously reported by suggestion 0. Suggestion messages should be unique within an error./u);
 		});
 
 		it("should throw an error if a rule that doesn't have `meta.hasSuggestions` enabled produces suggestions", () => {
@@ -4074,7 +4079,7 @@ describe("RuleTester", () => {
 						],
 					},
 				);
-			}, "Rules with suggestions must set the `meta.hasSuggestions` property to `true`.");
+			}, /Rules with suggestions must set the `meta.hasSuggestions` property to `true`./u);
 		});
 	});
 
@@ -4371,7 +4376,7 @@ describe("RuleTester", () => {
 
 	// https://github.com/eslint/eslint/issues/11615
 	it("should fail the case if autofix made a syntax error.", () => {
-		assert.throw(() => {
+		assert.throws(() => {
 			ruleTester.run(
 				"foo",
 				{
@@ -4544,7 +4549,7 @@ describe("RuleTester", () => {
 							invalid: [],
 						},
 					);
-				}, "detected duplicate test case");
+				}, /detected duplicate test case/u);
 			});
 
 			it("throws with duplicate object test cases", () => {
@@ -4562,7 +4567,7 @@ describe("RuleTester", () => {
 							invalid: [],
 						},
 					);
-				}, "detected duplicate test case");
+				}, /detected duplicate test case/u);
 			});
 
 			it("throws with string and object test cases", () => {
@@ -4580,7 +4585,7 @@ describe("RuleTester", () => {
 							invalid: [],
 						},
 					);
-				}, "detected duplicate test case");
+				}, /detected duplicate test case/u);
 			});
 
 			it("ignores the name property", () => {
@@ -4601,7 +4606,7 @@ describe("RuleTester", () => {
 							invalid: [],
 						},
 					);
-				}, "detected duplicate test case");
+				}, /detected duplicate test case/u);
 			});
 
 			it("does not ignore top level test case properties nested in other test case properties", () => {
@@ -4680,7 +4685,7 @@ describe("RuleTester", () => {
 							],
 						},
 					);
-				}, "detected duplicate test case");
+				}, /detected duplicate test case/u);
 			});
 
 			it("throws with duplicate object test cases when options is a primitive", () => {
@@ -4713,7 +4718,7 @@ describe("RuleTester", () => {
 							],
 						},
 					);
-				}, "detected duplicate test case");
+				}, /detected duplicate test case/u);
 			});
 
 			it("throws with duplicate object test cases when options is a nested serializable object", () => {
@@ -4750,7 +4755,7 @@ describe("RuleTester", () => {
 							],
 						},
 					);
-				}, "detected duplicate test case");
+				}, /detected duplicate test case/u);
 			});
 
 			it("throws with duplicate object test cases even when property order differs", () => {
@@ -4781,7 +4786,7 @@ describe("RuleTester", () => {
 							],
 						},
 					);
-				}, "detected duplicate test case");
+				}, /detected duplicate test case/u);
 			});
 
 			it("ignores duplicate test case when non-serializable property present (settings)", () => {
@@ -4937,7 +4942,7 @@ describe("RuleTester", () => {
 							],
 						},
 					);
-				}, "detected duplicate test case");
+				}, /detected duplicate test case/u);
 			});
 
 			it("detects duplicate test cases even if the presence of the output property differs", () => {
@@ -4966,7 +4971,7 @@ describe("RuleTester", () => {
 							],
 						},
 					);
-				}, "detected duplicate test case");
+				}, /detected duplicate test case/u);
 			});
 		});
 	});

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	util = require("node:util"),
 	espree = require("espree"),
 	astUtils = require("../../../../lib/rules/utils/ast-utils"),
@@ -52,7 +52,7 @@ describe("ast-utils", () => {
 
 	afterEach(() => {
 		callCounts.forEach((callCount, func) => {
-			assert(
+			assert.ok(
 				callCount > 0,
 				`Expected ${func.toString()} to be called at least once but it was not called`,
 			);
@@ -61,29 +61,38 @@ describe("ast-utils", () => {
 
 	describe("ECMASCRIPT_GLOBALS", () => {
 		it("should contain es3 globals", () => {
-			assert.ownInclude(astUtils.ECMASCRIPT_GLOBALS, { Object: false });
+			assert.ok(Object.hasOwn(astUtils.ECMASCRIPT_GLOBALS, "Object"));
+			assert.strictEqual(astUtils.ECMASCRIPT_GLOBALS.Object, false);
 		});
 
 		it("should contain es5 globals", () => {
-			assert.ownInclude(astUtils.ECMASCRIPT_GLOBALS, { JSON: false });
+			assert.ok(Object.hasOwn(astUtils.ECMASCRIPT_GLOBALS, "JSON"));
+			assert.strictEqual(astUtils.ECMASCRIPT_GLOBALS.JSON, false);
 		});
 
 		it("should contain es2015 globals", () => {
-			assert.ownInclude(astUtils.ECMASCRIPT_GLOBALS, { Promise: false });
+			assert.ok(Object.hasOwn(astUtils.ECMASCRIPT_GLOBALS, "Promise"));
+			assert.strictEqual(astUtils.ECMASCRIPT_GLOBALS.Promise, false);
 		});
 
 		it("should contain es2017 globals", () => {
-			assert.ownInclude(astUtils.ECMASCRIPT_GLOBALS, {
-				SharedArrayBuffer: false,
-			});
+			assert.ok(
+				Object.hasOwn(astUtils.ECMASCRIPT_GLOBALS, "SharedArrayBuffer"),
+			);
+			assert.strictEqual(
+				astUtils.ECMASCRIPT_GLOBALS.SharedArrayBuffer,
+				false,
+			);
 		});
 
 		it("should contain es2020 globals", () => {
-			assert.ownInclude(astUtils.ECMASCRIPT_GLOBALS, { BigInt: false });
+			assert.ok(Object.hasOwn(astUtils.ECMASCRIPT_GLOBALS, "BigInt"));
+			assert.strictEqual(astUtils.ECMASCRIPT_GLOBALS.BigInt, false);
 		});
 
 		it("should contain es2021 globals", () => {
-			assert.ownInclude(astUtils.ECMASCRIPT_GLOBALS, { WeakRef: false });
+			assert.ok(Object.hasOwn(astUtils.ECMASCRIPT_GLOBALS, "WeakRef"));
+			assert.strictEqual(astUtils.ECMASCRIPT_GLOBALS.WeakRef, false);
 		});
 	});
 
@@ -92,11 +101,12 @@ describe("ast-utils", () => {
 			linter.defineRule("checker", {
 				create: mustCall(context => ({
 					BlockStatement: mustCall(node => {
-						assert.isFalse(
+						assert.strictEqual(
 							astUtils.isTokenOnSameLine(
 								context.sourceCode.getTokenBefore(node),
 								node,
 							),
+							false,
 						);
 					}),
 				})),
@@ -109,11 +119,12 @@ describe("ast-utils", () => {
 			linter.defineRule("checker", {
 				create: mustCall(context => ({
 					BlockStatement: mustCall(node => {
-						assert.isTrue(
+						assert.strictEqual(
 							astUtils.isTokenOnSameLine(
 								context.sourceCode.getTokenBefore(node),
 								node,
 							),
+							true,
 						);
 					}),
 				})),
@@ -125,59 +136,66 @@ describe("ast-utils", () => {
 
 	describe("isNullOrUndefined", () => {
 		it("should return true if the argument is null", () => {
-			assert.isTrue(
+			assert.strictEqual(
 				astUtils.isNullOrUndefined(
 					espree.parse("null").body[0].expression,
 				),
+				true,
 			);
 		});
 
 		it("should return true if the argument is undefined", () => {
-			assert.isTrue(
+			assert.strictEqual(
 				astUtils.isNullOrUndefined(
 					espree.parse("undefined").body[0].expression,
 				),
+				true,
 			);
 		});
 
 		it("should return false if the argument is a number", () => {
-			assert.isFalse(
+			assert.strictEqual(
 				astUtils.isNullOrUndefined(
 					espree.parse("1").body[0].expression,
 				),
+				false,
 			);
 		});
 
 		it("should return false if the argument is a string", () => {
-			assert.isFalse(
+			assert.strictEqual(
 				astUtils.isNullOrUndefined(
 					espree.parse("'test'").body[0].expression,
 				),
+				false,
 			);
 		});
 
 		it("should return false if the argument is a boolean", () => {
-			assert.isFalse(
+			assert.strictEqual(
 				astUtils.isNullOrUndefined(
 					espree.parse("true").body[0].expression,
 				),
+				false,
 			);
 		});
 
 		it("should return false if the argument is an object", () => {
-			assert.isFalse(
+			assert.strictEqual(
 				astUtils.isNullOrUndefined(
 					espree.parse("({})").body[0].expression,
 				),
+				false,
 			);
 		});
 
 		it("should return false if the argument is a unicode regex", () => {
-			assert.isFalse(
+			assert.strictEqual(
 				astUtils.isNullOrUndefined(
 					espree.parse("/abc/u", { ecmaVersion: 6 }).body[0]
 						.expression,
 				),
+				false,
 			);
 		});
 	});
@@ -191,10 +209,10 @@ describe("ast-utils", () => {
 						const variables =
 							context.sourceCode.getDeclaredVariables(node);
 
-						assert.lengthOf(
+						assert.strictEqual(
 							astUtils.getModifyingReferences(
 								variables[0].references,
-							),
+							).length,
 							1,
 						);
 					}),
@@ -214,10 +232,10 @@ describe("ast-utils", () => {
 						const variables =
 							context.sourceCode.getDeclaredVariables(node);
 
-						assert.lengthOf(
+						assert.strictEqual(
 							astUtils.getModifyingReferences(
 								variables[0].references,
-							),
+							).length,
 							1,
 						);
 					}),
@@ -237,10 +255,10 @@ describe("ast-utils", () => {
 						const variables =
 							context.sourceCode.getDeclaredVariables(node);
 
-						assert.lengthOf(
+						assert.strictEqual(
 							astUtils.getModifyingReferences(
 								variables[0].references,
-							),
+							).length,
 							0,
 						);
 					}),
@@ -261,16 +279,16 @@ describe("ast-utils", () => {
 						const variables =
 							context.sourceCode.getDeclaredVariables(node);
 
-						assert.lengthOf(
+						assert.strictEqual(
 							astUtils.getModifyingReferences(
 								variables[0].references,
-							),
+							).length,
 							1,
 						);
-						assert.lengthOf(
+						assert.strictEqual(
 							astUtils.getModifyingReferences(
 								variables[1].references,
-							),
+							).length,
 							0,
 						);
 					}),
@@ -290,10 +308,10 @@ describe("ast-utils", () => {
 						const variables =
 							context.sourceCode.getDeclaredVariables(node);
 
-						assert.lengthOf(
+						assert.strictEqual(
 							astUtils.getModifyingReferences(
 								variables[0].references,
-							),
+							).length,
 							0,
 						);
 					}),
@@ -314,7 +332,7 @@ describe("ast-utils", () => {
 		 * @returns {void}
 		 */
 		function assertFalse(node) {
-			assert.isFalse(astUtils.isDirectiveComment(node));
+			assert.strictEqual(astUtils.isDirectiveComment(node), false);
 		}
 
 		/**
@@ -323,7 +341,7 @@ describe("ast-utils", () => {
 		 * @returns {void}
 		 */
 		function assertTrue(node) {
-			assert.isTrue(astUtils.isDirectiveComment(node));
+			assert.strictEqual(astUtils.isDirectiveComment(node), true);
 		}
 
 		it("should return false if it is not a directive line comment", () => {
@@ -396,8 +414,9 @@ describe("ast-utils", () => {
 			const ast = espree.parse(code, ESPREE_CONFIG);
 			const sourceCode = new SourceCode(code, ast);
 
-			assert.isFalse(
+			assert.strictEqual(
 				astUtils.isParenthesised(sourceCode, ast.body[0].expression),
+				false,
 			);
 		});
 
@@ -406,8 +425,9 @@ describe("ast-utils", () => {
 			const ast = espree.parse(code, ESPREE_CONFIG);
 			const sourceCode = new SourceCode(code, ast);
 
-			assert.isTrue(
+			assert.strictEqual(
 				astUtils.isParenthesised(sourceCode, ast.body[0].expression),
+				true,
 			);
 		});
 	});
@@ -417,29 +437,29 @@ describe("ast-utils", () => {
 			const ast = espree.parse("function a() {}");
 			const node = ast.body[0];
 
-			assert(astUtils.isFunction(node));
+			assert.ok(astUtils.isFunction(node));
 		});
 
 		it("should return true for FunctionExpression", () => {
 			const ast = espree.parse("(function a() {})");
 			const node = ast.body[0].expression;
 
-			assert(astUtils.isFunction(node));
+			assert.ok(astUtils.isFunction(node));
 		});
 
 		it("should return true for AllowFunctionExpression", () => {
 			const ast = espree.parse("(() => {})", { ecmaVersion: 6 });
 			const node = ast.body[0].expression;
 
-			assert(astUtils.isFunction(node));
+			assert.ok(astUtils.isFunction(node));
 		});
 
 		it("should return false for Program, VariableDeclaration, BlockStatement", () => {
 			const ast = espree.parse("var a; { }");
 
-			assert(!astUtils.isFunction(ast));
-			assert(!astUtils.isFunction(ast.body[0]));
-			assert(!astUtils.isFunction(ast.body[1]));
+			assert.ok(!astUtils.isFunction(ast));
+			assert.ok(!astUtils.isFunction(ast.body[0]));
+			assert.ok(!astUtils.isFunction(ast.body[1]));
 		});
 	});
 
@@ -448,14 +468,14 @@ describe("ast-utils", () => {
 			const ast = espree.parse("do {} while (a)");
 			const node = ast.body[0];
 
-			assert(astUtils.isLoop(node));
+			assert.ok(astUtils.isLoop(node));
 		});
 
 		it("should return true for ForInStatement", () => {
 			const ast = espree.parse("for (var k in obj) {}");
 			const node = ast.body[0];
 
-			assert(astUtils.isLoop(node));
+			assert.ok(astUtils.isLoop(node));
 		});
 
 		it("should return true for ForOfStatement", () => {
@@ -464,29 +484,29 @@ describe("ast-utils", () => {
 			});
 			const node = ast.body[0];
 
-			assert(astUtils.isLoop(node));
+			assert.ok(astUtils.isLoop(node));
 		});
 
 		it("should return true for ForStatement", () => {
 			const ast = espree.parse("for (var i = 0; i < 10; ++i) {}");
 			const node = ast.body[0];
 
-			assert(astUtils.isLoop(node));
+			assert.ok(astUtils.isLoop(node));
 		});
 
 		it("should return true for WhileStatement", () => {
 			const ast = espree.parse("while (a) {}");
 			const node = ast.body[0];
 
-			assert(astUtils.isLoop(node));
+			assert.ok(astUtils.isLoop(node));
 		});
 
 		it("should return false for Program, VariableDeclaration, BlockStatement", () => {
 			const ast = espree.parse("var a; { }");
 
-			assert(!astUtils.isLoop(ast));
-			assert(!astUtils.isLoop(ast.body[0]));
-			assert(!astUtils.isLoop(ast.body[1]));
+			assert.ok(!astUtils.isLoop(ast));
+			assert.ok(!astUtils.isLoop(ast.body[0]));
+			assert.ok(!astUtils.isLoop(ast.body[1]));
 		});
 	});
 
@@ -516,7 +536,7 @@ describe("ast-utils", () => {
 				parserOptions: { ecmaVersion: 6 },
 			});
 
-			assert.lengthOf(results, 1);
+			assert.strictEqual(results.length, 1);
 			assert.strictEqual(results[0], expectedInLoop);
 		}
 
@@ -1937,8 +1957,10 @@ describe("ast-utils", () => {
 
 	describe("createGlobalLinebreakMatcher", () => {
 		it("returns a regular expression with the g flag", () => {
-			assert.instanceOf(astUtils.createGlobalLinebreakMatcher(), RegExp);
-			assert(
+			assert.ok(
+				astUtils.createGlobalLinebreakMatcher() instanceof RegExp,
+			);
+			assert.ok(
 				astUtils
 					.createGlobalLinebreakMatcher()
 					.toString()

--- a/tests/lib/rules/utils/fix-tracker.js
+++ b/tests/lib/rules/utils/fix-tracker.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	espree = require("espree"),
 	FixTracker = require("../../../../lib/rules/utils/fix-tracker"),
 	{ RuleFixer } = require("../../../../lib/linter/rule-fixer"),

--- a/tests/lib/shared/runtime-info.js
+++ b/tests/lib/shared/runtime-info.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const sinon = require("sinon");
 const spawn = require("cross-spawn");
 const os = require("node:os");
@@ -218,7 +218,7 @@ describe("RuntimeInfo", () => {
 
 			assert.throws(
 				RuntimeInfo.environment,
-				/^Unexpected token .*T.* JSON/u,
+				/SyntaxError: Unexpected token .*T.* JSON/u,
 			);
 			assert.strictEqual(
 				logErrorStub.args[0][0],
@@ -232,7 +232,7 @@ describe("RuntimeInfo", () => {
 
 			assert.throws(
 				RuntimeInfo.environment,
-				/^Unexpected token .*T.* JSON/u,
+				/SyntaxError: Unexpected token .*T.* JSON/u,
 			);
 			assert.strictEqual(
 				logErrorStub.args[0][0],

--- a/tests/lib/shared/serialization.js
+++ b/tests/lib/shared/serialization.js
@@ -5,105 +5,115 @@
 
 "use strict";
 
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const { isSerializable } = require("../../../lib/shared/serialization");
 
 describe("serialization", () => {
 	describe("isSerializable", () => {
 		it("string", () => {
-			assert.isTrue(isSerializable(""));
-			assert.isTrue(isSerializable("abc"));
+			assert.strictEqual(isSerializable(""), true);
+			assert.strictEqual(isSerializable("abc"), true);
 		});
 
 		it("boolean", () => {
-			assert.isTrue(isSerializable(true));
-			assert.isTrue(isSerializable(false));
-			assert.isTrue(isSerializable({ a: true }));
-			assert.isTrue(isSerializable([true]));
+			assert.strictEqual(isSerializable(true), true);
+			assert.strictEqual(isSerializable(false), true);
+			assert.strictEqual(isSerializable({ a: true }), true);
+			assert.strictEqual(isSerializable([true]), true);
 		});
 
 		it("number", () => {
-			assert.isTrue(isSerializable(123));
-			assert.isTrue(isSerializable({ a: 123 }));
-			assert.isTrue(isSerializable([123]));
+			assert.strictEqual(isSerializable(123), true);
+			assert.strictEqual(isSerializable({ a: 123 }), true);
+			assert.strictEqual(isSerializable([123]), true);
 		});
 
 		it("function", () => {
-			assert.isFalse(isSerializable(() => {}));
-			assert.isFalse(isSerializable({ a() {} }));
-			assert.isFalse(isSerializable([() => {}]));
+			assert.strictEqual(
+				isSerializable(() => {}),
+				false,
+			);
+			assert.strictEqual(isSerializable({ a() {} }), false);
+			assert.strictEqual(isSerializable([() => {}]), false);
 		});
 
 		it("RegExp", () => {
-			assert.isFalse(isSerializable(/abc/u));
-			assert.isFalse(isSerializable({ a: /abc/u }));
-			assert.isFalse(isSerializable([/abc/u]));
+			assert.strictEqual(isSerializable(/abc/u), false);
+			assert.strictEqual(isSerializable({ a: /abc/u }), false);
+			assert.strictEqual(isSerializable([/abc/u]), false);
 		});
 
 		it("null", () => {
-			assert.isTrue(isSerializable(null));
-			assert.isTrue(isSerializable({ a: null }));
-			assert.isTrue(isSerializable([null]));
+			assert.strictEqual(isSerializable(null), true);
+			assert.strictEqual(isSerializable({ a: null }), true);
+			assert.strictEqual(isSerializable([null]), true);
 		});
 
 		it("undefined", () => {
-			assert.isFalse(isSerializable(void 0));
-			assert.isFalse(isSerializable({ a: void 0 }));
-			assert.isFalse(isSerializable([void 0]));
+			assert.strictEqual(isSerializable(void 0), false);
+			assert.strictEqual(isSerializable({ a: void 0 }), false);
+			assert.strictEqual(isSerializable([void 0]), false);
 		});
 
 		describe("object", () => {
 			it("plain objects", () => {
-				assert.isTrue(isSerializable({}));
-				assert.isTrue(isSerializable({ a: 123 }));
-				assert.isTrue(isSerializable({ a: { b: 456 } }));
+				assert.strictEqual(isSerializable({}), true);
+				assert.strictEqual(isSerializable({ a: 123 }), true);
+				assert.strictEqual(isSerializable({ a: { b: 456 } }), true);
 			});
 
 			it("object with function", () => {
-				assert.isFalse(isSerializable({ a() {} }));
-				assert.isFalse(isSerializable({ a: { b() {} } }));
+				assert.strictEqual(isSerializable({ a() {} }), false);
+				assert.strictEqual(isSerializable({ a: { b() {} } }), false);
 			});
 
 			it("object with RegExp", () => {
-				assert.isFalse(isSerializable({ a: /abc/u }));
-				assert.isFalse(isSerializable({ a: { b: /abc/u } }));
+				assert.strictEqual(isSerializable({ a: /abc/u }), false);
+				assert.strictEqual(isSerializable({ a: { b: /abc/u } }), false);
 			});
 		});
 
 		describe("array", () => {
 			it("plain array", () => {
-				assert.isTrue(isSerializable([]));
-				assert.isTrue(isSerializable([1, 2, 3]));
+				assert.strictEqual(isSerializable([]), true);
+				assert.strictEqual(isSerializable([1, 2, 3]), true);
 			});
 
 			it("array with function", () => {
-				assert.isFalse(isSerializable([function () {}]));
+				assert.strictEqual(isSerializable([function () {}]), false);
 			});
 
 			it("array with RegExp", () => {
-				assert.isFalse(isSerializable([/abc/u]));
+				assert.strictEqual(isSerializable([/abc/u]), false);
 			});
 
 			it("array with plain/nested objects", () => {
-				assert.isTrue(
+				assert.strictEqual(
 					isSerializable([
 						{ a: 1 },
 						{ b: 2 },
 						{ c: { nested: true } },
 					]),
+					true,
 				);
 			});
 
 			it("array with object with nested function", () => {
-				assert.isFalse(isSerializable([{ a: { fn() {} } }]));
+				assert.strictEqual(isSerializable([{ a: { fn() {} } }]), false);
 			});
 
 			it("array with object with nested array with object", () => {
-				assert.isTrue(isSerializable([{ a: { b: [{ c: 123 }] } }]));
+				assert.strictEqual(
+					isSerializable([{ a: { b: [{ c: 123 }] } }]),
+					true,
+				);
 			});
 
 			it("array with object with nested array with object with function", () => {
-				assert.isFalse(isSerializable([{ a: { b: [{ c() {} }] } }]));
+				assert.strictEqual(
+					isSerializable([{ a: { b: [{ c() {} }] } }]),
+					false,
+				);
 			});
 		});
 	});

--- a/tests/lib/shared/string-utils.js
+++ b/tests/lib/shared/string-utils.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert;
+const assert = require("node:assert");
 
 const {
 	upperCaseFirst,
@@ -38,24 +38,24 @@ function escapeControlCharacters(text) {
 
 describe("upperCaseFirst", () => {
 	it("uppercases the first letter of a string", () => {
-		assert(upperCaseFirst("e") === "E");
-		assert(upperCaseFirst("alphabet") === "Alphabet");
-		assert(upperCaseFirst("one two three") === "One two three");
+		assert.ok(upperCaseFirst("e") === "E");
+		assert.ok(upperCaseFirst("alphabet") === "Alphabet");
+		assert.ok(upperCaseFirst("one two three") === "One two three");
 	});
 
 	it("only changes the case of the first letter", () => {
-		assert(upperCaseFirst("alphaBet") === "AlphaBet");
-		assert(upperCaseFirst("one TWO three") === "One TWO three");
+		assert.ok(upperCaseFirst("alphaBet") === "AlphaBet");
+		assert.ok(upperCaseFirst("one TWO three") === "One TWO three");
 	});
 
 	it("does not change the case if the first letter is already uppercase", () => {
-		assert(upperCaseFirst("E") === "E");
-		assert(upperCaseFirst("Alphabet") === "Alphabet");
-		assert(upperCaseFirst("One Two Three") === "One Two Three");
+		assert.ok(upperCaseFirst("E") === "E");
+		assert.ok(upperCaseFirst("Alphabet") === "Alphabet");
+		assert.ok(upperCaseFirst("One Two Three") === "One Two Three");
 	});
 
 	it("properly handles an empty string", () => {
-		assert(upperCaseFirst("") === "");
+		assert.ok(upperCaseFirst("") === "");
 	});
 });
 

--- a/tests/lib/shared/traverser.js
+++ b/tests/lib/shared/traverser.js
@@ -4,7 +4,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const Traverser = require("../../../lib/shared/traverser");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/unsupported-api.js
+++ b/tests/lib/unsupported-api.js
@@ -9,7 +9,7 @@
 // Requirements
 //-----------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	{
 		LazyLoadingRuleMap,
 	} = require("../../lib/rules/utils/lazy-loading-rule-map"),
@@ -21,30 +21,30 @@ const assert = require("chai").assert,
 
 describe("unsupported-api", () => {
 	it("should have FileEnumerator exposed", () => {
-		assert.isFunction(api.FileEnumerator);
+		assert.strictEqual(typeof api.FileEnumerator, "function");
 	});
 
 	it("should have FlatESLint exposed", () => {
-		assert.isFunction(api.FlatESLint);
+		assert.strictEqual(typeof api.FlatESLint, "function");
 	});
 
 	it("should have LegacyESLint exposed", () => {
-		assert.isFunction(api.LegacyESLint);
+		assert.strictEqual(typeof api.LegacyESLint, "function");
 	});
 
 	it("should not have ESLint exposed", () => {
-		assert.isUndefined(api.ESLint);
+		assert.strictEqual(typeof api.ESLint, "undefined");
 	});
 
 	it("should have shouldUseFlatConfig exposed", () => {
-		assert.isFunction(api.shouldUseFlatConfig);
+		assert.strictEqual(typeof api.shouldUseFlatConfig, "function");
 	});
 
 	it("should not have FlatRuleTester exposed", () => {
-		assert.isUndefined(api.FlatRuleTester);
+		assert.strictEqual(typeof api.FlatRuleTester, "undefined");
 	});
 
 	it("should have builtinRules exposed", () => {
-		assert.instanceOf(api.builtinRules, LazyLoadingRuleMap);
+		assert.ok(api.builtinRules instanceof LazyLoadingRuleMap);
 	});
 });

--- a/tests/tests.htm
+++ b/tests/tests.htm
@@ -9,7 +9,6 @@
     <div id="mocha"></div>
     <!-- test framework -->
     <script src="../node_modules/mocha/mocha.js"></script>
-    <script src="../node_modules/chai/chai.js"></script>
     <script src="../node_modules/sinon/pkg/sinon.js"></script>
     <script src="../node_modules/phantomjs-polyfill/bind-polyfill.js"></script>
 

--- a/tests/tools/code-sample-minimizer.js
+++ b/tests/tools/code-sample-minimizer.js
@@ -4,7 +4,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const { assert } = require("chai");
+const assert = require("node:assert");
 const reduceBadExampleSize = require("../../tools/code-sample-minimizer");
 
 //------------------------------------------------------------------------------

--- a/tests/tools/config-rule.js
+++ b/tests/tools/config-rule.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
 	{
 		createCoreRuleConfigs,
 		generateConfigsFromSchema,
@@ -43,7 +43,7 @@ describe("ConfigRule", () => {
 			});
 
 			it("should create an array of configs", () => {
-				assert.isArray(actualConfigs);
+				assert.ok(Array.isArray(actualConfigs));
 				assert.strictEqual(actualConfigs.length, 3);
 			});
 
@@ -60,7 +60,7 @@ describe("ConfigRule", () => {
 			});
 
 			it("should return configs with each enumerated value in the schema", () => {
-				assert.sameDeepMembers(actualConfigs, [
+				assert.deepStrictEqual(actualConfigs, [
 					SEVERITY,
 					[SEVERITY, "always"],
 					[SEVERITY, "never"],
@@ -80,7 +80,10 @@ describe("ConfigRule", () => {
 				actualConfigs.slice(1).forEach(actualConfig => {
 					const actualConfigOption = actualConfig[1]; // severity is first element, option is second
 
-					assert.isObject(actualConfigOption);
+					assert.ok(
+						actualConfigOption !== null &&
+							typeof actualConfigOption === "object",
+					);
 				});
 			});
 
@@ -91,7 +94,7 @@ describe("ConfigRule", () => {
 				actualConfigs.slice(1).forEach(actualConfig => {
 					const actualConfigOption = actualConfig[1];
 
-					assert.property(actualConfigOption, propName);
+					assert.ok(propName in actualConfigOption);
 				});
 			});
 
@@ -104,7 +107,7 @@ describe("ConfigRule", () => {
 
 					actualValues.push(configOption[propName]);
 				});
-				assert.sameMembers(actualValues, ["always", "never"]);
+				assert.deepStrictEqual(actualValues, ["always", "never"]);
 			});
 		});
 
@@ -123,7 +126,10 @@ describe("ConfigRule", () => {
 					const configOption = actualConfig[1];
 					const actualProperties = Object.keys(configOption);
 
-					assert.sameMembers(actualProperties, expectedProperties);
+					assert.deepStrictEqual(
+						actualProperties,
+						expectedProperties,
+					);
 				});
 			});
 
@@ -140,7 +146,22 @@ describe("ConfigRule", () => {
 					.slice(1)
 					.map(actualConfig => actualConfig[1]);
 
-				assert.sameDeepMembers(actualConfigOptions, expectedConfigs);
+				expectedConfigs.forEach(expectedConfig => {
+					const found = actualConfigOptions.some(actualConfig =>
+						Object.keys(expectedConfig).every(
+							key => expectedConfig[key] === actualConfig[key],
+						),
+					);
+					assert.ok(
+						found,
+						`Expected config ${JSON.stringify(expectedConfig)} not found`,
+					);
+				});
+
+				assert.strictEqual(
+					actualConfigOptions.length,
+					expectedConfigs.length,
+				);
 			});
 		});
 
@@ -156,7 +177,10 @@ describe("ConfigRule", () => {
 				actualConfigs.slice(1).forEach(actualConfig => {
 					const actualConfigOption = actualConfig[1];
 
-					assert.isObject(actualConfigOption);
+					assert.ok(
+						actualConfigOption !== null &&
+							typeof actualConfigOption === "object",
+					);
 				});
 			});
 
@@ -167,7 +191,7 @@ describe("ConfigRule", () => {
 				actualConfigs.slice(1).forEach(actualConfig => {
 					const actualConfigOption = actualConfig[1];
 
-					assert.property(actualConfigOption, propName);
+					assert.ok(propName in actualConfigOption);
 				});
 			});
 
@@ -180,7 +204,7 @@ describe("ConfigRule", () => {
 
 					actualValues.push(configOption[propName]);
 				});
-				assert.sameMembers(actualValues, [true, false]);
+				assert.deepStrictEqual(actualValues, [true, false]);
 			});
 		});
 
@@ -199,7 +223,10 @@ describe("ConfigRule", () => {
 					const configOption = config[1];
 					const actualProperties = Object.keys(configOption);
 
-					assert.sameMembers(actualProperties, expectedProperties);
+					assert.deepStrictEqual(
+						actualProperties,
+						expectedProperties,
+					);
 				});
 			});
 
@@ -214,9 +241,21 @@ describe("ConfigRule", () => {
 					.slice(1)
 					.map(config => config[1]);
 
-				assert.sameDeepMembers(
-					actualConfigOptions,
-					expectedConfigOptions,
+				expectedConfigOptions.forEach(expectedConfig => {
+					const found = actualConfigOptions.some(actualConfig =>
+						Object.keys(expectedConfig).every(
+							key => expectedConfig[key] === actualConfig[key],
+						),
+					);
+					assert.ok(
+						found,
+						`Expected config ${JSON.stringify(expectedConfig)} not found`,
+					);
+				});
+
+				assert.strictEqual(
+					actualConfigOptions.length,
+					expectedConfigOptions.length,
 				);
 			});
 		});
@@ -236,14 +275,16 @@ describe("ConfigRule", () => {
 					actualConfigs[2][1],
 				];
 
-				assert.sameMembers(actualOptions, ["always", "never"]);
+				assert.deepStrictEqual(actualOptions, ["always", "never"]);
 			});
 
 			it("should create configs with a string and an object", () => {
 				assert.strictEqual(actualConfigs.length, 7);
 				actualConfigs.slice(3).forEach(config => {
-					assert.isString(config[1]);
-					assert.isObject(config[2]);
+					assert.strictEqual(typeof config[1], "string");
+					assert.ok(
+						config[2] !== null && typeof config[2] === "object",
+					);
 				});
 			});
 		});
@@ -258,7 +299,32 @@ describe("ConfigRule", () => {
 			it("should create config only for the enum", () => {
 				const expectedConfigs = [2, [2, "always"], [2, "never"]];
 
-				assert.sameDeepMembers(actualConfigs, expectedConfigs);
+				expectedConfigs.forEach(expectedConfig => {
+					const found = actualConfigs.some(actualConfig => {
+						if (
+							Array.isArray(expectedConfig) &&
+							Array.isArray(actualConfig)
+						) {
+							return (
+								expectedConfig.length === actualConfig.length &&
+								expectedConfig.every(
+									(value, index) =>
+										value === actualConfig[index],
+								)
+							);
+						}
+						return expectedConfig === actualConfig;
+					});
+					assert.ok(
+						found,
+						`Expected config ${JSON.stringify(expectedConfig)} not found`,
+					);
+				});
+
+				assert.strictEqual(
+					actualConfigs.length,
+					expectedConfigs.length,
+				);
 			});
 		});
 
@@ -272,7 +338,32 @@ describe("ConfigRule", () => {
 			it("should not create a config for the enum", () => {
 				const expectedConfigs = [2];
 
-				assert.sameDeepMembers(actualConfigs, expectedConfigs);
+				expectedConfigs.forEach(expectedConfig => {
+					const found = actualConfigs.some(actualConfig => {
+						if (
+							Array.isArray(expectedConfig) &&
+							Array.isArray(actualConfig)
+						) {
+							return (
+								expectedConfig.length === actualConfig.length &&
+								expectedConfig.every(
+									(value, index) =>
+										value === actualConfig[index],
+								)
+							);
+						}
+						return expectedConfig === actualConfig;
+					});
+					assert.ok(
+						found,
+						`Expected config ${JSON.stringify(expectedConfig)} not found`,
+					);
+				});
+
+				assert.strictEqual(
+					actualConfigs.length,
+					expectedConfigs.length,
+				);
 			});
 		});
 
@@ -286,7 +377,32 @@ describe("ConfigRule", () => {
 			it("should not create a config for the enum", () => {
 				const expectedConfigs = [2];
 
-				assert.sameDeepMembers(actualConfigs, expectedConfigs);
+				expectedConfigs.forEach(expectedConfig => {
+					const found = actualConfigs.some(actualConfig => {
+						if (
+							Array.isArray(expectedConfig) &&
+							Array.isArray(actualConfig)
+						) {
+							return (
+								expectedConfig.length === actualConfig.length &&
+								expectedConfig.every(
+									(value, index) =>
+										value === actualConfig[index],
+								)
+							);
+						}
+						return expectedConfig === actualConfig;
+					});
+					assert.ok(
+						found,
+						`Expected config ${JSON.stringify(expectedConfig)} not found`,
+					);
+				});
+
+				assert.strictEqual(
+					actualConfigs.length,
+					expectedConfigs.length,
+				);
 			});
 		});
 
@@ -296,7 +412,7 @@ describe("ConfigRule", () => {
 			});
 
 			it("should create a set of configs", () => {
-				assert.isArray(actualConfigs);
+				assert.ok(Array.isArray(actualConfigs));
 			});
 		});
 
@@ -306,7 +422,7 @@ describe("ConfigRule", () => {
 			});
 
 			it("should create a set of configs", () => {
-				assert.isArray(actualConfigs);
+				assert.ok(Array.isArray(actualConfigs));
 			});
 		});
 	});
@@ -318,7 +434,7 @@ describe("ConfigRule", () => {
 			const expectedRules = Array.from(builtInRules.keys()),
 				actualRules = Object.keys(rulesConfig);
 
-			assert.sameMembers(actualRules, expectedRules);
+			assert.deepStrictEqual(actualRules, expectedRules);
 		});
 
 		it("should allow to ignore deprecated rules", () => {
@@ -331,19 +447,19 @@ describe("ConfigRule", () => {
 					.map(([id]) => id),
 				actualRules = Object.keys(createCoreRuleConfigs(true));
 
-			assert.sameMembers(actualRules, expectedRules);
+			assert.deepStrictEqual(actualRules, expectedRules);
 
 			// Make sure it doesn't contain deprecated rules.
-			assert.notInclude(actualRules, "newline-after-var");
+			assert.ok(!actualRules.includes("newline-after-var"));
 		});
 
 		it("should create arrays of configs for rules", () => {
-			assert.isArray(rulesConfig.quotes);
-			assert.include(rulesConfig.quotes, 2);
+			assert.ok(Array.isArray(rulesConfig.quotes));
+			assert.ok(rulesConfig.quotes.includes(2));
 		});
 
 		it("should create configs for rules with meta", () => {
-			assert(rulesConfig["accessor-pairs"].length > 1);
+			assert.ok(rulesConfig["accessor-pairs"].length > 1);
 		});
 	});
 });

--- a/tests/tools/eslint-fuzzer.js
+++ b/tests/tools/eslint-fuzzer.js
@@ -4,7 +4,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert;
+const assert = require("node:assert");
 const eslint = require("../..");
 const espree = require("espree");
 const sinon = require("sinon");


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

To reduce the project's dependency footprint by replacing the chai assertion library with node.js built-in assert module. This change maintains the same test coverage and functionality while removing an external dependency.

#### What changes did you make? (Give an overview)

- Replaced chai imports with node.js assert in all test files.
- Updated assertion syntax to use node.js assert equivalents.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
