### PR TITLE
feat: support explicit resource management in `no-undef-init`

### DIFF
--- a/docs/src/rules/no-undef-init.md
+++ b/docs/src/rules/no-undef-init.md
@@ -54,7 +54,7 @@ let bar;
 
 :::
 
-Please note that this rule does not check `const` declarations, destructuring patterns, function parameters, and class fields.
+Please note that this rule does not check `const` declarations, `using` declarations, `await using` declarations, destructuring patterns, function parameters, and class fields.
 
 Examples of additional **correct** code for this rule:
 
@@ -64,6 +64,10 @@ Examples of additional **correct** code for this rule:
 /*eslint no-undef-init: "error"*/
 
 const foo = undefined;
+
+using foo1 = undefined;
+
+await using foo2 = undefined;
 
 let { bar = undefined } = baz;
 
@@ -159,7 +163,7 @@ Another such case is when a variable is redeclared using `var`. For example:
 function foo() {
     var x = 1;
     console.log(x); // output: 1
-    
+
     var x;
     console.log(x); // output: 1
 

--- a/lib/rules/no-undef-init.js
+++ b/lib/rules/no-undef-init.js
@@ -5,7 +5,17 @@
 
 "use strict";
 
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
 const astUtils = require("./utils/ast-utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const CONSTANT_BINDINGS = new Set(["const", "using", "await using"]);
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -49,7 +59,7 @@ module.exports = {
 
 				if (
 					init === "undefined" &&
-					node.parent.kind !== "const" &&
+					!CONSTANT_BINDINGS.has(node.parent.kind) &&
 					!shadowed
 				) {
 					context.report({

--- a/tests/lib/rules/no-undef-init.js
+++ b/tests/lib/rules/no-undef-init.js
@@ -22,6 +22,14 @@ ruleTester.run("no-undef-init", rule, {
 	valid: [
 		"var a;",
 		{ code: "const foo = undefined", languageOptions: { ecmaVersion: 6 } },
+		{
+			code: "using foo = undefined",
+			languageOptions: { ecmaVersion: 2026 },
+		},
+		{
+			code: "await using foo = undefined",
+			languageOptions: { ecmaVersion: 2026 },
+		},
 		"var undefined = 5; var foo = undefined;",
 
 		// doesn't apply to class fields


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #19792, adds support for explicit resource management to the `no-undef-init` rule.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updates the `no-undef-init` rule to not report on initializing `using` and `await using` variables to `undefined`.

#### Is there anything you'd like reviewers to focus on?

Omitting the initializer would be a syntax error. Whether or not it makes sense to unconditionally initialize `using` and `await using` variables to `undefined` shouldn't be a responsibility of this rule, I think, because this rule is just stylistic. We could consider adding another rule that disallows this pattern as a possible error.

<!-- markdownlint-disable-file MD004 -->
