### PR TITLE
build: use `ESLint` class to generate formatter examples

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -21,6 +21,8 @@
         "tests/performance/jshint.js",
         // Many are required using dynamic paths such as `fs.readFileSync(path.join())`:
         "tests/fixtures/**",
+        // Run from Makefile.js
+        "tools/generate-formatter-examples.js",
       ],
       "ignoreDependencies": [
         "c8",

--- a/tools/generate-formatter-examples.js
+++ b/tools/generate-formatter-examples.js
@@ -1,0 +1,114 @@
+/**
+ * @fileoverview Generates documentation files for formatters:
+ *    - docs/src/use/formatters/index.md
+ *    - docs/src/use/formatters/html-formatter-example.html
+ * @author Milos Djermanovic
+ */
+
+"use strict";
+
+//-----------------------------------------------------------------------------
+// Requirements
+//-----------------------------------------------------------------------------
+
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const util = require("node:util");
+
+const ejs = require("ejs");
+
+const { ESLint } = require("../lib/api");
+const { defineConfig } = require("../lib/config-api");
+const js = require("../packages/js");
+
+const formattersMetadata = require("../lib/cli-engine/formatters/formatters-meta.json");
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+const FORMATTERS_DOCS_DIR = path.join(__dirname, "../docs/src/use/formatters");
+const INDEX_FILENAME = path.resolve(FORMATTERS_DOCS_DIR, "index.md");
+const HTML_FORMATTER_FILENAME = path.resolve(
+	FORMATTERS_DOCS_DIR,
+	"html-formatter-example.html",
+);
+
+const TEMPLATE_FILENAME = path.resolve(
+	__dirname,
+	"../templates/formatter-examples.md.ejs",
+);
+
+const exampleCode = [
+	"function addOne(i) {",
+	"    if (i != NaN) {",
+	"        return i ++",
+	"    } else {",
+	"      return",
+	"    }",
+	"};",
+].join("\n");
+
+const exampleConfig = defineConfig([
+	js.configs.recommended,
+	{
+		rules: {
+			"consistent-return": 2,
+			indent: [1, 4],
+			"no-else-return": 1,
+			semi: [1, "always"],
+			"space-unary-ops": 2,
+		},
+	},
+]);
+
+/**
+ * Gets linting results from every formatter, based on a hard-coded snippet and config
+ * @returns {Promise<Object>} Output from each formatter
+ */
+async function getFormatterResults() {
+	const eslint = new ESLint({
+		ignore: false,
+		overrideConfigFile: true,
+		baseConfig: exampleConfig,
+	});
+
+	const lintResults = await eslint.lintText(exampleCode, {
+		filePath: "fullOfProblems.js",
+	});
+
+	return Object.fromEntries(
+		await Promise.all(
+			formattersMetadata.map(async ({ name, description }) => {
+				const formatter = await eslint.loadFormatter(name);
+
+				return [
+					name,
+					{
+						result: util.stripVTControlCharacters(
+							formatter.format(lintResults),
+						),
+						description,
+					},
+				];
+			}),
+		),
+	);
+}
+
+//-----------------------------------------------------------------------------
+// CLI
+//-----------------------------------------------------------------------------
+
+(async () => {
+	const formatterResults = await getFormatterResults();
+	const indexFileContent = ejs.render(
+		await fs.readFile(TEMPLATE_FILENAME, "utf8"),
+		{ formatterResults },
+	);
+
+	await Promise.all([
+		fs.writeFile(INDEX_FILENAME, indexFileContent),
+		fs.writeFile(HTML_FORMATTER_FILENAME, formatterResults.html.result),
+	]);
+})();


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Updates release process to use `ESLint` class instead of the old `CLIEngine` class when generating formatters docs.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Extracted generating formatters docs into a separate file to be able to run it synchronously and updated it to use the `ESLint` class. This ensures correctness of formatter examples in ESLint v9 (when using the default flat config mode) and is something we'd need to do sooner or later since the `CLIEngine` will be removed in ESLint v10. 

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
