### PR TITLE
docs: playground button for TypeScript code example

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -219,11 +219,7 @@ module.exports = function (eleventyConfig) {
 
 			const isRuleRemoved = !Object.hasOwn(env.rules_meta, env.title);
 
-			/*
-			 * TypeScript isn't yet supported on the playground:
-			 * https://github.com/eslint/eslint.org/issues/709
-			 */
-			if (isRuleRemoved || isTypeScriptCode) {
+			if (isRuleRemoved) {
 				return `<div class="${type}">`;
 			}
 

--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -232,6 +232,10 @@ module.exports = function (eleventyConfig) {
 				},
 			};
 
+			const languageOptionsForPlayground = languageOptions
+				? { languageOptions }
+				: void 0;
+
 			if (isRuleRemoved) {
 				return `<div class="${type}">`;
 			}
@@ -241,9 +245,7 @@ module.exports = function (eleventyConfig) {
 				JSON.stringify({
 					options: isTypeScriptCode
 						? tsLanguageOptions
-						: languageOptions
-							? { languageOptions }
-							: void 0,
+						: languageOptionsForPlayground,
 					text: code,
 				}),
 			);

--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -219,6 +219,19 @@ module.exports = function (eleventyConfig) {
 
 			const isRuleRemoved = !Object.hasOwn(env.rules_meta, env.title);
 
+			const tsLanguageOptions = {
+				languageOptions: {
+					...languageOptions,
+					parser: "@typescript-eslint/parser",
+					parserOptions: {
+						ecmaFeatures: {
+							jsx: true,
+						},
+						sourceType: "module",
+					},
+				},
+			};
+
 			if (isRuleRemoved) {
 				return `<div class="${type}">`;
 			}
@@ -226,7 +239,11 @@ module.exports = function (eleventyConfig) {
 			// See https://github.com/eslint/eslint.org/blob/29e1d8a000592245e4a30c1996e794643e9b263a/src/playground/App.js#L91-L105
 			const state = encodeToBase64(
 				JSON.stringify({
-					options: languageOptions ? { languageOptions } : void 0,
+					options: isTypeScriptCode
+						? tsLanguageOptions
+						: languageOptions
+							? { languageOptions }
+							: void 0,
 					text: code,
 				}),
 			);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Enabled `open in playground` button for TypeScript code examples.

#### Is there anything you'd like reviewers to focus on?
Can be merged once https://github.com/eslint/eslint.org/pull/714 is finished.

<!-- markdownlint-disable-file MD004 -->
