### PR TITLE
feat: add `allowSeparateTypeImports` option to `no-duplicate-imports`

### DIFF
--- a/docs/src/rules/no-duplicate-imports.md
+++ b/docs/src/rules/no-duplicate-imports.md
@@ -61,7 +61,12 @@ import * as something from 'module';
 
 ## Options
 
-This rule takes one optional argument, an object with a single key, `includeExports` which is a `boolean`. It defaults to `false`.
+This rule has an object option:
+
+* `"includeExports"`: `true` (default `false`) checks for exports in addition to imports.
+* `"allowSeparateTypeImports"`: `true` (default `false`) allows a type import alongside a value import from the same module in TypeScript files.
+
+### includeExports
 
 If re-exporting from an imported module, you should add the imports to the `import`-statement, and export that directly, not use `export ... from`.
 
@@ -107,6 +112,62 @@ export * as something from 'module';
 
 // cannot be written differently
 export * from 'module';
+```
+
+:::
+
+### allowSeparateTypeImports
+
+TypeScript allows specifying a `type` keyword on imports to indicate that the export exists only in the type system, not at runtime. This allows transpilers to drop imports without knowing the types of the dependencies.
+
+Example of **incorrect** TypeScript code for this rule with the default `{ "allowSeparateTypeImports": false }` option:
+
+::: incorrect
+
+```ts
+/*eslint no-duplicate-imports: ["error", { "allowSeparateTypeImports": false }]*/
+
+import { someValue } from 'module';
+import type { SomeType } from 'module';
+```
+
+:::
+
+Example of **correct** TypeScript code for this rule with the default `{ "allowSeparateTypeImports": false }` option:
+
+::: incorrect
+
+```ts
+/*eslint no-duplicate-imports: ["error", { "allowSeparateTypeImports": false }]*/
+
+import { someValue, type SomeType } from 'module';
+```
+
+:::
+
+Example of **incorrect** TypeScript code for this rule with the `{ "allowSeparateTypeImports": true }` option:
+
+::: incorrect
+
+```ts
+/*eslint no-duplicate-imports: ["error", { "allowSeparateTypeImports": true }]*/
+
+import { someValue } from 'module';
+import type { SomeType } from 'module';
+import type { AnotherType } from 'module';
+```
+
+:::
+
+Example of **correct** TypeScript code for this rule with the `{ "allowSeparateTypeImports": true }` option:
+
+::: correct
+
+```ts
+/*eslint no-duplicate-imports: ["error", { "allowSeparateTypeImports": true }]*/
+
+import { someValue } from 'module';
+import type { SomeType, AnotherType } from 'module';
 ```
 
 :::

--- a/docs/src/rules/no-duplicate-imports.md
+++ b/docs/src/rules/no-duplicate-imports.md
@@ -135,7 +135,7 @@ import type { SomeType } from 'module';
 
 Example of **correct** TypeScript code for this rule with the default `{ "allowSeparateTypeImports": false }` option:
 
-::: incorrect
+::: correct
 
 ```ts
 /*eslint no-duplicate-imports: ["error", { "allowSeparateTypeImports": false }]*/

--- a/docs/src/rules/no-duplicate-imports.md
+++ b/docs/src/rules/no-duplicate-imports.md
@@ -118,7 +118,7 @@ export * from 'module';
 
 ### allowSeparateTypeImports
 
-TypeScript allows specifying a `type` keyword on imports to indicate that the export exists only in the type system, not at runtime. This allows transpilers to drop imports without knowing the types of the dependencies.
+TypeScript allows importing types using `import type`. By default, this rule flags instances of `import type` that have the same specifier as `import`. The `allowSeparateTypeImports` option allows you to override this behavior.
 
 Example of **incorrect** TypeScript code for this rule with the default `{ "allowSeparateTypeImports": false }` option:
 

