### PR TITLE
feat: support explicit resource management in `no-loop-func`

### DIFF
--- a/docs/src/rules/no-loop-func.md
+++ b/docs/src/rules/no-loop-func.md
@@ -126,19 +126,19 @@ for (using i of foo) {
 }
 
 for (var i=10; i; i--) {
-	const foo = getsomething(i);
+    const foo = getsomething(i);
     var a = function() { return foo; }; // OK, all references are referring to block scoped variables in the loop.
     a();
 }
 
 for (var i=10; i; i--) {
-	using foo = getsomething(i);
+    using foo = getsomething(i);
     var a = function() { return foo; }; // OK, all references are referring to block scoped variables in the loop.
     a();
 }
 
 for (var i=10; i; i--) {
-	await using foo = getsomething(i);
+    await using foo = getsomething(i);
     var a = function() { return foo; }; // OK, all references are referring to block scoped variables in the loop.
     a();
 }

--- a/docs/src/rules/no-loop-func.md
+++ b/docs/src/rules/no-loop-func.md
@@ -115,6 +115,34 @@ for (let i=10; i; i--) {
     a();
 }
 
+for (const i of foo) {
+    var a = function() { return i; }; // OK, all references are referring to block scoped variables in the loop.
+    a();
+}
+
+for (using i of foo) {
+    var a = function() { return i; }; // OK, all references are referring to block scoped variables in the loop.
+    a();
+}
+
+for (var i=10; i; i--) {
+	const foo = getsomething(i);
+    var a = function() { return foo; }; // OK, all references are referring to block scoped variables in the loop.
+    a();
+}
+
+for (var i=10; i; i--) {
+	using foo = getsomething(i);
+    var a = function() { return foo; }; // OK, all references are referring to block scoped variables in the loop.
+    a();
+}
+
+for (var i=10; i; i--) {
+	await using foo = getsomething(i);
+    var a = function() { return foo; }; // OK, all references are referring to block scoped variables in the loop.
+    a();
+}
+
 var foo = 100;
 for (let i=10; i; i--) {
     var a = function() { return foo; }; // OK, all references are referring to never modified variables.

--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -9,6 +9,8 @@
 // Helpers
 //------------------------------------------------------------------------------
 
+const CONSTANT_BINDINGS = new Set(["const", "using", "await using"]);
+
 /**
  * Identifies is a node is a FunctionExpression which is part of an IIFE
  * @param {ASTNode} node Node to test
@@ -148,8 +150,8 @@ module.exports = {
 					? declaration.kind
 					: "";
 
-			// Variables which are declared by `const` is safe.
-			if (kind === "const") {
+			// Constant variables are safe.
+			if (CONSTANT_BINDINGS.has(kind)) {
 				return true;
 			}
 

--- a/tests/lib/rules/no-loop-func.js
+++ b/tests/lib/rules/no-loop-func.js
@@ -51,6 +51,22 @@ ruleTester.run("no-loop-func", rule, {
 			languageOptions: { ecmaVersion: 6 },
 		},
 		{
+			code: "for (using i of foo) { (function() { i; }) }",
+			languageOptions: { ecmaVersion: 2026 },
+		},
+		{
+			code: "for (await using i of foo) { (function() { i; }) }",
+			languageOptions: { ecmaVersion: 2026 },
+		},
+		{
+			code: "for (var i = 0; i < 10; ++i) { using foo = bar(i); (function() { foo; }) }",
+			languageOptions: { ecmaVersion: 2026 },
+		},
+		{
+			code: "for (var i = 0; i < 10; ++i) { await using foo = bar(i); (function() { foo; }) }",
+			languageOptions: { ecmaVersion: 2026 },
+		},
+		{
 			code: "for (let i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }",
 			languageOptions: { ecmaVersion: 6 },
 		},
@@ -170,7 +186,7 @@ ruleTester.run("no-loop-func", rule, {
                 current.c;
                 current.d;
             })();
-            
+
             current = current.upper;
             }
             `,
@@ -207,6 +223,42 @@ ruleTester.run("no-loop-func", rule, {
             }
             `,
 			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: `
+            const foo = bar;
+
+            for (var i = 0; i < 5; i++) {
+                arr.push(() => foo);
+            }
+
+			foo = baz; // This is a runtime error, but not concern of this rule. For this rule, variable 'foo' is constant.
+            `,
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: `
+            using foo = bar;
+
+            for (var i = 0; i < 5; i++) {
+                arr.push(() => foo);
+            }
+
+			foo = baz; // This is a runtime error, but not concern of this rule. For this rule, variable 'foo' is constant.
+            `,
+			languageOptions: { ecmaVersion: 2026 },
+		},
+		{
+			code: `
+            await using foo = bar;
+
+            for (var i = 0; i < 5; i++) {
+                arr.push(() => foo);
+            }
+
+			foo = baz; // This is a runtime error, but not concern of this rule. For this rule, variable 'foo' is constant.
+            `,
+			languageOptions: { ecmaVersion: 2026 },
 		},
 	],
 	invalid: [
@@ -471,7 +523,7 @@ ruleTester.run("no-loop-func", rule, {
                     current;
                     arr.push(f);
                 })();
-                
+
                 current = current.upper;
             }
             `,
@@ -615,7 +667,7 @@ ruleTester.run("no-loop-func", rule, {
 
             for (var i = 0; i < 5; i++) {
                 arr.push((() => {
-                    return () => 
+                    return () =>
                         (() => i)();
                 })());
             }
@@ -666,7 +718,7 @@ ruleTester.run("no-loop-func", rule, {
                         return i;
                     })();
                 })();
-            
+
             }
             `,
 			languageOptions: { ecmaVersion: 2022 },
@@ -839,7 +891,7 @@ ruleTesterTypeScript.run("no-loop-func", rule, {
       // ConfiguredType is in globals, UnconfiguredType is not
       // Both should be considered safe as they are type references
       const process = (configItem: ConfiguredType, unconfigItem: UnconfiguredType) => {
-        return { 
+        return {
           config: configItem.value,
           unconfig: unconfigItem.value
         };
@@ -892,14 +944,14 @@ ruleTesterTypeScript.run("no-loop-func", rule, {
     id: number;
     name: string;
   }
-  
+
   const items: Item[] = [];
   for (var i = 0; i < 10; i++) {
     items.push({
       id: i,
       name: "Item " + i
     });
-    
+
     const process = function(callback: (item: Item) => void): void {
       callback({ id: i, name: "Item " + i });
     };
@@ -916,7 +968,7 @@ ruleTesterTypeScript.run("no-loop-func", rule, {
 		{
 			code: `
   type Processor<T> = (item: T) => void;
-		
+
   for (var i = 0; i < 10; i++) {
     const processor: Processor<number> = (item) => {
       return item + i;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #19792, adds support for explicit resource management to the `no-loop-func` rule.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updates the `no-loop-func` rule to not report on references to `using` and `await using` variables, because they are constant.

#### Is there anything you'd like reviewers to focus on?

For `using`/`await using` variables declared inside the loop body, it might make sense to warn when they are referenced from a function because they might be used after the loop, which would be after the disposal. However, I don't think this potential error is specific to loops, but to any blocks. Thus, I think the mentioned is out of scope for this rule, which targets cases where the referenced variables are reassigned.

<!-- markdownlint-disable-file MD004 -->
