### PR TITLE
feat: add global object access detection to no-restricted-globals

### DIFF
--- a/docs/src/rules/no-restricted-globals.md
+++ b/docs/src/rules/no-restricted-globals.md
@@ -148,19 +148,18 @@ function onClick() {
 
 :::
 
-### checkGlobalObjectAccess
+### checkGlobalObject
 
 A boolean option that enables detection of restricted globals accessed via global objects. Default is `false`.
 
-Examples of **incorrect** code for `checkGlobalObjectAccess: true` option:
+Examples of **incorrect** code for `checkGlobalObject: true` option:
 
 ::: incorrect
 
 ```js
-/*global global, globalThis, self, window*/
-/*eslint no-restricted-globals: ["error", { globals: ["Promise"], checkGlobalObjectAccess: true }]*/
+/*global globalThis, self, window*/
+/*eslint no-restricted-globals: ["error", { globals: ["Promise"], checkGlobalObject: true }]*/
 
-global.Promise
 globalThis.Promise
 self.Promise
 window.Promise
@@ -170,21 +169,20 @@ window.Promise
 
 ### globalObjects
 
-An array option that specifies additional global object names to check when `checkGlobalObjectAccess` is enabled. By default, the rule checks these global objects: `global`, `globalThis`, `self`, and `window`.
+An array option that specifies additional global object names to check when `checkGlobalObject` is enabled. By default, the rule checks these global objects: `globalThis`, `self`, and `window`.
 
 Examples of **incorrect** code for `globalObjects` option:
 
 ::: incorrect
 
 ```js
-/*global global, globalThis, self, window, myGlobal*/
+/*global globalThis, self, window, myGlobal*/
 /*eslint no-restricted-globals: ["error", {
     globals: ["Promise"],
-    checkGlobalObjectAccess: true,
+    checkGlobalObject: true,
     globalObjects: ["myGlobal"]
 }]*/
 
-global.Promise
 globalThis.Promise
 self.Promise
 window.Promise

--- a/lib/rules/no-restricted-globals.js
+++ b/lib/rules/no-restricted-globals.js
@@ -22,13 +22,13 @@ const TYPE_NODES = new Set([
 	"TSQualifiedName",
 ]);
 
-const GLOBAL_OBJECTS = new Set(["global", "globalThis", "self", "window"]);
+const GLOBAL_OBJECTS = new Set(["globalThis", "self", "window"]);
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const arrayOfStringsOrObjects = {
+const arrayOfGlobals = {
 	type: "array",
 	items: {
 		oneOf: [
@@ -65,15 +65,15 @@ module.exports = {
 
 		schema: {
 			anyOf: [
-				arrayOfStringsOrObjects,
+				arrayOfGlobals,
 				{
 					type: "array",
 					items: [
 						{
 							type: "object",
 							properties: {
-								globals: arrayOfStringsOrObjects,
-								checkGlobalObjectAccess: {
+								globals: arrayOfGlobals,
+								checkGlobalObject: {
 									type: "boolean",
 								},
 								globalObjects: {
@@ -110,8 +110,8 @@ module.exports = {
 		const restrictedGlobals = isGlobalsObject
 			? options[0].globals
 			: options;
-		const checkGlobalObjectAccess = isGlobalsObject
-			? options[0].checkGlobalObjectAccess
+		const checkGlobalObject = isGlobalsObject
+			? options[0].checkGlobalObject
 			: false;
 		const userGlobalObjects = isGlobalsObject
 			? options[0].globalObjects || []
@@ -210,7 +210,7 @@ module.exports = {
 			},
 
 			"Program:exit"(node) {
-				if (!checkGlobalObjectAccess) {
+				if (!checkGlobalObject) {
 					return;
 				}
 

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -3407,7 +3407,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 									message?: string | undefined;
 							  }
 						>;
-						checkGlobalObjectAccess?: boolean;
+						checkGlobalObject?: boolean;
 						globalObjects?: string[];
 				  }>
 			),

--- a/tests/lib/rules/no-restricted-globals.js
+++ b/tests/lib/rules/no-restricted-globals.js
@@ -104,11 +104,6 @@ ruleTester.run("no-restricted-globals", rule, {
 			languageOptions: { globals: globals.browser },
 		},
 		{
-			code: "global.foo()",
-			options: [{ globals: ["foo"] }],
-			languageOptions: { sourceType: "commonjs" },
-		},
-		{
 			code: "globalThis.foo()",
 			options: [{ globals: ["foo"] }],
 			languageOptions: { ecmaVersion: 2020 },
@@ -128,7 +123,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 				},
 			],
 		},
@@ -137,16 +132,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
-				},
-			],
-		},
-		{
-			code: "global.foo()",
-			options: [
-				{
-					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 				},
 			],
 		},
@@ -155,7 +141,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 				},
 			],
 			languageOptions: { ecmaVersion: 6 },
@@ -165,7 +151,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 					globalObjects: ["myGlobal"],
 				},
 			],
@@ -175,7 +161,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 					globalObjects: ["myGlobal"],
 				},
 			],
@@ -186,7 +172,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["bar"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 				},
 			],
 			languageOptions: { globals: globals.browser },
@@ -196,27 +182,17 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["bar"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 				},
 			],
 			languageOptions: { globals: globals.browser },
-		},
-		{
-			code: "foo.global.bar()",
-			options: [
-				{
-					globals: ["bar"],
-					checkGlobalObjectAccess: true,
-				},
-			],
-			languageOptions: { sourceType: "commonjs" },
 		},
 		{
 			code: "foo.globalThis.bar()",
 			options: [
 				{
 					globals: ["bar"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 				},
 			],
 			languageOptions: { ecmaVersion: 2020 },
@@ -226,7 +202,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["bar"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 					globalObjects: ["myGlobal"],
 				},
 			],
@@ -237,7 +213,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 				},
 			],
 			languageOptions: { globals: globals.browser },
