### PR TITLE
feat: add ternary-spacing rule (#19928)

### DIFF
--- a/docs/src/_data/further_reading_links.json
+++ b/docs/src/_data/further_reading_links.json
@@ -1,800 +1,800 @@
 {
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "setter - JavaScript | MDN",
-        "description": "The set syntax binds an object property to a function to be called when there is an attempt to set that property."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "getter - JavaScript | MDN",
-        "description": "The get syntax binds an object property to a function that will be called when that property is looked up."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Working with objects - JavaScript | MDN",
-        "description": "JavaScript is designed on a simple object-based paradigm. An object is a collection of properties, and a property is an association between a name (or key) and a value. A property’s value can be a function, in which case the property is known as a method. In addition to objects that are predefined i…"
-    },
-    "https://github.com/airbnb/javascript#arrows--one-arg-parens": {
-        "domain": "github.com",
-        "url": "https://github.com/airbnb/javascript#arrows--one-arg-parens",
-        "logo": "https://github.com/fluidicon.png",
-        "title": "GitHub - airbnb/javascript: JavaScript Style Guide",
-        "description": "JavaScript Style Guide. Contribute to airbnb/javascript development by creating an account on GitHub."
-    },
-    "https://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html": {
-        "domain": "www.adequatelygood.com",
-        "url": "https://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html",
-        "logo": "https://www.adequatelygood.com/favicon.ico",
-        "title": "JavaScript Scoping and Hoisting",
-        "description": null
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "var - JavaScript | MDN",
-        "description": "The var statement declares a function-scoped or globally-scoped variable, optionally initializing it to a value."
-    },
-    "https://en.wikipedia.org/wiki/Indent_style": {
-        "domain": "en.wikipedia.org",
-        "url": "https://en.wikipedia.org/wiki/Indent_style",
-        "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
-        "title": "Indentation style - Wikipedia",
-        "description": null
-    },
-    "https://github.com/maxogden/art-of-node#callbacks": {
-        "domain": "github.com",
-        "url": "https://github.com/maxogden/art-of-node#callbacks",
-        "logo": "https://github.com/fluidicon.png",
-        "title": "GitHub - maxogden/art-of-node: a short introduction to node.js",
-        "description": ":snowflake: a short introduction to node.js. Contribute to maxogden/art-of-node development by creating an account on GitHub."
-    },
-    "https://web.archive.org/web/20171224042620/https://docs.nodejitsu.com/articles/errors/what-are-the-error-conventions/": {
-        "domain": "web.archive.org",
-        "url": "https://web.archive.org/web/20171224042620/https://docs.nodejitsu.com/articles/errors/what-are-the-error-conventions/",
-        "logo": "https://archive.org/favicon.ico",
-        "title": "What are the error conventions? - docs.nodejitsu.com",
-        "description": "docs.nodejitsu.com is a growing collection of how-to articles for node.js, written by the community and curated by Nodejitsu and friends. These articles range from basic to advanced, and provide relevant code samples and insights into the design and philosophy of node itself."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Classes - JavaScript | MDN",
-        "description": "Classes are a template for creating objects. They encapsulate data with code to work on that data. Classes in JS are built on prototypes but also have some syntax and semantics that are not shared with ES5 class-like semantics."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "static - JavaScript | MDN",
-        "description": "The static keyword defines a static method or property for a class, or a class static initialization block (see the link for more information about this usage). Neither static methods nor static properties can be called on instances of the class. Instead, they’re called on the class itself."
-    },
-    "https://www.crockford.com/code.html": {
-        "domain": "www.crockford.com",
-        "url": "https://www.crockford.com/code.html",
-        "logo": "https://www.crockford.com/favicon.png",
-        "title": "Code Conventions for the JavaScript Programming Language",
-        "description": null
-    },
-    "https://dojotoolkit.org/reference-guide/1.9/developer/styleguide.html": {
-        "domain": "dojotoolkit.org",
-        "url": "https://dojotoolkit.org/reference-guide/1.9/developer/styleguide.html",
-        "logo": "https://dojotoolkit.org/images/favicons/apple-touch-icon-152x152.png",
-        "title": "Dojo Style Guide — The Dojo Toolkit - Reference Guide",
-        "description": null
-    },
-    "https://gist.github.com/isaacs/357981": {
-        "domain": "gist.github.com",
-        "url": "https://gist.github.com/isaacs/357981",
-        "logo": "https://gist.github.com/fluidicon.png",
-        "title": "A better coding convention for lists and object literals in JavaScript",
-        "description": "A better coding convention for lists and object literals in JavaScript - comma-first-var.js"
-    },
-    "https://en.wikipedia.org/wiki/Cyclomatic_complexity": {
-        "domain": "en.wikipedia.org",
-        "url": "https://en.wikipedia.org/wiki/Cyclomatic_complexity",
-        "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
-        "title": "Cyclomatic complexity - Wikipedia",
-        "description": null
-    },
-    "https://ariya.io/2012/12/complexity-analysis-of-javascript-code": {
-        "domain": "ariya.io",
-        "url": "https://ariya.io/2012/12/complexity-analysis-of-javascript-code",
-        "logo": "https://ariya.io/favicon.ico",
-        "title": "Complexity Analysis of JavaScript Code",
-        "description": "Nobody likes to read complex code, especially if it’s someone’s else code. A preventive approach to block any complex code entering the application is by watching its complexity carefully."
-    },
-    "https://craftsmanshipforsoftware.com/2015/05/25/complexity-for-javascript/": {
-        "domain": "craftsmanshipforsoftware.com",
-        "url": "https://craftsmanshipforsoftware.com/2015/05/25/complexity-for-javascript/",
-        "logo": "https://s0.wp.com/i/webclip.png",
-        "title": "Complexity for JavaScript",
-        "description": "The control of complexity control presents the core problem of software development. The huge variety of decisions a developer faces on a day-to-day basis cry for methods of controlling and contain…"
-    },
-    "https://web.archive.org/web/20160808115119/http://jscomplexity.org/complexity": {
-        "domain": "web.archive.org",
-        "url": "https://web.archive.org/web/20160808115119/http://jscomplexity.org/complexity",
-        "logo": "https://archive.org/favicon.ico",
-        "title": "About complexity | JSComplexity.org",
-        "description": "A discussion of software complexity metrics and how they are calculated."
-    },
-    "https://github.com/eslint/eslint/issues/4808#issuecomment-167795140": {
-        "domain": "github.com",
-        "url": "https://github.com/eslint/eslint/issues/4808#issuecomment-167795140",
-        "logo": "https://github.com/fluidicon.png",
-        "title": "Complexity has no default · Issue #4808 · eslint/eslint",
-        "description": "Enabling the complexity rule with only a severity has no effect. We have tried to give sane defaults to all rules, and I think this should be no exception. I don&#39;t know what a good number would..."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "switch - JavaScript | MDN",
-        "description": "The switch statement evaluates an expression, matching the expression’s value to a case clause, and executes statements associated with that case, as well as statements in cases that follow the matching case."
-    },
-    "https://web.archive.org/web/20201112040809/http://markdaggett.com/blog/2013/02/15/functions-explained/": {
-        "domain": "web.archive.org",
-        "url": "https://web.archive.org/web/20201112040809/http://markdaggett.com/blog/2013/02/15/functions-explained/",
-        "logo": "https://web.archive.org/web/20201112040809im_/http://markdaggett.com/favicon.ico",
-        "title": "Functions Explained - Mark Daggett’s Blog",
-        "description": "A Deep Dive into JavaScript Functions\nBased on my readership I have to assume most of you are familiar with JavaScript already. Therefore, it may …"
-    },
-    "https://2ality.com/2015/09/function-names-es6.html": {
-        "domain": "2ality.com",
-        "url": "https://2ality.com/2015/09/function-names-es6.html",
-        "logo": "https://2ality.com/img/favicon.png",
-        "title": "The names of functions in ES6",
-        "description": null
-    },
-    "https://leanpub.com/understandinges6/read/#leanpub-auto-generators": {
-        "domain": "leanpub.com",
-        "url": "https://leanpub.com/understandinges6/read/#leanpub-auto-generators",
-        "logo": "https://leanpub.com/understandinges6/read/favicons/mstile-310x310.png",
-        "title": "Read Understanding ECMAScript 6 | Leanpub",
-        "description": null
-    },
-    "https://leanpub.com/understandinges6/read/#leanpub-auto-accessor-properties": {
-        "domain": "leanpub.com",
-        "url": "https://leanpub.com/understandinges6/read/#leanpub-auto-accessor-properties",
-        "logo": "https://leanpub.com/understandinges6/read/favicons/mstile-310x310.png",
-        "title": "Read Understanding ECMAScript 6 | Leanpub",
-        "description": null
-    },
-    "https://javascriptweblog.wordpress.com/2011/01/04/exploring-javascript-for-in-loops/": {
-        "domain": "javascriptweblog.wordpress.com",
-        "url": "https://javascriptweblog.wordpress.com/2011/01/04/exploring-javascript-for-in-loops/",
-        "logo": "https://s1.wp.com/i/favicon.ico",
-        "title": "Exploring JavaScript for-in loops",
-        "description": "The for-in loop is the only cross-browser technique for iterating the properties of generic objects. There’s a bunch of literature about the dangers of using for-in to iterate arrays and when…"
-    },
-    "https://2ality.com/2012/01/objects-as-maps.html": {
-        "domain": "2ality.com",
-        "url": "https://2ality.com/2012/01/objects-as-maps.html",
-        "logo": "https://2ality.com/img/favicon.png",
-        "title": "The pitfalls of using objects as maps in JavaScript",
-        "description": null
-    },
-    "https://web.archive.org/web/20160725154648/http://www.mind2b.com/component/content/article/24-software-module-size-and-file-size": {
-        "domain": "web.archive.org",
-        "url": "https://web.archive.org/web/20160725154648/http://www.mind2b.com/component/content/article/24-software-module-size-and-file-size",
-        "logo": "https://archive.org/favicon.ico",
-        "title": "Software Module size and file size",
-        "description": null
-    },
-    "http://book.mixu.net/node/ch7.html": {
-        "domain": "book.mixu.net",
-        "url": "http://book.mixu.net/node/ch7.html",
-        "logo": null,
-        "title": "7. Control flow - Mixu’s Node book",
-        "description": null
-    },
-    "https://web.archive.org/web/20220104141150/https://howtonode.org/control-flow": {
-        "domain": "web.archive.org",
-        "url": "https://web.archive.org/web/20220104141150/https://howtonode.org/control-flow",
-        "logo": "https://web.archive.org/web/20220104141150im_/https://howtonode.org/favicon.ico",
-        "title": "Control Flow in Node - How To Node - NodeJS",
-        "description": "Learn the zen of coding in NodeJS."
-    },
-    "https://web.archive.org/web/20220127215850/https://howtonode.org/control-flow-part-ii": {
-        "domain": "web.archive.org",
-        "url": "https://web.archive.org/web/20220127215850/https://howtonode.org/control-flow-part-ii",
-        "logo": "https://web.archive.org/web/20220127215850im_/https://howtonode.org/favicon.ico",
-        "title": "Control Flow in Node Part II - How To Node - NodeJS",
-        "description": "Learn the zen of coding in NodeJS."
-    },
-    "https://nodejs.org/api/buffer.html": {
-        "domain": "nodejs.org",
-        "url": "https://nodejs.org/api/buffer.html",
-        "logo": "https://nodejs.org/favicon.ico",
-        "title": "Buffer | Node.js v18.2.0 Documentation",
-        "description": null
-    },
-    "https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md": {
-        "domain": "github.com",
-        "url": "https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md",
-        "logo": "https://github.com/fluidicon.png",
-        "title": "notes/Lets-fix-Buffer-API.md at master · ChALkeR/notes",
-        "description": "Some public notes. Contribute to ChALkeR/notes development by creating an account on GitHub."
-    },
-    "https://github.com/nodejs/node/issues/4660": {
-        "domain": "github.com",
-        "url": "https://github.com/nodejs/node/issues/4660",
-        "logo": "https://github.com/fluidicon.png",
-        "title": "Buffer(number) is unsafe · Issue #4660 · nodejs/node",
-        "description": "tl;dr This issue proposes: Change new Buffer(number) to return safe, zeroed-out memory Create a new API for creating uninitialized Buffers, Buffer.alloc(number) Update: Jan 15, 2016 Upon further co..."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "debugger - JavaScript | MDN",
-        "description": "The debugger statement invokes any available debugging functionality, such as setting a breakpoint. If no debugging functionality is available, this statement has no effect."
-    },
-    "https://ericlippert.com/2003/11/01/eval-is-evil-part-one/": {
-        "domain": "ericlippert.com",
-        "url": "https://ericlippert.com/2003/11/01/eval-is-evil-part-one/",
-        "logo": "https://s1.wp.com/i/favicon.ico",
-        "title": "Eval is evil, part one",
-        "description": "The eval method — which takes a string containing JScript code, compiles it and runs it — is probably the most powerful and most misused method in JScript. There are a few scenarios in …"
-    },
-    "https://javascriptweblog.wordpress.com/2010/04/19/how-evil-is-eval/": {
-        "domain": "javascriptweblog.wordpress.com",
-        "url": "https://javascriptweblog.wordpress.com/2010/04/19/how-evil-is-eval/",
-        "logo": "https://s1.wp.com/i/favicon.ico",
-        "title": "How evil is eval?",
-        "description": "“eval is Evil: The eval function is the most misused feature of JavaScript. Avoid it” Douglas Crockford in JavaScript: The Good Parts I like The Good Parts. It’s essential reading…"
-    },
-    "https://bocoup.com/blog/the-catch-with-try-catch": {
-        "domain": "bocoup.com",
-        "url": "https://bocoup.com/blog/the-catch-with-try-catch",
-        "logo": "https://static3.bocoup.com/assets/2015/10/06163533/favicon.png",
-        "title": "The",
-        "description": "I’ve recently been working on an update to JavaScript Debug, which has me doing a lot of cross-browser testing, and I noticed a few “interesting quirks” with try…catch in Internet Explorer 6-8 that I couldn’t find documented anywhere."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Function.prototype.bind() - JavaScript | MDN",
-        "description": "The bind() method creates a new function that, when called, has its this keyword set to the provided value, with a given sequence of arguments preceding any provided when the new function is called."
-    },
-    "https://www.smashingmagazine.com/2014/01/understanding-javascript-function-prototype-bind/": {
-        "domain": "www.smashingmagazine.com",
-        "url": "https://www.smashingmagazine.com/2014/01/understanding-javascript-function-prototype-bind/",
-        "logo": "https://www.smashingmagazine.com/images/favicon/apple-touch-icon.png",
-        "title": "Understanding JavaScript Bind () — Smashing Magazine",
-        "description": "Function binding is probably your least concern when beginning with JavaScript, but when you realize that you need a solution to the problem of how to keep the context of “this” within another function, then you might not realize that what you actually need is Function.prototype.bind()."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Operator precedence - JavaScript | MDN",
-        "description": "Operator precedence determines how operators are parsed concerning each other. Operators with higher precedence become the operands of operators with lower precedence."
-    },
-    "https://es5.github.io/#C": {
-        "domain": "es5.github.io",
-        "url": "https://es5.github.io/#C",
-        "logo": "https://es5.github.io/favicon.ico",
-        "title": "Annotated ES5",
-        "description": null
-    },
-    "https://benalman.com/news/2010/11/immediately-invoked-function-expression/": {
-        "domain": "benalman.com",
-        "url": "https://benalman.com/news/2010/11/immediately-invoked-function-expression/",
-        "logo": "https://benalman.com/favicon.ico",
-        "title": "Ben Alman » Immediately-Invoked Function Expression (IIFE)",
-        "description": null
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "ReferenceError: assignment to undeclared variable “x” - JavaScript | MDN",
-        "description": "The JavaScript strict mode-only exception “Assignment to undeclared variable” occurs when the value has been assigned to an undeclared variable."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "let - JavaScript | MDN",
-        "description": "The let statement declares a block-scoped local variable, optionally initializing it to a value."
-    },
-    "https://es5.github.io/#x7.8.5": {
-        "domain": "es5.github.io",
-        "url": "https://es5.github.io/#x7.8.5",
-        "logo": "https://es5.github.io/favicon.ico",
-        "title": "Annotated ES5",
-        "description": null
-    },
-    "https://es5.github.io/#x7.2": {
-        "domain": "es5.github.io",
-        "url": "https://es5.github.io/#x7.2",
-        "logo": "https://es5.github.io/favicon.ico",
-        "title": "Annotated ES5",
-        "description": null
-    },
-    "https://web.archive.org/web/20200414142829/http://timelessrepo.com/json-isnt-a-javascript-subset": {
-        "domain": "web.archive.org",
-        "url": "https://web.archive.org/web/20200414142829/http://timelessrepo.com/json-isnt-a-javascript-subset",
-        "logo": "https://archive.org/favicon.ico",
-        "title": "JSON: The JavaScript subset that isn’t - Timeless",
-        "description": null
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Iterators and generators - JavaScript | MDN",
-        "description": "Iterators and Generators bring the concept of iteration directly into the core language and provide a mechanism for customizing the behavior of for...of loops."
-    },
-    "https://kangax.github.io/es5-compat-table/es6/#Iterators": {
-        "domain": "kangax.github.io",
-        "url": "https://kangax.github.io/es5-compat-table/es6/#Iterators",
-        "logo": "https://github.io/favicon.ico",
-        "title": null,
-        "description": null
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#Object_methods": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#Object_methods",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Deprecated and obsolete features - JavaScript | MDN",
-        "description": "This page lists features of JavaScript that are deprecated (that is, still available but planned for removal) and obsolete (that is, no longer usable)."
-    },
-    "https://www.emacswiki.org/emacs/SmartTabs": {
-        "domain": "www.emacswiki.org",
-        "url": "https://www.emacswiki.org/emacs/SmartTabs",
-        "logo": "https://www.emacswiki.org/favicon.ico",
-        "title": "EmacsWiki: Smart Tabs",
-        "description": null
-    },
-    "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects": {
-        "domain": "www.ecma-international.org",
-        "url": "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects",
-        "logo": "https://www.ecma-international.org/ecma-262/6.0/favicon.ico",
-        "title": "ECMAScript 2015 Language Specification – ECMA-262 6th Edition",
-        "description": null
-    },
-    "https://www.inkling.com/read/javascript-definitive-guide-david-flanagan-6th/chapter-3/wrapper-objects": {
-        "domain": "www.inkling.com",
-        "url": "https://www.inkling.com/read/javascript-definitive-guide-david-flanagan-6th/chapter-3/wrapper-objects",
-        "logo": "https://inklingstatic.a.ssl.fastly.net/static_assets/20220214.223700z.8c5796a9.docker/images/favicon.ico",
-        "title": "Unsupported Browser",
-        "description": null
-    },
-    "https://tc39.es/ecma262/#prod-annexB-NonOctalDecimalEscapeSequence": {
-        "domain": "tc39.es",
-        "url": "https://tc39.es/ecma262/#prod-annexB-NonOctalDecimalEscapeSequence",
-        "logo": "https://tc39.es/ecma262/img/favicon.ico",
-        "title": "ECMAScript® 2023 Language Specification",
-        "description": null
-    },
-    "https://es5.github.io/#x15.8": {
-        "domain": "es5.github.io",
-        "url": "https://es5.github.io/#x15.8",
-        "logo": "https://es5.github.io/favicon.ico",
-        "title": "Annotated ES5",
-        "description": null
-    },
-    "https://spin.atomicobject.com/2011/04/10/javascript-don-t-reassign-your-function-arguments/": {
-        "domain": "spin.atomicobject.com",
-        "url": "https://spin.atomicobject.com/2011/04/10/javascript-don-t-reassign-your-function-arguments/",
-        "logo": "https://spin.atomicobject.com/wp-content/themes/spin/images/favicon.ico",
-        "title": "JavaScript: Don’t Reassign Your Function Arguments",
-        "description": "The point of this post is to raise awareness that reassigning the value of an argument variable mutates the arguments object."
-    },
-    "https://stackoverflow.com/questions/5869216/how-to-store-node-js-deployment-settings-configuration-files": {
-        "domain": "stackoverflow.com",
-        "url": "https://stackoverflow.com/questions/5869216/how-to-store-node-js-deployment-settings-configuration-files",
-        "logo": "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png?v=c78bd457575a",
-        "title": "How to store Node.js deployment settings/configuration files?",
-        "description": "I have been working on a few Node apps, and I’ve been looking for a good pattern of storing deployment-related settings. In the Django world (where I come from), the common practise would be to hav..."
-    },
-    "https://blog.benhall.me.uk/2012/02/storing-application-config-data-in/": {
-        "domain": "blog.benhall.me.uk",
-        "url": "https://blog.benhall.me.uk/2012/02/storing-application-config-data-in/",
-        "logo": null,
-        "title": "Storing Node.js application config data – Ben Hall’s Blog",
-        "description": null
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Promise - JavaScript | MDN",
-        "description": "The Promise object represents the eventual completion (or failure) of an asynchronous operation and its resulting value."
-    },
-    "https://johnresig.com/blog/objectgetprototypeof/": {
-        "domain": "johnresig.com",
-        "url": "https://johnresig.com/blog/objectgetprototypeof/",
-        "logo": "https://johnresig.com/wp-content/uploads/2017/04/cropped-jeresig-2016.1024-270x270.jpg",
-        "title": "John Resig - Object.getPrototypeOf",
-        "description": null
-    },
-    "https://kangax.github.io/compat-table/es5/#Reserved_words_as_property_names": {
-        "domain": "kangax.github.io",
-        "url": "https://kangax.github.io/compat-table/es5/#Reserved_words_as_property_names",
-        "logo": "https://kangax.github.io/compat-table/favicon.ico",
-        "title": "ECMAScript 5 compatibility table",
-        "description": null
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "async function - JavaScript | MDN",
-        "description": "An async function is a function declared with the async keyword, and the await keyword is permitted within it. The async and await keywords enable asynchronous, promise-based behavior to be written in a cleaner style, avoiding the need to explicitly configure promise chains."
-    },
-    "https://jakearchibald.com/2017/await-vs-return-vs-return-await/": {
-        "domain": "jakearchibald.com",
-        "url": "https://jakearchibald.com/2017/await-vs-return-vs-return-await/",
-        "logo": "https://jakearchibald.com/c/favicon-67801369.png",
-        "title": "await vs return vs return await",
-        "description": null
-    },
-    "https://stackoverflow.com/questions/13497971/what-is-the-matter-with-script-targeted-urls": {
-        "domain": "stackoverflow.com",
-        "url": "https://stackoverflow.com/questions/13497971/what-is-the-matter-with-script-targeted-urls",
-        "logo": "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png?v=c78bd457575a",
-        "title": "What is the matter with script-targeted URLs?",
-        "description": "I’m using JSHint, and it got the following error: Script URL. Which I noticed that happened because on this particular line there is a string containing a javascript:... URL. I know that JSHint"
-    },
-    "https://es5.github.io/#x15.1.1": {
-        "domain": "es5.github.io",
-        "url": "https://es5.github.io/#x15.1.1",
-        "logo": "https://es5.github.io/favicon.ico",
-        "title": "Annotated ES5",
-        "description": null
-    },
-    "https://en.wikipedia.org/wiki/Variable_shadowing": {
-        "domain": "en.wikipedia.org",
-        "url": "https://en.wikipedia.org/wiki/Variable_shadowing",
-        "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
-        "title": "Variable shadowing - Wikipedia",
-        "description": null
-    },
-    "https://www.nczonline.net/blog/2007/09/09/inconsistent-array-literals/": {
-        "domain": "www.nczonline.net",
-        "url": "https://www.nczonline.net/blog/2007/09/09/inconsistent-array-literals/",
-        "logo": "https://www.nczonline.net/images/favicon.png",
-        "title": "Inconsistent array literals",
-        "description": "Back at the Rich Web Experience, I helped lead a “birds of a feather” group discussion on JavaScript. In that discussion, someone called me a JavaScript expert. I quickly explained that I don’t..."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "undefined - JavaScript | MDN",
-        "description": "The global undefined property represents the primitive value undefined. It is one of JavaScript’s primitive types."
-    },
-    "https://javascriptweblog.wordpress.com/2010/08/16/understanding-undefined-and-preventing-referenceerrors/": {
-        "domain": "javascriptweblog.wordpress.com",
-        "url": "https://javascriptweblog.wordpress.com/2010/08/16/understanding-undefined-and-preventing-referenceerrors/",
-        "logo": "https://s1.wp.com/i/favicon.ico",
-        "title": "Understanding JavaScript’s ‘undefined’",
-        "description": "Compared to other languages, JavaScript’s concept of undefined is a little confusing. In particular, trying to understand ReferenceErrors (“x is not defined”) and how best to code…"
-    },
-    "https://es5.github.io/#x15.1.1.3": {
-        "domain": "es5.github.io",
-        "url": "https://es5.github.io/#x15.1.1.3",
-        "logo": "https://es5.github.io/favicon.ico",
-        "title": "Annotated ES5",
-        "description": null
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Regular expressions - JavaScript | MDN",
-        "description": "Regular expressions are patterns used to match character combinations in strings. In JavaScript, regular expressions are also objects. These patterns are used with the exec() and test() methods of RegExp, and with the match(), matchAll(), replace(), replaceAll(), search(), and split() methods of S…"
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "void operator - JavaScript | MDN",
-        "description": "The void operator evaluates the given expression and then returns undefined."
-    },
-    "https://oreilly.com/javascript/excerpts/javascript-good-parts/bad-parts.html": {
-        "domain": "oreilly.com",
-        "url": "https://oreilly.com/javascript/excerpts/javascript-good-parts/bad-parts.html",
-        "logo": "https://www.oreilly.com/favicon.ico",
-        "title": "O’Reilly Media - Technology and Business Training",
-        "description": "Gain technology and business knowledge and hone your skills with learning resources created and curated by O’Reilly’s experts: live online training, video, books, our platform has content from 200+ of the world’s best publishers."
-    },
-    "https://web.archive.org/web/20200717110117/https://yuiblog.com/blog/2006/04/11/with-statement-considered-harmful/": {
-        "domain": "web.archive.org",
-        "url": "https://web.archive.org/web/20200717110117/https://yuiblog.com/blog/2006/04/11/with-statement-considered-harmful/",
-        "logo": "https://web.archive.org/web/20200717110117im_/https://yuiblog.com/favicon.ico",
-        "title": "with Statement Considered Harmful",
-        "description": null
-    },
-    "https://jscs-dev.github.io/rule/requireNewlineBeforeSingleStatementsInIf": {
-        "domain": "jscs-dev.github.io",
-        "url": "https://jscs-dev.github.io/rule/requireNewlineBeforeSingleStatementsInIf",
-        "logo": "https://jscs-dev.github.io/favicon.ico",
-        "title": "JSCS",
-        "description": null
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Object initializer - JavaScript | MDN",
-        "description": "Objects can be initialized using new Object(), Object.create(), or using the literal notation (initializer notation). An object initializer is a comma-delimited list of zero or more pairs of property names and associated values of an object, enclosed in curly braces ({})."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Arrow function expressions - JavaScript | MDN",
-        "description": "An arrow function expression is a compact alternative to a traditional function expression, but is limited and can’t be used in all situations."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Destructuring assignment - JavaScript | MDN",
-        "description": "The destructuring assignment syntax is a JavaScript expression that makes it possible to unpack values from arrays, or properties from objects, into distinct variables."
-    },
-    "https://2ality.com/2015/01/es6-destructuring.html": {
-        "domain": "2ality.com",
-        "url": "https://2ality.com/2015/01/es6-destructuring.html",
-        "logo": "https://2ality.com/img/favicon.png",
-        "title": "Destructuring and parameter handling in ECMAScript 6",
-        "description": null
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Expressions and operators - JavaScript | MDN",
-        "description": "This chapter documents all the JavaScript language operators, expressions and keywords."
-    },
-    "https://bugs.chromium.org/p/v8/issues/detail?id=5848": {
-        "domain": "bugs.chromium.org",
-        "url": "https://bugs.chromium.org/p/v8/issues/detail?id=5848",
-        "logo": "https://bugs.chromium.org/static/images/monorail.ico",
-        "title": "5848 - v8 - V8 JavaScript Engine - Monorail",
-        "description": null
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Object.hasOwn() - JavaScript | MDN",
-        "description": "The Object.hasOwn() static method returns true if the specified object has the indicated property as its own property. If the property is inherited, or does not exist, the method returns false."
-    },
-    "http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-rejected-with-a-non-error": {
-        "domain": "bluebirdjs.com",
-        "url": "http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-rejected-with-a-non-error",
-        "logo": "//bluebirdjs.com/img/favicon.png",
-        "title": "Warning Explanations | bluebird",
-        "description": "Bluebird is a fully featured JavaScript promises library with unmatched performance."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "RegExp - JavaScript | MDN",
-        "description": "The RegExp object is used for matching text with a pattern."
-    },
-    "https://mathiasbynens.be/notes/javascript-properties": {
-        "domain": "mathiasbynens.be",
-        "url": "https://mathiasbynens.be/notes/javascript-properties",
-        "logo": "https://mathiasbynens.be/favicon.ico",
-        "title": "Unquoted property names / object keys in JavaScript · Mathias Bynens",
-        "description": null
-    },
-    "https://davidwalsh.name/parseint-radix": {
-        "domain": "davidwalsh.name",
-        "url": "https://davidwalsh.name/parseint-radix",
-        "logo": "https://davidwalsh.name/wp-content/themes/punky/images/favicon-144.png",
-        "title": "parseInt Radix",
-        "description": "The radix is important if you’re need to guarantee accuracy with variable input (basic number, binary, etc.). For best results, always use a radix of 10!"
-    },
-    "https://github.com/tc39/proposal-object-rest-spread": {
-        "domain": "github.com",
-        "url": "https://github.com/tc39/proposal-object-rest-spread",
-        "logo": "https://github.com/fluidicon.png",
-        "title": "GitHub - tc39/proposal-object-rest-spread: Rest/Spread Properties for ECMAScript",
-        "description": "Rest/Spread Properties for ECMAScript. Contribute to tc39/proposal-object-rest-spread development by creating an account on GitHub."
-    },
-    "https://blog.izs.me/2010/12/an-open-letter-to-javascript-leaders-regarding/": {
-        "domain": "blog.izs.me",
-        "url": "https://blog.izs.me/2010/12/an-open-letter-to-javascript-leaders-regarding/",
-        "logo": "https://blog.izs.me/favicon.ico",
-        "title": "An Open Letter to JavaScript Leaders Regarding Semicolons",
-        "description": "Writing and Stuff from Isaac Z. Schlueter"
-    },
-    "https://web.archive.org/web/20200420230322/http://inimino.org/~inimino/blog/javascript_semicolons": {
-        "domain": "web.archive.org",
-        "url": "https://web.archive.org/web/20200420230322/http://inimino.org/~inimino/blog/javascript_semicolons",
-        "logo": "https://archive.org/favicon.ico",
-        "title": "JavaScript Semicolon Insertion",
-        "description": null
-    },
-    "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-description": {
-        "domain": "www.ecma-international.org",
-        "url": "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-description",
-        "logo": "https://www.ecma-international.org/ecma-262/6.0/favicon.ico",
-        "title": "ECMAScript 2015 Language Specification – ECMA-262 6th Edition",
-        "description": null
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Template literals (Template strings) - JavaScript | MDN",
-        "description": "Template literals are literals delimited with backtick (`) characters, allowing for multi-line strings, for string interpolation with embedded expressions, and for special constructs called tagged templates."
-    },
-    "https://exploringjs.com/es6/ch_template-literals.html#_examples-of-using-tagged-template-literals": {
-        "domain": "exploringjs.com",
-        "url": "https://exploringjs.com/es6/ch_template-literals.html#_examples-of-using-tagged-template-literals",
-        "logo": "https://exploringjs.com/es6/images/favicon-128.png",
-        "title": "8. Template literals",
-        "description": null
-    },
-    "https://jsdoc.app": {
-        "domain": "jsdoc.app",
-        "url": "https://jsdoc.app",
-        "logo": null,
-        "title": "Use JSDoc: Index",
-        "description": "Official documentation for JSDoc 3."
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "typeof - JavaScript | MDN",
-        "description": "The typeof operator returns a string indicating the type of the unevaluated operand."
-    },
-    "https://danhough.com/blog/single-var-pattern-rant/": {
-        "domain": "danhough.com",
-        "url": "https://danhough.com/blog/single-var-pattern-rant/",
-        "logo": "https://danhough.com/img/meta/apple-touch-icon-152x152.png",
-        "title": "A criticism of the Single Var Pattern in JavaScript, and a simple alternative — Dan Hough",
-        "description": "Dan Hough is a software developer & consultant, a writer and public speaker."
-    },
-    "https://benalman.com/news/2012/05/multiple-var-statements-javascript/": {
-        "domain": "benalman.com",
-        "url": "https://benalman.com/news/2012/05/multiple-var-statements-javascript/",
-        "logo": "https://benalman.com/favicon.ico",
-        "title": "Ben Alman » Multiple var statements in JavaScript, not superfluous",
-        "description": null
-    },
-    "https://en.wikipedia.org/wiki/Yoda_conditions": {
-        "domain": "en.wikipedia.org",
-        "url": "https://en.wikipedia.org/wiki/Yoda_conditions",
-        "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
-        "title": "Yoda conditions - Wikipedia",
-        "description": null
-    },
-    "http://thomas.tuerke.net/on/design/?with=1249091668#msg1146181680": {
-        "domain": "thomas.tuerke.net",
-        "url": "http://thomas.tuerke.net/on/design/?with=1249091668#msg1146181680",
-        "logo": "//thomas.tuerke.net/images/tmtlogo.ico",
-        "title": "Coding in Style",
-        "description": "Thomas M. Tuerke topical weblog"
-    },
-    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation": {
-        "domain": "developer.mozilla.org",
-        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation",
-        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-        "title": "Exponentiation (**) - JavaScript | MDN",
-        "description": "The exponentiation operator (**) returns the result of raising the first operand to the power of the second operand. It is equivalent to Math.pow, except it also accepts BigInts as operands."
-    },
-    "https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/": {
-        "domain": "eslint.org",
-        "url": "https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/",
-        "logo": "https://eslint.org/apple-touch-icon.png",
-        "title": "Interesting bugs caught by no-constant-binary-expression - ESLint - Pluggable JavaScript Linter",
-        "description": "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease."
-    },
-    "https://github.com/tc39/proposal-class-static-block": {
-        "domain": "github.com",
-        "url": "https://github.com/tc39/proposal-class-static-block",
-        "logo": "https://github.com/fluidicon.png",
-        "title": "GitHub - tc39/proposal-class-static-block: ECMAScript class static initialization blocks",
-        "description": "ECMAScript class static initialization blocks. Contribute to tc39/proposal-class-static-block development by creating an account on GitHub."
-    },
-    "https://tc39.es/ecma262/#sec-symbol-constructor": {
-        "domain": "tc39.es",
-        "url": "https://tc39.es/ecma262/#sec-symbol-constructor",
-        "logo": "https://tc39.es/ecma262/img/favicon.ico",
-        "title": "ECMAScript® 2023 Language Specification",
-        "description": null
-    },
-    "https://tc39.es/ecma262/#sec-bigint-constructor": {
-        "domain": "tc39.es",
-        "url": "https://tc39.es/ecma262/#sec-bigint-constructor",
-        "logo": "https://tc39.es/ecma262/img/favicon.ico",
-        "title": "ECMAScript® 2023 Language Specification",
-        "description": null
-    },
-    "https://v8.dev/blog/fast-async": {
-        "domain": "v8.dev",
-        "url": "https://v8.dev/blog/fast-async",
-        "logo": "https://v8.dev/favicon.ico",
-        "title": "Faster async functions and promises · V8",
-        "description": "Faster and easier-to-debug async functions and promises are coming to V8 v7.2 / Chrome 72."
-    },
-    "https://github.com/tc39/proposal-regexp-v-flag": {
-        "domain": "github.com",
-        "url": "https://github.com/tc39/proposal-regexp-v-flag",
-        "logo": "https://github.com/fluidicon.png",
-        "title": "GitHub - tc39/proposal-regexp-v-flag: UTS18 set notation in regular expressions",
-        "description": "UTS18 set notation in regular expressions. Contribute to tc39/proposal-regexp-v-flag development by creating an account on GitHub."
-    },
-    "https://v8.dev/features/regexp-v-flag": {
-        "domain": "v8.dev",
-        "url": "https://v8.dev/features/regexp-v-flag",
-        "logo": "https://v8.dev/favicon.ico",
-        "title": "RegExp v flag with set notation and properties of strings · V8",
-        "description": "The new RegExp `v` flag enables `unicodeSets` mode, unlocking support for extended character classes, including Unicode properties of strings, set notation, and improved case-insensitive matching."
-    },
-    "https://codepoints.net/U+1680": {
-        "domain": "codepoints.net",
-        "url": "https://codepoints.net/U+1680",
-        "logo": "https://codepoints.net/favicon.ico",
-        "title": "U+1680 OGHAM SPACE MARK:   – Unicode – Codepoints",
-        "description": " , codepoint U+1680 OGHAM SPACE MARK in Unicode, is located in the block “Ogham”. It belongs to the Ogham script and is a Space Separator."
-    },
-    "https://en.wikipedia.org/wiki/Dead_store": {
-        "domain": "en.wikipedia.org",
-        "url": "https://en.wikipedia.org/wiki/Dead_store",
-        "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
-        "title": "Dead store - Wikipedia",
-        "description": null
-    },
-    "https://rules.sonarsource.com/javascript/RSPEC-1854/": {
-        "domain": "rules.sonarsource.com",
-        "url": "https://rules.sonarsource.com/javascript/RSPEC-1854/",
-        "logo": "https://rules.sonarsource.com/favicon.ico",
-        "title": "JavaScript static code analysis: Unused assignments should be removed",
-        "description": "Dead stores refer to assignments made to local variables that are subsequently never used or immediately overwritten. Such assignments are\nunnecessary and don’t contribute to the functionality or clarity of the code. They may even negatively impact performance. Removing them enhances code\ncleanlines…"
-    },
-    "https://cwe.mitre.org/data/definitions/563.html": {
-        "domain": "cwe.mitre.org",
-        "url": "https://cwe.mitre.org/data/definitions/563.html",
-        "logo": "https://cwe.mitre.org/favicon.ico",
-        "title": "CWE - CWE-563: Assignment to Variable without Use (4.13)",
-        "description": "Common Weakness Enumeration (CWE) is a list of software weaknesses."
-    },
-    "https://wiki.sei.cmu.edu/confluence/display/c/MSC13-C.+Detect+and+remove+unused+values": {
-        "domain": "wiki.sei.cmu.edu",
-        "url": "https://wiki.sei.cmu.edu/confluence/display/c/MSC13-C.+Detect+and+remove+unused+values",
-        "logo": "https://wiki.sei.cmu.edu/confluence/s/-ctumb3/9012/tu5x00/7/_/favicon.ico",
-        "title": "MSC13-C. Detect and remove unused values - SEI CERT C Coding Standard - Confluence",
-        "description": null
-    },
-    "https://wiki.sei.cmu.edu/confluence/display/java/MSC56-J.+Detect+and+remove+superfluous+code+and+values": {
-        "domain": "wiki.sei.cmu.edu",
-        "url": "https://wiki.sei.cmu.edu/confluence/display/java/MSC56-J.+Detect+and+remove+superfluous+code+and+values",
-        "logo": "https://wiki.sei.cmu.edu/confluence/s/-ctumb3/9012/tu5x00/7/_/favicon.ico",
-        "title": "MSC56-J. Detect and remove superfluous code and values - SEI CERT Oracle Coding Standard for Java - Confluence",
-        "description": null
-    },
-    "https://262.ecma-international.org/11.0/#sec-value-properties-of-the-global-object": {
-        "domain": "262.ecma-international.org",
-        "url": "https://262.ecma-international.org/11.0/#sec-value-properties-of-the-global-object",
-        "logo": "https://tc39.es/ecma262/2020/img/favicon.ico",
-        "title": "ECMAScript® 2020 Language Specification",
-        "description": null
-    },
-    "https://262.ecma-international.org/11.0/#sec-strict-mode-of-ecmascript": {
-        "domain": "262.ecma-international.org",
-        "url": "https://262.ecma-international.org/11.0/#sec-strict-mode-of-ecmascript",
-        "logo": "https://tc39.es/ecma262/2020/img/favicon.ico",
-        "title": "ECMAScript® 2020 Language Specification",
-        "description": null
-    }
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "setter - JavaScript | MDN",
+    "description": "The set syntax binds an object property to a function to be called when there is an attempt to set that property."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "getter - JavaScript | MDN",
+    "description": "The get syntax binds an object property to a function that will be called when that property is looked up."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Working with objects - JavaScript | MDN",
+    "description": "JavaScript is designed on a simple object-based paradigm. An object is a collection of properties, and a property is an association between a name (or key) and a value. A property’s value can be a function, in which case the property is known as a method. In addition to objects that are predefined i…"
+  },
+  "https://github.com/airbnb/javascript#arrows--one-arg-parens": {
+    "domain": "github.com",
+    "url": "https://github.com/airbnb/javascript#arrows--one-arg-parens",
+    "logo": "https://github.com/fluidicon.png",
+    "title": "GitHub - airbnb/javascript: JavaScript Style Guide",
+    "description": "JavaScript Style Guide. Contribute to airbnb/javascript development by creating an account on GitHub."
+  },
+  "https://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html": {
+    "domain": "www.adequatelygood.com",
+    "url": "https://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html",
+    "logo": "https://www.adequatelygood.com/favicon.ico",
+    "title": "JavaScript Scoping and Hoisting",
+    "description": null
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "var - JavaScript | MDN",
+    "description": "The var statement declares a function-scoped or globally-scoped variable, optionally initializing it to a value."
+  },
+  "https://en.wikipedia.org/wiki/Indent_style": {
+    "domain": "en.wikipedia.org",
+    "url": "https://en.wikipedia.org/wiki/Indent_style",
+    "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
+    "title": "Indentation style - Wikipedia",
+    "description": null
+  },
+  "https://github.com/maxogden/art-of-node#callbacks": {
+    "domain": "github.com",
+    "url": "https://github.com/maxogden/art-of-node#callbacks",
+    "logo": "https://github.com/fluidicon.png",
+    "title": "GitHub - maxogden/art-of-node: a short introduction to node.js",
+    "description": ":snowflake: a short introduction to node.js. Contribute to maxogden/art-of-node development by creating an account on GitHub."
+  },
+  "https://web.archive.org/web/20171224042620/https://docs.nodejitsu.com/articles/errors/what-are-the-error-conventions/": {
+    "domain": "web.archive.org",
+    "url": "https://web.archive.org/web/20171224042620/https://docs.nodejitsu.com/articles/errors/what-are-the-error-conventions/",
+    "logo": "https://archive.org/favicon.ico",
+    "title": "What are the error conventions? - docs.nodejitsu.com",
+    "description": "docs.nodejitsu.com is a growing collection of how-to articles for node.js, written by the community and curated by Nodejitsu and friends. These articles range from basic to advanced, and provide relevant code samples and insights into the design and philosophy of node itself."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Classes - JavaScript | MDN",
+    "description": "Classes are a template for creating objects. They encapsulate data with code to work on that data. Classes in JS are built on prototypes but also have some syntax and semantics that are not shared with ES5 class-like semantics."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "static - JavaScript | MDN",
+    "description": "The static keyword defines a static method or property for a class, or a class static initialization block (see the link for more information about this usage). Neither static methods nor static properties can be called on instances of the class. Instead, they’re called on the class itself."
+  },
+  "https://www.crockford.com/code.html": {
+    "domain": "www.crockford.com",
+    "url": "https://www.crockford.com/code.html",
+    "logo": "https://www.crockford.com/favicon.png",
+    "title": "Code Conventions for the JavaScript Programming Language",
+    "description": null
+  },
+  "https://dojotoolkit.org/reference-guide/1.9/developer/styleguide.html": {
+    "domain": "dojotoolkit.org",
+    "url": "https://dojotoolkit.org/reference-guide/1.9/developer/styleguide.html",
+    "logo": "https://dojotoolkit.org/images/favicons/apple-touch-icon-152x152.png",
+    "title": "Dojo Style Guide — The Dojo Toolkit - Reference Guide",
+    "description": null
+  },
+  "https://gist.github.com/isaacs/357981": {
+    "domain": "gist.github.com",
+    "url": "https://gist.github.com/isaacs/357981",
+    "logo": "https://gist.github.com/fluidicon.png",
+    "title": "A better coding convention for lists and object literals in JavaScript",
+    "description": "A better coding convention for lists and object literals in JavaScript - comma-first-var.js"
+  },
+  "https://en.wikipedia.org/wiki/Cyclomatic_complexity": {
+    "domain": "en.wikipedia.org",
+    "url": "https://en.wikipedia.org/wiki/Cyclomatic_complexity",
+    "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
+    "title": "Cyclomatic complexity - Wikipedia",
+    "description": null
+  },
+  "https://ariya.io/2012/12/complexity-analysis-of-javascript-code": {
+    "domain": "ariya.io",
+    "url": "https://ariya.io/2012/12/complexity-analysis-of-javascript-code",
+    "logo": "https://ariya.io/favicon.ico",
+    "title": "Complexity Analysis of JavaScript Code",
+    "description": "Nobody likes to read complex code, especially if it’s someone’s else code. A preventive approach to block any complex code entering the application is by watching its complexity carefully."
+  },
+  "https://craftsmanshipforsoftware.com/2015/05/25/complexity-for-javascript/": {
+    "domain": "craftsmanshipforsoftware.com",
+    "url": "https://craftsmanshipforsoftware.com/2015/05/25/complexity-for-javascript/",
+    "logo": "https://s0.wp.com/i/webclip.png",
+    "title": "Complexity for JavaScript",
+    "description": "The control of complexity control presents the core problem of software development. The huge variety of decisions a developer faces on a day-to-day basis cry for methods of controlling and contain…"
+  },
+  "https://web.archive.org/web/20160808115119/http://jscomplexity.org/complexity": {
+    "domain": "web.archive.org",
+    "url": "https://web.archive.org/web/20160808115119/http://jscomplexity.org/complexity",
+    "logo": "https://archive.org/favicon.ico",
+    "title": "About complexity | JSComplexity.org",
+    "description": "A discussion of software complexity metrics and how they are calculated."
+  },
+  "https://github.com/eslint/eslint/issues/4808#issuecomment-167795140": {
+    "domain": "github.com",
+    "url": "https://github.com/eslint/eslint/issues/4808#issuecomment-167795140",
+    "logo": "https://github.com/fluidicon.png",
+    "title": "Complexity has no default · Issue #4808 · eslint/eslint",
+    "description": "Enabling the complexity rule with only a severity has no effect. We have tried to give sane defaults to all rules, and I think this should be no exception. I don&#39;t know what a good number would..."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "switch - JavaScript | MDN",
+    "description": "The switch statement evaluates an expression, matching the expression’s value to a case clause, and executes statements associated with that case, as well as statements in cases that follow the matching case."
+  },
+  "https://web.archive.org/web/20201112040809/http://markdaggett.com/blog/2013/02/15/functions-explained/": {
+    "domain": "web.archive.org",
+    "url": "https://web.archive.org/web/20201112040809/http://markdaggett.com/blog/2013/02/15/functions-explained/",
+    "logo": "https://web.archive.org/web/20201112040809im_/http://markdaggett.com/favicon.ico",
+    "title": "Functions Explained - Mark Daggett’s Blog",
+    "description": "A Deep Dive into JavaScript Functions\nBased on my readership I have to assume most of you are familiar with JavaScript already. Therefore, it may …"
+  },
+  "https://2ality.com/2015/09/function-names-es6.html": {
+    "domain": "2ality.com",
+    "url": "https://2ality.com/2015/09/function-names-es6.html",
+    "logo": "https://2ality.com/img/favicon.png",
+    "title": "The names of functions in ES6",
+    "description": null
+  },
+  "https://leanpub.com/understandinges6/read/#leanpub-auto-generators": {
+    "domain": "leanpub.com",
+    "url": "https://leanpub.com/understandinges6/read/#leanpub-auto-generators",
+    "logo": "https://leanpub.com/understandinges6/read/favicons/mstile-310x310.png",
+    "title": "Read Understanding ECMAScript 6 | Leanpub",
+    "description": null
+  },
+  "https://leanpub.com/understandinges6/read/#leanpub-auto-accessor-properties": {
+    "domain": "leanpub.com",
+    "url": "https://leanpub.com/understandinges6/read/#leanpub-auto-accessor-properties",
+    "logo": "https://leanpub.com/understandinges6/read/favicons/mstile-310x310.png",
+    "title": "Read Understanding ECMAScript 6 | Leanpub",
+    "description": null
+  },
+  "https://javascriptweblog.wordpress.com/2011/01/04/exploring-javascript-for-in-loops/": {
+    "domain": "javascriptweblog.wordpress.com",
+    "url": "https://javascriptweblog.wordpress.com/2011/01/04/exploring-javascript-for-in-loops/",
+    "logo": "https://s1.wp.com/i/favicon.ico",
+    "title": "Exploring JavaScript for-in loops",
+    "description": "The for-in loop is the only cross-browser technique for iterating the properties of generic objects. There’s a bunch of literature about the dangers of using for-in to iterate arrays and when…"
+  },
+  "https://2ality.com/2012/01/objects-as-maps.html": {
+    "domain": "2ality.com",
+    "url": "https://2ality.com/2012/01/objects-as-maps.html",
+    "logo": "https://2ality.com/img/favicon.png",
+    "title": "The pitfalls of using objects as maps in JavaScript",
+    "description": null
+  },
+  "https://web.archive.org/web/20160725154648/http://www.mind2b.com/component/content/article/24-software-module-size-and-file-size": {
+    "domain": "web.archive.org",
+    "url": "https://web.archive.org/web/20160725154648/http://www.mind2b.com/component/content/article/24-software-module-size-and-file-size",
+    "logo": "https://archive.org/favicon.ico",
+    "title": "Software Module size and file size",
+    "description": null
+  },
+  "http://book.mixu.net/node/ch7.html": {
+    "domain": "book.mixu.net",
+    "url": "http://book.mixu.net/node/ch7.html",
+    "logo": null,
+    "title": "7. Control flow - Mixu’s Node book",
+    "description": null
+  },
+  "https://web.archive.org/web/20220104141150/https://howtonode.org/control-flow": {
+    "domain": "web.archive.org",
+    "url": "https://web.archive.org/web/20220104141150/https://howtonode.org/control-flow",
+    "logo": "https://web.archive.org/web/20220104141150im_/https://howtonode.org/favicon.ico",
+    "title": "Control Flow in Node - How To Node - NodeJS",
+    "description": "Learn the zen of coding in NodeJS."
+  },
+  "https://web.archive.org/web/20220127215850/https://howtonode.org/control-flow-part-ii": {
+    "domain": "web.archive.org",
+    "url": "https://web.archive.org/web/20220127215850/https://howtonode.org/control-flow-part-ii",
+    "logo": "https://web.archive.org/web/20220127215850im_/https://howtonode.org/favicon.ico",
+    "title": "Control Flow in Node Part II - How To Node - NodeJS",
+    "description": "Learn the zen of coding in NodeJS."
+  },
+  "https://nodejs.org/api/buffer.html": {
+    "domain": "nodejs.org",
+    "url": "https://nodejs.org/api/buffer.html",
+    "logo": "https://nodejs.org/favicon.ico",
+    "title": "Buffer | Node.js v18.2.0 Documentation",
+    "description": null
+  },
+  "https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md": {
+    "domain": "github.com",
+    "url": "https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md",
+    "logo": "https://github.com/fluidicon.png",
+    "title": "notes/Lets-fix-Buffer-API.md at master · ChALkeR/notes",
+    "description": "Some public notes. Contribute to ChALkeR/notes development by creating an account on GitHub."
+  },
+  "https://github.com/nodejs/node/issues/4660": {
+    "domain": "github.com",
+    "url": "https://github.com/nodejs/node/issues/4660",
+    "logo": "https://github.com/fluidicon.png",
+    "title": "Buffer(number) is unsafe · Issue #4660 · nodejs/node",
+    "description": "tl;dr This issue proposes: Change new Buffer(number) to return safe, zeroed-out memory Create a new API for creating uninitialized Buffers, Buffer.alloc(number) Update: Jan 15, 2016 Upon further co..."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "debugger - JavaScript | MDN",
+    "description": "The debugger statement invokes any available debugging functionality, such as setting a breakpoint. If no debugging functionality is available, this statement has no effect."
+  },
+  "https://ericlippert.com/2003/11/01/eval-is-evil-part-one/": {
+    "domain": "ericlippert.com",
+    "url": "https://ericlippert.com/2003/11/01/eval-is-evil-part-one/",
+    "logo": "https://s1.wp.com/i/favicon.ico",
+    "title": "Eval is evil, part one",
+    "description": "The eval method — which takes a string containing JScript code, compiles it and runs it — is probably the most powerful and most misused method in JScript. There are a few scenarios in …"
+  },
+  "https://javascriptweblog.wordpress.com/2010/04/19/how-evil-is-eval/": {
+    "domain": "javascriptweblog.wordpress.com",
+    "url": "https://javascriptweblog.wordpress.com/2010/04/19/how-evil-is-eval/",
+    "logo": "https://s1.wp.com/i/favicon.ico",
+    "title": "How evil is eval?",
+    "description": "“eval is Evil: The eval function is the most misused feature of JavaScript. Avoid it” Douglas Crockford in JavaScript: The Good Parts I like The Good Parts. It’s essential reading…"
+  },
+  "https://bocoup.com/blog/the-catch-with-try-catch": {
+    "domain": "bocoup.com",
+    "url": "https://bocoup.com/blog/the-catch-with-try-catch",
+    "logo": "https://static3.bocoup.com/assets/2015/10/06163533/favicon.png",
+    "title": "The",
+    "description": "I’ve recently been working on an update to JavaScript Debug, which has me doing a lot of cross-browser testing, and I noticed a few “interesting quirks” with try…catch in Internet Explorer 6-8 that I couldn’t find documented anywhere."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Function.prototype.bind() - JavaScript | MDN",
+    "description": "The bind() method creates a new function that, when called, has its this keyword set to the provided value, with a given sequence of arguments preceding any provided when the new function is called."
+  },
+  "https://www.smashingmagazine.com/2014/01/understanding-javascript-function-prototype-bind/": {
+    "domain": "www.smashingmagazine.com",
+    "url": "https://www.smashingmagazine.com/2014/01/understanding-javascript-function-prototype-bind/",
+    "logo": "https://www.smashingmagazine.com/images/favicon/apple-touch-icon.png",
+    "title": "Understanding JavaScript Bind () — Smashing Magazine",
+    "description": "Function binding is probably your least concern when beginning with JavaScript, but when you realize that you need a solution to the problem of how to keep the context of “this” within another function, then you might not realize that what you actually need is Function.prototype.bind()."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Operator precedence - JavaScript | MDN",
+    "description": "Operator precedence determines how operators are parsed concerning each other. Operators with higher precedence become the operands of operators with lower precedence."
+  },
+  "https://es5.github.io/#C": {
+    "domain": "es5.github.io",
+    "url": "https://es5.github.io/#C",
+    "logo": "https://es5.github.io/favicon.ico",
+    "title": "Annotated ES5",
+    "description": null
+  },
+  "https://benalman.com/news/2010/11/immediately-invoked-function-expression/": {
+    "domain": "benalman.com",
+    "url": "https://benalman.com/news/2010/11/immediately-invoked-function-expression/",
+    "logo": "https://benalman.com/favicon.ico",
+    "title": "Ben Alman » Immediately-Invoked Function Expression (IIFE)",
+    "description": null
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "ReferenceError: assignment to undeclared variable “x” - JavaScript | MDN",
+    "description": "The JavaScript strict mode-only exception “Assignment to undeclared variable” occurs when the value has been assigned to an undeclared variable."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "let - JavaScript | MDN",
+    "description": "The let statement declares a block-scoped local variable, optionally initializing it to a value."
+  },
+  "https://es5.github.io/#x7.8.5": {
+    "domain": "es5.github.io",
+    "url": "https://es5.github.io/#x7.8.5",
+    "logo": "https://es5.github.io/favicon.ico",
+    "title": "Annotated ES5",
+    "description": null
+  },
+  "https://es5.github.io/#x7.2": {
+    "domain": "es5.github.io",
+    "url": "https://es5.github.io/#x7.2",
+    "logo": "https://es5.github.io/favicon.ico",
+    "title": "Annotated ES5",
+    "description": null
+  },
+  "https://web.archive.org/web/20200414142829/http://timelessrepo.com/json-isnt-a-javascript-subset": {
+    "domain": "web.archive.org",
+    "url": "https://web.archive.org/web/20200414142829/http://timelessrepo.com/json-isnt-a-javascript-subset",
+    "logo": "https://archive.org/favicon.ico",
+    "title": "JSON: The JavaScript subset that isn’t - Timeless",
+    "description": null
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Iterators and generators - JavaScript | MDN",
+    "description": "Iterators and Generators bring the concept of iteration directly into the core language and provide a mechanism for customizing the behavior of for...of loops."
+  },
+  "https://kangax.github.io/es5-compat-table/es6/#Iterators": {
+    "domain": "kangax.github.io",
+    "url": "https://kangax.github.io/es5-compat-table/es6/#Iterators",
+    "logo": "https://github.io/favicon.ico",
+    "title": null,
+    "description": null
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#Object_methods": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#Object_methods",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Deprecated and obsolete features - JavaScript | MDN",
+    "description": "This page lists features of JavaScript that are deprecated (that is, still available but planned for removal) and obsolete (that is, no longer usable)."
+  },
+  "https://www.emacswiki.org/emacs/SmartTabs": {
+    "domain": "www.emacswiki.org",
+    "url": "https://www.emacswiki.org/emacs/SmartTabs",
+    "logo": "https://www.emacswiki.org/favicon.ico",
+    "title": "EmacsWiki: Smart Tabs",
+    "description": null
+  },
+  "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects": {
+    "domain": "www.ecma-international.org",
+    "url": "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects",
+    "logo": "https://www.ecma-international.org/ecma-262/6.0/favicon.ico",
+    "title": "ECMAScript 2015 Language Specification – ECMA-262 6th Edition",
+    "description": null
+  },
+  "https://www.inkling.com/read/javascript-definitive-guide-david-flanagan-6th/chapter-3/wrapper-objects": {
+    "domain": "www.inkling.com",
+    "url": "https://www.inkling.com/read/javascript-definitive-guide-david-flanagan-6th/chapter-3/wrapper-objects",
+    "logo": "https://inklingstatic.a.ssl.fastly.net/static_assets/20220214.223700z.8c5796a9.docker/images/favicon.ico",
+    "title": "Unsupported Browser",
+    "description": null
+  },
+  "https://tc39.es/ecma262/#prod-annexB-NonOctalDecimalEscapeSequence": {
+    "domain": "tc39.es",
+    "url": "https://tc39.es/ecma262/#prod-annexB-NonOctalDecimalEscapeSequence",
+    "logo": "https://tc39.es/ecma262/img/favicon.ico",
+    "title": "ECMAScript® 2023 Language Specification",
+    "description": null
+  },
+  "https://es5.github.io/#x15.8": {
+    "domain": "es5.github.io",
+    "url": "https://es5.github.io/#x15.8",
+    "logo": "https://es5.github.io/favicon.ico",
+    "title": "Annotated ES5",
+    "description": null
+  },
+  "https://spin.atomicobject.com/2011/04/10/javascript-don-t-reassign-your-function-arguments/": {
+    "domain": "spin.atomicobject.com",
+    "url": "https://spin.atomicobject.com/2011/04/10/javascript-don-t-reassign-your-function-arguments/",
+    "logo": "https://spin.atomicobject.com/wp-content/themes/spin/images/favicon.ico",
+    "title": "JavaScript: Don’t Reassign Your Function Arguments",
+    "description": "The point of this post is to raise awareness that reassigning the value of an argument variable mutates the arguments object."
+  },
+  "https://stackoverflow.com/questions/5869216/how-to-store-node-js-deployment-settings-configuration-files": {
+    "domain": "stackoverflow.com",
+    "url": "https://stackoverflow.com/questions/5869216/how-to-store-node-js-deployment-settings-configuration-files",
+    "logo": "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png?v=c78bd457575a",
+    "title": "How to store Node.js deployment settings/configuration files?",
+    "description": "I have been working on a few Node apps, and I’ve been looking for a good pattern of storing deployment-related settings. In the Django world (where I come from), the common practise would be to hav..."
+  },
+  "https://blog.benhall.me.uk/2012/02/storing-application-config-data-in/": {
+    "domain": "blog.benhall.me.uk",
+    "url": "https://blog.benhall.me.uk/2012/02/storing-application-config-data-in/",
+    "logo": null,
+    "title": "Storing Node.js application config data – Ben Hall’s Blog",
+    "description": null
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Promise - JavaScript | MDN",
+    "description": "The Promise object represents the eventual completion (or failure) of an asynchronous operation and its resulting value."
+  },
+  "https://johnresig.com/blog/objectgetprototypeof/": {
+    "domain": "johnresig.com",
+    "url": "https://johnresig.com/blog/objectgetprototypeof/",
+    "logo": "https://johnresig.com/wp-content/uploads/2017/04/cropped-jeresig-2016.1024-270x270.jpg",
+    "title": "John Resig - Object.getPrototypeOf",
+    "description": null
+  },
+  "https://kangax.github.io/compat-table/es5/#Reserved_words_as_property_names": {
+    "domain": "kangax.github.io",
+    "url": "https://kangax.github.io/compat-table/es5/#Reserved_words_as_property_names",
+    "logo": "https://kangax.github.io/compat-table/favicon.ico",
+    "title": "ECMAScript 5 compatibility table",
+    "description": null
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "async function - JavaScript | MDN",
+    "description": "An async function is a function declared with the async keyword, and the await keyword is permitted within it. The async and await keywords enable asynchronous, promise-based behavior to be written in a cleaner style, avoiding the need to explicitly configure promise chains."
+  },
+  "https://jakearchibald.com/2017/await-vs-return-vs-return-await/": {
+    "domain": "jakearchibald.com",
+    "url": "https://jakearchibald.com/2017/await-vs-return-vs-return-await/",
+    "logo": "https://jakearchibald.com/c/favicon-67801369.png",
+    "title": "await vs return vs return await",
+    "description": null
+  },
+  "https://stackoverflow.com/questions/13497971/what-is-the-matter-with-script-targeted-urls": {
+    "domain": "stackoverflow.com",
+    "url": "https://stackoverflow.com/questions/13497971/what-is-the-matter-with-script-targeted-urls",
+    "logo": "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png?v=c78bd457575a",
+    "title": "What is the matter with script-targeted URLs?",
+    "description": "I’m using JSHint, and it got the following error: Script URL. Which I noticed that happened because on this particular line there is a string containing a javascript:... URL. I know that JSHint"
+  },
+  "https://es5.github.io/#x15.1.1": {
+    "domain": "es5.github.io",
+    "url": "https://es5.github.io/#x15.1.1",
+    "logo": "https://es5.github.io/favicon.ico",
+    "title": "Annotated ES5",
+    "description": null
+  },
+  "https://en.wikipedia.org/wiki/Variable_shadowing": {
+    "domain": "en.wikipedia.org",
+    "url": "https://en.wikipedia.org/wiki/Variable_shadowing",
+    "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
+    "title": "Variable shadowing - Wikipedia",
+    "description": null
+  },
+  "https://www.nczonline.net/blog/2007/09/09/inconsistent-array-literals/": {
+    "domain": "www.nczonline.net",
+    "url": "https://www.nczonline.net/blog/2007/09/09/inconsistent-array-literals/",
+    "logo": "https://www.nczonline.net/images/favicon.png",
+    "title": "Inconsistent array literals",
+    "description": "Back at the Rich Web Experience, I helped lead a “birds of a feather” group discussion on JavaScript. In that discussion, someone called me a JavaScript expert. I quickly explained that I don’t..."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "undefined - JavaScript | MDN",
+    "description": "The global undefined property represents the primitive value undefined. It is one of JavaScript’s primitive types."
+  },
+  "https://javascriptweblog.wordpress.com/2010/08/16/understanding-undefined-and-preventing-referenceerrors/": {
+    "domain": "javascriptweblog.wordpress.com",
+    "url": "https://javascriptweblog.wordpress.com/2010/08/16/understanding-undefined-and-preventing-referenceerrors/",
+    "logo": "https://s1.wp.com/i/favicon.ico",
+    "title": "Understanding JavaScript’s ‘undefined’",
+    "description": "Compared to other languages, JavaScript’s concept of undefined is a little confusing. In particular, trying to understand ReferenceErrors (“x is not defined”) and how best to code…"
+  },
+  "https://es5.github.io/#x15.1.1.3": {
+    "domain": "es5.github.io",
+    "url": "https://es5.github.io/#x15.1.1.3",
+    "logo": "https://es5.github.io/favicon.ico",
+    "title": "Annotated ES5",
+    "description": null
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Regular expressions - JavaScript | MDN",
+    "description": "Regular expressions are patterns used to match character combinations in strings. In JavaScript, regular expressions are also objects. These patterns are used with the exec() and test() methods of RegExp, and with the match(), matchAll(), replace(), replaceAll(), search(), and split() methods of S…"
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "void operator - JavaScript | MDN",
+    "description": "The void operator evaluates the given expression and then returns undefined."
+  },
+  "https://oreilly.com/javascript/excerpts/javascript-good-parts/bad-parts.html": {
+    "domain": "oreilly.com",
+    "url": "https://oreilly.com/javascript/excerpts/javascript-good-parts/bad-parts.html",
+    "logo": "https://www.oreilly.com/favicon.ico",
+    "title": "O’Reilly Media - Technology and Business Training",
+    "description": "Gain technology and business knowledge and hone your skills with learning resources created and curated by O’Reilly’s experts: live online training, video, books, our platform has content from 200+ of the world’s best publishers."
+  },
+  "https://web.archive.org/web/20200717110117/https://yuiblog.com/blog/2006/04/11/with-statement-considered-harmful/": {
+    "domain": "web.archive.org",
+    "url": "https://web.archive.org/web/20200717110117/https://yuiblog.com/blog/2006/04/11/with-statement-considered-harmful/",
+    "logo": "https://web.archive.org/web/20200717110117im_/https://yuiblog.com/favicon.ico",
+    "title": "with Statement Considered Harmful",
+    "description": null
+  },
+  "https://jscs-dev.github.io/rule/requireNewlineBeforeSingleStatementsInIf": {
+    "domain": "jscs-dev.github.io",
+    "url": "https://jscs-dev.github.io/rule/requireNewlineBeforeSingleStatementsInIf",
+    "logo": "https://jscs-dev.github.io/favicon.ico",
+    "title": "JSCS",
+    "description": null
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Object initializer - JavaScript | MDN",
+    "description": "Objects can be initialized using new Object(), Object.create(), or using the literal notation (initializer notation). An object initializer is a comma-delimited list of zero or more pairs of property names and associated values of an object, enclosed in curly braces ({})."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Arrow function expressions - JavaScript | MDN",
+    "description": "An arrow function expression is a compact alternative to a traditional function expression, but is limited and can’t be used in all situations."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Destructuring assignment - JavaScript | MDN",
+    "description": "The destructuring assignment syntax is a JavaScript expression that makes it possible to unpack values from arrays, or properties from objects, into distinct variables."
+  },
+  "https://2ality.com/2015/01/es6-destructuring.html": {
+    "domain": "2ality.com",
+    "url": "https://2ality.com/2015/01/es6-destructuring.html",
+    "logo": "https://2ality.com/img/favicon.png",
+    "title": "Destructuring and parameter handling in ECMAScript 6",
+    "description": null
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Expressions and operators - JavaScript | MDN",
+    "description": "This chapter documents all the JavaScript language operators, expressions and keywords."
+  },
+  "https://bugs.chromium.org/p/v8/issues/detail?id=5848": {
+    "domain": "bugs.chromium.org",
+    "url": "https://bugs.chromium.org/p/v8/issues/detail?id=5848",
+    "logo": "https://bugs.chromium.org/static/images/monorail.ico",
+    "title": "5848 - v8 - V8 JavaScript Engine - Monorail",
+    "description": null
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Object.hasOwn() - JavaScript | MDN",
+    "description": "The Object.hasOwn() static method returns true if the specified object has the indicated property as its own property. If the property is inherited, or does not exist, the method returns false."
+  },
+  "http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-rejected-with-a-non-error": {
+    "domain": "bluebirdjs.com",
+    "url": "http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-rejected-with-a-non-error",
+    "logo": "//bluebirdjs.com/img/favicon.png",
+    "title": "Warning Explanations | bluebird",
+    "description": "Bluebird is a fully featured JavaScript promises library with unmatched performance."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "RegExp - JavaScript | MDN",
+    "description": "The RegExp object is used for matching text with a pattern."
+  },
+  "https://mathiasbynens.be/notes/javascript-properties": {
+    "domain": "mathiasbynens.be",
+    "url": "https://mathiasbynens.be/notes/javascript-properties",
+    "logo": "https://mathiasbynens.be/favicon.ico",
+    "title": "Unquoted property names / object keys in JavaScript · Mathias Bynens",
+    "description": null
+  },
+  "https://davidwalsh.name/parseint-radix": {
+    "domain": "davidwalsh.name",
+    "url": "https://davidwalsh.name/parseint-radix",
+    "logo": "https://davidwalsh.name/wp-content/themes/punky/images/favicon-144.png",
+    "title": "parseInt Radix",
+    "description": "The radix is important if you’re need to guarantee accuracy with variable input (basic number, binary, etc.). For best results, always use a radix of 10!"
+  },
+  "https://github.com/tc39/proposal-object-rest-spread": {
+    "domain": "github.com",
+    "url": "https://github.com/tc39/proposal-object-rest-spread",
+    "logo": "https://github.com/fluidicon.png",
+    "title": "GitHub - tc39/proposal-object-rest-spread: Rest/Spread Properties for ECMAScript",
+    "description": "Rest/Spread Properties for ECMAScript. Contribute to tc39/proposal-object-rest-spread development by creating an account on GitHub."
+  },
+  "https://blog.izs.me/2010/12/an-open-letter-to-javascript-leaders-regarding/": {
+    "domain": "blog.izs.me",
+    "url": "https://blog.izs.me/2010/12/an-open-letter-to-javascript-leaders-regarding/",
+    "logo": "https://blog.izs.me/favicon.ico",
+    "title": "An Open Letter to JavaScript Leaders Regarding Semicolons",
+    "description": "Writing and Stuff from Isaac Z. Schlueter"
+  },
+  "https://web.archive.org/web/20200420230322/http://inimino.org/~inimino/blog/javascript_semicolons": {
+    "domain": "web.archive.org",
+    "url": "https://web.archive.org/web/20200420230322/http://inimino.org/~inimino/blog/javascript_semicolons",
+    "logo": "https://archive.org/favicon.ico",
+    "title": "JavaScript Semicolon Insertion",
+    "description": null
+  },
+  "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-description": {
+    "domain": "www.ecma-international.org",
+    "url": "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-description",
+    "logo": "https://www.ecma-international.org/ecma-262/6.0/favicon.ico",
+    "title": "ECMAScript 2015 Language Specification – ECMA-262 6th Edition",
+    "description": null
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Template literals (Template strings) - JavaScript | MDN",
+    "description": "Template literals are literals delimited with backtick (`) characters, allowing for multi-line strings, for string interpolation with embedded expressions, and for special constructs called tagged templates."
+  },
+  "https://exploringjs.com/es6/ch_template-literals.html#_examples-of-using-tagged-template-literals": {
+    "domain": "exploringjs.com",
+    "url": "https://exploringjs.com/es6/ch_template-literals.html#_examples-of-using-tagged-template-literals",
+    "logo": "https://exploringjs.com/es6/images/favicon-128.png",
+    "title": "8. Template literals",
+    "description": null
+  },
+  "https://jsdoc.app": {
+    "domain": "jsdoc.app",
+    "url": "https://jsdoc.app",
+    "logo": null,
+    "title": "Use JSDoc: Index",
+    "description": "Official documentation for JSDoc 3."
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "typeof - JavaScript | MDN",
+    "description": "The typeof operator returns a string indicating the type of the unevaluated operand."
+  },
+  "https://danhough.com/blog/single-var-pattern-rant/": {
+    "domain": "danhough.com",
+    "url": "https://danhough.com/blog/single-var-pattern-rant/",
+    "logo": "https://danhough.com/img/meta/apple-touch-icon-152x152.png",
+    "title": "A criticism of the Single Var Pattern in JavaScript, and a simple alternative — Dan Hough",
+    "description": "Dan Hough is a software developer & consultant, a writer and public speaker."
+  },
+  "https://benalman.com/news/2012/05/multiple-var-statements-javascript/": {
+    "domain": "benalman.com",
+    "url": "https://benalman.com/news/2012/05/multiple-var-statements-javascript/",
+    "logo": "https://benalman.com/favicon.ico",
+    "title": "Ben Alman » Multiple var statements in JavaScript, not superfluous",
+    "description": null
+  },
+  "https://en.wikipedia.org/wiki/Yoda_conditions": {
+    "domain": "en.wikipedia.org",
+    "url": "https://en.wikipedia.org/wiki/Yoda_conditions",
+    "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
+    "title": "Yoda conditions - Wikipedia",
+    "description": null
+  },
+  "http://thomas.tuerke.net/on/design/?with=1249091668#msg1146181680": {
+    "domain": "thomas.tuerke.net",
+    "url": "http://thomas.tuerke.net/on/design/?with=1249091668#msg1146181680",
+    "logo": "//thomas.tuerke.net/images/tmtlogo.ico",
+    "title": "Coding in Style",
+    "description": "Thomas M. Tuerke topical weblog"
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation",
+    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+    "title": "Exponentiation (**) - JavaScript | MDN",
+    "description": "The exponentiation operator (**) returns the result of raising the first operand to the power of the second operand. It is equivalent to Math.pow, except it also accepts BigInts as operands."
+  },
+  "https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/": {
+    "domain": "eslint.org",
+    "url": "https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/",
+    "logo": "https://eslint.org/apple-touch-icon.png",
+    "title": "Interesting bugs caught by no-constant-binary-expression - ESLint - Pluggable JavaScript Linter",
+    "description": "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease."
+  },
+  "https://github.com/tc39/proposal-class-static-block": {
+    "domain": "github.com",
+    "url": "https://github.com/tc39/proposal-class-static-block",
+    "logo": "https://github.com/fluidicon.png",
+    "title": "GitHub - tc39/proposal-class-static-block: ECMAScript class static initialization blocks",
+    "description": "ECMAScript class static initialization blocks. Contribute to tc39/proposal-class-static-block development by creating an account on GitHub."
+  },
+  "https://tc39.es/ecma262/#sec-symbol-constructor": {
+    "domain": "tc39.es",
+    "url": "https://tc39.es/ecma262/#sec-symbol-constructor",
+    "logo": "https://tc39.es/ecma262/img/favicon.ico",
+    "title": "ECMAScript® 2023 Language Specification",
+    "description": null
+  },
+  "https://tc39.es/ecma262/#sec-bigint-constructor": {
+    "domain": "tc39.es",
+    "url": "https://tc39.es/ecma262/#sec-bigint-constructor",
+    "logo": "https://tc39.es/ecma262/img/favicon.ico",
+    "title": "ECMAScript® 2023 Language Specification",
+    "description": null
+  },
+  "https://v8.dev/blog/fast-async": {
+    "domain": "v8.dev",
+    "url": "https://v8.dev/blog/fast-async",
+    "logo": "https://v8.dev/favicon.ico",
+    "title": "Faster async functions and promises · V8",
+    "description": "Faster and easier-to-debug async functions and promises are coming to V8 v7.2 / Chrome 72."
+  },
+  "https://github.com/tc39/proposal-regexp-v-flag": {
+    "domain": "github.com",
+    "url": "https://github.com/tc39/proposal-regexp-v-flag",
+    "logo": "https://github.com/fluidicon.png",
+    "title": "GitHub - tc39/proposal-regexp-v-flag: UTS18 set notation in regular expressions",
+    "description": "UTS18 set notation in regular expressions. Contribute to tc39/proposal-regexp-v-flag development by creating an account on GitHub."
+  },
+  "https://v8.dev/features/regexp-v-flag": {
+    "domain": "v8.dev",
+    "url": "https://v8.dev/features/regexp-v-flag",
+    "logo": "https://v8.dev/favicon.ico",
+    "title": "RegExp v flag with set notation and properties of strings · V8",
+    "description": "The new RegExp `v` flag enables `unicodeSets` mode, unlocking support for extended character classes, including Unicode properties of strings, set notation, and improved case-insensitive matching."
+  },
+  "https://codepoints.net/U+1680": {
+    "domain": "codepoints.net",
+    "url": "https://codepoints.net/U+1680",
+    "logo": "https://codepoints.net/favicon.ico",
+    "title": "U+1680 OGHAM SPACE MARK:   – Unicode – Codepoints",
+    "description": " , codepoint U+1680 OGHAM SPACE MARK in Unicode, is located in the block “Ogham”. It belongs to the Ogham script and is a Space Separator."
+  },
+  "https://en.wikipedia.org/wiki/Dead_store": {
+    "domain": "en.wikipedia.org",
+    "url": "https://en.wikipedia.org/wiki/Dead_store",
+    "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
+    "title": "Dead store - Wikipedia",
+    "description": null
+  },
+  "https://rules.sonarsource.com/javascript/RSPEC-1854/": {
+    "domain": "rules.sonarsource.com",
+    "url": "https://rules.sonarsource.com/javascript/RSPEC-1854/",
+    "logo": "https://rules.sonarsource.com/favicon.ico",
+    "title": "JavaScript static code analysis: Unused assignments should be removed",
+    "description": "Dead stores refer to assignments made to local variables that are subsequently never used or immediately overwritten. Such assignments are\nunnecessary and don’t contribute to the functionality or clarity of the code. They may even negatively impact performance. Removing them enhances code\ncleanlines…"
+  },
+  "https://cwe.mitre.org/data/definitions/563.html": {
+    "domain": "cwe.mitre.org",
+    "url": "https://cwe.mitre.org/data/definitions/563.html",
+    "logo": "https://cwe.mitre.org/favicon.ico",
+    "title": "CWE - CWE-563: Assignment to Variable without Use (4.13)",
+    "description": "Common Weakness Enumeration (CWE) is a list of software weaknesses."
+  },
+  "https://wiki.sei.cmu.edu/confluence/display/c/MSC13-C.+Detect+and+remove+unused+values": {
+    "domain": "wiki.sei.cmu.edu",
+    "url": "https://wiki.sei.cmu.edu/confluence/display/c/MSC13-C.+Detect+and+remove+unused+values",
+    "logo": "https://wiki.sei.cmu.edu/confluence/s/-ctumb3/9012/tu5x00/7/_/favicon.ico",
+    "title": "MSC13-C. Detect and remove unused values - SEI CERT C Coding Standard - Confluence",
+    "description": null
+  },
+  "https://wiki.sei.cmu.edu/confluence/display/java/MSC56-J.+Detect+and+remove+superfluous+code+and+values": {
+    "domain": "wiki.sei.cmu.edu",
+    "url": "https://wiki.sei.cmu.edu/confluence/display/java/MSC56-J.+Detect+and+remove+superfluous+code+and+values",
+    "logo": "https://wiki.sei.cmu.edu/confluence/s/-ctumb3/9012/tu5x00/7/_/favicon.ico",
+    "title": "MSC56-J. Detect and remove superfluous code and values - SEI CERT Oracle Coding Standard for Java - Confluence",
+    "description": null
+  },
+  "https://262.ecma-international.org/11.0/#sec-value-properties-of-the-global-object": {
+    "domain": "262.ecma-international.org",
+    "url": "https://262.ecma-international.org/11.0/#sec-value-properties-of-the-global-object",
+    "logo": "https://tc39.es/ecma262/2020/img/favicon.ico",
+    "title": "ECMAScript® 2020 Language Specification",
+    "description": null
+  },
+  "https://262.ecma-international.org/11.0/#sec-strict-mode-of-ecmascript": {
+    "domain": "262.ecma-international.org",
+    "url": "https://262.ecma-international.org/11.0/#sec-strict-mode-of-ecmascript",
+    "logo": "https://tc39.es/ecma262/2020/img/favicon.ico",
+    "title": "ECMAScript® 2020 Language Specification",
+    "description": null
+  }
 }

