### PR TITLE
test: mock `process.emitWarning` to prevent output disruption

### DIFF
--- a/tests/lib/mcp/mcp-server.js
+++ b/tests/lib/mcp/mcp-server.js
@@ -14,6 +14,7 @@ const assert = require("chai").assert;
 const path = require("node:path");
 const { Client } = require("@modelcontextprotocol/sdk/client/index.js");
 const { InMemoryTransport } = require("@modelcontextprotocol/sdk/inMemory.js");
+const sinon = require("sinon");
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -55,6 +56,14 @@ describe("MCP Server", () => {
 		// Note: must connect server first or else client hangs
 		await mcpServer.connect(serverTransport);
 		await client.connect(clientTransport);
+
+		sinon
+			.stub(process, "emitWarning")
+			.withArgs(sinon.match.any, "ESLintIgnoreWarning");
+	});
+
+	afterEach(async () => {
+		sinon.restore();
 	});
 
 	describe("Tools", () => {

--- a/tests/lib/mcp/mcp-server.js
+++ b/tests/lib/mcp/mcp-server.js
@@ -62,7 +62,7 @@ describe("MCP Server", () => {
 			.withArgs(sinon.match.any, "ESLintIgnoreWarning");
 	});
 
-	afterEach(async () => {
+	afterEach(() => {
 		sinon.restore();
 	});
 

--- a/tests/lib/mcp/mcp-server.js
+++ b/tests/lib/mcp/mcp-server.js
@@ -59,7 +59,9 @@ describe("MCP Server", () => {
 
 		sinon
 			.stub(process, "emitWarning")
-			.withArgs(sinon.match.any, "ESLintIgnoreWarning");
+			.callThrough()
+			.withArgs(sinon.match.any, "ESLintIgnoreWarning")
+			.returns();
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Fix the output of `npm test`

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I noticed that the deprecation warning printed by ESLint when it finds an `.eslintignore` file was being printed to stderr during the MCP server tests, breaking the output of `npm test`. So I replaced `process.emitWarning` with a stub in the tests.

Before:

```shell
$ npm test 

> eslint@9.26.0 test
> node Makefile.js test

Validating rules
Running unit tests

  [▬▬▬................................](node:25189) ESLintIgnoreWarning: The ".eslintignore" file is no longer supported. Switch to using the "ignores" property in "eslint.config.js": https://eslint.org/docs/latest/use/configure/migration-guide#ignoring-files
(Use `node --trace-warnings ...` to show where the warning was created)
(node:25189) ESLintIgnoreWarning: The ".eslintignore" file is no longer supported. Switch to using the "ignores" property in "eslint.config.js": https://eslint.org/docs/latest/use/configure/migration-guide#ignoring-files
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  38420 passing (29s)
  26 pending


=============================== Coverage summary ===============================
Statements   : 99.19% ( 97179/97972 )
Branches     : 98.25% ( 16289/16579 )
Functions    : 99.42% ( 3485/3505 )
Lines        : 99.19% ( 97179/97972 )
================================================================================
Fuzzing rules [=======================] 100%, 0.9s elapsed, eta 0.0s, errors so far: 0
Validating licenses
```

After:

```shell
$ npm test

> eslint@9.26.0 test
> node Makefile.js test

Validating rules
Running unit tests

  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  38420 passing (29s)
  26 pending


=============================== Coverage summary ===============================
Statements   : 99.19% ( 97179/97972 )
Branches     : 98.25% ( 16290/16580 )
Functions    : 99.42% ( 3485/3505 )
Lines        : 99.19% ( 97179/97972 )
================================================================================
Fuzzing rules [=======================] 100%, 0.9s elapsed, eta 0.0s, errors so far: 0
Validating licenses
```

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
