### PR TITLE
feat: Allow flags to be set in ESLINT_FLAGS env variable

### DIFF
--- a/docs/src/pages/flags.md
+++ b/docs/src/pages/flags.md
@@ -108,6 +108,10 @@ const linter = new Linter({
 });
 ```
 
+::: tip
+The `ESLint` class also reads the `ESLINT_FLAGS` environment variable to set flags.
+:::
+
 ### Enable Feature Flags in VS Code
 
 To enable flags in the VS Code ESLint Extension for the editor, specify the flags you'd like in the `eslint.options` setting in your `settings.json` file:

--- a/docs/src/pages/flags.md
+++ b/docs/src/pages/flags.md
@@ -82,6 +82,16 @@ On the command line, you can specify feature flags using the `--flag` option. Yo
     args: ["--flag", "flag_one", "--flag", "flag_two", "file.js"]
 }) }}
 
+### Enable Feature Flags with Environment Variables
+
+You can also set feature flags using the `ESLINT_FLAGS` environment variable. Multiple flags can be specified as a comma-separated list. For example, here's how you can add feature flags to your `.bashrc` or `.base_profile` files:
+
+```bash
+export ESLINT_FLAGS="flag_one,flag_two"
+```
+
+This approach is especially useful in CI/CD pipelines or when you want to enable the same flags across multiple ESLint commands.
+
 ### Enable Feature Flags with the API
 
 When using the API, you can pass a `flags` array to both the `ESLint` and `Linter` classes:

--- a/docs/src/pages/flags.md
+++ b/docs/src/pages/flags.md
@@ -84,7 +84,7 @@ On the command line, you can specify feature flags using the `--flag` option. Yo
 
 ### Enable Feature Flags with Environment Variables
 
-You can also set feature flags using the `ESLINT_FLAGS` environment variable. Multiple flags can be specified as a comma-separated list. For example, here's how you can add feature flags to your `.bashrc` or `.base_profile` files:
+You can also set feature flags using the `ESLINT_FLAGS` environment variable. Multiple flags can be specified as a comma-separated list. For example, here's how you can add feature flags to your `.bashrc` or `.bash_profile` files:
 
 ```bash
 export ESLINT_FLAGS="flag_one,flag_two"

--- a/docs/src/pages/flags.md
+++ b/docs/src/pages/flags.md
@@ -84,7 +84,7 @@ On the command line, you can specify feature flags using the `--flag` option. Yo
 
 ### Enable Feature Flags with Environment Variables
 
