### PR TITLE
test: switch to `Linter.Config` in `ESLintRules` type tests

### DIFF
--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -1824,35 +1824,40 @@ for (const result of results) {
 
 // #region ESLintRules
 
-let eslintConfig: Linter.LegacyConfig<ESLintRules>;
+let eslintConfig: Linter.Config<ESLintRules>[];
 
-eslintConfig = {
-	rules: {
-		"capitalized-comments": [2, "always", { ignorePattern: "const|let" }],
-		"no-promise-executor-return": [2, { allowVoid: true }],
-		"sort-keys": [2, "asc", { allowLineSeparatedGroups: true }],
+eslintConfig = [
+	{
+		rules: {
+			"capitalized-comments": [
+				2,
+				"always",
+				{ ignorePattern: "const|let" },
+			],
+			"no-promise-executor-return": [2, { allowVoid: true }],
+			"sort-keys": [2, "asc", { allowLineSeparatedGroups: true }],
+		},
 	},
-	overrides: [
-		{
-			files: "*.json",
-			rules: {
-				"max-len": 0,
-			},
+	{
+		files: ["**/*.json"],
+		rules: {
+			"no-restricted-syntax": 0,
 		},
-		{
-			files: "*.ts",
-			rules: {
-				"@typescript-eslint/no-invalid-void-type": [
-					2,
-					{ allowAsThisParameter: true },
-				],
-			},
+	},
+	{
+		files: ["**/*.ts"],
+		rules: {
+			"@typescript-eslint/no-invalid-void-type": [
+				2,
+				{ allowAsThisParameter: true },
+			],
 		},
-	],
-};
+	},
+];
 
-eslintConfig.rules; // $ExpectType Partial<ESLintRules> | undefined
-eslintConfig.overrides?.[0].rules; // $ExpectType Partial<ESLintRules> | undefined
+(configIndex: number) => {
+	eslintConfig[configIndex].rules; // $ExpectType Partial<ESLintRules> | undefined
+};
 
 interface TSLinterRules {
 	"@typescript-eslint/no-invalid-void-type"?: Linter.RuleEntry<
@@ -1865,19 +1870,17 @@ interface TSLinterRules {
 	>;
 }
 
-const eslintConfig2: Linter.LegacyConfig<
-	ESLintRules,
-	ESLintRules & TSLinterRules
-> = eslintConfig;
+const eslintConfig2: Linter.Config<ESLintRules & TSLinterRules>[] =
+	eslintConfig;
 
-eslintConfig2.rules; // $ExpectType Partial<ESLintRules> | undefined
-eslintConfig2.overrides?.[1].rules; // $ExpectType Partial<ESLintRules & TSLinterRules> | undefined
+(configIndex: number) => {
+	eslintConfig2[configIndex].rules; // $ExpectType Partial<ESLintRules & TSLinterRules> | undefined
+};
 
-const eslintConfig3: Linter.LegacyConfig<ESLintRules & TSLinterRules> =
-	eslintConfig2;
-
-eslintConfig3.rules; // $ExpectType Partial<ESLintRules & TSLinterRules> | undefined
-eslintConfig3.overrides?.[1].rules; // $ExpectType Partial<ESLintRules & TSLinterRules> | undefined
+(configIndex: number) => {
+	const rules: Partial<Linter.RulesRecord> | undefined =
+		eslintConfig2[configIndex].rules;
+};
 
 // #endregion
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Update type tests

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

This pull request updates the type tests, specifically for `ESLintRules`, to use `Linter.Config` instead of `Linter.LegacyConfig`. This will be necessary in order to remove the deprecated `Linter.LegacyConfig` type.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Switched `Linter.LegacyConfig` to `Linter.Config` in type tests.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
