### PR TITLE
fix: correct mismatched removed rules

### DIFF
--- a/conf/rule-type-list.json
+++ b/conf/rule-type-list.json
@@ -69,7 +69,8 @@
       "removed": "space-in-brackets",
       "replacedBy": [
         { "rule": { "name": "object-curly-spacing" } },
-        { "rule": { "name": "array-bracket-spacing" } }
+        { "rule": { "name": "array-bracket-spacing" } },
+        { "rule": { "name": "computed-property-spacing" } }
       ]
     },
     {

--- a/docs/src/_data/rules.json
+++ b/docs/src/_data/rules.json
@@ -3445,6 +3445,11 @@
                     "rule": {
                         "name": "array-bracket-spacing"
                     }
+                },
+                {
+                    "rule": {
+                        "name": "computed-property-spacing"
+                    }
                 }
             ]
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,

While looking into [`replacements.json`](https://github.com/eslint/eslint/blob/main/conf/replacements.json#L18-L20), I noticed that `space-in-brackets` was replaced by `object-curly-spacing`, `array-bracket-spacing`, and `computed-property-spacing`.

However, `computed-property-spacing` was missing from both `rule-type-list.json` and `rules.json`.

So, I've added it to keep things in sync.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
