### PR TITLE
docs: typo in comment for unused variables handling

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -1152,7 +1152,7 @@ module.exports = {
 
 				// fix for { a: { b } }
 				if (parentNode.parent.type === "ObjectPattern") {
-					// fix for unused variables in dectructured object with single property in variable decalartion and function parameter
+					// fix for unused variables in dectructured object with single property in variable declaration and function parameter
 					if (parentNode.parent.properties.length === 1) {
 						return fixVariables(parentNode.parent);
 					}

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -1152,7 +1152,7 @@ module.exports = {
 
 				// fix for { a: { b } }
 				if (parentNode.parent.type === "ObjectPattern") {
-					// fix for unused variables in dectructured object with single property in variable declaration and function parameter
+					// fix for unused variables in destructured object with single property in variable declaration and function parameter
 					if (parentNode.parent.properties.length === 1) {
 						return fixVariables(parentNode.parent);
 					}


### PR DESCRIPTION


Description:  
Corrects a typo in the comment within the no-unused-vars rule, improving code clarity and documentation.