-You can also set feature flags using the `ESLINT_FLAGS` environment variable. Multiple flags can be specified as a comma-separated list. For example, here's how you can add feature flags to your `.bashrc` or `.bash_profile` files:
+You can also set feature flags using the `ESLINT_FLAGS` environment variable. Multiple flags can be specified as a comma-separated list and are merged with any flags passed on the CLI or in the API. For example, here's how you can add feature flags to your `.bashrc` or `.bash_profile` files:
 
 ```bash
 export ESLINT_FLAGS="flag_one,flag_two"

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -280,17 +280,6 @@ async function translateOptions(
 		options.flags = flag;
 
 		/*
-		 * If there are any flags set in the environment, prepend them to the list of flags
-		 * passed in via the command line. This allows users to set flags in their environment
-		 * and have them apply to all ESLint runs.
-		 */
-		if (process.env.ESLINT_FLAGS) {
-			const envFlags = process.env.ESLINT_FLAGS.split(/\s*,\s*/gu);
-			const cliFlags = options.flags || [];
-			options.flags = Array.from(new Set([...envFlags, ...cliFlags]));
-		}
-
-		/*
 		 * For performance reasons rules not marked as 'error' are filtered out in quiet mode. As maxWarnings
 		 * requires rules set to 'warn' to be run, we only filter out 'warn' rules if maxWarnings is not specified.
 		 */

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -280,6 +280,17 @@ async function translateOptions(
 		options.flags = flag;
 
 		/*
+		 * If there are any flags set in the environment, prepend them to the list of flags
+		 * passed in via the command line. This allows users to set flags in their environment
+		 * and have them apply to all ESLint runs.
+		 */
+		if (process.env.ESLINT_FLAGS) {
+			const envFlags = process.env.ESLINT_FLAGS.split(/\s*,\s*/gu);
+			const cliFlags = options.flags || [];
+			options.flags = Array.from(new Set([...envFlags, ...cliFlags]));
+		}
+
+		/*
 		 * For performance reasons rules not marked as 'error' are filtered out in quiet mode. As maxWarnings
 		 * requires rules set to 'warn' to be run, we only filter out 'warn' rules if maxWarnings is not specified.
 		 */

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -389,6 +389,20 @@ function getFixerForFixTypes(fix, fixTypesSet, config) {
 		originalFix(message);
 }
 
+/**
+ * Retrieves flags from the environment variable ESLINT_FLAGS.
+ * @param {string[]} flags The flags defined via the API.
+ * @returns {string[]} The merged flags to use.
+ */
+function mergeEnvironmentFlags(flags) {
+	if (!process.env.ESLINT_FLAGS) {
+		return flags;
+	}
+
+	const envFlags = process.env.ESLINT_FLAGS.split(/\s*,\s*/gu);
+	return Array.from(new Set([...envFlags, ...flags]));
+}
+
 //-----------------------------------------------------------------------------
 // Main API
 //-----------------------------------------------------------------------------
@@ -419,7 +433,7 @@ class ESLint {
 		const linter = new Linter({
 			cwd: processedOptions.cwd,
 			configType: "flat",
-			flags: processedOptions.flags,
+			flags: mergeEnvironmentFlags(processedOptions.flags),
 		});
 
 		const cacheFilePath = getCacheFile(

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -399,7 +399,7 @@ function mergeEnvironmentFlags(flags) {
 		return flags;
 	}
 
-	const envFlags = process.env.ESLINT_FLAGS.split(/\s*,\s*/gu);
+	const envFlags = process.env.ESLINT_FLAGS.trim().split(/\s*,\s*/gu);
 	return Array.from(new Set([...envFlags, ...flags]));
 }
 

--- a/lib/shared/flags.js
+++ b/lib/shared/flags.js
@@ -27,6 +27,7 @@
  */
 const activeFlags = new Map([
 	["test_only", "Used only for testing."],
+	["test_only_2", "Used only for testing."],
 	[
 		"unstable_config_lookup_from_file",
 		"Look up `eslint.config.js` from the file being linted.",

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -2741,10 +2741,27 @@ describe("cli", () => {
 						.returns();
 				});
 
+				afterEach(() => {
+					sinon.restore();
+					delete process.env.ESLINT_FLAGS;
+				});
+
 				it("should throw an error when an inactive flag whose feature has been abandoned is used", async () => {
 					const configPath = getFixturePath("eslint.config.js");
 					const filePath = getFixturePath("passing.js");
 					const input = `--flag test_only_abandoned --config ${configPath} ${filePath}`;
+
+					await stdAssert.rejects(async () => {
+						await cli.execute(input, null, true);
+					}, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned\./u);
+				});
+
+				it("should throw an error when an inactive flag whose feature has been abandoned is used in an environment variable", async () => {
+					const configPath = getFixturePath("eslint.config.js");
+					const filePath = getFixturePath("passing.js");
+
+					process.env.ESLINT_FLAGS = "test_only_abandoned";
+					const input = `--config ${configPath} ${filePath}`;
 
 					await stdAssert.rejects(async () => {
 						await cli.execute(input, null, true);
@@ -2761,10 +2778,44 @@ describe("cli", () => {
 					}, /Unknown flag 'test_only_oldx'\./u);
 				});
 
+				it("should error out when an unknown flag is used in an environment variable", async () => {
+					const configPath = getFixturePath("eslint.config.js");
+					const filePath = getFixturePath("passing.js");
+					const input = `--config ${configPath} ${filePath}`;
+
+					process.env.ESLINT_FLAGS = "test_only_oldx";
+
+					await stdAssert.rejects(async () => {
+						await cli.execute(input, null, true);
+					}, /Unknown flag 'test_only_oldx'\./u);
+				});
+
 				it("should emit a warning and not error out when an inactive flag that has been replaced by another flag is used", async () => {
 					const configPath = getFixturePath("eslint.config.js");
 					const filePath = getFixturePath("passing.js");
 					const input = `--flag test_only_replaced --config ${configPath} ${filePath}`;
+					const exitCode = await cli.execute(input, null, true);
+
+					assert.strictEqual(
+						processStub.callCount,
+						1,
+						"calls `process.emitWarning()` for flags once",
+					);
+					assert.deepStrictEqual(processStub.getCall(0).args, [
+						"The flag 'test_only_replaced' is inactive: This flag has been renamed 'test_only' to reflect its stabilization. Please use 'test_only' instead.",
+						"ESLintInactiveFlag_test_only_replaced",
+					]);
+					sinon.assert.notCalled(log.error);
+					assert.strictEqual(exitCode, 0);
+				});
+
+				it("should emit a warning and not error out when an inactive flag that has been replaced by another flag is used in an environment variable", async () => {
+					const configPath = getFixturePath("eslint.config.js");
+					const filePath = getFixturePath("passing.js");
+					const input = `--config ${configPath} ${filePath}`;
+
+					process.env.ESLINT_FLAGS = "test_only_replaced";
+
 					const exitCode = await cli.execute(input, null, true);
 
 					assert.strictEqual(
@@ -2799,6 +2850,27 @@ describe("cli", () => {
 					assert.strictEqual(exitCode, 0);
 				});
 
+				it("should emit a warning and not error out when an inactive flag whose feature is enabled by default is used in an environment variable", async () => {
+					const configPath = getFixturePath("eslint.config.js");
+					const filePath = getFixturePath("passing.js");
+					const input = `--config ${configPath} ${filePath}`;
+
+					process.env.ESLINT_FLAGS = "test_only_enabled_by_default";
+
+					const exitCode = await cli.execute(input, null, true);
+					assert.strictEqual(
+						processStub.callCount,
+						1,
+						"calls `process.emitWarning()` for flags once",
+					);
+					assert.deepStrictEqual(processStub.getCall(0).args, [
+						"The flag 'test_only_enabled_by_default' is inactive: This feature is now enabled by default.",
+						"ESLintInactiveFlag_test_only_enabled_by_default",
+					]);
+					sinon.assert.notCalled(log.error);
+					assert.strictEqual(exitCode, 0);
+				});
+
 				it("should not error when a valid flag is used", async () => {
 					const configPath = getFixturePath("eslint.config.js");
 					const filePath = getFixturePath("passing.js");
@@ -2807,6 +2879,31 @@ describe("cli", () => {
 
 					sinon.assert.notCalled(log.error);
 					assert.strictEqual(exitCode, 0);
+				});
+
+				it("should not error when a valid flag is used in an environment variable", async () => {
+					const configPath = getFixturePath("eslint.config.js");
+					const filePath = getFixturePath("passing.js");
+					const input = `--config ${configPath} ${filePath}`;
+
+					process.env.ESLINT_FLAGS = "test_only";
+
+					const exitCode = await cli.execute(input, null, true);
+
+					sinon.assert.notCalled(log.error);
+					assert.strictEqual(exitCode, 0);
+				});
+
+				it("should error when a valid flag is used in an environment variable with an abandoned flag", async () => {
+					const configPath = getFixturePath("eslint.config.js");
+					const filePath = getFixturePath("passing.js");
+					const input = `--config ${configPath} ${filePath}`;
+
+					process.env.ESLINT_FLAGS = "test_only,test_only_abandoned";
+
+					await stdAssert.rejects(async () => {
+						await cli.execute(input, null, true);
+					}, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned\./u);
 				});
 			});
 

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -448,7 +448,7 @@ describe("ESLint", () => {
 				});
 				assert.strictEqual(eslint.hasFlag("test_only"), true);
 			});
-			
+
 			it("should merge flags passed through API with flags passed through ESLINT_FLAGS", () => {
 				process.env.ESLINT_FLAGS = "test_only";
 				eslint = new ESLint({

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -471,6 +471,17 @@ describe("ESLint", () => {
 				assert.strictEqual(eslint.hasFlag("test_only_2"), true);
 			});
 
+			it("should return true for multiple flags in ESLINT_FLAGS if the flag is present and active and there is leading and trailing white space", () => {
+				process.env.ESLINT_FLAGS = " test_only, test_only_2 ";
+
+				eslint = new ESLint({
+					cwd: getFixturePath(),
+				});
+
+				assert.strictEqual(eslint.hasFlag("test_only"), true);
+				assert.strictEqual(eslint.hasFlag("test_only_2"), true);
+			});
+
 			it("should return true for the replacement flag if an inactive flag that has been replaced is used", () => {
 				eslint = new ESLint({
 					cwd: getFixturePath(),

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -448,6 +448,16 @@ describe("ESLint", () => {
 				});
 				assert.strictEqual(eslint.hasFlag("test_only"), true);
 			});
+			
+			it("should merge flags passed through API with flags passed through ESLINT_FLAGS", () => {
+				process.env.ESLINT_FLAGS = "test_only";
+				eslint = new ESLint({
+					cwd: getFixturePath(),
+					flags: ["test_only_2"],
+				});
+				assert.strictEqual(eslint.hasFlag("test_only"), true);
+				assert.strictEqual(eslint.hasFlag("test_only_2"), true);
+			});
 
 			it("should return true for multiple flags in ESLINT_FLAGS if the flag is present and active and one is duplicated in the API", () => {
 				process.env.ESLINT_FLAGS = "test_only,test_only_2";

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -445,7 +445,6 @@ describe("ESLint", () => {
 				process.env.ESLINT_FLAGS = "test_only";
 				eslint = new ESLint({
 					cwd: getFixturePath(),
-					flags: ["test_only"],
 				});
 				assert.strictEqual(eslint.hasFlag("test_only"), true);
 			});

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -428,6 +428,10 @@ describe("ESLint", () => {
 					.returns();
 			});
 
+			afterEach(() => {
+				delete process.env.ESLINT_FLAGS;
+			});
+
 			it("should return true if the flag is present and active", () => {
 				eslint = new ESLint({
 					cwd: getFixturePath(),
@@ -435,6 +439,27 @@ describe("ESLint", () => {
 				});
 
 				assert.strictEqual(eslint.hasFlag("test_only"), true);
+			});
+
+			it("should return true if the flag is present and active with ESLINT_FLAGS", () => {
+				process.env.ESLINT_FLAGS = "test_only";
+				eslint = new ESLint({
+					cwd: getFixturePath(),
+					flags: ["test_only"],
+				});
+				assert.strictEqual(eslint.hasFlag("test_only"), true);
+			});
+
+			it("should return true for multiple flags in ESLINT_FLAGS if the flag is present and active and one is duplicated in the API", () => {
+				process.env.ESLINT_FLAGS = "test_only,test_only_2";
+
+				eslint = new ESLint({
+					cwd: getFixturePath(),
+					flags: ["test_only"], // intentional duplication
+				});
+
+				assert.strictEqual(eslint.hasFlag("test_only"), true);
+				assert.strictEqual(eslint.hasFlag("test_only_2"), true);
 			});
 
 			it("should return true for the replacement flag if an inactive flag that has been replaced is used", () => {
@@ -485,11 +510,29 @@ describe("ESLint", () => {
 				}, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned/u);
 			});
 
+			it("should throw an error if an inactive flag whose feature has been abandoned is used in ESLINT_FLAGS", () => {
+				process.env.ESLINT_FLAGS = "test_only_abandoned";
+				assert.throws(() => {
+					eslint = new ESLint({
+						cwd: getFixturePath(),
+					});
+				}, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned/u);
+			});
+
 			it("should throw an error if the flag is unknown", () => {
 				assert.throws(() => {
 					eslint = new ESLint({
 						cwd: getFixturePath(),
 						flags: ["foo_bar"],
+					});
+				}, /Unknown flag 'foo_bar'/u);
+			});
+
+			it("should throw an error if the flag is unknown in ESLINT_FLAGS", () => {
+				process.env.ESLINT_FLAGS = "foo_bar";
+				assert.throws(() => {
+					eslint = new ESLint({
+						cwd: getFixturePath(),
 					});
 				}, /Unknown flag 'foo_bar'/u);
 			});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added the ability to set `ESLINT_FLAGS` environment variable to set flags in the CLI.

fixes #19100

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
