### PR TITLE
fix: Add support for component syntax to code-path-analyzer

### DIFF
--- a/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -144,6 +144,7 @@ function isIdentifierReference(node) {
 			return false;
 
 		case "FunctionDeclaration":
+		case "ComponentDeclaration":
 		case "FunctionExpression":
 		case "ArrowFunctionExpression":
 		case "ClassDeclaration":
@@ -445,6 +446,7 @@ function processCodePathToEnter(analyzer, node) {
 			break;
 
 		case "FunctionDeclaration":
+		case "ComponentDeclaration":
 		case "FunctionExpression":
 		case "ArrowFunctionExpression":
 			startCodePath("function");
@@ -693,6 +695,7 @@ function postprocess(analyzer, node) {
 	switch (node.type) {
 		case "Program":
 		case "FunctionDeclaration":
+		case "ComponentDeclaration":
 		case "FunctionExpression":
 		case "ArrowFunctionExpression":
 		case "StaticBlock": {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This change updates `code-path-analyzer` to support [component syntax](https://flow.org/en/docs/react/component-syntax/), which is the primary method of writing React components at Meta. 

In particular, any rules which rely on `onCodePathStart` / `onCodePathEnd` don't trigger correctly when using component syntax.

For example, given the following components:
```
export component ComponentWithUnreachableLoop() {
  for (let i = 0; i < 100; i++) {
    break;
  }
  return null;
}

export component ComponentWithFunctionWithUnreachableLoop() {
  function loop() {
    for (let i = 0; i < 100; i++) {
      break;
    }
  }
  loop();
  return null;
}
```

the `no-unreachable-loop` rule would only trigger on the 2nd component, but not the first one. This is because, for the first component, the start of the component's body is represented by a `ComponentDeclaration` node and so currently nothing is starting a new code path nor ending a code path. In the 2nd case, it triggers correctly because we have an additional function wrapper, and so the `FunctionDeclaration` properly begins and ends the code path.

With the changes from this PR, the first component now properly triggers the lint warning:
![image](https://github.com/user-attachments/assets/90e37750-8491-4060-9749-38056d74391e)


#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
