### PR TITLE
docs: fix internal usages of `ConfigData` type

### DIFF
--- a/docs/src/integrate/nodejs-api.md
+++ b/docs/src/integrate/nodejs-api.md
@@ -140,9 +140,9 @@ The `ESLint` constructor takes an `options` object. If you omit the `options` ob
 
 - `options.allowInlineConfig` (`boolean`)<br>
   Default is `true`. If `false` is present, ESLint suppresses directive comments in source code. If this option is `false`, it overrides the `noInlineConfig` setting in your configurations.
-- `options.baseConfig` (`ConfigData | ConfigData[] | null`)<br>
+- `options.baseConfig` (`Config | Config[] | null`)<br>
   Default is `null`. [Configuration object], extended by all configurations used with this instance. You can use this option to define the default settings that will be used if your configuration files don't configure it.
-- `options.overrideConfig` (`ConfigData | ConfigData[] | null`)<br>
+- `options.overrideConfig` (`Config | Config[] | null`)<br>
   Default is `null`. [Configuration object], added after any existing configuration and therefore applies after what's contained in your configuration file (if used).
 - `options.overrideConfigFile` (`null | true | string`)<br>
   Default is `null`. By default, ESLint searches for a configuration file. When this option is set to `true`, ESLint does not search for a configuration file. When this option is set to a `string` value, ESLint does not search for a configuration file, and uses the provided value as the path to the configuration file.

--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -58,15 +58,15 @@ const validFixTypes = new Set(["directive", "problem", "suggestion", "layout"]);
 //------------------------------------------------------------------------------
 
 // For VSCode IntelliSense
-/** @typedef {import("../shared/types").ConfigData} ConfigData */
 /** @typedef {import("../shared/types").DeprecatedRuleInfo} DeprecatedRuleInfo */
 /** @typedef {import("../shared/types").LintMessage} LintMessage */
 /** @typedef {import("../shared/types").SuppressedLintMessage} SuppressedLintMessage */
 /** @typedef {import("../shared/types").ParserOptions} ParserOptions */
 /** @typedef {import("../shared/types").RuleConf} RuleConf */
-/** @typedef {import("../types").Rule.RuleModule} Rule */
+/** @typedef {import("../types").ESLint.ConfigData} ConfigData */
 /** @typedef {import("../types").ESLint.FormatterFunction} FormatterFunction */
 /** @typedef {import("../types").ESLint.Plugin} Plugin */
+/** @typedef {import("../types").Rule.RuleModule} Rule */
 /** @typedef {ReturnType<CascadingConfigArrayFactory.getConfigArrayForFile>} ConfigArray */
 /** @typedef {ReturnType<ConfigArray.extractConfig>} ExtractedConfig */
 

--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -20,19 +20,17 @@ const { FlatConfigArray } = require("./flat-config-array");
 // Types
 //-----------------------------------------------------------------------------
 
-/**
- * @import { ConfigData, ConfigData as FlatConfigObject } from "../shared/types.js";
- */
+/** @typedef {import("../types").Linter.Config} Config */
 
 /**
  * @typedef {Object} ConfigLoaderOptions
  * @property {string|false|undefined} configFile The path to the config file to use.
  * @property {string} cwd The current working directory.
  * @property {boolean} ignoreEnabled Indicates if ignore patterns should be honored.
- * @property {FlatConfigArray} [baseConfig] The base config to use.
- * @property {Array<FlatConfigObject>} [defaultConfigs] The default configs to use.
+ * @property {Config|Array<Config>} [baseConfig] The base config to use.
+ * @property {Array<Config>} [defaultConfigs] The default configs to use.
  * @property {Array<string>} [ignorePatterns] The ignore patterns to use.
- * @property {FlatConfigObject|Array<FlatConfigObject>} [overrideConfig] The override config to use.
+ * @property {Config|Array<Config>} [overrideConfig] The override config to use.
  * @property {boolean} [hasUnstableNativeNodeJsTSConfigFlag] The flag to indicate whether the `unstable_native_nodejs_ts_config` flag is enabled.
  */
 
