### PR TITLE
refactor: use `CustomRuleDefinitionType` in `JSRuleDefinition`

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -27,15 +27,17 @@
 
 import * as ESTree from "estree";
 import type {
-	RuleVisitor,
-	TextSourceCode,
-	Language,
-	SourceRange,
-	TraversalStep,
-	LanguageOptions as GenericLanguageOptions,
-	RuleDefinition,
-	RuleContext as CoreRuleContext,
+	CustomRuleDefinitionType,
+	CustomRuleTypeDefinitions,
 	DeprecatedInfo,
+	Language,
+	LanguageOptions as GenericLanguageOptions,
+	RuleContext as CoreRuleContext,
+	RuleDefinition,
+	RuleVisitor,
+	SourceRange,
+	TextSourceCode,
+	TraversalStep,
 } from "@eslint/core";
 import { JSONSchema4 } from "json-schema";
 import { LegacyESLint } from "./use-at-your-own-risk.js";
@@ -1250,27 +1252,18 @@ export namespace Rule {
 	}
 }
 
-export type JSRuleDefinitionTypeOptions = {
-	RuleOptions: unknown[];
-	MessageIds: string;
-	ExtRuleDocs: Record<string, unknown>;
-};
+export type JSRuleDefinitionTypeOptions = CustomRuleTypeDefinitions;
 
 export type JSRuleDefinition<
 	Options extends Partial<JSRuleDefinitionTypeOptions> = {},
-> = RuleDefinition<
-	// Language specific type options (non-configurable)
+> = CustomRuleDefinitionType<
 	{
 		LangOptions: Linter.LanguageOptions;
 		Code: SourceCode;
 		Visitor: Rule.NodeListener;
 		Node: JSSyntaxElement;
-	} & Required<
-		// Rule specific type options (custom)
-		Options &
-			// Rule specific type options (defaults)
-			Omit<JSRuleDefinitionTypeOptions, keyof Options>
-	>
+	},
+	Options
 >;
 
 // #region Linter


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Simplify type definitions.

Refs: eslint/rewrite#177

Related PRs: eslint/css#203, eslint/json#121, eslint/markdown#471

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Refactored the type definition of `JSRuleDefinition` using the core [`CustomRuleDefinitionType`](https://github.com/eslint/rewrite/blob/core-v0.15.0/packages/core/src/types.ts#L598-L631) type.
* Redefined `JSRuleDefinitionTypeOptions` as an alias for the core [`CustomRuleTypeDefinitions`](https://github.com/eslint/rewrite/blob/core-v0.15.0/packages/core/src/types.ts#L589-L596) type.

This change should not have a visible impact on users.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
