### PR TITLE
docs: upfront recommend against using the no-return-await rule

### DIFF
--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -14,17 +14,9 @@ It is NOT recommended to use the `no-return-await` rule anymore because:
 
 Historical context: When promises were first introduced, calling `return await` introduced an additional microtask, one for the `await` and one for the return value of the async function. Each extra microtask delays the computation of a result and so this rule was added to help avoid this performance trap. Later, [V8 changed the way](https://v8.dev/blog/fast-async) `return await` worked so it would create a single microtask, which means this rule is no longer necessary.
 
-***
-
-This rule warns on any usage of `return await`.
-
-Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited has resolved. `return await` can also be used in a try/catch statement to catch errors from another function that returns a Promise.
-
-You can avoid the extra microtask by not awaiting the return value, with the trade off of the function no longer being a part of the stack trace if an error is thrown asynchronously from the Promise being returned. This can make debugging more difficult.
-
 ## Rule Details
 
-This rule aims to prevent a likely common performance hazard due to a lack of understanding of the semantics of `async function`.
+This rule warns on any usage of `return await`.
 
 Examples of **incorrect** code for this rule:
 
@@ -74,8 +66,4 @@ async function foo4() {
 
 ## When Not To Use It
 
-There are a few reasons you might want to turn this rule off:
-
-* If you want to use `await` to denote a value that is a thenable
-* If you do not want the performance benefit of avoiding `return await`
-* If you want the functions to show up in stack traces (useful for debugging purposes)
+You should not use this rule. There is no reason to avoid `return await`.

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -16,7 +16,7 @@ Historical context: When promises were first introduced, calling `return await` 
 
 ## Rule Details
 
-This rule warns on any usage of `return await`.
+This rule warns on any usage of `return await` except in `try` blocks.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -9,8 +9,8 @@ further_reading:
 
 It is NOT recommended to use the `no-return-await` rule anymore because:
 
-- `return await` on a promise will not result in an extra microtask.
-- `return await` yields a better stack trace for debugging.
+* `return await` on a promise will not result in an extra microtask.
+* `return await` yields a better stack trace for debugging.
 
 The following documentation is kept for historical context, and is not necessarily accurate anymore.
 

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -12,7 +12,7 @@ It is NOT recommended to use the `no-return-await` rule anymore because:
 * `return await` on a promise will not result in an extra microtask.
 * `return await` yields a better stack trace for debugging.
 
-Historical context: When promises were first introduced, calling `return await` introduced an additional microtask, one for the `await` and one for the return value of the async function. Each extra microtask delays the computation of a result and so this rule was added to help avoid this performance trap. Later, [V8 changed the way](https://v8.dev/blog/fast-async) `return await` worked so it would create a single microtask, which means this rule is no longer necessary.
+Historical context: When promises were first introduced, calling `return await` introduced an additional microtask, one for the `await` and one for the return value of the async function. Each extra microtask delays the computation of a result and so this rule was added to help avoid this performance trap. Later, [ECMA-262 changed the way](https://github.com/tc39/ecma262/pull/1250) `return await` worked so it would create a single microtask, which means this rule is no longer necessary.
 
 ## Rule Details
 

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -18,7 +18,7 @@ Historical context: When promises were first introduced, calling `return await` 
 
 This rule warns on any usage of `return await`.
 
-Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited has resolved, at the cost of an extra microtask before resolving the outer Promise. `return await` can also be used in a try/catch statement to catch errors from another function that returns a Promise.
+Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited has resolved. `return await` can also be used in a try/catch statement to catch errors from another function that returns a Promise.
 
 You can avoid the extra microtask by not awaiting the return value, with the trade off of the function no longer being a part of the stack trace if an error is thrown asynchronously from the Promise being returned. This can make debugging more difficult.
 

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -12,9 +12,11 @@ It is NOT recommended to use the `no-return-await` rule anymore because:
 * `return await` on a promise will not result in an extra microtask.
 * `return await` yields a better stack trace for debugging.
 
-The following documentation is kept for historical context, and is not necessarily accurate anymore.
+Historical context: When promises were first introduced, calling `return await` introduced an additional microtask, one for the `await` and one for the return value of the async function. Each extra microtask delays the computation of a result and so this rule was added to help avoid this performance trap. Later, [V8 changed the way](https://v8.dev/blog/fast-async) `return await` worked so it would create a single microtask, which means this rule is no longer necessary.
 
-The original intent of this rule was to discourage the use of `return await`, to avoid an extra microtask. However, due to the fact that JavaScript now handles native `Promise`s differently, there is no longer an extra microtask. More technical information can be found in [this V8 blog entry](https://v8.dev/blog/fast-async).
+***
+
+This rule warns on any usage of `return await`.
 
 Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited has resolved, at the cost of an extra microtask before resolving the outer Promise. `return await` can also be used in a try/catch statement to catch errors from another function that returns a Promise.
 

--- a/docs/src/rules/no-return-await.md
+++ b/docs/src/rules/no-return-await.md
@@ -7,6 +7,13 @@ further_reading:
 - https://jakearchibald.com/2017/await-vs-return-vs-return-await/
 ---
 
+It is NOT recommended to use the `no-return-await` rule anymore because:
+
+- `return await` on a promise will not result in an extra microtask.
+- `return await` yields a better stack trace for debugging.
+
+The following documentation is kept for historical context, and is not necessarily accurate anymore.
+
 The original intent of this rule was to discourage the use of `return await`, to avoid an extra microtask. However, due to the fact that JavaScript now handles native `Promise`s differently, there is no longer an extra microtask. More technical information can be found in [this V8 blog entry](https://v8.dev/blog/fast-async).
 
 Using `return await` inside an `async function` keeps the current function in the call stack until the Promise that is being awaited has resolved, at the cost of an extra microtask before resolving the outer Promise. `return await` can also be used in a try/catch statement to catch errors from another function that returns a Promise.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

Upfront recommendation in the docs against not using this rule anymore.

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

A lot of rules have valid reasons to not use them, but in this case I don't see any reason anymore to even entertain this rule. Since this was a rule that made sense previously, it would be nice if now referencing it or glancing back at it, that it would upfront tell you that it is now not recommended.

![chrome_ZOfXN8mWw8](https://github.com/user-attachments/assets/d2c64862-140f-4858-987e-34949a6899eb)


#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
