### PR TITLE
fix: remove unnecessary semicolon from fixes

### DIFF
--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1193,6 +1193,35 @@ let needsPrecedingSemicolon;
 		"WithStatement",
 	]);
 
+	const TS_TYPE_NODE_TYPES = new Set([
+		"TSAsExpression",
+		"TSSatisfiesExpression",
+		"TSTypeAliasDeclaration",
+		"TSTypeAnnotation",
+	]);
+
+	/**
+	 * Determines whether a specified node is inside a TypeScript type context.
+	 * @param {ASTNode} node The node to check.
+	 * @returns {boolean} Whether the node is inside a TypeScript type context.
+	 */
+	function isInType(node) {
+		for (let currNode = node; ; ) {
+			const { parent } = currNode;
+			if (!parent) {
+				break;
+			}
+			if (
+				TS_TYPE_NODE_TYPES.has(parent.type) &&
+				currNode === parent.typeAnnotation
+			) {
+				return true;
+			}
+			currNode = parent;
+		}
+		return false;
+	}
+
 	needsPrecedingSemicolon = function (sourceCode, node) {
 		const prevToken = sourceCode.getTokenBefore(node);
 
@@ -1205,6 +1234,16 @@ let needsPrecedingSemicolon;
 		}
 
 		const prevNode = sourceCode.getNodeByRangeIndex(prevToken.range[0]);
