### PR TITLE
feat: support explicit resource management

### DIFF
--- a/docs/src/rules/no-unused-vars.md
+++ b/docs/src/rules/no-unused-vars.md
@@ -20,6 +20,7 @@ A variable `foo` is considered to be used if any of the following are true:
 * It is read (`let bar = foo`)
 * It is passed into a function as an argument (`doSomething(foo)`)
 * It is read inside of a function that is passed to another function (`doSomething(function() { foo(); })`)
+* It uses explicit resource management by declaring the variable with `using` or `await using`
 
 A variable is *not* considered to be used if it is only ever declared (`let foo = 5`) or assigned to (`foo = 7`).
 

--- a/lib/rules/no-await-in-loop.js
+++ b/lib/rules/no-await-in-loop.js
@@ -76,6 +76,10 @@ module.exports = {
 		 * @returns {void}
 		 */
 		function validate(awaitNode) {
+			if (awaitNode.type === "VariableDeclaration" && awaitNode.kind !== "await using") {
+				return;
+			}
+
 			if (awaitNode.type === "ForOfStatement" && !awaitNode.await) {
 				return;
 			}
@@ -99,6 +103,7 @@ module.exports = {
 		return {
 			AwaitExpression: validate,
 			ForOfStatement: validate,
+			VariableDeclaration: validate,
 		};
 	},
 };

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -358,6 +358,20 @@ module.exports = {
 		}
 
 		/**
+		 * Determines if a given variable uses the explicit resource management protocol.
+		 * @param {Variable} variable eslint-scope variable object.
+		 * @returns {boolean} True if the variable is declared with "using" or "await using"
+		 * @private
+		 */
+		function usesExplicitResourceManagement(variable) {
+			const [definition] = variable.defs;
+
+			return definition?.type === 'Variable' &&
+			       definition.parent.type === 'VariableDeclaration' &&
+			       (definition.parent.kind === 'using' || definition.parent.kind === 'await using');
+		}
+
+		/**
 		 * Checks whether a node is a sibling of the rest property or not.
 		 * @param {ASTNode} node a node to check
 		 * @returns {boolean} True if the node is a sibling of the rest property, otherwise false.
@@ -922,6 +936,7 @@ module.exports = {
 					if (
 						!isUsedVariable(variable) &&
 						!isExported(variable) &&
+						!usesExplicitResourceManagement(variable) &&
 						!hasRestSpreadSibling(variable)
 					) {
 						unusedVars.push(variable);

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -293,6 +293,11 @@ module.exports = {
 				return;
 			}
 
+			// Variable declarations using explicit resource management cannot use destructuring (parse error)
+			if (node.parent.kind === "using" || node.parent.kind === "await using") {
+				return;
+			}
+
 			// We only care about member expressions past this point
 			if (node.init.type !== "MemberExpression") {
 				return;

--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -170,6 +170,15 @@ module.exports = {
 					scopeInfo.hasAwait = true;
 				}
 			},
+			VariableDeclaration(node) {
+				if (!scopeInfo) {
+					return;
+				}
+
+				if (node.kind === 'await using') {
+					scopeInfo.hasAwait = true;
+				}
+			},
 		};
 	},
 };

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -2528,16 +2528,17 @@ module.exports = {
 	 */
 	areBracesNecessary(node, sourceCode) {
 		/**
-		 * Determines if the given node is a lexical declaration (let, const, function, or class)
+		 * Determines if the given node is a lexical declaration (let, const, using, await using, function, or class)
 		 * @param {ASTNode} nodeToCheck The node to check
 		 * @returns {boolean} True if the node is a lexical declaration
 		 * @private
 		 */
 		function isLexicalDeclaration(nodeToCheck) {
 			if (nodeToCheck.type === "VariableDeclaration") {
-				return (
-					nodeToCheck.kind === "const" || nodeToCheck.kind === "let"
-				);
+				return nodeToCheck.kind === "const" ||
+				       nodeToCheck.kind === "let" ||
+				       nodeToCheck.kind === 'using' ||
+				       nodeToCheck.kind === 'await using';
 			}
 
 			return (

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -175,6 +175,11 @@ ruleTester.run("curly", rule, {
 			languageOptions: { ecmaVersion: 6 },
 		},
 		{
+			code: "if (foo) { const bar = 'baz'; }",
+			options: ["multi"],
+			languageOptions: { ecmaVersion: 2026, sourceType: "module", parser: require("@typescript-eslint/parser") },
+		},
+		{
 			code: "while (foo) { let bar = 'baz'; }",
 			options: ["multi"],
 			languageOptions: { ecmaVersion: 6 },

--- a/tests/lib/rules/no-await-in-loop.js
+++ b/tests/lib/rules/no-await-in-loop.js
@@ -50,6 +50,33 @@ ruleTester.run("no-await-in-loop", rule, {
 
 		// Asynchronous iteration intentionally
 		"async function foo() { for await (var x of xs) { await f(x) } }",
+
+		// Explicit Resource Management
+		"while (true) { const value = 0; }",
+		"while (true) { let value = 0; }",
+		"while (true) { var value = 0; }",
+		{
+			code: "await using resource = getResource();",
+			languageOptions: {
+				sourceType: "module",
+				ecmaVersion: 2026,
+				parser: require("@typescript-eslint/parser"),
+			}
+		}, {
+			code: "while (true) { using resource = getResource(); }",
+			languageOptions: {
+				sourceType: "module",
+				ecmaVersion: 2026,
+				parser: require("@typescript-eslint/parser"),
+			}
+		}, {
+			code: "async function foo() { while (true) { async function foo() { await using resource = getResource(); } } }",
+			languageOptions: {
+				sourceType: "module",
+				ecmaVersion: 2026,
+				parser: require("@typescript-eslint/parser"),
+			}
+		},
 	],
 	invalid: [
 		// While loops
@@ -122,6 +149,18 @@ ruleTester.run("no-await-in-loop", rule, {
 		{
 			code: "async function foo() { for await (var x of xs) { while (1) await f(x) } }",
 			errors: [error],
+		},
+
+		// Explicit Resource Management
+		{
+			code: "while (true) { await using resource = getResource(); }",
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+			errors: [{ ...error, type: 'VariableDeclaration' }],
+		},
+		{
+			code: "for (;;) { await using resource = getResource(); }",
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+			errors: [{ ...error, type: 'VariableDeclaration' }],
 		},
 	],
 });

--- a/tests/lib/rules/no-const-assign.js
+++ b/tests/lib/rules/no-const-assign.js
@@ -30,6 +30,14 @@ ruleTester.run("no-const-assign", rule, {
 		// ignores non constant.
 		"var x = 0; x = 1;",
 		"let x = 0; x = 1;",
+		{
+			code: 'using resource = fn();',
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+		},
+		{
+			code: 'await using resource = fn();',
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+		},
 		"function x() {} x = 1;",
 		"function foo(x) { x = 1; }",
 		"class X {} X = 1;",

--- a/tests/lib/rules/no-inner-declarations.js
+++ b/tests/lib/rules/no-inner-declarations.js
@@ -52,6 +52,16 @@ ruleTester.run("no-inner-declarations", rule, {
 			options: ["both"],
 			languageOptions: { ecmaVersion: 6 },
 		},
+		{
+			code: "if (test) { using x = 1; }",
+			options: ["both"],
+			languageOptions: { ecmaVersion: 2026, sourceType: "module", parser: require("@typescript-eslint/parser") },
+		},
+		{
+			code: "if (test) { await using x = 1; }",
+			options: ["both"],
+			languageOptions: { ecmaVersion: 2026, sourceType: "module", parser: require("@typescript-eslint/parser") },
+		},
 		"function doSomething() { while (test) { var foo; } }",
 		{ code: "var foo;", options: ["both"] },
 		{ code: "var foo = 42;", options: ["both"] },

--- a/tests/lib/rules/no-loop-func.js
+++ b/tests/lib/rules/no-loop-func.js
@@ -950,5 +950,20 @@ ruleTesterTypeScript.run("no-loop-func", rule, {
 				},
 			],
 		},
+		{
+			code: `
+            for (const value of values) {
+                using resource = getResource();
+                () => resource; 
+            }
+            `,
+			errors: [
+				{
+					messageId: "unsafeRefs",
+					data: { varNames: "'resource'" },
+					type: "ArrowFunctionExpression",
+				},
+			],
+		},
 	],
 });

--- a/tests/lib/rules/no-undef-init.js
+++ b/tests/lib/rules/no-undef-init.js
@@ -29,6 +29,10 @@ ruleTester.run("no-undef-init", rule, {
 			code: "class C { field = undefined; }",
 			languageOptions: { ecmaVersion: 2022 },
 		},
+		{
+			code: "using a = condition ? getDisposableResource() : undefined;",
+			languageOptions: { ecmaVersion: 2026, sourceType: "module", parser: require("@typescript-eslint/parser") },
+		},
 	],
 	invalid: [
 		{

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -765,6 +765,18 @@ ruleTester.run("no-unused-vars", rule, {
 			],
 			languageOptions: { ecmaVersion: 6 },
 		},
+		{
+			code: "using resource = getResource();\nresource;",
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") }
+		},
+		{
+			code: "using resource = getResource();",
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") }
+		},
+		{
+			code: "await using resource = getResource();",
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") }
+		}
 	],
 	invalid: [
 		{

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -36,6 +36,14 @@ ruleTester.run("no-var", rule, {
 				parserOptions: { ecmaFeatures: { globalReturn: true } },
 			},
 		},
+		{
+			code: "using moo = 'car';",
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+		},
+		{
+			code: "await using moo = 'car';",
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+		},
 	],
 
 	invalid: [

--- a/tests/lib/rules/one-var-declaration-per-line.js
+++ b/tests/lib/rules/one-var-declaration-per-line.js
@@ -166,6 +166,21 @@ ruleTester.run("one-var-declaration-per-line", rule, {
 			languageOptions: { ecmaVersion: 6 },
 			errors: [errorAt(1, 14)],
 		},
+		{
+			code: "using a = 0, b = 0;",
+			output: "using a = 0, \nb = 0;",
+			options: ["always"],
+			languageOptions: { ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+			errors: [errorAt(1, 14)],
+		},
+		{
+			code: "await using a = 0, b = 0;",
+			output: "await using a = 0, \nb = 0;",
+			options: ["always"],
+			languageOptions: { ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+			errors: [errorAt(1, 20)],
+		},
+
 
 		{
 			code: "var foo, bar, baz = 0;",

--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -270,6 +270,16 @@ ruleTester.run("one-var", rule, {
 			options: ["consecutive"],
 			languageOptions: { ecmaVersion: 6 },
 		},
+		{
+			code: "using a = 0, b = 1;",
+			options: ["consecutive"],
+			languageOptions: { sourceType: "module", parser: require("@typescript-eslint/parser") },
+		},
+		{
+			code: "using a = 0; await using b = 1;",
+			options: ["consecutive"],
+			languageOptions: { sourceType: "module", parser: require("@typescript-eslint/parser") },
+		},
 
 		// https://github.com/eslint/eslint/issues/10784
 		{
@@ -637,6 +647,17 @@ ruleTester.run("one-var", rule, {
 			options: [{ initialized: "consecutive" }],
 			languageOptions: { ecmaVersion: 2022 },
 		},
+		{
+			code: "using a = 0; using b = 1;",
+			options: ["consecutive"],
+			languageOptions: { ecmaVersion: 2026, sourceType: "module", parser: require("@typescript-eslint/parser") },
+		},
+		{
+			code: "await using a = 0; await using b = 1;",
+			options: ["consecutive"],
+			languageOptions: { ecmaVersion: 2026, sourceType: "module", parser: require("@typescript-eslint/parser") },
+		},
+
 	],
 	invalid: [
 		{

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -44,6 +44,14 @@ ruleTester.run("prefer-const", rule, {
 		"let x;",
 		"let x; { x = 0; } foo(x);",
 		"let x = 0; x = 1;",
+		{
+			code: "using resource = fn();",
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+		},
+		{
+			code: "await using resource = fn();",
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+		},
 		"const x = 0;",
 		"for (let i = 0, end = 10; i < end; ++i) {}",
 		"for (let i in [1,2,3]) { i = 0; }",

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -256,6 +256,22 @@ ruleTester.run("prefer-destructuring", rule, {
 				{ enforceForRenamedProperties: true },
 			],
 		},
+		{
+			code: "using foo = array[0];",
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+		},
+		{
+			code: "using foo = object.foo;",
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+		},
+			{
+			code: "await using foo = array[0];",
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+		},
+		{
+			code: "await using foo = object.foo;",
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+		},
 	],
 
 	invalid: [

--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -89,6 +89,14 @@ ruleTester.run("require-await", rule, {
 			code: 'async function* run() { console.log("bar") }',
 			languageOptions: { ecmaVersion: 9 },
 		},
+		{
+			code: 'await using resource = getResource();',
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") }
+		},
+		{
+			code: 'async function run() { await using resource = getResource(); }',
+			languageOptions: { sourceType: "module", ecmaVersion: 2026, parser: require("@typescript-eslint/parser") }
+		}
 	],
 	invalid: [
 		{
@@ -335,5 +343,21 @@ ruleTester.run("require-await", rule, {
 				},
 			],
 		},
+		{
+			code: 'async function run() { using resource = getResource(); }',
+			languageOptions: { ecmaVersion: 2026, parser: require("@typescript-eslint/parser") },
+			errors: [
+				{
+					messageId: "missingAwait",
+					data: { name: "Async function 'run'" },
+					suggestions: [
+						{
+							output: 'function run() { using resource = getResource(); }',
+							messageId: "removeAsync",
+						},
+					],
+				},
+			],
+		}
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Support new syntax

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
This PR adds preliminary support for the [explicit resource management proposal](https://github.com/tc39/proposal-explicit-resource-management) which will likely be included in ES2026 (fixes #19792).
Most of the changes are additional tests for existing rules except the following behavior changes:
- `curly`: allows using/await using as only statement as otherwise parser error (same as for `let/const`)
- `no-unused-vars`: counts the variables as used as their `Symbol.dispose` is implicitly called at the end of its scope
- `prefer-destructuring`: allows not destructuring as this would be a parse error
- `require-await` + `no-await-in-loop`: counts `await using` as an await

Notes:
- Marked this as a draft as espree does not parse this yet but [acorn](https://github.com/acornjs/acorn/pull/1369) has unreleased support for it (using the typescript-eslint parser for the tests in the meantime)
- Did not update `func-*` or `no-magic-numbers` as they would be runtime errors (have no `Symbol.dispose`)
- Added no tests if there were non for especially `let/const` (e.g. `block-scoped-var`)
- `no-undef-init`: does not need to be updated as it is a parse error for initializing to undefined in this case
- `no-case-declarations`: does not need to be updated as it is a syntax error

#### Is there anything you'd like reviewers to focus on?
- There were open questions in the original issue, e.g. for the behavior of `no-loop-func`
- How should updates to the types be handled (some reference `@types/estree`)
- Should options be added for the frozen `one-var` as it normalizes the options only to the prior known `var/let/const` (in other words `using` and `await using` are just ignored)
- `no-unassigned-vars` + `init-declarations`: Have a [special condition for `const`](https://github.com/eslint/eslint/blob/7abe42e2de931289e19e34e390d16936cf6faf64/lib/rules/no-unassigned-vars.js#L49) even though it is a parse error to omit the initial value. Should `using` and `await using` be included?
- `require-await` + `no-await-in-loop`: Should the rule documentation explicitly mention `await using`?

<!-- markdownlint-disable-file MD004 -->
