### PR TITLE
fix: use `process.version` in `--env-info`

### DIFF
--- a/lib/shared/runtime-info.js
+++ b/lib/shared/runtime-info.js
@@ -150,7 +150,7 @@ function environment() {
 	return [
 		"Environment Info:",
 		"",
-		`Node version: ${getBinVersion("node")}`,
+		`Node version: ${process.version}`,
 		`npm version: ${getBinVersion("npm")}`,
 		`Local ESLint version: ${getNpmPackageVersion("eslint", { global: false })}`,
 		`Global ESLint version: ${getNpmPackageVersion("eslint", { global: true })}`,

--- a/tests/lib/shared/runtime-info.js
+++ b/tests/lib/shared/runtime-info.js
@@ -55,6 +55,7 @@ describe("RuntimeInfo", () => {
 	describe("environment()", () => {
 		let spawnSyncStub;
 		let logErrorStub;
+		let processVersionStub;
 		let originalProcessArgv;
 		let spawnSyncStubArgs;
 		const originalOsPlatform = os.platform;
@@ -65,10 +66,12 @@ describe("RuntimeInfo", () => {
 			os.release = () => "20.3.0";
 			spawnSyncStub = sinon.stub(spawn, "sync");
 			logErrorStub = sinon.stub(log, "error");
+			processVersionStub = sinon
+				.stub(process, "version")
+				.value("v12.8.0");
 			originalProcessArgv = process.argv;
 			process.argv[1] = LOCAL_ESLINT_BIN_PATH;
 			spawnSyncStubArgs = [
-				"v12.8.0",
 				"6.11.3",
 				unIndent`
                     {
@@ -99,6 +102,7 @@ describe("RuntimeInfo", () => {
 		afterEach(() => {
 			spawnSyncStub.restore();
 			logErrorStub.restore();
+			processVersionStub.restore();
 			process.argv = originalProcessArgv;
 			os.platform = originalOsPlatform;
 			os.release = originalOsRelease;
@@ -141,7 +145,7 @@ describe("RuntimeInfo", () => {
 
 		it("should return a string containing environment information when not installed locally", () => {
 			spawnSyncStubArgs.splice(
-				2,
+				1,
 				2,
 				unIndent`
                 {
@@ -169,7 +173,7 @@ describe("RuntimeInfo", () => {
 		});
 
 		it("should return a string containing environment information when not installed globally", () => {
-			spawnSyncStubArgs[4] = "{}";
+			spawnSyncStubArgs[3] = "{}";
 			setupSpawnSyncStubReturnVals(spawnSyncStub, spawnSyncStubArgs);
 
 			assert.strictEqual(
@@ -189,7 +193,7 @@ describe("RuntimeInfo", () => {
 		it("log and throw an error when npm version can not be found", () => {
 			const expectedErr = new Error("npm can not be found");
 
-			spawnSyncStubArgs[1] = expectedErr;
+			spawnSyncStubArgs[0] = expectedErr;
 			setupSpawnSyncStubReturnVals(spawnSyncStub, spawnSyncStubArgs);
 
 			assert.throws(RuntimeInfo.environment, expectedErr);
@@ -202,7 +206,7 @@ describe("RuntimeInfo", () => {
 		it("log and throw an error when npm binary path can not be found", () => {
 			const expectedErr = new Error("npm can not be found");
 
-			spawnSyncStubArgs[3] = expectedErr;
+			spawnSyncStubArgs[2] = expectedErr;
 			setupSpawnSyncStubReturnVals(spawnSyncStub, spawnSyncStubArgs);
 
 			assert.throws(RuntimeInfo.environment, expectedErr);
@@ -213,7 +217,7 @@ describe("RuntimeInfo", () => {
 		});
 
 		it("log and throw an error when checking for local ESLint version when returned output of command is malformed", () => {
-			spawnSyncStubArgs[2] = "This is not JSON";
+			spawnSyncStubArgs[1] = "This is not JSON";
 			setupSpawnSyncStubReturnVals(spawnSyncStub, spawnSyncStubArgs);
 
 			assert.throws(
@@ -227,7 +231,7 @@ describe("RuntimeInfo", () => {
 		});
 
 		it("log and throw an error when checking for global ESLint version when returned output of command is malformed", () => {
-			spawnSyncStubArgs[4] = "This is not JSON";
+			spawnSyncStubArgs[3] = "This is not JSON";
 			setupSpawnSyncStubReturnVals(spawnSyncStub, spawnSyncStubArgs);
 
 			assert.throws(


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Modified the `--env-info` command to use `process.version` instead of spawning `node --version` to get the Node.js version.

Fixes #19848

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
