### PR TITLE
fix: Remove configured global variables from `GlobalScope#implicit`

### DIFF
--- a/docs/src/extend/scope-manager-interface.md
+++ b/docs/src/extend/scope-manager-interface.md
@@ -374,7 +374,7 @@ Those members are defined but not used in ESLint.
 | `"CatchClause"`            | `CatchClause`                                                              |
 | `"ClassName"`              | `ClassDeclaration` or `ClassExpression`                                    |
 | `"FunctionName"`           | `FunctionDeclaration` or `FunctionExpression`                              |
-| `"ImplicitGlobalVariable"` | `AssignmentExpression`                                                     |
+| `"ImplicitGlobalVariable"` | `AssignmentExpression` or `ForInStatement` or `ForOfStatement`             |
 | `"ImportBinding"`          | `ImportSpecifier`, `ImportDefaultSpecifier`, or `ImportNamespaceSpecifier` |
 | `"Parameter"`              | `FunctionDeclaration`, `FunctionExpression`, or `ArrowFunctionExpression`  |
 | `"Variable"`               | `VariableDeclarator`                                                       |

--- a/lib/languages/js/source-code/source-code.js
+++ b/lib/languages/js/source-code/source-code.js
@@ -316,6 +316,36 @@ function addDeclaredGlobals(
 
 		return true;
 	});
+
+	/*
+	 * "implicit" contains information about implicit global variables (those created
+	 * implicitly by assigning values to undeclared variables in non-strict code).
+	 * Since we augment the global scope using configuration, we need to remove
+	 * the ones that were added by configuration, as they are either built-in
+	 * or declared elsewhere, therefore not implicit.
+	 * Since the "implicit" property was not documented, first we'll check if it exists
+	 * because it's possible that not all custom scope managers create this property.
+	 * If it exists, we assume it has properties `variables` and `set`. Property
+	 * `left` is considered optional (for example, typescript-eslint's scope manage
+	 * has this property named `leftToBeResolved`).
+	 */
+	const { implicit } = globalScope;
+	if (typeof implicit === "object" && implicit !== null) {
+		implicit.variables = implicit.variables.filter(variable => {
+			const name = variable.name;
+			if (globalScope.set.has(name)) {
+				implicit.set.delete(name);
+				return false;
+			}
+			return true;
+		});
+
+		if (implicit.left) {
+			implicit.left = implicit.left.filter(
+				reference => !globalScope.set.has(reference.identifier.name),
+			);
+		}
+	}
 }
 
 /**

--- a/lib/rules/no-implicit-globals.js
+++ b/lib/rules/no-implicit-globals.js
@@ -142,27 +142,31 @@ module.exports = {
 							}
 						}
 					});
+
+					if (
+						isReadonlyEslintGlobalVariable &&
+						variable.defs.length === 0
+					) {
+						variable.references.forEach(reference => {
+							if (
+								reference.isWrite() &&
+								!reference.init &&
+								!reference.isRead()
+							) {
+								report(
+									reference.identifier.parent,
+									"assignmentToReadonlyGlobal",
+								);
+							}
+						});
+					}
 				});
 
 				// Undeclared assigned variables.
 				scope.implicit.variables.forEach(variable => {
-					const scopeVariable = scope.set.get(variable.name);
-					let messageId;
-
-					if (scopeVariable) {
-						// ESLint global variable
-						if (scopeVariable.writeable) {
-							return;
-						}
-						messageId = "assignmentToReadonlyGlobal";
-					} else {
-						// Reference to an unknown variable, possible global leak.
-						messageId = "globalVariableLeak";
-					}
-
 					// def.node is an AssignmentExpression, ForInStatement or ForOfStatement.
 					variable.defs.forEach(def => {
-						report(def.node, messageId);
+						report(def.node, "globalVariableLeak");
 					});
 				});
 			},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Fixes #19766

#### What changes did you make? (Give an overview)

* Updated `SourceCode#finalize()` to remove configured globals from global scope's `implicit` properties.
* Updated `no-implicit-globals` rule to retain existing functionalities.

#### Is there anything you'd like reviewers to focus on?

I think we should revisit `no-implicit-globals`. In particular, I don't think it should be reporting anything about readonly globals, as they're not "implicit", and those checks are handled by other rules (namely, `no-global-assign` and `no-redeclare`).

TODO: add more regression tests for `no-implicit-globals`.

<!-- markdownlint-disable-file MD004 -->
