### PR TITLE
perf: Switch SafeEmitter to use a map

### DIFF
--- a/lib/linter/safe-emitter.js
+++ b/lib/linter/safe-emitter.js
@@ -30,23 +30,23 @@
  * @returns {SafeEmitter} An emitter
  */
 module.exports = () => {
-	const listeners = Object.create(null);
+	const listeners = new Map();
 
 	return Object.freeze({
 		on(eventName, listener) {
-			if (eventName in listeners) {
-				listeners[eventName].push(listener);
+			if (listeners.has(eventName)) {
+				listeners.get(eventName).push(listener);
 			} else {
-				listeners[eventName] = [listener];
+				listeners.set(eventName, [listener]);
 			}
 		},
 		emit(eventName, ...args) {
-			if (eventName in listeners) {
-				listeners[eventName].forEach(listener => listener(...args));
+			if (listeners.has(eventName)) {
+				listeners.get(eventName).forEach(listener => listener(...args));
 			}
 		},
 		eventNames() {
-			return Object.keys(listeners);
+			return Array.from(listeners.keys());
 		},
 	});
 };


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Perf-related

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This switches `SafeEmitter` to use a `Map` internally instead of `Object.create(null)`.

#### Is there anything you'd like reviewers to focus on?

I'm not quite sure if this is improving performance, so wanted to post it here for others to look at and benchmark. When I run `npm run test:performance` before this change:

```shell
$ npm run test:performance

> eslint@9.25.1 test:performance
> node Makefile.js perf


Loading:
  Load performance Run #1:  256.9882ms
  Load performance Run #2:  313.9244ms
  Load performance Run #3:  318.4319ms
  Load performance Run #4:  295.5394ms
  Load performance Run #5:  380.4595ms

  Load Performance median:  313.9244ms   


Single File:
  CPU Speed is 2304 with multiplier 13000000
  Performance Run #1:  5378.7815ms
  Performance Run #2:  4636.3223ms
  Performance Run #3:  4482.7956ms
  Performance Run #4:  4521.2752ms
  Performance Run #5:  4369.4745ms

  Performance budget ok:  4521.2752ms (limit: 5642.361111111111ms)


Multi Files (450 files):
  CPU Speed is 2304 with multiplier 39000000
  Performance Run #1:  12435.7309ms
  Performance Run #2:  14057.0678ms
  Performance Run #3:  11519.1179ms
  Performance Run #4:  11270.5193ms
  Performance Run #5:  11191.2605ms

  Performance budget ok:  11519.1179ms (limit: 16927.083333333332ms)
```

After this change:

```shell
$ npm run test:performance

> eslint@9.25.1 test:performance
> node Makefile.js perf


Loading:
  Load performance Run #1:  362.0527ms
  Load performance Run #2:  315.9612ms
  Load performance Run #3:  455.2299ms
  Load performance Run #4:  495.9643ms
  Load performance Run #5:  377.0506ms

  Load Performance median:  377.0506ms   


Single File:
  CPU Speed is 2304 with multiplier 13000000
  Performance Run #1:  5437.6848ms
  Performance Run #2:  5112.2521ms
  Performance Run #3:  4637.8319ms
  Performance Run #4:  4546.3193ms
  Performance Run #5:  4556.5538ms

  Performance budget ok:  4637.8319ms (limit: 5642.361111111111ms)


Multi Files (450 files):
  CPU Speed is 2304 with multiplier 39000000
  Performance Run #1:  13119.8381ms
  Performance Run #2:  11957.2058ms
  Performance Run #3:  11163.3981ms
  Performance Run #4:  11167.7888ms
  Performance Run #5:  11267.6105ms

  Performance budget ok:  11267.6105ms (limit: 16927.083333333332ms)
```

<!-- markdownlint-disable-file MD004 -->
