### PR TITLE
fix: add `allowReserved` to `Linter.ParserOptions` type

### DIFF
--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -60,11 +60,11 @@ const validFixTypes = new Set(["directive", "problem", "suggestion", "layout"]);
 // For VSCode IntelliSense
 /** @typedef {import("../shared/types").LintMessage} LintMessage */
 /** @typedef {import("../shared/types").SuppressedLintMessage} SuppressedLintMessage */
-/** @typedef {import("../shared/types").ParserOptions} ParserOptions */
 /** @typedef {import("../shared/types").RuleConf} RuleConf */
 /** @typedef {import("../types").ESLint.ConfigData} ConfigData */
 /** @typedef {import("../types").ESLint.DeprecatedRuleUse} DeprecatedRuleInfo */
 /** @typedef {import("../types").ESLint.FormatterFunction} FormatterFunction */
+/** @typedef {import("../types").Linter.ParserOptions} ParserOptions */
 /** @typedef {import("../types").ESLint.Plugin} Plugin */
 /** @typedef {import("../types").Rule.RuleModule} Rule */
 /** @typedef {ReturnType<CascadingConfigArrayFactory.getConfigArrayForFile>} ConfigArray */

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -79,12 +79,12 @@ const STEP_KIND_CALL = 2;
 /** @typedef {import("../shared/types").GlobalConf} GlobalConf */
 /** @typedef {import("../shared/types").LintMessage} LintMessage */
 /** @typedef {import("../shared/types").SuppressedLintMessage} SuppressedLintMessage */
-/** @typedef {import("../shared/types").ParserOptions} ParserOptions */
 /** @typedef {import("../shared/types").Processor} Processor */
 /** @typedef {import("../shared/types").Times} Times */
 /** @typedef {import("../types").Linter.Config} Config */
 /** @typedef {import("../types").ESLint.ConfigData} ConfigData */
 /** @typedef {import("../types").Linter.LanguageOptions} JSLanguageOptions */
+/** @typedef {import("../types").Linter.ParserOptions} ParserOptions */
 /** @typedef {import("../types").Linter.StringSeverity} StringSeverity */
 /** @typedef {import("../types").Rule.RuleModule} Rule */
 

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1560,9 +1560,16 @@ export namespace Linter {
 	/**
 	 * Parser options.
 	 *
-	 * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options-deprecated#specifying-parser-options)
+	 * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options#specifying-parser-options)
 	 */
 	interface ParserOptions {
+		/**
+		 * Allow the use of reserved words as identifiers (if `ecmaVersion` is 3).
+		 *
+		 * @default false
+		 */
+		allowReserved?: boolean | undefined;
+
 		/**
 		 * Accepts any valid ECMAScript version number or `'latest'`:
 		 *

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -945,6 +945,16 @@ linter.verify(
 	},
 	"test.js",
 );
+linter.verify(
+	SOURCE,
+	{
+		parserOptions: {
+			ecmaVersion: 3,
+			allowReserved: true,
+		},
+	},
+	"test.js",
+);
 linter.verify(SOURCE, { env: { node: true } }, "test.js");
 linter.verify(SOURCE, { globals: { foo: true } }, "test.js");
 linter.verify(SOURCE, { globals: { foo: "off" } }, "test.js");
@@ -1336,6 +1346,16 @@ linterWithEslintrcConfig.verify(
 		parserOptions: {
 			ecmaVersion: 6,
 			ecmaFeatures: { experimentalObjectRestSpread: true },
+		},
+	},
+	"test.js",
+);
+linterWithEslintrcConfig.verify(
+	SOURCE,
+	{
+		parserOptions: {
+			ecmaVersion: 3,
+			allowReserved: true,
 		},
 	},
 	"test.js",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Updates `Linter.ParserOptions` to include the `allowReserved` property.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds the `allowReserved` property to the `Linter.ParserOptions` and updates local typedefs of `ParserOptions` to import the TypeScript type instead of the internal type from `lib/shared/types.js` (which does include the property).

`allowReserved` is a documented property of `parserOptions` both in the current language options docs and in the deprecated docs.

https://github.com/eslint/eslint/blob/7bc6c71ca350fa37531291e1d704be6ed408c5dc/docs/src/use/configure/language-options.md?plain=1#L46

https://github.com/eslint/eslint/blob/7bc6c71ca350fa37531291e1d704be6ed408c5dc/docs/src/use/configure/language-options-deprecated.md?plain=1#L198

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
