### PR TITLE
fix: correct breaking deprecation of FlatConfig type

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1831,7 +1831,7 @@ export namespace Linter {
 	}
 
 	/** @deprecated  Use `Config` instead of `FlatConfig` */
-	type FlatConfig = Config;
+	type FlatConfig<Rules extends RulesRecord = RulesRecord> = Config<Rules>;
 
 	type GlobalConf =
 		| boolean

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -2135,6 +2135,12 @@ let flatConfig!: Linter.FlatConfig;
 config = flatConfig;
 flatConfig = config;
 
+let configWithRules!: Linter.Config<ESLintRules>;
+let flatConfigWithRules!: Linter.FlatConfig<ESLintRules>;
+configWithRules = flatConfigWithRules;
+flatConfigWithRules = configWithRules;
+flatConfigWithRules.rules; // $ExpectType Partial<ESLintRules> | undefined
+
 // #endregion Config
 
 // #region Plugins


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

[Almost a year ago when @types/eslint was upgrade to v9](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/23fde1f04766f759428a6302a9ee107200391429) the type alias for the deprecated `FlatConfig` was added but without any type arguments. This was breaking change for any packages which defined their own `Rules` (which `tsc` may do by default) rather than relying on the default `RulesRecord`. 

This pr simply re-adds the parameter and proxies it to the new `Config` type.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
