### PR TITLE
fix: remove outdated types in `ParserOptions.ecmaFeatures`

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1597,7 +1597,6 @@ export namespace Linter {
 					globalReturn?: boolean | undefined;
 					impliedStrict?: boolean | undefined;
 					jsx?: boolean | undefined;
-					experimentalObjectRestSpread?: boolean | undefined;
 					[key: string]: any;
 			  }
 			| undefined;

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -933,16 +933,6 @@ linter.verify(
 	SOURCE,
 	{
 		parserOptions: {
-			ecmaVersion: 6,
-			ecmaFeatures: { experimentalObjectRestSpread: true },
-		},
-	},
-	"test.js",
-);
-linter.verify(
-	SOURCE,
-	{
-		parserOptions: {
 			ecmaVersion: 3,
 			allowReserved: true,
 		},
@@ -1356,16 +1346,6 @@ linterWithEslintrcConfig.verify(
 linterWithEslintrcConfig.verify(
 	SOURCE,
 	{ parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } } },
-	"test.js",
-);
-linterWithEslintrcConfig.verify(
-	SOURCE,
-	{
-		parserOptions: {
-			ecmaVersion: 6,
-			ecmaFeatures: { experimentalObjectRestSpread: true },
-		},
-	},
 	"test.js",
 );
 linterWithEslintrcConfig.verify(


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fix #19942

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR removes oudated types `ParserOptions.ecmaFeatures.experimentalObjectRestSpread`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