--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -91,13 +91,33 @@ function isImportExportCanBeMerged(node1, node2) {
  * Returns a boolean if we should report (import|export).
  * @param {ASTNode} node A node to be reported or not.
  * @param {[ASTNode]} previousNodes An array contains previous nodes of the module imported or exported.
+ * @param {boolean} allowSeparateTypeImports Whether to allow separate type and value imports.
  * @returns {boolean} True if the (import|export) should be reported.
  */
-function shouldReportImportExport(node, previousNodes) {
+function shouldReportImportExport(
+	node,
+	previousNodes,
+	allowSeparateTypeImports,
+) {
 	let i = 0;
 
 	while (i < previousNodes.length) {
-		if (isImportExportCanBeMerged(node, previousNodes[i])) {
+		const previousNode = previousNodes[i];
+
+		if (allowSeparateTypeImports) {
+			const isTypeNode =
+				node.importKind === "type" || node.exportKind === "type";
+			const isTypePrevious =
+				previousNode.importKind === "type" ||
+				previousNode.exportKind === "type";
+
+			if (isTypeNode !== isTypePrevious) {
+				i++;
+				continue;
+			}
+		}
+
+		if (isImportExportCanBeMerged(node, previousNode)) {
 			return true;
 		}
 		i++;
@@ -136,6 +156,7 @@ function getModule(node) {
  * @param {Map} modules A Map object contains as a key a module name and as value an array contains objects, each object contains a node and a declaration type.
  * @param {string} declarationType A declaration type can be an import or export.
  * @param {boolean} includeExports Whether or not to check for exports in addition to imports.
+ * @param {boolean} allowSeparateTypeImports Whether to allow separate type and value imports.
  * @returns {void} No return value.
  */
 function checkAndReport(
@@ -144,6 +165,7 @@ function checkAndReport(
 	modules,
 	declarationType,
 	includeExports,
+	allowSeparateTypeImports,
 ) {
 	const module = getModule(node);
 
@@ -157,19 +179,43 @@ function checkAndReport(
 			exportNodes = getNodesByDeclarationType(previousNodes, "export");
 		}
 		if (declarationType === "import") {
-			if (shouldReportImportExport(node, importNodes)) {
+			if (
+				shouldReportImportExport(
+					node,
+					importNodes,
+					allowSeparateTypeImports,
+				)
+			) {
 				messagesIds.push("import");
 			}
 			if (includeExports) {
-				if (shouldReportImportExport(node, exportNodes)) {
+				if (
+					shouldReportImportExport(
+						node,
+						exportNodes,
+						allowSeparateTypeImports,
+					)
+				) {
 					messagesIds.push("importAs");
 				}
 			}
 		} else if (declarationType === "export") {
-			if (shouldReportImportExport(node, exportNodes)) {
+			if (
+				shouldReportImportExport(
+					node,
+					exportNodes,
+					allowSeparateTypeImports,
+				)
+			) {
 				messagesIds.push("export");
 			}
-			if (shouldReportImportExport(node, importNodes)) {
+			if (
+				shouldReportImportExport(
+					node,
+					importNodes,
+					allowSeparateTypeImports,
+				)
+			) {
 				messagesIds.push("exportAs");
 			}
 		}
@@ -196,6 +242,7 @@ function checkAndReport(
  * @param {Map} modules A Map object contains as a key a module name and as value an array contains objects, each object contains a node and a declaration type.
  * @param {string} declarationType A declaration type can be an import or export.
  * @param {boolean} includeExports Whether or not to check for exports in addition to imports.
+ * @param {boolean} allowSeparateTypeImports Whether to allow separate type and value imports.
  * @returns {nodeCallback} A function passed to ESLint to handle the statement.
  */
 function handleImportsExports(
@@ -203,6 +250,7 @@ function handleImportsExports(
 	modules,
 	declarationType,
 	includeExports,
+	allowSeparateTypeImports,
 ) {
 	return function (node) {
 		const module = getModule(node);
@@ -214,6 +262,7 @@ function handleImportsExports(
 				modules,
 				declarationType,
 				includeExports,
+				allowSeparateTypeImports,
 			);
 			const currentNode = { node, declarationType };
 			let nodes = [currentNode];
@@ -231,11 +280,14 @@ function handleImportsExports(
 /** @type {import('../types').Rule.RuleModule} */
 module.exports = {
 	meta: {
+		dialects: ["javascript", "typescript"],
+		language: "javascript",
 		type: "problem",
 
 		defaultOptions: [
 			{
 				includeExports: false,
+				allowSeparateTypeImports: false,
 			},
 		],
 
@@ -252,6 +304,9 @@ module.exports = {
 					includeExports: {
 						type: "boolean",
 					},
+					allowSeparateTypeImports: {
+						type: "boolean",
+					},
 				},
 				additionalProperties: false,
 			},
@@ -266,7 +321,7 @@ module.exports = {
 	},
 
 	create(context) {
-		const [{ includeExports }] = context.options;
+		const [{ includeExports, allowSeparateTypeImports }] = context.options;
 		const modules = new Map();
 		const handlers = {
 			ImportDeclaration: handleImportsExports(
@@ -274,6 +329,7 @@ module.exports = {
 				modules,
 				"import",
 				includeExports,
+				allowSeparateTypeImports,
 			),
 		};
 
@@ -283,12 +339,14 @@ module.exports = {
 				modules,
 				"export",
 				includeExports,
+				allowSeparateTypeImports,
 			);
 			handlers.ExportAllDeclaration = handleImportsExports(
 				context,
 				modules,
 				"export",
 				includeExports,
+				allowSeparateTypeImports,
 			);
 		}
 		return handlers;

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -2288,6 +2288,10 @@ export interface ESLintRules extends Linter.RulesRecord {
 				 * @default false
 				 */
 				includeExports: boolean;
+				/**
+				 * @default false
+				 */
+				allowSeparateTypeImports: boolean;
 			}>,
 		]
 	>;

--- a/tests/lib/rules/no-duplicate-imports.js
+++ b/tests/lib/rules/no-duplicate-imports.js
@@ -228,3 +228,405 @@ ruleTester.run("no-duplicate-imports", rule, {
 		},
 	],
 });
+
+const ruleTesterTypeScript = new RuleTester({
+	languageOptions: {
+		parser: require("@typescript-eslint/parser"),
+	},
+});
+
+ruleTesterTypeScript.run("no-duplicate-imports", rule, {
+	valid: [
+		'import type { Os } from "os";\nimport type { Fs } from "fs";',
+		'import { type Os } from "os";\nimport type { Fs } from "fs";',
+		'import type { Merge } from "lodash-es";',
+		'import _, { type Merge } from "lodash-es";',
+		'import type * as Foobar from "async";',
+		'import type Os from "os";\nexport type { Something } from "os";',
+		'import type Os from "os";\nexport { type Something } from "os";',
+		'import type * as Bar from "os";\nimport { type Baz } from "os";',
+		'import foo, * as bar from "os";\nimport { type Baz } from "os";',
+		'import foo, { type bar } from "os";\nimport type * as Baz from "os";',
+		{
+			code: 'import type Os from "os";\nexport { type Hello } from "hello";',
+			options: [{ includeExports: true }],
+		},
+		{
+			code: 'import type Os from "os";\nexport type * from "hello";',
+			options: [{ includeExports: true }],
+		},
+		{
+			code: 'import type Os from "os";\nexport { type Hello as Hi } from "hello";',
+			options: [{ includeExports: true }],
+		},
+		{
+			code: 'import type Os from "os";\nexport default function(){};',
+			options: [{ includeExports: true }],
+		},
+		{
+			code: 'import { type Merge } from "lodash-es";\nexport { Merge as lodashMerge }',
+			options: [{ includeExports: true }],
+		},
+		{
+			code: 'export type { Something } from "os";\nexport * as os from "os";',
+			options: [{ includeExports: true }],
+		},
+		{
+			code: 'import { type Something } from "os";\nexport * as os from "os";',
+			options: [{ includeExports: true }],
+		},
+		{
+			code: 'import type * as Os from "os";\nexport { something } from "os";',
+			options: [{ includeExports: true }],
+		},
+		{
+			code: 'import type Os from "os";\nexport * from "os";',
+			options: [{ includeExports: true }],
+		},
+		{
+			code: 'export type { Something } from "os";\nexport * from "os";',
+			options: [{ includeExports: true }],
+		},
+		{
+			code: 'import { foo, type Bar } from "module";',
+			options: [{ allowSeparateTypeImports: true }],
+		},
+		{
+			code: 'import { foo } from "module";\nimport type { Bar } from "module";',
+			options: [{ allowSeparateTypeImports: true }],
+		},
+		{
+			code: 'import { type Foo } from "module";\nimport type { Bar } from "module";',
+			options: [{ allowSeparateTypeImports: true }],
+		},
+		{
+			code: 'import { foo, type Bar } from "module";\nexport { type Baz } from "module2";',
+			options: [{ allowSeparateTypeImports: true, includeExports: true }],
+		},
+		{
+			code: 'import type { Foo } from "module";\nexport { bar, type Baz } from "module";',
+			options: [{ allowSeparateTypeImports: true, includeExports: true }],
+		},
+		{
+			code: 'import { type Foo } from "module";\nexport type { Bar } from "module";',
+			options: [{ allowSeparateTypeImports: true, includeExports: true }],
+		},
+		{
+			code: 'import type * as Foo from "module";\nexport { type Bar } from "module";',
+			options: [{ allowSeparateTypeImports: true, includeExports: true }],
+		},
+		{
+			code: 'import { type Foo } from "module";\nexport type * as Bar from "module";',
+			options: [{ allowSeparateTypeImports: true, includeExports: true }],
+		},
+	],
+	invalid: [
+		{
+			code: 'import "fs";\nimport "fs"',
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "fs" },
+					type: "ImportDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import { type Merge } from "lodash-es";\nimport { type Find } from "lodash-es";',
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "lodash-es" },
+					type: "ImportDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import { type Merge } from "lodash-es";\nimport type { Find } from "lodash-es";',
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "lodash-es" },
+					type: "ImportDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import type { Merge } from "lodash-es";\nimport type { Find } from "lodash-es";',
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "lodash-es" },
+					type: "ImportDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import type { Merge } from "lodash-es";\nimport type _ from "lodash-es";',
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "lodash-es" },
+					type: "ImportDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import type Os from "os";\nimport type { Something } from "os";\nimport type * as Foobar from "os";',
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "os" },
+					type: "ImportDeclaration",
+				},
+				{
+					messageId: "import",
+					data: { module: "os" },
+					type: "ImportDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import type * as Modns from "lodash-es";\nimport type { Merge } from "lodash-es";\nimport type { Baz } from "lodash-es";',
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "lodash-es" },
+					type: "ImportDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import { type Foo } from "module";\nexport type { Bar } from "module";',
+			options: [{ includeExports: true }],
+			errors: [
+				{
+					messageId: "exportAs",
+					data: { module: "module" },
+					type: "ExportNamedDeclaration",
+				},
+			],
+		},
+		{
+			code: 'export { os } from "os";\nexport type { Something } from "os";',
+			options: [{ includeExports: true }],
+			errors: [
+				{
+					messageId: "export",
+					data: { module: "os" },
+					type: "ExportNamedDeclaration",
+				},
+			],
+		},
+		{
+			code: 'export type { Os } from "os";\nexport type { Something } from "os";',
+			options: [{ includeExports: true }],
+			errors: [
+				{
+					messageId: "export",
+					data: { module: "os" },
+					type: "ExportNamedDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import type { Os } from "os";\nexport type { Os as Foobar } from "os";\nexport type { Something } from "os";',
+			options: [{ includeExports: true }],
+			errors: [
+				{
+					messageId: "exportAs",
+					data: { module: "os" },
+					type: "ExportNamedDeclaration",
+				},
+				{
+					messageId: "export",
+					data: { module: "os" },
+					type: "ExportNamedDeclaration",
+				},
+				{
+					messageId: "exportAs",
+					data: { module: "os" },
+					type: "ExportNamedDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import type { Os } from "os";\nexport type { Something } from "os";',
+			options: [{ includeExports: true }],
+			errors: [
+				{
+					messageId: "exportAs",
+					data: { module: "os" },
+					type: "ExportNamedDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import type Os from "os";\nexport type * as Os from "os";',
+			options: [{ includeExports: true }],
+			errors: [
+				{
+					messageId: "exportAs",
+					data: { module: "os" },
+					type: "ExportAllDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import type * as Modns from "mod";\nexport type * as Modns from "mod";',
+			options: [{ includeExports: true }],
+			errors: [
+				{
+					messageId: "exportAs",
+					data: { module: "mod" },
+					type: "ExportAllDeclaration",
+				},
+			],
+		},
+		{
+			code: 'export type * from "os";\nexport type * from "os";',
+			options: [{ includeExports: true }],
+			errors: [
+				{
+					messageId: "export",
+					data: { module: "os" },
+					type: "ExportAllDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import "os";\nexport type { Os } from "os";',
+			options: [{ includeExports: true }],
+			errors: [
+				{
+					messageId: "exportAs",
+					data: { module: "os" },
+					type: "ExportNamedDeclaration",
+				},
+			],
+		},
+		{
+			code: "import { someValue } from 'module';\nimport { anotherValue } from 'module';",
+			options: [{ allowSeparateTypeImports: true }],
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "module" },
+					type: "ImportDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import type { Merge } from "lodash-es";\nimport type { Find } from "lodash-es";',
+			options: [{ allowSeparateTypeImports: true }],
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "lodash-es" },
+					type: "ImportDeclaration",
+				},
+			],
+		},
+		{
+			code: "import { someValue, type Foo } from 'module';\nimport type { SomeType } from 'module';\nimport type { AnotherType } from 'module';",
+			options: [{ allowSeparateTypeImports: true }],
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "module" },
+					type: "ImportDeclaration",
+				},
+			],
+		},
+		{
+			code: "import { type Foo } from 'module';\nimport { type Bar } from 'module';",
+			options: [{ allowSeparateTypeImports: true }],
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "module" },
+					type: "ImportDeclaration",
+				},
+			],
+		},
+		{
+			code: 'export type { Foo } from "module";\nexport type { Bar } from "module";',
+			options: [{ allowSeparateTypeImports: true, includeExports: true }],
+			errors: [
+				{
+					messageId: "export",
+					data: { module: "module" },
+					type: "ExportNamedDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import { type Foo } from "module";\nexport { type Bar } from "module";\nexport { type Baz } from "module";',
+			options: [{ allowSeparateTypeImports: true, includeExports: true }],
+			errors: [
+				{
+					messageId: "exportAs",
+					data: { module: "module" },
+					type: "ExportNamedDeclaration",
+				},
+				{
+					messageId: "export",
+					data: { module: "module" },
+					type: "ExportNamedDeclaration",
+				},
+				{
+					messageId: "exportAs",
+					data: { module: "module" },
+					type: "ExportNamedDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import { type Foo } from "module";\nexport { type Bar } from "module";\nexport { regular } from "module";',
+			options: [{ allowSeparateTypeImports: true, includeExports: true }],
+			errors: [
+				{
+					messageId: "exportAs",
+					data: { module: "module" },
+					type: "ExportNamedDeclaration",
+				},
+				{
+					messageId: "export",
+					data: { module: "module" },
+					type: "ExportNamedDeclaration",
+				},
+				{
+					messageId: "exportAs",
+					data: { module: "module" },
+					type: "ExportNamedDeclaration",
+				},
+			],
+		},
+		{
+			code: 'import { type Foo } from "module";\nimport { regular } from "module";\nexport { type Bar } from "module";\nexport { regular as other } from "module";',
+			options: [{ allowSeparateTypeImports: true, includeExports: true }],
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "module" },
+					type: "ImportDeclaration",
+				},
+				{
+					messageId: "exportAs",
+					data: { module: "module" },
+					type: "ExportNamedDeclaration",
+				},
+				{
+					messageId: "export",
+					data: { module: "module" },
+					type: "ExportNamedDeclaration",
+				},
+				{
+					messageId: "exportAs",
+					data: { module: "module" },
+					type: "ExportNamedDeclaration",
+				},
+			],
+		},
+	],
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added a new allowSeparateTypeImports option to the no-duplicate-imports rule that allows a type import alongside a value import from the same module in TypeScript files.

Closes #19834
 
#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
