### PR TITLE
perf: improve time complexity of `getLocFromIndex`

### DIFF
--- a/lib/languages/js/source-code/source-code.js
+++ b/lib/languages/js/source-code/source-code.js
@@ -690,9 +690,9 @@ class SourceCode extends TokenStore {
 
 	/**
 	 * Converts a source text index into a (line, column) pair.
-	 * @param {number} index The index of a character in a file
+	 * @param {number} index The index of a character in a file.
 	 * @throws {TypeError|RangeError} If non-numeric index or index out of range.
-	 * @returns {{line: number, column: number}} A {line, column} location object with a 0-indexed column
+	 * @returns {{line: number, column: number}} A {line, column} location object with a 0-indexed column.
 	 * @public
 	 */
 	getLocFromIndex(index) {

--- a/lib/languages/js/source-code/source-code.js
+++ b/lib/languages/js/source-code/source-code.js
@@ -419,6 +419,7 @@ class SourceCode extends TokenStore {
 			["scopes", new WeakMap()],
 			["vars", new Map()],
 			["configNodes", void 0],
+			["indexToLoc", new Map()], // Cache for getLocFromIndex.
 		]);
 
 		/**
@@ -719,7 +720,7 @@ class SourceCode extends TokenStore {
 	 * Converts a source text index into a (line, column) pair.
 	 * @param {number} index The index of a character in a file.
 	 * @throws {TypeError|RangeError} If non-numeric index or index out of range.
-	 * @returns {{line: number, column: number}} A {line, column} location object with a 0-indexed column.
+	 * @returns {{line: number, column: number}} A {line, column} location object with 1-indexed line and 0-indexed column.
 	 * @public
 	 */
 	getLocFromIndex(index) {
@@ -731,6 +732,18 @@ class SourceCode extends TokenStore {
 			throw new RangeError(
 				`Index out of range (requested index ${index}, but source text has length ${this.text.length}).`,
 			);
+		}
+
+		/** @type {Map<number, {line: number, column: number}>} */
+		const indexToLocCache = this[caches].get("indexToLoc");
+		const cachedLoc = indexToLocCache.get(index);
+
+		/*
+		 * If the location is cached, return it immediately.
+		 * This is a performance optimization to avoid recalculating the location.
+		 */
+		if (cachedLoc) {
+			return cachedLoc;
 		}
 
 		/*
@@ -756,10 +769,17 @@ class SourceCode extends TokenStore {
 				? this.lineStartIndices.length
 				: findLineNumberBinarySearch(this.lineStartIndices, index);
 
-		return {
+		const loc = {
 			line: lineNumber,
 			column: index - this.lineStartIndices[lineNumber - 1],
 		};
+
+		/*
+		 * Cache the result for future lookups.
+		 */
+		indexToLocCache.set(index, loc);
+
+		return loc;
 	}
 
 	/**
@@ -821,6 +841,11 @@ class SourceCode extends TokenStore {
 				`Column number out of range (column ${loc.column} requested, but the length of line ${loc.line} is ${lineEndIndex - lineStartIndex}).`,
 			);
 		}
+
+		/*
+		 * Cache the reverse mapping to optimize future getLocFromIndex calls.
+		 */
+		this[caches].get("indexToLoc").set(positionIndex, loc);
 
 		return positionIndex;
 	}

