### PR TITLE
docs: clarify that boolean is still allowed for rule `meta.deprecated`

### DIFF
--- a/docs/src/extend/rule-deprecation.md
+++ b/docs/src/extend/rule-deprecation.md
@@ -3,8 +3,8 @@ title: Rule Deprecation
 ---
 
 The rule deprecation metadata describes whether a rule is deprecated and how the rule can be replaced if there is a replacement.
-The legacy format used the two top-level [rule meta](./custom-rules#rule-structure) properties `deprecated: true` and `replacedBy`.
-In the new format `deprecated` is an object of type `DeprecatedInfo` and `replacedBy` should be defined inside `deprecated` instead of the top-level.
+The legacy format used the two top-level [rule meta](./custom-rules#rule-structure) properties `deprecated` (as a boolean only) and `replacedBy`.
+In the new format, `deprecated` is a boolean or an object of type `DeprecatedInfo`, and `replacedBy` should be defined inside `deprecated` instead of at the top-level.
 
 ## ◆ DeprecatedInfo type
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Clarify that the rule `meta.deprecated` property can be provided as either a boolean or an object.

The current documentation is conflicting:

- https://eslint.org/docs/latest/extend/custom-rules indicates that the property can be a boolean or an object
   > deprecated: (boolean | DeprecatedInfo) Indicates whether the rule has been deprecated. You may omit the `deprecated` property if the rule has not been deprecated.
- https://eslint.org/docs/latest/extend/rule-deprecation implies that the property should only be an object
   > In the new format `deprecated` is an object of type `DeprecatedInfo`...

The RFC which I started and @DMartens finished shows the property as a boolean or an object:
- https://github.com/eslint/rfcs/pull/124

```ts
type RuleMeta = {
  deprecated?:
    | boolean // Existing boolean option, backwards compatible.
    | DeprecatedInfo // Proposed extension
```

My original intention in writing this RFC was that the boolean format would continue to be allowed. In my mind, the `DeprecatedInfo` object format is only necessary to use when additional information about the deprecation is available. That's why all of the new fields in `DeprecatedInfo` are optional and can be provided as the rule author sees fit or as additional information is available. Otherwise, simply providing the property as a boolean to indicate the deprecation is totally sufficient.
- Let me know if there's any disagreement about that.

So I've updated the documentation to clarify that boolean or object is acceptable for rule `meta.deprecated`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
