### PR TITLE
fix: allow separate default and named type imports

### DIFF
--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -66,6 +66,17 @@ function isImportExportCanBeMerged(node1, node2) {
 	const importExportType1 = getImportExportType(node1);
 	const importExportType2 = getImportExportType(node2);
 
+	if (node1.importKind === "type" && node2.importKind === "type") {
+		const isDefault1 = importExportType1 === "ImportDefaultSpecifier";
+		const isDefault2 = importExportType2 === "ImportDefaultSpecifier";
+		const isNamed1 = isImportExportSpecifier(importExportType1, "named");
+		const isNamed2 = isImportExportSpecifier(importExportType2, "named");
+
+		if ((isDefault1 && isNamed2) || (isDefault2 && isNamed1)) {
+			return false;
+		}
+	}
+
 	if (
 		(importExportType1 === "ExportAll" &&
 			importExportType2 !== "ExportAll" &&

--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -66,7 +66,10 @@ function isImportExportCanBeMerged(node1, node2) {
 	const importExportType1 = getImportExportType(node1);
 	const importExportType2 = getImportExportType(node2);
 
-	if (node1.importKind === "type" && node2.importKind === "type") {
+	if (
+		(node1.importKind === "type" || node1.exportKind === "type") &&
+		(node2.importKind === "type" || node2.exportKind === "type")
+	) {
 		const isDefault1 = importExportType1 === "ImportDefaultSpecifier";
 		const isDefault2 = importExportType2 === "ImportDefaultSpecifier";
 		const isNamed1 = isImportExportSpecifier(importExportType1, "named");

--- a/tests/lib/rules/no-duplicate-imports.js
+++ b/tests/lib/rules/no-duplicate-imports.js
@@ -247,6 +247,7 @@ ruleTesterTypeScript.run("no-duplicate-imports", rule, {
 		'import type * as Bar from "os";\nimport { type Baz } from "os";',
 		'import foo, * as bar from "os";\nimport { type Baz } from "os";',
 		'import foo, { type bar } from "os";\nimport type * as Baz from "os";',
+		'import type { Merge } from "lodash-es";\nimport type _ from "lodash-es";',
 		{
 			code: 'import type Os from "os";\nexport { type Hello } from "hello";',
 			options: [{ includeExports: true }],
@@ -362,23 +363,8 @@ ruleTesterTypeScript.run("no-duplicate-imports", rule, {
 			],
 		},
 		{
-			code: 'import type { Merge } from "lodash-es";\nimport type _ from "lodash-es";',
-			errors: [
-				{
-					messageId: "import",
-					data: { module: "lodash-es" },
-					type: "ImportDeclaration",
-				},
-			],
-		},
-		{
 			code: 'import type Os from "os";\nimport type { Something } from "os";\nimport type * as Foobar from "os";',
 			errors: [
-				{
-					messageId: "import",
-					data: { module: "os" },
-					type: "ImportDeclaration",
-				},
 				{
 					messageId: "import",
 					data: { module: "os" },

--- a/tests/lib/rules/no-duplicate-imports.js
+++ b/tests/lib/rules/no-duplicate-imports.js
@@ -285,6 +285,10 @@ ruleTesterTypeScript.run("no-duplicate-imports", rule, {
 			options: [{ includeExports: true }],
 		},
 		{
+			code: 'import type Os from "os";\nexport type { Something } from "os";',
+			options: [{ includeExports: true }],
+		},
+		{
 			code: 'export type { Something } from "os";\nexport * from "os";',
 			options: [{ includeExports: true }],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

This PR fixes a false positive in no-duplicate-imports rule where it incorrectly flagged separate default and named TypeScript type imports as duplicates. Since TypeScript syntax prohibits combining these into a single import statement, the rule should allow them to coexist without warnings.

#### What changes did you make? (Give an overview)

- Fixed no-duplicate-imports rule to not flag separate default + named type imports (e.g., import type A from "a"; import type { B } from "a") as duplicates.
- Updated tests to verify the new behavior.

Fixes #19898

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
