### PR TITLE
fix: correct `service` property name in `Linter.ESLintParseResult` type

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1668,8 +1668,8 @@ export namespace Linter {
 		messages: LintMessage[];
 	}
 
-	// Temporarily loosen type for just flat config files (see #68232)
-	type NonESTreeParser = Omit<ESTreeParser, "parseForESLint"> &
+	// Temporarily loosen type for just flat config files (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68232)
+	type NonESTreeParser = ESLint.ObjectMetaProperties &
 		(
 			| {
 					parse(text: string, options?: any): unknown;
@@ -1694,9 +1694,16 @@ export namespace Linter {
 	type Parser = NonESTreeParser | ESTreeParser;
 
 	interface ESLintParseResult {
+		/** The AST object. */
 		ast: AST.Program;
-		parserServices?: SourceCode.ParserServices | undefined;
+
+		/** The services that the parser provides. */
+		services?: SourceCode.ParserServices | undefined;
+
+		/** The scope manager of the AST. */
 		scopeManager?: Scope.ScopeManager | undefined;
+
+		/** The visitor keys of the AST. */
 		visitorKeys?: SourceCode.VisitorKeys | undefined;
 	}
 

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -1083,11 +1083,11 @@ linter.defineParser("custom-parser", {
 		name: "foo",
 		version: "1.2.3",
 	},
-	parseForESLint(src, opts) {
+	parseForESLint(src, opts): Linter.ESLintParseResult {
 		return {
 			ast: AST,
 			visitorKeys: {},
-			parserServices: {},
+			services: {},
 			scopeManager,
 		};
 	},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Updates type `Linter.ESLintParseResult` with the correct name of the `service` property.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR replaces the incorrect property name `parserServices` with `services` in the properties of the `Linter.ESLintParseResult` type. This is the return type of `parseForESLint()`. The correct property name is `services`.

https://github.com/eslint/eslint/blob/addd0a6a62d1b89dc7ab49cbd08c5a6af3e7da29/docs/src/extend/custom-parsers.md?plain=1#L48 

I also simplified a related type definition and copied the TSDoc comments from the internal type `ParserResult` in `lib/shared/types.js`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
