### PR TITLE
fix: handle `null` type `loc` in `getIndexFromLoc` method

### DIFF
--- a/lib/languages/js/source-code/source-code.js
+++ b/lib/languages/js/source-code/source-code.js
@@ -795,6 +795,7 @@ class SourceCode extends TokenStore {
 	 */
 	getIndexFromLoc(loc) {
 		if (
+			loc === null ||
 			typeof loc !== "object" ||
 			typeof loc.line !== "number" ||
 			typeof loc.column !== "number"

--- a/tests/lib/languages/js/source-code/source-code.js
+++ b/tests/lib/languages/js/source-code/source-code.js
@@ -2312,6 +2312,11 @@ describe("SourceCode", () => {
 			);
 
 			assert.throws(
+				() => sourceCode.getIndexFromLoc(null),
+				/Expected `loc` to be an object with numeric `line` and `column` properties\./u,
+			);
+
+			assert.throws(
 				() =>
 					sourceCode.getIndexFromLoc({
 						line: "three",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,

In this PR, I've added handling logic for `null`-type `loc` to the `getIndexFromLoc` method.

Currently, passing `null` to `getIndexFromLoc` results in an unrelated error because accessing `loc.line` throws when `loc` is `null`.

So, I’ve updated the error message to more precisely indicate that an incorrect type was passed to the `getIndexFromLoc` method.

- Before:

![image](https://github.com/user-attachments/assets/3dcf1962-e699-431d-8871-ae857ba7f066)

- After:

![image](https://github.com/user-attachments/assets/16a4e186-5fde-4fe9-8c76-a9b868fe5f07)

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