@@ -247,27 +223,17 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 				},
 			],
 			languageOptions: { globals: globals.browser },
-		},
-		{
-			code: "let global; global.foo()",
-			options: [
-				{
-					globals: ["foo"],
-					checkGlobalObjectAccess: true,
-				},
-			],
-			languageOptions: { sourceType: "commonjs" },
 		},
 		{
 			code: "let globalThis; globalThis.foo()",
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 				},
 			],
 			languageOptions: { ecmaVersion: 2020 },
@@ -277,7 +243,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 					globalObjects: ["myGlobal"],
 				},
 			],
@@ -834,7 +800,7 @@ ruleTester.run("no-restricted-globals", rule, {
 		},
 		{
 			code: "window.foo()",
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
 			languageOptions: { globals: globals.browser },
 			errors: [
 				{
@@ -846,7 +812,7 @@ ruleTester.run("no-restricted-globals", rule, {
 		},
 		{
 			code: "self.foo()",
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
 			languageOptions: { globals: globals.browser },
 			errors: [
 				{
@@ -858,7 +824,7 @@ ruleTester.run("no-restricted-globals", rule, {
 		},
 		{
 			code: "window.window.foo()",
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
 			languageOptions: { globals: globals.browser },
 			errors: [
 				{
@@ -870,7 +836,7 @@ ruleTester.run("no-restricted-globals", rule, {
 		},
 		{
 			code: "self.self.foo()",
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
 			languageOptions: { globals: globals.browser },
 			errors: [
 				{
@@ -881,32 +847,8 @@ ruleTester.run("no-restricted-globals", rule, {
 			],
 		},
 		{
-			code: "global.foo()",
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
-			languageOptions: { sourceType: "commonjs" },
-			errors: [
-				{
-					messageId: "defaultMessage",
-					data: { name: "foo" },
-					type: "Identifier",
-				},
-			],
-		},
-		{
-			code: "global.global.foo()",
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
-			languageOptions: { sourceType: "commonjs" },
-			errors: [
-				{
-					messageId: "defaultMessage",
-					data: { name: "foo" },
-					type: "Identifier",
-				},
-			],
-		},
-		{
 			code: "globalThis.foo()",
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
 			languageOptions: { ecmaVersion: 2020 },
 			errors: [
 				{
@@ -918,7 +860,7 @@ ruleTester.run("no-restricted-globals", rule, {
 		},
 		{
 			code: "globalThis.globalThis.foo()",
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
 			languageOptions: { ecmaVersion: 2020 },
 			errors: [
 				{
@@ -933,7 +875,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 					globalObjects: ["myGlobal"],
 				},
 			],
@@ -951,7 +893,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 					globalObjects: ["myGlobal"],
 				},
 			],
@@ -966,7 +908,7 @@ ruleTester.run("no-restricted-globals", rule, {
 		},
 		{
 			code: 'window["foo"]',
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
 			languageOptions: { globals: globals.browser },
 			errors: [
 				{
@@ -978,7 +920,7 @@ ruleTester.run("no-restricted-globals", rule, {
 		},
 		{
 			code: 'self["foo"]',
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
 			languageOptions: { globals: globals.browser },
 			errors: [
 				{
@@ -989,20 +931,8 @@ ruleTester.run("no-restricted-globals", rule, {
 			],
 		},
 		{
-			code: 'global["foo"]',
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
-			languageOptions: { sourceType: "commonjs" },
-			errors: [
-				{
-					messageId: "defaultMessage",
-					data: { name: "foo" },
-					type: "Literal",
-				},
-			],
-		},
-		{
 			code: 'globalThis["foo"]',
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
 			languageOptions: { ecmaVersion: 2020 },
 			errors: [
 				{
@@ -1017,7 +947,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 					globalObjects: ["myGlobal"],
 				},
 			],
@@ -1032,7 +962,7 @@ ruleTester.run("no-restricted-globals", rule, {
 		},
 		{
 			code: "window?.foo()",
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
 			languageOptions: { globals: globals.browser },
 			errors: [
 				{
@@ -1044,7 +974,7 @@ ruleTester.run("no-restricted-globals", rule, {
 		},
 		{
 			code: "self?.foo()",
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
 			languageOptions: { globals: globals.browser },
 			errors: [
 				{
@@ -1059,7 +989,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 					globalObjects: ["myGlobal"],
 				},
 			],
@@ -1084,7 +1014,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo", "bar"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 					globalObjects: ["myGlobal", "myOtherGlobal"],
 				},
 			],
@@ -1106,7 +1036,7 @@ ruleTester.run("no-restricted-globals", rule, {
 		},
 		{
 			code: "foo(); window.foo()",
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
 			languageOptions: { globals: globals.browser },
 			errors: [
 				{
@@ -1123,7 +1053,7 @@ ruleTester.run("no-restricted-globals", rule, {
 		},
 		{
 			code: "foo(); self.foo()",
-			options: [{ globals: ["foo"], checkGlobalObjectAccess: true }],
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
 			languageOptions: { globals: globals.browser },
 			errors: [
 				{
@@ -1143,7 +1073,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["foo"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 					globalObjects: ["myGlobal"],
 				},
 			],
@@ -1168,7 +1098,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["event"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 				},
 			],
 			languageOptions: { globals: globals.browser },
@@ -1189,7 +1119,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["event"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 				},
 			],
 			languageOptions: { globals: globals.browser },
@@ -1206,32 +1136,11 @@ ruleTester.run("no-restricted-globals", rule, {
 			],
 		},
 		{
-			code: "function onClick(event) { console.log(event); console.log(global.event); }",
-			options: [
-				{
-					globals: ["event"],
-					checkGlobalObjectAccess: true,
-				},
-			],
-			languageOptions: { sourceType: "commonjs" },
-			errors: [
-				{
-					messageId: "defaultMessage",
-					data: { name: "event" },
-					type: "Identifier",
-					line: 1,
-					column: 66,
-					endLine: 1,
-					endColumn: 71,
-				},
-			],
-		},
-		{
 			code: "function onClick(event) { console.log(event); console.log(globalThis.event); }",
 			options: [
 				{
 					globals: ["event"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 				},
 			],
 			languageOptions: { ecmaVersion: 2020 },
@@ -1252,7 +1161,7 @@ ruleTester.run("no-restricted-globals", rule, {
 			options: [
 				{
 					globals: ["event"],
-					checkGlobalObjectAccess: true,
+					checkGlobalObject: true,
 					globalObjects: ["myGlobal"],
 				},
 			],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds new options to the no-restricted-globals rule to allow detection of restricted globals accessed via global objects (such as window.Promise). Specifically:

- Introduces the checkGlobalObjectAccess boolean option, which, when enabled, reports usage of restricted globals as properties of known global objects (window, global,  globalThis).
- Adds the globalObjects option, allowing users to specify additional global object names to check.
- Updates the rule schema and implementation to support three configuration styles: an array of strings, an array of objects, or a single options object with a globals array and the new options.
- Updates documentation and tests to cover the new options and usage patterns.

Fixes #19804

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
