### PR TITLE
test: switch to flat config mode in eslint-fuzzer

### DIFF
--- a/tests/tools/eslint-fuzzer.js
+++ b/tests/tools/eslint-fuzzer.js
@@ -9,6 +9,7 @@ const eslint = require("../..");
 const espree = require("espree");
 const sinon = require("sinon");
 const configRule = require("../../tools/config-rule");
+const coreRules = require("../../lib/rules");
 
 //------------------------------------------------------------------------------
 // Tests
@@ -23,8 +24,7 @@ describe("eslint-fuzzer", function () {
 	 */
 	this.timeout(15000); // eslint-disable-line no-invalid-this -- Mocha timeout
 
-	const linter = new eslint.Linter({ configType: "eslintrc" });
-	const coreRules = linter.getRules();
+	const linter = new eslint.Linter();
 	const fixableRuleNames = Array.from(coreRules)
 		.filter(rulePair => rulePair[1].meta && rulePair[1].meta.fixable)
 		.map(rulePair => rulePair[0]);
@@ -50,10 +50,25 @@ describe("eslint-fuzzer", function () {
 		configRule.createCoreRuleConfigs.restore();
 	});
 
+	afterEach(() => {
+		/*
+		 * LazyLoadingRuleMap prototype has the `delete` property set to `undefined`
+		 * in order to prevent accidental mutations, so we need to call `Map.prototype.delete`
+		 * directly here.
+		 */
+		Map.prototype.delete.call(coreRules, "test-fuzzer-rule");
+	});
+
+	/*
+	 * LazyLoadingRuleMap prototype has the `set` property set to `undefined`
+	 * in order to prevent accidental mutations, so we need to call `Map.prototype.set`
+	 * directly in tests that add `test-fuzzer-rule`.
+	 */
+
 	describe("when running in crash-only mode", () => {
 		describe("when a rule crashes on the given input", () => {
 			it("should report the crash with a minimal config", () => {
-				linter.defineRule("test-fuzzer-rule", {
+				Map.prototype.set.call(coreRules, "test-fuzzer-rule", () => ({
 					create: context => ({
 						Program() {
 							if (context.sourceCode.text === "foo") {
@@ -61,7 +76,7 @@ describe("eslint-fuzzer", function () {
 							}
 						},
 					}),
-				});
+				}));
 
 				const results = fuzz({
 					count: 1,
@@ -82,7 +97,9 @@ describe("eslint-fuzzer", function () {
 
 		describe("when no rules crash", () => {
 			it("should return an empty array", () => {
-				linter.defineRule("test-fuzzer-rule", { create: () => ({}) });
+				Map.prototype.set.call(coreRules, "test-fuzzer-rule", () => ({
+					create: () => ({}),
+				}));
 
 				assert.deepStrictEqual(
 					fuzz({
@@ -109,7 +126,7 @@ describe("eslint-fuzzer", function () {
 
 		describe("when a rule crashes on the given input", () => {
 			it("should report the crash with a minimal config", () => {
-				linter.defineRule("test-fuzzer-rule", {
+				Map.prototype.set.call(coreRules, "test-fuzzer-rule", () => ({
 					create: context => ({
 						Program() {
 							if (context.sourceCode.text === "foo") {
@@ -117,7 +134,7 @@ describe("eslint-fuzzer", function () {
 							}
 						},
 					}),
-				});
+				}));
 
 				const results = fuzz({
 					count: 1,
@@ -139,7 +156,7 @@ describe("eslint-fuzzer", function () {
 		describe("when a rule's autofix produces valid syntax", () => {
 			it("does not report any errors", () => {
 				// Replaces programs that start with "foo" with "bar"
-				linter.defineRule("test-fuzzer-rule", {
+				Map.prototype.set.call(coreRules, "test-fuzzer-rule", () => ({
 					meta: { fixable: "code" },
 					create: context => ({
 						Program(node) {
@@ -159,7 +176,7 @@ describe("eslint-fuzzer", function () {
 							}
 						},
 					}),
-				});
+				}));
 
 				const results = fuzz({
 					count: 1,
@@ -180,7 +197,7 @@ describe("eslint-fuzzer", function () {
 		describe("when a rule's autofix produces invalid syntax on the first pass", () => {
 			it("reports an autofix error with a minimal config", () => {
 				// Replaces programs that start with "foo" with invalid syntax
-				linter.defineRule("test-fuzzer-rule", {
+				Map.prototype.set.call(coreRules, "test-fuzzer-rule", () => ({
 					meta: { fixable: "code" },
 					create: context => ({
 						Program(node) {
@@ -202,7 +219,7 @@ describe("eslint-fuzzer", function () {
 							}
 						},
 					}),
-				});
+				}));
 
 				const results = fuzz({
 					count: 1,
@@ -237,7 +254,7 @@ describe("eslint-fuzzer", function () {
 				const intermediateCode = `bar ${disableFixableRulesComment}`;
 
 				// Replaces programs that start with "foo" with invalid syntax
-				linter.defineRule("test-fuzzer-rule", {
+				Map.prototype.set.call(coreRules, "test-fuzzer-rule", () => ({
 					meta: { fixable: "code" },
 					create: context => ({
 						Program(node) {
@@ -262,7 +279,7 @@ describe("eslint-fuzzer", function () {
 							}
 						},
 					}),
-				});
+				}));
 
 				const results = fuzz({
 					count: 1,
@@ -292,7 +309,7 @@ describe("eslint-fuzzer", function () {
 		describe("when a rule crashes on the second autofix pass", () => {
 			it("reports a crash error with a minimal config", () => {
 				// Replaces programs that start with "foo" with invalid syntax
-				linter.defineRule("test-fuzzer-rule", {
+				Map.prototype.set.call(coreRules, "test-fuzzer-rule", () => ({
 					meta: { fixable: "code" },
 					create: context => ({
 						Program(node) {
@@ -313,7 +330,7 @@ describe("eslint-fuzzer", function () {
 							}
 						},
 					}),
-				});
+				}));
 
 				const results = fuzz({
 					count: 1,

--- a/tools/eslint-fuzzer.js
+++ b/tools/eslint-fuzzer.js
@@ -158,10 +158,11 @@ function fuzz(options) {
 	 * @param {ConfigData} config The config used
 	 * @returns {Parser} a parser
 	 */
-	function getParser({ parserOptions }) {
+	function getParser(config) {
 		return sourceText =>
 			espree.parse(sourceText, {
-				...parserOptions,
+				sourceType: config.languageOptions.sourceType,
+				ecmaVersion: "latest",
 				loc: true,
 				range: true,
 				raw: true,
@@ -181,9 +182,11 @@ function fuzz(options) {
 		const text = codeGenerator({ sourceType });
 		const config = {
 			rules,
-			parserOptions: {
+			languageOptions: {
 				sourceType,
-				ecmaVersion: espree.latestEcmaVersion,
+			},
+			linterOptions: {
+				reportUnusedDisableDirectives: "off", // needed for tests
 			},
 		};
 

--- a/tools/fuzzer-runner.js
+++ b/tools/fuzzer-runner.js
@@ -12,7 +12,7 @@
 const ProgressBar = require("progress");
 const fuzz = require("./eslint-fuzzer");
 const eslint = require("..");
-const linter = new eslint.Linter({ configType: "eslintrc" });
+const linter = new eslint.Linter();
 
 //------------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Updates eslint-fuzzer to use `Linter` in flat config mode instead of eslintrc mode. We'd need to do this sooner or later since the eslintrc mode will be removed in ESLint v10.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated eslint-fuzzer and its tests to use Linter in flat config mode.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
