### PR TITLE
fix: Remove incorrect RuleContext types

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1186,25 +1186,7 @@ export namespace Rule {
 			RuleOptions: any[];
 			Node: JSSyntaxElement;
 			MessageIds: string;
-		}> {
-		/*
-		 * Need to extend the `RuleContext` interface to include the
-		 * deprecated methods that have not yet been removed.
-		 * TODO: Remove in v10.0.0.
-		 */
-
-		/** @deprecated Use `sourceCode.getAncestors()` instead */
-		getAncestors(): ESTree.Node[];
-
-		/** @deprecated Use `sourceCode.getDeclaredVariables()` instead */
-		getDeclaredVariables(node: ESTree.Node): Scope.Variable[];
-
-		/** @deprecated Use `sourceCode.getScope()` instead */
-		getScope(): Scope.Scope;
-
-		/** @deprecated Use `sourceCode.markVariableAsUsed()` instead */
-		markVariableAsUsed(name: string): boolean;
-	}
+		}> {}
 
 	type ReportFixer = (
 		fixer: RuleFixer,

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -625,10 +625,6 @@ rule = {
 
 rule = {
 	create(context: Rule.RuleContext) {
-		context.getAncestors();
-
-		context.getDeclaredVariables(AST);
-
 		context.filename;
 
 		context.getFilename();
@@ -653,15 +649,11 @@ rule = {
 		context.getSourceCode();
 		context.getSourceCode().getLocFromIndex(42);
 
-		context.getScope();
-
 		if (typeof context.parserPath === "string") {
 			context.parserPath;
 		} else {
 			context.languageOptions?.parser;
 		}
-
-		context.markVariableAsUsed("foo");
 
 		// @ts-expect-error wrong `node` type
 		context.report({ message: "foo", node: {} });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed type definitions and related tests for:

- `context.getAncestors()`
- `context.getDeclaredVariables(AST)`
- `context.getScope()`
- `context.markVariableAsUsed("foo")`

fixes #19903

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
