### PR TITLE
feat: Enhancement to the no-duplicate-imports rule to better support TypeScript syntax

### DIFF
--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -60,9 +60,10 @@ function getImportExportType(node) {
  * Returns a boolean indicates if two (import|export) can be merged
  * @param {ASTNode} node1 A node to check.
  * @param {ASTNode} node2 A node to check.
+ * @param {boolean} allowSeparateType Determines whether type-only imports must remain separate from regular value imports.
  * @returns {boolean} True if two (import|export) can be merged, false if they can't.
  */
-function isImportExportCanBeMerged(node1, node2) {
+function isImportExportCanBeMerged(node1, node2, allowSeparateType) {
 	const importExportType1 = getImportExportType(node1);
 	const importExportType2 = getImportExportType(node2);
 
@@ -84,6 +85,14 @@ function isImportExportCanBeMerged(node1, node2) {
 	) {
 		return false;
 	}
+	if (allowSeparateType) {
+		const isNode1Type = node1.importKind === "type";
+		const isNode2Type = node2.importKind === "type";
+
+		if ((isNode1Type && !isNode2Type) || (!isNode1Type && isNode2Type)) {
+			return false;
+		}
+	}
 	return true;
 }
 
@@ -91,13 +100,16 @@ function isImportExportCanBeMerged(node1, node2) {
  * Returns a boolean if we should report (import|export).
  * @param {ASTNode} node A node to be reported or not.
  * @param {[ASTNode]} previousNodes An array contains previous nodes of the module imported or exported.
+ * @param {boolean} allowSeparateType Determines whether type-only imports must remain separate from regular value imports.
  * @returns {boolean} True if the (import|export) should be reported.
  */
-function shouldReportImportExport(node, previousNodes) {
+function shouldReportImportExport(node, previousNodes, allowSeparateType) {
 	let i = 0;
 
 	while (i < previousNodes.length) {
-		if (isImportExportCanBeMerged(node, previousNodes[i])) {
+		if (
+			isImportExportCanBeMerged(node, previousNodes[i], allowSeparateType)
+		) {
 			return true;
 		}
 		i++;
@@ -136,6 +148,7 @@ function getModule(node) {
  * @param {Map} modules A Map object contains as a key a module name and as value an array contains objects, each object contains a node and a declaration type.
  * @param {string} declarationType A declaration type can be an import or export.
  * @param {boolean} includeExports Whether or not to check for exports in addition to imports.
+ * @param {boolean} allowSeparateType Determines whether type-only imports must remain separate from regular value imports.
  * @returns {void} No return value.
  */
 function checkAndReport(
@@ -144,6 +157,7 @@ function checkAndReport(
 	modules,
 	declarationType,
 	includeExports,
+	allowSeparateType,
 ) {
 	const module = getModule(node);
 
@@ -157,19 +171,31 @@ function checkAndReport(
 			exportNodes = getNodesByDeclarationType(previousNodes, "export");
 		}
 		if (declarationType === "import") {
-			if (shouldReportImportExport(node, importNodes)) {
+			if (
+				shouldReportImportExport(node, importNodes, allowSeparateType)
+			) {
 				messagesIds.push("import");
 			}
 			if (includeExports) {
-				if (shouldReportImportExport(node, exportNodes)) {
+				if (
+					shouldReportImportExport(
+						node,
+						exportNodes,
+						allowSeparateType,
+					)
+				) {
 					messagesIds.push("importAs");
 				}
 			}
 		} else if (declarationType === "export") {
-			if (shouldReportImportExport(node, exportNodes)) {
+			if (
+				shouldReportImportExport(node, exportNodes, allowSeparateType)
+			) {
 				messagesIds.push("export");
 			}
-			if (shouldReportImportExport(node, importNodes)) {
+			if (
+				shouldReportImportExport(node, importNodes, allowSeparateType)
+			) {
 				messagesIds.push("exportAs");
 			}
 		}
@@ -177,9 +203,7 @@ function checkAndReport(
 			context.report({
 				node,
 				messageId,
-				data: {
-					module,
-				},
+				data: { module },
 			}),
 		);
 	}
@@ -196,6 +220,7 @@ function checkAndReport(
  * @param {Map} modules A Map object contains as a key a module name and as value an array contains objects, each object contains a node and a declaration type.
  * @param {string} declarationType A declaration type can be an import or export.
  * @param {boolean} includeExports Whether or not to check for exports in addition to imports.
+ * @param {boolean} allowSeparateType Determines whether type-only imports must remain separate from regular value imports.
  * @returns {nodeCallback} A function passed to ESLint to handle the statement.
  */
 function handleImportsExports(
@@ -203,6 +228,7 @@ function handleImportsExports(
 	modules,
 	declarationType,
 	includeExports,
+	allowSeparateType,
 ) {
 	return function (node) {
 		const module = getModule(node);
@@ -214,6 +240,7 @@ function handleImportsExports(
 				modules,
 				declarationType,
 				includeExports,
+				allowSeparateType,
 			);
 			const currentNode = { node, declarationType };
 			let nodes = [currentNode];
@@ -236,6 +263,7 @@ module.exports = {
 		defaultOptions: [
 			{
 				includeExports: false,
+				allowSeparateType: false,
 			},
 		],
 
@@ -249,9 +277,8 @@ module.exports = {
 			{
 				type: "object",
 				properties: {
-					includeExports: {
-						type: "boolean",
-					},
+					includeExports: { type: "boolean" },
+					allowSeparateType: { type: "boolean" },
 				},
 				additionalProperties: false,
 			},
@@ -266,7 +293,7 @@ module.exports = {
 	},
 
 	create(context) {
-		const [{ includeExports }] = context.options;
+		const [{ includeExports, allowSeparateType }] = context.options;
 		const modules = new Map();
 		const handlers = {
 			ImportDeclaration: handleImportsExports(
@@ -274,6 +301,7 @@ module.exports = {
 				modules,
 				"import",
 				includeExports,
+				allowSeparateType,
 			),
 		};
 
@@ -283,12 +311,14 @@ module.exports = {
 				modules,
 				"export",
 				includeExports,
+				allowSeparateType,
 			);
 			handlers.ExportAllDeclaration = handleImportsExports(
 				context,
 				modules,
 				"export",
 				includeExports,
+				allowSeparateType,
 			);
 		}
 		return handlers;

--- a/tests/lib/rules/no-duplicate-imports.js
+++ b/tests/lib/rules/no-duplicate-imports.js
@@ -9,8 +9,9 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require("../../../lib/rules/no-duplicate-imports"),
-	RuleTester = require("../../../lib/rule-tester/rule-tester");
+const rule = require("../../../lib/rules/no-duplicate-imports");
+const RuleTester = require("../../../lib/rule-tester/rule-tester");
+const tsParser = require("@typescript-eslint/parser");
 
 //------------------------------------------------------------------------------
 // Tests
@@ -212,6 +213,72 @@ ruleTester.run("no-duplicate-imports", rule, {
 					messageId: "export",
 					data: { module: "os" },
 					type: "ExportAllDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import "os";\nexport * from "os";',
+			options: [{ includeExports: true }],
+			errors: [
+				{
+					messageId: "exportAs",
+					data: { module: "os" },
+					type: "ExportAllDeclaration",
+				},
+			],
+		},
+	],
+});
+
+const tsRuleTester = new RuleTester({
+	languageOptions: {
+		ecmaVersion: 12,
+		sourceType: "module",
+		parser: tsParser,
+	},
+});
+
+tsRuleTester.run("no-duplicate-imports", rule, {
+	valid: [
+		'import { Foo, type Bar } from "./foo"',
+		'import { type Foo, type Bar } from "./foo"',
+		'import type { Foo, Bar } from "./foo"',
+		{
+			code: 'import { Foo } from "./foo"\nimport type { Bar } from "./foo"',
+			options: [{ allowSeparateType: true }],
+		},
+	],
+	invalid: [
+		{
+			code: 'import { foo } from "./foo";\nimport type { bar } from "./foo";',
+			options: [{ allowSeparateType: false }],
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "./foo" },
+					type: "ImportDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import { foo } from "./foo";\nimport { bar } from "./foo";',
+			options: [{ allowSeparateType: false }],
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "./foo" },
+					type: "ImportDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import { foo } from "./foo";\nimport { bar } from "./foo";',
+			options: [{ allowSeparateType: true }],
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "./foo" },
+					type: "ImportDeclaration",
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? 

Added support for `allowSeparateType` option in the `no-duplicate-imports` ESLint rule to allow separate type and value imports from the same module. 

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

**What rule do you want to change?**

`no-duplicate-imports`

**What change do you want to make (place an "X" next to just one item)?**

[ ] Generate more warnings
[ ] Generate fewer warnings
[ ] Implement autofix
[x] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[x] A new option
[ ] A new default behavior
[ ] Other

**What does the rule currently do for this code?**

It currently reports an error in type imports separated in a different import statement

```js
/*eslint no-duplicate-imports: "error"*/
import { Foo } from './foo'
import type { Bar } from './foo' // error  './foo' import is duplicated  no-duplicate-imports
```

**What will the rule do after it's changed?**

```js
/*eslint no-duplicate-imports: ["error", { "allowTypeImports": true }]*/
import { Foo } from './foo'
import type { Bar } from './foo' // Ok!
```
