### PR TITLE
docs: remove frozen tag for deprecated rules page

### DIFF
--- a/docs/src/_includes/layouts/doc.html
+++ b/docs/src/_includes/layouts/doc.html
@@ -88,7 +88,7 @@ layout: base.html
                     index: id,
                     recommended: rule_meta.docs.recommended,
                     fixable: rule_meta.fixable,
-                    frozen: rule_meta.docs.frozen,
+                    frozen: false if rule_meta.deprecated else rule_meta.docs.frozen,
                     hasSuggestions: rule_meta.hasSuggestions
                     }) }}
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
![Screenshot 2025-04-28 200220](https://github.com/user-attachments/assets/d01b8164-329e-415c-9b77-9d29911640a9)

`Frozen` category is still visible for the deprecated rules in there page.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