--- a/lib/languages/js/source-code/source-code.js
+++ b/lib/languages/js/source-code/source-code.js
@@ -419,7 +419,6 @@ class SourceCode extends TokenStore {
 			["scopes", new WeakMap()],
 			["vars", new Map()],
 			["configNodes", void 0],
-			["indexToLoc", new Map()], // Cache for getLocFromIndex.
 		]);
 
 		/**
@@ -734,18 +733,6 @@ class SourceCode extends TokenStore {
 			);
 		}
 
-		/** @type {Map<number, {line: number, column: number}>} */
-		const indexToLocCache = this[caches].get("indexToLoc");
-		const cachedLoc = indexToLocCache.get(index);
-
-		/*
-		 * If the location is cached, return it immediately.
-		 * This is a performance optimization to avoid recalculating the location.
-		 */
-		if (cachedLoc) {
-			return cachedLoc;
-		}
-
 		/*
 		 * For an argument of this.text.length, return the location one "spot" past the last character
 		 * of the file. If the last character is a linebreak, the location will be column 0 of the next
@@ -769,17 +756,10 @@ class SourceCode extends TokenStore {
 				? this.lineStartIndices.length
 				: findLineNumberBinarySearch(this.lineStartIndices, index);
 
-		const loc = {
+		return {
 			line: lineNumber,
 			column: index - this.lineStartIndices[lineNumber - 1],
 		};
-
-		/*
-		 * Cache the result for future lookups.
-		 */
-		indexToLocCache.set(index, loc);
-
-		return loc;
 	}
 
 	/**
@@ -841,11 +821,6 @@ class SourceCode extends TokenStore {
 				`Column number out of range (column ${loc.column} requested, but the length of line ${loc.line} is ${lineEndIndex - lineStartIndex}).`,
 			);
 		}
-
-		/*
-		 * Cache the reverse mapping to optimize future getLocFromIndex calls.
-		 */
-		this[caches].get("indexToLoc").set(positionIndex, loc);
 
 		return positionIndex;
 	}

--- a/lib/languages/js/source-code/source-code.js
+++ b/lib/languages/js/source-code/source-code.js
@@ -240,6 +240,33 @@ function isSpaceBetween(sourceCode, first, second, checkInsideOfJSXText) {
 	return false;
 }
 
+/**
+ * Performs binary search to find the line number containing a given character index.
+ * Returns the lower bound - the index of the first element greater than the target.
+ * **Please note that the `lineStartIndices` should be sorted in ascending order**.
+ * - Time Complexity: O(log n) - Significantly faster than linear search for large files.
+ * @param {number[]} lineStartIndices Sorted array of line start indices.
+ * @param {number} target The character index to find the line number for.
+ * @returns {number} The 1-based line number for the target index.
+ * @private
+ */
+function findLineNumberBinarySearch(lineStartIndices, target) {
+	let low = 0;
+	let high = lineStartIndices.length;
+
+	while (low < high) {
+		const mid = Math.floor((low + high) / 2);
+
+		if (target < lineStartIndices[mid]) {
+			high = mid;
+		} else {
+			low = mid + 1;
+		}
+	}
+
+	return low;
+}
+
 //-----------------------------------------------------------------------------
 // Directive Comments
 //-----------------------------------------------------------------------------
