### PR TITLE
feat: add allowProperties option to no-restricted-properties

### DIFF
--- a/docs/src/rules/no-restricted-properties.md
+++ b/docs/src/rules/no-restricted-properties.md
@@ -85,7 +85,21 @@ If you want to restrict a property globally but allow specific objects to use it
 }
 ```
 
-Note that the `allowObjects` option cannot be used together with the `object` option since they are mutually exclusive.
+If you want to restrict all properties on an object except for specific ones, you can use the `allowProperties` option:
+
+```json
+{
+    "rules": {
+        "no-restricted-properties": [2, {
+            "object": "config",
+            "allowProperties": ["settings", "version"],
+            "message": "Accessing other properties is restricted."
+        }]
+    }
+}
+```
+
+Note that the `allowObjects` option cannot be used together with the `object` option since they are mutually exclusive. Similarly, the `allowProperties` option cannot be used together with the `property` option since they are also mutually exclusive.
 
 Examples of **incorrect** code for this rule:
 
@@ -145,6 +159,20 @@ myArray.push(5);
 
 :::
 
+::: incorrect
+
+```js
+/* eslint no-restricted-properties: [2, {
+    "object": "config",
+    "allowProperties": ["settings", "version"]
+}] */
+
+config.apiKey = "12345";
+config.timeout = 5000;
+```
+
+:::
+
 Examples of **correct** code for this rule:
 
 ::: correct
@@ -184,6 +212,20 @@ require('foo');
 
 router.push('/home');
 history.push('/about');
+```
+
+:::
+
+::: correct
+
+```js
+/* eslint no-restricted-properties: [2, {
+    "object": "config",
+    "allowProperties": ["settings", "version"]
+}] */
+
+config.settings = { theme: "dark" };
+config.version = "1.0.0";  
 ```
 
 :::

--- a/lib/rules/no-restricted-properties.js
+++ b/lib/rules/no-restricted-properties.js
@@ -40,6 +40,13 @@ module.exports = {
 						},
 						uniqueItems: true,
 					},
+					allowProperties: {
+						type: "array",
+						items: {
+							type: "string",
+						},
+						uniqueItems: true,
+					},
 					message: {
 						type: "string",
 					},
@@ -53,7 +60,10 @@ module.exports = {
 					},
 				],
 				not: {
-					required: ["allowObjects", "object"],
+					anyOf: [
+						{ required: ["allowObjects", "object"] },
+						{ required: ["allowProperties", "property"] },
+					],
 				},
 				additionalProperties: false,
 			},
@@ -92,6 +102,7 @@ module.exports = {
 				});
 			} else if (typeof propertyName === "undefined") {
 				globallyRestrictedObjects.set(objectName, {
+					allowProperties: option.allowProperties,
 					message: option.message,
 				});
 			} else {
@@ -106,17 +117,17 @@ module.exports = {
 		});
 
 		/**
-		 * Checks if an object name is in the allowed objects list.
-		 * @param {string} objectName The name of the object to check
-		 * @param {string[]} [allowObjects] The list of objects to allow
-		 * @returns {boolean} True if the object is allowed, false otherwise
+		 * Checks if a name is in the allowed list.
+		 * @param {string} name The name to check
+		 * @param {string[]} [allowedList] The list of allowed names
+		 * @returns {boolean} True if the name is allowed, false otherwise
 		 */
