### PR TITLE
fix: Fixed potential bug in check-emfile-handling.js

### DIFF
--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -36,7 +36,13 @@ let FILE_COUNT = DEFAULT_FILE_COUNT;
 // if the platform isn't windows, get the ulimit to see what the actual limit is
 if (os.platform() !== "win32") {
 	try {
-		FILE_COUNT = parseInt(execSync("ulimit -n").toString().trim(), 10) + 1;
+		const limit = execSync("ulimit -n").toString().trim();
+		const parsedLimit = parseInt(limit, 10);
+
+		// "unlimited" will result in NaN, in which case use the default value
+		if (!isNaN(parsedLimit)) {
+			FILE_COUNT = parsedLimit + 1;
+		}
 
 		console.log(`Detected Linux file limit of ${FILE_COUNT}.`);
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


#### What changes did you make? (Give an overview)
**Problem**: 
On Linux and macOS, the command ulimit -n checks the maximum number of files that can be opened at one time. However, if this setting is set to "unlimited," the script will try to convert the string "unlimited" to a number and will fail (resulting in NaN) and will not correctly calculate the number of files to use in the test.

**Fix**:
If the result of ulimit -n cannot be treated as a number, modify it to use the predetermined default number of files (15,000) without forcing the calculation.

```diff
// if the platform isn't windows, get the ulimit to see what the actual limit is
if (os.platform() !== "win32") {
	try {
		--- FILE_COUNT = parseInt(execSync("ulimit -n").toString().trim(), 10) + 1;
		+++ const limit = execSync("ulimit -n").toString().trim();
		+++ const parsedLimit = parseInt(limit, 10);

		+++ // "unlimited" will result in NaN, in which case use the default value
		+++ if (!isNaN(parsedLimit)) {
			+++ FILE_COUNT = parsedLimit + 1;
		+++ }

		console.log(`Detected Linux file limit of ${FILE_COUNT}.`);
```