--- a/docs/src/_data/further_reading_links.json
+++ b/docs/src/_data/further_reading_links.json
@@ -1,800 +1,800 @@
 {
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "setter - JavaScript | MDN",
-    "description": "The set syntax binds an object property to a function to be called when there is an attempt to set that property."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "getter - JavaScript | MDN",
-    "description": "The get syntax binds an object property to a function that will be called when that property is looked up."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Working with objects - JavaScript | MDN",
-    "description": "JavaScript is designed on a simple object-based paradigm. An object is a collection of properties, and a property is an association between a name (or key) and a value. A property’s value can be a function, in which case the property is known as a method. In addition to objects that are predefined i…"
-  },
-  "https://github.com/airbnb/javascript#arrows--one-arg-parens": {
-    "domain": "github.com",
-    "url": "https://github.com/airbnb/javascript#arrows--one-arg-parens",
-    "logo": "https://github.com/fluidicon.png",
-    "title": "GitHub - airbnb/javascript: JavaScript Style Guide",
-    "description": "JavaScript Style Guide. Contribute to airbnb/javascript development by creating an account on GitHub."
-  },
-  "https://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html": {
-    "domain": "www.adequatelygood.com",
-    "url": "https://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html",
-    "logo": "https://www.adequatelygood.com/favicon.ico",
-    "title": "JavaScript Scoping and Hoisting",
-    "description": null
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "var - JavaScript | MDN",
-    "description": "The var statement declares a function-scoped or globally-scoped variable, optionally initializing it to a value."
-  },
-  "https://en.wikipedia.org/wiki/Indent_style": {
-    "domain": "en.wikipedia.org",
-    "url": "https://en.wikipedia.org/wiki/Indent_style",
-    "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
-    "title": "Indentation style - Wikipedia",
-    "description": null
-  },
-  "https://github.com/maxogden/art-of-node#callbacks": {
-    "domain": "github.com",
-    "url": "https://github.com/maxogden/art-of-node#callbacks",
-    "logo": "https://github.com/fluidicon.png",
-    "title": "GitHub - maxogden/art-of-node: a short introduction to node.js",
-    "description": ":snowflake: a short introduction to node.js. Contribute to maxogden/art-of-node development by creating an account on GitHub."
-  },
-  "https://web.archive.org/web/20171224042620/https://docs.nodejitsu.com/articles/errors/what-are-the-error-conventions/": {
-    "domain": "web.archive.org",
-    "url": "https://web.archive.org/web/20171224042620/https://docs.nodejitsu.com/articles/errors/what-are-the-error-conventions/",
-    "logo": "https://archive.org/favicon.ico",
-    "title": "What are the error conventions? - docs.nodejitsu.com",
-    "description": "docs.nodejitsu.com is a growing collection of how-to articles for node.js, written by the community and curated by Nodejitsu and friends. These articles range from basic to advanced, and provide relevant code samples and insights into the design and philosophy of node itself."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Classes - JavaScript | MDN",
-    "description": "Classes are a template for creating objects. They encapsulate data with code to work on that data. Classes in JS are built on prototypes but also have some syntax and semantics that are not shared with ES5 class-like semantics."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "static - JavaScript | MDN",
-    "description": "The static keyword defines a static method or property for a class, or a class static initialization block (see the link for more information about this usage). Neither static methods nor static properties can be called on instances of the class. Instead, they’re called on the class itself."
-  },
-  "https://www.crockford.com/code.html": {
-    "domain": "www.crockford.com",
-    "url": "https://www.crockford.com/code.html",
-    "logo": "https://www.crockford.com/favicon.png",
-    "title": "Code Conventions for the JavaScript Programming Language",
-    "description": null
-  },
-  "https://dojotoolkit.org/reference-guide/1.9/developer/styleguide.html": {
-    "domain": "dojotoolkit.org",
-    "url": "https://dojotoolkit.org/reference-guide/1.9/developer/styleguide.html",
-    "logo": "https://dojotoolkit.org/images/favicons/apple-touch-icon-152x152.png",
-    "title": "Dojo Style Guide — The Dojo Toolkit - Reference Guide",
-    "description": null
-  },
-  "https://gist.github.com/isaacs/357981": {
-    "domain": "gist.github.com",
-    "url": "https://gist.github.com/isaacs/357981",
-    "logo": "https://gist.github.com/fluidicon.png",
-    "title": "A better coding convention for lists and object literals in JavaScript",
-    "description": "A better coding convention for lists and object literals in JavaScript - comma-first-var.js"
-  },
-  "https://en.wikipedia.org/wiki/Cyclomatic_complexity": {
-    "domain": "en.wikipedia.org",
-    "url": "https://en.wikipedia.org/wiki/Cyclomatic_complexity",
-    "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
-    "title": "Cyclomatic complexity - Wikipedia",
-    "description": null
-  },
-  "https://ariya.io/2012/12/complexity-analysis-of-javascript-code": {
-    "domain": "ariya.io",
-    "url": "https://ariya.io/2012/12/complexity-analysis-of-javascript-code",
-    "logo": "https://ariya.io/favicon.ico",
-    "title": "Complexity Analysis of JavaScript Code",
-    "description": "Nobody likes to read complex code, especially if it’s someone’s else code. A preventive approach to block any complex code entering the application is by watching its complexity carefully."
-  },
-  "https://craftsmanshipforsoftware.com/2015/05/25/complexity-for-javascript/": {
-    "domain": "craftsmanshipforsoftware.com",
-    "url": "https://craftsmanshipforsoftware.com/2015/05/25/complexity-for-javascript/",
-    "logo": "https://s0.wp.com/i/webclip.png",
-    "title": "Complexity for JavaScript",
-    "description": "The control of complexity control presents the core problem of software development. The huge variety of decisions a developer faces on a day-to-day basis cry for methods of controlling and contain…"
-  },
-  "https://web.archive.org/web/20160808115119/http://jscomplexity.org/complexity": {
-    "domain": "web.archive.org",
-    "url": "https://web.archive.org/web/20160808115119/http://jscomplexity.org/complexity",
-    "logo": "https://archive.org/favicon.ico",
-    "title": "About complexity | JSComplexity.org",
-    "description": "A discussion of software complexity metrics and how they are calculated."
-  },
-  "https://github.com/eslint/eslint/issues/4808#issuecomment-167795140": {
-    "domain": "github.com",
-    "url": "https://github.com/eslint/eslint/issues/4808#issuecomment-167795140",
-    "logo": "https://github.com/fluidicon.png",
-    "title": "Complexity has no default · Issue #4808 · eslint/eslint",
-    "description": "Enabling the complexity rule with only a severity has no effect. We have tried to give sane defaults to all rules, and I think this should be no exception. I don&#39;t know what a good number would..."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "switch - JavaScript | MDN",
-    "description": "The switch statement evaluates an expression, matching the expression’s value to a case clause, and executes statements associated with that case, as well as statements in cases that follow the matching case."
-  },
-  "https://web.archive.org/web/20201112040809/http://markdaggett.com/blog/2013/02/15/functions-explained/": {
-    "domain": "web.archive.org",
-    "url": "https://web.archive.org/web/20201112040809/http://markdaggett.com/blog/2013/02/15/functions-explained/",
-    "logo": "https://web.archive.org/web/20201112040809im_/http://markdaggett.com/favicon.ico",
-    "title": "Functions Explained - Mark Daggett’s Blog",
-    "description": "A Deep Dive into JavaScript Functions\nBased on my readership I have to assume most of you are familiar with JavaScript already. Therefore, it may …"
-  },
-  "https://2ality.com/2015/09/function-names-es6.html": {
-    "domain": "2ality.com",
-    "url": "https://2ality.com/2015/09/function-names-es6.html",
-    "logo": "https://2ality.com/img/favicon.png",
-    "title": "The names of functions in ES6",
-    "description": null
-  },
-  "https://leanpub.com/understandinges6/read/#leanpub-auto-generators": {
-    "domain": "leanpub.com",
-    "url": "https://leanpub.com/understandinges6/read/#leanpub-auto-generators",
-    "logo": "https://leanpub.com/understandinges6/read/favicons/mstile-310x310.png",
-    "title": "Read Understanding ECMAScript 6 | Leanpub",
-    "description": null
-  },
-  "https://leanpub.com/understandinges6/read/#leanpub-auto-accessor-properties": {
-    "domain": "leanpub.com",
-    "url": "https://leanpub.com/understandinges6/read/#leanpub-auto-accessor-properties",
-    "logo": "https://leanpub.com/understandinges6/read/favicons/mstile-310x310.png",
-    "title": "Read Understanding ECMAScript 6 | Leanpub",
-    "description": null
-  },
-  "https://javascriptweblog.wordpress.com/2011/01/04/exploring-javascript-for-in-loops/": {
-    "domain": "javascriptweblog.wordpress.com",
-    "url": "https://javascriptweblog.wordpress.com/2011/01/04/exploring-javascript-for-in-loops/",
-    "logo": "https://s1.wp.com/i/favicon.ico",
-    "title": "Exploring JavaScript for-in loops",
-    "description": "The for-in loop is the only cross-browser technique for iterating the properties of generic objects. There’s a bunch of literature about the dangers of using for-in to iterate arrays and when…"
-  },
-  "https://2ality.com/2012/01/objects-as-maps.html": {
-    "domain": "2ality.com",
-    "url": "https://2ality.com/2012/01/objects-as-maps.html",
-    "logo": "https://2ality.com/img/favicon.png",
-    "title": "The pitfalls of using objects as maps in JavaScript",
-    "description": null
-  },
-  "https://web.archive.org/web/20160725154648/http://www.mind2b.com/component/content/article/24-software-module-size-and-file-size": {
-    "domain": "web.archive.org",
-    "url": "https://web.archive.org/web/20160725154648/http://www.mind2b.com/component/content/article/24-software-module-size-and-file-size",
-    "logo": "https://archive.org/favicon.ico",
-    "title": "Software Module size and file size",
-    "description": null
-  },
-  "http://book.mixu.net/node/ch7.html": {
-    "domain": "book.mixu.net",
-    "url": "http://book.mixu.net/node/ch7.html",
-    "logo": null,
-    "title": "7. Control flow - Mixu’s Node book",
-    "description": null
-  },
-  "https://web.archive.org/web/20220104141150/https://howtonode.org/control-flow": {
-    "domain": "web.archive.org",
-    "url": "https://web.archive.org/web/20220104141150/https://howtonode.org/control-flow",
-    "logo": "https://web.archive.org/web/20220104141150im_/https://howtonode.org/favicon.ico",
-    "title": "Control Flow in Node - How To Node - NodeJS",
-    "description": "Learn the zen of coding in NodeJS."
-  },
-  "https://web.archive.org/web/20220127215850/https://howtonode.org/control-flow-part-ii": {
-    "domain": "web.archive.org",
-    "url": "https://web.archive.org/web/20220127215850/https://howtonode.org/control-flow-part-ii",
-    "logo": "https://web.archive.org/web/20220127215850im_/https://howtonode.org/favicon.ico",
-    "title": "Control Flow in Node Part II - How To Node - NodeJS",
-    "description": "Learn the zen of coding in NodeJS."
-  },
-  "https://nodejs.org/api/buffer.html": {
-    "domain": "nodejs.org",
-    "url": "https://nodejs.org/api/buffer.html",
-    "logo": "https://nodejs.org/favicon.ico",
-    "title": "Buffer | Node.js v18.2.0 Documentation",
-    "description": null
-  },
-  "https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md": {
-    "domain": "github.com",
-    "url": "https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md",
-    "logo": "https://github.com/fluidicon.png",
-    "title": "notes/Lets-fix-Buffer-API.md at master · ChALkeR/notes",
-    "description": "Some public notes. Contribute to ChALkeR/notes development by creating an account on GitHub."
-  },
-  "https://github.com/nodejs/node/issues/4660": {
-    "domain": "github.com",
-    "url": "https://github.com/nodejs/node/issues/4660",
-    "logo": "https://github.com/fluidicon.png",
-    "title": "Buffer(number) is unsafe · Issue #4660 · nodejs/node",
-    "description": "tl;dr This issue proposes: Change new Buffer(number) to return safe, zeroed-out memory Create a new API for creating uninitialized Buffers, Buffer.alloc(number) Update: Jan 15, 2016 Upon further co..."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "debugger - JavaScript | MDN",
-    "description": "The debugger statement invokes any available debugging functionality, such as setting a breakpoint. If no debugging functionality is available, this statement has no effect."
-  },
-  "https://ericlippert.com/2003/11/01/eval-is-evil-part-one/": {
-    "domain": "ericlippert.com",
-    "url": "https://ericlippert.com/2003/11/01/eval-is-evil-part-one/",
-    "logo": "https://s1.wp.com/i/favicon.ico",
-    "title": "Eval is evil, part one",
-    "description": "The eval method — which takes a string containing JScript code, compiles it and runs it — is probably the most powerful and most misused method in JScript. There are a few scenarios in …"
-  },
-  "https://javascriptweblog.wordpress.com/2010/04/19/how-evil-is-eval/": {
-    "domain": "javascriptweblog.wordpress.com",
-    "url": "https://javascriptweblog.wordpress.com/2010/04/19/how-evil-is-eval/",
-    "logo": "https://s1.wp.com/i/favicon.ico",
-    "title": "How evil is eval?",
-    "description": "“eval is Evil: The eval function is the most misused feature of JavaScript. Avoid it” Douglas Crockford in JavaScript: The Good Parts I like The Good Parts. It’s essential reading…"
-  },
-  "https://bocoup.com/blog/the-catch-with-try-catch": {
-    "domain": "bocoup.com",
-    "url": "https://bocoup.com/blog/the-catch-with-try-catch",
-    "logo": "https://static3.bocoup.com/assets/2015/10/06163533/favicon.png",
-    "title": "The",
-    "description": "I’ve recently been working on an update to JavaScript Debug, which has me doing a lot of cross-browser testing, and I noticed a few “interesting quirks” with try…catch in Internet Explorer 6-8 that I couldn’t find documented anywhere."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Function.prototype.bind() - JavaScript | MDN",
-    "description": "The bind() method creates a new function that, when called, has its this keyword set to the provided value, with a given sequence of arguments preceding any provided when the new function is called."
-  },
-  "https://www.smashingmagazine.com/2014/01/understanding-javascript-function-prototype-bind/": {
-    "domain": "www.smashingmagazine.com",
-    "url": "https://www.smashingmagazine.com/2014/01/understanding-javascript-function-prototype-bind/",
-    "logo": "https://www.smashingmagazine.com/images/favicon/apple-touch-icon.png",
-    "title": "Understanding JavaScript Bind () — Smashing Magazine",
-    "description": "Function binding is probably your least concern when beginning with JavaScript, but when you realize that you need a solution to the problem of how to keep the context of “this” within another function, then you might not realize that what you actually need is Function.prototype.bind()."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Operator precedence - JavaScript | MDN",
-    "description": "Operator precedence determines how operators are parsed concerning each other. Operators with higher precedence become the operands of operators with lower precedence."
-  },
-  "https://es5.github.io/#C": {
-    "domain": "es5.github.io",
-    "url": "https://es5.github.io/#C",
-    "logo": "https://es5.github.io/favicon.ico",
-    "title": "Annotated ES5",
-    "description": null
-  },
-  "https://benalman.com/news/2010/11/immediately-invoked-function-expression/": {
-    "domain": "benalman.com",
-    "url": "https://benalman.com/news/2010/11/immediately-invoked-function-expression/",
-    "logo": "https://benalman.com/favicon.ico",
-    "title": "Ben Alman » Immediately-Invoked Function Expression (IIFE)",
-    "description": null
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "ReferenceError: assignment to undeclared variable “x” - JavaScript | MDN",
-    "description": "The JavaScript strict mode-only exception “Assignment to undeclared variable” occurs when the value has been assigned to an undeclared variable."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "let - JavaScript | MDN",
-    "description": "The let statement declares a block-scoped local variable, optionally initializing it to a value."
-  },
-  "https://es5.github.io/#x7.8.5": {
-    "domain": "es5.github.io",
-    "url": "https://es5.github.io/#x7.8.5",
-    "logo": "https://es5.github.io/favicon.ico",
-    "title": "Annotated ES5",
-    "description": null
-  },
-  "https://es5.github.io/#x7.2": {
-    "domain": "es5.github.io",
-    "url": "https://es5.github.io/#x7.2",
-    "logo": "https://es5.github.io/favicon.ico",
-    "title": "Annotated ES5",
-    "description": null
-  },
-  "https://web.archive.org/web/20200414142829/http://timelessrepo.com/json-isnt-a-javascript-subset": {
-    "domain": "web.archive.org",
-    "url": "https://web.archive.org/web/20200414142829/http://timelessrepo.com/json-isnt-a-javascript-subset",
-    "logo": "https://archive.org/favicon.ico",
-    "title": "JSON: The JavaScript subset that isn’t - Timeless",
-    "description": null
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Iterators and generators - JavaScript | MDN",
-    "description": "Iterators and Generators bring the concept of iteration directly into the core language and provide a mechanism for customizing the behavior of for...of loops."
-  },
-  "https://kangax.github.io/es5-compat-table/es6/#Iterators": {
-    "domain": "kangax.github.io",
-    "url": "https://kangax.github.io/es5-compat-table/es6/#Iterators",
-    "logo": "https://github.io/favicon.ico",
-    "title": null,
-    "description": null
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#Object_methods": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#Object_methods",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Deprecated and obsolete features - JavaScript | MDN",
-    "description": "This page lists features of JavaScript that are deprecated (that is, still available but planned for removal) and obsolete (that is, no longer usable)."
-  },
-  "https://www.emacswiki.org/emacs/SmartTabs": {
-    "domain": "www.emacswiki.org",
-    "url": "https://www.emacswiki.org/emacs/SmartTabs",
-    "logo": "https://www.emacswiki.org/favicon.ico",
-    "title": "EmacsWiki: Smart Tabs",
-    "description": null
-  },
-  "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects": {
-    "domain": "www.ecma-international.org",
-    "url": "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects",
-    "logo": "https://www.ecma-international.org/ecma-262/6.0/favicon.ico",
-    "title": "ECMAScript 2015 Language Specification – ECMA-262 6th Edition",
-    "description": null
-  },
-  "https://www.inkling.com/read/javascript-definitive-guide-david-flanagan-6th/chapter-3/wrapper-objects": {
-    "domain": "www.inkling.com",
-    "url": "https://www.inkling.com/read/javascript-definitive-guide-david-flanagan-6th/chapter-3/wrapper-objects",
-    "logo": "https://inklingstatic.a.ssl.fastly.net/static_assets/20220214.223700z.8c5796a9.docker/images/favicon.ico",
-    "title": "Unsupported Browser",
-    "description": null
-  },
-  "https://tc39.es/ecma262/#prod-annexB-NonOctalDecimalEscapeSequence": {
-    "domain": "tc39.es",
-    "url": "https://tc39.es/ecma262/#prod-annexB-NonOctalDecimalEscapeSequence",
-    "logo": "https://tc39.es/ecma262/img/favicon.ico",
-    "title": "ECMAScript® 2023 Language Specification",
-    "description": null
-  },
-  "https://es5.github.io/#x15.8": {
-    "domain": "es5.github.io",
-    "url": "https://es5.github.io/#x15.8",
-    "logo": "https://es5.github.io/favicon.ico",
-    "title": "Annotated ES5",
-    "description": null
-  },
-  "https://spin.atomicobject.com/2011/04/10/javascript-don-t-reassign-your-function-arguments/": {
-    "domain": "spin.atomicobject.com",
-    "url": "https://spin.atomicobject.com/2011/04/10/javascript-don-t-reassign-your-function-arguments/",
-    "logo": "https://spin.atomicobject.com/wp-content/themes/spin/images/favicon.ico",
-    "title": "JavaScript: Don’t Reassign Your Function Arguments",
-    "description": "The point of this post is to raise awareness that reassigning the value of an argument variable mutates the arguments object."
-  },
-  "https://stackoverflow.com/questions/5869216/how-to-store-node-js-deployment-settings-configuration-files": {
-    "domain": "stackoverflow.com",
-    "url": "https://stackoverflow.com/questions/5869216/how-to-store-node-js-deployment-settings-configuration-files",
-    "logo": "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png?v=c78bd457575a",
-    "title": "How to store Node.js deployment settings/configuration files?",
-    "description": "I have been working on a few Node apps, and I’ve been looking for a good pattern of storing deployment-related settings. In the Django world (where I come from), the common practise would be to hav..."
-  },
-  "https://blog.benhall.me.uk/2012/02/storing-application-config-data-in/": {
-    "domain": "blog.benhall.me.uk",
-    "url": "https://blog.benhall.me.uk/2012/02/storing-application-config-data-in/",
-    "logo": null,
-    "title": "Storing Node.js application config data – Ben Hall’s Blog",
-    "description": null
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Promise - JavaScript | MDN",
-    "description": "The Promise object represents the eventual completion (or failure) of an asynchronous operation and its resulting value."
-  },
-  "https://johnresig.com/blog/objectgetprototypeof/": {
-    "domain": "johnresig.com",
-    "url": "https://johnresig.com/blog/objectgetprototypeof/",
-    "logo": "https://johnresig.com/wp-content/uploads/2017/04/cropped-jeresig-2016.1024-270x270.jpg",
-    "title": "John Resig - Object.getPrototypeOf",
-    "description": null
-  },
-  "https://kangax.github.io/compat-table/es5/#Reserved_words_as_property_names": {
-    "domain": "kangax.github.io",
-    "url": "https://kangax.github.io/compat-table/es5/#Reserved_words_as_property_names",
-    "logo": "https://kangax.github.io/compat-table/favicon.ico",
-    "title": "ECMAScript 5 compatibility table",
-    "description": null
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "async function - JavaScript | MDN",
-    "description": "An async function is a function declared with the async keyword, and the await keyword is permitted within it. The async and await keywords enable asynchronous, promise-based behavior to be written in a cleaner style, avoiding the need to explicitly configure promise chains."
-  },
-  "https://jakearchibald.com/2017/await-vs-return-vs-return-await/": {
-    "domain": "jakearchibald.com",
-    "url": "https://jakearchibald.com/2017/await-vs-return-vs-return-await/",
-    "logo": "https://jakearchibald.com/c/favicon-67801369.png",
-    "title": "await vs return vs return await",
-    "description": null
-  },
-  "https://stackoverflow.com/questions/13497971/what-is-the-matter-with-script-targeted-urls": {
-    "domain": "stackoverflow.com",
-    "url": "https://stackoverflow.com/questions/13497971/what-is-the-matter-with-script-targeted-urls",
-    "logo": "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png?v=c78bd457575a",
-    "title": "What is the matter with script-targeted URLs?",
-    "description": "I’m using JSHint, and it got the following error: Script URL. Which I noticed that happened because on this particular line there is a string containing a javascript:... URL. I know that JSHint"
-  },
-  "https://es5.github.io/#x15.1.1": {
-    "domain": "es5.github.io",
-    "url": "https://es5.github.io/#x15.1.1",
-    "logo": "https://es5.github.io/favicon.ico",
-    "title": "Annotated ES5",
-    "description": null
-  },
-  "https://en.wikipedia.org/wiki/Variable_shadowing": {
-    "domain": "en.wikipedia.org",
-    "url": "https://en.wikipedia.org/wiki/Variable_shadowing",
-    "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
-    "title": "Variable shadowing - Wikipedia",
-    "description": null
-  },
-  "https://www.nczonline.net/blog/2007/09/09/inconsistent-array-literals/": {
-    "domain": "www.nczonline.net",
-    "url": "https://www.nczonline.net/blog/2007/09/09/inconsistent-array-literals/",
-    "logo": "https://www.nczonline.net/images/favicon.png",
-    "title": "Inconsistent array literals",
-    "description": "Back at the Rich Web Experience, I helped lead a “birds of a feather” group discussion on JavaScript. In that discussion, someone called me a JavaScript expert. I quickly explained that I don’t..."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "undefined - JavaScript | MDN",
-    "description": "The global undefined property represents the primitive value undefined. It is one of JavaScript’s primitive types."
-  },
-  "https://javascriptweblog.wordpress.com/2010/08/16/understanding-undefined-and-preventing-referenceerrors/": {
-    "domain": "javascriptweblog.wordpress.com",
-    "url": "https://javascriptweblog.wordpress.com/2010/08/16/understanding-undefined-and-preventing-referenceerrors/",
-    "logo": "https://s1.wp.com/i/favicon.ico",
-    "title": "Understanding JavaScript’s ‘undefined’",
-    "description": "Compared to other languages, JavaScript’s concept of undefined is a little confusing. In particular, trying to understand ReferenceErrors (“x is not defined”) and how best to code…"
-  },
-  "https://es5.github.io/#x15.1.1.3": {
-    "domain": "es5.github.io",
-    "url": "https://es5.github.io/#x15.1.1.3",
-    "logo": "https://es5.github.io/favicon.ico",
-    "title": "Annotated ES5",
-    "description": null
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Regular expressions - JavaScript | MDN",
-    "description": "Regular expressions are patterns used to match character combinations in strings. In JavaScript, regular expressions are also objects. These patterns are used with the exec() and test() methods of RegExp, and with the match(), matchAll(), replace(), replaceAll(), search(), and split() methods of S…"
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "void operator - JavaScript | MDN",
-    "description": "The void operator evaluates the given expression and then returns undefined."
-  },
-  "https://oreilly.com/javascript/excerpts/javascript-good-parts/bad-parts.html": {
-    "domain": "oreilly.com",
-    "url": "https://oreilly.com/javascript/excerpts/javascript-good-parts/bad-parts.html",
-    "logo": "https://www.oreilly.com/favicon.ico",
-    "title": "O’Reilly Media - Technology and Business Training",
-    "description": "Gain technology and business knowledge and hone your skills with learning resources created and curated by O’Reilly’s experts: live online training, video, books, our platform has content from 200+ of the world’s best publishers."
-  },
-  "https://web.archive.org/web/20200717110117/https://yuiblog.com/blog/2006/04/11/with-statement-considered-harmful/": {
-    "domain": "web.archive.org",
-    "url": "https://web.archive.org/web/20200717110117/https://yuiblog.com/blog/2006/04/11/with-statement-considered-harmful/",
-    "logo": "https://web.archive.org/web/20200717110117im_/https://yuiblog.com/favicon.ico",
-    "title": "with Statement Considered Harmful",
-    "description": null
-  },
-  "https://jscs-dev.github.io/rule/requireNewlineBeforeSingleStatementsInIf": {
-    "domain": "jscs-dev.github.io",
-    "url": "https://jscs-dev.github.io/rule/requireNewlineBeforeSingleStatementsInIf",
-    "logo": "https://jscs-dev.github.io/favicon.ico",
-    "title": "JSCS",
-    "description": null
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Object initializer - JavaScript | MDN",
-    "description": "Objects can be initialized using new Object(), Object.create(), or using the literal notation (initializer notation). An object initializer is a comma-delimited list of zero or more pairs of property names and associated values of an object, enclosed in curly braces ({})."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Arrow function expressions - JavaScript | MDN",
-    "description": "An arrow function expression is a compact alternative to a traditional function expression, but is limited and can’t be used in all situations."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Destructuring assignment - JavaScript | MDN",
-    "description": "The destructuring assignment syntax is a JavaScript expression that makes it possible to unpack values from arrays, or properties from objects, into distinct variables."
-  },
-  "https://2ality.com/2015/01/es6-destructuring.html": {
-    "domain": "2ality.com",
-    "url": "https://2ality.com/2015/01/es6-destructuring.html",
-    "logo": "https://2ality.com/img/favicon.png",
-    "title": "Destructuring and parameter handling in ECMAScript 6",
-    "description": null
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Expressions and operators - JavaScript | MDN",
-    "description": "This chapter documents all the JavaScript language operators, expressions and keywords."
-  },
-  "https://bugs.chromium.org/p/v8/issues/detail?id=5848": {
-    "domain": "bugs.chromium.org",
-    "url": "https://bugs.chromium.org/p/v8/issues/detail?id=5848",
-    "logo": "https://bugs.chromium.org/static/images/monorail.ico",
-    "title": "5848 - v8 - V8 JavaScript Engine - Monorail",
-    "description": null
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Object.hasOwn() - JavaScript | MDN",
-    "description": "The Object.hasOwn() static method returns true if the specified object has the indicated property as its own property. If the property is inherited, or does not exist, the method returns false."
-  },
-  "http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-rejected-with-a-non-error": {
-    "domain": "bluebirdjs.com",
-    "url": "http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-rejected-with-a-non-error",
-    "logo": "//bluebirdjs.com/img/favicon.png",
-    "title": "Warning Explanations | bluebird",
-    "description": "Bluebird is a fully featured JavaScript promises library with unmatched performance."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "RegExp - JavaScript | MDN",
-    "description": "The RegExp object is used for matching text with a pattern."
-  },
-  "https://mathiasbynens.be/notes/javascript-properties": {
-    "domain": "mathiasbynens.be",
-    "url": "https://mathiasbynens.be/notes/javascript-properties",
-    "logo": "https://mathiasbynens.be/favicon.ico",
-    "title": "Unquoted property names / object keys in JavaScript · Mathias Bynens",
-    "description": null
-  },
-  "https://davidwalsh.name/parseint-radix": {
-    "domain": "davidwalsh.name",
-    "url": "https://davidwalsh.name/parseint-radix",
-    "logo": "https://davidwalsh.name/wp-content/themes/punky/images/favicon-144.png",
-    "title": "parseInt Radix",
-    "description": "The radix is important if you’re need to guarantee accuracy with variable input (basic number, binary, etc.). For best results, always use a radix of 10!"
-  },
-  "https://github.com/tc39/proposal-object-rest-spread": {
-    "domain": "github.com",
-    "url": "https://github.com/tc39/proposal-object-rest-spread",
-    "logo": "https://github.com/fluidicon.png",
-    "title": "GitHub - tc39/proposal-object-rest-spread: Rest/Spread Properties for ECMAScript",
-    "description": "Rest/Spread Properties for ECMAScript. Contribute to tc39/proposal-object-rest-spread development by creating an account on GitHub."
-  },
-  "https://blog.izs.me/2010/12/an-open-letter-to-javascript-leaders-regarding/": {
-    "domain": "blog.izs.me",
-    "url": "https://blog.izs.me/2010/12/an-open-letter-to-javascript-leaders-regarding/",
-    "logo": "https://blog.izs.me/favicon.ico",
-    "title": "An Open Letter to JavaScript Leaders Regarding Semicolons",
-    "description": "Writing and Stuff from Isaac Z. Schlueter"
-  },
-  "https://web.archive.org/web/20200420230322/http://inimino.org/~inimino/blog/javascript_semicolons": {
-    "domain": "web.archive.org",
-    "url": "https://web.archive.org/web/20200420230322/http://inimino.org/~inimino/blog/javascript_semicolons",
-    "logo": "https://archive.org/favicon.ico",
-    "title": "JavaScript Semicolon Insertion",
-    "description": null
-  },
-  "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-description": {
-    "domain": "www.ecma-international.org",
-    "url": "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-description",
-    "logo": "https://www.ecma-international.org/ecma-262/6.0/favicon.ico",
-    "title": "ECMAScript 2015 Language Specification – ECMA-262 6th Edition",
-    "description": null
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Template literals (Template strings) - JavaScript | MDN",
-    "description": "Template literals are literals delimited with backtick (`) characters, allowing for multi-line strings, for string interpolation with embedded expressions, and for special constructs called tagged templates."
-  },
-  "https://exploringjs.com/es6/ch_template-literals.html#_examples-of-using-tagged-template-literals": {
-    "domain": "exploringjs.com",
-    "url": "https://exploringjs.com/es6/ch_template-literals.html#_examples-of-using-tagged-template-literals",
-    "logo": "https://exploringjs.com/es6/images/favicon-128.png",
-    "title": "8. Template literals",
-    "description": null
-  },
-  "https://jsdoc.app": {
-    "domain": "jsdoc.app",
-    "url": "https://jsdoc.app",
-    "logo": null,
-    "title": "Use JSDoc: Index",
-    "description": "Official documentation for JSDoc 3."
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "typeof - JavaScript | MDN",
-    "description": "The typeof operator returns a string indicating the type of the unevaluated operand."
-  },
-  "https://danhough.com/blog/single-var-pattern-rant/": {
-    "domain": "danhough.com",
-    "url": "https://danhough.com/blog/single-var-pattern-rant/",
-    "logo": "https://danhough.com/img/meta/apple-touch-icon-152x152.png",
-    "title": "A criticism of the Single Var Pattern in JavaScript, and a simple alternative — Dan Hough",
-    "description": "Dan Hough is a software developer & consultant, a writer and public speaker."
-  },
-  "https://benalman.com/news/2012/05/multiple-var-statements-javascript/": {
-    "domain": "benalman.com",
-    "url": "https://benalman.com/news/2012/05/multiple-var-statements-javascript/",
-    "logo": "https://benalman.com/favicon.ico",
-    "title": "Ben Alman » Multiple var statements in JavaScript, not superfluous",
-    "description": null
-  },
-  "https://en.wikipedia.org/wiki/Yoda_conditions": {
-    "domain": "en.wikipedia.org",
-    "url": "https://en.wikipedia.org/wiki/Yoda_conditions",
-    "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
-    "title": "Yoda conditions - Wikipedia",
-    "description": null
-  },
-  "http://thomas.tuerke.net/on/design/?with=1249091668#msg1146181680": {
-    "domain": "thomas.tuerke.net",
-    "url": "http://thomas.tuerke.net/on/design/?with=1249091668#msg1146181680",
-    "logo": "//thomas.tuerke.net/images/tmtlogo.ico",
-    "title": "Coding in Style",
-    "description": "Thomas M. Tuerke topical weblog"
-  },
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation": {
-    "domain": "developer.mozilla.org",
-    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation",
-    "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
-    "title": "Exponentiation (**) - JavaScript | MDN",
-    "description": "The exponentiation operator (**) returns the result of raising the first operand to the power of the second operand. It is equivalent to Math.pow, except it also accepts BigInts as operands."
-  },
-  "https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/": {
-    "domain": "eslint.org",
-    "url": "https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/",
-    "logo": "https://eslint.org/apple-touch-icon.png",
-    "title": "Interesting bugs caught by no-constant-binary-expression - ESLint - Pluggable JavaScript Linter",
-    "description": "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease."
-  },
-  "https://github.com/tc39/proposal-class-static-block": {
-    "domain": "github.com",
-    "url": "https://github.com/tc39/proposal-class-static-block",
-    "logo": "https://github.com/fluidicon.png",
-    "title": "GitHub - tc39/proposal-class-static-block: ECMAScript class static initialization blocks",
-    "description": "ECMAScript class static initialization blocks. Contribute to tc39/proposal-class-static-block development by creating an account on GitHub."
-  },
-  "https://tc39.es/ecma262/#sec-symbol-constructor": {
-    "domain": "tc39.es",
-    "url": "https://tc39.es/ecma262/#sec-symbol-constructor",
-    "logo": "https://tc39.es/ecma262/img/favicon.ico",
-    "title": "ECMAScript® 2023 Language Specification",
-    "description": null
-  },
-  "https://tc39.es/ecma262/#sec-bigint-constructor": {
-    "domain": "tc39.es",
-    "url": "https://tc39.es/ecma262/#sec-bigint-constructor",
-    "logo": "https://tc39.es/ecma262/img/favicon.ico",
-    "title": "ECMAScript® 2023 Language Specification",
-    "description": null
-  },
-  "https://v8.dev/blog/fast-async": {
-    "domain": "v8.dev",
-    "url": "https://v8.dev/blog/fast-async",
-    "logo": "https://v8.dev/favicon.ico",
-    "title": "Faster async functions and promises · V8",
-    "description": "Faster and easier-to-debug async functions and promises are coming to V8 v7.2 / Chrome 72."
-  },
-  "https://github.com/tc39/proposal-regexp-v-flag": {
-    "domain": "github.com",
-    "url": "https://github.com/tc39/proposal-regexp-v-flag",
-    "logo": "https://github.com/fluidicon.png",
-    "title": "GitHub - tc39/proposal-regexp-v-flag: UTS18 set notation in regular expressions",
-    "description": "UTS18 set notation in regular expressions. Contribute to tc39/proposal-regexp-v-flag development by creating an account on GitHub."
-  },
-  "https://v8.dev/features/regexp-v-flag": {
-    "domain": "v8.dev",
-    "url": "https://v8.dev/features/regexp-v-flag",
-    "logo": "https://v8.dev/favicon.ico",
-    "title": "RegExp v flag with set notation and properties of strings · V8",
-    "description": "The new RegExp `v` flag enables `unicodeSets` mode, unlocking support for extended character classes, including Unicode properties of strings, set notation, and improved case-insensitive matching."
-  },
-  "https://codepoints.net/U+1680": {
-    "domain": "codepoints.net",
-    "url": "https://codepoints.net/U+1680",
-    "logo": "https://codepoints.net/favicon.ico",
-    "title": "U+1680 OGHAM SPACE MARK:   – Unicode – Codepoints",
-    "description": " , codepoint U+1680 OGHAM SPACE MARK in Unicode, is located in the block “Ogham”. It belongs to the Ogham script and is a Space Separator."
-  },
-  "https://en.wikipedia.org/wiki/Dead_store": {
-    "domain": "en.wikipedia.org",
-    "url": "https://en.wikipedia.org/wiki/Dead_store",
-    "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
-    "title": "Dead store - Wikipedia",
-    "description": null
-  },
-  "https://rules.sonarsource.com/javascript/RSPEC-1854/": {
-    "domain": "rules.sonarsource.com",
-    "url": "https://rules.sonarsource.com/javascript/RSPEC-1854/",
-    "logo": "https://rules.sonarsource.com/favicon.ico",
-    "title": "JavaScript static code analysis: Unused assignments should be removed",
-    "description": "Dead stores refer to assignments made to local variables that are subsequently never used or immediately overwritten. Such assignments are\nunnecessary and don’t contribute to the functionality or clarity of the code. They may even negatively impact performance. Removing them enhances code\ncleanlines…"
-  },
-  "https://cwe.mitre.org/data/definitions/563.html": {
-    "domain": "cwe.mitre.org",
-    "url": "https://cwe.mitre.org/data/definitions/563.html",
-    "logo": "https://cwe.mitre.org/favicon.ico",
-    "title": "CWE - CWE-563: Assignment to Variable without Use (4.13)",
-    "description": "Common Weakness Enumeration (CWE) is a list of software weaknesses."
-  },
-  "https://wiki.sei.cmu.edu/confluence/display/c/MSC13-C.+Detect+and+remove+unused+values": {
-    "domain": "wiki.sei.cmu.edu",
-    "url": "https://wiki.sei.cmu.edu/confluence/display/c/MSC13-C.+Detect+and+remove+unused+values",
-    "logo": "https://wiki.sei.cmu.edu/confluence/s/-ctumb3/9012/tu5x00/7/_/favicon.ico",
-    "title": "MSC13-C. Detect and remove unused values - SEI CERT C Coding Standard - Confluence",
-    "description": null
-  },
-  "https://wiki.sei.cmu.edu/confluence/display/java/MSC56-J.+Detect+and+remove+superfluous+code+and+values": {
-    "domain": "wiki.sei.cmu.edu",
-    "url": "https://wiki.sei.cmu.edu/confluence/display/java/MSC56-J.+Detect+and+remove+superfluous+code+and+values",
-    "logo": "https://wiki.sei.cmu.edu/confluence/s/-ctumb3/9012/tu5x00/7/_/favicon.ico",
-    "title": "MSC56-J. Detect and remove superfluous code and values - SEI CERT Oracle Coding Standard for Java - Confluence",
-    "description": null
-  },
-  "https://262.ecma-international.org/11.0/#sec-value-properties-of-the-global-object": {
-    "domain": "262.ecma-international.org",
-    "url": "https://262.ecma-international.org/11.0/#sec-value-properties-of-the-global-object",
-    "logo": "https://tc39.es/ecma262/2020/img/favicon.ico",
-    "title": "ECMAScript® 2020 Language Specification",
-    "description": null
-  },
-  "https://262.ecma-international.org/11.0/#sec-strict-mode-of-ecmascript": {
-    "domain": "262.ecma-international.org",
-    "url": "https://262.ecma-international.org/11.0/#sec-strict-mode-of-ecmascript",
-    "logo": "https://tc39.es/ecma262/2020/img/favicon.ico",
-    "title": "ECMAScript® 2020 Language Specification",
-    "description": null
-  }
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "setter - JavaScript | MDN",
+        "description": "The set syntax binds an object property to a function to be called when there is an attempt to set that property."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "getter - JavaScript | MDN",
+        "description": "The get syntax binds an object property to a function that will be called when that property is looked up."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Working with objects - JavaScript | MDN",
+        "description": "JavaScript is designed on a simple object-based paradigm. An object is a collection of properties, and a property is an association between a name (or key) and a value. A property’s value can be a function, in which case the property is known as a method. In addition to objects that are predefined i…"
+    },
+    "https://github.com/airbnb/javascript#arrows--one-arg-parens": {
+        "domain": "github.com",
+        "url": "https://github.com/airbnb/javascript#arrows--one-arg-parens",
+        "logo": "https://github.com/fluidicon.png",
+        "title": "GitHub - airbnb/javascript: JavaScript Style Guide",
+        "description": "JavaScript Style Guide. Contribute to airbnb/javascript development by creating an account on GitHub."
+    },
+    "https://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html": {
+        "domain": "www.adequatelygood.com",
+        "url": "https://www.adequatelygood.com/JavaScript-Scoping-and-Hoisting.html",
+        "logo": "https://www.adequatelygood.com/favicon.ico",
+        "title": "JavaScript Scoping and Hoisting",
+        "description": null
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "var - JavaScript | MDN",
+        "description": "The var statement declares a function-scoped or globally-scoped variable, optionally initializing it to a value."
+    },
+    "https://en.wikipedia.org/wiki/Indent_style": {
+        "domain": "en.wikipedia.org",
+        "url": "https://en.wikipedia.org/wiki/Indent_style",
+        "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
+        "title": "Indentation style - Wikipedia",
+        "description": null
+    },
+    "https://github.com/maxogden/art-of-node#callbacks": {
+        "domain": "github.com",
+        "url": "https://github.com/maxogden/art-of-node#callbacks",
+        "logo": "https://github.com/fluidicon.png",
+        "title": "GitHub - maxogden/art-of-node: a short introduction to node.js",
+        "description": ":snowflake: a short introduction to node.js. Contribute to maxogden/art-of-node development by creating an account on GitHub."
+    },
+    "https://web.archive.org/web/20171224042620/https://docs.nodejitsu.com/articles/errors/what-are-the-error-conventions/": {
+        "domain": "web.archive.org",
+        "url": "https://web.archive.org/web/20171224042620/https://docs.nodejitsu.com/articles/errors/what-are-the-error-conventions/",
+        "logo": "https://archive.org/favicon.ico",
+        "title": "What are the error conventions? - docs.nodejitsu.com",
+        "description": "docs.nodejitsu.com is a growing collection of how-to articles for node.js, written by the community and curated by Nodejitsu and friends. These articles range from basic to advanced, and provide relevant code samples and insights into the design and philosophy of node itself."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Classes - JavaScript | MDN",
+        "description": "Classes are a template for creating objects. They encapsulate data with code to work on that data. Classes in JS are built on prototypes but also have some syntax and semantics that are not shared with ES5 class-like semantics."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "static - JavaScript | MDN",
+        "description": "The static keyword defines a static method or property for a class, or a class static initialization block (see the link for more information about this usage). Neither static methods nor static properties can be called on instances of the class. Instead, they’re called on the class itself."
+    },
+    "https://www.crockford.com/code.html": {
+        "domain": "www.crockford.com",
+        "url": "https://www.crockford.com/code.html",
+        "logo": "https://www.crockford.com/favicon.png",
+        "title": "Code Conventions for the JavaScript Programming Language",
+        "description": null
+    },
+    "https://dojotoolkit.org/reference-guide/1.9/developer/styleguide.html": {
+        "domain": "dojotoolkit.org",
+        "url": "https://dojotoolkit.org/reference-guide/1.9/developer/styleguide.html",
+        "logo": "https://dojotoolkit.org/images/favicons/apple-touch-icon-152x152.png",
+        "title": "Dojo Style Guide — The Dojo Toolkit - Reference Guide",
+        "description": null
+    },
+    "https://gist.github.com/isaacs/357981": {
+        "domain": "gist.github.com",
+        "url": "https://gist.github.com/isaacs/357981",
+        "logo": "https://gist.github.com/fluidicon.png",
+        "title": "A better coding convention for lists and object literals in JavaScript",
+        "description": "A better coding convention for lists and object literals in JavaScript - comma-first-var.js"
+    },
+    "https://en.wikipedia.org/wiki/Cyclomatic_complexity": {
+        "domain": "en.wikipedia.org",
+        "url": "https://en.wikipedia.org/wiki/Cyclomatic_complexity",
+        "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
+        "title": "Cyclomatic complexity - Wikipedia",
+        "description": null
+    },
+    "https://ariya.io/2012/12/complexity-analysis-of-javascript-code": {
+        "domain": "ariya.io",
+        "url": "https://ariya.io/2012/12/complexity-analysis-of-javascript-code",
+        "logo": "https://ariya.io/favicon.ico",
+        "title": "Complexity Analysis of JavaScript Code",
+        "description": "Nobody likes to read complex code, especially if it’s someone’s else code. A preventive approach to block any complex code entering the application is by watching its complexity carefully."
+    },
+    "https://craftsmanshipforsoftware.com/2015/05/25/complexity-for-javascript/": {
+        "domain": "craftsmanshipforsoftware.com",
+        "url": "https://craftsmanshipforsoftware.com/2015/05/25/complexity-for-javascript/",
+        "logo": "https://s0.wp.com/i/webclip.png",
+        "title": "Complexity for JavaScript",
+        "description": "The control of complexity control presents the core problem of software development. The huge variety of decisions a developer faces on a day-to-day basis cry for methods of controlling and contain…"
+    },
+    "https://web.archive.org/web/20160808115119/http://jscomplexity.org/complexity": {
+        "domain": "web.archive.org",
+        "url": "https://web.archive.org/web/20160808115119/http://jscomplexity.org/complexity",
+        "logo": "https://archive.org/favicon.ico",
+        "title": "About complexity | JSComplexity.org",
+        "description": "A discussion of software complexity metrics and how they are calculated."
+    },
+    "https://github.com/eslint/eslint/issues/4808#issuecomment-167795140": {
+        "domain": "github.com",
+        "url": "https://github.com/eslint/eslint/issues/4808#issuecomment-167795140",
+        "logo": "https://github.com/fluidicon.png",
+        "title": "Complexity has no default · Issue #4808 · eslint/eslint",
+        "description": "Enabling the complexity rule with only a severity has no effect. We have tried to give sane defaults to all rules, and I think this should be no exception. I don&#39;t know what a good number would..."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "switch - JavaScript | MDN",
+        "description": "The switch statement evaluates an expression, matching the expression’s value to a case clause, and executes statements associated with that case, as well as statements in cases that follow the matching case."
+    },
+    "https://web.archive.org/web/20201112040809/http://markdaggett.com/blog/2013/02/15/functions-explained/": {
+        "domain": "web.archive.org",
+        "url": "https://web.archive.org/web/20201112040809/http://markdaggett.com/blog/2013/02/15/functions-explained/",
+        "logo": "https://web.archive.org/web/20201112040809im_/http://markdaggett.com/favicon.ico",
+        "title": "Functions Explained - Mark Daggett’s Blog",
+        "description": "A Deep Dive into JavaScript Functions\nBased on my readership I have to assume most of you are familiar with JavaScript already. Therefore, it may …"
+    },
+    "https://2ality.com/2015/09/function-names-es6.html": {
+        "domain": "2ality.com",
+        "url": "https://2ality.com/2015/09/function-names-es6.html",
+        "logo": "https://2ality.com/img/favicon.png",
+        "title": "The names of functions in ES6",
+        "description": null
+    },
+    "https://leanpub.com/understandinges6/read/#leanpub-auto-generators": {
+        "domain": "leanpub.com",
+        "url": "https://leanpub.com/understandinges6/read/#leanpub-auto-generators",
+        "logo": "https://leanpub.com/understandinges6/read/favicons/mstile-310x310.png",
+        "title": "Read Understanding ECMAScript 6 | Leanpub",
+        "description": null
+    },
+    "https://leanpub.com/understandinges6/read/#leanpub-auto-accessor-properties": {
+        "domain": "leanpub.com",
+        "url": "https://leanpub.com/understandinges6/read/#leanpub-auto-accessor-properties",
+        "logo": "https://leanpub.com/understandinges6/read/favicons/mstile-310x310.png",
+        "title": "Read Understanding ECMAScript 6 | Leanpub",
+        "description": null
+    },
+    "https://javascriptweblog.wordpress.com/2011/01/04/exploring-javascript-for-in-loops/": {
+        "domain": "javascriptweblog.wordpress.com",
+        "url": "https://javascriptweblog.wordpress.com/2011/01/04/exploring-javascript-for-in-loops/",
+        "logo": "https://s1.wp.com/i/favicon.ico",
+        "title": "Exploring JavaScript for-in loops",
+        "description": "The for-in loop is the only cross-browser technique for iterating the properties of generic objects. There’s a bunch of literature about the dangers of using for-in to iterate arrays and when…"
+    },
+    "https://2ality.com/2012/01/objects-as-maps.html": {
+        "domain": "2ality.com",
+        "url": "https://2ality.com/2012/01/objects-as-maps.html",
+        "logo": "https://2ality.com/img/favicon.png",
+        "title": "The pitfalls of using objects as maps in JavaScript",
+        "description": null
+    },
+    "https://web.archive.org/web/20160725154648/http://www.mind2b.com/component/content/article/24-software-module-size-and-file-size": {
+        "domain": "web.archive.org",
+        "url": "https://web.archive.org/web/20160725154648/http://www.mind2b.com/component/content/article/24-software-module-size-and-file-size",
+        "logo": "https://archive.org/favicon.ico",
+        "title": "Software Module size and file size",
+        "description": null
+    },
+    "http://book.mixu.net/node/ch7.html": {
+        "domain": "book.mixu.net",
+        "url": "http://book.mixu.net/node/ch7.html",
+        "logo": null,
+        "title": "7. Control flow - Mixu’s Node book",
+        "description": null
+    },
+    "https://web.archive.org/web/20220104141150/https://howtonode.org/control-flow": {
+        "domain": "web.archive.org",
+        "url": "https://web.archive.org/web/20220104141150/https://howtonode.org/control-flow",
+        "logo": "https://web.archive.org/web/20220104141150im_/https://howtonode.org/favicon.ico",
+        "title": "Control Flow in Node - How To Node - NodeJS",
+        "description": "Learn the zen of coding in NodeJS."
+    },
+    "https://web.archive.org/web/20220127215850/https://howtonode.org/control-flow-part-ii": {
+        "domain": "web.archive.org",
+        "url": "https://web.archive.org/web/20220127215850/https://howtonode.org/control-flow-part-ii",
+        "logo": "https://web.archive.org/web/20220127215850im_/https://howtonode.org/favicon.ico",
+        "title": "Control Flow in Node Part II - How To Node - NodeJS",
+        "description": "Learn the zen of coding in NodeJS."
+    },
+    "https://nodejs.org/api/buffer.html": {
+        "domain": "nodejs.org",
+        "url": "https://nodejs.org/api/buffer.html",
+        "logo": "https://nodejs.org/favicon.ico",
+        "title": "Buffer | Node.js v18.2.0 Documentation",
+        "description": null
+    },
+    "https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md": {
+        "domain": "github.com",
+        "url": "https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md",
+        "logo": "https://github.com/fluidicon.png",
+        "title": "notes/Lets-fix-Buffer-API.md at master · ChALkeR/notes",
+        "description": "Some public notes. Contribute to ChALkeR/notes development by creating an account on GitHub."
+    },
+    "https://github.com/nodejs/node/issues/4660": {
+        "domain": "github.com",
+        "url": "https://github.com/nodejs/node/issues/4660",
+        "logo": "https://github.com/fluidicon.png",
+        "title": "Buffer(number) is unsafe · Issue #4660 · nodejs/node",
+        "description": "tl;dr This issue proposes: Change new Buffer(number) to return safe, zeroed-out memory Create a new API for creating uninitialized Buffers, Buffer.alloc(number) Update: Jan 15, 2016 Upon further co..."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "debugger - JavaScript | MDN",
+        "description": "The debugger statement invokes any available debugging functionality, such as setting a breakpoint. If no debugging functionality is available, this statement has no effect."
+    },
+    "https://ericlippert.com/2003/11/01/eval-is-evil-part-one/": {
+        "domain": "ericlippert.com",
+        "url": "https://ericlippert.com/2003/11/01/eval-is-evil-part-one/",
+        "logo": "https://s1.wp.com/i/favicon.ico",
+        "title": "Eval is evil, part one",
+        "description": "The eval method — which takes a string containing JScript code, compiles it and runs it — is probably the most powerful and most misused method in JScript. There are a few scenarios in …"
+    },
+    "https://javascriptweblog.wordpress.com/2010/04/19/how-evil-is-eval/": {
+        "domain": "javascriptweblog.wordpress.com",
+        "url": "https://javascriptweblog.wordpress.com/2010/04/19/how-evil-is-eval/",
+        "logo": "https://s1.wp.com/i/favicon.ico",
+        "title": "How evil is eval?",
+        "description": "“eval is Evil: The eval function is the most misused feature of JavaScript. Avoid it” Douglas Crockford in JavaScript: The Good Parts I like The Good Parts. It’s essential reading…"
+    },
+    "https://bocoup.com/blog/the-catch-with-try-catch": {
+        "domain": "bocoup.com",
+        "url": "https://bocoup.com/blog/the-catch-with-try-catch",
+        "logo": "https://static3.bocoup.com/assets/2015/10/06163533/favicon.png",
+        "title": "The",
+        "description": "I’ve recently been working on an update to JavaScript Debug, which has me doing a lot of cross-browser testing, and I noticed a few “interesting quirks” with try…catch in Internet Explorer 6-8 that I couldn’t find documented anywhere."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Function.prototype.bind() - JavaScript | MDN",
+        "description": "The bind() method creates a new function that, when called, has its this keyword set to the provided value, with a given sequence of arguments preceding any provided when the new function is called."
+    },
+    "https://www.smashingmagazine.com/2014/01/understanding-javascript-function-prototype-bind/": {
+        "domain": "www.smashingmagazine.com",
+        "url": "https://www.smashingmagazine.com/2014/01/understanding-javascript-function-prototype-bind/",
+        "logo": "https://www.smashingmagazine.com/images/favicon/apple-touch-icon.png",
+        "title": "Understanding JavaScript Bind () — Smashing Magazine",
+        "description": "Function binding is probably your least concern when beginning with JavaScript, but when you realize that you need a solution to the problem of how to keep the context of “this” within another function, then you might not realize that what you actually need is Function.prototype.bind()."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Operator precedence - JavaScript | MDN",
+        "description": "Operator precedence determines how operators are parsed concerning each other. Operators with higher precedence become the operands of operators with lower precedence."
+    },
+    "https://es5.github.io/#C": {
+        "domain": "es5.github.io",
+        "url": "https://es5.github.io/#C",
+        "logo": "https://es5.github.io/favicon.ico",
+        "title": "Annotated ES5",
+        "description": null
+    },
+    "https://benalman.com/news/2010/11/immediately-invoked-function-expression/": {
+        "domain": "benalman.com",
+        "url": "https://benalman.com/news/2010/11/immediately-invoked-function-expression/",
+        "logo": "https://benalman.com/favicon.ico",
+        "title": "Ben Alman » Immediately-Invoked Function Expression (IIFE)",
+        "description": null
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "ReferenceError: assignment to undeclared variable “x” - JavaScript | MDN",
+        "description": "The JavaScript strict mode-only exception “Assignment to undeclared variable” occurs when the value has been assigned to an undeclared variable."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "let - JavaScript | MDN",
+        "description": "The let statement declares a block-scoped local variable, optionally initializing it to a value."
+    },
+    "https://es5.github.io/#x7.8.5": {
+        "domain": "es5.github.io",
+        "url": "https://es5.github.io/#x7.8.5",
+        "logo": "https://es5.github.io/favicon.ico",
+        "title": "Annotated ES5",
+        "description": null
+    },
+    "https://es5.github.io/#x7.2": {
+        "domain": "es5.github.io",
+        "url": "https://es5.github.io/#x7.2",
+        "logo": "https://es5.github.io/favicon.ico",
+        "title": "Annotated ES5",
+        "description": null
+    },
+    "https://web.archive.org/web/20200414142829/http://timelessrepo.com/json-isnt-a-javascript-subset": {
+        "domain": "web.archive.org",
+        "url": "https://web.archive.org/web/20200414142829/http://timelessrepo.com/json-isnt-a-javascript-subset",
+        "logo": "https://archive.org/favicon.ico",
+        "title": "JSON: The JavaScript subset that isn’t - Timeless",
+        "description": null
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Iterators and generators - JavaScript | MDN",
+        "description": "Iterators and Generators bring the concept of iteration directly into the core language and provide a mechanism for customizing the behavior of for...of loops."
+    },
+    "https://kangax.github.io/es5-compat-table/es6/#Iterators": {
+        "domain": "kangax.github.io",
+        "url": "https://kangax.github.io/es5-compat-table/es6/#Iterators",
+        "logo": "https://github.io/favicon.ico",
+        "title": null,
+        "description": null
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#Object_methods": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#Object_methods",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Deprecated and obsolete features - JavaScript | MDN",
+        "description": "This page lists features of JavaScript that are deprecated (that is, still available but planned for removal) and obsolete (that is, no longer usable)."
+    },
+    "https://www.emacswiki.org/emacs/SmartTabs": {
+        "domain": "www.emacswiki.org",
+        "url": "https://www.emacswiki.org/emacs/SmartTabs",
+        "logo": "https://www.emacswiki.org/favicon.ico",
+        "title": "EmacsWiki: Smart Tabs",
+        "description": null
+    },
+    "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects": {
+        "domain": "www.ecma-international.org",
+        "url": "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-objects",
+        "logo": "https://www.ecma-international.org/ecma-262/6.0/favicon.ico",
+        "title": "ECMAScript 2015 Language Specification – ECMA-262 6th Edition",
+        "description": null
+    },
+    "https://www.inkling.com/read/javascript-definitive-guide-david-flanagan-6th/chapter-3/wrapper-objects": {
+        "domain": "www.inkling.com",
+        "url": "https://www.inkling.com/read/javascript-definitive-guide-david-flanagan-6th/chapter-3/wrapper-objects",
+        "logo": "https://inklingstatic.a.ssl.fastly.net/static_assets/20220214.223700z.8c5796a9.docker/images/favicon.ico",
+        "title": "Unsupported Browser",
+        "description": null
+    },
+    "https://tc39.es/ecma262/#prod-annexB-NonOctalDecimalEscapeSequence": {
+        "domain": "tc39.es",
+        "url": "https://tc39.es/ecma262/#prod-annexB-NonOctalDecimalEscapeSequence",
+        "logo": "https://tc39.es/ecma262/img/favicon.ico",
+        "title": "ECMAScript® 2023 Language Specification",
+        "description": null
+    },
+    "https://es5.github.io/#x15.8": {
+        "domain": "es5.github.io",
+        "url": "https://es5.github.io/#x15.8",
+        "logo": "https://es5.github.io/favicon.ico",
+        "title": "Annotated ES5",
+        "description": null
+    },
+    "https://spin.atomicobject.com/2011/04/10/javascript-don-t-reassign-your-function-arguments/": {
+        "domain": "spin.atomicobject.com",
+        "url": "https://spin.atomicobject.com/2011/04/10/javascript-don-t-reassign-your-function-arguments/",
+        "logo": "https://spin.atomicobject.com/wp-content/themes/spin/images/favicon.ico",
+        "title": "JavaScript: Don’t Reassign Your Function Arguments",
+        "description": "The point of this post is to raise awareness that reassigning the value of an argument variable mutates the arguments object."
+    },
+    "https://stackoverflow.com/questions/5869216/how-to-store-node-js-deployment-settings-configuration-files": {
+        "domain": "stackoverflow.com",
+        "url": "https://stackoverflow.com/questions/5869216/how-to-store-node-js-deployment-settings-configuration-files",
+        "logo": "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png?v=c78bd457575a",
+        "title": "How to store Node.js deployment settings/configuration files?",
+        "description": "I have been working on a few Node apps, and I’ve been looking for a good pattern of storing deployment-related settings. In the Django world (where I come from), the common practise would be to hav..."
+    },
+    "https://blog.benhall.me.uk/2012/02/storing-application-config-data-in/": {
+        "domain": "blog.benhall.me.uk",
+        "url": "https://blog.benhall.me.uk/2012/02/storing-application-config-data-in/",
+        "logo": null,
+        "title": "Storing Node.js application config data – Ben Hall’s Blog",
+        "description": null
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Promise - JavaScript | MDN",
+        "description": "The Promise object represents the eventual completion (or failure) of an asynchronous operation and its resulting value."
+    },
+    "https://johnresig.com/blog/objectgetprototypeof/": {
+        "domain": "johnresig.com",
+        "url": "https://johnresig.com/blog/objectgetprototypeof/",
+        "logo": "https://johnresig.com/wp-content/uploads/2017/04/cropped-jeresig-2016.1024-270x270.jpg",
+        "title": "John Resig - Object.getPrototypeOf",
+        "description": null
+    },
+    "https://kangax.github.io/compat-table/es5/#Reserved_words_as_property_names": {
+        "domain": "kangax.github.io",
+        "url": "https://kangax.github.io/compat-table/es5/#Reserved_words_as_property_names",
+        "logo": "https://kangax.github.io/compat-table/favicon.ico",
+        "title": "ECMAScript 5 compatibility table",
+        "description": null
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "async function - JavaScript | MDN",
+        "description": "An async function is a function declared with the async keyword, and the await keyword is permitted within it. The async and await keywords enable asynchronous, promise-based behavior to be written in a cleaner style, avoiding the need to explicitly configure promise chains."
+    },
+    "https://jakearchibald.com/2017/await-vs-return-vs-return-await/": {
+        "domain": "jakearchibald.com",
+        "url": "https://jakearchibald.com/2017/await-vs-return-vs-return-await/",
+        "logo": "https://jakearchibald.com/c/favicon-67801369.png",
+        "title": "await vs return vs return await",
+        "description": null
+    },
+    "https://stackoverflow.com/questions/13497971/what-is-the-matter-with-script-targeted-urls": {
+        "domain": "stackoverflow.com",
+        "url": "https://stackoverflow.com/questions/13497971/what-is-the-matter-with-script-targeted-urls",
+        "logo": "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png?v=c78bd457575a",
+        "title": "What is the matter with script-targeted URLs?",
+        "description": "I’m using JSHint, and it got the following error: Script URL. Which I noticed that happened because on this particular line there is a string containing a javascript:... URL. I know that JSHint"
+    },
+    "https://es5.github.io/#x15.1.1": {
+        "domain": "es5.github.io",
+        "url": "https://es5.github.io/#x15.1.1",
+        "logo": "https://es5.github.io/favicon.ico",
+        "title": "Annotated ES5",
+        "description": null
+    },
+    "https://en.wikipedia.org/wiki/Variable_shadowing": {
+        "domain": "en.wikipedia.org",
+        "url": "https://en.wikipedia.org/wiki/Variable_shadowing",
+        "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
+        "title": "Variable shadowing - Wikipedia",
+        "description": null
+    },
+    "https://www.nczonline.net/blog/2007/09/09/inconsistent-array-literals/": {
+        "domain": "www.nczonline.net",
+        "url": "https://www.nczonline.net/blog/2007/09/09/inconsistent-array-literals/",
+        "logo": "https://www.nczonline.net/images/favicon.png",
+        "title": "Inconsistent array literals",
+        "description": "Back at the Rich Web Experience, I helped lead a “birds of a feather” group discussion on JavaScript. In that discussion, someone called me a JavaScript expert. I quickly explained that I don’t..."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "undefined - JavaScript | MDN",
+        "description": "The global undefined property represents the primitive value undefined. It is one of JavaScript’s primitive types."
+    },
+    "https://javascriptweblog.wordpress.com/2010/08/16/understanding-undefined-and-preventing-referenceerrors/": {
+        "domain": "javascriptweblog.wordpress.com",
+        "url": "https://javascriptweblog.wordpress.com/2010/08/16/understanding-undefined-and-preventing-referenceerrors/",
+        "logo": "https://s1.wp.com/i/favicon.ico",
+        "title": "Understanding JavaScript’s ‘undefined’",
+        "description": "Compared to other languages, JavaScript’s concept of undefined is a little confusing. In particular, trying to understand ReferenceErrors (“x is not defined”) and how best to code…"
+    },
+    "https://es5.github.io/#x15.1.1.3": {
+        "domain": "es5.github.io",
+        "url": "https://es5.github.io/#x15.1.1.3",
+        "logo": "https://es5.github.io/favicon.ico",
+        "title": "Annotated ES5",
+        "description": null
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Regular expressions - JavaScript | MDN",
+        "description": "Regular expressions are patterns used to match character combinations in strings. In JavaScript, regular expressions are also objects. These patterns are used with the exec() and test() methods of RegExp, and with the match(), matchAll(), replace(), replaceAll(), search(), and split() methods of S…"
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "void operator - JavaScript | MDN",
+        "description": "The void operator evaluates the given expression and then returns undefined."
+    },
+    "https://oreilly.com/javascript/excerpts/javascript-good-parts/bad-parts.html": {
+        "domain": "oreilly.com",
+        "url": "https://oreilly.com/javascript/excerpts/javascript-good-parts/bad-parts.html",
+        "logo": "https://www.oreilly.com/favicon.ico",
+        "title": "O’Reilly Media - Technology and Business Training",
+        "description": "Gain technology and business knowledge and hone your skills with learning resources created and curated by O’Reilly’s experts: live online training, video, books, our platform has content from 200+ of the world’s best publishers."
+    },
+    "https://web.archive.org/web/20200717110117/https://yuiblog.com/blog/2006/04/11/with-statement-considered-harmful/": {
+        "domain": "web.archive.org",
+        "url": "https://web.archive.org/web/20200717110117/https://yuiblog.com/blog/2006/04/11/with-statement-considered-harmful/",
+        "logo": "https://web.archive.org/web/20200717110117im_/https://yuiblog.com/favicon.ico",
+        "title": "with Statement Considered Harmful",
+        "description": null
+    },
+    "https://jscs-dev.github.io/rule/requireNewlineBeforeSingleStatementsInIf": {
+        "domain": "jscs-dev.github.io",
+        "url": "https://jscs-dev.github.io/rule/requireNewlineBeforeSingleStatementsInIf",
+        "logo": "https://jscs-dev.github.io/favicon.ico",
+        "title": "JSCS",
+        "description": null
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Object initializer - JavaScript | MDN",
+        "description": "Objects can be initialized using new Object(), Object.create(), or using the literal notation (initializer notation). An object initializer is a comma-delimited list of zero or more pairs of property names and associated values of an object, enclosed in curly braces ({})."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Arrow function expressions - JavaScript | MDN",
+        "description": "An arrow function expression is a compact alternative to a traditional function expression, but is limited and can’t be used in all situations."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Destructuring assignment - JavaScript | MDN",
+        "description": "The destructuring assignment syntax is a JavaScript expression that makes it possible to unpack values from arrays, or properties from objects, into distinct variables."
+    },
+    "https://2ality.com/2015/01/es6-destructuring.html": {
+        "domain": "2ality.com",
+        "url": "https://2ality.com/2015/01/es6-destructuring.html",
+        "logo": "https://2ality.com/img/favicon.png",
+        "title": "Destructuring and parameter handling in ECMAScript 6",
+        "description": null
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Expressions and operators - JavaScript | MDN",
+        "description": "This chapter documents all the JavaScript language operators, expressions and keywords."
+    },
+    "https://bugs.chromium.org/p/v8/issues/detail?id=5848": {
+        "domain": "bugs.chromium.org",
+        "url": "https://bugs.chromium.org/p/v8/issues/detail?id=5848",
+        "logo": "https://bugs.chromium.org/static/images/monorail.ico",
+        "title": "5848 - v8 - V8 JavaScript Engine - Monorail",
+        "description": null
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Object.hasOwn() - JavaScript | MDN",
+        "description": "The Object.hasOwn() static method returns true if the specified object has the indicated property as its own property. If the property is inherited, or does not exist, the method returns false."
+    },
+    "http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-rejected-with-a-non-error": {
+        "domain": "bluebirdjs.com",
+        "url": "http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-rejected-with-a-non-error",
+        "logo": "//bluebirdjs.com/img/favicon.png",
+        "title": "Warning Explanations | bluebird",
+        "description": "Bluebird is a fully featured JavaScript promises library with unmatched performance."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "RegExp - JavaScript | MDN",
+        "description": "The RegExp object is used for matching text with a pattern."
+    },
+    "https://mathiasbynens.be/notes/javascript-properties": {
+        "domain": "mathiasbynens.be",
+        "url": "https://mathiasbynens.be/notes/javascript-properties",
+        "logo": "https://mathiasbynens.be/favicon.ico",
+        "title": "Unquoted property names / object keys in JavaScript · Mathias Bynens",
+        "description": null
+    },
+    "https://davidwalsh.name/parseint-radix": {
+        "domain": "davidwalsh.name",
+        "url": "https://davidwalsh.name/parseint-radix",
+        "logo": "https://davidwalsh.name/wp-content/themes/punky/images/favicon-144.png",
+        "title": "parseInt Radix",
+        "description": "The radix is important if you’re need to guarantee accuracy with variable input (basic number, binary, etc.). For best results, always use a radix of 10!"
+    },
+    "https://github.com/tc39/proposal-object-rest-spread": {
+        "domain": "github.com",
+        "url": "https://github.com/tc39/proposal-object-rest-spread",
+        "logo": "https://github.com/fluidicon.png",
+        "title": "GitHub - tc39/proposal-object-rest-spread: Rest/Spread Properties for ECMAScript",
+        "description": "Rest/Spread Properties for ECMAScript. Contribute to tc39/proposal-object-rest-spread development by creating an account on GitHub."
+    },
+    "https://blog.izs.me/2010/12/an-open-letter-to-javascript-leaders-regarding/": {
+        "domain": "blog.izs.me",
+        "url": "https://blog.izs.me/2010/12/an-open-letter-to-javascript-leaders-regarding/",
+        "logo": "https://blog.izs.me/favicon.ico",
+        "title": "An Open Letter to JavaScript Leaders Regarding Semicolons",
+        "description": "Writing and Stuff from Isaac Z. Schlueter"
+    },
+    "https://web.archive.org/web/20200420230322/http://inimino.org/~inimino/blog/javascript_semicolons": {
+        "domain": "web.archive.org",
+        "url": "https://web.archive.org/web/20200420230322/http://inimino.org/~inimino/blog/javascript_semicolons",
+        "logo": "https://archive.org/favicon.ico",
+        "title": "JavaScript Semicolon Insertion",
+        "description": null
+    },
+    "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-description": {
+        "domain": "www.ecma-international.org",
+        "url": "https://www.ecma-international.org/ecma-262/6.0/#sec-symbol-description",
+        "logo": "https://www.ecma-international.org/ecma-262/6.0/favicon.ico",
+        "title": "ECMAScript 2015 Language Specification – ECMA-262 6th Edition",
+        "description": null
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Template literals (Template strings) - JavaScript | MDN",
+        "description": "Template literals are literals delimited with backtick (`) characters, allowing for multi-line strings, for string interpolation with embedded expressions, and for special constructs called tagged templates."
+    },
+    "https://exploringjs.com/es6/ch_template-literals.html#_examples-of-using-tagged-template-literals": {
+        "domain": "exploringjs.com",
+        "url": "https://exploringjs.com/es6/ch_template-literals.html#_examples-of-using-tagged-template-literals",
+        "logo": "https://exploringjs.com/es6/images/favicon-128.png",
+        "title": "8. Template literals",
+        "description": null
+    },
+    "https://jsdoc.app": {
+        "domain": "jsdoc.app",
+        "url": "https://jsdoc.app",
+        "logo": null,
+        "title": "Use JSDoc: Index",
+        "description": "Official documentation for JSDoc 3."
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "typeof - JavaScript | MDN",
+        "description": "The typeof operator returns a string indicating the type of the unevaluated operand."
+    },
+    "https://danhough.com/blog/single-var-pattern-rant/": {
+        "domain": "danhough.com",
+        "url": "https://danhough.com/blog/single-var-pattern-rant/",
+        "logo": "https://danhough.com/img/meta/apple-touch-icon-152x152.png",
+        "title": "A criticism of the Single Var Pattern in JavaScript, and a simple alternative — Dan Hough",
+        "description": "Dan Hough is a software developer & consultant, a writer and public speaker."
+    },
+    "https://benalman.com/news/2012/05/multiple-var-statements-javascript/": {
+        "domain": "benalman.com",
+        "url": "https://benalman.com/news/2012/05/multiple-var-statements-javascript/",
+        "logo": "https://benalman.com/favicon.ico",
+        "title": "Ben Alman » Multiple var statements in JavaScript, not superfluous",
+        "description": null
+    },
+    "https://en.wikipedia.org/wiki/Yoda_conditions": {
+        "domain": "en.wikipedia.org",
+        "url": "https://en.wikipedia.org/wiki/Yoda_conditions",
+        "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
+        "title": "Yoda conditions - Wikipedia",
+        "description": null
+    },
+    "http://thomas.tuerke.net/on/design/?with=1249091668#msg1146181680": {
+        "domain": "thomas.tuerke.net",
+        "url": "http://thomas.tuerke.net/on/design/?with=1249091668#msg1146181680",
+        "logo": "//thomas.tuerke.net/images/tmtlogo.ico",
+        "title": "Coding in Style",
+        "description": "Thomas M. Tuerke topical weblog"
+    },
+    "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation": {
+        "domain": "developer.mozilla.org",
+        "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation",
+        "logo": "https://developer.mozilla.org/favicon-48x48.cbbd161b.png",
+        "title": "Exponentiation (**) - JavaScript | MDN",
+        "description": "The exponentiation operator (**) returns the result of raising the first operand to the power of the second operand. It is equivalent to Math.pow, except it also accepts BigInts as operands."
+    },
+    "https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/": {
+        "domain": "eslint.org",
+        "url": "https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/",
+        "logo": "https://eslint.org/apple-touch-icon.png",
+        "title": "Interesting bugs caught by no-constant-binary-expression - ESLint - Pluggable JavaScript Linter",
+        "description": "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease."
+    },
+    "https://github.com/tc39/proposal-class-static-block": {
+        "domain": "github.com",
+        "url": "https://github.com/tc39/proposal-class-static-block",
+        "logo": "https://github.com/fluidicon.png",
+        "title": "GitHub - tc39/proposal-class-static-block: ECMAScript class static initialization blocks",
+        "description": "ECMAScript class static initialization blocks. Contribute to tc39/proposal-class-static-block development by creating an account on GitHub."
+    },
+    "https://tc39.es/ecma262/#sec-symbol-constructor": {
+        "domain": "tc39.es",
+        "url": "https://tc39.es/ecma262/#sec-symbol-constructor",
+        "logo": "https://tc39.es/ecma262/img/favicon.ico",
+        "title": "ECMAScript® 2023 Language Specification",
+        "description": null
+    },
+    "https://tc39.es/ecma262/#sec-bigint-constructor": {
+        "domain": "tc39.es",
+        "url": "https://tc39.es/ecma262/#sec-bigint-constructor",
+        "logo": "https://tc39.es/ecma262/img/favicon.ico",
+        "title": "ECMAScript® 2023 Language Specification",
+        "description": null
+    },
+    "https://v8.dev/blog/fast-async": {
+        "domain": "v8.dev",
+        "url": "https://v8.dev/blog/fast-async",
+        "logo": "https://v8.dev/favicon.ico",
+        "title": "Faster async functions and promises · V8",
+        "description": "Faster and easier-to-debug async functions and promises are coming to V8 v7.2 / Chrome 72."
+    },
+    "https://github.com/tc39/proposal-regexp-v-flag": {
+        "domain": "github.com",
+        "url": "https://github.com/tc39/proposal-regexp-v-flag",
+        "logo": "https://github.com/fluidicon.png",
+        "title": "GitHub - tc39/proposal-regexp-v-flag: UTS18 set notation in regular expressions",
+        "description": "UTS18 set notation in regular expressions. Contribute to tc39/proposal-regexp-v-flag development by creating an account on GitHub."
+    },
+    "https://v8.dev/features/regexp-v-flag": {
+        "domain": "v8.dev",
+        "url": "https://v8.dev/features/regexp-v-flag",
+        "logo": "https://v8.dev/favicon.ico",
+        "title": "RegExp v flag with set notation and properties of strings · V8",
+        "description": "The new RegExp `v` flag enables `unicodeSets` mode, unlocking support for extended character classes, including Unicode properties of strings, set notation, and improved case-insensitive matching."
+    },
+    "https://codepoints.net/U+1680": {
+        "domain": "codepoints.net",
+        "url": "https://codepoints.net/U+1680",
+        "logo": "https://codepoints.net/favicon.ico",
+        "title": "U+1680 OGHAM SPACE MARK:   – Unicode – Codepoints",
+        "description": " , codepoint U+1680 OGHAM SPACE MARK in Unicode, is located in the block “Ogham”. It belongs to the Ogham script and is a Space Separator."
+    },
+    "https://en.wikipedia.org/wiki/Dead_store": {
+        "domain": "en.wikipedia.org",
+        "url": "https://en.wikipedia.org/wiki/Dead_store",
+        "logo": "https://en.wikipedia.org/static/apple-touch/wikipedia.png",
+        "title": "Dead store - Wikipedia",
+        "description": null
+    },
+    "https://rules.sonarsource.com/javascript/RSPEC-1854/": {
+        "domain": "rules.sonarsource.com",
+        "url": "https://rules.sonarsource.com/javascript/RSPEC-1854/",
+        "logo": "https://rules.sonarsource.com/favicon.ico",
+        "title": "JavaScript static code analysis: Unused assignments should be removed",
+        "description": "Dead stores refer to assignments made to local variables that are subsequently never used or immediately overwritten. Such assignments are\nunnecessary and don’t contribute to the functionality or clarity of the code. They may even negatively impact performance. Removing them enhances code\ncleanlines…"
+    },
+    "https://cwe.mitre.org/data/definitions/563.html": {
+        "domain": "cwe.mitre.org",
+        "url": "https://cwe.mitre.org/data/definitions/563.html",
+        "logo": "https://cwe.mitre.org/favicon.ico",
+        "title": "CWE - CWE-563: Assignment to Variable without Use (4.13)",
+        "description": "Common Weakness Enumeration (CWE) is a list of software weaknesses."
+    },
+    "https://wiki.sei.cmu.edu/confluence/display/c/MSC13-C.+Detect+and+remove+unused+values": {
+        "domain": "wiki.sei.cmu.edu",
+        "url": "https://wiki.sei.cmu.edu/confluence/display/c/MSC13-C.+Detect+and+remove+unused+values",
+        "logo": "https://wiki.sei.cmu.edu/confluence/s/-ctumb3/9012/tu5x00/7/_/favicon.ico",
+        "title": "MSC13-C. Detect and remove unused values - SEI CERT C Coding Standard - Confluence",
+        "description": null
+    },
+    "https://wiki.sei.cmu.edu/confluence/display/java/MSC56-J.+Detect+and+remove+superfluous+code+and+values": {
+        "domain": "wiki.sei.cmu.edu",
+        "url": "https://wiki.sei.cmu.edu/confluence/display/java/MSC56-J.+Detect+and+remove+superfluous+code+and+values",
+        "logo": "https://wiki.sei.cmu.edu/confluence/s/-ctumb3/9012/tu5x00/7/_/favicon.ico",
+        "title": "MSC56-J. Detect and remove superfluous code and values - SEI CERT Oracle Coding Standard for Java - Confluence",
+        "description": null
+    },
+    "https://262.ecma-international.org/11.0/#sec-value-properties-of-the-global-object": {
+        "domain": "262.ecma-international.org",
+        "url": "https://262.ecma-international.org/11.0/#sec-value-properties-of-the-global-object",
+        "logo": "https://tc39.es/ecma262/2020/img/favicon.ico",
+        "title": "ECMAScript® 2020 Language Specification",
+        "description": null
+    },
+    "https://262.ecma-international.org/11.0/#sec-strict-mode-of-ecmascript": {
+        "domain": "262.ecma-international.org",
+        "url": "https://262.ecma-international.org/11.0/#sec-strict-mode-of-ecmascript",
+        "logo": "https://tc39.es/ecma262/2020/img/favicon.ico",
+        "title": "ECMAScript® 2020 Language Specification",
+        "description": null
+    }
 }

