### PR TITLE
fix: add `info` to `ESLint.DeprecatedRuleUse` type

### DIFF
--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -58,12 +58,12 @@ const validFixTypes = new Set(["directive", "problem", "suggestion", "layout"]);
 //------------------------------------------------------------------------------
 
 // For VSCode IntelliSense
-/** @typedef {import("../shared/types").DeprecatedRuleInfo} DeprecatedRuleInfo */
 /** @typedef {import("../shared/types").LintMessage} LintMessage */
 /** @typedef {import("../shared/types").SuppressedLintMessage} SuppressedLintMessage */
 /** @typedef {import("../shared/types").ParserOptions} ParserOptions */
 /** @typedef {import("../shared/types").RuleConf} RuleConf */
 /** @typedef {import("../types").ESLint.ConfigData} ConfigData */
+/** @typedef {import("../types").ESLint.DeprecatedRuleUse} DeprecatedRuleInfo */
 /** @typedef {import("../types").ESLint.FormatterFunction} FormatterFunction */
 /** @typedef {import("../types").ESLint.Plugin} Plugin */
 /** @typedef {import("../types").Rule.RuleModule} Rule */

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -57,11 +57,12 @@ const { ConfigLoader, LegacyConfigLoader } = require("../config/config-loader");
  * @import { CLIEngineLintReport } from "./legacy-eslint.js";
  * @import { FlatConfigArray } from "../config/flat-config-array.js";
  * @import { RuleDefinition } from "@eslint/core";
- * @import { DeprecatedRuleInfo, LintMessage, LintResult, ResultsMeta } from "../shared/types.js";
+ * @import { LintMessage, LintResult, ResultsMeta } from "../shared/types.js";
  */
 
 /** @typedef {ReturnType<ConfigArray.extractConfig>} ExtractedConfig */
 /** @typedef {import("../types").Linter.Config} Config */
+/** @typedef {import("../types").ESLint.DeprecatedRuleUse} DeprecatedRuleInfo */
 /** @typedef {import("../types").ESLint.Plugin} Plugin */
 
 /**

--- a/lib/eslint/legacy-eslint.js
+++ b/lib/eslint/legacy-eslint.js
@@ -30,12 +30,12 @@ const { version } = require("../../package.json");
 //------------------------------------------------------------------------------
 
 /** @typedef {import("../cli-engine/cli-engine").LintReport} CLIEngineLintReport */
-/** @typedef {import("../shared/types").DeprecatedRuleInfo} DeprecatedRuleInfo */
 /** @typedef {import("../shared/types").LintMessage} LintMessage */
 /** @typedef {import("../shared/types").SuppressedLintMessage} SuppressedLintMessage */
 /** @typedef {import("../shared/types").LintResult} LintResult */
 /** @typedef {import("../shared/types").ResultsMeta} ResultsMeta */
 /** @typedef {import("../types").ESLint.ConfigData} ConfigData */
+/** @typedef {import("../types").ESLint.DeprecatedRuleUse} DeprecatedRuleInfo */
 /** @typedef {import("../types").ESLint.Plugin} Plugin */
 /** @typedef {import("../types").Rule.RuleModule} Rule */
 

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -2072,7 +2072,7 @@ export namespace ESLint {
 		replacedBy: string[];
 
 		/**
-		 * The raw deprecated info provided by rule.
+		 * The raw deprecated info provided by the rule.
 		 * Unset if the rule's `meta.deprecated` property is a boolean.
 		 */
 		info?: DeprecatedInfo;

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -2057,9 +2057,25 @@ export namespace ESLint {
 		};
 	}
 
+	/**
+	 * Information about deprecated rules.
+	 */
 	interface DeprecatedRuleUse {
+		/**
+		 * The rule ID.
+		 */
 		ruleId: string;
+
+		/**
+		 * The rule IDs that replace this deprecated rule.
+		 */
 		replacedBy: string[];
+
+		/**
+		 * The raw deprecated info provided by rule.
+		 * Unset if the rule's `meta.deprecated` property is a boolean.
+		 */
+		info?: DeprecatedInfo;
 	}
 
 	interface ResultsMeta {

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -1774,6 +1774,20 @@ for (const result of results) {
 	};
 	delete result.stats;
 
+	const deprecatedRule = result.usedDeprecatedRules[0];
+	deprecatedRule.ruleId = "foo";
+	deprecatedRule.replacedBy = ["bar"];
+	deprecatedRule.info = {
+		message: "use bar instead",
+		replacedBy: [
+			{
+				rule: {
+					name: "bar",
+				},
+			},
+		],
+	};
+
 	for (const message of result.messages) {
 		message.ruleId = "foo";
 	}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Updates `ESLint.DeprecatedRuleUse` to include the `info` property.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The TypeScript type `ESLint.DeprecatedRuleUse` is the equivalent of the internal type `DeprecatedRuleInfo`.

https://github.com/eslint/eslint/blob/8ed32734cc22988173f99fd0703d50f94c60feb8/lib/shared/types.js#L124-L130

In #19238 the `info` property was added to `DeprecatedRuleInfo` but we forgot to also update `ESLint.DeprecatedRuleUse`. This PR adds the missing `info` property to `ESLint.DeprecatedRuleUse` and updates local typedefs of `DeprecatedRuleInfo` to import the TypeScript type instead of the internal type from `lib/shared/types.js`.

I also added TSDoc comments to `ESLint.DeprecatedRuleUse` on the example of `DeprecatedRuleInfo`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
