### PR TITLE
fix: retry on EMFILE when writing autofix results

### DIFF
--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -530,6 +530,11 @@ class ESLint {
 			throw new Error("'results' must be an array");
 		}
 
+		const retryCodes = new Set(["ENFILE", "EMFILE"]);
+		const retrier = new Retrier(error => retryCodes.has(error.code), {
+			concurrency: 100,
+		});
+
 		await Promise.all(
 			results
 				.filter(result => {
@@ -541,7 +546,9 @@ class ESLint {
 						path.isAbsolute(result.filePath)
 					);
 				})
-				.map(r => fs.writeFile(r.filePath, r.output)),
+				.map(r =>
+					retrier.retry(() => fs.writeFile(r.filePath, r.output)),
+				),
 		);
 	}
 

--- a/tests/fixtures/emfile/eslint.config.js
+++ b/tests/fixtures/emfile/eslint.config.js
@@ -1,5 +1,5 @@
 module.exports = {
     rules: {
-        "no-unused-vars": "error"
+        "capitalized-comments": "error"
     }
 };

--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -102,6 +102,13 @@ execSync(
 );
 console.log("✅ No errors encountered running ESLint.");
 
+console.log("Running ESLint with --fix...");
+execSync(
+	`node bin/eslint.js ${OUTPUT_DIRECTORY} --fix --no-config-lookup --rule "eol-last: [error, always]"`,
+	{ stdio: "inherit" },
+);
+console.log("✅ No errors encountered running ESLint with --fix.");
+
 console.log(
 	"Checking that this number of files would cause an EMFILE error...",
 );

--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -63,7 +63,7 @@ function generateFiles() {
 
 	for (let i = 0; i < FILE_COUNT; i++) {
 		const fileName = `file_${i}.js`;
-		const fileContent = `// This is file ${i}`;
+		const fileContent = `// this is file ${i}`;
 
 		fs.writeFileSync(`${OUTPUT_DIRECTORY}/${fileName}`, fileContent);
 	}
@@ -97,17 +97,10 @@ generateFiles();
 
 console.log("Running ESLint...");
 execSync(
-	`node bin/eslint.js ${OUTPUT_DIRECTORY} -c ${CONFIG_DIRECTORY}/eslint.config.js`,
+	`node bin/eslint.js ${OUTPUT_DIRECTORY} -c ${CONFIG_DIRECTORY}/eslint.config.js --fix`,
 	{ stdio: "inherit" },
 );
 console.log("✅ No errors encountered running ESLint.");
-
-console.log("Running ESLint with --fix...");
-execSync(
-	`node bin/eslint.js ${OUTPUT_DIRECTORY} --fix --no-config-lookup --rule "eol-last: [error, always]"`,
-	{ stdio: "inherit" },
-);
-console.log("✅ No errors encountered running ESLint with --fix.");
 
 console.log(
 	"Checking that this number of files would cause an EMFILE error...",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added retry logic to the `outputFixes` method to handle EMFILE errors when writing autofix results. This prevents ESLint from crashing if the system runs out of file descriptors during autofix operations.

Fixes #19924

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