@@ -727,7 +754,7 @@ class SourceCode extends TokenStore {
 		const lineNumber =
 			index >= this.lineStartIndices.at(-1)
 				? this.lineStartIndices.length
-				: this.lineStartIndices.findIndex(el => index < el);
+				: findLineNumberBinarySearch(this.lineStartIndices, index);
 
 		return {
 			line: lineNumber,

--- a/lib/languages/js/source-code/source-code.js
+++ b/lib/languages/js/source-code/source-code.js
@@ -255,7 +255,7 @@ function findLineNumberBinarySearch(lineStartIndices, target) {
 	let high = lineStartIndices.length;
 
 	while (low < high) {
-		const mid = Math.floor((low + high) / 2);
+		const mid = ((low + high) / 2) | 0; // Use bitwise OR to floor the division
 
 		if (target < lineStartIndices[mid]) {
 			high = mid;

--- a/tests/lib/languages/js/source-code/source-code.js
+++ b/tests/lib/languages/js/source-code/source-code.js
@@ -2231,14 +2231,6 @@ describe("SourceCode", () => {
 			});
 		});
 
-		it("should cache the location of a range index", () => {
-			const loc1 = sourceCode.getLocFromIndex(3);
-			const loc2 = sourceCode.getLocFromIndex(3);
-			assert.strictEqual(loc1, loc2);
-			assert.deepStrictEqual(loc1, { line: 1, column: 3 });
-			assert.deepStrictEqual(loc2, { line: 1, column: 3 });
-		});
-
 		it("should throw if given a bad input", () => {
 			assert.throws(
 				() => sourceCode.getLocFromIndex({ line: 1, column: 1 }),

--- a/tests/lib/languages/js/source-code/source-code.js
+++ b/tests/lib/languages/js/source-code/source-code.js
@@ -2231,6 +2231,14 @@ describe("SourceCode", () => {
 			});
 		});
 
+		it("should cache the location of a range index", () => {
+			const loc1 = sourceCode.getLocFromIndex(3);
+			const loc2 = sourceCode.getLocFromIndex(3);
+			assert.strictEqual(loc1, loc2);
+			assert.deepStrictEqual(loc1, { line: 1, column: 3 });
+			assert.deepStrictEqual(loc2, { line: 1, column: 3 });
+		});
+
 		it("should throw if given a bad input", () => {
 			assert.throws(
 				() => sourceCode.getLocFromIndex({ line: 1, column: 1 }),

--- a/tests/lib/languages/js/source-code/source-code.js
+++ b/tests/lib/languages/js/source-code/source-code.js
@@ -2205,9 +2205,9 @@ describe("SourceCode", () => {
 		});
 
 		it("should return the location of a range index", () => {
-			assert.deepStrictEqual(sourceCode.getLocFromIndex(5), {
-				line: 2,
-				column: 1,
+			assert.deepStrictEqual(sourceCode.getLocFromIndex(0), {
+				line: 1,
+				column: 0,
 			});
 			assert.deepStrictEqual(sourceCode.getLocFromIndex(3), {
 				line: 1,
@@ -2216,6 +2216,14 @@ describe("SourceCode", () => {
 			assert.deepStrictEqual(sourceCode.getLocFromIndex(4), {
 				line: 2,
 				column: 0,
+			});
+			assert.deepStrictEqual(sourceCode.getLocFromIndex(5), {
+				line: 2,
+				column: 1,
+			});
+			assert.deepStrictEqual(sourceCode.getLocFromIndex(15), {
+				line: 4,
+				column: 2,
 			});
 			assert.deepStrictEqual(sourceCode.getLocFromIndex(21), {
 				line: 6,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,

In this PR, I've improved the time complexity of `getLocFromIndex`.

> 1. We should be caching every index's location after it's calculated.
> 1. We should keep track of every index that begins a new line when we find it
> 1. We may be able to use the loc property on nodes to cheat when calculating some locations
> 1. (Plus one I noticed) — we might be able to use binary search for faster lookups.

Thanks to the hints suggested by @nzakas, I found several opportunities to improve this method.

---

### Current Problem

The `getLocFromIndex` function currently has a time complexity of \$O(n)\$.

This is because `this.lineStartIndices.findIndex(el => index < el)` performs a linear search, which takes up to `n` iterations in the worst and average cases.

So, if a file has 10,000 lines, this function may run up to 10,000 iterations to return a result.

---

### Room for Improvement — 1

While reviewing how `lineStartIndices` is constructed, I discovered something useful:

Since the `SourceCode` class processes lines sequentially, the `lineStartIndices` array is always **sorted in ascending order**.

A sorted array? That means we can use **binary search**, reducing the complexity to \$O(\log n)\$!

So, I replaced `findIndex` with binary search — and it worked!

Now, `getLocFromIndex` performs in \$O(\log n)\$ time instead of \$O(n)\$.

With 10,000 lines, the function only performs about 14 operations instead of 10,000.

---

### Room for Improvement — 2

But should we stop at \$O(\log n)\$?

Thanks again to the earlier suggestions, I was able to add caching — which means we can now achieve **\$O(1)\$ performance on cache hits**.

I reused the existing caching mechanism and introduced an `indexToLoc` cache.

---

### Result

* **Before**: `getLocFromIndex` always ran in \$O(n)\$ time, where `n` is the number of lines in the file.
* **After**: It now runs in \$O(1)\$ with cache hits, and \$O(\log n)\$ with cache misses.

#### Is there anything you'd like reviewers to focus on?

Since `getIndexFromLoc` already works in $O(1)$ time, I didn’t change its current behavior.

Refs: https://github.com/eslint/rewrite/issues/166, https://github.com/eslint/rewrite/pull/212, https://github.com/eslint/markdown/pull/376

<!-- markdownlint-disable-file MD004 -->