@@ -394,8 +392,7 @@ class ConfigLoader {
 	 * This is the same logic used by the ESLint CLI executable to determine
 	 * configuration for each file it processes.
 	 * @param {string} filePath The path of the file or directory to retrieve config for.
-	 * @returns {Promise<ConfigData|undefined>} A configuration object for the file
-	 *      or `undefined` if there is no configuration data for the file.
+	 * @returns {Promise<FlatConfigArray>} A configuration object for the file.
 	 * @throws {Error} If no configuration for `filePath` exists.
 	 */
 	async loadConfigArrayForFile(filePath) {
@@ -415,8 +412,7 @@ class ConfigLoader {
 	 * This is the same logic used by the ESLint CLI executable to determine
 	 * configuration for each file it processes.
 	 * @param {string} dirPath The path of the directory to retrieve config for.
-	 * @returns {Promise<ConfigData|undefined>} A configuration object for the directory
-	 *      or `undefined` if there is no configuration data for the directory.
+	 * @returns {Promise<FlatConfigArray>} A configuration object for the directory.
 	 */
 	async loadConfigArrayForDirectory(dirPath) {
 		assertValidFilePath(dirPath);
@@ -440,8 +436,7 @@ class ConfigLoader {
 	 * intended to be used in locations where we know the config file has already
 	 * been loaded and we just need to get the configuration for a file.
 	 * @param {string} filePath The path of the file to retrieve a config object for.
-	 * @returns {ConfigData|undefined} A configuration object for the file
-	 *     or `undefined` if there is no configuration data for the file.
+	 * @returns {FlatConfigArray} A configuration object for the file.
 	 * @throws {Error} If `filePath` is not a non-empty string.
 	 * @throws {Error} If `filePath` is not an absolute path.
 	 * @throws {Error} If the config file was not already loaded.
@@ -460,8 +455,7 @@ class ConfigLoader {
 	 * intended to be used in locations where we know the config file has already
 	 * been loaded and we just need to get the configuration for a file.
 	 * @param {string} fileOrDirPath The path of the directory to retrieve a config object for.
-	 * @returns {ConfigData|undefined} A configuration object for the directory
-	 *     or `undefined` if there is no configuration data for the directory.
+	 * @returns {FlatConfigArray} A configuration object for the directory.
 	 * @throws {Error} If `dirPath` is not a non-empty string.
 	 * @throws {Error} If `dirPath` is not an absolute path.
 	 * @throws {Error} If the config file was not already loaded.
@@ -789,8 +783,7 @@ class LegacyConfigLoader extends ConfigLoader {
 	 * This is the same logic used by the ESLint CLI executable to determine
 	 * configuration for each file it processes.
 	 * @param {string} dirPath The path of the directory to retrieve config for.
-	 * @returns {Promise<ConfigData|undefined>} A configuration object for the file
-	 *      or `undefined` if there is no configuration data for the file.
+	 * @returns {Promise<FlatConfigArray>} A configuration object for the file.
 	 */
 	async loadConfigArrayForDirectory(dirPath) {
 		assertValidFilePath(dirPath);
@@ -812,8 +805,7 @@ class LegacyConfigLoader extends ConfigLoader {
 	 * intended to be used in locations where we know the config file has already
 	 * been loaded and we just need to get the configuration for a file.
 	 * @param {string} dirPath The path of the directory to retrieve a config object for.
-	 * @returns {ConfigData|undefined} A configuration object for the file
-	 *     or `undefined` if there is no configuration data for the file.
+	 * @returns {FlatConfigArray} A configuration object for the file.
 	 * @throws {Error} If `dirPath` is not a non-empty string.
 	 * @throws {Error} If `dirPath` is not an absolute path.
 	 * @throws {Error} If the config file was not already loaded.

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -57,17 +57,18 @@ const { ConfigLoader, LegacyConfigLoader } = require("../config/config-loader");
  * @import { CLIEngineLintReport } from "./legacy-eslint.js";
  * @import { FlatConfigArray } from "../config/flat-config-array.js";
  * @import { RuleDefinition } from "@eslint/core";
- * @import { ConfigData, DeprecatedRuleInfo, LintMessage, LintResult, ResultsMeta } from "../shared/types.js";
+ * @import { DeprecatedRuleInfo, LintMessage, LintResult, ResultsMeta } from "../shared/types.js";
  */
 
 /** @typedef {ReturnType<ConfigArray.extractConfig>} ExtractedConfig */
+/** @typedef {import("../types").Linter.Config} Config */
 /** @typedef {import("../types").ESLint.Plugin} Plugin */
 
 /**
  * The options with which to configure the ESLint instance.
  * @typedef {Object} ESLintOptions
  * @property {boolean} [allowInlineConfig] Enable or disable inline configuration comments.
- * @property {ConfigData|Array<ConfigData>} [baseConfig] Base config, extended by all configs used with this instance
+ * @property {Config|Array<Config>} [baseConfig] Base config, extended by all configs used with this instance
  * @property {boolean} [cache] Enable result caching.
  * @property {string} [cacheLocation] The cache file to use instead of .eslintcache.
  * @property {"metadata" | "content"} [cacheStrategy] The strategy used to detect changed files.
@@ -79,7 +80,7 @@ const { ConfigLoader, LegacyConfigLoader } = require("../config/config-loader");
  * @property {boolean} [globInputPaths] Set to false to skip glob resolution of input file paths to lint (default: true). If false, each input file paths is assumed to be a non-glob path to an existing file.
  * @property {boolean} [ignore] False disables all ignore patterns except for the default ones.
  * @property {string[]} [ignorePatterns] Ignore file patterns to use in addition to config ignores. These patterns are relative to `cwd`.
- * @property {ConfigData|Array<ConfigData>} [overrideConfig] Override config, overrides all configs used with this instance
+ * @property {Config|Array<Config>} [overrideConfig] Override config, overrides all configs used with this instance
  * @property {boolean|string} [overrideConfigFile] Searches for default config file when falsy;
  *      doesn't do any config file lookup when `true`; considered to be a config filename
  *      when a string.
@@ -1068,7 +1069,7 @@ class ESLint {
 	 * This is the same logic used by the ESLint CLI executable to determine
 	 * configuration for each file it processes.
 	 * @param {string} filePath The path of the file to retrieve a config object for.
-	 * @returns {Promise<ConfigData|undefined>} A configuration object for the file
+	 * @returns {Promise<Config|undefined>} A configuration object for the file
 	 *      or `undefined` if there is no configuration data for the object.
 	 */
 	async calculateConfigForFile(filePath) {

--- a/lib/eslint/legacy-eslint.js
+++ b/lib/eslint/legacy-eslint.js
@@ -31,11 +31,11 @@ const { version } = require("../../package.json");
 
 /** @typedef {import("../cli-engine/cli-engine").LintReport} CLIEngineLintReport */
 /** @typedef {import("../shared/types").DeprecatedRuleInfo} DeprecatedRuleInfo */
-/** @typedef {import("../shared/types").ConfigData} ConfigData */
 /** @typedef {import("../shared/types").LintMessage} LintMessage */
 /** @typedef {import("../shared/types").SuppressedLintMessage} SuppressedLintMessage */
 /** @typedef {import("../shared/types").LintResult} LintResult */
 /** @typedef {import("../shared/types").ResultsMeta} ResultsMeta */
+/** @typedef {import("../types").ESLint.ConfigData} ConfigData */
 /** @typedef {import("../types").ESLint.Plugin} Plugin */
 /** @typedef {import("../types").Rule.RuleModule} Rule */
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -75,7 +75,6 @@ const STEP_KIND_CALL = 2;
 
 /** @import { Language, LanguageOptions, RuleConfig, RuleDefinition, RuleSeverity } from "@eslint/core" */
 
-/** @typedef {import("../shared/types").ConfigData} ConfigData */
 /** @typedef {import("../shared/types").Environment} Environment */
 /** @typedef {import("../shared/types").GlobalConf} GlobalConf */
 /** @typedef {import("../shared/types").LintMessage} LintMessage */
@@ -83,6 +82,8 @@ const STEP_KIND_CALL = 2;
 /** @typedef {import("../shared/types").ParserOptions} ParserOptions */
 /** @typedef {import("../shared/types").Processor} Processor */
 /** @typedef {import("../shared/types").Times} Times */
+/** @typedef {import("../types").Linter.Config} Config */
+/** @typedef {import("../types").ESLint.ConfigData} ConfigData */
 /** @typedef {import("../types").Linter.LanguageOptions} JSLanguageOptions */
 /** @typedef {import("../types").Linter.StringSeverity} StringSeverity */
 /** @typedef {import("../types").Rule.RuleModule} Rule */
@@ -350,7 +351,7 @@ function asArray(value) {
 
 /**
  * Pushes a problem to inlineConfigProblems if ruleOptions are redundant.
- * @param {ConfigData} config Provided config.
+ * @param {Config} config Provided config.
  * @param {Object} loc A line/column location
  * @param {Array} problems Problems that may be added to.
  * @param {string} ruleId The rule ID.
@@ -901,7 +902,7 @@ function normalizeFilename(filename) {
  * Normalizes the possible options for `linter.verify` and `linter.verifyAndFix` to a
  * consistent shape.
  * @param {VerifyOptions} providedOptions Options
- * @param {ConfigData} config Config.
+ * @param {Config|ConfigData} config Config.
  * @returns {Required<VerifyOptions> & InternalOptions} Normalized options
  */
 function normalizeVerifyOptions(providedOptions, config) {
@@ -1885,7 +1886,7 @@ class Linter {
 	/**
 	 * Verify with a processor.
 	 * @param {string|SourceCode} textOrSourceCode The source code.
-	 * @param {FlatConfig} config The config array.
+	 * @param {Config} config The config array.
 	 * @param {VerifyOptions&ProcessorOptions} options The options.
 	 * @param {FlatConfigArray} [configForRecursive] The `ConfigArray` object to apply multiple processors recursively.
 	 * @returns {(LintMessage|SuppressedLintMessage)[]} The found problems.
@@ -1986,7 +1987,7 @@ class Linter {
 	/**
 	 * Verify using flat config and without any processors.
 	 * @param {VFile} file The file to lint.
-	 * @param {FlatConfig} providedConfig An ESLintConfig instance to configure everything.
+	 * @param {Config} providedConfig An ESLintConfig instance to configure everything.
 	 * @param {VerifyOptions} [providedOptions] The optional filename of the file being checked.
 	 * @throws {Error} If during rule execution.
 	 * @returns {(LintMessage|SuppressedLintMessage)[]} The results as an array of messages or an empty array if no messages.
@@ -2348,7 +2349,7 @@ class Linter {
 	/**
 	 * Same as linter.verify, except without support for processors.
 	 * @param {string|SourceCode} textOrSourceCode The text to parse or a SourceCode object.
-	 * @param {FlatConfig} providedConfig An ESLintConfig instance to configure everything.
+	 * @param {Config} providedConfig An ESLintConfig instance to configure everything.
 	 * @param {VerifyOptions} [providedOptions] The optional filename of the file being checked.
 	 * @throws {Error} If during rule execution.
 	 * @returns {(LintMessage|SuppressedLintMessage)[]} The results as an array of messages or an empty array if no messages.

--- a/lib/shared/types.js
+++ b/lib/shared/types.js
@@ -27,42 +27,6 @@ module.exports = {};
  */
 
 /**
- * @typedef {Object} ConfigData
- * @property {Record<string, boolean>} [env] The environment settings.
- * @property {string | string[]} [extends] The path to other config files or the package name of shareable configs.
- * @property {Record<string, GlobalConf>} [globals] The global variable settings.
- * @property {string | string[]} [ignorePatterns] The glob patterns that ignore to lint.
- * @property {boolean} [noInlineConfig] The flag that disables directive comments.
- * @property {OverrideConfigData[]} [overrides] The override settings per kind of files.
- * @property {string} [parser] The path to a parser or the package name of a parser.
- * @property {ParserOptions} [parserOptions] The parser options.
- * @property {string[]} [plugins] The plugin specifiers.
- * @property {string} [processor] The processor specifier.
- * @property {boolean} [reportUnusedDisableDirectives] The flag to report unused `eslint-disable` comments.
- * @property {boolean} [root] The root flag.
- * @property {Record<string, RuleConf>} [rules] The rule settings.
- * @property {Object} [settings] The shared settings.
- */
-
-/**
- * @typedef {Object} OverrideConfigData
- * @property {Record<string, boolean>} [env] The environment settings.
- * @property {string | string[]} [excludedFiles] The glob patterns for excluded files.
- * @property {string | string[]} [extends] The path to other config files or the package name of shareable configs.
- * @property {string | string[]} files The glob patterns for target files.
- * @property {Record<string, GlobalConf>} [globals] The global variable settings.
- * @property {boolean} [noInlineConfig] The flag that disables directive comments.
- * @property {OverrideConfigData[]} [overrides] The override settings per kind of files.
- * @property {string} [parser] The path to a parser or the package name of a parser.
- * @property {ParserOptions} [parserOptions] The parser options.
- * @property {string[]} [plugins] The plugin specifiers.
- * @property {string} [processor] The processor specifier.
- * @property {boolean} [reportUnusedDisableDirectives] The flag to report unused `eslint-disable` comments.
- * @property {Record<string, RuleConf>} [rules] The rule settings.
- * @property {Object} [settings] The shared settings.
- */
-
-/**
  * @typedef {Object} ParseResult
  * @property {Object} ast The AST.
  * @property {ScopeManager} [scopeManager] The scope manager of the AST.

--- a/tools/eslint-fuzzer.js
+++ b/tools/eslint-fuzzer.js
@@ -17,6 +17,12 @@ const ruleConfigs = require("./config-rule").createCoreRuleConfigs(true);
 const sampleMinimizer = require("./code-sample-minimizer");
 
 //------------------------------------------------------------------------------
+// Typedefs
+//------------------------------------------------------------------------------
+
+/** @typedef {import("../lib/types").ESLint.ConfigData} ConfigData */
+
+//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR replaces usages of the `ConfigData` type with `Config` for flat config objects, or with `FlatConfigArray` for flat config arrays. At the same time it removes `ConfigData` and another related type from `lib/shared/types.js` in favor of the TypeScript definitions for eslintrc objects. I tagged this with `docs:` because there is also a fix in the `Linter` documentation.

#### Is there anything you'd like reviewers to focus on?

Please double-check the changes in the `Linter` class.

<!-- markdownlint-disable-file MD004 -->
