### PR TITLE
fix: sort keys in eslint-suppressions.json to avoid git churn

### DIFF
--- a/lib/services/suppressions-service.js
+++ b/lib/services/suppressions-service.js
@@ -12,6 +12,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { calculateStatsPerFile } = require("../eslint/eslint-helpers");
+const stringify = require("json-stable-stringify-without-jsonify");
 
 //------------------------------------------------------------------------------
 // Typedefs
@@ -224,7 +225,7 @@ class SuppressionsService {
 	save(suppressions) {
 		return fs.promises.writeFile(
 			this.filePath,
-			JSON.stringify(suppressions, null, 2),
+			stringify(suppressions, { space: 2 }),
 		);
 	}
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

- the suppressions system introduced by https://github.com/eslint/eslint/pull/19159 doesn't enforce a consistent ordering of filenames or rule identifiers
- this can cause unnecessary `git` churn and even `git` conflicts when multiple contributors to a project submit changes that include generated changes to the eslint-suppressions.json file

#### What changes did you make? (Give an overview)

- this PR uses the pre-existing dependency upon https://www.npmjs.com/package/json-stable-stringify-without-jsonify to sort the keys in the suppressions data just prior to writing the JSON file

#### Is there anything you'd like reviewers to focus on?

- nope
- the existing test coverage for suppressions passes without issues
