### PR TITLE
chore: disambiguate internal types `LanguageOptions` and `Rule`

### DIFF
--- a/docs/tools/markdown-it-rule-example.js
+++ b/docs/tools/markdown-it-rule-example.js
@@ -2,7 +2,7 @@
 
 const { docsExampleCodeToParsableCode } = require("./code-block-utils");
 
-/** @typedef {import("../../lib/shared/types").LanguageOptions} LanguageOptions */
+/** @typedef {import("../../lib/types").Linter.LanguageOptions} JSLanguageOptions */
 
 /**
  * A callback function to handle the opening of container blocks.
@@ -10,7 +10,7 @@ const { docsExampleCodeToParsableCode } = require("./code-block-utils");
  * @param {Object} data Callback data.
  * @param {"correct" | "incorrect"} data.type The type of the example.
  * @param {string} data.code The example code.
- * @param {LanguageOptions | undefined} data.languageOptions The language options to be passed to the Playground.
+ * @param {JSLanguageOptions | undefined} data.languageOptions The language options to be passed to the Playground.
  * @param {Object} data.codeBlockToken The `markdown-it` token for the code block inside the container.
  * @param {Object} data.env Additional Eleventy metadata, if available.
  * @returns {string | undefined} If a text is returned, it will be appended to the rendered output

--- a/docs/tools/prism-eslint-hook.js
+++ b/docs/tools/prism-eslint-hook.js
@@ -26,7 +26,7 @@ try {
 	// ignore
 }
 
-/** @typedef {import("../../lib/shared/types").LanguageOptions} LanguageOptions */
+/** @typedef {import("../../lib/types").Linter.LanguageOptions} JSLanguageOptions */
 
 /**
  * Content that needs to be marked with ESLint
@@ -35,15 +35,15 @@ try {
 let contentMustBeMarked;
 
 /**
- * Parser options received from the `::: incorrect` or `::: correct` container.
- * @type {LanguageOptions|undefined}
+ * Language options received from the `::: incorrect` or `::: correct` container.
+ * @type {JSLanguageOptions|undefined}
  */
 let contentLanguageOptions;
 
 /**
  * Set content that needs to be marked.
  * @param {string} content Source code content that marks ESLint errors.
- * @param {LanguageOptions} options The options used for validation.
+ * @param {JSLanguageOptions} options The options used for validation.
  * @returns {void}
  */
 function addContentMustBeMarked(content, options) {

--- a/lib/languages/js/index.js
+++ b/lib/languages/js/index.js
@@ -25,6 +25,7 @@ const { LATEST_ECMA_VERSION } = require("../../../conf/ecma-version");
 /** @typedef {import("@eslint/core").File} File */
 /** @typedef {import("@eslint/core").Language} Language */
 /** @typedef {import("@eslint/core").OkParseResult} OkParseResult */
+/** @typedef {import("../../types").Linter.LanguageOptions} JSLanguageOptions */
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -37,7 +38,7 @@ const parserSymbol = Symbol.for("eslint.RuleTester.parser");
 /**
  * Analyze scope of the given AST.
  * @param {ASTNode} ast The `Program` node to analyze.
- * @param {LanguageOptions} languageOptions The parser options.
+ * @param {JSLanguageOptions} languageOptions The parser options.
  * @param {Record<string, string[]>} visitorKeys The visitor keys.
  * @returns {ScopeManager} The analysis result.
  */
@@ -230,7 +231,7 @@ module.exports = {
 	 * Parses the given file into an AST.
 	 * @param {File} file The virtual file to parse.
 	 * @param {Object} options Additional options passed from ESLint.
-	 * @param {LanguageOptions} options.languageOptions The language options.
+	 * @param {JSLanguageOptions} options.languageOptions The language options.
 	 * @returns {Object} The result of parsing.
 	 */
 	parse(file, { languageOptions }) {
@@ -309,7 +310,7 @@ module.exports = {
 	 * @param {File} file The virtual file to create a `SourceCode` object from.
 	 * @param {OkParseResult} parseResult The result returned from `parse()`.
 	 * @param {Object} options Additional options passed from ESLint.
-	 * @param {LanguageOptions} options.languageOptions The language options.
+	 * @param {JSLanguageOptions} options.languageOptions The language options.
 	 * @returns {SourceCode} The new `SourceCode` object.
 	 */
 	createSourceCode(file, parseResult, { languageOptions }) {

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -73,20 +73,19 @@ const STEP_KIND_CALL = 2;
 // Typedefs
 //------------------------------------------------------------------------------
 
+/** @import { Language, LanguageOptions, RuleConfig, RuleDefinition, RuleSeverity } from "@eslint/core" */
+
 /** @typedef {import("../shared/types").ConfigData} ConfigData */
 /** @typedef {import("../shared/types").Environment} Environment */
 /** @typedef {import("../shared/types").GlobalConf} GlobalConf */
 /** @typedef {import("../shared/types").LintMessage} LintMessage */
 /** @typedef {import("../shared/types").SuppressedLintMessage} SuppressedLintMessage */
 /** @typedef {import("../shared/types").ParserOptions} ParserOptions */
-/** @typedef {import("../shared/types").LanguageOptions} LanguageOptions */
 /** @typedef {import("../shared/types").Processor} Processor */
-/** @typedef {import("../types").Rule.RuleModule} Rule */
 /** @typedef {import("../shared/types").Times} Times */
-/** @typedef {import("@eslint/core").Language} Language */
-/** @typedef {import("@eslint/core").RuleSeverity} RuleSeverity */
-/** @typedef {import("@eslint/core").RuleConfig} RuleConfig */
+/** @typedef {import("../types").Linter.LanguageOptions} JSLanguageOptions */
 /** @typedef {import("../types").Linter.StringSeverity} StringSeverity */
+/** @typedef {import("../types").Rule.RuleModule} Rule */
 
 /* eslint-disable jsdoc/valid-types -- https://github.com/jsdoc-type-pratt-parser/jsdoc-type-pratt-parser/issues/4#issuecomment-778805577 */
 /**
@@ -1011,7 +1010,7 @@ function resolveParserOptions(parser, providedOptions, enabledEnvironments) {
  * @param {Object} config.globals Global variable definitions.
  * @param {Parser} config.parser The parser to use.
  * @param {ParserOptions} config.parserOptions The parserOptions to use.
- * @returns {LanguageOptions} The languageOptions equivalent.
+ * @returns {JSLanguageOptions} The languageOptions equivalent.
  */
 function createLanguageOptions({
 	globals: configuredGlobals,
@@ -1091,7 +1090,7 @@ function getRuleOptions(ruleConfig, defaultOptions) {
 /**
  * Analyze scope of the given AST.
  * @param {ASTNode} ast The `Program` node to analyze.
- * @param {LanguageOptions} languageOptions The parser options.
+ * @param {JSLanguageOptions} languageOptions The language options.
  * @param {Record<string, string[]>} visitorKeys The visitor keys.
  * @returns {ScopeManager} The analysis result.
  */
@@ -1113,7 +1112,7 @@ function analyzeScope(ast, languageOptions, visitorKeys) {
 
 /**
  * Runs a rule, and gets its listeners
- * @param {Rule} rule A rule object
+ * @param {RuleDefinition} rule A rule object
  * @param {Context} ruleContext The context that should be passed to the rule
  * @throws {TypeError} If `rule` is not an object with a `create` method
  * @throws {any} Any error during the rule's `create`
@@ -1142,7 +1141,7 @@ function createRuleListeners(rule, ruleContext) {
  * Runs the given rules on the given SourceCode object
  * @param {SourceCode} sourceCode A SourceCode object for the given text
  * @param {Object} configuredRules The rules configuration
- * @param {function(string): Rule} ruleMapper A mapper function from rule names to rules
+ * @param {function(string): RuleDefinition} ruleMapper A mapper function from rule names to rules
  * @param {string | undefined} parserName The name of the parser in the config
  * @param {Language} language The language object used for parsing.
  * @param {LanguageOptions} languageOptions The options for parsing the code.
@@ -2645,7 +2644,7 @@ class Linter {
 	/**
 	 * Defines a new linting rule.
 	 * @param {string} ruleId A unique rule identifier
-	 * @param {Rule} rule A rule object
+	 * @param {JSRuleDefinition} rule A rule object
 	 * @returns {void}
 	 */
 	defineRule(ruleId, rule) {

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -2644,7 +2644,7 @@ class Linter {
 	/**
 	 * Defines a new linting rule.
 	 * @param {string} ruleId A unique rule identifier
-	 * @param {JSRuleDefinition} rule A rule object
+	 * @param {Rule} rule A rule object
 	 * @returns {void}
 	 */
 	defineRule(ruleId, rule) {

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -39,9 +39,9 @@ const { SourceCode } = require("../languages/js/source-code");
 // Typedefs
 //------------------------------------------------------------------------------
 
+/** @import { LanguageOptions, RuleDefinition } from "@eslint/core" */
+
 /** @typedef {import("../shared/types").Parser} Parser */
-/** @typedef {import("../shared/types").LanguageOptions} LanguageOptions */
-/** @typedef {import("../types").Rule.RuleModule} Rule */
 
 /**
  * A test case that is expected to pass lint.
@@ -553,7 +553,7 @@ class RuleTester {
 	/**
 	 * Adds a new rule test to execute.
 	 * @param {string} ruleName The name of the rule to run.
-	 * @param {Rule} rule The rule to test.
+	 * @param {RuleDefinition} rule The rule to test.
 	 * @param {{
 	 *   valid: (ValidTestCase | string)[],
 	 *   invalid: InvalidTestCase[]

--- a/lib/services/processor-service.js
+++ b/lib/services/processor-service.js
@@ -20,7 +20,6 @@ const { VFile } = require("../linter/vfile.js");
 /** @typedef {import("../shared/types.js").LintMessage} LintMessage */
 /** @typedef {import("../linter/vfile.js").VFile} VFile */
 /** @typedef {import("@eslint/core").Language} Language */
-/** @typedef {import("@eslint/core").LanguageOptions} LanguageOptions */
 /** @typedef {import("eslint").Linter.Processor} Processor */
 
 //-----------------------------------------------------------------------------

--- a/lib/shared/types.js
+++ b/lib/shared/types.js
@@ -27,15 +27,6 @@ module.exports = {};
  */
 
 /**
- * @typedef {Object} LanguageOptions
- * @property {number|"latest"} [ecmaVersion] The ECMAScript version (or revision number).
- * @property {Record<string, GlobalConf>} [globals] The global variable settings.
- * @property {"script"|"module"|"commonjs"} [sourceType] The source code type.
- * @property {string|Object} [parser] The parser to use.
- * @property {Object} [parserOptions] The parser options to use.
- */
-
-/**
  * @typedef {Object} ConfigData
  * @property {Record<string, boolean>} [env] The environment settings.
  * @property {string | string[]} [extends] The path to other config files or the package name of shareable configs.

--- a/tools/check-rule-examples.js
+++ b/tools/check-rule-examples.js
@@ -22,7 +22,6 @@ const { Linter } = require("../lib/linter");
 
 /** @typedef {import("../lib/shared/types").LintMessage} LintMessage */
 /** @typedef {import("../lib/shared/types").LintResult} LintResult */
-/** @typedef {import("../lib/shared/types").LanguageOptions} LanguageOptions */
 
 //------------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Fix internal types

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In the ESLint code, the types `LanguageOptions` and `Rule` are currently being used for both language-generic types (which now have equivalents in the core types) and for JavaScript-specific types. This PR resolves the ambiguities as follows:

* For language-generic language options, the type `LanguageOptions` from core types is used.
* For language-generic rule objects, the type `RuleDefinition` from core types is used.
* For JS-specific language options, the type `Linter.LanguageOptions` from the ESLint types is used with the alias `JSLanguageOptions`. This is probably the name we'll use when the JS language logic is moved to the `@eslint/js` plugin (similar to `CSSLanguageOptions` or `MarkdownLanguageOptions`), so I chose to use `JSLanguageOptions` to avoid confusion.
* For JS-specific rules, the type `Rule.RuleModule` from the ESLint types is used with the alias `Rule`. `Rule.RuleModule` is the type historically found in place of `JSRuleDefinition` in legacy code or for built-in rules.

I also removed the unused `LanguageOptions` type from `lib/shared/types.js`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