-		function isAllowedObject(objectName, allowObjects) {
-			if (!allowObjects) {
+		function isAllowed(name, allowedList) {
+			if (!allowedList) {
 				return false;
 			}
 
-			return allowObjects.includes(objectName);
+			return allowedList.includes(name);
 		}
 
 		/**
@@ -137,7 +148,10 @@ module.exports = {
 			const globalMatchedProperty =
 				globallyRestrictedProperties.get(propertyName);
 
-			if (matchedObjectProperty) {
+			if (
+				matchedObjectProperty &&
+				!isAllowed(propertyName, matchedObjectProperty.allowProperties)
+			) {
 				const message = matchedObjectProperty.message
 					? ` ${matchedObjectProperty.message}`
 					: "";
@@ -153,7 +167,7 @@ module.exports = {
 				});
 			} else if (
 				globalMatchedProperty &&
-				!isAllowedObject(objectName, globalMatchedProperty.allowObjects)
+				!isAllowed(objectName, globalMatchedProperty.allowObjects)
 			) {
 				const message = globalMatchedProperty.message
 					? ` ${globalMatchedProperty.message}`

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -3450,6 +3450,11 @@ export interface ESLintRules extends Linter.RulesRecord {
 						allowObjects?: string[];
 						message?: string | undefined;
 				  }
+				| {
+						object: string;
+						allowProperties?: string[];
+						message?: string | undefined;
+				  }
 			>,
 		]
 	>;

--- a/tests/lib/rules/no-restricted-properties.js
+++ b/tests/lib/rules/no-restricted-properties.js
@@ -279,6 +279,65 @@ ruleTester.run("no-restricted-properties", rule, {
 			options: [{ property: "baz", allowObjects: ["foo"] }],
 			languageOptions: { ecmaVersion: 6 },
 		},
+		{
+			code: "someObject.disallowedProperty",
+			options: [
+				{
+					object: "someObject",
+					allowProperties: ["disallowedProperty"],
+				},
+			],
+		},
+		{
+			code: "someObject.disallowedProperty; someObject.anotherDisallowedProperty();",
+			options: [
+				{
+					object: "someObject",
+					allowProperties: [
+						"disallowedProperty",
+						"anotherDisallowedProperty",
+					],
+				},
+			],
+		},
+		{
+			code: "someObject.disallowedProperty()",
+			options: [
+				{
+					object: "someObject",
+					allowProperties: ["disallowedProperty"],
+				},
+			],
+		},
+		{
+			code: "someObject['disallowedProperty']()",
+			options: [
+				{
+					object: "someObject",
+					allowProperties: ["disallowedProperty"],
+				},
+			],
+		},
+		{
+			code: "let {bar} = foo;",
+			options: [
+				{
+					object: "foo",
+					allowProperties: ["bar"],
+				},
+			],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "let {baz: bar} = foo;",
+			options: [
+				{
+					object: "foo",
+					allowProperties: ["baz"],
+				},
+			],
+			languageOptions: { ecmaVersion: 6 },
+		},
 	],
 
 	invalid: [
@@ -981,6 +1040,81 @@ ruleTester.run("no-restricted-properties", rule, {
 				{
 					messageId: "restrictedProperty",
 					data: {
+						propertyName: "anotherDisallowedProperty",
+						message: "",
+					},
+					type: "MemberExpression",
+				},
+			],
+		},
+		{
+			code: "someObject.disallowedProperty",
+			options: [
+				{
+					object: "someObject",
+					allowProperties: ["allowedProperty"],
+				},
+			],
+			errors: [
+				{
+					messageId: "restrictedObjectProperty",
+					data: {
+						objectName: "someObject",
+						propertyName: "disallowedProperty",
+						message: "",
+					},
+					type: "MemberExpression",
+				},
+			],
+		},
+		{
+			code: "someObject.disallowedProperty",
+			options: [
+				{
+					object: "someObject",
+					allowProperties: ["allowedProperty"],
+					message: "Please use someObject.allowedProperty instead.",
+				},
+			],
+			errors: [
+				{
+					messageId: "restrictedObjectProperty",
+					data: {
+						objectName: "someObject",
+						propertyName: "disallowedProperty",
+						message:
+							" Please use someObject.allowedProperty instead.",
+					},
+					type: "MemberExpression",
+				},
+			],
+		},
+		{
+			code: "someObject.disallowedProperty; anotherObject.anotherDisallowedProperty()",
+			options: [
+				{
+					object: "someObject",
+					allowProperties: ["anotherDisallowedProperty"],
+				},
+				{
+					object: "anotherObject",
+					allowProperties: ["disallowedProperty"],
+				},
+			],
+			errors: [
+				{
+					messageId: "restrictedObjectProperty",
+					data: {
+						objectName: "someObject",
+						propertyName: "disallowedProperty",
+						message: "",
+					},
+					type: "MemberExpression",
+				},
+				{
+					messageId: "restrictedObjectProperty",
+					data: {
+						objectName: "anotherObject",
 						propertyName: "anotherDisallowedProperty",
 						message: "",
 					},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds a new allowProperties option to the no-restricted-properties rule, allowing users to restrict all properties on an object except for specific ones.

Closes #19762

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