+
+		if (
+			prevNode.type === "TSDeclareFunction" ||
+			prevNode.parent.type === "TSImportEqualsDeclaration" ||
+			prevNode.parent.parent?.type === "TSImportEqualsDeclaration" ||
+			TS_TYPE_NODE_TYPES.has(prevNode.type) ||
+			isInType(prevNode)
+		) {
+			return false;
+		}
 
 		if (isClosingParenToken(prevToken)) {
 			return !STATEMENTS.has(prevNode.type);
@@ -1222,6 +1261,12 @@ let needsPrecedingSemicolon;
 		}
 
 		if (IDENTIFIER_OR_KEYWORD.has(prevToken.type)) {
+			if (
+				prevNode.parent.type === "VariableDeclarator" &&
+				!prevNode.parent.init
+			) {
+				return false;
+			}
 			if (BREAK_OR_CONTINUE.has(prevNode.parent.type)) {
 				return false;
 			}

--- a/tests/lib/rules/no-array-constructor.js
+++ b/tests/lib/rules/no-array-constructor.js
@@ -493,6 +493,18 @@ ruleTester.run("no-array-constructor", rule, {
                 }
                 `,
 			},
+			{
+				code: `
+                var foo
+                Array()
+                `,
+			},
+			{
+				code: `
+                let bar
+                Array()
+                `,
+			},
 		].map(props => ({
 			...props,
 			output: props.code.replace(
@@ -970,6 +982,75 @@ ruleTesterTypeScript.run("no-array-constructor", rule, {
 						},
 					],
 				},
+			],
+		},
+
+		// No semicolon required after TypeScript syntax
+		...[
+			"type T = Foo",
+			"type T = Foo<Bar>",
+			"type T = (A | B)",
+			"type T = -1",
+			"type T = 'foo'",
+			"const foo",
+			"declare const foo",
+			"function foo()",
+			"declare function foo()",
+			"function foo(): []",
+			"declare function foo(): []",
+			"function foo(): (Foo)",
+			"declare function foo(): (Foo)",
+			"let foo: bar",
+			"import Foo = require('foo')",
+			"import Foo = Bar",
+			"import Foo = Bar.Baz.Qux",
+		].map(code => ({
+			code: `${code}\nArray(0, 1)`,
+			output: `${code}\n[0, 1]`,
+			errors: [{ messageId: "preferLiteral" }],
+		})),
+		{
+			code: `
+			(function () {
+				Fn
+				Array() // ";" required
+			}) as Fn
+			Array() // ";" not required
+			`,
+			output: `
+			(function () {
+				Fn
+				;[] // ";" required
+			}) as Fn
+			[] // ";" not required
+			`,
+			errors: [
+				{ messageId: "preferLiteral" },
+				{ messageId: "preferLiteral" },
+			],
+		},
+		{
+			code: `
+			({
+				foo() {
+					Object
+					Array() // ";" required
+				}
+			}) as Object
+			Array() // ";" not required
+			`,
+			output: `
+			({
+				foo() {
+					Object
+					;[] // ";" required
+				}
+			}) as Object
+			[] // ";" not required
+			`,
+			errors: [
+				{ messageId: "preferLiteral" },
+				{ messageId: "preferLiteral" },
 			],
 		},
 	],

--- a/tests/lib/rules/no-object-constructor.js
+++ b/tests/lib/rules/no-object-constructor.js
@@ -379,6 +379,18 @@ ruleTester.run("no-object-constructor", rule, {
                 }
                 `,
 			},
+			{
+				code: `
+                var foo
+                Object()
+                `,
+			},
+			{
+				code: `
+                let bar
+                Object()
+                `,
+			},
 		].map(props => ({
 			...props,
 			errors: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v24.2.0
npm version: v11.3.0
Local ESLint version: v9.24.0 - v9.29.0
Global ESLint version:
Operating System: darwin 24.5.0

**What parser are you using (place an "X" next to just one item)?**

[X] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [
    {
        "rules": {
            "no-array-constructor": [
                "error"
            ]
        }
    }
];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
let foo
Array(1, 2, 3).forEach(doSomething)
```

[**Playground Link**](https://eslint.org/play/#eyJ0ZXh0IjoibGV0IGZvb1xuQXJyYXkoMSwgMiwgMykuZm9yRWFjaChkb1NvbWV0aGluZykiLCJvcHRpb25zIjp7InJ1bGVzIjp7Im5vLWFycmF5LWNvbnN0cnVjdG9yIjpbImVycm9yIl19LCJsYW5ndWFnZU9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hRmVhdHVyZXMiOnt9fX19fQ==)

**What did you expect to happen?**

The autofix for the above code should not introduce a semicolon between the let declaration and the following statement, i.e. the fixed code should look like this:

```js
let foo
[1, 2, 3].forEach(doSomething)
```

**What actually happened? Please include the actual, raw output from ESLint.**

The autofixed code includes an additional semicolon:

```js
let foo
;[1, 2, 3].forEach(doSomething)
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This pull requests affects autofixes and suggestions provided by `no-array-constructor` and `no-object-constructor`. In some cases, mostly related to TypeScript syntax, the rules would previously insert an unnecessary semicolon before the fixed code. The logic to determine if a semicolon is necessary resides in the `needsPrecedingSemicolon` function in lib/rules/utils/ast-utils.js. This function was updated to handle cases where an expression statement is predeced by:
1. an uninitialized variable declaration
2. TypeScript syntax that does not require a following semicolon

This change affects autofixes and suggestions provided by `no-array-constructor` and `no-object-constructor`.

These are some examples of code where the mentioned rules will no longer add a semicolon before an array or object literal that replaces `new Array()` or `new Object()`:

```js
/* eslint no-object-constructor: "error" */

var a
new Object()

/* eslint no-array-constructor: "error" */

let foo
new Array(1, 2)

// The next examples require the typescript-eslint parser

type xtring = string
Array()

declare function test(): void
new Array("A", "B")

const bar = Math.sign(Math.random() - .5) as -1 | 0 | 1
new Array(0, 1)
```

[**Playground Link**](https://typescript-eslint.io/play#ts=5.8.2&fileType=.tsx&code=PQKgBApgzgNglgOwC5gQewLRoEYCsIDGSGBaCUSATgK5FqUBcYARBJZfc2CMAFC8A3AIaUwQ3gggB3MAHk8hJAAoAlP1CRYiFOgwjKQgJ4kyFGnUYs2HSlx78YEFADM0aCdLABBdkaUBGABowACY1XmBgMAAVAAsIVAgADxRkoQBbAAdHKDBKCABHajh8sCR4ssNM6AJKOEziaHhkMEyRKDZ%2BJCqElLqEAHMwAF4wM0QB3h8DQ1V%2BABNCGBEE52oEIjgyMuhlFSYBNDh5jxlpv2YvZmDmACFmcNJyFGwREbAAWSFygDooOAGCCUX1%2BBgQ8zQ6VUYAwYB%2BAFYVGJchh-GAAD5gAAMGLA-lO3l8syxwX8aiAA&eslintrc=N4KABGBEBOCuA2BTAzpAXGYBfEWg&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEAviDUA&tokens=false)

More examples for code that will no longer have a semicolon added before the next statement can be found in the unit tests for `no-array-constructor`:

https://github.com/eslint/eslint/blob/0d3d4bdf5960ccd857d30d88e4e5a966ce12795c/tests/lib/rules/no-array-constructor.js#L990-L1006

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->