### PR TITLE
fix: avoid false positive in `no-unassigned-vars` for declare module

### DIFF
--- a/docs/src/rules/no-unassigned-vars.md
+++ b/docs/src/rules/no-unassigned-vars.md
@@ -129,6 +129,11 @@ In TypeScript:
 
 declare let value: number | undefined;
 console.log(value);
+
+declare module "my-module" {
+  let value: string;
+  export = value;
+}
 ```
 
 :::

--- a/lib/rules/no-unassigned-vars.js
+++ b/lib/rules/no-unassigned-vars.js
@@ -31,17 +31,18 @@ module.exports = {
 
 	create(context) {
 		const sourceCode = context.sourceCode;
+		let insideDeclareModule = false;
 
 		return {
+			"TSModuleDeclaration[declare=true]"() {
+				insideDeclareModule = true;
+			},
+			"TSModuleDeclaration[declare=true]:exit"() {
+				insideDeclareModule = false;
+			},
 			VariableDeclarator(node) {
 				/** @type {import('estree').VariableDeclaration} */
 				const declaration = node.parent;
-				const ancestors = context.sourceCode.getAncestors(node);
-				const insideDeclareModule = ancestors.some(
-					ancestorNode =>
-						ancestorNode.type === "TSModuleDeclaration" &&
-						ancestorNode.declare === true,
-				);
 				const shouldSkip =
 					node.init ||
 					node.id.type !== "Identifier" ||

--- a/lib/rules/no-unassigned-vars.js
+++ b/lib/rules/no-unassigned-vars.js
@@ -36,12 +36,19 @@ module.exports = {
 			VariableDeclarator(node) {
 				/** @type {import('estree').VariableDeclaration} */
 				const declaration = node.parent;
-				const shouldCheck =
-					!node.init &&
-					node.id.type === "Identifier" &&
-					declaration.kind !== "const" &&
-					!declaration.declare;
-				if (!shouldCheck) {
+				const ancestors = context.sourceCode.getAncestors(node);
+				const insideDeclareModule = ancestors.some(
+					ancestorNode =>
+						ancestorNode.type === "TSModuleDeclaration" &&
+						ancestorNode.declare === true,
+				);
+				const shouldSkip =
+					node.init ||
+					node.id.type !== "Identifier" ||
+					declaration.kind === "const" ||
+					declaration.declare ||
+					insideDeclareModule;
+				if (shouldSkip) {
 					return;
 				}
 				const [variable] = sourceCode.getDeclaredVariables(node);

--- a/tests/lib/rules/no-unassigned-vars.js
+++ b/tests/lib/rules/no-unassigned-vars.js
@@ -140,6 +140,13 @@ ruleTesterTypeScript.run("no-unassigned-vars", rule, {
 				}
 			}
 		`,
+		unIndent`
+			declare module 'module' {
+				import type { T } from 'module';
+				let x: T;
+				export = x;
+			}
+		`,
 	],
 	invalid: [
 		{

--- a/tests/lib/rules/no-unassigned-vars.js
+++ b/tests/lib/rules/no-unassigned-vars.js
@@ -182,5 +182,22 @@ ruleTesterTypeScript.run("no-unassigned-vars", rule, {
 				},
 			],
 		},
+		{
+			code: unIndent`
+				declare module 'module' {
+					let x: string;
+				}
+				let y: string;
+				console.log(y);
+			`,
+			errors: [
+				{
+					messageId: "unassigned",
+					line: 4,
+					column: 9,
+					data: { name: "y" },
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

This PR fixes a false positive in the `no-unassigned-vars` rule that occurred when using `let` or `var` declarations inside `declare module` blocks in TypeScript.

Such declarations are part of module interface definitions and are not expected to be assigned. However, the rule currently does not account for the `declare` modifier at the module level, leading to incorrect lint errors.

My code:

```ts
declare module 'eslint-plugin-qwik' {
  import type { ESLint } from 'eslint'
  let plugin: ESLint.Plugin
  export = plugin
}
```

Error: `'plugin' is always 'undefined' because it's never assigned.`

The rule now checks whether the variable is declared within a `TSModuleDeclaration` node marked with declare: true (i.e., a `declare module` block), and skips the check in such cases.

A valid test case for `declare module` was added under TypeScript tests.

#### Is there anything you'd like reviewers to focus on?

Nope.