--- a/docs/src/rules/ternary-spacing.md
+++ b/docs/src/rules/ternary-spacing.md
@@ -20,6 +20,8 @@ Examples of **incorrect** code for this rule:
 ::: incorrect
 
 ```js
+/* eslint ternary-spacing: "error" */
+
 // No spaces
 const badExample1 = condition?value1:value2;
 
@@ -50,6 +52,8 @@ Examples of **correct** code for this rule:
 ::: correct
 
 ```js
+/* eslint ternary-spacing: "error" */
+
 const goodExample1 = condition ? value1 : value2;
 
 const goodExample2 = a ? b : c ? d : e;

--- a/docs/src/rules/ternary-spacing.md
+++ b/docs/src/rules/ternary-spacing.md
@@ -1,0 +1,68 @@
+---
+title: ternary-spacing
+rule_type: layout
+---
+
+Enforces consistent spacing around the `?` and `:` tokens in ternary expressions.
+
+## Rule Details
+
+This rule improves code readability by enforcing **exactly one space** before and after the `?` and `:` operators in ternary expressions.
+
+### Options
+
+This rule does **not** accept any options.
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+::: incorrect
+
+```js
+// No spaces
+const badExample1 = condition?value1:value2;
+
+// Missing space before `?`
+const badExample2 = condition? value1 : value2;
+
+// Too many spaces after `:`
+const badExample3 = condition ? value1 :  value2;
+
+// Nested ternary with bad spacing
+const badExample4 = a?b:c?d:e;
+
+// Line-broken ternary with no space after `?`
+const badExample5 = condition
+    ?value1
+    : value2;
+
+// Line-broken ternary with too many spaces after `:`
+const badExample6 = condition
+    ? value1
+    :  value2;
+```
+
+:::
+
+Examples of **correct** code for this rule:
+
+::: correct
+
+```js
+const goodExample1 = condition ? value1 : value2;
+
+const goodExample2 = a ? b : c ? d : e;
+
+const goodExample3 = condition
+    ? value1
+    : value2;
+```
+
+:::
+
+## When Not To Use It
+
+You may choose to disable this rule if
+- You already use a formatter like Prettier that enforces spacing around ternary operators, or
+- You do not prioritize consistent spacing in ternary expressions as part of your style guide.

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -319,6 +319,7 @@ module.exports = new LazyLoadingRuleMap(
 		"symbol-description": () => require("./symbol-description"),
 		"template-curly-spacing": () => require("./template-curly-spacing"),
 		"template-tag-spacing": () => require("./template-tag-spacing"),
+		"ternary-spacing": () => require("./ternary-spacing"),
 		"unicode-bom": () => require("./unicode-bom"),
 		"use-isnan": () => require("./use-isnan"),
 		"valid-typeof": () => require("./valid-typeof"),

--- a/lib/rules/ternary-spacing.js
+++ b/lib/rules/ternary-spacing.js
@@ -1,0 +1,122 @@
+/**
+ * @fileoverview Rule to enforce spacing in ternary expressions.
+ * @author Dawson Huang
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import('../types').Rule.RuleModule} */
+module.exports = {
+	meta: {
+		type: "layout",
+		docs: {
+			description: "Enforce spacing around `?` and `:` in ternary expressions",
+			recommended: false,
+			url: "https://eslint.org/docs/latest/rules/ternary-spacing",
+		},
+		fixable: "whitespace",
+		schema: [],
+		messages: {
+			expectedSpaceBeforeQuestion: "Expected exactly one space before '?'.",
+			expectedSpaceAfterQuestion: "Expected exactly one space after '?'.",
+			expectedSpaceBeforeColon: "Expected exactly one space before ':'.",
+			expectedSpaceAfterColon: "Expected exactly one space after ':'.",
+		},
+	},
+
+	create(context) {
+		const sourceCode = context.sourceCode;
+
+		return {
+			ConditionalExpression(node) {
+				const questionToken = sourceCode.getTokenBefore(
+					node.consequent,
+					token => token.value === "?",
+				);
+				const beforeQuestion = sourceCode.getTokenBefore(questionToken);
+				const afterQuestion = sourceCode.getTokenAfter(questionToken);
+
+				const colonToken = sourceCode.getTokenBefore(
+					node.alternate,
+					token => token.value === ":",
+				);
+				const beforeColon = sourceCode.getTokenBefore(colonToken);
+				const afterColon = sourceCode.getTokenAfter(colonToken);
+
+				// Check exactly one space before '?' unless it's the first token on the line
+				const spaceBeforeQ =
+					questionToken.range[0] - beforeQuestion.range[1];
+				if (
+					questionToken.loc.start.column !== 0 &&
+					spaceBeforeQ !== 1
+				) {
+					context.report({
+						node,
+						loc: questionToken.loc,
+						messageId: "expectedSpaceBeforeQuestion",
+						fix: fixer =>
+							fixer.replaceTextRange(
+								[
+									beforeQuestion.range[1],
+									questionToken.range[0],
+								],
+								" ",
+							),
+					});
+				}
+
+				// Check exactly one space after '?'
+				const spaceAfterQ =
+					afterQuestion.range[0] - questionToken.range[1];
+				if (spaceAfterQ !== 1) {
+					context.report({
+						node,
+						loc: questionToken.loc,
+						messageId: "expectedSpaceAfterQuestion",
+						fix: fixer =>
+							fixer.replaceTextRange(
+								[
+									questionToken.range[1],
+									afterQuestion.range[0],
+								],
+								" ",
+							),
+					});
+				}
+
+				// Check exactly one space before ':' unless it's the first token on the line
+				const spaceBeforeC = colonToken.range[0] - beforeColon.range[1];
+				if (colonToken.loc.start.column !== 0 && spaceBeforeC !== 1) {
+					context.report({
+						node,
+						loc: colonToken.loc,
+						messageId: "expectedSpaceBeforeColon",
+						fix: fixer =>
+							fixer.replaceTextRange(
+								[beforeColon.range[1], colonToken.range[0]],
+								" ",
+							),
+					});
+				}
+
+				// Check exactly one space after ':'
+				const spaceAfterC = afterColon.range[0] - colonToken.range[1];
+				if (spaceAfterC !== 1) {
+					context.report({
+						node,
+						loc: colonToken.loc,
+						messageId: "expectedSpaceAfterColon",
+						fix: fixer =>
+							fixer.replaceTextRange(
+								[colonToken.range[1], afterColon.range[0]],
+								" ",
+							),
+					});
+				}
+			},
+		};
+	},
+};

--- a/lib/rules/ternary-spacing.js
+++ b/lib/rules/ternary-spacing.js
@@ -13,14 +13,16 @@ module.exports = {
 	meta: {
 		type: "layout",
 		docs: {
-			description: "Enforce spacing around `?` and `:` in ternary expressions",
+			description:
+				"Enforce spacing around `?` and `:` in ternary expressions",
 			recommended: false,
 			url: "https://eslint.org/docs/latest/rules/ternary-spacing",
 		},
 		fixable: "whitespace",
 		schema: [],
 		messages: {
-			expectedSpaceBeforeQuestion: "Expected exactly one space before '?'.",
+			expectedSpaceBeforeQuestion:
+				"Expected exactly one space before '?'.",
 			expectedSpaceAfterQuestion: "Expected exactly one space after '?'.",
 			expectedSpaceBeforeColon: "Expected exactly one space before ':'.",
 			expectedSpaceAfterColon: "Expected exactly one space after ':'.",
@@ -29,6 +31,26 @@ module.exports = {
 
 	create(context) {
 		const sourceCode = context.sourceCode;
+
+		//--------------------------------------------------------------------------
+		// Helpers
+		//--------------------------------------------------------------------------
+
+		/**
+		 * Checks whether the given token is the first token on its line.
+		 * @param {Token} token The token to check.
+		 * @returns {boolean} True if the token is the first on the line, false otherwise.
+		 */
+		function isFirstTokenOnLine(token) {
+			const prev = sourceCode.getTokenBefore(token, {
+				includeComments: true,
+			});
+			return !prev || prev.loc.end.line < token.loc.start.line;
+		}
+
+		//--------------------------------------------------------------------------
+		// Public
+		//--------------------------------------------------------------------------
 
 		return {
 			ConditionalExpression(node) {
@@ -46,13 +68,10 @@ module.exports = {
 				const beforeColon = sourceCode.getTokenBefore(colonToken);
 				const afterColon = sourceCode.getTokenAfter(colonToken);
 
-				// Check exactly one space before '?' unless it's the first token on the line
+				// Check space before '?'
 				const spaceBeforeQ =
 					questionToken.range[0] - beforeQuestion.range[1];
-				if (
-					questionToken.loc.start.column !== 0 &&
-					spaceBeforeQ !== 1
-				) {
+				if (!isFirstTokenOnLine(questionToken) && spaceBeforeQ !== 1) {
 					context.report({
 						node,
 						loc: questionToken.loc,
@@ -68,7 +87,7 @@ module.exports = {
 					});
 				}
 
-				// Check exactly one space after '?'
+				// Check space after '?'
 				const spaceAfterQ =
 					afterQuestion.range[0] - questionToken.range[1];
 				if (spaceAfterQ !== 1) {
@@ -87,9 +106,9 @@ module.exports = {
 					});
 				}
 
-				// Check exactly one space before ':' unless it's the first token on the line
+				// Check space before ':'
 				const spaceBeforeC = colonToken.range[0] - beforeColon.range[1];
-				if (colonToken.loc.start.column !== 0 && spaceBeforeC !== 1) {
+				if (!isFirstTokenOnLine(colonToken) && spaceBeforeC !== 1) {
 					context.report({
 						node,
 						loc: colonToken.loc,
@@ -102,7 +121,7 @@ module.exports = {
 					});
 				}
 
-				// Check exactly one space after ':'
+				// Check space after ':'
 				const spaceAfterC = afterColon.range[0] - colonToken.range[1];
 				if (spaceAfterC !== 1) {
 					context.report({

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -5278,6 +5278,13 @@ export interface ESLintRules extends Linter.RulesRecord {
 	"template-tag-spacing": Linter.RuleEntry<["never" | "always"]>;
 
 	/**
+	 * Rule to enforce spacing around `?` and `:` in ternary expressions.
+	 *
+	 * @see https://eslint.org/docs/latest/rules/ternary-spacing
+	 */
+	"ternary-spacing": Linter.RuleEntry<[]>;
+
+	/**
 	 * Rule to require or disallow Unicode byte order mark (BOM).
 	 *
 	 * @since 2.11.0

--- a/packages/js/src/configs/eslint-all.js
+++ b/packages/js/src/configs/eslint-all.js
@@ -207,6 +207,7 @@ module.exports = Object.freeze({
         "sort-vars": "error",
         "strict": "error",
         "symbol-description": "error",
+        "ternary-spacing": "error",
         "unicode-bom": "error",
         "use-isnan": "error",
         "valid-typeof": "error",

--- a/tests/lib/rules/ternary-spacing.js
+++ b/tests/lib/rules/ternary-spacing.js
@@ -1,0 +1,498 @@
+/**
+ * @fileoverview Tests for ternary-spacing rule
+ * @author Dawson Huang
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/ternary-spacing");
+const RuleTester = require("../../../lib/rule-tester/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("ternary-spacing", rule, {
+	valid: [
+		// correctly spaced
+		"const result = condition ? value1 : value2;",
+		"const foo = true ? 'yes' : 'no';",
+
+		// nested ternary (clean)
+		"const val = a ? b ? 1 : 2 : 3;",
+		"const output = isValid ? 'ok' : isFatal ? 'fatal' : 'warn';",
+		"const nested = condition1 ? (condition2 ? 'x' : 'y') : 'z';",
+
+		// nested with parentheses (still clean)
+		"const x = (a > b) ? (c > d ? 1 : 2) : 3;",
+		"let msg = user ? (admin ? 'Admin' : 'User') : 'Guest';",
+
+		// broken-line ternary (clean spacing)
+		`
+        const message =
+            condition
+                ? 'A'
+                : 'B';
+        `,
+		`
+        const level = user.isAdmin
+            ? user.isSuperAdmin
+                ? 'super'
+                : 'admin'
+            : 'guest';
+        `,
+	],
+
+	invalid: [
+		// No spaces at all
+		{
+			code: "const x = a?b:c;",
+			output: "const x = a ? b : c;",
+			errors: [
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Only missing space before ?
+		{
+			code: "const x = a? b : c;",
+			output: "const x = a ? b : c;",
+			errors: [{ messageId: "expectedSpaceBeforeQuestion" }],
+		},
+
+		// Only missing space after ?
+		{
+			code: "const x = a ?b : c;",
+			output: "const x = a ? b : c;",
+			errors: [{ messageId: "expectedSpaceAfterQuestion" }],
+		},
+
+		// Only missing space before :
+		{
+			code: "const x = a ? b: c;",
+			output: "const x = a ? b : c;",
+			errors: [{ messageId: "expectedSpaceBeforeColon" }],
+		},
+
+		// Only missing space after :
+		{
+			code: "const x = a ? b :c;",
+			output: "const x = a ? b : c;",
+			errors: [{ messageId: "expectedSpaceAfterColon" }],
+		},
+
+		// Too many spaces before ?
+		{
+			code: "const x = a  ? b : c;",
+			output: "const x = a ? b : c;",
+			errors: [{ messageId: "expectedSpaceBeforeQuestion" }],
+		},
+
+		// Too many spaces after ?
+		{
+			code: "const x = a ?  b : c;",
+			output: "const x = a ? b : c;",
+			errors: [{ messageId: "expectedSpaceAfterQuestion" }],
+		},
+
+		// Too many spaces before :
+		{
+			code: "const x = a ? b  : c;",
+			output: "const x = a ? b : c;",
+			errors: [{ messageId: "expectedSpaceBeforeColon" }],
+		},
+
+		// Too many spaces after :
+		{
+			code: "const x = a ? b :  c;",
+			output: "const x = a ? b : c;",
+			errors: [{ messageId: "expectedSpaceAfterColon" }],
+		},
+
+		// All too many
+		{
+			code: "const x = a  ?  b  :  c;",
+			output: "const x = a ? b : c;",
+			errors: [
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Nested ternary — no spaces at all
+		{
+			code: "const x = a?b:c?d:e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Nested ternary — missing space before ?
+		{
+			code: "const x = a? b : c ? d : e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [{ messageId: "expectedSpaceBeforeQuestion" }],
+		},
+
+		// Nested ternary — missing space after ?
+		{
+			code: "const x = a ?b : c ? d : e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [{ messageId: "expectedSpaceAfterQuestion" }],
+		},
+
+		// Nested ternary — missing space before :
+		{
+			code: "const x = a ? b: c ? d : e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [{ messageId: "expectedSpaceBeforeColon" }],
+		},
+
+		// Nested ternary — missing space after :
+		{
+			code: "const x = a ? b :c ? d : e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [{ messageId: "expectedSpaceAfterColon" }],
+		},
+
+		// Nested ternary — too many spaces before ?
+		{
+			code: "const x = a  ? b : c ? d : e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [{ messageId: "expectedSpaceBeforeQuestion" }],
+		},
+
+		// Nested ternary — too many spaces after ?
+		{
+			code: "const x = a ?  b : c ? d : e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [{ messageId: "expectedSpaceAfterQuestion" }],
+		},
+
+		// Nested ternary — too many spaces before :
+		{
+			code: "const x = a ? b  : c ? d : e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [{ messageId: "expectedSpaceBeforeColon" }],
+		},
+
+		// Nested ternary — too many spaces after :
+		{
+			code: "const x = a ? b :  c ? d : e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [{ messageId: "expectedSpaceAfterColon" }],
+		},
+
+		// Nested ternary — missing space before ?
+		{
+			code: "const x = a? b : c? d : e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceBeforeQuestion" },
+			],
+		},
+
+		// Nested ternary — missing space after ?
+		{
+			code: "const x = a ?b : c ?d : e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+			],
+		},
+
+		// Nested ternary — missing space before :
+		{
+			code: "const x = a ? b: c ? d: e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceBeforeColon" },
+			],
+		},
+
+		// Nested ternary — missing space after :
+		{
+			code: "const x = a ? b :c ? d :e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [
+				{ messageId: "expectedSpaceAfterColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Nested ternary — too many spaces before ?
+		{
+			code: "const x = a  ? b : c  ? d : e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceBeforeQuestion" },
+			],
+		},
+
+		// Nested ternary — too many spaces after ?
+		{
+			code: "const x = a ?  b : c ?  d : e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+			],
+		},
+
+		// Nested ternary — too many spaces before :
+		{
+			code: "const x = a ? b  : c ? d  : e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceBeforeColon" },
+			],
+		},
+
+		// Nested ternary — too many spaces after :
+		{
+			code: "const x = a ? b :  c ? d :  e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [
+				{ messageId: "expectedSpaceAfterColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Nested ternary — all too many
+		{
+			code: "const x = a  ?  b  :  c  ?  d  :  e;",
+			output: "const x = a ? b : c ? d : e;",
+			errors: [
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Line-broken — no space after '?'
+		{
+			code: `
+                const result =
+                    condition
+                        ?value1
+                        : value2;
+            `,
+			output: `
+                const result =
+                    condition
+                        ? value1
+                        : value2;
+            `,
+			errors: [{ messageId: "expectedSpaceAfterQuestion" }],
+		},
+
+		// Line-broken — too many spaces after ':'
+		{
+			code: `
+                const result =
+                    condition
+                        ? value1
+                        :  value2;
+            `,
+			output: `
+                const result =
+                    condition
+                        ? value1
+                        : value2;
+            `,
+			errors: [{ messageId: "expectedSpaceAfterColon" }],
+		},
+
+		// Line-broken — no space after '?' and too many after ':'
+		{
+			code: `
+                const result =
+                    condition
+                        ?value1
+                        :  value2;
+            `,
+			output: `
+                const result =
+                    condition
+                        ? value1
+                        : value2;
+            `,
+			errors: [
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Multi-nested line-breaks — various spacing issues
+		{
+			code: `
+                const level = user.isAdmin
+                    ?user.isSuperAdmin
+                        ?'super'
+                        :  'admin'
+                    :  'guest';
+            `,
+			output: `
+                const level = user.isAdmin
+                    ? user.isSuperAdmin
+                        ? 'super'
+                        : 'admin'
+                    : 'guest';
+            `,
+			errors: [
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceAfterColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Ternary inside return
+		{
+			code: "function f() { return a?b:c; }",
+			output: "function f() { return a ? b : c; }",
+			errors: [
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Ternary inside arrow function
+		{
+			code: "const f = () => a?b:c;",
+			output: "const f = () => a ? b : c;",
+			errors: [
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Ternary inside function argument
+		{
+			code: "call(a?b:c);",
+			output: "call(a ? b : c);",
+			errors: [
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Ternary inside template literal
+		{
+			code: "const str = `result: ${a?b:c}`;",
+			output: "const str = `result: ${a ? b : c}`;",
+			errors: [
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Ternaries in array literals
+		{
+			code: "const arr = [a?b:c, x?y:z];",
+			output: "const arr = [a ? b : c, x ? y : z];",
+			errors: [
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Deeply nested and line-broken ternary
+		{
+			code: `
+                const val =
+                    a
+                        ?b
+                            ?c
+                                ?d
+                                :e
+                            :f
+                        :g;
+            `,
+			output: `
+                const val =
+                    a
+                        ? b
+                            ? c
+                                ? d
+                                : e
+                            : f
+                        : g;
+            `,
+			errors: [
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceAfterColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Chained assignment with ternary
+		{
+			code: "let a = b = c?d:e;",
+			output: "let a = b = c ? d : e;",
+			errors: [
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+
+		// Ternary inside logical expression
+		{
+			code: "const x = (a && b)?c:d;",
+			output: "const x = (a && b) ? c : d;",
+			errors: [
+				{ messageId: "expectedSpaceBeforeQuestion" },
+				{ messageId: "expectedSpaceAfterQuestion" },
+				{ messageId: "expectedSpaceBeforeColon" },
+				{ messageId: "expectedSpaceAfterColon" },
+			],
+		},
+	],
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[X] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR introduces a new rule `ternary-spacing` (fixable, layout-type) that enforces exactly one space around `?` and `:` in ternary expressions. It improves readability and enforces consistent formatting.

#### Is there anything you'd like reviewers to focus on?

Please review the edge case handling (nested ternaries, line breaks, and comments), and let me know if further refinements or exclusions are preferred for comment-sensitive formatting.

<!-- markdownlint-disable-file MD004 -->
