### PR TITLE
docs: clarify how config arrays can apply to subsets of files

### DIFF
--- a/docs/src/use/configure/combine-configs.md
+++ b/docs/src/use/configure/combine-configs.md
@@ -98,7 +98,7 @@ export default defineConfig([
 
 ### Apply a Config Array to a Subset of Files
 
-You can apply a config array to just a subset of files by using the `extends` key. For example:
+You can apply a config array — that is, an array of configuration objects — to just a subset of files by using the `extends` key. For example:
 
 ```js
 // eslint.config.js


### PR DESCRIPTION
I've updated the section on combining configs to make it clearer that config arrays — that is, arrays of configuration objects — can be applied to subsets of files using the extends key.

This clarification should help reduce confusion for users new to flat config, especially when using shared arrays like exampleConfigs.

Let me know if any additional context or edits would help.

### Prerequisites checklist

- [x] I have read the contributing guidelines.

### What is the purpose of this pull request?

- [x] Documentation update

### What changes did you make? (Give an overview)

Clarified how config arrays can be applied to subsets of files using the `extends` key. Added a brief explanation to avoid confusion when working with shared config arrays.

### Is there anything you'd like reviewers to focus on?

Nothing specific — open to suggestions if you'd like the wording adjusted.
